### PR TITLE
feat(api): add connector runtime diagnostics

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -94,6 +94,7 @@ import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-a
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
 import { zeroConnectorCatalogRoutes } from "./routes/zero-connector-catalog";
+import { zeroConnectorCheckRoutes } from "./routes/zero-connector-check";
 import { zeroConnectorPermissionDenyRoutes } from "./routes/zero-connector-permission-deny";
 import { zeroConnectorsExternalCodeRoutes } from "./routes/zero-connectors-external-code";
 import { zeroConnectorsOauthDeviceAuthRoutes } from "./routes/zero-connectors-oauth-device-auth";
@@ -290,6 +291,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,
   ...zeroConnectorCatalogRoutes,
+  ...zeroConnectorCheckRoutes,
   ...zeroConnectorPermissionDenyRoutes,
   ...zeroConnectorsExternalCodeRoutes,
   ...zeroConnectorsOauthDeviceAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -402,6 +402,17 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       run: { status: "not-scoped" },
       permission: { outcome: "unavailable", basis: "not-run-scoped" },
     });
+    const siblingAlias = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+      environmentName: "GH_TOKEN",
+    });
+    expect(siblingAlias.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "github" },
+      environmentNames: ["GH_TOKEN"],
+    });
     const unknownEnvironment = await checkWithSession(actor, {
       mode: "environment",
       environmentName: "UNKNOWN_CONNECTOR_VALUE",
@@ -489,6 +500,16 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     });
     expect(unknownConnector.body).toStrictEqual({
       outcome: "unknown-connector",
+    });
+
+    const segmentBoundary = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com.evil.example/repos/vm0-ai/vm0",
+    });
+    expect(segmentBoundary.body).toStrictEqual({
+      outcome: "no-match",
+      scope: "catalog",
     });
   });
 
@@ -664,6 +685,33 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       connector: { connectorRef: "reap" },
     });
 
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [
+          {
+            kind: "builtin",
+            name: "reap",
+            baseUrlVars: { REAP_API_BASE_URL: runBase },
+          },
+        ],
+      },
+    ]);
+    const unavailablePolicies = await checkWithToken(token, {
+      mode: "environment",
+      environmentName: "REAP_API_KEY",
+      permission: "read",
+    });
+    expect(unavailablePolicies.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "reap" },
+      run: { status: "configured", bases: [runBase] },
+      permission: {
+        outcome: "unavailable",
+        basis: "policies-unavailable",
+      },
+    });
+
     context.mocks.axiom.query.mockResolvedValue([]);
     const missingSnapshot = await checkWithToken(token, {
       mode: "environment",
@@ -734,6 +782,20 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
               },
             ],
           },
+          {
+            name: "github",
+            apis: [
+              {
+                base: "https://api.github.com",
+                permissions: [
+                  {
+                    name: "repository.read",
+                    rules: ["GET /repos/{owner}/{repo}"],
+                  },
+                ],
+              },
+            ],
+          },
           { kind: "builtin", name: "unknown-non-connector" },
         ],
         networkPolicyEntries: [
@@ -760,7 +822,10 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       outcome: "resolved",
       connector: { connectorRef: "github" },
       environmentNames: null,
-      run: { status: "configured", bases: [inlineBase] },
+      run: {
+        status: "configured",
+        bases: ["https://api.github.com", inlineBase],
+      },
       relativePath: "/repos/vm0-ai/vm0/issues",
       permission: {
         kind: "matched",
@@ -786,5 +851,41 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     ]) {
       expect(serialized).not.toContain(forbidden);
     }
+
+    const recoveredEnvironment = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+      connectorRef: "github",
+    });
+    expect(recoveredEnvironment.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "github" },
+      environmentNames: ["GITHUB_TOKEN"],
+      permission: {
+        kind: "matched",
+        permissions: [
+          {
+            name: "repository.read",
+            policy: { outcome: "allow", basis: "allow-list" },
+          },
+        ],
+      },
+    });
+
+    const inlineUnknownEndpoint = await checkWithToken(token, {
+      mode: "url",
+      method: "OPTIONS",
+      url: `${inlineBase}/not-a-real-endpoint`,
+      connectorRef: "github",
+    });
+    expect(inlineUnknownEndpoint.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "github" },
+      permission: {
+        kind: "unknown-endpoint",
+        policy: { outcome: "deny", basis: "unknown-policy" },
+      },
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -1,0 +1,790 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type ConnectorCheckRequest,
+  zeroConnectorCheckContract,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
+import { createStore } from "ccstate";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+const bdd = createBddApi(context);
+const connectorsApi = createConnectorBddApi(context);
+const authDevice = createAuthDeviceApiActions(context);
+const runsApi = createRunsApi(context);
+const store = createStore();
+
+interface ConnectedFixture {
+  readonly actor: ApiTestUser;
+  readonly type: "reap";
+}
+
+const trackConnectedFixture = createFixtureTracker<ConnectedFixture>(
+  async (fixture) => {
+    await connectorsApi.deleteConnectorByType(fixture.actor, fixture.type);
+  },
+);
+const trackOrgMembershipFixture = createFixtureTracker<OrgMembershipFixture>(
+  async (fixture) => {
+    await store.set(deleteOrgMembership$, fixture, context.signal);
+  },
+);
+
+function client() {
+  return setupApp({ context })(zeroConnectorCheckContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function requireOrgId(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped actor");
+  }
+  return actor.orgId;
+}
+
+async function checkWithSession(
+  actor: ApiTestUser,
+  body: ConnectorCheckRequest,
+) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return await accept(
+    client().check({
+      headers: { authorization: "Bearer clerk-session" },
+      body,
+    }),
+    [200],
+  );
+}
+
+async function checkWithToken(token: string, body: ConnectorCheckRequest) {
+  return await accept(
+    client().check({
+      headers: { authorization: `Bearer ${token}` },
+      body,
+    }),
+    [200],
+  );
+}
+
+async function issueDevicePat(actor: ApiTestUser): Promise<string> {
+  const started = await authDevice.startCliDevice();
+  const approved = await authDevice.requestCliApproval(
+    actor,
+    { device_code: started.device_code },
+    [200],
+  );
+  expect(approved.body).toStrictEqual({ success: true });
+
+  const token = await authDevice.requestCliToken(started.device_code, [200]);
+  if (token.status !== 200) {
+    throw new Error(`Expected CLI token exchange, got ${token.status}`);
+  }
+  return token.body.access_token;
+}
+
+async function seedZeroMembership(actor: ApiTestUser): Promise<void> {
+  await trackOrgMembershipFixture(
+    store.set(
+      seedOrgMembership$,
+      {
+        orgId: requireOrgId(actor),
+        userId: actor.userId,
+        role: "admin",
+      },
+      context.signal,
+    ),
+  );
+}
+
+function zeroToken(
+  actor: ApiTestUser,
+  runId: string,
+  capabilities: readonly string[],
+): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: actor.userId,
+    orgId: requireOrgId(actor),
+    runId,
+    capabilities,
+    iat: seconds,
+    exp: seconds + 600,
+  });
+}
+
+async function connectReap(
+  actor: ApiTestUser,
+  apiBaseUrl: string,
+): Promise<void> {
+  await connectorsApi.connectManualGrant(actor, "reap", "api-token", {
+    apiKey: "reap-test-api-key",
+    apiBaseUrl,
+  });
+  await trackConnectedFixture(Promise.resolve({ actor, type: "reap" }));
+}
+
+async function createOwnedRun(actor: ApiTestUser): Promise<string> {
+  bdd.acceptAgentStorageWrites();
+  runsApi.acceptStorageDownloads();
+  runsApi.acceptTelemetryIngest();
+  runsApi.configureRunnerGroup();
+  await runsApi.grantProEntitlement(actor);
+  await runsApi.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: `Connector check ${randomUUID()}`,
+    visibility: "private",
+  });
+  const run = await runsApi.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "Create a connector check fixture",
+    modelProvider: "anthropic-api-key",
+  });
+  return run.runId;
+}
+
+beforeEach(() => {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: false,
+  });
+  context.mocks.axiom.query.mockResolvedValue([]);
+});
+
+describe("POST /api/zero/connectors/diagnostics/check", () => {
+  it("requires organization auth and both Zero capabilities", async () => {
+    const body = {
+      mode: "url" as const,
+      method: "POST",
+      url: "https://slack.com/api/chat.postMessage",
+    };
+    const unauthenticated = await accept(
+      client().check({ headers: {}, body }),
+      [401],
+    );
+    expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
+
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const withoutOrganization = await accept(
+      client().check({
+        headers: { authorization: "Bearer clerk-session" },
+        body,
+      }),
+      [401],
+    );
+    expect(withoutOrganization.body.error.code).toBe("UNAUTHORIZED");
+
+    const actor = bdd.user();
+    await seedZeroMembership(actor);
+    const runId = await createOwnedRun(actor);
+    const withoutConnectorRead = await accept(
+      client().check({
+        headers: {
+          authorization: `Bearer ${zeroToken(actor, runId, ["agent-run:read"])}`,
+        },
+        body,
+      }),
+      [403],
+    );
+    expect(withoutConnectorRead.body.error).toStrictEqual({
+      code: "FORBIDDEN",
+      message: "Missing required capability: connector:read",
+    });
+
+    const withoutRunRead = await accept(
+      client().check({
+        headers: {
+          authorization: `Bearer ${zeroToken(actor, runId, ["connector:read"])}`,
+        },
+        body,
+      }),
+      [403],
+    );
+    expect(withoutRunRead.body.error).toStrictEqual({
+      code: "FORBIDDEN",
+      message: "Missing required capability: agent-run:read",
+    });
+
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [{ kind: "builtin", name: "slack" }],
+        networkPolicyEntries: [
+          {
+            name: "slack",
+            policy: {
+              allow: [],
+              deny: ["chat:write"],
+              ask: [],
+              unknownPolicy: "ask",
+            },
+          },
+        ],
+      },
+    ]);
+    const allowed = await checkWithToken(
+      zeroToken(actor, runId, ["connector:read", "agent-run:read"]),
+      body,
+    );
+    expect(allowed.body).toMatchObject({
+      outcome: "resolved",
+      mode: "url",
+      connector: { connectorRef: "slack", label: "Slack" },
+      run: { status: "configured" },
+      permission: {
+        kind: "matched",
+        permissions: [
+          {
+            name: "chat:write",
+            policy: { outcome: "deny", basis: "deny-list" },
+          },
+        ],
+      },
+    });
+    expect(context.mocks.axiom.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces strict bodies and returns sanitized unsafe-input outcomes", async () => {
+    const actor = bdd.user();
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const malformed = await createApp({ signal: context.signal }).request(
+      "/api/zero/connectors/diagnostics/check",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer clerk-session",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          mode: "url",
+          method: "GET",
+          url: "https://api.github.com/repos/vm0-ai/vm0",
+          unexpected: true,
+        }),
+      },
+    );
+    expect(malformed.status).toBe(400);
+
+    const invalidMethod = await checkWithSession(actor, {
+      mode: "url",
+      method: "TRACE",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+    });
+    expect(invalidMethod.body).toStrictEqual({
+      outcome: "unsafe-input",
+      reason: "invalid-method",
+    });
+
+    for (const url of [
+      "api.github.com/repos/vm0-ai/vm0",
+      "https://user@example.com/path",
+      "https://api%2eexample.com/path",
+      "https://例子.example/path",
+      String.raw`https://example.com\path`,
+      "https://example.com/has whitespace",
+    ]) {
+      const invalidUrl = await checkWithSession(actor, {
+        mode: "url",
+        method: "GET",
+        url,
+      });
+      expect(invalidUrl.body).toStrictEqual({
+        outcome: "unsafe-input",
+        reason: "invalid-url",
+      });
+    }
+
+    const unsafePath = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/%2e%2e/private",
+    });
+    expect(unsafePath.body).toStrictEqual({
+      outcome: "unsafe-input",
+      reason: "unsafe-path",
+    });
+  });
+
+  it("supports a real PAT and resolves hidden server-authored metadata without private refs", async () => {
+    const actor = bdd.user();
+    const token = await issueDevicePat(actor);
+    const slack = await checkWithToken(token, {
+      mode: "url",
+      method: "POST",
+      url: "https://slack.com/api/chat.postMessage?query-sentinel=secret#fragment-sentinel",
+    });
+    expect(slack.body).toMatchObject({
+      outcome: "resolved",
+      mode: "url",
+      connector: {
+        connectorRef: "slack",
+        visibility: "available",
+        credentialResolution: "network-boundary",
+      },
+      run: { status: "not-scoped" },
+      method: "POST",
+      base: "https://slack.com/api",
+      relativePath: "/chat.postMessage",
+      permission: {
+        kind: "matched",
+        permissions: [
+          {
+            name: "chat:write",
+            policy: {
+              outcome: "unavailable",
+              basis: "not-run-scoped",
+            },
+          },
+        ],
+      },
+    });
+    const serializedSlack = JSON.stringify(slack.body);
+    expect(serializedSlack).not.toContain("query-sentinel");
+    expect(serializedSlack).not.toContain("fragment-sentinel");
+
+    const hidden = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: "https://tenant.preview.vm6.ai/api/test/oauth-provider/echo",
+      connectorRef: "test-oauth",
+    });
+    expect(hidden.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        connectorRef: "test-oauth",
+        label: "Test OAuth (internal)",
+        visibility: "unavailable",
+      },
+      relativePath: "/echo",
+    });
+    expect(JSON.stringify(hidden.body)).not.toContain("vars.");
+    expect(JSON.stringify(hidden.body)).not.toContain("TEST_OAUTH_TENANT_ID");
+  });
+
+  it("resolves environment aliases, ambiguity, and URL selectors deterministically", async () => {
+    const actor = bdd.user();
+    const knownEnvironment = await checkWithSession(actor, {
+      mode: "environment",
+      environmentName: "GH_TOKEN",
+      permission: "contents:read",
+    });
+    expect(knownEnvironment.body).toStrictEqual({
+      outcome: "resolved",
+      mode: "environment",
+      connector: {
+        connectorRef: "github",
+        label: "GitHub",
+        visibility: "available",
+        credentialResolution: "network-boundary",
+      },
+      environmentName: "GH_TOKEN",
+      run: { status: "not-scoped" },
+      permission: { outcome: "unavailable", basis: "not-run-scoped" },
+    });
+    const unknownEnvironment = await checkWithSession(actor, {
+      mode: "environment",
+      environmentName: "UNKNOWN_CONNECTOR_VALUE",
+    });
+    expect(unknownEnvironment.body).toStrictEqual({
+      outcome: "unknown-environment",
+    });
+
+    const nintendoUrl = "https://api.accounts.nintendo.com/2.0.0/users/me";
+    const ambiguous = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: nintendoUrl,
+    });
+    expect(ambiguous.body).toStrictEqual({
+      outcome: "ambiguous",
+      candidates: [
+        { connectorRef: "nintendo-store", label: "Nintendo Store" },
+        {
+          connectorRef: "nintendo-switch-parental-controls",
+          label: "Nintendo Switch Parental Controls",
+        },
+      ],
+    });
+
+    const selected = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: nintendoUrl,
+      connectorRef: "nintendo-switch-parental-controls",
+    });
+    expect(selected.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        connectorRef: "nintendo-switch-parental-controls",
+      },
+      environmentNames: ["NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN"],
+    });
+
+    const mismatch = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+      connectorRef: "slack",
+    });
+    expect(mismatch.body).toMatchObject({
+      outcome: "connector-mismatch",
+      connector: { connectorRef: "github" },
+    });
+
+    const notOwned = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+      environmentName: "SLACK_TOKEN",
+    });
+    expect(notOwned.body).toMatchObject({
+      outcome: "environment-not-owned",
+      connector: { connectorRef: "github" },
+    });
+
+    const notUsed = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: nintendoUrl,
+      connectorRef: "nintendo-switch-parental-controls",
+      environmentName: "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+    });
+    expect(notUsed.body).toStrictEqual({
+      outcome: "environment-not-used",
+      connector: {
+        connectorRef: "nintendo-switch-parental-controls",
+        label: "Nintendo Switch Parental Controls",
+        visibility: "unavailable",
+        credentialResolution: "network-boundary",
+      },
+      environmentNames: ["NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN"],
+    });
+
+    const unknownConnector = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://example.com/path",
+      connectorRef: "missing-connector",
+    });
+    expect(unknownConnector.body).toStrictEqual({
+      outcome: "unknown-connector",
+    });
+  });
+
+  it("uses one isolated stored-state snapshot for opaque dynamic bases", async () => {
+    const owner = bdd.user();
+    const orgId = requireOrgId(owner);
+    const sameOrgOtherUser = bdd.user({ orgId });
+    const sameUserOtherOrg = bdd.user({ userId: owner.userId });
+    const storedBase = "https://sandbox.api.reap.global/v1";
+    const request = {
+      mode: "url" as const,
+      method: "GET",
+      url: `${storedBase}/users`,
+      connectorRef: "reap",
+    };
+
+    const unresolved = await checkWithSession(owner, request);
+    expect(unresolved.body).toMatchObject({
+      outcome: "unresolved-dynamic-base",
+      connector: { connectorRef: "reap" },
+    });
+
+    await connectReap(owner, storedBase);
+    const resolved = await checkWithSession(owner, request);
+    expect(resolved.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "reap" },
+      base: storedBase,
+      relativePath: "/users",
+      run: { status: "not-scoped" },
+    });
+    const serialized = JSON.stringify(resolved.body);
+    expect(serialized).not.toContain("REAP_API_BASE_URL");
+    expect(serialized).not.toContain("reap-test-api-key");
+
+    for (const actor of [sameOrgOtherUser, sameUserOtherOrg]) {
+      const isolated = await checkWithSession(actor, request);
+      expect(isolated.body).toMatchObject({
+        outcome: "unresolved-dynamic-base",
+        connector: { connectorRef: "reap" },
+      });
+    }
+  });
+
+  it("uses only an owned Zero snapshot, including dynamic bases and final policies", async () => {
+    const owner = bdd.user();
+    const runId = await createOwnedRun(owner);
+    await seedZeroMembership(owner);
+    const token = zeroToken(owner, runId, ["connector:read", "agent-run:read"]);
+    const runBase = "https://prod.api.reap.global/v1";
+    const secondRunBase = "https://sandbox.api.reap.global/v1";
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [
+          {
+            kind: "builtin",
+            name: "reap",
+            baseUrlVars: { REAP_API_BASE_URL: runBase },
+          },
+          {
+            kind: "builtin",
+            name: "reap",
+            baseUrlVars: { REAP_API_BASE_URL: secondRunBase },
+          },
+        ],
+        networkPolicyEntries: [
+          {
+            name: "reap",
+            policy: {
+              allow: [],
+              deny: [],
+              ask: ["read"],
+              unknownPolicy: "deny",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const urlResult = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: `${runBase}/users`,
+    });
+    expect(urlResult.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "reap" },
+      run: { status: "configured", bases: [runBase, secondRunBase] },
+      base: runBase,
+      permission: {
+        kind: "matched",
+        permissions: [
+          {
+            name: "read",
+            policy: { outcome: "ask", basis: "ask-list" },
+          },
+        ],
+      },
+    });
+
+    const environmentResult = await checkWithToken(token, {
+      mode: "environment",
+      environmentName: "REAP_API_KEY",
+      permission: "write",
+    });
+    expect(environmentResult.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "reap" },
+      run: { status: "configured", bases: [runBase, secondRunBase] },
+      permission: { outcome: "allow", basis: "not-blocked" },
+    });
+
+    const unknownEndpoint = await checkWithToken(token, {
+      mode: "url",
+      method: "OPTIONS",
+      url: `${runBase}/not-a-real-endpoint`,
+    });
+    expect(unknownEndpoint.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "reap" },
+      permission: {
+        kind: "unknown-endpoint",
+        policy: { outcome: "deny", basis: "unknown-policy" },
+      },
+    });
+
+    const notConfiguredEnvironment = await checkWithToken(token, {
+      mode: "environment",
+      environmentName: "GH_TOKEN",
+      permission: "contents:read",
+    });
+    expect(notConfiguredEnvironment.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "github" },
+      run: { status: "not-configured" },
+      permission: {
+        outcome: "unavailable",
+        basis: "connector-not-configured",
+      },
+    });
+
+    const globalFallbackDenied = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+    });
+    expect(globalFallbackDenied.body).toStrictEqual({
+      outcome: "no-match",
+      scope: "run",
+    });
+
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [
+          {
+            kind: "builtin",
+            name: "reap",
+            baseUrlVars: { REAP_API_BASE_URL: "http://127.0.0.1" },
+          },
+        ],
+      },
+    ]);
+    const rejectedDynamicBase = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: "http://127.0.0.1/users",
+      connectorRef: "reap",
+    });
+    expect(rejectedDynamicBase.body).toMatchObject({
+      outcome: "unresolved-dynamic-base",
+      connector: { connectorRef: "reap" },
+    });
+
+    context.mocks.axiom.query.mockResolvedValue([]);
+    const missingSnapshot = await checkWithToken(token, {
+      mode: "environment",
+      environmentName: "REAP_API_KEY",
+    });
+    expect(missingSnapshot.body).toStrictEqual({
+      outcome: "run-context-unavailable",
+    });
+
+    const intruder = bdd.user({ orgId: requireOrgId(owner) });
+    await seedZeroMembership(intruder);
+    const wrongOwner = await accept(
+      client().check({
+        headers: {
+          authorization: `Bearer ${zeroToken(intruder, runId, [
+            "connector:read",
+            "agent-run:read",
+          ])}`,
+        },
+        body: {
+          mode: "environment",
+          environmentName: "REAP_API_KEY",
+        },
+      }),
+      [404],
+    );
+    expect(wrongOwner.body.error).toStrictEqual({
+      code: "NOT_FOUND",
+      message: "Agent run not found",
+    });
+  });
+
+  it("diagnoses sanitized inline entries without exposing their source snapshot", async () => {
+    const actor = bdd.user();
+    const runId = await createOwnedRun(actor);
+    await seedZeroMembership(actor);
+    const token = zeroToken(actor, runId, ["connector:read", "agent-run:read"]);
+    const inlineBase = "https://legacy-github.example.com";
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [
+          {
+            name: "github",
+            apis: [
+              {
+                base: inlineBase,
+                permissions: [
+                  {
+                    name: "repository.read",
+                    rules: ["GET /repos/{owner}/{repo}"],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: "github",
+            apis: [
+              {
+                base: inlineBase,
+                permissions: [
+                  {
+                    name: "issues.write",
+                    rules: ["POST /repos/{owner}/{repo}/issues"],
+                  },
+                ],
+              },
+            ],
+          },
+          { kind: "builtin", name: "unknown-non-connector" },
+        ],
+        networkPolicyEntries: [
+          {
+            name: "github",
+            policy: {
+              allow: ["repository.read"],
+              deny: [],
+              ask: ["issues.write"],
+              unknownPolicy: "deny",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await checkWithToken(token, {
+      mode: "url",
+      method: "POST",
+      url: `${inlineBase}/repos/vm0-ai/vm0/issues?query-private=1#fragment-private`,
+      connectorRef: "github",
+    });
+    expect(result.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorRef: "github" },
+      environmentNames: null,
+      run: { status: "configured", bases: [inlineBase] },
+      relativePath: "/repos/vm0-ai/vm0/issues",
+      permission: {
+        kind: "matched",
+        permissions: [
+          {
+            name: "issues.write",
+            policy: { outcome: "ask", basis: "ask-list" },
+          },
+        ],
+      },
+    });
+    const serialized = JSON.stringify(result.body);
+    for (const forbidden of [
+      "query-private",
+      "fragment-private",
+      "runId",
+      "networkPolicies",
+      '"allow":',
+      '"deny":',
+      '"ask":',
+      "repository.read",
+      "unknown-non-connector",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connector-check.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-check.ts
@@ -1,0 +1,72 @@
+import { zeroConnectorCheckContract } from "@vm0/api-contracts/contracts/zero-connector-check";
+import { command } from "ccstate";
+
+import {
+  organizationAuthContext$,
+  type AuthErrorResponse,
+} from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { resolveConnectorCheck$ } from "../services/connector-check.service";
+import { notFound } from "../../lib/error";
+
+function missingAgentRunReadCapability(): AuthErrorResponse {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: "Missing required capability: agent-run:read",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
+const checkInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(bodyResultOf(zeroConnectorCheckContract.check));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  if (
+    auth.tokenType === "zero" &&
+    !auth.capabilities.includes("agent-run:read")
+  ) {
+    return missingAgentRunReadCapability();
+  }
+
+  const result = await set(
+    resolveConnectorCheck$,
+    {
+      request: bodyResult.data,
+      orgId: auth.orgId,
+      userId: auth.userId,
+      stateSource:
+        auth.tokenType === "zero"
+          ? { kind: "run", runId: auth.runId }
+          : { kind: "stored" },
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (result.kind === "not-found") {
+    return notFound("Agent run not found");
+  }
+  return { status: 200 as const, body: result.diagnostic };
+});
+
+export const zeroConnectorCheckRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroConnectorCheckContract.check,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "connector:read",
+      },
+      checkInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -1,0 +1,1099 @@
+import type {
+  ConnectorCheckDiagnosticResult,
+  ConnectorCheckPolicy,
+  ConnectorCheckRequest,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
+import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import {
+  getAvailableConnectorAuthMethodIds,
+  getConnectorAuthMethodRuntimeMetadata,
+  getConnectorEnvBindingEntries,
+} from "@vm0/connectors/connector-utils";
+import {
+  CONNECTOR_TYPE_KEYS,
+  CONNECTOR_TYPES,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+import {
+  matchFirewallBaseUrl,
+  matchFirewallRequestDecision,
+  type FirewallRequestDecision,
+} from "@vm0/connectors/firewall-rule-matcher";
+import {
+  FIREWALL_ROUTING_METADATA_INDEX,
+  type FirewallRoutingRouteMetadata,
+} from "@vm0/connectors/firewall-metadata/routing";
+import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
+import type { NetworkPolicies } from "@vm0/connectors/firewall-types";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { connectors } from "@vm0/db/schema/connector";
+import { variables } from "@vm0/db/schema/variable";
+import { command } from "ccstate";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { type Db, writeDb$ } from "../external/db";
+import {
+  buildConnectorDiagnosticBaseCandidates,
+  loadConnectorDiagnosticCatalogView,
+  parseConnectorDiagnosticRequest,
+  publicConnectorDiagnosticBase,
+  resolveConnectorDiagnosticBase,
+  type ConnectorDiagnosticBaseCandidate,
+  type ConnectorDiagnosticCatalogView,
+  type ParsedConnectorDiagnosticRequest,
+} from "./connector-diagnostic-runtime.service";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
+import { zeroRunContext } from "./zero-run-detail.service";
+
+type FeatureStates = ReturnType<typeof getAllFeatureStates>;
+
+interface ConnectorCheckIdentity {
+  readonly connectorRef: ConnectorType;
+  readonly label: string;
+  readonly visibility: "available" | "unavailable";
+  readonly credentialResolution: "network-boundary" | "none";
+}
+
+interface ConnectorCheckRoutingConfig {
+  readonly type: ConnectorType;
+  readonly candidates: readonly ConnectorDiagnosticBaseCandidate[];
+  readonly hasUnresolvedDynamicBase: boolean;
+}
+
+interface StoredRuntimeState {
+  readonly baseUrlVarsByType: ReadonlyMap<
+    ConnectorType,
+    Readonly<Record<string, string>> | null
+  >;
+}
+
+type ConnectorCheckTimeline =
+  | { readonly kind: "stored"; readonly state: StoredRuntimeState }
+  | { readonly kind: "run"; readonly context: RunContextResponse };
+
+interface ResolveConnectorCheckArgs {
+  readonly request: ConnectorCheckRequest;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly stateSource:
+    | { readonly kind: "stored" }
+    | { readonly kind: "run"; readonly runId: string };
+}
+
+type ResolveConnectorCheckResult =
+  | {
+      readonly kind: "ok";
+      readonly diagnostic: ConnectorCheckDiagnosticResult;
+    }
+  | { readonly kind: "not-found" };
+
+interface DecisionPermission {
+  readonly name: string;
+  readonly rules: readonly string[];
+}
+
+type RunContextFirewall = RunContextResponse["firewalls"][number];
+type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
+type RunContextInlinePermission =
+  RunContextInlineFirewall["apis"][number]["permissions"] extends
+    | readonly (infer Permission)[]
+    | undefined
+    ? Permission
+    : never;
+
+function isConnectorType(value: string): value is ConnectorType {
+  return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, value);
+}
+
+function baseKey(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function connectorCredentialResolution(
+  type: ConnectorType,
+): "network-boundary" | "none" {
+  return (getFirewallExecutionMetadata(type)?.secretPlaceholderNames.length ??
+    0) > 0
+    ? "network-boundary"
+    : "none";
+}
+
+function connectorIdentity(
+  type: ConnectorType,
+  featureStates: FeatureStates,
+): ConnectorCheckIdentity {
+  return {
+    connectorRef: type,
+    label: CONNECTOR_TYPES[type].label,
+    visibility:
+      getAvailableConnectorAuthMethodIds(type, featureStates, {
+        apiAuthMethodPolicy: "include",
+      }).length > 0
+        ? "available"
+        : "unavailable",
+    credentialResolution: connectorCredentialResolution(type),
+  };
+}
+
+const connectorCheckFeatureStates$ = command(
+  async ({ get }, orgId: string, userId: string): Promise<FeatureStates> => {
+    const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+    return getAllFeatureStates({ orgId, userId, overrides });
+  },
+);
+
+async function loadStoredRuntimeState(
+  db: Db,
+  args: { readonly orgId: string; readonly userId: string },
+): Promise<StoredRuntimeState> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+    );
+
+    const connectorRows = await tx
+      .select({ type: connectors.type, authMethod: connectors.authMethod })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+        ),
+      );
+
+    const pending = new Map<
+      ConnectorType,
+      ReadonlyMap<string, string> | null
+    >();
+    const requiredStorageNames = new Set<string>();
+
+    for (const row of connectorRows) {
+      if (!isConnectorType(row.type)) {
+        continue;
+      }
+      if (pending.has(row.type)) {
+        throw new Error(`Duplicate stored connector state for ${row.type}`);
+      }
+      const requiredRuntimeNames =
+        getFirewallExecutionMetadata(row.type)?.baseUrlVarNames ?? [];
+      if (requiredRuntimeNames.length === 0) {
+        pending.set(row.type, new Map());
+        continue;
+      }
+
+      const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
+        row.type,
+        row.authMethod,
+      );
+      if (!runtimeMetadata) {
+        throw new Error(`Invalid stored auth method for ${row.type}`);
+      }
+      const requiredNameSet = new Set(requiredRuntimeNames);
+      const storageNameByRuntimeName = new Map<string, string>();
+      for (const binding of runtimeMetadata.runtimeBindings) {
+        if (
+          requiredNameSet.has(binding.envName) &&
+          binding.source.kind === "connector-variable"
+        ) {
+          storageNameByRuntimeName.set(binding.envName, binding.source.name);
+        }
+      }
+      if (storageNameByRuntimeName.size !== requiredNameSet.size) {
+        pending.set(row.type, null);
+        continue;
+      }
+      for (const storageName of storageNameByRuntimeName.values()) {
+        requiredStorageNames.add(storageName);
+      }
+      pending.set(row.type, storageNameByRuntimeName);
+    }
+
+    const variableRows =
+      requiredStorageNames.size === 0
+        ? []
+        : await tx
+            .select({ name: variables.name, value: variables.value })
+            .from(variables)
+            .where(
+              and(
+                eq(variables.orgId, args.orgId),
+                eq(variables.userId, args.userId),
+                eq(variables.type, "connector"),
+                inArray(variables.name, [...requiredStorageNames]),
+              ),
+            );
+    const valueByStorageName = new Map(
+      variableRows.map((row) => {
+        return [row.name, row.value] as const;
+      }),
+    );
+    const baseUrlVarsByType = new Map<
+      ConnectorType,
+      Readonly<Record<string, string>> | null
+    >();
+    for (const [type, storageNameByRuntimeName] of pending) {
+      if (storageNameByRuntimeName === null) {
+        baseUrlVarsByType.set(type, null);
+        continue;
+      }
+      const values: Record<string, string> = {};
+      let complete = true;
+      for (const [runtimeName, storageName] of storageNameByRuntimeName) {
+        const value = valueByStorageName.get(storageName);
+        if (!value) {
+          complete = false;
+          break;
+        }
+        values[runtimeName] = value;
+      }
+      baseUrlVarsByType.set(type, complete ? values : null);
+    }
+
+    return { baseUrlVarsByType };
+  });
+}
+
+function routesToDecisionPermissions(
+  routes: readonly FirewallRoutingRouteMetadata[],
+): DecisionPermission[] {
+  const rulesByPermission = new Map<string, string[]>();
+  for (const route of routes) {
+    const rules = rulesByPermission.get(route.permissionName);
+    if (rules) {
+      rules.push(route.rule);
+    } else {
+      rulesByPermission.set(route.permissionName, [route.rule]);
+    }
+  }
+  return [...rulesByPermission].map(([name, rules]) => {
+    return { name, rules };
+  });
+}
+
+function configsToDecisionFirewalls(
+  configs: readonly ConnectorCheckRoutingConfig[],
+) {
+  return configs.map((config) => {
+    return {
+      name: config.type,
+      apis: config.candidates.map((candidate) => {
+        return {
+          base: candidate.decisionBase,
+          auth: {},
+          permissions: routesToDecisionPermissions(candidate.routes),
+        };
+      }),
+    };
+  });
+}
+
+function configFromCatalogView(
+  view: ConnectorDiagnosticCatalogView,
+  baseUrlVars: Readonly<Record<string, string>> | null,
+  allowStructuralDynamic: boolean,
+): ConnectorCheckRoutingConfig {
+  const result = buildConnectorDiagnosticBaseCandidates(view, baseUrlVars, {
+    allowStructuralDynamic,
+  });
+  return {
+    type: view.type,
+    candidates: result.candidates,
+    hasUnresolvedDynamicBase: result.hasUnresolvedDynamicBase,
+  };
+}
+
+function runContextPermissionRoutes(
+  permissions: readonly RunContextInlinePermission[] | undefined,
+): FirewallRoutingRouteMetadata[] {
+  const routes: FirewallRoutingRouteMetadata[] = [];
+  const seenPermissionNames = new Set<string>();
+  for (const permission of permissions ?? []) {
+    if (seenPermissionNames.has(permission.name)) {
+      continue;
+    }
+    seenPermissionNames.add(permission.name);
+    for (const rule of permission.rules) {
+      routes.push({ permissionName: permission.name, rule });
+    }
+  }
+  return routes;
+}
+
+function sameStrings(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+function inlineApiEnvironmentNames(
+  base: string,
+  view: ConnectorDiagnosticCatalogView | null,
+): readonly string[] | null {
+  if (!view) {
+    return null;
+  }
+  const matches = view.apis.filter((api) => {
+    return api.base === base;
+  });
+  const [first, ...others] = matches;
+  if (!first) {
+    return null;
+  }
+  return others.every((api) => {
+    return sameStrings(first.environmentNames, api.environmentNames);
+  })
+    ? first.environmentNames
+    : null;
+}
+
+function configFromInlineRunContext(
+  firewall: RunContextInlineFirewall,
+  type: ConnectorType,
+  view: ConnectorDiagnosticCatalogView | null,
+): ConnectorCheckRoutingConfig {
+  return {
+    type,
+    candidates: firewall.apis.map((api) => {
+      return {
+        sourceBase: api.base,
+        decisionBase: api.base,
+        displayBase: baseKey(api.base),
+        routes: runContextPermissionRoutes(api.permissions),
+        environmentNames: inlineApiEnvironmentNames(api.base, view),
+      };
+    }),
+    hasUnresolvedDynamicBase: false,
+  };
+}
+
+function completeRunBaseUrlVars(
+  firewall: Exclude<RunContextFirewall, { apis: unknown }>,
+  requiredNames: readonly string[],
+): Readonly<Record<string, string>> | null {
+  if (requiredNames.length === 0) {
+    return {};
+  }
+  if (!("baseUrlVars" in firewall) || !firewall.baseUrlVars) {
+    return null;
+  }
+  const values: Record<string, string> = {};
+  for (const name of requiredNames) {
+    const value = firewall.baseUrlVars[name];
+    if (!value) {
+      return null;
+    }
+    values[name] = value;
+  }
+  return values;
+}
+
+async function loadRunRoutingConfigs(
+  runContext: RunContextResponse,
+): Promise<ConnectorCheckRoutingConfig[]> {
+  const viewPromises = new Map<
+    ConnectorType,
+    Promise<ConnectorDiagnosticCatalogView | null>
+  >();
+  const loadView = (
+    type: ConnectorType,
+  ): Promise<ConnectorDiagnosticCatalogView | null> => {
+    let promise = viewPromises.get(type);
+    if (!promise) {
+      promise = loadConnectorDiagnosticCatalogView(type);
+      viewPromises.set(type, promise);
+    }
+    return promise;
+  };
+
+  const configs: ConnectorCheckRoutingConfig[] = [];
+  for (const firewall of runContext.firewalls) {
+    if (!isConnectorType(firewall.name)) {
+      continue;
+    }
+    const type = firewall.name;
+    const view = await loadView(type);
+    if ("apis" in firewall) {
+      configs.push(configFromInlineRunContext(firewall, type, view));
+      continue;
+    }
+    if (!view) {
+      throw new Error(`Missing builtin firewall metadata for ${type}`);
+    }
+    const baseUrlVars = completeRunBaseUrlVars(firewall, view.baseUrlVarNames);
+    configs.push(configFromCatalogView(view, baseUrlVars, false));
+  }
+
+  const merged = new Map<ConnectorType, ConnectorCheckRoutingConfig>();
+  for (const config of configs) {
+    const existing = merged.get(config.type);
+    merged.set(config.type, {
+      type: config.type,
+      candidates: existing
+        ? [...existing.candidates, ...config.candidates]
+        : config.candidates,
+      hasUnresolvedDynamicBase:
+        (existing?.hasUnresolvedDynamicBase ?? false) ||
+        config.hasUnresolvedDynamicBase,
+    });
+  }
+  return [...merged.values()];
+}
+
+async function catalogConfig(
+  type: ConnectorType,
+  state: StoredRuntimeState,
+): Promise<ConnectorCheckRoutingConfig | null> {
+  const view = await loadConnectorDiagnosticCatalogView(type);
+  if (!view) {
+    return null;
+  }
+  return configFromCatalogView(
+    view,
+    state.baseUrlVarsByType.get(type) ?? null,
+    true,
+  );
+}
+
+async function loadGlobalCatalogConfigs(
+  request: ParsedConnectorDiagnosticRequest,
+  requestedType: ConnectorType | undefined,
+  state: StoredRuntimeState,
+): Promise<ConnectorCheckRoutingConfig[]> {
+  let bestScore: number | null = null;
+  const ownerTypes = new Set<ConnectorType>();
+
+  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
+    const baseUrlVars = state.baseUrlVarsByType.get(metadata.type) ?? null;
+    for (const api of metadata.apis) {
+      const resolution = resolveConnectorDiagnosticBase(
+        metadata.type,
+        api.base,
+        baseUrlVars,
+        { allowStructuralDynamic: true },
+      );
+      if (!resolution.candidate) {
+        continue;
+      }
+      const match = matchFirewallBaseUrl(
+        request.url,
+        resolution.candidate.decisionBase,
+      );
+      if (!match) {
+        continue;
+      }
+      if (bestScore === null || match.score > bestScore) {
+        bestScore = match.score;
+        ownerTypes.clear();
+      }
+      if (match.score === bestScore) {
+        ownerTypes.add(metadata.type);
+      }
+    }
+  }
+
+  if (ownerTypes.size === 0 && requestedType) {
+    const selected = await catalogConfig(requestedType, state);
+    return selected ? [selected] : [];
+  }
+
+  const configs = await Promise.all(
+    [...ownerTypes].sort().map(async (type) => {
+      const config = await catalogConfig(type, state);
+      if (!config) {
+        throw new Error(`Missing indexed firewall metadata for ${type}`);
+      }
+      return config;
+    }),
+  );
+  return configs;
+}
+
+function decisionOwnerNames(
+  decision: FirewallRequestDecision,
+): readonly string[] {
+  if (decision.kind === "ambiguous") {
+    return decision.candidates;
+  }
+  if (decision.kind === "allow" || decision.kind === "block") {
+    return [decision.firewallName];
+  }
+  return [];
+}
+
+function environmentNamesForWinningCandidates(
+  config: ConnectorCheckRoutingConfig,
+  request: ParsedConnectorDiagnosticRequest,
+): readonly string[] | null {
+  const candidateByOwner = new Map<string, ConnectorDiagnosticBaseCandidate>();
+  const firewalls = config.candidates.map((candidate, index) => {
+    const name = `diagnostic-api-${index}`;
+    candidateByOwner.set(name, candidate);
+    return {
+      name,
+      apis: [
+        {
+          base: candidate.decisionBase,
+          auth: {},
+          permissions: routesToDecisionPermissions(candidate.routes),
+        },
+      ],
+    };
+  });
+  const decision = matchFirewallRequestDecision(
+    firewalls,
+    request.method,
+    request.url,
+  );
+  const names = new Set<string>();
+  let found = false;
+  for (const owner of decisionOwnerNames(decision)) {
+    const candidate = candidateByOwner.get(owner);
+    if (!candidate) {
+      continue;
+    }
+    found = true;
+    if (candidate.environmentNames === null) {
+      return null;
+    }
+    for (const name of candidate.environmentNames) {
+      names.add(name);
+    }
+  }
+  return found ? [...names].sort() : null;
+}
+
+function environmentValueRefs(
+  type: ConnectorType,
+  environmentName: string,
+): ReadonlySet<string> {
+  return new Set(
+    getConnectorEnvBindingEntries(type)
+      .filter((entry) => {
+        return entry.envName === environmentName;
+      })
+      .map((entry) => {
+        return entry.valueRef;
+      }),
+  );
+}
+
+function environmentNameSupportsRoute(
+  type: ConnectorType,
+  environmentName: string,
+  routeEnvironmentNames: readonly string[],
+): boolean {
+  const requestedRefs = environmentValueRefs(type, environmentName);
+  return routeEnvironmentNames.some((routeEnvironmentName) => {
+    if (routeEnvironmentName === environmentName) {
+      return true;
+    }
+    const routeRefs = environmentValueRefs(type, routeEnvironmentName);
+    return [...requestedRefs].some((valueRef) => {
+      return routeRefs.has(valueRef);
+    });
+  });
+}
+
+function configuredBases(config: ConnectorCheckRoutingConfig): string[] {
+  return [
+    ...new Set(
+      config.candidates.map((candidate) => {
+        return publicConnectorDiagnosticBase(candidate.displayBase);
+      }),
+    ),
+  ].sort();
+}
+
+function runStatus(
+  timeline: ConnectorCheckTimeline,
+  config: ConnectorCheckRoutingConfig | undefined,
+) {
+  if (timeline.kind === "stored") {
+    return { status: "not-scoped" as const };
+  }
+  if (!config) {
+    return { status: "not-configured" as const };
+  }
+  return { status: "configured" as const, bases: configuredBases(config) };
+}
+
+function unavailablePolicy(
+  timeline: ConnectorCheckTimeline,
+  configured: boolean,
+): ConnectorCheckPolicy | null {
+  if (timeline.kind === "stored") {
+    return { outcome: "unavailable", basis: "not-run-scoped" };
+  }
+  if (!configured) {
+    return { outcome: "unavailable", basis: "connector-not-configured" };
+  }
+  if (timeline.context.networkPolicies === null) {
+    return { outcome: "unavailable", basis: "policies-unavailable" };
+  }
+  return null;
+}
+
+function permissionPolicy(
+  type: ConnectorType,
+  permission: string,
+  timeline: ConnectorCheckTimeline,
+  configured: boolean,
+): ConnectorCheckPolicy {
+  const unavailable = unavailablePolicy(timeline, configured);
+  if (unavailable) {
+    return unavailable;
+  }
+  if (timeline.kind !== "run" || timeline.context.networkPolicies === null) {
+    throw new Error("Missing resolved run policy timeline");
+  }
+  const policy = timeline.context.networkPolicies[type];
+  if (!policy) {
+    return { outcome: "allow", basis: "no-policy" };
+  }
+  if (policy.deny.includes(permission)) {
+    return { outcome: "deny", basis: "deny-list" };
+  }
+  if (policy.ask.includes(permission)) {
+    return { outcome: "ask", basis: "ask-list" };
+  }
+  if (policy.allow.includes(permission)) {
+    return { outcome: "allow", basis: "allow-list" };
+  }
+  return { outcome: "allow", basis: "not-blocked" };
+}
+
+function unknownPolicy(
+  type: ConnectorType,
+  timeline: ConnectorCheckTimeline,
+  configured: boolean,
+): ConnectorCheckPolicy {
+  const unavailable = unavailablePolicy(timeline, configured);
+  if (unavailable) {
+    return unavailable;
+  }
+  if (timeline.kind !== "run" || timeline.context.networkPolicies === null) {
+    throw new Error("Missing resolved run policy timeline");
+  }
+  const policy = timeline.context.networkPolicies[type];
+  if (!policy) {
+    return { outcome: "allow", basis: "no-policy" };
+  }
+  switch (policy.unknownPolicy) {
+    case "allow": {
+      return { outcome: "allow", basis: "unknown-policy" };
+    }
+    case "deny": {
+      return { outcome: "deny", basis: "unknown-policy" };
+    }
+    case "ask": {
+      return { outcome: "ask", basis: "unknown-policy" };
+    }
+  }
+}
+
+function decisionPermissionResult(
+  type: ConnectorType,
+  decision: Exclude<
+    FirewallRequestDecision,
+    { readonly kind: "no_match" | "ambiguous" }
+  >,
+  timeline: ConnectorCheckTimeline,
+) {
+  if (decision.kind === "allow") {
+    if (decision.permission === undefined) {
+      return {
+        kind: "unknown-endpoint" as const,
+        policy: unknownPolicy(type, timeline, true),
+      };
+    }
+    return {
+      kind: "matched" as const,
+      permissions: [
+        {
+          name: decision.permission,
+          policy: permissionPolicy(type, decision.permission, timeline, true),
+        },
+      ],
+    };
+  }
+
+  if (decision.reason === "unknown_endpoint") {
+    return {
+      kind: "unknown-endpoint" as const,
+      policy: unknownPolicy(type, timeline, true),
+    };
+  }
+  if (decision.reason !== "permission_denied") {
+    throw new Error(
+      `Invalid connector diagnostic decision: ${decision.reason}`,
+    );
+  }
+  const permissions = [...new Set(decision.permissions)].sort().map((name) => {
+    const policy = permissionPolicy(type, name, timeline, true);
+    if (policy.outcome !== "deny" && policy.outcome !== "ask") {
+      throw new Error(`Inconsistent blocked permission policy for ${type}`);
+    }
+    return { name, policy };
+  });
+  if (permissions.length === 0) {
+    throw new Error(`Missing blocked permissions for ${type}`);
+  }
+  return { kind: "matched" as const, permissions };
+}
+
+function displayBaseForDecision(
+  config: ConnectorCheckRoutingConfig,
+  decisionBase: string,
+): string {
+  const candidate = config.candidates.find((entry) => {
+    return baseKey(entry.decisionBase) === baseKey(decisionBase);
+  });
+  if (!candidate) {
+    throw new Error(`Missing diagnostic display base for ${config.type}`);
+  }
+  return publicConnectorDiagnosticBase(candidate.displayBase);
+}
+
+function connectorTypeForEnvironmentName(
+  environmentName: string,
+): ConnectorType | null {
+  const owners = CONNECTOR_TYPE_KEYS.filter((type) => {
+    return getConnectorEnvBindingEntries(type).some((entry) => {
+      return entry.envName === environmentName;
+    });
+  });
+  const [owner, ...others] = owners;
+  if (!owner) {
+    return null;
+  }
+  if (others.length > 0) {
+    throw new Error(`Ambiguous connector environment name: ${environmentName}`);
+  }
+  return owner;
+}
+
+function policyMap(timeline: ConnectorCheckTimeline): NetworkPolicies | null {
+  return timeline.kind === "run" ? timeline.context.networkPolicies : null;
+}
+
+function noMatchDiagnostic(
+  requestedType: ConnectorType | undefined,
+  configs: readonly ConnectorCheckRoutingConfig[],
+  timeline: ConnectorCheckTimeline,
+  featureStates: FeatureStates,
+): ConnectorCheckDiagnosticResult {
+  const selectedConfig = requestedType
+    ? configs.find((config) => {
+        return config.type === requestedType;
+      })
+    : undefined;
+  if (requestedType && selectedConfig?.hasUnresolvedDynamicBase) {
+    return {
+      outcome: "unresolved-dynamic-base",
+      connector: connectorIdentity(requestedType, featureStates),
+    };
+  }
+  return {
+    outcome: "no-match",
+    scope: timeline.kind === "run" ? "run" : "catalog",
+  };
+}
+
+function ambiguousDiagnostic(
+  decision: Extract<FirewallRequestDecision, { readonly kind: "ambiguous" }>,
+): ConnectorCheckDiagnosticResult {
+  return {
+    outcome: "ambiguous",
+    candidates: decision.candidates.map((candidate) => {
+      if (!isConnectorType(candidate)) {
+        throw new Error("Matched an unknown connector firewall");
+      }
+      return {
+        connectorRef: candidate,
+        label: CONNECTOR_TYPES[candidate].label,
+      };
+    }),
+  };
+}
+
+type UrlEnvironmentSelection =
+  | {
+      readonly kind: "selected";
+      readonly environmentNames: string[] | null;
+    }
+  | {
+      readonly kind: "diagnostic";
+      readonly diagnostic: ConnectorCheckDiagnosticResult;
+    };
+
+function selectUrlEnvironmentNames(
+  type: ConnectorType,
+  config: ConnectorCheckRoutingConfig,
+  parsed: ParsedConnectorDiagnosticRequest,
+  requestedEnvironmentName: string | undefined,
+  identity: ConnectorCheckIdentity,
+): UrlEnvironmentSelection {
+  const environmentNames = environmentNamesForWinningCandidates(config, parsed);
+  if (requestedEnvironmentName === undefined) {
+    return {
+      kind: "selected",
+      environmentNames:
+        environmentNames === null ? null : [...environmentNames],
+    };
+  }
+  const owned = getConnectorEnvBindingEntries(type).some((entry) => {
+    return entry.envName === requestedEnvironmentName;
+  });
+  if (!owned) {
+    return {
+      kind: "diagnostic",
+      diagnostic: { outcome: "environment-not-owned", connector: identity },
+    };
+  }
+  if (
+    environmentNames !== null &&
+    !environmentNameSupportsRoute(
+      type,
+      requestedEnvironmentName,
+      environmentNames,
+    )
+  ) {
+    return {
+      kind: "diagnostic",
+      diagnostic: {
+        outcome: "environment-not-used",
+        connector: identity,
+        environmentNames: [...environmentNames],
+      },
+    };
+  }
+  return {
+    kind: "selected",
+    environmentNames: [requestedEnvironmentName],
+  };
+}
+
+interface ResolvedUrlDiagnosticArgs {
+  readonly request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>;
+  readonly parsed: ParsedConnectorDiagnosticRequest;
+  readonly decision: Exclude<
+    FirewallRequestDecision,
+    { readonly kind: "no_match" | "ambiguous" }
+  >;
+  readonly configs: readonly ConnectorCheckRoutingConfig[];
+  readonly timeline: ConnectorCheckTimeline;
+  readonly featureStates: FeatureStates;
+}
+
+function resolvedUrlDiagnostic(
+  args: ResolvedUrlDiagnosticArgs,
+): ConnectorCheckDiagnosticResult {
+  const { request, parsed, decision, configs, timeline, featureStates } = args;
+  if (decision.kind === "block" && decision.reason === "unsafe_path") {
+    return { outcome: "unsafe-input", reason: "unsafe-path" };
+  }
+  if (
+    decision.kind === "block" &&
+    (decision.reason === "malformed_firewall_config" ||
+      decision.reason === "malformed_network_policy")
+  ) {
+    throw new Error(
+      `Invalid connector diagnostic decision: ${decision.reason}`,
+    );
+  }
+  if (!isConnectorType(decision.firewallName)) {
+    throw new Error("Matched an unknown connector firewall");
+  }
+  const type = decision.firewallName;
+  if (request.connectorRef !== undefined && type !== request.connectorRef) {
+    return {
+      outcome: "connector-mismatch",
+      connector: connectorIdentity(type, featureStates),
+    };
+  }
+  const config = configs.find((entry) => {
+    return entry.type === type;
+  });
+  if (!config) {
+    throw new Error(`Missing selected connector routing config for ${type}`);
+  }
+
+  const identity = connectorIdentity(type, featureStates);
+  const environmentSelection = selectUrlEnvironmentNames(
+    type,
+    config,
+    parsed,
+    request.environmentName,
+    identity,
+  );
+  if (environmentSelection.kind === "diagnostic") {
+    return environmentSelection.diagnostic;
+  }
+  return {
+    outcome: "resolved",
+    mode: "url",
+    connector: identity,
+    environmentNames: environmentSelection.environmentNames,
+    run: runStatus(timeline, config),
+    method: parsed.method,
+    base: displayBaseForDecision(config, decision.base),
+    relativePath: decision.relativePath,
+    permission: decisionPermissionResult(type, decision, timeline),
+  };
+}
+
+async function resolveUrlMode(
+  request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>,
+  parsed: ParsedConnectorDiagnosticRequest,
+  timeline: ConnectorCheckTimeline,
+  featureStates: FeatureStates,
+): Promise<ConnectorCheckDiagnosticResult> {
+  const requestedType = request.connectorRef;
+  if (requestedType !== undefined && !isConnectorType(requestedType)) {
+    return { outcome: "unknown-connector" };
+  }
+
+  const configs =
+    timeline.kind === "run"
+      ? await loadRunRoutingConfigs(timeline.context)
+      : await loadGlobalCatalogConfigs(parsed, requestedType, timeline.state);
+  const decision = matchFirewallRequestDecision(
+    configsToDecisionFirewalls(configs),
+    parsed.method,
+    parsed.url,
+    policyMap(timeline),
+    requestedType
+      ? { status: "present", value: requestedType }
+      : { status: "absent" },
+  );
+
+  if (decision.kind === "no_match") {
+    return noMatchDiagnostic(requestedType, configs, timeline, featureStates);
+  }
+  if (decision.kind === "ambiguous") {
+    return ambiguousDiagnostic(decision);
+  }
+  return resolvedUrlDiagnostic({
+    request,
+    parsed,
+    decision,
+    configs,
+    timeline,
+    featureStates,
+  });
+}
+
+async function resolveEnvironmentMode(
+  request: Extract<ConnectorCheckRequest, { readonly mode: "environment" }>,
+  timeline: ConnectorCheckTimeline,
+  featureStates: FeatureStates,
+): Promise<ConnectorCheckDiagnosticResult> {
+  const type = connectorTypeForEnvironmentName(request.environmentName);
+  if (!type) {
+    return { outcome: "unknown-environment" };
+  }
+  const configs =
+    timeline.kind === "run"
+      ? await loadRunRoutingConfigs(timeline.context)
+      : [];
+  const config = configs.find((entry) => {
+    return entry.type === type;
+  });
+  return {
+    outcome: "resolved",
+    mode: "environment",
+    connector: connectorIdentity(type, featureStates),
+    environmentName: request.environmentName,
+    run: runStatus(timeline, config),
+    permission:
+      request.permission === undefined
+        ? null
+        : permissionPolicy(
+            type,
+            request.permission,
+            timeline,
+            config !== undefined,
+          ),
+  };
+}
+
+export const resolveConnectorCheck$ = command(
+  async (
+    { get, set },
+    args: ResolveConnectorCheckArgs,
+    signal: AbortSignal,
+  ): Promise<ResolveConnectorCheckResult> => {
+    let parsed: ParsedConnectorDiagnosticRequest | null = null;
+    if (args.request.mode === "url") {
+      const parseResult = parseConnectorDiagnosticRequest(
+        args.request.method,
+        args.request.url,
+      );
+      if ("outcome" in parseResult) {
+        return { kind: "ok", diagnostic: parseResult };
+      }
+      parsed = parseResult;
+    }
+
+    let timeline: ConnectorCheckTimeline;
+    if (args.stateSource.kind === "run") {
+      const runContext = await get(
+        zeroRunContext(args.stateSource.runId, args.userId, args.orgId),
+      );
+      signal.throwIfAborted();
+      if (runContext.kind === "not-found") {
+        return { kind: "not-found" };
+      }
+      if (runContext.kind === "no-snapshot") {
+        return {
+          kind: "ok",
+          diagnostic: { outcome: "run-context-unavailable" },
+        };
+      }
+      timeline = { kind: "run", context: runContext.context };
+    } else {
+      const state =
+        args.request.mode === "url"
+          ? await loadStoredRuntimeState(set(writeDb$), {
+              orgId: args.orgId,
+              userId: args.userId,
+            })
+          : { baseUrlVarsByType: new Map() };
+      signal.throwIfAborted();
+      timeline = { kind: "stored", state };
+    }
+
+    const featureStates = await set(
+      connectorCheckFeatureStates$,
+      args.orgId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+    let diagnostic: ConnectorCheckDiagnosticResult;
+    if (args.request.mode === "url") {
+      if (!parsed) {
+        throw new Error("Missing parsed connector diagnostic request");
+      }
+      diagnostic = await resolveUrlMode(
+        args.request,
+        parsed,
+        timeline,
+        featureStates,
+      );
+    } else {
+      diagnostic = await resolveEnvironmentMode(
+        args.request,
+        timeline,
+        featureStates,
+      );
+    }
+    signal.throwIfAborted();
+    return { kind: "ok", diagnostic };
+  },
+);

--- a/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
@@ -1,0 +1,461 @@
+import type { ConnectorType } from "@vm0/connectors/connectors";
+import {
+  loadFirewallRoutingMetadata,
+  type FirewallRoutingRouteMetadata,
+} from "@vm0/connectors/firewall-metadata/routing";
+import {
+  getFirewallExecutionMetadata,
+  type FirewallExecutionMetadata,
+} from "@vm0/connectors/firewall-metadata/server";
+import {
+  FirewallBaseUrlResolutionError,
+  hasUnsafeFirewallPath,
+  resolveFirewallBaseUrlTemplate,
+  type FirewallBaseHostPolicy,
+} from "@vm0/connectors/firewall-types";
+
+import { safeSync, safeUrlParse } from "../utils";
+
+const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+interface ConnectorDiagnosticExecutionTemplate {
+  readonly credentialed: boolean;
+  readonly hostPolicy?: FirewallBaseHostPolicy;
+}
+
+export interface ConnectorDiagnosticCatalogApi {
+  readonly base: string;
+  readonly routes: readonly FirewallRoutingRouteMetadata[];
+  readonly environmentNames: readonly string[];
+  readonly executionTemplate: ConnectorDiagnosticExecutionTemplate | null;
+}
+
+export interface ConnectorDiagnosticCatalogView {
+  readonly type: ConnectorType;
+  readonly label: string;
+  readonly credentialResolution: "network-boundary" | "none";
+  readonly baseUrlVarNames: readonly string[];
+  readonly apis: readonly ConnectorDiagnosticCatalogApi[];
+}
+
+export interface ConnectorDiagnosticBaseCandidate {
+  readonly sourceBase: string;
+  readonly decisionBase: string;
+  readonly displayBase: string;
+  readonly routes: readonly FirewallRoutingRouteMetadata[];
+  readonly environmentNames: readonly string[] | null;
+}
+
+export interface ParsedConnectorDiagnosticRequest {
+  readonly method: string;
+  readonly url: string;
+}
+
+interface ConnectorDiagnosticUnsafeInput {
+  readonly outcome: "unsafe-input";
+  readonly reason: "invalid-method" | "invalid-url" | "unsafe-path";
+}
+
+function isValidMethod(method: string): boolean {
+  return (
+    method === "GET" ||
+    method === "POST" ||
+    method === "PUT" ||
+    method === "PATCH" ||
+    method === "DELETE" ||
+    method === "HEAD" ||
+    method === "OPTIONS"
+  );
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function baseKey(value: string): string {
+  return stripTrailingSlash(value);
+}
+
+function connectorDiagnosticBaseUrlVarNames(base: string): readonly string[] {
+  return [
+    ...new Set(
+      [...base.matchAll(BASE_URL_VAR_PATTERN)].map((match) => {
+        return match[1]!;
+      }),
+    ),
+  ];
+}
+
+function sameNames(left: readonly string[], right: readonly string[]): boolean {
+  const leftSorted = [...new Set(left)].sort();
+  const rightSorted = [...new Set(right)].sort();
+  return (
+    leftSorted.length === rightSorted.length &&
+    leftSorted.every((name, index) => {
+      return name === rightSorted[index];
+    })
+  );
+}
+
+function executionTemplatesByBase(
+  metadata: FirewallExecutionMetadata,
+): ReadonlyMap<string, ConnectorDiagnosticExecutionTemplate> {
+  const templates = new Map<string, ConnectorDiagnosticExecutionTemplate>();
+  for (const template of metadata.baseUrlTemplates) {
+    const key = baseKey(template.base);
+    if (templates.has(key)) {
+      throw new Error(
+        `Duplicate firewall execution base template for ${metadata.type}`,
+      );
+    }
+    templates.set(key, {
+      credentialed: template.credentialed,
+      ...(template.hostPolicy === undefined
+        ? {}
+        : { hostPolicy: template.hostPolicy }),
+    });
+  }
+  return templates;
+}
+
+export async function loadConnectorDiagnosticCatalogView(
+  connectorRef: string,
+): Promise<ConnectorDiagnosticCatalogView | null> {
+  const routing = await loadFirewallRoutingMetadata(connectorRef);
+  if (!routing) {
+    return null;
+  }
+
+  const execution = getFirewallExecutionMetadata(routing.type);
+  if (!execution || execution.type !== routing.type) {
+    throw new Error(`Missing firewall execution metadata for ${routing.type}`);
+  }
+
+  const executionTemplates = executionTemplatesByBase(execution);
+  const routingBaseUrlVarNames = new Set<string>();
+  const dynamicBaseKeys = new Set<string>();
+  const apis: ConnectorDiagnosticCatalogApi[] = [];
+
+  for (const api of routing.apis) {
+    const names = connectorDiagnosticBaseUrlVarNames(api.base);
+    for (const name of names) {
+      routingBaseUrlVarNames.add(name);
+    }
+    const key = baseKey(api.base);
+    const executionTemplate =
+      names.length === 0 ? null : (executionTemplates.get(key) ?? null);
+    if (names.length > 0 && !executionTemplate) {
+      throw new Error(
+        `Missing firewall execution base template for ${routing.type}`,
+      );
+    }
+    if (executionTemplate) {
+      dynamicBaseKeys.add(key);
+    }
+    apis.push({
+      base: api.base,
+      routes: api.routes,
+      environmentNames: api.environmentNames,
+      executionTemplate,
+    });
+  }
+
+  if (
+    !sameNames([...routingBaseUrlVarNames], execution.baseUrlVarNames) ||
+    executionTemplates.size !== dynamicBaseKeys.size
+  ) {
+    throw new Error(`Mismatched firewall base metadata for ${routing.type}`);
+  }
+
+  return {
+    type: routing.type,
+    label: routing.label,
+    credentialResolution:
+      execution.secretPlaceholderNames.length > 0 ? "network-boundary" : "none",
+    baseUrlVarNames: [...routingBaseUrlVarNames].sort(),
+    apis,
+  };
+}
+
+function rawAuthorityFromUrl(url: string): string | null {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd === -1) {
+    return null;
+  }
+
+  const authorityStart = schemeEnd + 3;
+  let authorityEnd = url.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const index = url.indexOf(delimiter, authorityStart);
+    if (index !== -1) {
+      authorityEnd = Math.min(authorityEnd, index);
+    }
+  }
+  return url.slice(authorityStart, authorityEnd);
+}
+
+function rawAuthorityHasUnsafeSyntax(url: string): boolean {
+  const authority = rawAuthorityFromUrl(url);
+  if (authority === null) {
+    return false;
+  }
+  return (
+    authority === "" ||
+    authority.includes("\\") ||
+    authority.includes("%") ||
+    [...authority].some((character) => {
+      return character.charCodeAt(0) > 0x7f;
+    })
+  );
+}
+
+function stripQueryAndFragment(url: string): string {
+  const queryIndex = url.indexOf("?");
+  const fragmentIndex = url.indexOf("#");
+  let end = url.length;
+  if (queryIndex !== -1) {
+    end = Math.min(end, queryIndex);
+  }
+  if (fragmentIndex !== -1) {
+    end = Math.min(end, fragmentIndex);
+  }
+  return url.slice(0, end);
+}
+
+function rawPathFromUrl(url: string): string {
+  const schemeEnd = url.indexOf("://");
+  const authorityStart = schemeEnd === -1 ? 0 : schemeEnd + 3;
+  const pathStart = url.indexOf("/", authorityStart);
+  return pathStart === -1 ? "/" : url.slice(pathStart);
+}
+
+export function parseConnectorDiagnosticRequest(
+  method: string,
+  url: string,
+): ParsedConnectorDiagnosticRequest | ConnectorDiagnosticUnsafeInput {
+  const upperMethod = method.toUpperCase();
+  if (!isValidMethod(upperMethod)) {
+    return { outcome: "unsafe-input", reason: "invalid-method" };
+  }
+
+  if (
+    !url.includes("://") ||
+    /\s/u.test(url) ||
+    rawAuthorityHasUnsafeSyntax(url)
+  ) {
+    return { outcome: "unsafe-input", reason: "invalid-url" };
+  }
+
+  const parsed = safeUrlParse(url);
+  if (
+    !parsed ||
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    return { outcome: "unsafe-input", reason: "invalid-url" };
+  }
+
+  const sanitizedUrl = stripQueryAndFragment(url);
+  if (hasUnsafeFirewallPath(rawPathFromUrl(sanitizedUrl))) {
+    return { outcome: "unsafe-input", reason: "unsafe-path" };
+  }
+
+  return { method: upperMethod, url: sanitizedUrl };
+}
+
+function dynamicTemplateToPattern(base: string): string | null {
+  const pattern = base.replace(BASE_URL_VAR_PATTERN, (_match, name: string) => {
+    return `{${name}}`;
+  });
+  return pattern.includes("://") ? pattern : null;
+}
+
+function executionTemplateForBase(
+  type: ConnectorType,
+  base: string,
+): ConnectorDiagnosticExecutionTemplate {
+  const execution = getFirewallExecutionMetadata(type);
+  const template = execution?.baseUrlTemplates.find((entry) => {
+    return baseKey(entry.base) === baseKey(base);
+  });
+  if (!template) {
+    throw new Error(`Missing firewall execution base template for ${type}`);
+  }
+  return {
+    credentialed: template.credentialed,
+    ...(template.hostPolicy === undefined
+      ? {}
+      : { hostPolicy: template.hostPolicy }),
+  };
+}
+
+interface ConnectorDiagnosticBaseResolution {
+  readonly candidate: {
+    readonly sourceBase: string;
+    readonly decisionBase: string;
+    readonly displayBase: string;
+  } | null;
+  readonly unresolved: boolean;
+}
+
+export function resolveConnectorDiagnosticBase(
+  type: ConnectorType,
+  base: string,
+  baseUrlVars: Readonly<Record<string, string>> | null,
+  options: { readonly allowStructuralDynamic: boolean },
+): ConnectorDiagnosticBaseResolution {
+  const names = connectorDiagnosticBaseUrlVarNames(base);
+  if (names.length === 0) {
+    return {
+      candidate: {
+        sourceBase: base,
+        decisionBase: base,
+        displayBase: stripTrailingSlash(base),
+      },
+      unresolved: false,
+    };
+  }
+
+  const executionTemplate = executionTemplateForBase(type, base);
+  if (baseUrlVars) {
+    const resolution = safeSync(() => {
+      return resolveFirewallBaseUrlTemplate({
+        serviceName: type,
+        base,
+        vars: baseUrlVars,
+        credentialed: executionTemplate.credentialed,
+        ...(executionTemplate.hostPolicy === undefined
+          ? {}
+          : { hostPolicy: executionTemplate.hostPolicy }),
+      });
+    });
+    if ("error" in resolution) {
+      if (!(resolution.error instanceof FirewallBaseUrlResolutionError)) {
+        throw resolution.error;
+      }
+      return { candidate: null, unresolved: true };
+    }
+    return {
+      candidate: {
+        sourceBase: base,
+        decisionBase: resolution.ok,
+        displayBase: stripTrailingSlash(resolution.ok),
+      },
+      unresolved: false,
+    };
+  }
+
+  if (!options.allowStructuralDynamic) {
+    return { candidate: null, unresolved: true };
+  }
+  const pattern = dynamicTemplateToPattern(base);
+  if (!pattern) {
+    return { candidate: null, unresolved: true };
+  }
+  return {
+    candidate: {
+      sourceBase: base,
+      decisionBase: pattern,
+      displayBase: stripTrailingSlash(base),
+    },
+    unresolved: false,
+  };
+}
+
+export function buildConnectorDiagnosticBaseCandidates(
+  view: ConnectorDiagnosticCatalogView,
+  baseUrlVars: Readonly<Record<string, string>> | null,
+  options: { readonly allowStructuralDynamic: boolean } = {
+    allowStructuralDynamic: true,
+  },
+): {
+  readonly candidates: readonly ConnectorDiagnosticBaseCandidate[];
+  readonly hasUnresolvedDynamicBase: boolean;
+} {
+  const candidates: ConnectorDiagnosticBaseCandidate[] = [];
+  let hasUnresolvedDynamicBase = false;
+  const sourceBaseByDecisionBase = new Map<string, string>();
+
+  for (const api of view.apis) {
+    const resolution = resolveConnectorDiagnosticBase(
+      view.type,
+      api.base,
+      baseUrlVars,
+      options,
+    );
+    hasUnresolvedDynamicBase ||= resolution.unresolved;
+    if (!resolution.candidate) {
+      continue;
+    }
+    const decisionKey = baseKey(resolution.candidate.decisionBase);
+    const existingSourceBase = sourceBaseByDecisionBase.get(decisionKey);
+    if (
+      existingSourceBase !== undefined &&
+      baseKey(existingSourceBase) !== baseKey(api.base)
+    ) {
+      throw new Error(`Conflicting resolved firewall bases for ${view.type}`);
+    }
+    sourceBaseByDecisionBase.set(decisionKey, api.base);
+    candidates.push({
+      ...resolution.candidate,
+      routes: api.routes,
+      environmentNames: api.environmentNames,
+    });
+  }
+
+  return { candidates, hasUnresolvedDynamicBase };
+}
+
+function sameStrings(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+export function mergeConnectorDiagnosticBaseCandidates(
+  candidates: readonly ConnectorDiagnosticBaseCandidate[],
+): ConnectorDiagnosticBaseCandidate[] {
+  const merged = new Map<string, ConnectorDiagnosticBaseCandidate>();
+  for (const candidate of candidates) {
+    const key = baseKey(candidate.decisionBase);
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, candidate);
+      continue;
+    }
+    if (baseKey(existing.sourceBase) !== baseKey(candidate.sourceBase)) {
+      throw new Error("Conflicting diagnostic base sources");
+    }
+    const environmentNames =
+      existing.environmentNames !== null &&
+      candidate.environmentNames !== null &&
+      sameStrings(existing.environmentNames, candidate.environmentNames)
+        ? existing.environmentNames
+        : null;
+    merged.set(key, {
+      ...existing,
+      routes: [...existing.routes, ...candidate.routes],
+      environmentNames,
+    });
+  }
+  return [...merged.values()];
+}
+
+export function publicConnectorDiagnosticBase(base: string): string {
+  const publicNameByPrivateName = new Map<string, string>();
+  return base.replace(BASE_URL_VAR_PATTERN, (_match, name: string) => {
+    let publicName = publicNameByPrivateName.get(name);
+    if (!publicName) {
+      publicName = `parameter${publicNameByPrivateName.size + 1}`;
+      publicNameByPrivateName.set(name, publicName);
+    }
+    return `{${publicName}}`;
+  });
+}

--- a/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
@@ -27,13 +27,11 @@ export interface ConnectorDiagnosticCatalogApi {
   readonly base: string;
   readonly routes: readonly FirewallRoutingRouteMetadata[];
   readonly environmentNames: readonly string[];
-  readonly executionTemplate: ConnectorDiagnosticExecutionTemplate | null;
 }
 
 export interface ConnectorDiagnosticCatalogView {
   readonly type: ConnectorType;
   readonly label: string;
-  readonly credentialResolution: "network-boundary" | "none";
   readonly baseUrlVarNames: readonly string[];
   readonly apis: readonly ConnectorDiagnosticCatalogApi[];
 }
@@ -156,7 +154,6 @@ export async function loadConnectorDiagnosticCatalogView(
       base: api.base,
       routes: api.routes,
       environmentNames: api.environmentNames,
-      executionTemplate,
     });
   }
 
@@ -170,8 +167,6 @@ export async function loadConnectorDiagnosticCatalogView(
   return {
     type: routing.type,
     label: routing.label,
-    credentialResolution:
-      execution.secretPlaceholderNames.length > 0 ? "network-boundary" : "none",
     baseUrlVarNames: [...routingBaseUrlVarNames].sort(),
     apis,
   };

--- a/turbo/apps/api/src/signals/services/connector-permission-deny.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-permission-deny.service.ts
@@ -3,77 +3,28 @@ import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs"
 import { getConnectorAuthMethodRuntimeMetadata } from "@vm0/connectors/connector-utils";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { matchFirewallRequestDecision } from "@vm0/connectors/firewall-rule-matcher";
-import {
-  loadFirewallRoutingMetadata,
-  type FirewallRoutingRouteMetadata,
-} from "@vm0/connectors/firewall-metadata/routing";
-import {
-  getFirewallExecutionMetadata,
-  type FirewallExecutionMetadata,
-} from "@vm0/connectors/firewall-metadata/server";
-import {
-  FirewallBaseUrlResolutionError,
-  hasUnsafeFirewallPath,
-  resolveFirewallBaseUrlTemplate,
-  type Firewall,
-  type FirewallBaseHostPolicy,
-  type NetworkPolicies,
-} from "@vm0/connectors/firewall-types";
+import type { FirewallRoutingRouteMetadata } from "@vm0/connectors/firewall-metadata/routing";
+import type { Firewall, NetworkPolicies } from "@vm0/connectors/firewall-types";
 import { connectors } from "@vm0/db/schema/connector";
 import { variables } from "@vm0/db/schema/variable";
 import { command } from "ccstate";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { type Db, writeDb$ } from "../external/db";
-import { safeSync, safeUrlParse } from "../utils";
+import {
+  buildConnectorDiagnosticBaseCandidates,
+  loadConnectorDiagnosticCatalogView,
+  mergeConnectorDiagnosticBaseCandidates,
+  parseConnectorDiagnosticRequest,
+  type ConnectorDiagnosticBaseCandidate,
+  type ConnectorDiagnosticCatalogView,
+  type ParsedConnectorDiagnosticRequest,
+} from "./connector-diagnostic-runtime.service";
 import { zeroRunContext } from "./zero-run-detail.service";
-
-const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
-
-interface DiagnosticExecutionTemplate {
-  readonly credentialed: boolean;
-  readonly hostPolicy?: FirewallBaseHostPolicy;
-}
-
-interface DiagnosticCatalogApi {
-  readonly base: string;
-  readonly routes: readonly FirewallRoutingRouteMetadata[];
-  readonly executionTemplate: DiagnosticExecutionTemplate | null;
-}
-
-interface DiagnosticCatalogView {
-  readonly type: ConnectorType;
-  readonly label: string;
-  readonly baseUrlVarNames: readonly string[];
-  readonly apis: readonly DiagnosticCatalogApi[];
-}
-
-interface DiagnosticBaseCandidate {
-  readonly decisionBase: string;
-  readonly displayBase: string;
-  readonly routes: readonly FirewallRoutingRouteMetadata[];
-}
 
 interface DiagnosticDecisionPermission {
   readonly name: string;
   readonly rules: string[];
-}
-
-interface ParsedDiagnosticRequest {
-  readonly method: string;
-  readonly url: string;
-}
-
-function isValidMethod(method: string): boolean {
-  return (
-    method === "GET" ||
-    method === "POST" ||
-    method === "PUT" ||
-    method === "PATCH" ||
-    method === "DELETE" ||
-    method === "HEAD" ||
-    method === "OPTIONS"
-  );
 }
 
 type DynamicStateSource =
@@ -87,217 +38,6 @@ interface ResolveConnectorPermissionDenyArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly stateSource: DynamicStateSource;
-}
-
-function stripTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-function baseKey(value: string): string {
-  return stripTrailingSlash(value);
-}
-
-function baseUrlVarNames(base: string): readonly string[] {
-  return [
-    ...new Set(
-      [...base.matchAll(BASE_URL_VAR_PATTERN)].map((match) => {
-        return match[1]!;
-      }),
-    ),
-  ];
-}
-
-function sameNames(left: readonly string[], right: readonly string[]): boolean {
-  const leftSorted = [...new Set(left)].sort();
-  const rightSorted = [...new Set(right)].sort();
-  return (
-    leftSorted.length === rightSorted.length &&
-    leftSorted.every((name, index) => {
-      return name === rightSorted[index];
-    })
-  );
-}
-
-function executionTemplatesByBase(
-  metadata: FirewallExecutionMetadata,
-): ReadonlyMap<string, DiagnosticExecutionTemplate> {
-  const templates = new Map<string, DiagnosticExecutionTemplate>();
-  for (const template of metadata.baseUrlTemplates) {
-    const key = baseKey(template.base);
-    if (templates.has(key)) {
-      throw new Error(
-        `Duplicate firewall execution base template for ${metadata.type}`,
-      );
-    }
-    templates.set(key, {
-      credentialed: template.credentialed,
-      ...(template.hostPolicy === undefined
-        ? {}
-        : { hostPolicy: template.hostPolicy }),
-    });
-  }
-  return templates;
-}
-
-async function loadDiagnosticCatalogView(
-  connectorRef: string,
-): Promise<DiagnosticCatalogView | null> {
-  const routing = await loadFirewallRoutingMetadata(connectorRef);
-  if (!routing) {
-    return null;
-  }
-
-  const execution = getFirewallExecutionMetadata(routing.type);
-  if (!execution || execution.type !== routing.type) {
-    throw new Error(`Missing firewall execution metadata for ${routing.type}`);
-  }
-
-  const executionTemplates = executionTemplatesByBase(execution);
-  const groupedApis = new Map<
-    string,
-    {
-      readonly base: string;
-      readonly routes: FirewallRoutingRouteMetadata[];
-      readonly executionTemplate: DiagnosticExecutionTemplate | null;
-    }
-  >();
-  const routingBaseUrlVarNames = new Set<string>();
-
-  for (const api of routing.apis) {
-    const names = baseUrlVarNames(api.base);
-    for (const name of names) {
-      routingBaseUrlVarNames.add(name);
-    }
-    const key = baseKey(api.base);
-    const executionTemplate =
-      names.length === 0 ? null : (executionTemplates.get(key) ?? null);
-    if (names.length > 0 && !executionTemplate) {
-      throw new Error(
-        `Missing firewall execution base template for ${routing.type}`,
-      );
-    }
-
-    const existing = groupedApis.get(key);
-    if (existing) {
-      if (existing.executionTemplate !== executionTemplate) {
-        throw new Error(
-          `Conflicting firewall base metadata for ${routing.type}`,
-        );
-      }
-      existing.routes.push(...api.routes);
-      continue;
-    }
-
-    groupedApis.set(key, {
-      base: api.base,
-      routes: [...api.routes],
-      executionTemplate,
-    });
-  }
-
-  const dynamicApiCount = [...groupedApis.values()].filter((api) => {
-    return api.executionTemplate !== null;
-  }).length;
-  if (
-    !sameNames([...routingBaseUrlVarNames], execution.baseUrlVarNames) ||
-    executionTemplates.size !== dynamicApiCount
-  ) {
-    throw new Error(`Mismatched firewall base metadata for ${routing.type}`);
-  }
-
-  return {
-    type: routing.type,
-    label: routing.label,
-    baseUrlVarNames: [...routingBaseUrlVarNames].sort(),
-    apis: [...groupedApis.values()],
-  };
-}
-
-function rawAuthorityFromUrl(url: string): string | null {
-  const schemeEnd = url.indexOf("://");
-  if (schemeEnd === -1) {
-    return null;
-  }
-
-  const authorityStart = schemeEnd + 3;
-  let authorityEnd = url.length;
-  for (const delimiter of ["/", "?", "#"]) {
-    const index = url.indexOf(delimiter, authorityStart);
-    if (index !== -1) {
-      authorityEnd = Math.min(authorityEnd, index);
-    }
-  }
-  return url.slice(authorityStart, authorityEnd);
-}
-
-function rawAuthorityHasUnsafeSyntax(url: string): boolean {
-  const authority = rawAuthorityFromUrl(url);
-  if (authority === null) {
-    return false;
-  }
-  return (
-    authority === "" ||
-    authority.includes("\\") ||
-    authority.includes("%") ||
-    [...authority].some((character) => {
-      return character.charCodeAt(0) > 0x7f;
-    })
-  );
-}
-
-function stripQueryAndFragment(url: string): string {
-  const queryIndex = url.indexOf("?");
-  const fragmentIndex = url.indexOf("#");
-  let end = url.length;
-  if (queryIndex !== -1) {
-    end = Math.min(end, queryIndex);
-  }
-  if (fragmentIndex !== -1) {
-    end = Math.min(end, fragmentIndex);
-  }
-  return url.slice(0, end);
-}
-
-function rawPathFromUrl(url: string): string {
-  const schemeEnd = url.indexOf("://");
-  const authorityStart = schemeEnd === -1 ? 0 : schemeEnd + 3;
-  const pathStart = url.indexOf("/", authorityStart);
-  return pathStart === -1 ? "/" : url.slice(pathStart);
-}
-
-function parseDiagnosticRequest(
-  method: string,
-  url: string,
-): ParsedDiagnosticRequest | ConnectorPermissionDenyDiagnosticResult {
-  const upperMethod = method.toUpperCase();
-  if (!isValidMethod(upperMethod)) {
-    return { outcome: "unsafe-input", reason: "invalid-method" };
-  }
-
-  if (
-    !url.includes("://") ||
-    /\s/u.test(url) ||
-    rawAuthorityHasUnsafeSyntax(url)
-  ) {
-    return { outcome: "unsafe-input", reason: "invalid-url" };
-  }
-
-  const parsed = safeUrlParse(url);
-  if (
-    !parsed ||
-    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
-    parsed.username !== "" ||
-    parsed.password !== ""
-  ) {
-    return { outcome: "unsafe-input", reason: "invalid-url" };
-  }
-
-  const sanitizedUrl = stripQueryAndFragment(url);
-  if (hasUnsafeFirewallPath(rawPathFromUrl(sanitizedUrl))) {
-    return { outcome: "unsafe-input", reason: "unsafe-path" };
-  }
-
-  return { method: upperMethod, url: sanitizedUrl };
 }
 
 async function loadStoredBaseUrlVars(
@@ -409,90 +149,6 @@ function baseUrlVarsFromRunContext(
   return null;
 }
 
-function dynamicTemplateToPattern(base: string): string | null {
-  const pattern = base.replace(BASE_URL_VAR_PATTERN, (_match, name: string) => {
-    return `{${name}}`;
-  });
-  return pattern.includes("://") ? pattern : null;
-}
-
-function buildBaseCandidates(
-  view: DiagnosticCatalogView,
-  baseUrlVars: Record<string, string> | null,
-): {
-  readonly candidates: readonly DiagnosticBaseCandidate[];
-  readonly hasUnresolvedDynamicBase: boolean;
-} {
-  const candidates: DiagnosticBaseCandidate[] = [];
-  let hasUnresolvedDynamicBase = false;
-
-  for (const api of view.apis) {
-    const names = baseUrlVarNames(api.base);
-    if (names.length === 0) {
-      candidates.push({
-        decisionBase: api.base,
-        displayBase: stripTrailingSlash(api.base),
-        routes: api.routes,
-      });
-      continue;
-    }
-    const executionTemplate = api.executionTemplate;
-    if (!executionTemplate) {
-      throw new Error(`Missing firewall execution base for ${view.type}`);
-    }
-
-    if (baseUrlVars) {
-      const resolution = safeSync(() => {
-        return resolveFirewallBaseUrlTemplate({
-          serviceName: view.type,
-          base: api.base,
-          vars: baseUrlVars,
-          credentialed: executionTemplate.credentialed,
-          ...(executionTemplate.hostPolicy === undefined
-            ? {}
-            : { hostPolicy: executionTemplate.hostPolicy }),
-        });
-      });
-      if ("error" in resolution) {
-        if (!(resolution.error instanceof FirewallBaseUrlResolutionError)) {
-          throw resolution.error;
-        }
-        hasUnresolvedDynamicBase = true;
-        continue;
-      }
-
-      candidates.push({
-        decisionBase: resolution.ok,
-        displayBase: stripTrailingSlash(resolution.ok),
-        routes: api.routes,
-      });
-      continue;
-    }
-
-    const pattern = dynamicTemplateToPattern(api.base);
-    if (!pattern) {
-      hasUnresolvedDynamicBase = true;
-      continue;
-    }
-    candidates.push({
-      decisionBase: pattern,
-      displayBase: stripTrailingSlash(api.base),
-      routes: api.routes,
-    });
-  }
-
-  const seenDecisionBases = new Set<string>();
-  for (const candidate of candidates) {
-    const key = baseKey(candidate.decisionBase);
-    if (seenDecisionBases.has(key)) {
-      throw new Error(`Conflicting resolved firewall bases for ${view.type}`);
-    }
-    seenDecisionBases.add(key);
-  }
-
-  return { candidates, hasUnresolvedDynamicBase };
-}
-
 function decisionPermissions(
   routes: readonly FirewallRoutingRouteMetadata[],
 ): DiagnosticDecisionPermission[] {
@@ -510,10 +166,14 @@ function decisionPermissions(
   });
 }
 
+function baseKey(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
 function matchDiagnosticRequest(
-  view: DiagnosticCatalogView,
-  request: ParsedDiagnosticRequest,
-  candidates: readonly DiagnosticBaseCandidate[],
+  view: ConnectorDiagnosticCatalogView,
+  request: ParsedConnectorDiagnosticRequest,
+  candidates: readonly ConnectorDiagnosticBaseCandidate[],
   hasUnresolvedDynamicBase: boolean,
 ): ConnectorPermissionDenyDiagnosticResult {
   if (candidates.length === 0) {
@@ -567,7 +227,6 @@ function matchDiagnosticRequest(
   if (decision.kind === "allow") {
     throw new Error(`Unexpected allowed firewall decision for ${view.type}`);
   }
-
   if (decision.reason === "unsafe_path") {
     return { outcome: "unsafe-input", reason: "unsafe-path" };
   }
@@ -610,12 +269,12 @@ export const resolveConnectorPermissionDeny$ = command(
     args: ResolveConnectorPermissionDenyArgs,
     signal: AbortSignal,
   ): Promise<ConnectorPermissionDenyDiagnosticResult> => {
-    const request = parseDiagnosticRequest(args.method, args.url);
-    if (!("method" in request)) {
+    const request = parseConnectorDiagnosticRequest(args.method, args.url);
+    if ("outcome" in request) {
       return request;
     }
 
-    const view = await loadDiagnosticCatalogView(args.connectorRef);
+    const view = await loadConnectorDiagnosticCatalogView(args.connectorRef);
     signal.throwIfAborted();
     if (!view) {
       return { outcome: "unknown-connector" };
@@ -646,11 +305,14 @@ export const resolveConnectorPermissionDeny$ = command(
       }
     }
 
-    const candidateResult = buildBaseCandidates(view, baseUrlVars);
+    const candidateResult = buildConnectorDiagnosticBaseCandidates(
+      view,
+      baseUrlVars,
+    );
     return matchDiagnosticRequest(
       view,
       request,
-      candidateResult.candidates,
+      mergeConnectorDiagnosticBaseCandidates(candidateResult.candidates),
       candidateResult.hasUnresolvedDynamicBase,
     );
   },

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1109,6 +1109,16 @@ export {
   type ConnectorPermissionDenyDiagnosticResult,
   type ZeroConnectorPermissionDenyContract,
 } from "./zero-connector-permission-deny";
+export {
+  connectorCheckDiagnosticResultSchema,
+  connectorCheckPolicySchema,
+  connectorCheckRequestSchema,
+  zeroConnectorCheckContract,
+  type ConnectorCheckDiagnosticResult,
+  type ConnectorCheckPolicy,
+  type ConnectorCheckRequest,
+  type ZeroConnectorCheckContract,
+} from "./zero-connector-check";
 export { CONNECTOR_REF_MAX_LENGTH, connectorRefSchema } from "./connector-ref";
 export {
   CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH,

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
@@ -1,0 +1,264 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { connectorCatalogRefSchema } from "./connector-identity";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const boundedNameSchema = z.string().min(1).max(255);
+
+const connectorCheckUrlRequestSchema = z
+  .object({
+    mode: z.literal("url"),
+    method: z.string().min(1).max(16),
+    url: z.string().min(1).max(8192),
+    connectorRef: connectorCatalogRefSchema.optional(),
+    environmentName: boundedNameSchema.optional(),
+  })
+  .strict();
+
+const connectorCheckEnvironmentRequestSchema = z
+  .object({
+    mode: z.literal("environment"),
+    environmentName: boundedNameSchema,
+    permission: boundedNameSchema.optional(),
+  })
+  .strict();
+
+export const connectorCheckRequestSchema = z.discriminatedUnion("mode", [
+  connectorCheckUrlRequestSchema,
+  connectorCheckEnvironmentRequestSchema,
+]);
+
+export type ConnectorCheckRequest = z.infer<typeof connectorCheckRequestSchema>;
+
+const connectorCheckIdentitySchema = z
+  .object({
+    connectorRef: connectorCatalogRefSchema,
+    label: z.string().min(1),
+    visibility: z.enum(["available", "unavailable"]),
+    credentialResolution: z.enum(["network-boundary", "none"]),
+  })
+  .strict();
+
+const connectorCheckCandidateSchema = z
+  .object({
+    connectorRef: connectorCatalogRefSchema,
+    label: z.string().min(1),
+  })
+  .strict();
+
+const connectorCheckNotScopedRunSchema = z
+  .object({ status: z.literal("not-scoped") })
+  .strict();
+
+const connectorCheckConfiguredRunSchema = z
+  .object({
+    status: z.literal("configured"),
+    bases: z.array(z.string().min(1)),
+  })
+  .strict();
+
+const connectorCheckNotConfiguredRunSchema = z
+  .object({ status: z.literal("not-configured") })
+  .strict();
+
+const connectorCheckRunSchema = z.discriminatedUnion("status", [
+  connectorCheckNotScopedRunSchema,
+  connectorCheckConfiguredRunSchema,
+  connectorCheckNotConfiguredRunSchema,
+]);
+
+const connectorCheckAllowPolicySchema = z
+  .object({
+    outcome: z.literal("allow"),
+    basis: z.enum(["allow-list", "not-blocked", "no-policy", "unknown-policy"]),
+  })
+  .strict();
+
+const connectorCheckDenyPolicySchema = z
+  .object({
+    outcome: z.literal("deny"),
+    basis: z.enum(["deny-list", "unknown-policy"]),
+  })
+  .strict();
+
+const connectorCheckAskPolicySchema = z
+  .object({
+    outcome: z.literal("ask"),
+    basis: z.enum(["ask-list", "unknown-policy"]),
+  })
+  .strict();
+
+const connectorCheckUnavailablePolicySchema = z
+  .object({
+    outcome: z.literal("unavailable"),
+    basis: z.enum([
+      "not-run-scoped",
+      "policies-unavailable",
+      "connector-not-configured",
+    ]),
+  })
+  .strict();
+
+export const connectorCheckPolicySchema = z.discriminatedUnion("outcome", [
+  connectorCheckAllowPolicySchema,
+  connectorCheckDenyPolicySchema,
+  connectorCheckAskPolicySchema,
+  connectorCheckUnavailablePolicySchema,
+]);
+
+export type ConnectorCheckPolicy = z.infer<typeof connectorCheckPolicySchema>;
+
+const connectorCheckMatchedPermissionSchema = z
+  .object({
+    name: z.string().min(1),
+    policy: connectorCheckPolicySchema,
+  })
+  .strict();
+
+const connectorCheckMatchedPermissionsSchema = z
+  .object({
+    kind: z.literal("matched"),
+    permissions: z.array(connectorCheckMatchedPermissionSchema).min(1),
+  })
+  .strict();
+
+const connectorCheckUnknownEndpointSchema = z
+  .object({
+    kind: z.literal("unknown-endpoint"),
+    policy: connectorCheckPolicySchema,
+  })
+  .strict();
+
+const connectorCheckPermissionResultSchema = z.discriminatedUnion("kind", [
+  connectorCheckMatchedPermissionsSchema,
+  connectorCheckUnknownEndpointSchema,
+]);
+
+const connectorCheckResolvedUrlSchema = z
+  .object({
+    outcome: z.literal("resolved"),
+    mode: z.literal("url"),
+    connector: connectorCheckIdentitySchema,
+    environmentNames: z.array(boundedNameSchema).nullable(),
+    run: connectorCheckRunSchema,
+    method: z.string().min(1).max(16),
+    base: z.string().min(1),
+    relativePath: z.string().min(1),
+    permission: connectorCheckPermissionResultSchema,
+  })
+  .strict();
+
+const connectorCheckResolvedEnvironmentSchema = z
+  .object({
+    outcome: z.literal("resolved"),
+    mode: z.literal("environment"),
+    connector: connectorCheckIdentitySchema,
+    environmentName: boundedNameSchema,
+    run: connectorCheckRunSchema,
+    permission: connectorCheckPolicySchema.nullable(),
+  })
+  .strict();
+
+const connectorCheckUnsafeInputSchema = z
+  .object({
+    outcome: z.literal("unsafe-input"),
+    reason: z.enum(["invalid-method", "invalid-url", "unsafe-path"]),
+  })
+  .strict();
+
+const connectorCheckUnknownConnectorSchema = z
+  .object({ outcome: z.literal("unknown-connector") })
+  .strict();
+
+const connectorCheckUnknownEnvironmentSchema = z
+  .object({ outcome: z.literal("unknown-environment") })
+  .strict();
+
+const connectorCheckNoMatchSchema = z
+  .object({
+    outcome: z.literal("no-match"),
+    scope: z.enum(["run", "catalog"]),
+  })
+  .strict();
+
+const connectorCheckAmbiguousSchema = z
+  .object({
+    outcome: z.literal("ambiguous"),
+    candidates: z.array(connectorCheckCandidateSchema).min(2),
+  })
+  .strict();
+
+const connectorCheckMismatchSchema = z
+  .object({
+    outcome: z.literal("connector-mismatch"),
+    connector: connectorCheckIdentitySchema,
+  })
+  .strict();
+
+const connectorCheckEnvironmentNotOwnedSchema = z
+  .object({
+    outcome: z.literal("environment-not-owned"),
+    connector: connectorCheckIdentitySchema,
+  })
+  .strict();
+
+const connectorCheckEnvironmentNotUsedSchema = z
+  .object({
+    outcome: z.literal("environment-not-used"),
+    connector: connectorCheckIdentitySchema,
+    environmentNames: z.array(boundedNameSchema),
+  })
+  .strict();
+
+const connectorCheckUnresolvedDynamicBaseSchema = z
+  .object({
+    outcome: z.literal("unresolved-dynamic-base"),
+    connector: connectorCheckIdentitySchema,
+  })
+  .strict();
+
+const connectorCheckRunContextUnavailableSchema = z
+  .object({ outcome: z.literal("run-context-unavailable") })
+  .strict();
+
+export const connectorCheckDiagnosticResultSchema = z.union([
+  connectorCheckResolvedUrlSchema,
+  connectorCheckResolvedEnvironmentSchema,
+  connectorCheckUnsafeInputSchema,
+  connectorCheckUnknownConnectorSchema,
+  connectorCheckUnknownEnvironmentSchema,
+  connectorCheckNoMatchSchema,
+  connectorCheckAmbiguousSchema,
+  connectorCheckMismatchSchema,
+  connectorCheckEnvironmentNotOwnedSchema,
+  connectorCheckEnvironmentNotUsedSchema,
+  connectorCheckUnresolvedDynamicBaseSchema,
+  connectorCheckRunContextUnavailableSchema,
+]);
+
+export type ConnectorCheckDiagnosticResult = z.infer<
+  typeof connectorCheckDiagnosticResultSchema
+>;
+
+export const zeroConnectorCheckContract = c.router({
+  check: {
+    method: "POST",
+    path: "/api/zero/connectors/diagnostics/check",
+    headers: authHeadersSchema,
+    body: connectorCheckRequestSchema,
+    responses: {
+      200: connectorCheckDiagnosticResultSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Resolve connector runtime diagnostics",
+  },
+});
+
+export type ZeroConnectorCheckContract = typeof zeroConnectorCheckContract;


### PR DESCRIPTION
## Summary

- add a strict authenticated `POST /api/zero/connectors/diagnostics/check` contract for URL and environment diagnostics
- resolve connector identity, visibility, dynamic bases, run configuration, and final policy facts from one server-owned request view
- enforce owned Zero run snapshots with both required capabilities and no fallback to current/global state
- share the security-sensitive URL and dynamic-base validation used by permission-deny, with route-level regression coverage
- keep responses task-specific and sanitized instead of exposing catalog, auth, routing, policy-source, storage, or credential projections

## Compatibility and scope

- the API change is additive; existing CLI behavior is unchanged until #21220
- no database migration, persisted-state change, runner protocol change, frontend route, catalog version, or R2 adapter is included
- PAT/session diagnostics use one repeatable-read stored-state snapshot; Zero diagnostics use the owned run snapshot exactly once

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (401 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-check.test.ts src/signals/routes/__tests__/zero-connector-permission-deny.test.ts` (17 tests)
- `pnpm knip`
- pre-commit full Turbo typecheck (13 workspaces)

Closes #21219

Delivery parent: #21140
