### PR TITLE
fix(runner): gate namespace pooling on dns readiness

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1024,6 +1024,20 @@ jobs:
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
 
+          DNS_READINESS_LOGGED=false
+          for _ in $(seq 1 30); do
+            STARTUP_LOGS=$(sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 300 2>&1) \
+              || fail "failed to read runner startup logs"
+            if printf '%s\n' "$STARTUP_LOGS" \
+              | grep -F "namespace DNS readiness probe succeeded" >/dev/null; then
+              DNS_READINESS_LOGGED=true
+              break
+            fi
+            sleep 1
+          done
+          [ "$DNS_READINESS_LOGGED" = true ] \
+            || fail "runner did not activate namespace DNS readiness"
+
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1026,12 +1026,17 @@ jobs:
 
           DNS_READINESS_LOGGED=false
           for _ in $(seq 1 30); do
-            STARTUP_LOGS=$(sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 300 2>&1) \
-              || fail "failed to read runner startup logs"
-            if printf '%s\n' "$STARTUP_LOGS" \
-              | grep -F "namespace DNS readiness probe succeeded" >/dev/null; then
-              DNS_READINESS_LOGGED=true
-              break
+            INVOCATION_ID=$(sudo systemctl show "vm0-runner-${SVC}.service" \
+              --property=InvocationID --value 2>/dev/null) || true
+            if [ -n "$INVOCATION_ID" ]; then
+              STARTUP_LOGS=$(sudo journalctl --no-pager --lines 300 \
+                "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+                || fail "failed to read runner startup logs"
+              if printf '%s\n' "$STARTUP_LOGS" \
+                | grep -F "namespace DNS readiness probe succeeded" >/dev/null; then
+                DNS_READINESS_LOGGED=true
+                break
+              fi
             fi
             sleep 1
           done

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -569,7 +569,25 @@ async fn run_start_with_home(
         )
         .await
         {
-            Ok(handle) => break (runtime, handle),
+            Ok(handle) => {
+                if let Err(e) = runtime.activate_dns_readiness().await {
+                    memory_prefetch.cancel();
+                    handle.stop().await;
+                    runtime.shutdown().await;
+                    if let Err(kill_error) = mitm.kill_now().await {
+                        warn!(
+                            error = %kill_error,
+                            "failed to kill proxy after namespace DNS readiness failed"
+                        );
+                    }
+                    kmsg_handle.stop().await;
+                    memory_prefetch.drain().await;
+                    return Err(RunnerError::Internal(format!(
+                        "sandbox runtime DNS readiness: {e}"
+                    )));
+                }
+                break (runtime, handle);
+            }
             Err(e)
                 if e.kind() == std::io::ErrorKind::AddrInUse
                     && dns_start_attempt < DNS_START_MAX_ATTEMPTS =>

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -4,6 +4,8 @@ use tokio::io::AsyncReadExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use sandbox_fc::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
+
 use super::log::tail_stderr;
 use super::port::DnsPortReservation;
 use crate::child_cleanup::kill_and_reap_child_on_drop;
@@ -200,6 +202,8 @@ fn dnsmasq_args(port: u16, interface_pattern: &str) -> Vec<String> {
         // VM host-side veth devices are created after dnsmasq starts.
         format!("--interface={interface_pattern}"),
         "--bind-dynamic".into(),
+        format!("--address=/{DNS_READINESS_HOSTNAME}/{DNS_READINESS_IPV4}"),
+        format!("--local=/{DNS_READINESS_HOSTNAME}/"),
         "--server".into(),
         "8.8.8.8".into(),
         "--server".into(),
@@ -234,6 +238,8 @@ mod tests {
                 "5353",
                 "--interface=vm0-ve-0a-*",
                 "--bind-dynamic",
+                "--address=/vm0-readiness.invalid/192.0.2.1",
+                "--local=/vm0-readiness.invalid/",
                 "--server",
                 "8.8.8.8",
                 "--server",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -10,7 +10,7 @@ futures-util.workspace = true
 guest-contracts.workspace = true
 nbd-cow.workspace = true
 libc.workspace = true
-nix = { workspace = true, features = ["user", "inotify", "fs", "signal"] }
+nix = { workspace = true, features = ["user", "inotify", "fs", "signal", "sched"] }
 reqwest.workspace = true
 sandbox.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -54,7 +54,8 @@ pub use config::{
 pub use control::FirecrackerControl;
 pub use factory::{PREWARM_SCRIPT, config_hash};
 pub use network::{
-    NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
+    DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4, NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig,
+    ParsedNetnsName, parse_netns_name,
 };
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,

--- a/crates/sandbox-fc/src/network/error.rs
+++ b/crates/sandbox-fc/src/network/error.rs
@@ -6,6 +6,8 @@
 
 use crate::command::CommandError;
 
+use super::readiness::DnsReadinessError;
+
 /// Network subsystem result alias using [`NetworkError`].
 pub type Result<T> = std::result::Result<T, NetworkError>;
 
@@ -29,6 +31,14 @@ pub enum NetworkError {
     #[error("pool is not active")]
     PoolNotActive,
 
+    /// A DNS-enabled namespace pool has not completed functional readiness activation.
+    #[error("namespace pool DNS readiness is not active")]
+    PoolDnsNotReady,
+
+    /// No startup-prewarmed namespace passed the functional DNS readiness probe.
+    #[error("no namespace passed DNS readiness activation")]
+    NoDnsReadyNamespaces,
+
     /// The default outbound network interface could not be detected from route output.
     #[error("failed to detect default network interface from: {0}")]
     NoDefaultInterface(String),
@@ -40,6 +50,10 @@ pub enum NetworkError {
     /// A required host or network prerequisite failed while preparing namespaces.
     #[error("prerequisite check failed: {0}")]
     Prerequisite(String),
+
+    /// A namespace failed its bounded functional DNS readiness probe.
+    #[error(transparent)]
+    DnsReadiness(#[from] DnsReadinessError),
 
     /// A namespace lease failed validation against the pool's current ownership state.
     #[error("invalid namespace lease: {0}")]

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -1,6 +1,7 @@
 mod error;
 mod guest;
 mod pool;
+mod readiness;
 
 pub(crate) use guest::generate_boot_args;
 pub(crate) use guest::{GUEST_NETWORK, GuestNetwork};
@@ -8,3 +9,4 @@ pub(crate) use pool::NetnsPoolHandle;
 pub use pool::{
     NetnsInfo, NetnsLease, NetnsPool, NetnsPoolConfig, ParsedNetnsName, parse_netns_name,
 };
+pub use readiness::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -1023,8 +1023,8 @@ impl NetnsPoolInner {
             }
         }
 
-        delete_namespaces_with_ops(plan.ops, failed.clone()).await;
         let failed_names = cleanup_namespace_names(&failed);
+        delete_namespaces_with_ops(plan.ops, failed).await;
         let mut state = self.state.lock().await;
         state.commit_dns_activation(&failed_names, successful)?;
         info!(

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -3,7 +3,9 @@ use std::fs::File;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
+use futures_util::future::join_all;
 use nix::fcntl::Flock;
 #[cfg(test)]
 use nix::fcntl::FlockArg;
@@ -13,6 +15,12 @@ use tracing::{error, info, warn};
 use crate::paths::LockPaths;
 
 use super::super::error::{NetworkError, Result};
+#[cfg(test)]
+use super::super::readiness::DnsReadinessError;
+use super::super::readiness::{
+    DNS_READINESS_OPERATION_TIMEOUT, DnsReadinessProbe, production_dns_readiness_probe,
+    run_dns_readiness_probe,
+};
 #[cfg(test)]
 use super::host::ConntrackFlushOutcome;
 use super::host::{
@@ -25,6 +33,21 @@ use super::types::{
 };
 
 const BUFFER_SIZE: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DnsReadinessState {
+    NotRequired,
+    Pending,
+    Activating,
+    Ready,
+}
+
+struct DnsActivationPlan {
+    candidates: Vec<NetnsInfo>,
+    probe: DnsReadinessProbe,
+    timeout: Duration,
+    ops: NetnsLifecycleOps,
+}
 
 /// Monotonic in-process identity for [`NetnsPool`] instances.
 static NEXT_NETNS_POOL_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
@@ -164,6 +187,10 @@ struct NetnsPoolState {
     pool_index: u32,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    dns_readiness_state: DnsReadinessState,
+    dns_readiness_probe: DnsReadinessProbe,
+    dns_readiness_timeout: Duration,
+    creation_failure: Option<NetworkError>,
     default_iface: String,
     ops: NetnsLifecycleOps,
     #[cfg(test)]
@@ -218,6 +245,10 @@ impl NetnsPoolState {
             pool_index: 0,
             proxy_port: None,
             dns_port: None,
+            dns_readiness_state: DnsReadinessState::NotRequired,
+            dns_readiness_probe: production_dns_readiness_probe(),
+            dns_readiness_timeout: DNS_READINESS_OPERATION_TIMEOUT,
+            creation_failure: None,
             default_iface: "test0".into(),
             ops: NetnsLifecycleOps::trusted_for_test(),
             acquire_waiting_notify: None,
@@ -280,6 +311,14 @@ impl NetnsPoolState {
             pool_index: index,
             proxy_port: config.proxy_port,
             dns_port: config.dns_port,
+            dns_readiness_state: if config.dns_port.is_some() && config.proxy_port.is_some() {
+                DnsReadinessState::Pending
+            } else {
+                DnsReadinessState::NotRequired
+            },
+            dns_readiness_probe: production_dns_readiness_probe(),
+            dns_readiness_timeout: DNS_READINESS_OPERATION_TIMEOUT,
+            creation_failure: None,
             default_iface,
             ops: NetnsLifecycleOps::default(),
             #[cfg(test)]
@@ -404,6 +443,49 @@ impl NetnsPoolState {
         }
     }
 
+    fn prepare_dns_activation(&mut self) -> Result<Option<DnsActivationPlan>> {
+        if !self.active {
+            return Err(NetworkError::PoolNotActive);
+        }
+        match self.dns_readiness_state {
+            DnsReadinessState::NotRequired | DnsReadinessState::Ready => Ok(None),
+            DnsReadinessState::Activating => Err(NetworkError::PoolDnsNotReady),
+            DnsReadinessState::Pending => {
+                self.dns_readiness_state = DnsReadinessState::Activating;
+                Ok(Some(DnsActivationPlan {
+                    candidates: self.proxy_queue.iter().cloned().collect(),
+                    probe: Arc::clone(&self.dns_readiness_probe),
+                    timeout: self.dns_readiness_timeout,
+                    ops: self.ops.clone(),
+                }))
+            }
+        }
+    }
+
+    fn commit_dns_activation(
+        &mut self,
+        failed_names: &HashSet<String>,
+        successful: usize,
+    ) -> Result<()> {
+        if !self.active {
+            return Err(NetworkError::PoolNotActive);
+        }
+        if !matches!(self.dns_readiness_state, DnsReadinessState::Activating) {
+            return Err(NetworkError::PoolDnsNotReady);
+        }
+
+        self.remove_queued_namespaces(failed_names);
+        if successful == 0 {
+            self.dns_readiness_state = DnsReadinessState::Pending;
+            return Err(NetworkError::NoDnsReadyNamespaces);
+        }
+
+        self.dns_readiness_state = DnsReadinessState::Ready;
+        self.creation_failure = None;
+        self.maybe_replenish_kind(NetnsKind::Proxy);
+        Ok(())
+    }
+
     fn spawn_creation(&mut self, kind: NetnsKind) -> Result<()> {
         let ns_index = self.reserve_ns_index()?;
         let pool_index = self.pool_index;
@@ -421,11 +503,26 @@ impl NetnsPoolState {
         };
         let id = self.reserve_pending_id();
         self.pending_set_mut(kind).insert(id);
+        let readiness = if matches!(kind, NetnsKind::Proxy)
+            && matches!(self.dns_readiness_state, DnsReadinessState::Ready)
+        {
+            Some((
+                Arc::clone(&self.dns_readiness_probe),
+                self.dns_readiness_timeout,
+            ))
+        } else {
+            None
+        };
+        let ops = self.ops.clone();
         spawn_creation_worker(
             id,
             kind,
             self.creation_notifier(),
-            create_single_namespace(pool_index, ns_index, default_iface, proxy_port, dns_port),
+            create_namespace_with_readiness(
+                create_single_namespace(pool_index, ns_index, default_iface, proxy_port, dns_port),
+                readiness,
+                ops,
+            ),
         );
         Ok(())
     }
@@ -438,6 +535,29 @@ impl NetnsPoolState {
         let id = self.reserve_pending_id();
         self.pending_plain.insert(id);
         spawn_creation_worker(id, NetnsKind::Plain, self.creation_notifier(), future);
+    }
+
+    #[cfg(test)]
+    fn spawn_proxy_creation_for_test<F>(&mut self, future: F)
+    where
+        F: Future<Output = Result<NetnsInfo>> + Send + 'static,
+    {
+        let id = self.reserve_pending_id();
+        self.pending_proxy.insert(id);
+        let readiness = if matches!(self.dns_readiness_state, DnsReadinessState::Ready) {
+            Some((
+                Arc::clone(&self.dns_readiness_probe),
+                self.dns_readiness_timeout,
+            ))
+        } else {
+            None
+        };
+        spawn_creation_worker(
+            id,
+            NetnsKind::Proxy,
+            self.creation_notifier(),
+            create_namespace_with_readiness(future, readiness, self.ops.clone()),
+        );
     }
 
     #[cfg(test)]
@@ -511,6 +631,11 @@ impl NetnsPoolState {
                     error = %e,
                     "background namespace creation failed"
                 );
+                if !queue_when_inactive
+                    && matches!(self.dns_readiness_state, DnsReadinessState::Ready)
+                {
+                    self.creation_failure = Some(e);
+                }
             }
         }
     }
@@ -520,12 +645,21 @@ impl NetnsPoolState {
             if !self.active {
                 return Err(NetworkError::PoolNotActive);
             }
+            if matches!(
+                self.dns_readiness_state,
+                DnsReadinessState::Pending | DnsReadinessState::Activating
+            ) {
+                return Err(NetworkError::PoolDnsNotReady);
+            }
             let delete = self.drain_completed(false);
             if !delete.is_empty() {
                 return Ok(AcquirePlan::Delete(delete, self.ops.clone()));
             }
             if let Some(lease) = self.try_checkout_ready()? {
                 return Ok(AcquirePlan::Ready(lease));
+            }
+            if let Some(error) = self.creation_failure.take() {
+                return Err(error);
             }
 
             let kind = self.active_kind();
@@ -546,6 +680,9 @@ impl NetnsPoolState {
             }
             if let Some(lease) = self.try_checkout_ready()? {
                 return Ok(AcquirePlan::Ready(lease));
+            }
+            if let Some(error) = self.creation_failure.take() {
+                return Err(error);
             }
             if self.pending_set(kind).is_empty() {
                 continue;
@@ -761,6 +898,7 @@ impl NetnsPoolState {
 
     fn prepare_cleanup(&mut self) -> CleanupPlan {
         self.active = false;
+        self.creation_failure = None;
         if !self.in_flight.is_empty() {
             warn!(
                 in_flight = self.in_flight.len(),
@@ -857,6 +995,46 @@ impl NetnsPoolInner {
         }
     }
 
+    async fn activate_dns_readiness(&self) -> Result<()> {
+        let Some(plan) = ({
+            let mut state = self.state.lock().await;
+            state.prepare_dns_activation()?
+        }) else {
+            return Ok(());
+        };
+
+        let results = join_all(plan.candidates.iter().cloned().map(|namespace| {
+            let probe = Arc::clone(&plan.probe);
+            async move {
+                let result =
+                    run_dns_readiness_probe(namespace.name.clone(), probe, plan.timeout).await;
+                (namespace, result)
+            }
+        }))
+        .await;
+
+        let mut failed = Vec::new();
+        let mut successful = 0;
+        for (namespace, result) in results {
+            if result.is_ok() {
+                successful += 1;
+            } else {
+                failed.push(namespace);
+            }
+        }
+
+        delete_namespaces_with_ops(plan.ops, failed.clone()).await;
+        let failed_names = cleanup_namespace_names(&failed);
+        let mut state = self.state.lock().await;
+        state.commit_dns_activation(&failed_names, successful)?;
+        info!(
+            successful,
+            failed = failed_names.len(),
+            "namespace DNS readiness activated"
+        );
+        Ok(())
+    }
+
     async fn release_outcome(&self, lease: &mut Option<NetnsLease>) -> NetnsReleaseOutcome {
         let plan = {
             let mut state = self.state.lock().await;
@@ -948,6 +1126,10 @@ impl NetnsPool {
     /// Automatically acquires a unique pool index (0–63) via flock. Enables
     /// host IP forwarding and reconciles orphaned resources from any idle
     /// pool index before creating new namespaces.
+    ///
+    /// A pool configured with both proxy and DNS ports remains non-acquirable
+    /// until [`Self::activate_dns_readiness`] succeeds after the DNS service
+    /// starts listening.
     pub async fn create(config: NetnsPoolConfig) -> Result<Self> {
         let config = config
             .into_checked()
@@ -964,6 +1146,15 @@ impl NetnsPool {
     /// Acquire a namespace from the pool, or create one on-demand if empty.
     pub async fn acquire(&mut self) -> Result<NetnsLease> {
         self.inner.acquire().await
+    }
+
+    /// Validate and admit namespaces that redirect DNS to runner-managed DNS.
+    ///
+    /// Call this after the DNS service is listening and before the first
+    /// [`Self::acquire`] when both proxy and DNS ports are configured. Pools
+    /// without DNS redirect return immediately.
+    pub async fn activate_dns_readiness(&self) -> Result<()> {
+        self.inner.activate_dns_readiness().await
     }
 
     /// Return a namespace to the pool, or delete it if the pool is inactive.
@@ -1041,6 +1232,10 @@ impl NetnsPoolHandle {
         self.inner.acquire().await
     }
 
+    pub(crate) async fn activate_dns_readiness(&self) -> Result<()> {
+        self.inner.activate_dns_readiness().await
+    }
+
     pub(crate) async fn release(&self, lease: &mut Option<NetnsLease>) -> NetnsReleaseOutcome {
         self.inner.release_outcome(lease).await
     }
@@ -1052,6 +1247,26 @@ impl NetnsPoolHandle {
     pub(crate) async fn host_device_pattern(&self) -> String {
         self.inner.host_device_pattern().await
     }
+}
+
+async fn create_namespace_with_readiness<F>(
+    create: F,
+    readiness: Option<(DnsReadinessProbe, Duration)>,
+    ops: NetnsLifecycleOps,
+) -> Result<NetnsInfo>
+where
+    F: Future<Output = Result<NetnsInfo>>,
+{
+    let namespace = create.await?;
+    let Some((probe, timeout)) = readiness else {
+        return Ok(namespace);
+    };
+
+    if let Err(error) = run_dns_readiness_probe(namespace.name.clone(), probe, timeout).await {
+        delete_namespaces_with_ops(ops, vec![namespace]).await;
+        return Err(NetworkError::DnsReadiness(error));
+    }
+    Ok(namespace)
 }
 
 fn spawn_creation_worker<F>(id: PendingId, kind: NetnsKind, notifier: CreationNotifier, future: F)
@@ -1116,6 +1331,26 @@ mod tests {
 
     fn test_info(name: &str) -> NetnsInfo {
         NetnsInfo::new(name.into(), "test-ve".into(), "10.200.0.2".into())
+    }
+
+    fn probe_for_test<F, Fut>(probe: F) -> DnsReadinessProbe
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = std::result::Result<u16, DnsReadinessError>> + Send + 'static,
+    {
+        Arc::new(move |namespace| Box::pin(probe(namespace)))
+    }
+
+    fn dns_pending_state(names: &[&str], ops: NetnsLifecycleOps) -> NetnsPoolState {
+        let mut state = NetnsPoolState::inactive_for_test();
+        state.active = true;
+        state.proxy_port = Some(8080);
+        state.dns_port = Some(5353);
+        state.dns_readiness_state = DnsReadinessState::Pending;
+        state.next_ns_index = MAX_NAMESPACES;
+        state.ops = ops;
+        state.proxy_queue = names.iter().map(|name| test_info(name)).collect();
+        state
     }
 
     struct CountedLifecycle {
@@ -1369,6 +1604,213 @@ mod tests {
             flush_count,
             delete_count,
         }
+    }
+
+    #[tokio::test]
+    async fn dns_pending_pool_rejects_acquire_without_removing_ready_entry() {
+        let state = dns_pending_state(&["vm0-ns-test-00"], NetnsLifecycleOps::trusted_for_test());
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        let error = pool.acquire().await.unwrap_err();
+
+        assert!(matches!(error, NetworkError::PoolDnsNotReady));
+        assert_eq!(
+            pool.inner
+                .with_state_for_test(|state| state.proxy_queue.len()),
+            1
+        );
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dns_activation_admits_successfully_probed_initial_namespaces() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_probe = Arc::clone(&calls);
+        let mut state = dns_pending_state(
+            &[
+                "vm0-ns-test-00",
+                "vm0-ns-test-01",
+                "vm0-ns-test-02",
+                "vm0-ns-test-03",
+            ],
+            NetnsLifecycleOps::trusted_for_test(),
+        );
+        state.dns_readiness_probe = probe_for_test(move |_| {
+            let calls = Arc::clone(&calls_for_probe);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(1)
+            }
+        });
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        pool.activate_dns_readiness().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert!(pool.inner.with_state_for_test(|state| matches!(
+            state.dns_readiness_state,
+            DnsReadinessState::Ready
+        )));
+        let mut lease = Some(pool.acquire().await.unwrap());
+        pool.release(&mut lease).await.unwrap();
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dns_activation_deletes_only_failed_initial_namespaces() {
+        let lifecycle = counted_deleted_lifecycle();
+        let mut state = dns_pending_state(
+            &[
+                "vm0-ns-test-00",
+                "vm0-ns-test-01",
+                "vm0-ns-test-02",
+                "vm0-ns-test-03",
+            ],
+            lifecycle.ops,
+        );
+        state.dns_readiness_probe = probe_for_test(|namespace| async move {
+            if namespace.ends_with("-02") {
+                Err(DnsReadinessError::timeout())
+            } else {
+                Ok(1)
+            }
+        });
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        pool.activate_dns_readiness().await.unwrap();
+
+        assert_eq!(lifecycle.delete_count.load(Ordering::SeqCst), 1);
+        let names = pool.inner.with_state_for_test(|state| {
+            state
+                .proxy_queue
+                .iter()
+                .map(|namespace| namespace.name.clone())
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(names.len(), 3);
+        assert!(!names.iter().any(|name| name.ends_with("-02")));
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dns_activation_fails_when_every_initial_probe_times_out() {
+        let lifecycle = counted_deleted_lifecycle();
+        let mut state = dns_pending_state(&["vm0-ns-test-00", "vm0-ns-test-01"], lifecycle.ops);
+        state.dns_readiness_timeout = Duration::from_millis(10);
+        state.dns_readiness_probe = probe_for_test(|_| async {
+            std::future::pending::<std::result::Result<u16, DnsReadinessError>>().await
+        });
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        let error = pool.activate_dns_readiness().await.unwrap_err();
+
+        assert!(matches!(error, NetworkError::NoDnsReadyNamespaces));
+        assert_eq!(lifecycle.delete_count.load(Ordering::SeqCst), 2);
+        assert!(pool.inner.with_state_for_test(|state| {
+            state.proxy_queue.is_empty()
+                && matches!(state.dns_readiness_state, DnsReadinessState::Pending)
+        }));
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_dns_activation_leaves_initial_entries_owned_by_pool() {
+        let lifecycle = counted_deleted_lifecycle();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let entered_for_probe = Arc::clone(&entered);
+        let release_for_probe = Arc::clone(&release);
+        let mut state = dns_pending_state(&["vm0-ns-test-00"], lifecycle.ops);
+        state.dns_readiness_probe = probe_for_test(move |_| {
+            let entered = Arc::clone(&entered_for_probe);
+            let release = Arc::clone(&release_for_probe);
+            async move {
+                entered.notify_one();
+                release.notified().await;
+                Ok(1)
+            }
+        });
+        let mut pool = NetnsPool::from_state_for_test(state);
+        let inner = pool.inner.clone();
+        let activation = tokio::spawn(async move { inner.activate_dns_readiness().await });
+        entered.notified().await;
+
+        activation.abort();
+        assert!(activation.await.unwrap_err().is_cancelled());
+        assert!(pool.inner.with_state_for_test(|state| {
+            state.proxy_queue.len() == 1
+                && matches!(state.dns_readiness_state, DnsReadinessState::Activating)
+        }));
+        pool.cleanup().await.unwrap();
+        assert_eq!(lifecycle.delete_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn post_activation_creation_is_probed_before_acquire() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_probe = Arc::clone(&calls);
+        let mut state = dns_pending_state(&[], NetnsLifecycleOps::trusted_for_test());
+        state.dns_readiness_state = DnsReadinessState::Ready;
+        state.dns_readiness_probe = probe_for_test(move |_| {
+            let calls = Arc::clone(&calls_for_probe);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(1)
+            }
+        });
+        state.spawn_proxy_creation_for_test(async { Ok(test_info("vm0-ns-test-04")) });
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        let mut lease = Some(pool.acquire().await.unwrap());
+
+        assert_eq!(lease.as_ref().unwrap().name(), "vm0-ns-test-04");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        pool.release(&mut lease).await.unwrap();
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn failed_post_activation_probe_is_deleted_and_returned_to_acquire() {
+        let lifecycle = counted_deleted_lifecycle();
+        let mut state = dns_pending_state(&[], lifecycle.ops);
+        state.next_ns_index = 7;
+        state.dns_readiness_state = DnsReadinessState::Ready;
+        state.dns_readiness_probe = probe_for_test(|_| async { Err(DnsReadinessError::timeout()) });
+        state.spawn_proxy_creation_for_test(async { Ok(test_info("vm0-ns-test-04")) });
+        let mut pool = NetnsPool::from_state_for_test(state);
+
+        let error = pool.acquire().await.unwrap_err();
+
+        assert!(matches!(error, NetworkError::DnsReadiness(_)));
+        assert_eq!(lifecycle.delete_count.load(Ordering::SeqCst), 1);
+        assert!(pool.inner.with_state_for_test(|state| {
+            state.proxy_queue.is_empty()
+                && state.pending_proxy.is_empty()
+                && state.next_ns_index == 7
+        }));
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn healthy_entry_wins_over_parallel_readiness_failure() {
+        let lifecycle = counted_deleted_lifecycle();
+        let mut state = dns_pending_state(&["vm0-ns-test-good"], lifecycle.ops);
+        state.dns_readiness_state = DnsReadinessState::Ready;
+        state.dns_readiness_probe = probe_for_test(|_| async { Err(DnsReadinessError::timeout()) });
+        let mut completion = state.completion_wake_tx.subscribe();
+        state.spawn_proxy_creation_for_test(async { Ok(test_info("vm0-ns-test-bad")) });
+        let mut pool = NetnsPool::from_state_for_test(state);
+        completion.changed().await.unwrap();
+
+        let mut lease = Some(pool.acquire().await.unwrap());
+
+        assert_eq!(lease.as_ref().unwrap().name(), "vm0-ns-test-good");
+        assert!(pool.inner.with_state_for_test(|state| {
+            state.creation_failure.is_some() && state.proxy_queue.is_empty()
+        }));
+        assert_eq!(lifecycle.delete_count.load(Ordering::SeqCst), 1);
+        pool.release(&mut lease).await.unwrap();
+        pool.cleanup().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -118,6 +118,8 @@ impl Drop for NetnsLease {
 /// When `proxy_port` is set, the pool pre-warms and acquires from the proxy
 /// queue only. Without `proxy_port`, it pre-warms and acquires from the plain
 /// queue. This avoids keeping an unreachable plain queue alive in proxy mode.
+/// When both proxy and DNS ports are set, callers must start the DNS service
+/// and call [`super::NetnsPool::activate_dns_readiness`] before acquiring.
 pub struct NetnsPoolConfig {
     /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
     pub proxy_port: Option<u16>,

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -489,17 +489,21 @@ mod tests {
             std::net::SocketAddr::V6(_) => panic!("test server should use IPv4"),
         };
         let (received_tx, received_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
         let server_thread = std::thread::spawn(move || {
             let mut query = [0_u8; DNS_RESPONSE_MAX_BYTES];
             server.recv_from(&mut query).unwrap();
             received_tx.send(()).unwrap();
-            std::thread::sleep(Duration::from_millis(100));
+            release_rx.recv().unwrap();
         });
 
-        let error = probe_dns_endpoint(destination, Duration::from_millis(30)).unwrap_err();
+        let result = probe_dns_endpoint(destination, Duration::from_millis(30));
 
-        received_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let received = received_rx.recv_timeout(Duration::from_secs(1));
+        release_tx.send(()).unwrap();
         server_thread.join().unwrap();
+        received.unwrap();
+        let error = result.unwrap_err();
         assert_eq!(error.stage_name(), DnsReadinessStage::Timeout);
     }
 }

--- a/crates/sandbox-fc/src/network/readiness.rs
+++ b/crates/sandbox-fc/src/network/readiness.rs
@@ -1,0 +1,505 @@
+use std::fmt;
+use std::fs::File;
+use std::future::Future;
+use std::io;
+use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::{Duration, Instant};
+
+use nix::sched::{CloneFlags, setns};
+use tokio::sync::oneshot;
+use tracing::{info, warn};
+
+use crate::duration::duration_ms;
+
+/// Local-only hostname used to validate a namespace's DNS redirect path.
+pub const DNS_READINESS_HOSTNAME: &str = "vm0-readiness.invalid";
+
+/// TEST-NET address returned for [`DNS_READINESS_HOSTNAME`].
+pub const DNS_READINESS_IPV4: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+
+pub(super) const DNS_READINESS_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(super) type DnsReadinessFuture =
+    Pin<Box<dyn Future<Output = Result<u16, DnsReadinessError>> + Send>>;
+pub(super) type DnsReadinessProbe = Arc<dyn Fn(String) -> DnsReadinessFuture + Send + Sync>;
+
+const DNS_PORT: u16 = 53;
+const DNS_RESPONSE_MAX_BYTES: usize = 512;
+const DNS_QUERY_FLAGS_RECURSION_DESIRED: u16 = 0x0100;
+const DNS_RESPONSE_FLAG: u16 = 0x8000;
+const DNS_RESPONSE_CODE_MASK: u16 = 0x000f;
+const DNS_TYPE_A: u16 = 1;
+const DNS_CLASS_IN: u16 = 1;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const PROBE_THREAD_GRACE: Duration = Duration::from_millis(250);
+const PROBE_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(200);
+const PROBE_RETRY_DELAY: Duration = Duration::from_millis(25);
+const NETNS_DIR: &str = "/var/run/netns";
+
+static NEXT_TRANSACTION_ID: AtomicU16 = AtomicU16::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DnsReadinessStage {
+    SpawnThread,
+    OpenCurrentNamespace,
+    OpenTargetNamespace,
+    EnterNamespace,
+    BindSocket,
+    ConnectSocket,
+    ConfigureSocket,
+    BuildQuery,
+    SendQuery,
+    ReceiveResponse,
+    ValidateResponse,
+    RestoreNamespace,
+    WaitForThread,
+    Timeout,
+}
+
+impl fmt::Display for DnsReadinessStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::SpawnThread => "spawn_thread",
+            Self::OpenCurrentNamespace => "open_current_namespace",
+            Self::OpenTargetNamespace => "open_target_namespace",
+            Self::EnterNamespace => "enter_namespace",
+            Self::BindSocket => "bind_socket",
+            Self::ConnectSocket => "connect_socket",
+            Self::ConfigureSocket => "configure_socket",
+            Self::BuildQuery => "build_query",
+            Self::SendQuery => "send_query",
+            Self::ReceiveResponse => "receive_response",
+            Self::ValidateResponse => "validate_response",
+            Self::RestoreNamespace => "restore_namespace",
+            Self::WaitForThread => "wait_for_thread",
+            Self::Timeout => "timeout",
+        })
+    }
+}
+
+/// Bounded failure from the runner-owned namespace DNS readiness probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DnsReadinessError {
+    stage: DnsReadinessStage,
+    io_kind: Option<io::ErrorKind>,
+    attempts: u16,
+}
+
+impl DnsReadinessError {
+    fn stage(stage: DnsReadinessStage) -> Self {
+        Self {
+            stage,
+            io_kind: None,
+            attempts: 0,
+        }
+    }
+
+    fn io(stage: DnsReadinessStage, error: &io::Error) -> Self {
+        Self {
+            stage,
+            io_kind: Some(error.kind()),
+            attempts: 0,
+        }
+    }
+
+    fn errno(stage: DnsReadinessStage, errno: nix::errno::Errno) -> Self {
+        let error = io::Error::from_raw_os_error(errno as i32);
+        Self::io(stage, &error)
+    }
+
+    fn stage_name(&self) -> DnsReadinessStage {
+        self.stage
+    }
+
+    fn io_kind(&self) -> Option<io::ErrorKind> {
+        self.io_kind
+    }
+
+    fn attempts(&self) -> u16 {
+        self.attempts
+    }
+
+    pub(super) fn timeout() -> Self {
+        Self::stage(DnsReadinessStage::Timeout)
+    }
+
+    fn with_attempts(mut self, attempts: u16) -> Self {
+        self.attempts = attempts;
+        self
+    }
+}
+
+impl fmt::Display for DnsReadinessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DNS readiness failed at stage={}", self.stage)?;
+        if let Some(kind) = self.io_kind {
+            write!(f, " io_kind={kind:?}")?;
+        }
+        write!(f, " attempts={}", self.attempts)?;
+        Ok(())
+    }
+}
+
+impl std::error::Error for DnsReadinessError {}
+
+pub(super) fn production_dns_readiness_probe() -> DnsReadinessProbe {
+    Arc::new(|namespace| Box::pin(probe_namespace_dns(namespace)))
+}
+
+pub(super) async fn run_dns_readiness_probe(
+    namespace: String,
+    probe: DnsReadinessProbe,
+    timeout: Duration,
+) -> Result<u16, DnsReadinessError> {
+    let started = Instant::now();
+    let result = match tokio::time::timeout(timeout, probe(namespace.clone())).await {
+        Ok(result) => result,
+        Err(_) => Err(DnsReadinessError::timeout()),
+    };
+    match &result {
+        Ok(attempts) => info!(
+            name = %namespace,
+            attempts,
+            elapsed_ms = duration_ms(started.elapsed()),
+            "namespace DNS readiness probe succeeded"
+        ),
+        Err(error) => warn!(
+            name = %namespace,
+            stage = %error.stage_name(),
+            io_kind = ?error.io_kind(),
+            attempts = error.attempts(),
+            elapsed_ms = duration_ms(started.elapsed()),
+            "namespace DNS readiness probe failed"
+        ),
+    }
+    result
+}
+
+pub(super) async fn probe_namespace_dns(namespace: String) -> Result<u16, DnsReadinessError> {
+    let (tx, rx) = oneshot::channel();
+    std::thread::Builder::new()
+        .name("vm0-dns-readiness".into())
+        .spawn(move || {
+            let result = probe_namespace_dns_blocking(&namespace);
+            let _ = tx.send(result);
+        })
+        .map_err(|error| DnsReadinessError::io(DnsReadinessStage::SpawnThread, &error))?;
+
+    match tokio::time::timeout(PROBE_TIMEOUT + PROBE_THREAD_GRACE, rx).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err(DnsReadinessError::stage(DnsReadinessStage::WaitForThread)),
+        Err(_) => Err(DnsReadinessError::stage(DnsReadinessStage::Timeout)),
+    }
+}
+
+fn probe_namespace_dns_blocking(namespace: &str) -> Result<u16, DnsReadinessError> {
+    let current = File::open("/proc/self/ns/net")
+        .map_err(|error| DnsReadinessError::io(DnsReadinessStage::OpenCurrentNamespace, &error))?;
+    let target = File::open(Path::new(NETNS_DIR).join(namespace))
+        .map_err(|error| DnsReadinessError::io(DnsReadinessStage::OpenTargetNamespace, &error))?;
+    setns(&target, CloneFlags::CLONE_NEWNET)
+        .map_err(|errno| DnsReadinessError::errno(DnsReadinessStage::EnterNamespace, errno))?;
+
+    let result = probe_dns_endpoint(
+        SocketAddrV4::new(DNS_READINESS_IPV4, DNS_PORT),
+        PROBE_TIMEOUT,
+    );
+    let restore = setns(&current, CloneFlags::CLONE_NEWNET)
+        .map_err(|errno| DnsReadinessError::errno(DnsReadinessStage::RestoreNamespace, errno));
+
+    restore?;
+    result
+}
+
+fn probe_dns_endpoint(
+    destination: SocketAddrV4,
+    timeout: Duration,
+) -> Result<u16, DnsReadinessError> {
+    let socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+        .map_err(|error| DnsReadinessError::io(DnsReadinessStage::BindSocket, &error))?;
+    socket
+        .connect(destination)
+        .map_err(|error| DnsReadinessError::io(DnsReadinessStage::ConnectSocket, &error))?;
+
+    let started = Instant::now();
+    let deadline = started + timeout;
+    let mut attempts = 0_u16;
+    let mut last_error = DnsReadinessError::timeout();
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(last_error);
+        }
+        let attempt_timeout = PROBE_ATTEMPT_TIMEOUT.min(deadline.saturating_duration_since(now));
+        socket
+            .set_read_timeout(Some(attempt_timeout))
+            .map_err(|error| DnsReadinessError::io(DnsReadinessStage::ConfigureSocket, &error))?;
+
+        attempts = attempts.saturating_add(1);
+        let transaction_id = NEXT_TRANSACTION_ID.fetch_add(1, Ordering::Relaxed);
+        let query =
+            build_dns_query(transaction_id).map_err(|error| error.with_attempts(attempts))?;
+        if let Err(error) = socket.send(&query) {
+            last_error =
+                DnsReadinessError::io(DnsReadinessStage::SendQuery, &error).with_attempts(attempts);
+            sleep_before_retry(deadline);
+            continue;
+        }
+
+        let mut response = [0_u8; DNS_RESPONSE_MAX_BYTES];
+        match socket.recv(&mut response) {
+            Ok(size) => {
+                let Some(response) = response.get(..size) else {
+                    last_error = invalid_response().with_attempts(attempts);
+                    sleep_before_retry(deadline);
+                    continue;
+                };
+                match validate_dns_response(response, transaction_id, DNS_READINESS_IPV4) {
+                    Ok(()) => return Ok(attempts),
+                    Err(error) => last_error = error.with_attempts(attempts),
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                last_error = DnsReadinessError::timeout().with_attempts(attempts);
+            }
+            Err(error) => {
+                last_error = DnsReadinessError::io(DnsReadinessStage::ReceiveResponse, &error)
+                    .with_attempts(attempts);
+            }
+        }
+        sleep_before_retry(deadline);
+    }
+}
+
+fn sleep_before_retry(deadline: Instant) {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if !remaining.is_zero() {
+        std::thread::sleep(PROBE_RETRY_DELAY.min(remaining));
+    }
+}
+
+fn build_dns_query(transaction_id: u16) -> Result<Vec<u8>, DnsReadinessError> {
+    let mut query = Vec::with_capacity(64);
+    query.extend_from_slice(&transaction_id.to_be_bytes());
+    query.extend_from_slice(&DNS_QUERY_FLAGS_RECURSION_DESIRED.to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+    for label in DNS_READINESS_HOSTNAME.split('.') {
+        let length = u8::try_from(label.len())
+            .map_err(|_| DnsReadinessError::stage(DnsReadinessStage::BuildQuery))?;
+        query.push(length);
+        query.extend_from_slice(label.as_bytes());
+    }
+    query.push(0);
+    query.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
+    query.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+    Ok(query)
+}
+
+fn validate_dns_response(
+    response: &[u8],
+    transaction_id: u16,
+    expected_ip: Ipv4Addr,
+) -> Result<(), DnsReadinessError> {
+    let mut cursor = 0;
+    let response_id = read_u16(response, &mut cursor)?;
+    let flags = read_u16(response, &mut cursor)?;
+    let question_count = read_u16(response, &mut cursor)?;
+    let answer_count = read_u16(response, &mut cursor)?;
+    let _authority_count = read_u16(response, &mut cursor)?;
+    let _additional_count = read_u16(response, &mut cursor)?;
+
+    if response_id != transaction_id
+        || flags & DNS_RESPONSE_FLAG == 0
+        || flags & DNS_RESPONSE_CODE_MASK != 0
+        || question_count != 1
+        || answer_count == 0
+    {
+        return Err(DnsReadinessError::stage(
+            DnsReadinessStage::ValidateResponse,
+        ));
+    }
+
+    skip_dns_name(response, &mut cursor)?;
+    skip_bytes(response, &mut cursor, 4)?;
+
+    for _ in 0..answer_count {
+        skip_dns_name(response, &mut cursor)?;
+        let record_type = read_u16(response, &mut cursor)?;
+        let class = read_u16(response, &mut cursor)?;
+        skip_bytes(response, &mut cursor, 4)?;
+        let data_len = usize::from(read_u16(response, &mut cursor)?);
+        let data_start = cursor;
+        skip_bytes(response, &mut cursor, data_len)?;
+        let expected_octets = expected_ip.octets();
+        if record_type == DNS_TYPE_A
+            && class == DNS_CLASS_IN
+            && data_len == 4
+            && response.get(data_start..cursor) == Some(expected_octets.as_ref())
+        {
+            return Ok(());
+        }
+    }
+
+    Err(DnsReadinessError::stage(
+        DnsReadinessStage::ValidateResponse,
+    ))
+}
+
+fn read_u16(response: &[u8], cursor: &mut usize) -> Result<u16, DnsReadinessError> {
+    let end = cursor.checked_add(2).ok_or_else(invalid_response)?;
+    let bytes = response
+        .get(*cursor..end)
+        .and_then(|bytes| <[u8; 2]>::try_from(bytes).ok())
+        .ok_or_else(invalid_response)?;
+    *cursor = end;
+    Ok(u16::from_be_bytes(bytes))
+}
+
+fn skip_bytes(response: &[u8], cursor: &mut usize, count: usize) -> Result<(), DnsReadinessError> {
+    *cursor = cursor.checked_add(count).ok_or_else(invalid_response)?;
+    if *cursor > response.len() {
+        return Err(invalid_response());
+    }
+    Ok(())
+}
+
+fn skip_dns_name(response: &[u8], cursor: &mut usize) -> Result<(), DnsReadinessError> {
+    loop {
+        let length = *response.get(*cursor).ok_or_else(invalid_response)?;
+        *cursor += 1;
+        if length == 0 {
+            return Ok(());
+        }
+        if length & 0xc0 == 0xc0 {
+            skip_bytes(response, cursor, 1)?;
+            return Ok(());
+        }
+        if length & 0xc0 != 0 {
+            return Err(invalid_response());
+        }
+        skip_bytes(response, cursor, usize::from(length))?;
+    }
+}
+
+fn invalid_response() -> DnsReadinessError {
+    DnsReadinessError::stage(DnsReadinessStage::ValidateResponse)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    fn response_for_query(query: &[u8], answer: Ipv4Addr) -> Vec<u8> {
+        let mut response = Vec::new();
+        response.extend_from_slice(query.get(..2).unwrap());
+        response.extend_from_slice(&0x8180_u16.to_be_bytes());
+        response.extend_from_slice(&1_u16.to_be_bytes());
+        response.extend_from_slice(&1_u16.to_be_bytes());
+        response.extend_from_slice(&0_u16.to_be_bytes());
+        response.extend_from_slice(&0_u16.to_be_bytes());
+        response.extend_from_slice(query.get(12..).unwrap());
+        response.extend_from_slice(&[0xc0, 0x0c]);
+        response.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
+        response.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+        response.extend_from_slice(&0_u32.to_be_bytes());
+        response.extend_from_slice(&4_u16.to_be_bytes());
+        response.extend_from_slice(&answer.octets());
+        response
+    }
+
+    #[test]
+    fn query_uses_readiness_name_and_a_record() {
+        let query = build_dns_query(0x1234).unwrap();
+
+        assert_eq!(query.get(..2).unwrap(), &0x1234_u16.to_be_bytes());
+        assert_eq!(
+            query.get(2..4).unwrap(),
+            &DNS_QUERY_FLAGS_RECURSION_DESIRED.to_be_bytes()
+        );
+        assert!(
+            query
+                .windows("vm0-readiness".len())
+                .any(|part| part == b"vm0-readiness")
+        );
+        assert_eq!(query.get(query.len() - 4..).unwrap(), &[0, 1, 0, 1]);
+    }
+
+    #[test]
+    fn response_validation_accepts_expected_compressed_a_record() {
+        let query = build_dns_query(0x1234).unwrap();
+        let response = response_for_query(&query, DNS_READINESS_IPV4);
+
+        validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).unwrap();
+    }
+
+    #[test]
+    fn response_validation_rejects_wrong_transaction_and_answer() {
+        let query = build_dns_query(0x1234).unwrap();
+        let response = response_for_query(&query, Ipv4Addr::new(192, 0, 2, 2));
+
+        assert!(validate_dns_response(&response, 0x4321, DNS_READINESS_IPV4).is_err());
+        assert!(validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).is_err());
+    }
+
+    #[test]
+    fn response_validation_rejects_truncated_name() {
+        let query = build_dns_query(0x1234).unwrap();
+        let mut response = response_for_query(&query, DNS_READINESS_IPV4);
+        response.truncate(13);
+
+        assert!(validate_dns_response(&response, 0x1234, DNS_READINESS_IPV4).is_err());
+    }
+
+    #[test]
+    fn endpoint_probe_accepts_controlled_local_response() {
+        let server = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let destination = match server.local_addr().unwrap() {
+            std::net::SocketAddr::V4(address) => address,
+            std::net::SocketAddr::V6(_) => panic!("test server should use IPv4"),
+        };
+        let server_thread = std::thread::spawn(move || {
+            let mut query = [0_u8; DNS_RESPONSE_MAX_BYTES];
+            let (size, peer) = server.recv_from(&mut query).unwrap();
+            let response = response_for_query(&query[..size], DNS_READINESS_IPV4);
+            server.send_to(&response, peer).unwrap();
+        });
+
+        probe_dns_endpoint(destination, Duration::from_secs(1)).unwrap();
+        server_thread.join().unwrap();
+    }
+
+    #[test]
+    fn endpoint_probe_times_out_without_response() {
+        let server = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let destination = match server.local_addr().unwrap() {
+            std::net::SocketAddr::V4(address) => address,
+            std::net::SocketAddr::V6(_) => panic!("test server should use IPv4"),
+        };
+        let (received_tx, received_rx) = mpsc::channel();
+        let server_thread = std::thread::spawn(move || {
+            let mut query = [0_u8; DNS_RESPONSE_MAX_BYTES];
+            server.recv_from(&mut query).unwrap();
+            received_tx.send(()).unwrap();
+            std::thread::sleep(Duration::from_millis(100));
+        });
+
+        let error = probe_dns_endpoint(destination, Duration::from_millis(30)).unwrap_err();
+
+        received_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        server_thread.join().unwrap();
+        assert_eq!(error.stage_name(), DnsReadinessStage::Timeout);
+    }
+}

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -127,6 +127,19 @@ impl SandboxRuntime for FirecrackerRuntime {
         }
     }
 
+    async fn activate_dns_readiness(&self) -> sandbox::Result<()> {
+        if self.dns_port.is_none() {
+            return Ok(());
+        }
+        self.netns_pool
+            .activate_dns_readiness()
+            .await
+            .map_err(|e| SandboxError::Initialization {
+                phase: SandboxInitializationPhase::Runtime,
+                message: format!("netns DNS readiness: {e}"),
+            })
+    }
+
     async fn shutdown(&mut self) {
         // Clean up shared netns pool.
         if let Err(e) = self.netns_pool.cleanup().await {

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -29,8 +29,19 @@ pub trait SandboxRuntime: Send + Sync {
     ///
     /// Backends that create VM-facing host interfaces can return a scoped
     /// pattern here so dnsmasq avoids listening on unrelated host interfaces.
+    /// When this returns a pattern, the caller must start DNS and call
+    /// [`Self::activate_dns_readiness`] before creating factories.
     async fn dns_interface_pattern(&self) -> Option<String> {
         None
+    }
+
+    /// Admit runtime resources that depend on runner-managed DNS.
+    ///
+    /// The runner calls this after starting DNS on the interface pattern
+    /// returned by [`Self::dns_interface_pattern`]. Backends without that
+    /// dependency can use the default no-op implementation.
+    async fn activate_dns_readiness(&self) -> Result<()> {
+        Ok(())
     }
 
     /// Release shared resources (network pools, device caches).
@@ -52,10 +63,13 @@ pub trait RuntimeProvider: Send + Sync {
     /// Implementations may validate these values and initialize
     /// backend-specific shared resources while creating the runtime.
     ///
-    /// On success, the returned runtime is ready for
-    /// [`SandboxRuntime::create_factory`] calls. This does not create or
-    /// initialize any factory; factory initialization remains part of
-    /// [`SandboxRuntime::create_factory`].
+    /// On success, a runtime that does not expose a DNS interface pattern is
+    /// ready for [`SandboxRuntime::create_factory`] calls. When
+    /// [`SandboxRuntime::dns_interface_pattern`] returns a pattern, the caller
+    /// must start runner-managed DNS and call
+    /// [`SandboxRuntime::activate_dns_readiness`] first. Runtime creation does
+    /// not create or initialize any factory; factory initialization remains
+    /// part of [`SandboxRuntime::create_factory`].
     ///
     /// The caller owns the returned runtime and is responsible for eventually
     /// calling [`SandboxRuntime::shutdown`] after all factories created from it


### PR DESCRIPTION
## Summary

- keep DNS-enabled namespace pools closed until their prewarmed namespaces pass a functional readiness probe
- validate the namespace route, veth, DNS REDIRECT, and dnsmasq listener with a bounded runner-owned UDP query and local `.invalid` answer
- delete failed namespaces before admission, probe later replenishment through the same boundary, and surface empty-pool creation failures without hot-looping through namespace indexes
- activate readiness after dnsmasq starts and assert the real startup event in the existing metal runner workflow

## Explicit exclusions

- keeps the pool-scoped dnsmasq `--interface` and `--bind-dynamic` security model unchanged
- does not add per-acquisition probes or depend on public DNS for readiness
- keeps the existing guest TCP DNS and upstream resolution checks as separate metal-host coverage

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `actionlint .github/workflows/crates.yml`
- `git diff --check`

Closes #21291
