### PR TITLE
perf(api): bound incomplete chat round loading

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3195,6 +3195,117 @@ describe("CHAT-02: auto-send after failures", () => {
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
+
+  it("keeps only the newest 20 incomplete rounds for normal and queued callback sends", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await startChatRun(actor, {
+      agentId,
+      prompt: "successful frontier anchor",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorHeaders);
+    await flushWaitUntilForTest();
+
+    const historyPrompts = Array.from({ length: 21 }, (_, index) => {
+      return `incomplete frontier history ${String(index).padStart(2, "0")}`;
+    });
+    for (const prompt of historyPrompts) {
+      const round = await startChatRun(actor, {
+        agentId,
+        threadId: anchor.threadId,
+        prompt,
+      });
+      await api.requestCancelRun(actor, round.runId, [200]);
+      await waitForRunStatus(actor, round.runId, "cancelled");
+    }
+    await flushWaitUntilForTest();
+
+    const normalPrompt = "normal frontier probe";
+    const normal = await startChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: normalPrompt,
+    });
+    const normalContext = await waitForRunContext(actor, normal.runId);
+    const normalAppended = normalContext.body.appendSystemPrompt ?? "";
+    expect(normalAppended).toContain("# Incomplete Rounds Context");
+    expect(normalAppended.match(/^- RUN_STATUS:/gm) ?? []).toHaveLength(20);
+    expect(normalAppended).not.toContain(historyPrompts[0]);
+    expect(normalAppended).not.toContain("successful frontier anchor");
+    for (const prompt of historyPrompts.slice(1)) {
+      expect(normalAppended).toContain(prompt);
+    }
+    const normalPositions = historyPrompts.slice(1).map((prompt) => {
+      return normalAppended.indexOf(prompt);
+    });
+    expect(normalPositions).toStrictEqual(
+      [...normalPositions].sort((left, right) => {
+        return left - right;
+      }),
+    );
+
+    const normalHeaders = await claimChatRun(runnerGroup, normal.runId);
+    const queuedPrompt = "queued callback frontier probe";
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: queuedPrompt,
+    });
+    await failChatRun(normal.runId, normalHeaders, "frontier probe failed");
+
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.content === queuedPrompt && message.runId !== undefined
+          );
+        });
+      },
+    );
+    const autoSent = userMessages(messages.messages).find((message) => {
+      return message.content === queuedPrompt && message.runId !== undefined;
+    });
+    if (!autoSent?.runId) {
+      throw new Error("Expected the queued frontier probe to auto-send");
+    }
+
+    const callbackContext = await waitForRunContext(actor, autoSent.runId);
+    const callbackAppended = callbackContext.body.appendSystemPrompt ?? "";
+    expect(callbackAppended).toContain("# Incomplete Rounds Context");
+    expect(callbackAppended.match(/^- RUN_STATUS:/gm) ?? []).toHaveLength(20);
+    expect(
+      callbackAppended.match(/^- RUN_STATUS: cancelled$/gm) ?? [],
+    ).toHaveLength(19);
+    expect(
+      callbackAppended.match(/^- RUN_STATUS: failed$/gm) ?? [],
+    ).toHaveLength(1);
+    expect(callbackAppended).not.toContain(historyPrompts[0]);
+    expect(callbackAppended).not.toContain(historyPrompts[1]);
+    expect(callbackAppended).toContain(normalPrompt);
+    for (const prompt of historyPrompts.slice(2)) {
+      expect(callbackAppended).toContain(prompt);
+    }
+    const callbackPositions = [...historyPrompts.slice(2), normalPrompt].map(
+      (prompt) => {
+        return callbackAppended.indexOf(prompt);
+      },
+    );
+    expect(callbackPositions).toStrictEqual(
+      [...callbackPositions].sort((left, right) => {
+        return left - right;
+      }),
+    );
+
+    await api.requestCancelRun(actor, autoSent.runId, [200]);
+    await waitForRunStatus(actor, autoSent.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
 });
 
 describe("CHAT-02: auto-send across a model switch", () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -86,6 +86,7 @@ import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
 } from "../services/zero-chat-message-shared.service";
+import { loadWebChatIncompleteContext } from "../services/zero-chat-incomplete-context.service";
 import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-marker.service";
 import { appendChatThreadEvent } from "../services/zero-chat-thread-event.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
@@ -172,27 +173,6 @@ interface WebChatPriorRun {
 interface LatestThreadSession {
   readonly sessionId: string;
   readonly selectedModel: string | null;
-}
-
-interface WebChatIncompleteRoundMessage {
-  readonly role: "user" | "assistant";
-  readonly content: string | null;
-  readonly error: string | null;
-  readonly attachFiles: readonly string[] | null;
-  readonly generationTemplate: ChatMessageGenerationTemplate | null;
-}
-
-interface WebChatIncompleteRound {
-  readonly runId: string;
-  readonly status: "cancelled" | "failed" | "timeout";
-  readonly messages: WebChatIncompleteRoundMessage[];
-}
-
-interface IncompleteRoundRow extends WebChatIncompleteRoundMessage {
-  readonly runId: string;
-  readonly runStatus: "cancelled" | "failed" | "timeout";
-  readonly createdAt: Date;
-  readonly sequenceNumber: number | null;
 }
 
 type IncomingModelSelection = NormalSendBody["modelSelection"];
@@ -319,7 +299,6 @@ const sendBody$ = bodyResultOf(chatMessagesContract.send);
 // prompt. Session compatibility is decided server-side from the target model.
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
-const WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
 const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
 
 function forbidden(message: string) {
@@ -600,13 +579,6 @@ function truncatePrior(value: string): string {
   return `${value.slice(0, WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP)}...[truncated]`;
 }
 
-function truncateIncomplete(value: string): string {
-  if (value.length <= WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP) {
-    return value;
-  }
-  return `${value.slice(0, WEB_CHAT_INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
-}
-
 function formatAttachFileIds(
   ids: readonly string[] | null | undefined,
 ): string {
@@ -676,97 +648,6 @@ function buildWebChatPriorRunsContext(
     "",
     "---",
   ].join("\n");
-}
-
-function formatIncompleteMessage(
-  message: WebChatIncompleteRoundMessage,
-): string {
-  const attach = formatAttachFileIds(message.attachFiles);
-  if (message.role === "user") {
-    const body =
-      message.content !== null && message.content !== ""
-        ? truncateIncomplete(message.content)
-        : "[empty message]";
-    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
-  }
-  if (message.content !== null && message.content !== "") {
-    return `Assistant (partial): ${truncateIncomplete(message.content)}`;
-  }
-  return "Assistant: [no response before run ended]";
-}
-
-function buildWebChatIncompleteContext(
-  rounds: readonly WebChatIncompleteRound[],
-): string {
-  if (rounds.length === 0) {
-    return "";
-  }
-  const total = rounds.length;
-  const blocks = rounds.map((round, index) => {
-    const relativeIndex = index - total + 1;
-    const rendered = round.messages.map(formatIncompleteMessage);
-    const hasAssistant = round.messages.some((message) => {
-      return message.role === "assistant";
-    });
-    if (!hasAssistant) {
-      rendered.push("Assistant: [no response before run ended]");
-    }
-    return [
-      "---",
-      "",
-      `- RELATIVE_INDEX: ${relativeIndex}`,
-      `- RUN_STATUS: ${round.status}`,
-      "",
-      ...rendered,
-    ].join("\n");
-  });
-  return [
-    "# Incomplete Rounds Context",
-    "",
-    "The rounds below were sent in this thread but their runs did not complete",
-    "(cancelled, failed, or timed out), so the CLI session history does not",
-    "contain them. Treat them as part of the conversation you are having with",
-    "the user. RELATIVE_INDEX 0 is the most recent incomplete round.",
-    "",
-    blocks.join("\n\n"),
-    "",
-    "---",
-  ].join("\n");
-}
-
-function isIncompleteRunStatus(
-  value: string | null,
-): value is "cancelled" | "failed" | "timeout" {
-  return value === "cancelled" || value === "failed" || value === "timeout";
-}
-
-function groupIncompleteRoundsByRunId(
-  rows: readonly IncompleteRoundRow[],
-): WebChatIncompleteRound[] {
-  const byRunId = new Map<string, WebChatIncompleteRound>();
-  const order: string[] = [];
-  for (const row of rows) {
-    let round = byRunId.get(row.runId);
-    if (!round) {
-      round = { runId: row.runId, status: row.runStatus, messages: [] };
-      byRunId.set(row.runId, round);
-      order.push(row.runId);
-    }
-    round.messages.push({
-      role: row.role,
-      content: row.content,
-      error: row.error,
-      attachFiles: row.attachFiles,
-      generationTemplate: row.generationTemplate,
-    });
-  }
-  return order.map((runId) => {
-    const round = byRunId.get(runId);
-    if (!round) {
-      throw new Error("Incomplete round grouping lost run id");
-    }
-    return round;
-  });
 }
 
 async function loadAgentForChatSend(
@@ -924,93 +805,6 @@ async function getLatestRunsByThreadId(
       prompt: run.prompt,
       messages: messagesByRunId.get(run.runId) ?? [],
     };
-  });
-}
-
-async function getIncompleteRoundsSinceLastSuccess(
-  db: Db,
-  threadId: string,
-  maxRounds = 20,
-): Promise<IncompleteRoundRow[]> {
-  const rows = await db
-    .select({
-      runId: chatMessages.runId,
-      role: chatMessages.role,
-      content: chatMessages.content,
-      error: chatMessages.error,
-      attachFiles: chatMessages.attachFiles,
-      createdAt: chatMessages.createdAt,
-      sequenceNumber: chatMessages.sequenceNumber,
-      runStatus: agentRuns.status,
-      generationTemplate: chatMessages.generationTemplate,
-    })
-    .from(chatMessages)
-    .innerJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
-    .where(
-      and(
-        eq(chatMessages.chatThreadId, threadId),
-        visibleChatMessageCondition(),
-        inArray(agentRuns.status, ["cancelled", "failed", "timeout"]),
-        inArray(chatMessages.role, ["user", "assistant"]),
-        sql`${chatMessages.createdAt} > COALESCE(
-          (
-            SELECT MAX(cm2.created_at)
-            FROM chat_messages cm2
-            INNER JOIN agent_runs ar2 ON ar2.id = cm2.run_id
-            WHERE cm2.chat_thread_id = ${threadId}
-              AND NOT EXISTS (
-                SELECT 1
-                FROM chat_messages revoker2
-                WHERE revoker2.revokes_message_id = cm2.id
-              )
-              AND ar2.result ? 'agentSessionId'
-              AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'
-          ),
-          '-infinity'::timestamptz
-        )`,
-      ),
-    )
-    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
-
-  const candidates: IncompleteRoundRow[] = [];
-  for (const row of rows) {
-    if (row.runId === null) {
-      continue;
-    }
-    if (!isIncompleteRunStatus(row.runStatus)) {
-      continue;
-    }
-    if (row.role !== "user" && row.role !== "assistant") {
-      continue;
-    }
-    candidates.push({
-      runId: row.runId,
-      runStatus: row.runStatus,
-      role: row.role,
-      content: row.content,
-      error: row.error,
-      attachFiles: row.attachFiles,
-      createdAt: row.createdAt,
-      sequenceNumber: row.sequenceNumber,
-      generationTemplate: row.generationTemplate,
-    });
-  }
-
-  const orderedRunIds: string[] = [];
-  const seen = new Set<string>();
-  for (const row of candidates) {
-    if (!seen.has(row.runId)) {
-      seen.add(row.runId);
-      orderedRunIds.push(row.runId);
-    }
-  }
-  if (orderedRunIds.length <= maxRounds) {
-    return candidates;
-  }
-
-  const keep = new Set(orderedRunIds.slice(orderedRunIds.length - maxRounds));
-  return candidates.filter((row) => {
-    return keep.has(row.runId);
   });
 }
 
@@ -1705,9 +1499,9 @@ async function resolveThread(params: {
     return notFound("Chat thread not found");
   }
 
-  const [latestSession, incompleteRows] = await Promise.all([
+  const [latestSession, incompleteContext] = await Promise.all([
     latestSessionForThread(params.db, thread.id),
-    getIncompleteRoundsSinceLastSuccess(params.db, thread.id),
+    loadWebChatIncompleteContext(params.db, thread.id),
   ]);
   const startNewSession = shouldStartNewSessionForSelectedModel({
     latestSession,
@@ -1719,11 +1513,7 @@ async function resolveThread(params: {
   return {
     threadId: thread.id,
     sessionId: startNewSession ? undefined : latestSession?.sessionId,
-    incompleteContext: startNewSession
-      ? ""
-      : buildWebChatIncompleteContext(
-          groupIncompleteRoundsByRunId(incompleteRows),
-        ),
+    incompleteContext: startNewSession ? "" : incompleteContext,
     computerUseHostId: thread.computerUseHostId,
     codexServiceTier: thread.codexServiceTier,
     isNewThread: false,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -59,6 +59,7 @@ import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
+import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { recommendedFollowupsMessageIdForRun } from "./assistant-message-id";
 import {
@@ -83,7 +84,6 @@ const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
-const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
 
 type ChatCallbackPreCreateTimingSpanKind = "top_level" | "nested";
 
@@ -299,30 +299,6 @@ interface CompletedChatOutputLoad {
   readonly resultFallback: ResultEventItem | null;
   readonly lastResultText: string | null;
   readonly skipExistingAssistantLookup: boolean;
-}
-
-interface IncompleteRoundRow {
-  readonly runId: string;
-  readonly runStatus: "cancelled" | "failed" | "timeout";
-  readonly role: "user" | "assistant";
-  readonly content: string | null;
-  readonly error: string | null;
-  readonly attachFiles: readonly string[] | null;
-  readonly generationTemplate: ChatMessageGenerationTemplate | null;
-}
-
-interface IncompleteRound {
-  readonly runId: string;
-  readonly status: "cancelled" | "failed" | "timeout";
-  readonly messages: IncompleteRoundMessage[];
-}
-
-interface IncompleteRoundMessage {
-  readonly role: "user" | "assistant";
-  readonly content: string | null;
-  readonly error: string | null;
-  readonly attachFiles: readonly string[] | null;
-  readonly generationTemplate: ChatMessageGenerationTemplate | null;
 }
 
 interface PriorRunMessage {
@@ -1291,13 +1267,6 @@ function truncatePrior(value: string): string {
   return `${value.slice(0, PRIOR_MESSAGE_CHAR_CAP)}...[truncated]`;
 }
 
-function truncateIncomplete(value: string): string {
-  if (value.length <= INCOMPLETE_MESSAGE_CHAR_CAP) {
-    return value;
-  }
-  return `${value.slice(0, INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
-}
-
 function formatPriorRunMessage(message: PriorRunMessage): string {
   const roleLabel = message.role === "user" ? "User" : "Assistant";
   const body = `${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`;
@@ -1336,181 +1305,6 @@ function buildWebChatPriorRunsContext(runs: readonly PriorRun[]): string {
     "",
     ...sections,
   ].join("\n");
-}
-
-function formatIncompleteMessage(message: IncompleteRoundMessage): string {
-  const attach = formatAttachFileIds(message.attachFiles);
-  if (message.role === "user") {
-    const body =
-      message.content !== null && message.content !== ""
-        ? truncateIncomplete(message.content)
-        : "[empty message]";
-    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
-  }
-  if (message.content !== null && message.content !== "") {
-    return `Assistant (partial): ${truncateIncomplete(message.content)}`;
-  }
-  return "Assistant: [no response before run ended]";
-}
-
-function buildWebChatIncompleteContext(
-  rounds: readonly IncompleteRound[],
-): string {
-  if (rounds.length === 0) {
-    return "";
-  }
-  const total = rounds.length;
-  const blocks = rounds.map((round, index) => {
-    const relativeIndex = index - total + 1;
-    const rendered = round.messages.map(formatIncompleteMessage);
-    const hasAssistant = round.messages.some((message) => {
-      return message.role === "assistant";
-    });
-    if (!hasAssistant) {
-      rendered.push("Assistant: [no response before run ended]");
-    }
-    return [
-      "---",
-      "",
-      `- RELATIVE_INDEX: ${relativeIndex}`,
-      `- RUN_STATUS: ${round.status}`,
-      "",
-      ...rendered,
-    ].join("\n");
-  });
-  return [
-    "# Incomplete Rounds Context",
-    "",
-    "The rounds below were sent in this thread but their runs did not complete",
-    "(cancelled, failed, or timed out), so the CLI session history does not",
-    "contain them. Treat them as part of the conversation you are having with",
-    "the user. RELATIVE_INDEX 0 is the most recent incomplete round.",
-    "",
-    blocks.join("\n\n"),
-    "",
-    "---",
-  ].join("\n");
-}
-
-function isIncompleteRunStatus(
-  value: string | null,
-): value is "cancelled" | "failed" | "timeout" {
-  return value === "cancelled" || value === "failed" || value === "timeout";
-}
-
-function groupIncompleteRoundsByRunId(
-  rows: readonly IncompleteRoundRow[],
-): readonly IncompleteRound[] {
-  const byRunId = new Map<string, IncompleteRound>();
-  const order: string[] = [];
-  for (const row of rows) {
-    let round = byRunId.get(row.runId);
-    if (!round) {
-      round = {
-        runId: row.runId,
-        status: row.runStatus,
-        messages: [],
-      };
-      byRunId.set(row.runId, round);
-      order.push(row.runId);
-    }
-    round.messages.push({
-      role: row.role,
-      content: row.content,
-      error: row.error,
-      attachFiles: row.attachFiles,
-      generationTemplate: row.generationTemplate,
-    });
-  }
-  return order.map((runId) => {
-    const round = byRunId.get(runId);
-    if (!round) {
-      throw new Error("Incomplete round grouping lost run id");
-    }
-    return round;
-  });
-}
-
-async function getIncompleteRoundsSinceLastSuccess(
-  db: Db,
-  threadId: string,
-  maxRounds = 20,
-): Promise<readonly IncompleteRoundRow[]> {
-  const rows = await db
-    .select({
-      runId: chatMessages.runId,
-      role: chatMessages.role,
-      content: chatMessages.content,
-      error: chatMessages.error,
-      attachFiles: chatMessages.attachFiles,
-      createdAt: chatMessages.createdAt,
-      sequenceNumber: chatMessages.sequenceNumber,
-      runStatus: agentRuns.status,
-      generationTemplate: chatMessages.generationTemplate,
-    })
-    .from(chatMessages)
-    .innerJoin(agentRuns, eq(agentRuns.id, chatMessages.runId))
-    .where(
-      and(
-        eq(chatMessages.chatThreadId, threadId),
-        visibleChatMessageCondition(),
-        inArray(agentRuns.status, ["cancelled", "failed", "timeout"]),
-        inArray(chatMessages.role, ["user", "assistant"]),
-        sql`${chatMessages.createdAt} > COALESCE(
-          (
-            SELECT MAX(cm2.created_at)
-            FROM chat_messages cm2
-            INNER JOIN agent_runs ar2 ON ar2.id = cm2.run_id
-            WHERE cm2.chat_thread_id = ${threadId}
-              AND NOT EXISTS (
-                SELECT 1
-                FROM chat_messages revoker2
-                WHERE revoker2.revokes_message_id = cm2.id
-              )
-              AND ar2.result ? 'agentSessionId'
-              AND jsonb_typeof(ar2.result->'agentSessionId') = 'string'
-          ),
-          '-infinity'::timestamptz
-        )`,
-      ),
-    )
-    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
-
-  const candidates: IncompleteRoundRow[] = [];
-  for (const row of rows) {
-    if (row.runId === null || !isIncompleteRunStatus(row.runStatus)) {
-      continue;
-    }
-    if (row.role !== "user" && row.role !== "assistant") {
-      continue;
-    }
-    candidates.push({
-      runId: row.runId,
-      runStatus: row.runStatus,
-      role: row.role,
-      content: row.content,
-      error: row.error,
-      attachFiles: row.attachFiles,
-      generationTemplate: row.generationTemplate,
-    });
-  }
-
-  const orderedRunIds: string[] = [];
-  const seen = new Set<string>();
-  for (const row of candidates) {
-    if (!seen.has(row.runId)) {
-      seen.add(row.runId);
-      orderedRunIds.push(row.runId);
-    }
-  }
-  if (orderedRunIds.length <= maxRounds) {
-    return candidates;
-  }
-
-  const keep = new Set(orderedRunIds.slice(orderedRunIds.length - maxRounds));
-  return candidates.filter((row) => {
-    return keep.has(row.runId);
-  });
 }
 
 async function getLatestRunsByThreadId(
@@ -1866,7 +1660,7 @@ async function buildCreateQueuedChatRunInput(args: {
     },
   );
 
-  const [latestSession, incompleteRows] =
+  const [latestSession, loadedIncompleteContext] =
     await measureChatCallbackPreCreateTiming(
       args.timing,
       "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
@@ -1874,7 +1668,7 @@ async function buildCreateQueuedChatRunInput(args: {
       () => {
         return Promise.all([
           latestSessionForThreadFromDb(args.db, args.threadId),
-          getIncompleteRoundsSinceLastSuccess(args.db, args.threadId),
+          loadWebChatIncompleteContext(args.db, args.threadId),
         ]);
       },
     );
@@ -1882,11 +1676,7 @@ async function buildCreateQueuedChatRunInput(args: {
     latestSession,
     queuedMessage: resolvedQueuedMessage,
   });
-  const incompleteContext = startNewSession
-    ? ""
-    : buildWebChatIncompleteContext(
-        groupIncompleteRoundsByRunId(incompleteRows),
-      );
+  const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prior_context",

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -184,7 +184,6 @@ async function loadSelectedIncompleteRounds(
     }),
   );
   const roundsByRunId = new Map<string, IncompleteRound>();
-  const orderedRunIds: string[] = [];
   for (const row of rows) {
     if (row.runId === null) {
       continue;
@@ -200,7 +199,6 @@ async function loadSelectedIncompleteRounds(
     if (round === undefined) {
       round = { runId: row.runId, status, messages: [] };
       roundsByRunId.set(row.runId, round);
-      orderedRunIds.push(row.runId);
     }
     round.messages.push({
       role: row.role,
@@ -209,13 +207,7 @@ async function loadSelectedIncompleteRounds(
     });
   }
 
-  return orderedRunIds.map((runId) => {
-    const round = roundsByRunId.get(runId);
-    if (round === undefined) {
-      throw new Error("Incomplete round grouping lost run id");
-    }
-    return round;
-  });
+  return [...roundsByRunId.values()];
 }
 
 function formatAttachFileIds(

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,8 +1,5 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import {
-  chatMessages,
-  type ChatMessageGenerationTemplate,
-} from "@vm0/db/schema/chat-message";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
@@ -21,9 +18,7 @@ interface IncompleteRoundSelection {
 interface IncompleteRoundMessage {
   readonly role: "user" | "assistant";
   readonly content: string | null;
-  readonly error: string | null;
   readonly attachFiles: readonly string[] | null;
-  readonly generationTemplate: ChatMessageGenerationTemplate | null;
 }
 
 interface IncompleteRound extends IncompleteRoundSelection {
@@ -54,7 +49,7 @@ async function selectIncompleteRoundFrontier(
   )`;
   // Terminal chat materialization runs in waitUntil, so lifecycle rows can lag
   // behind agent_runs.status. Walk the existing recent-message index instead.
-  // The fixed 21-run frontier is the 20-round output plus one success sentinel.
+  // The fixed 21-run frontier is the 20-round output plus one boundary candidate.
   const result = await db.execute<IncompleteRoundFrontierRow>(sql`
     WITH RECURSIVE incomplete_frontier AS (
       SELECT
@@ -167,9 +162,7 @@ async function loadSelectedIncompleteRounds(
       runId: chatMessages.runId,
       role: chatMessages.role,
       content: chatMessages.content,
-      error: chatMessages.error,
       attachFiles: chatMessages.attachFiles,
-      generationTemplate: chatMessages.generationTemplate,
     })
     .from(chatMessages)
     .where(
@@ -212,9 +205,7 @@ async function loadSelectedIncompleteRounds(
     round.messages.push({
       role: row.role,
       content: row.content,
-      error: row.error,
       attachFiles: row.attachFiles,
-      generationTemplate: row.generationTemplate,
     });
   }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,0 +1,311 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import {
+  chatMessages,
+  type ChatMessageGenerationTemplate,
+} from "@vm0/db/schema/chat-message";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
+
+const INCOMPLETE_ROUND_LIMIT = 20;
+const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+
+type IncompleteRunStatus = "cancelled" | "failed" | "timeout";
+
+interface IncompleteRoundSelection {
+  readonly runId: string;
+  readonly status: IncompleteRunStatus;
+}
+
+interface IncompleteRoundMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string | null;
+  readonly error: string | null;
+  readonly attachFiles: readonly string[] | null;
+  readonly generationTemplate: ChatMessageGenerationTemplate | null;
+}
+
+interface IncompleteRound extends IncompleteRoundSelection {
+  readonly messages: IncompleteRoundMessage[];
+}
+
+interface IncompleteRoundFrontierRow extends Record<string, unknown> {
+  readonly runId: string;
+  readonly runStatus: string;
+  readonly isSuccess: boolean;
+}
+
+function isIncompleteRunStatus(value: string): value is IncompleteRunStatus {
+  return value === "cancelled" || value === "failed" || value === "timeout";
+}
+
+async function selectIncompleteRoundFrontier(
+  db: Db,
+  threadId: string,
+): Promise<{
+  readonly rounds: readonly IncompleteRoundSelection[];
+  readonly successfulRunId: string | null;
+}> {
+  const isSuccessfulRun = sql<boolean>`COALESCE(
+    ${agentRuns.result} ? 'agentSessionId'
+    AND jsonb_typeof(${agentRuns.result}->'agentSessionId') = 'string',
+    FALSE
+  )`;
+  // Terminal chat materialization runs in waitUntil, so lifecycle rows can lag
+  // behind agent_runs.status. Walk the existing recent-message index instead.
+  // The fixed 21-run frontier is the 20-round output plus one success sentinel.
+  const result = await db.execute<IncompleteRoundFrontierRow>(sql`
+    WITH RECURSIVE incomplete_frontier AS (
+      SELECT
+        ARRAY[]::uuid[] AS seen_run_ids,
+        NULL::uuid AS run_id,
+        NULL::text AS run_status,
+        FALSE AS is_success,
+        0 AS depth
+
+      UNION ALL
+
+      SELECT
+        incomplete_frontier.seen_run_ids || candidate.run_id,
+        candidate.run_id,
+        candidate.run_status,
+        candidate.is_success,
+        incomplete_frontier.depth + 1
+      FROM incomplete_frontier
+      CROSS JOIN LATERAL (
+        SELECT
+          ${chatMessages.runId} AS run_id,
+          ${agentRuns.status} AS run_status,
+          (${isSuccessfulRun}) AS is_success
+        FROM ${chatMessages}
+        INNER JOIN ${agentRuns}
+          ON ${agentRuns.id} = ${chatMessages.runId}
+        WHERE ${chatMessages.chatThreadId} = ${threadId}
+          AND ${chatMessages.runId} IS NOT NULL
+          AND NOT (
+            ${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)
+          )
+          AND ${visibleChatMessageCondition()}
+          AND (
+            (${isSuccessfulRun})
+            OR (
+              ${agentRuns.status} IN ('cancelled', 'failed', 'timeout')
+              AND ${chatMessages.role} IN ('user', 'assistant')
+            )
+          )
+        ORDER BY
+          ${chatMessages.createdAt} DESC,
+          ${chatMessages.sequenceNumber} DESC NULLS FIRST,
+          ${chatMessages.id} DESC
+        LIMIT 1
+      ) AS candidate
+      WHERE incomplete_frontier.depth < ${INCOMPLETE_ROUND_LIMIT + 1}
+        AND NOT incomplete_frontier.is_success
+    )
+    SELECT
+      run_id AS "runId",
+      run_status AS "runStatus",
+      is_success AS "isSuccess"
+    FROM incomplete_frontier
+    WHERE depth > 0
+    ORDER BY depth
+  `);
+
+  const rounds: IncompleteRoundSelection[] = [];
+  let successfulRunId: string | null = null;
+  for (const row of result.rows) {
+    if (row.isSuccess) {
+      successfulRunId = row.runId;
+      break;
+    }
+    if (
+      rounds.length < INCOMPLETE_ROUND_LIMIT &&
+      isIncompleteRunStatus(row.runStatus)
+    ) {
+      rounds.push({ runId: row.runId, status: row.runStatus });
+    }
+  }
+
+  return { rounds: rounds.reverse(), successfulRunId };
+}
+
+function afterSuccessfulRunBoundary(threadId: string, successfulRunId: string) {
+  return sql<boolean>`${chatMessages.createdAt} > COALESCE(
+    (
+      SELECT MAX(boundary_message.created_at)
+      FROM chat_messages boundary_message
+      WHERE boundary_message.chat_thread_id = ${threadId}
+        AND boundary_message.run_id = ${successfulRunId}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM chat_messages boundary_revoker
+          WHERE boundary_revoker.revokes_message_id = boundary_message.id
+        )
+    ),
+    '-infinity'::timestamptz
+  )`;
+}
+
+async function loadSelectedIncompleteRounds(
+  db: Db,
+  threadId: string,
+  selection: {
+    readonly rounds: readonly IncompleteRoundSelection[];
+    readonly successfulRunId: string | null;
+  },
+): Promise<readonly IncompleteRound[]> {
+  if (selection.rounds.length === 0) {
+    return [];
+  }
+
+  const runIds = selection.rounds.map((round) => {
+    return round.runId;
+  });
+  const rows = await db
+    .select({
+      runId: chatMessages.runId,
+      role: chatMessages.role,
+      content: chatMessages.content,
+      error: chatMessages.error,
+      attachFiles: chatMessages.attachFiles,
+      generationTemplate: chatMessages.generationTemplate,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        inArray(chatMessages.runId, runIds),
+        inArray(chatMessages.role, ["user", "assistant"]),
+        visibleChatMessageCondition(),
+        ...(selection.successfulRunId === null
+          ? []
+          : [afterSuccessfulRunBoundary(threadId, selection.successfulRunId)]),
+      ),
+    )
+    .orderBy(asc(chatMessages.createdAt), asc(chatMessages.sequenceNumber));
+
+  const statusByRunId = new Map(
+    selection.rounds.map((round) => {
+      return [round.runId, round.status] as const;
+    }),
+  );
+  const roundsByRunId = new Map<string, IncompleteRound>();
+  const orderedRunIds: string[] = [];
+  for (const row of rows) {
+    if (row.runId === null) {
+      continue;
+    }
+    if (row.role !== "user" && row.role !== "assistant") {
+      continue;
+    }
+    const status = statusByRunId.get(row.runId);
+    if (status === undefined) {
+      continue;
+    }
+    let round = roundsByRunId.get(row.runId);
+    if (round === undefined) {
+      round = { runId: row.runId, status, messages: [] };
+      roundsByRunId.set(row.runId, round);
+      orderedRunIds.push(row.runId);
+    }
+    round.messages.push({
+      role: row.role,
+      content: row.content,
+      error: row.error,
+      attachFiles: row.attachFiles,
+      generationTemplate: row.generationTemplate,
+    });
+  }
+
+  return orderedRunIds.map((runId) => {
+    const round = roundsByRunId.get(runId);
+    if (round === undefined) {
+      throw new Error("Incomplete round grouping lost run id");
+    }
+    return round;
+  });
+}
+
+function formatAttachFileIds(
+  ids: readonly string[] | null | undefined,
+): string {
+  if (!ids || ids.length === 0) {
+    return "";
+  }
+  return ids
+    .map((id) => {
+      return `[Web file]\n   [ID] ${id}`;
+    })
+    .join("\n");
+}
+
+function truncateIncomplete(value: string): string {
+  if (value.length <= INCOMPLETE_MESSAGE_CHAR_CAP) {
+    return value;
+  }
+  return `${value.slice(0, INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
+}
+
+function formatIncompleteMessage(message: IncompleteRoundMessage): string {
+  const attach = formatAttachFileIds(message.attachFiles);
+  if (message.role === "user") {
+    const body =
+      message.content !== null && message.content !== ""
+        ? truncateIncomplete(message.content)
+        : "[empty message]";
+    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
+  }
+  if (message.content !== null && message.content !== "") {
+    return `Assistant (partial): ${truncateIncomplete(message.content)}`;
+  }
+  return "Assistant: [no response before run ended]";
+}
+
+function buildWebChatIncompleteContext(
+  rounds: readonly IncompleteRound[],
+): string {
+  if (rounds.length === 0) {
+    return "";
+  }
+  const total = rounds.length;
+  const blocks = rounds.map((round, index) => {
+    const relativeIndex = index - total + 1;
+    const rendered = round.messages.map(formatIncompleteMessage);
+    const hasAssistant = round.messages.some((message) => {
+      return message.role === "assistant";
+    });
+    if (!hasAssistant) {
+      rendered.push("Assistant: [no response before run ended]");
+    }
+    return [
+      "---",
+      "",
+      `- RELATIVE_INDEX: ${relativeIndex}`,
+      `- RUN_STATUS: ${round.status}`,
+      "",
+      ...rendered,
+    ].join("\n");
+  });
+  return [
+    "# Incomplete Rounds Context",
+    "",
+    "The rounds below were sent in this thread but their runs did not complete",
+    "(cancelled, failed, or timed out), so the CLI session history does not",
+    "contain them. Treat them as part of the conversation you are having with",
+    "the user. RELATIVE_INDEX 0 is the most recent incomplete round.",
+    "",
+    blocks.join("\n\n"),
+    "",
+    "---",
+  ].join("\n");
+}
+
+export async function loadWebChatIncompleteContext(
+  db: Db,
+  threadId: string,
+): Promise<string> {
+  const selection = await selectIncompleteRoundFrontier(db, threadId);
+  const rounds = await loadSelectedIncompleteRounds(db, threadId, selection);
+  return buildWebChatIncompleteContext(rounds);
+}


### PR DESCRIPTION
## Summary

- replace the two duplicated full-tail incomplete-round readers with one shared API service
- discover at most 20 incomplete runs plus one successful-session sentinel through a fixed-depth recursive recent-message frontier
- fetch and render messages only for the selected run IDs while preserving successful-boundary, visibility, ordering, attachment, truncation, and model-continuity behavior
- add a real-PostgreSQL public-API journey that verifies the newest-20 window for both normal sends and queued callback auto-sends

## Why

The previous query returned every visible message in the incomplete tail and applied the 20-round limit in JavaScript. Production attribution isolated that SQL at 112.4 ms p95 and 917.7 ms maximum. A lifecycle-marker-only optimization was rejected during implementation because terminal status becomes visible before detached callback materialization, so the next send can legitimately observe a failed or cancelled run before its lifecycle row exists.

The frontier therefore uses canonical `agent_runs.status` / `result` and visible `chat_messages`; lifecycle rows are neither required nor trusted as the selection source.

## Query-plan evidence

`EXPLAIN (ANALYZE, BUFFERS)` on the final SQL shape used the existing thread/time, run primary-key, and revocation indexes:

| Fixture | Frontier rows | Local buffers | Execution |
| --- | ---: | ---: | ---: |
| 21 failed runs, 2 messages/run | 21 | 273 | 0.150 ms |
| 10,000 failed runs, 2 messages/run, newest lifecycle marker absent | 21 | 715 | 0.169 ms |
| 10,000 failed runs, newest 20 expanded to 200 messages/run | 21 | 1,899 | 2.856 ms |

The high-volume second-stage fetch selected 3,999 messages belonging to the newest 20 runs only. The prior representative full-tail query returned and sorted all 20,000 messages in 11.327 ms. The recursive plan did not reach discarded old runs; its remaining growth is limited to messages in the recent selected prefix that must be inspected or rendered.

## Compatibility and rollout

- no schema, migration, API contract, persisted-data, queue payload, frontend, or runner protocol change
- old and new API instances can overlap safely because the change is read-only against existing columns and indexes
- rollback is a code rollback with no data operation
- existing `resolve_thread` and incomplete-query timing spans remain available for comparison with the #21245 production baseline

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts` — 30 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` — 25 passed
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full Turbo Knip and type checks
- final temporary PostgreSQL `EXPLAIN (ANALYZE, BUFFERS)` fixture described above

Closes #21296

Parent context: #18746
