### PR TITLE
refactor(cli): use server permission-deny diagnostics

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
@@ -407,7 +407,7 @@ describe("zero doctor permission-deny command", () => {
         "--method",
         "GET",
         "--url",
-        "mailto:user@example.com",
+        "ftp://slack.com/api/conversations.list",
       ],
       expectedMessage: "permission-deny requires --url to be a valid absolute",
     },

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
@@ -1,19 +1,30 @@
 /**
- * Tests for zero doctor permission-deny command
+ * Tests for zero doctor permission-deny command.
  *
- * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * Tests command-level behavior via parseAsync():
  * - Entry point: command.parseAsync()
- * - Real (internal): All CLI code, routing metadata from @vm0/connectors
- *
- * permission-deny is a pure diagnostic command — it identifies which permission
- * or unknown endpoint policy covers a denied request and tells the agent to run permission-change.
- * It does not generate platform URLs.
+ * - Mock (external): vm0 API via MSW
+ * - Real (internal): CLI validation, request construction, output, and errors
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import type { ConnectorPermissionDenyDiagnosticResult } from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { server } from "../../../../mocks/server";
 import { permissionDenyCommand } from "../permission-deny";
 
+const API_BASE_URL = "http://localhost:3000";
+const DIAGNOSTIC_ENDPOINT = `${API_BASE_URL}/api/zero/connectors/:connectorRef/diagnostics/permission-deny`;
+
+interface CapturedDiagnosticRequest {
+  readonly connectorRef: string;
+  readonly authorization: string | null;
+  readonly body: unknown;
+}
+
 describe("zero doctor permission-deny command", () => {
+  let requestCount = 0;
+
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
   }) as never);
@@ -21,895 +32,682 @@ describe("zero doctor permission-deny command", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
-  const mockConsoleDebug = vi
-    .spyOn(console, "debug")
-    .mockImplementation(() => {});
+
+  function stubDiagnostic(
+    result: ConnectorPermissionDenyDiagnosticResult,
+    capture?: (request: CapturedDiagnosticRequest) => void,
+  ) {
+    return http.post(DIAGNOSTIC_ENDPOINT, async ({ request, params }) => {
+      requestCount++;
+      capture?.({
+        connectorRef: String(params.connectorRef),
+        authorization: request.headers.get("authorization"),
+        body: await request.json(),
+      });
+      return HttpResponse.json(result);
+    });
+  }
+
+  async function runDiagnostic(
+    connectorRef: string,
+    method: string,
+    url: string,
+  ): Promise<void> {
+    await permissionDenyCommand.parseAsync([
+      "node",
+      "cli",
+      connectorRef,
+      "--method",
+      method,
+      "--url",
+      url,
+    ]);
+  }
+
+  async function expectCommandFailure(args: readonly string[]): Promise<void> {
+    await expect(permissionDenyCommand.parseAsync([...args])).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  }
+
+  beforeEach(() => {
+    requestCount = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", API_BASE_URL);
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("ZERO_TOKEN", "");
+
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Unexpected diagnostic request",
+              code: "UNEXPECTED_DIAGNOSTIC_REQUEST",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+  });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    mockConsoleDebug.mockClear();
   });
 
-  describe("known ref with matching permission", () => {
-    it("should output permission name and next-step command", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "slack",
-        "--method",
-        "GET",
-        "--url",
-        "https://slack.com/api/conversations.list",
-      ]);
+  it("uses a server-only ref and removes query and fragment before transport", async () => {
+    let captured: CapturedDiagnosticRequest | undefined;
+    server.use(
+      stubDiagnostic(
+        {
+          outcome: "matched",
+          label: "Remote Only",
+          base: "https://remote.example/v1",
+          relativePath: "/%7Eraw/accounts",
+          permissions: ["accounts.read"],
+        },
+        (request) => {
+          captured = request;
+        },
+      ),
+    );
+    vi.stubEnv("ZERO_AGENT_ID", "agent-1");
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Slack permission filtered GET /conversations.list",
-      );
-      expect(logCalls).toContain('covered by the "');
-      expect(logCalls).toContain(
-        "zero doctor permission-change slack --permission",
-      );
-      expect(logCalls).toContain("--enable");
-      expect(logCalls).toContain("--duration 1h");
-      expect(logCalls).not.toContain("--reason");
-      expect(mockConsoleDebug).not.toHaveBeenCalled();
+    await runDiagnostic(
+      "remote-only",
+      "get",
+      "https://remote.example/v1/%7Eraw/accounts?token=query-sentinel#fragment-sentinel",
+    );
+
+    expect(captured).toStrictEqual({
+      connectorRef: "remote-only",
+      authorization: "Bearer test-token",
+      body: {
+        method: "GET",
+        url: "https://remote.example/v1/%7Eraw/accounts",
+      },
     });
+    expect(requestCount).toBe(1);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      "Remote Only permission filtered GET /%7Eraw/accounts relative to base URL https://remote.example/v1",
+    );
+    expect(output).toContain('covered by the "accounts.read" permission');
+    expect(output).toContain(
+      "zero doctor permission-change remote-only --permission accounts.read --enable --duration 1h",
+    );
+    expect(output).not.toContain("query-sentinel");
+    expect(output).not.toContain("fragment-sentinel");
+    expect(output).not.toContain("token=");
+    expect(output).not.toContain("[Manage");
+    expect(output).not.toContain("[Request");
   });
 
-  describe("known ref with no matching permission", () => {
-    it("should output no-permission message", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "slack",
-        "--method",
-        "DELETE",
-        "--url",
-        "https://slack.com/api/some/nonexistent/endpoint/that/will/never/match",
-      ]);
+  it("sorts multiple returned permissions for deterministic guidance", async () => {
+    server.use(
+      stubDiagnostic({
+        outcome: "matched",
+        label: "Slack",
+        base: "https://slack.com/api",
+        relativePath: "/chat.postMessage",
+        permissions: ["zeta.write", "alpha.write"],
+      }),
+    );
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Slack permission filtered DELETE");
-      expect(logCalls).toContain("No named permission was found");
-      expect(logCalls).toContain(
-        "zero doctor permission-change slack --permission __unknown__ --enable --duration 1h",
-      );
-    });
+    await runDiagnostic(
+      "slack",
+      "POST",
+      "https://slack.com/api/chat.postMessage",
+    );
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      "This is covered by these permissions: alpha.write, zeta.write.",
+    );
+    expect(output.indexOf("To allow alpha.write")).toBeLessThan(
+      output.indexOf("To allow zeta.write"),
+    );
+    expect(output).toContain(
+      "zero doctor permission-change slack --permission alpha.write --enable --duration 1h",
+    );
+    expect(output).toContain(
+      "zero doctor permission-change slack --permission zeta.write --enable --duration 1h",
+    );
   });
 
-  describe("unknown ref", () => {
-    it("should exit with error for unrecognized connector ref", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "unknown_service",
-          "--method",
-          "GET",
-          "--url",
-          "https://api.example.com/foo",
-        ]);
-      }).rejects.toThrow("process.exit called");
+  it("renders unknown endpoint policy guidance from the server result", async () => {
+    server.use(
+      stubDiagnostic({
+        outcome: "unknown-endpoint",
+        label: "Slack",
+        base: "https://slack.com/api",
+        relativePath: "/not.real",
+      }),
+    );
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown connector type: unknown_service"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
+    await runDiagnostic("slack", "DELETE", "https://slack.com/api/not.real");
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      "Slack permission filtered DELETE /not.real relative to base URL https://slack.com/api",
+    );
+    expect(output).toContain("No named permission was found");
+    expect(output).toContain(
+      "This request is governed by the unknown endpoint policy.",
+    );
+    expect(output).toContain(
+      "zero doctor permission-change slack --permission __unknown__ --enable --duration 1h",
+    );
   });
 
-  describe("computer-use capability denials", () => {
-    it("should explain selected-host token grants for computer-use ref", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "computer-use",
-        "--method",
-        "POST",
-        "--url",
-        "https://zero.local/computer-use/list-apps",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Computer Use access is not managed as a connector permission.",
-      );
-      expect(logCalls).toContain("selected for the chat or thread");
-      expect(logCalls).toContain("Existing run tokens cannot be upgraded");
-      expect(logCalls).toContain("zero whoami");
-      expect(mockConsoleError).not.toHaveBeenCalled();
-    });
-
-    it("should recognize computer-use paths before connector validation", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "agent",
-        "--method",
-        "POST",
-        "--url",
-        "https://zero.local/computer-use/list-apps",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Computer Use access is not managed as a connector permission.",
-      );
-      expect(mockConsoleError).not.toHaveBeenCalled();
-    });
-
-    it("should not treat similar path prefixes as computer-use", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "agent",
-          "--method",
-          "POST",
-          "--url",
-          "https://zero.local/computer-useful/list-apps",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown connector type: agent"),
-      );
-      expect(mockConsoleLog).not.toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Computer Use access is not managed as a connector permission.",
-        ),
-      );
-    });
-
-    it("should not normalize encoded dot segments into computer-use guidance", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "agent",
-          "--method",
-          "POST",
-          "--url",
-          "https://zero.local/not-computer/%2e%2e/computer-use/list-apps",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Computer Use access is not managed as a connector permission.",
-        ),
-      );
-    });
-  });
-
-  describe("slack matching", () => {
-    it("should identify chat:write for POST /chat.postMessage", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "slack",
-        "--method",
-        "POST",
-        "--url",
-        "https://slack.com/api/chat.postMessage",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Slack permission filtered POST /chat.postMessage",
-      );
-      expect(logCalls).toContain('covered by the "chat:write"');
-      expect(logCalls).toContain(
-        "zero doctor permission-change slack --permission chat:write --enable --duration 1h",
-      );
-    });
-  });
-
-  describe("overlapping permissions", () => {
-    it("should pick the most specific (narrowest) permission for gmail send", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "gmail",
-        "--method",
-        "POST",
-        "--url",
-        "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain('covered by the "messages.send"');
-      expect(logCalls).toContain(
-        "--permission messages.send --enable --duration 1h",
-      );
-    });
-  });
-
-  describe("base-aware URL matching", () => {
-    it("should identify videos.write for the normal YouTube metadata update base", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "youtube",
-        "--method",
-        "PUT",
-        "--url",
-        "https://youtube.googleapis.com/youtube/v3/videos",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "YouTube permission filtered PUT /v3/videos relative to base URL https://youtube.googleapis.com/youtube",
-      );
-      expect(logCalls).toContain('covered by the "videos.write"');
-      expect(logCalls).toContain(
-        "zero doctor permission-change youtube --permission videos.write --enable --duration 1h",
-      );
-    });
-
-    it("should not report normal-base videos.write for the YouTube upload base", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "youtube",
-        "--method",
-        "PUT",
-        "--url",
-        "https://youtube.googleapis.com/upload/youtube/v3/videos",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "YouTube permission filtered PUT /v3/videos relative to base URL https://youtube.googleapis.com/upload/youtube",
-      );
-      expect(logCalls).not.toContain('"videos.write"');
-      expect(
-        logCalls.includes("No named permission was found") ||
-          logCalls.includes('"videos.create"'),
-      ).toBe(true);
-    });
-
-    it("should match base URL templates with path variables", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "quickbooks",
-        "--method",
-        "GET",
-        "--url",
-        "https://quickbooks.api.intuit.com/v3/company/123/companyinfo/123",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "QuickBooks permission filtered GET /companyinfo/123 relative to base URL https://quickbooks.api.intuit.com/v3/company/${{ vars.QUICKBOOKS_REALM_ID }}",
-      );
-      expect(logCalls).toContain('covered by the "company-info"');
-      expect(logCalls).toContain(
-        "zero doctor permission-change quickbooks --permission company-info --enable --duration 1h",
-      );
-    });
-
-    it("should use configured env base URL variables when available", async () => {
-      vi.stubEnv("REAP_API_BASE_URL", "https://sandbox.api.reap.global/v1");
-
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "reap",
-        "--method",
-        "GET",
-        "--url",
-        "https://sandbox.api.reap.global/v1/accounts",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Reap permission filtered GET /accounts relative to base URL https://sandbox.api.reap.global/v1",
-      );
-      expect(logCalls).toContain('covered by the "read"');
-      expect(logCalls).toContain(
-        "zero doctor permission-change reap --permission read --enable --duration 1h",
-      );
-    });
-
-    it("should diagnose single opaque base URL variable connectors without env", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "reap",
-        "--method",
-        "GET",
-        "--url",
-        "https://sandbox.api.reap.global/v1/accounts",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Reap permission filtered GET /v1/accounts relative to base URL ${{ vars.REAP_API_BASE_URL }}",
-      );
-      expect(logCalls).toContain('covered by the "read"');
-      expect(logCalls).toContain(
-        "zero doctor permission-change reap --permission read --enable --duration 1h",
-      );
-    });
-
-    it("should not use opaque base fallback when configured env mismatches", async () => {
-      vi.stubEnv("REAP_API_BASE_URL", "https://api.reap.global/v1");
-
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://sandbox.api.reap.global/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should not use opaque base fallback for unrelated hosts", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://example.com/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should not use opaque base fallback for connector substrings in host labels", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://notreap.example.com/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should not use opaque base fallback for connector tokens inside hyphenated host labels", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://foo-reap.com/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should not normalize host label punctuation for connector refs without punctuation", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://api.re-ap.global/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should not use opaque base fallback for connector labels outside the registered domain position", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://reap.example.com/v1/accounts",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Reap base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject percent-encoded authority before opaque base fallback", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://sandbox%2eapi.reap.global/v1/accounts?token=secret",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
+  const semanticErrorCases: readonly {
+    readonly name: string;
+    readonly connectorRef: string;
+    readonly result: ConnectorPermissionDenyDiagnosticResult;
+    readonly expectedMessage: string;
+  }[] = [
+    {
+      name: "unknown connector",
+      connectorRef: "missing-connector",
+      result: { outcome: "unknown-connector" },
+      expectedMessage: "Unknown connector type: missing-connector",
+    },
+    {
+      name: "no matching base",
+      connectorRef: "slack",
+      result: { outcome: "no-matching-base", label: "Slack" },
+      expectedMessage: "No registered Slack base URL matches the provided URL.",
+    },
+    {
+      name: "unresolved dynamic base",
+      connectorRef: "reap",
+      result: { outcome: "unresolved-dynamic-base", label: "Reap" },
+      expectedMessage:
+        "No authoritative Reap base URL is available for this diagnostic.",
+    },
+    {
+      name: "server-invalid method",
+      connectorRef: "slack",
+      result: { outcome: "unsafe-input", reason: "invalid-method" },
+      expectedMessage:
+        "permission-deny requires --method to be one of GET, POST, PUT, PATCH, DELETE, HEAD, or OPTIONS.",
+    },
+    {
+      name: "server-invalid url",
+      connectorRef: "slack",
+      result: { outcome: "unsafe-input", reason: "invalid-url" },
+      expectedMessage:
         "permission-deny requires --url to be a valid absolute http or https URL.",
-      );
-      expect(output).not.toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should reject Unicode authority normalization before opaque base fallback", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://sandbox.api.reap。global/v1/accounts?token=secret",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
-        "permission-deny requires --url to be a valid absolute http or https URL.",
-      );
-      expect(output).not.toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should reject empty authority normalization before opaque base fallback", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https:///sandbox.api.reap.global/v1/accounts?token=secret",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
-        "permission-deny requires --url to be a valid absolute http or https URL.",
-      );
-      expect(output).not.toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should preserve raw encoded paths for opaque base fallback", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "reap",
-        "--method",
-        "GET",
-        "--url",
-        "https://sandbox.api.reap.global/v1/%7Eraw/accounts?token=secret",
-      ]);
-
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
-        "Reap permission filtered GET /v1/%7Eraw/accounts relative to base URL ${{ vars.REAP_API_BASE_URL }}",
-      );
-      expect(output).toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-    });
-
-    it("should reject unsafe encoded dot segments before permission guidance", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://sandbox.api.reap.global/v1/%2e%2e/accounts?token=secret",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
+    },
+    {
+      name: "server-unsafe path",
+      connectorRef: "slack",
+      result: { outcome: "unsafe-input", reason: "unsafe-path" },
+      expectedMessage:
         "permission-deny cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
-      );
-      expect(output).not.toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
+    },
+  ];
 
-    it("should reject raw path backslashes as unsafe paths", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "reap",
-          "--method",
-          "GET",
-          "--url",
-          "https://sandbox.api.reap.global/v1\\accounts?token=secret",
-        ]);
-      }).rejects.toThrow("process.exit called");
+  it.each(semanticErrorCases)(
+    "exits for the $name semantic outcome without fallback",
+    async ({ connectorRef, result, expectedMessage }) => {
+      server.use(stubDiagnostic(result));
 
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
-        "permission-deny cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
-      );
-      expect(output).not.toContain('covered by the "read"');
-      expect(output).not.toContain("secret");
-      expect(output).not.toContain("token=");
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should not ignore configured env base URL variable mismatches", async () => {
-      vi.stubEnv("QUICKBOOKS_REALM_ID", "999");
-
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "quickbooks",
-          "--method",
-          "GET",
-          "--url",
-          "https://quickbooks.api.intuit.com/v3/company/123/companyinfo/123",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered QuickBooks base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject path-only diagnostics", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "youtube",
-          "--method",
-          "PUT",
-          "--path",
-          "/v3/videos",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny now requires --url because method/path alone can match the wrong API base.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject malformed URLs before computer-use guidance", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "computer-use",
-          "--method",
-          "POST",
-          "--url",
-          "not-a-url",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny requires --url to be a valid absolute http or https URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject non-http URLs", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "slack",
-          "--method",
-          "GET",
-          "--url",
-          "mailto:user@example.com",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny requires --url to be a valid absolute http or https URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject URLs with userinfo", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "slack",
-          "--method",
-          "GET",
-          "--url",
-          "https://user:secret@slack.com/api/conversations.list",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny requires --url to be a valid absolute http or https URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject raw authority backslashes before URL parser normalization", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "slack",
-          "--method",
-          "GET",
-          "--url",
-          "https://slack.com\\evil.example/api/conversations.list",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny requires --url to be a valid absolute http or https URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject invalid HTTP methods", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "slack",
-          "--method",
-          "BAD METHOD",
-          "--url",
-          "https://slack.com/api/conversations.list",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "permission-deny requires --method to be one of GET, POST, PUT, PATCH, DELETE, HEAD, or OPTIONS.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-    });
-
-    it("should reject URLs outside the selected connector bases", async () => {
-      await expect(async () => {
-        await permissionDenyCommand.parseAsync([
-          "node",
-          "cli",
-          "slack",
-          "--method",
-          "GET",
-          "--url",
-          "https://example.com/conversations.list",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "No registered Slack base URL matches the provided URL.",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should preserve raw encoded paths when matching the selected base", async () => {
-      await permissionDenyCommand.parseAsync([
+      await expectCommandFailure([
         "node",
         "cli",
-        "slack",
+        connectorRef,
         "--method",
         "GET",
         "--url",
-        "https://slack.com/api/%7Eraw/conversations.list",
+        "https://example.com/path",
       ]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "Slack permission filtered GET /%7Eraw/conversations.list relative to base URL https://slack.com/api",
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(expectedMessage),
       );
-      expect(logCalls).toContain("No named permission was found");
-      expect(mockConsoleError).not.toHaveBeenCalled();
-    });
+      expect(requestCount).toBe(1);
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    },
+  );
 
-    it("should not echo URL query strings in diagnostic output", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "slack",
-        "--method",
-        "POST",
-        "--url",
-        "https://slack.com/api/chat.postMessage?token=secret-token",
-      ]);
+  it("does not read or send a local dynamic-base environment value", async () => {
+    let capturedBody: unknown;
+    vi.stubEnv(
+      "REAP_API_BASE_URL",
+      "https://local-value-must-not-be-used.example/v1",
+    );
+    server.use(
+      stubDiagnostic(
+        { outcome: "unresolved-dynamic-base", label: "Reap" },
+        (request) => {
+          capturedBody = request.body;
+        },
+      ),
+    );
 
-      const output = [
-        ...mockConsoleLog.mock.calls.flat(),
-        ...mockConsoleError.mock.calls.flat(),
-      ].join("\n");
-      expect(output).toContain(
-        "Slack permission filtered POST /chat.postMessage relative to base URL https://slack.com/api",
-      );
-      expect(output).toContain('covered by the "chat:write"');
-      expect(output).not.toContain("secret-token");
-      expect(output).not.toContain("token=");
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "reap",
+      "--method",
+      "GET",
+      "--url",
+      "https://requested.example/v1/accounts",
+    ]);
+
+    expect(capturedBody).toStrictEqual({
+      method: "GET",
+      url: "https://requested.example/v1/accounts",
     });
+    const output = [
+      ...mockConsoleLog.mock.calls.flat(),
+      ...mockConsoleError.mock.calls.flat(),
+    ].join("\n");
+    expect(output).not.toContain("local-value-must-not-be-used");
+    expect(output).not.toContain("REAP_API_BASE_URL");
   });
 
-  describe("next-step command format", () => {
-    it("should include the exact connector ref in the suggested command", async () => {
-      await permissionDenyCommand.parseAsync([
+  it("handles computer-use guidance locally without authentication or HTTP", async () => {
+    vi.stubEnv("VM0_TOKEN", "");
+
+    await runDiagnostic(
+      "computer-use",
+      "POST",
+      "https://zero.local/computer-use/list-apps",
+    );
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      "Computer Use access is not managed as a connector permission.",
+    );
+    expect(output).toContain("Existing run tokens cannot be upgraded");
+    expect(output).toContain("zero whoami");
+    expect(requestCount).toBe(0);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a similar path prefix as computer-use", async () => {
+    server.use(stubDiagnostic({ outcome: "unknown-connector" }));
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "agent",
+      "--method",
+      "POST",
+      "--url",
+      "https://zero.local/computer-useful/list-apps",
+    ]);
+
+    expect(requestCount).toBe(1);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Unknown connector type: agent"),
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Computer Use access is not managed as a connector permission.",
+      ),
+    );
+  });
+
+  const localValidationCases: readonly {
+    readonly name: string;
+    readonly args: readonly string[];
+    readonly expectedMessage: string;
+  }[] = [
+    {
+      name: "deprecated path-only input",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--path",
+        "/api/conversations.list",
+      ],
+      expectedMessage: "permission-deny now requires --url",
+    },
+    {
+      name: "missing url",
+      args: ["node", "cli", "slack", "--method", "GET"],
+      expectedMessage: "permission-deny now requires --url",
+    },
+    {
+      name: "invalid method",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "BAD METHOD",
+        "--url",
+        "https://slack.com/api/conversations.list",
+      ],
+      expectedMessage: "permission-deny requires --method",
+    },
+    {
+      name: "malformed url",
+      args: ["node", "cli", "slack", "--method", "GET", "--url", "not-a-url"],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "non-http url",
+      args: [
         "node",
         "cli",
         "slack",
         "--method",
         "GET",
         "--url",
-        "https://slack.com/api/conversations.list",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      // The suggested command should contain the ref, permission, and --enable.
-      expect(logCalls).toMatch(
-        /zero doctor permission-change slack --permission \S+ --enable --duration 1h/,
-      );
-      expect(logCalls).not.toContain("--reason");
-    });
-
-    it("should suggest unknown endpoint permission-change when no permission matches", async () => {
-      await permissionDenyCommand.parseAsync([
-        "node",
-        "cli",
-        "slack",
-        "--method",
-        "PATCH",
-        "--url",
-        "https://slack.com/api/totally/unknown/endpoint",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "This request is governed by the unknown endpoint policy.",
-      );
-      expect(logCalls).toContain(
-        "zero doctor permission-change slack --permission __unknown__ --enable --duration 1h",
-      );
-      expect(logCalls).not.toContain("--reason");
-    });
-
-    it("should not generate any platform URL", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
-
-      await permissionDenyCommand.parseAsync([
+        "mailto:user@example.com",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "userinfo",
+      args: [
         "node",
         "cli",
         "slack",
         "--method",
         "GET",
         "--url",
-        "https://slack.com/api/conversations.list",
-      ]);
+        "https://user:secret@slack.com/api/conversations.list",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "authority backslash",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https://slack.com\\evil.example/api/conversations.list",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "encoded authority",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https://slack%2ecom/api/conversations.list?token=secret",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "unicode authority",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https://slack。com/api/conversations.list?token=secret",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "empty authority",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https:///slack.com/api/conversations.list?token=secret",
+      ],
+      expectedMessage: "permission-deny requires --url to be a valid absolute",
+    },
+    {
+      name: "encoded dot segment",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https://slack.com/api/%2e%2e/admin?token=secret",
+      ],
+      expectedMessage: "permission-deny cannot diagnose unsafe URL paths",
+    },
+    {
+      name: "raw path backslash",
+      args: [
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--url",
+        "https://slack.com/api\\admin?token=secret",
+      ],
+      expectedMessage: "permission-deny cannot diagnose unsafe URL paths",
+    },
+  ];
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).not.toContain("app.vm0.ai");
-      expect(logCalls).not.toContain("[Manage");
-      expect(logCalls).not.toContain("[Request");
-    });
+  it.each(localValidationCases)(
+    "rejects $name before authentication or HTTP",
+    async ({ args, expectedMessage }) => {
+      await expectCommandFailure(args);
+
+      const output = [
+        ...mockConsoleLog.mock.calls.flat(),
+        ...mockConsoleError.mock.calls.flat(),
+      ].join("\n");
+      expect(output).toContain(expectedMessage);
+      expect(output).not.toContain("token=secret");
+      expect(requestCount).toBe(0);
+    },
+  );
+
+  it("reports missing local authentication before making a request", async () => {
+    vi.stubEnv("VM0_TOKEN", "");
+    vi.stubEnv("HOME", "/nonexistent/vm0-permission-deny-test");
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    const output = mockConsoleError.mock.calls.flat().join("\n");
+    expect(output).toContain("Not authenticated");
+    expect(output).toContain("vm0 auth login");
+    expect(requestCount).toBe(0);
+  });
+
+  it("surfaces a server authentication failure without fallback", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.json(
+          { error: { message: "Expired token", code: "UNAUTHORIZED" } },
+          { status: 401 },
+        );
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Not authenticated",
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("surfaces authorization failure without fallback", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Connector read denied",
+              code: "DIAGNOSTIC_FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "403: Connector read denied",
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an older server's missing endpoint without fallback", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return new HttpResponse("Not Found", { status: 404 });
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      '404: Failed to diagnose permission denial for "slack"',
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("surfaces server failures without fallback", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Diagnostic service failed",
+              code: "DIAGNOSTIC_SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "500: Diagnostic service failed",
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("surfaces network failures without fallback", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.error();
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Failed to fetch",
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed declared responses through contract validation", async () => {
+    server.use(
+      http.post(DIAGNOSTIC_ENDPOINT, () => {
+        requestCount++;
+        return HttpResponse.json({
+          outcome: "matched",
+          label: "Slack",
+        });
+      }),
+    );
+
+    await expectCommandFailure([
+      "node",
+      "cli",
+      "slack",
+      "--method",
+      "GET",
+      "--url",
+      "https://slack.com/api/conversations.list",
+    ]);
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Response validation failed",
+    );
+    expect(requestCount).toBe(1);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -1,25 +1,15 @@
 import { Command, Option } from "commander";
-import {
-  matchFirewallBaseUrl,
-  matchFirewallRequestDecision,
-  type FirewallRoutingPermissionRoute,
-} from "@vm0/connectors/firewall-rule-matcher";
-import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
-import { loadFirewallRoutingMetadata } from "@vm0/connectors/firewall-metadata/routing";
+import type { ConnectorPermissionDenyDiagnosticResult } from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
 import {
   hasUnsafeFirewallPath,
-  type NetworkPolicies,
   UNKNOWN_PERMISSION_GRANT,
 } from "@vm0/connectors/firewall-types";
+import { diagnoseZeroConnectorPermissionDeny } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import {
   isComputerUsePermissionTarget,
   printComputerUsePermissionGuidance,
 } from "./computer-use-guidance";
-
-function unknownPermissionChangeCommand(connectorRef: string): string {
-  return `zero doctor permission-change ${connectorRef} --permission ${UNKNOWN_PERMISSION_GRANT} --enable --duration 1h`;
-}
 
 interface PermissionDenyOptions {
   readonly method: string;
@@ -27,33 +17,11 @@ interface PermissionDenyOptions {
   readonly path?: string;
 }
 
-interface PermissionDenyBaseMatch {
-  readonly apiBase: string;
-  readonly decisionBase: string;
-  readonly displayBase: string;
-  readonly relativePath: string;
-  readonly score: number;
-}
+type UnsafeInputReason = Extract<
+  ConnectorPermissionDenyDiagnosticResult,
+  { readonly outcome: "unsafe-input" }
+>["reason"];
 
-interface PermissionDenyDecisionPermission {
-  readonly name: string;
-  readonly rules: readonly string[];
-}
-
-interface PermissionDenyDecisionApi {
-  readonly base: string;
-  readonly auth: Record<string, never>;
-  readonly permissions: readonly PermissionDenyDecisionPermission[];
-}
-
-interface PermissionDenyDecisionFirewall {
-  readonly name: string;
-  readonly apis: readonly PermissionDenyDecisionApi[];
-}
-
-const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
-const WHOLE_BASE_URL_VAR_PATTERN =
-  /^\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}$/;
 const VALID_DENIED_METHODS = new Set([
   "GET",
   "POST",
@@ -63,6 +31,10 @@ const VALID_DENIED_METHODS = new Set([
   "HEAD",
   "OPTIONS",
 ]);
+
+function unknownPermissionChangeCommand(connectorRef: string): string {
+  return `zero doctor permission-change ${connectorRef} --permission ${UNKNOWN_PERMISSION_GRANT} --enable --duration 1h`;
+}
 
 function pathOnlyError(): Error {
   return new Error(
@@ -122,7 +94,7 @@ function rawAuthorityHasUnsafeSyntax(url: string): boolean {
   );
 }
 
-function parseDeniedUrl(url: string): URL {
+function validateDeniedUrl(url: string): void {
   if (
     !url.includes("://") ||
     /\s/.test(url) ||
@@ -139,82 +111,9 @@ function parseDeniedUrl(url: string): URL {
     if (parsed.username !== "" || parsed.password !== "") {
       throw invalidUrlError();
     }
-    return parsed;
   } catch {
     throw invalidUrlError();
   }
-}
-
-function baseUrlTemplateVarNames(base: string): string[] {
-  return [...base.matchAll(BASE_URL_VAR_PATTERN)].map((match) => {
-    return match[1]!;
-  });
-}
-
-function wholeBaseUrlTemplateVarName(base: string): string | null {
-  return WHOLE_BASE_URL_VAR_PATTERN.exec(base)?.[1] ?? null;
-}
-
-function resolveBaseUrlTemplateFromEnv(base: string): string | null {
-  const names = baseUrlTemplateVarNames(base);
-  if (names.length === 0) return base;
-
-  let missing = false;
-  const resolved = base.replace(
-    BASE_URL_VAR_PATTERN,
-    (_match, name: string) => {
-      const value = process.env[name];
-      if (!value) {
-        missing = true;
-        return "";
-      }
-      return value;
-    },
-  );
-  return missing ? null : resolved;
-}
-
-function baseUrlTemplateToPattern(base: string): string | null {
-  if (baseUrlTemplateVarNames(base).length === 0) return null;
-  const pattern = base.replace(BASE_URL_VAR_PATTERN, (_match, name: string) => {
-    return `{${name}}`;
-  });
-  return pattern.includes("://") ? pattern : null;
-}
-
-function connectorRefHostToken(connectorRef: string): string {
-  return connectorRef.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
-}
-
-function hostLabelToken(label: string): string {
-  return label.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
-}
-
-function hostLabelMatchesConnectorRef(
-  label: string,
-  connectorRef: string,
-): boolean {
-  const normalizedConnectorRef = connectorRef.toLowerCase();
-  const token = connectorRefHostToken(connectorRef);
-  const normalizedLabel = label.toLowerCase();
-  if (normalizedConnectorRef === token) {
-    return normalizedLabel === token;
-  }
-  return hostLabelToken(normalizedLabel) === token;
-}
-
-function hostnameMatchesConnectorRef(url: URL, connectorRef: string): boolean {
-  const token = connectorRefHostToken(connectorRef);
-  if (token.length < 3) return false;
-  const labels = (url.hostname || "")
-    .toLowerCase()
-    .replace(/\.$/, "")
-    .split(".")
-    .filter((part) => {
-      return part !== "";
-    });
-  if (labels.length < 2) return false;
-  return hostLabelMatchesConnectorRef(labels[labels.length - 2]!, connectorRef);
 }
 
 function stripUrlQueryAndFragment(url: string): string {
@@ -226,185 +125,12 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
-function stripTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
 function rawPathFromDeniedUrl(url: string): string {
   const urlWithoutQuery = stripUrlQueryAndFragment(url);
   const schemeEnd = urlWithoutQuery.indexOf("://");
   const authorityStart = schemeEnd === -1 ? 0 : schemeEnd + 3;
   const pathStart = urlWithoutQuery.indexOf("/", authorityStart);
   return pathStart === -1 ? "/" : urlWithoutQuery.slice(pathStart);
-}
-
-function matchApiBaseUrl(
-  url: string,
-  apiBase: string,
-): PermissionDenyBaseMatch | null {
-  const directMatch = matchFirewallBaseUrl(url, apiBase);
-  if (directMatch) {
-    return {
-      apiBase,
-      decisionBase: apiBase,
-      displayBase: directMatch.displayBase,
-      relativePath: directMatch.relativePath,
-      score: directMatch.score,
-    };
-  }
-
-  const resolvedBase = resolveBaseUrlTemplateFromEnv(apiBase);
-  if (resolvedBase !== null && resolvedBase !== apiBase) {
-    const resolvedMatch = matchFirewallBaseUrl(url, resolvedBase);
-    if (resolvedMatch) {
-      return {
-        apiBase,
-        decisionBase: resolvedBase,
-        displayBase: resolvedMatch.displayBase,
-        relativePath: resolvedMatch.relativePath,
-        score: resolvedMatch.score,
-      };
-    }
-    return null;
-  }
-
-  const patternBase = baseUrlTemplateToPattern(apiBase);
-  if (patternBase === null) return null;
-  const patternMatch = matchFirewallBaseUrl(url, patternBase);
-  if (!patternMatch) return null;
-  return {
-    apiBase,
-    decisionBase: patternBase,
-    displayBase: apiBase,
-    relativePath: patternMatch.relativePath,
-    score: patternMatch.score,
-  };
-}
-
-function findBestBaseMatch(
-  url: string,
-  deniedUrl: URL,
-  connectorRef: string,
-  apis: readonly { readonly base: string }[],
-): PermissionDenyBaseMatch | null {
-  let bestMatch: PermissionDenyBaseMatch | null = null;
-  for (const api of apis) {
-    const match = matchApiBaseUrl(url, api.base);
-    if (match && (!bestMatch || match.score > bestMatch.score)) {
-      bestMatch = match;
-    }
-  }
-  if (bestMatch !== null) return bestMatch;
-
-  const unresolvedWholeBaseApis = apis.filter((api) => {
-    const name = wholeBaseUrlTemplateVarName(api.base);
-    return name !== null && !process.env[name];
-  });
-  if (unresolvedWholeBaseApis.length !== 1) return null;
-  if (!hostnameMatchesConnectorRef(deniedUrl, connectorRef)) return null;
-
-  const api = unresolvedWholeBaseApis[0]!;
-  return {
-    apiBase: api.base,
-    decisionBase: deniedUrl.origin,
-    displayBase: api.base,
-    relativePath: rawPathFromDeniedUrl(url),
-    score: 0,
-  };
-}
-
-function routesForMatchedBase(
-  apis: readonly {
-    readonly base: string;
-    readonly routes: readonly FirewallRoutingPermissionRoute[];
-  }[],
-  apiBase: string,
-): readonly FirewallRoutingPermissionRoute[] {
-  const normalizedApiBase = stripTrailingSlash(apiBase);
-  const routes: FirewallRoutingPermissionRoute[] = [];
-  for (const api of apis) {
-    if (stripTrailingSlash(api.base) === normalizedApiBase) {
-      routes.push(...api.routes);
-    }
-  }
-  return routes;
-}
-
-function routesToDecisionPermissions(
-  routes: readonly FirewallRoutingPermissionRoute[],
-): PermissionDenyDecisionPermission[] {
-  const rulesByPermission = new Map<string, string[]>();
-  for (const route of routes) {
-    const rules = rulesByPermission.get(route.permissionName);
-    if (rules) {
-      rules.push(route.rule);
-    } else {
-      rulesByPermission.set(route.permissionName, [route.rule]);
-    }
-  }
-
-  return [...rulesByPermission.entries()].map(([name, rules]) => {
-    return { name, rules };
-  });
-}
-
-function buildDecisionFirewall(
-  connectorRef: string,
-  base: string,
-  permissions: readonly PermissionDenyDecisionPermission[],
-): readonly PermissionDenyDecisionFirewall[] {
-  return [
-    {
-      name: connectorRef,
-      apis: [
-        {
-          base,
-          auth: {},
-          permissions,
-        },
-      ],
-    },
-  ];
-}
-
-function buildAllDeniedNetworkPolicies(
-  connectorRef: string,
-  permissions: readonly PermissionDenyDecisionPermission[],
-): NetworkPolicies {
-  return {
-    [connectorRef]: {
-      allow: [],
-      deny: permissions.map((permission) => {
-        return permission.name;
-      }),
-      ask: [],
-      unknownPolicy: "deny",
-    },
-  };
-}
-
-function findDeniedDecisionPermissions(
-  connectorRef: string,
-  method: string,
-  url: string,
-  match: PermissionDenyBaseMatch,
-  apis: readonly {
-    readonly base: string;
-    readonly routes: readonly FirewallRoutingPermissionRoute[];
-  }[],
-): string[] {
-  const routes = routesForMatchedBase(apis, match.apiBase);
-  const permissions = routesToDecisionPermissions(routes);
-  const decision = matchFirewallRequestDecision(
-    buildDecisionFirewall(connectorRef, match.decisionBase, permissions),
-    method,
-    url,
-    buildAllDeniedNetworkPolicies(connectorRef, permissions),
-  );
-  if (decision.kind !== "block" || decision.reason !== "permission_denied") {
-    return [];
-  }
-  return [...decision.permissions];
 }
 
 function printPermissionChangeGuidance(
@@ -429,6 +155,74 @@ function printPermissionChangeGuidance(
       `To allow ${permission}, run: zero doctor permission-change ${connectorRef} --permission ${permission} --enable --duration 1h`,
     );
   }
+}
+
+function printFilteredRequest(
+  label: string,
+  method: string,
+  relativePath: string,
+  base: string,
+): void {
+  console.log(
+    `The ${label} permission filtered ${method} ${relativePath} relative to base URL ${base}.`,
+  );
+}
+
+function unsafeInputError(reason: UnsafeInputReason): Error {
+  switch (reason) {
+    case "invalid-method":
+      return invalidMethodError();
+    case "invalid-url":
+      return invalidUrlError();
+    case "unsafe-path":
+      return unsafePathError();
+  }
+}
+
+function handleDiagnosticResult(
+  connectorRef: string,
+  method: string,
+  result: ConnectorPermissionDenyDiagnosticResult,
+): void {
+  switch (result.outcome) {
+    case "matched":
+      printFilteredRequest(
+        result.label,
+        method,
+        result.relativePath,
+        result.base,
+      );
+      printPermissionChangeGuidance(connectorRef, result.permissions);
+      return;
+    case "unknown-endpoint":
+      printFilteredRequest(
+        result.label,
+        method,
+        result.relativePath,
+        result.base,
+      );
+      console.log("No named permission was found covering this request.");
+      console.log("This request is governed by the unknown endpoint policy.");
+      console.log(
+        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorRef)}`,
+      );
+      return;
+    case "unknown-connector":
+      throw new Error(`Unknown connector type: ${connectorRef}`);
+    case "no-matching-base":
+      throw new Error(
+        `No registered ${result.label} base URL matches the provided URL.`,
+      );
+    case "unresolved-dynamic-base":
+      throw new Error(
+        `No authoritative ${result.label} base URL is available for this diagnostic. Verify the ${connectorRef} connector configuration for the affected context and retry.`,
+      );
+    case "unsafe-input":
+      throw unsafeInputError(result.reason);
+  }
+
+  const exhaustiveResult: never = result;
+  return exhaustiveResult;
 }
 
 export const permissionDenyCommand = new Command()
@@ -475,8 +269,9 @@ Notes:
         if (!opts.url) {
           throw pathOnlyError();
         }
+
         const method = parseDeniedMethod(opts.method);
-        const deniedUrl = parseDeniedUrl(opts.url);
+        validateDeniedUrl(opts.url);
         const deniedPath = rawPathFromDeniedUrl(opts.url);
         if (hasUnsafeFirewallPath(deniedPath)) {
           throw unsafePathError();
@@ -492,49 +287,12 @@ Notes:
           return;
         }
 
-        const metadata = await loadFirewallRoutingMetadata(connectorRef);
-        if (!metadata) {
-          throw new Error(`Unknown connector type: ${connectorRef}`);
-        }
-
-        const label =
-          getFirewallPermissionSummary(connectorRef)?.label ?? connectorRef;
-        const match = findBestBaseMatch(
-          opts.url,
-          deniedUrl,
-          connectorRef,
-          metadata.apis,
-        );
-        if (!match) {
-          throw new Error(
-            `No registered ${label} base URL matches the provided URL.`,
-          );
-        }
-
-        const permissions = findDeniedDecisionPermissions(
+        const result = await diagnoseZeroConnectorPermissionDeny(
           connectorRef,
           method,
-          opts.url,
-          match,
-          metadata.apis,
+          stripUrlQueryAndFragment(opts.url),
         );
-
-        console.log(
-          `The ${label} permission filtered ${method} ${match.relativePath} relative to base URL ${match.displayBase}.`,
-        );
-
-        if (permissions.length === 0) {
-          console.log("No named permission was found covering this request.");
-          console.log(
-            "This request is governed by the unknown endpoint policy.",
-          );
-          console.log(
-            `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorRef)}`,
-          );
-          return;
-        }
-
-        printPermissionChangeGuidance(connectorRef, permissions);
+        handleDiagnosticResult(connectorRef, method, result);
       },
     ),
   );

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -17,6 +17,10 @@ import {
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
+  zeroConnectorPermissionDenyContract,
+  type ConnectorPermissionDenyDiagnosticResult,
+} from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
+import {
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorsContract,
   type CustomConnectorResponse,
@@ -117,6 +121,32 @@ export async function getZeroConnectorCatalogPermissions(
   handleError(
     result,
     `Failed to get connector permission metadata for "${connectorRef}"`,
+  );
+}
+
+export async function diagnoseZeroConnectorPermissionDeny(
+  connectorRef: string,
+  method: string,
+  url: string,
+): Promise<ConnectorPermissionDenyDiagnosticResult> {
+  const config = await getClientConfig();
+  const client = initClient(zeroConnectorPermissionDenyContract, {
+    ...config,
+    validateResponse: true,
+  });
+
+  const result = await client.diagnose({
+    params: { connectorRef },
+    body: { method, url },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(
+    result,
+    `Failed to diagnose permission denial for "${connectorRef}"`,
   );
 }
 

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -149,6 +149,7 @@ export {
   listZeroConnectorCatalog,
   listZeroConnectorCatalogStatus,
   getZeroConnectorCatalogPermissions,
+  diagnoseZeroConnectorPermissionDeny,
   connectZeroConnectorManualGrant,
   listZeroCustomConnectors,
   getZeroCustomConnector,


### PR DESCRIPTION
## Summary

- move `zero doctor permission-deny` connector matching and permission diagnosis to the authenticated server endpoint
- preserve local raw-input validation, query/fragment redaction, and the computer-use guidance short circuit
- remove bundled firewall metadata, dynamic-base environment lookup, hostname inference, and local fallback from the CLI
- validate declared diagnostic responses and render every server semantic outcome explicitly

## Not included

- no server contract or diagnostic implementation changes; those shipped in #21217
- no compatibility fallback to local connector metadata
- no changes to the remaining parent cleanup tracked by #21140

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/permission-deny.test.ts` (31 tests)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` against a clean temporary database (7,461 tests passed; 1 existing skip)
- `pnpm knip`
- pre-commit hooks: generated-firewall boundary, Prettier, Knip, type checks, and commitlint

Closes #21218

Parent delivery: #21140
