### PR TITLE
refactor(cli): consume server connector diagnostics

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -311,6 +311,30 @@ describe("zero doctor check-connector command", () => {
       expect(getErrorOutput()).not.toContain("access_token=secret");
     });
 
+    it("rejects URL userinfo before transport or output", async () => {
+      let diagnosticRequested = false;
+      server.use(
+        http.post(diagnosticEndpoint(), () => {
+          diagnosticRequested = true;
+          return HttpResponse.json(resolvedUrl());
+        }),
+      );
+
+      await expectCommandFailure([
+        "--url",
+        "https://sensitive-user:sensitive-password@api.github.com/repos/vm0-ai/vm0",
+      ]);
+
+      expect(diagnosticRequested).toBe(false);
+      expect(getErrorOutput()).toContain(
+        "requires --url to be a valid absolute http or https URL",
+      );
+      expect(getOutput()).not.toContain("sensitive-user");
+      expect(getOutput()).not.toContain("sensitive-password");
+      expect(getErrorOutput()).not.toContain("sensitive-user");
+      expect(getErrorOutput()).not.toContain("sensitive-password");
+    });
+
     it("sends an environment request with the explicit permission", async () => {
       let capturedBody: unknown;
       stubDiagnostic(

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -1,26 +1,41 @@
-/**
- * Tests for zero doctor check-connector command
- *
- * Tests command-level behavior via parseAsync() following CLI testing principles:
- * - Entry point: command.parseAsync()
- * - Mock (external): Web API via MSW
- * - Real (internal): All CLI code, connector metadata from @vm0/connectors
- */
+import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type {
+  ConnectorCheckDiagnosticResult,
+  ConnectorCheckPolicy,
+  ConnectorCheckRequest,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
+import chalk from "chalk";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { checkConnectorCommand } from "../check-connector";
-import chalk from "chalk";
 
-/** Build a fake ZERO_TOKEN JWT with the given payload fields. */
+const API_BASE_URL = "https://app.vm0.ai";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+
+type ResolvedDiagnostic = Extract<
+  ConnectorCheckDiagnosticResult,
+  { readonly outcome: "resolved" }
+>;
+type ResolvedUrlDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "url" }
+>;
+type ResolvedEnvironmentDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "environment" }
+>;
+type ConnectorIdentity = ResolvedDiagnostic["connector"];
+type ConnectorRun = ResolvedDiagnostic["run"];
+
 function buildZeroToken(
   overrides: Partial<{
-    userId: string;
-    runId: string;
-    orgId: string;
-    scope: string;
-    capabilities: string[];
+    readonly userId: string;
+    readonly runId: string;
+    readonly orgId: string;
+    readonly scope: string;
+    readonly capabilities: string[];
   }> = {},
 ): string {
   const payload = {
@@ -28,7 +43,7 @@ function buildZeroToken(
     runId: "run-abc-123",
     orgId: "org-1",
     scope: "zero",
-    capabilities: ["agent-run:read"],
+    capabilities: ["connector:read", "agent-run:read"],
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + 3600,
     ...overrides,
@@ -40,70 +55,174 @@ function buildZeroToken(
   return `vm0_sandbox_${header}.${body}.test-signature`;
 }
 
-/** Minimal valid connector response for MSW handlers */
-const connectedResponse = {
-  id: "conn-1",
-  type: "github",
-  authMethod: "oauth",
-  externalId: "ext-1",
-  externalUsername: "user",
-  externalEmail: "user@example.com",
-  oauthScopes: ["repo"],
-  connectionStatus: "connected",
-  createdAt: "2026-01-01T00:00:00Z",
-  updatedAt: "2026-01-01T00:00:00Z",
-};
-
-function stubAvailableConnectors(types: string[]) {
-  return http.get("https://app.vm0.ai/api/zero/connectors/search", () => {
-    return HttpResponse.json({
-      connectors: types.map((type) => {
-        return {
-          id: type,
-          label: type,
-          description: type,
-          authMethods: ["oauth"],
-        };
-      }),
-    });
-  });
+function connectorIdentity(
+  overrides: Partial<ConnectorIdentity> = {},
+): ConnectorIdentity {
+  return {
+    connectorRef: "github",
+    label: "GitHub",
+    visibility: "available",
+    credentialResolution: "network-boundary",
+    ...overrides,
+  };
 }
 
-/** Minimal run context response */
-const runContextResponse = {
-  prompt: "test",
-  appendSystemPrompt: null,
-  sessionId: null,
-  secretNames: [],
-  vars: null,
-  environment: {},
-  firewalls: [
-    {
-      name: "github",
-      apis: [
+function resolvedEnvironment(
+  options: {
+    readonly connector?: ConnectorIdentity;
+    readonly environmentName?: string;
+    readonly run?: ConnectorRun;
+    readonly permission?: ConnectorCheckPolicy | null;
+  } = {},
+): ResolvedEnvironmentDiagnostic {
+  return {
+    outcome: "resolved",
+    mode: "environment",
+    connector: options.connector ?? connectorIdentity(),
+    environmentName: options.environmentName ?? "GH_TOKEN",
+    run: options.run ?? {
+      status: "configured",
+      bases: ["https://api.github.com", "https://uploads.github.com"],
+    },
+    permission: options.permission ?? null,
+  };
+}
+
+function resolvedUrl(
+  options: {
+    readonly connector?: ConnectorIdentity;
+    readonly environmentNames?: string[] | null;
+    readonly run?: ConnectorRun;
+    readonly method?: string;
+    readonly base?: string;
+    readonly relativePath?: string;
+    readonly permission?: ResolvedUrlDiagnostic["permission"];
+  } = {},
+): ResolvedUrlDiagnostic {
+  return {
+    outcome: "resolved",
+    mode: "url",
+    connector: options.connector ?? connectorIdentity(),
+    environmentNames:
+      options.environmentNames === undefined
+        ? ["GITHUB_TOKEN"]
+        : options.environmentNames,
+    run: options.run ?? {
+      status: "configured",
+      bases: ["https://api.github.com", "https://uploads.github.com"],
+    },
+    method: options.method ?? "GET",
+    base: options.base ?? "https://api.github.com",
+    relativePath: options.relativePath ?? "/repos/vm0-ai/vm0",
+    permission: options.permission ?? {
+      kind: "matched",
+      permissions: [
         {
-          base: "https://api.github.com",
-          permissions: [],
-        },
-        {
-          base: "https://uploads.github.com",
-          permissions: [],
+          name: "contents:read",
+          policy: { outcome: "allow", basis: "allow-list" },
         },
       ],
     },
-  ],
-  networkPolicies: {
-    github: {
-      allow: ["contents:read"],
-      deny: ["admin"],
-      ask: ["actions:write"],
-      unknownPolicy: "allow" as const,
-    },
-  },
-  volumes: [],
-  artifact: null,
-  featureFlags: null,
-};
+  };
+}
+
+function connectorResponse(
+  connectorRef: string,
+  connectionStatus: ConnectorResponse["connectionStatus"] = "connected",
+): ConnectorResponse {
+  return {
+    id: "00000000-0000-4000-8000-000000000002",
+    type: connectorRef,
+    authMethod: "oauth",
+    externalId: "external-1",
+    externalUsername: "user",
+    externalEmail: "user@example.com",
+    oauthScopes: ["repo"],
+    connectionStatus,
+    reconnectReason:
+      connectionStatus === "reconnect-required"
+        ? "authorization_expired_or_revoked"
+        : null,
+    tokenExpiresAt: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function diagnosticEndpoint(baseUrl = API_BASE_URL): string {
+  return `${baseUrl}/api/zero/connectors/diagnostics/check`;
+}
+
+function stubDiagnostic(
+  result: ConnectorCheckDiagnosticResult,
+  onRequest?: (body: unknown) => void,
+  baseUrl = API_BASE_URL,
+): void {
+  server.use(
+    http.post(diagnosticEndpoint(baseUrl), async ({ request }) => {
+      const body: unknown = await request.json();
+      onRequest?.(body);
+      return HttpResponse.json(result);
+    }),
+  );
+}
+
+function stubConnector(
+  connectorRef: string,
+  response: ConnectorResponse | null = connectorResponse(connectorRef),
+  onRequest?: () => void,
+  baseUrl = API_BASE_URL,
+): void {
+  server.use(
+    http.get(`${baseUrl}/api/zero/connectors/${connectorRef}`, () => {
+      onRequest?.();
+      if (response === null) {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }
+      return HttpResponse.json(response);
+    }),
+  );
+}
+
+function stubAgentConnectors(
+  enabledTypes: string[],
+  onRequest?: () => void,
+  baseUrl = API_BASE_URL,
+): void {
+  server.use(
+    http.get(`${baseUrl}/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+      onRequest?.();
+      return HttpResponse.json({ enabledTypes });
+    }),
+  );
+}
+
+function stubResolvedDependencies(
+  connectorRef = "github",
+  options: {
+    readonly connector?: ConnectorResponse | null;
+    readonly enabledTypes?: string[];
+    readonly baseUrl?: string;
+  } = {},
+): void {
+  const baseUrl = options.baseUrl ?? API_BASE_URL;
+  stubConnector(
+    connectorRef,
+    options.connector === undefined
+      ? connectorResponse(connectorRef)
+      : options.connector,
+    undefined,
+    baseUrl,
+  );
+  stubAgentConnectors(
+    options.enabledTypes ?? [connectorRef],
+    undefined,
+    baseUrl,
+  );
+}
 
 describe("zero doctor check-connector command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -118,2336 +237,843 @@ describe("zero doctor check-connector command", () => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
     chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", API_BASE_URL);
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
     vi.stubEnv("GH_TOKEN", "");
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
   });
 
   function getOutput(): string {
     return mockConsoleLog.mock.calls.flat().join("\n");
   }
 
-  describe("step 1: sandbox environment name check", () => {
-    it("should report environment name present when it exists", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("GH_TOKEN", "ghp_test123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("present");
-      expect(output).toContain(
-        "non-secret connector settings or credential placeholders",
-      );
-    });
-
-    it("should report environment name not present when it is missing", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: [] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("not present");
-    });
-  });
-
-  describe("step 2: connector status", () => {
-    it("should report unavailable connectors without connect or authorize guidance", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors([]),
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: [] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "The GitHub connector is not available for this account.",
-      );
-      expect(output).toContain(
-        "Skipped — the GitHub connector is not available for this account.",
-      );
-      expect(output).not.toContain("[Connect GitHub]");
-      expect(output).not.toContain("[Authorize GitHub]");
-    });
-
-    it("should report connector not connected with a single authorize URL that covers both connect and authorize", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: [] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("not connected");
-      // When agentId is present, the /authorize page performs the OAuth connect
-      // before granting permission — so show only that link (see issue #9589).
-      expect(output).toContain(
-        "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
-      );
-      expect(output).not.toContain("[Connect GitHub]");
-      expect(output).toContain("needs to be connected and authorized");
-    });
-
-    it("should report connector authorized but not connected with a connect URL", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("not connected");
-      expect(output).toContain(
-        "The GitHub connector is authorized for this agent, but it is not connected.",
-      );
-      expect(output).toContain(
-        "[Connect GitHub](https://app.vm0.ai/connectors/github/connect?agentId=agent-abc-123)",
-      );
-      expect(output).not.toContain("[Authorize GitHub]");
-    });
-
-    it("should report connector expired with reconnect URL", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            connectionStatus: "reconnect-required",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("expired");
-      expect(output).toContain("needs to be reconnected");
-      expect(output).toContain(
-        "[Reconnect GitHub](https://app.vm0.ai/connectors)",
-      );
-    });
-
-    it("should report connector not authorized with authorize URL", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["slack"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("not authorized");
-      expect(output).toContain(
-        "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
-      );
-    });
-
-    it("should report connector connected and active when healthy", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("connected and active");
-      expect(output).toContain("authorized for this agent");
-    });
-
-    it("should use agent authorization inside workflow-triggered runs", async () => {
-      const workflowId = "11111111-1111-4111-8111-111111111111";
-      const triggerId = "22222222-2222-4222-8222-222222222222";
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_WORKFLOW_ID", workflowId);
-      vi.stubEnv("ZERO_WORKFLOW_TRIGGER_ID", triggerId);
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: [] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [],
-            networkPolicies: null,
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "contents:read",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Agent authorization");
-      expect(output).toContain(
-        "The GitHub connector is not authorized for this agent (agent-abc-123).",
-      );
-      expect(output).toContain(
-        "/connectors/github/authorize?agentId=agent-abc-123",
-      );
-      expect(output).not.toContain(`/workflows/${workflowId}/permissions?`);
-      expect(output).not.toContain(`triggerId=${triggerId}`);
-      expect(output).toContain("Check the agent authorization settings");
-      expect(output).not.toContain("fully permissive");
-    });
-  });
-
-  describe("step 2c: registered base URLs", () => {
-    it("should list configured domains from run context", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("https://api.github.com");
-      expect(output).toContain("https://uploads.github.com");
-      expect(output).toContain(
-        "configured for this run with the following base URLs:",
-      );
-    });
-
-    it("should report no firewall entry when connector not in run", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({ ...runContextResponse, firewalls: [] });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("No configuration found");
-    });
-  });
-
-  describe("step 3: permission policy check", () => {
-    it("should report permission in allow list", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "contents:read",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Step 3: Permission policy check");
-      expect(output).toContain('"contents:read" is in the allow list');
-    });
-
-    it("should report permission in deny list", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "admin",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain('"admin" is in the deny list');
-    });
-
-    it("should report permission in ask list", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "actions:write",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("ask list:   [actions:write]");
-      expect(output).toContain('"actions:write" is in the ask list');
-      expect(output).toContain("blocked until approval");
-    });
-
-    it("should report unmatched permission as allowed by permission policy", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "some-unknown-perm",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        '"some-unknown-perm" is not in the deny or ask list',
-      );
-      expect(output).toContain(
-        "the unknown endpoint policy only applies when no named permission matches a request",
-      );
-    });
-  });
-
-  describe("URL transformation", () => {
-    it("should transform www.vm0.ai to app.vm0.ai", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://www.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://www.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(
-            { error: { message: "Not found", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.get(
-          "https://www.vm0.ai/api/zero/agents/agent-1/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: [] });
-          },
-        ),
-        http.get("https://www.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "https://app.vm0.ai/connectors/github/authorize?agentId=agent-1",
-      );
-    });
-  });
-
-  describe("unknown environment name", () => {
-    it("should exit with error for unrecognized environment name", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "UNKNOWN_FOO_TOKEN",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown environment name: UNKNOWN_FOO_TOKEN"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should not accept stored connector secret names as environment names", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GITHUB_ACCESS_TOKEN",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Unknown environment name: GITHUB_ACCESS_TOKEN",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe("option validation", () => {
-    it("should require an environment name or URL", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync(["node", "cli"]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Either --env-name or --url is required"),
-      );
-    });
-
-    it("should reject --connector without --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GH_TOKEN",
-          "--connector",
-          "github",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--connector can only be used with --url"),
-      );
-    });
-
-    it("should reject an explicitly empty --connector without --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GH_TOKEN",
-          "--connector",
-          "",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--connector can only be used with --url"),
-      );
-    });
-
-    it("should reject --check-permission with --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.github.com/repos/owner/repo",
-          "--check-permission",
-          "contents:read",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--check-permission cannot be used with --url"),
-      );
-    });
-
-    it("should reject an explicitly empty --check-permission with --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.github.com/repos/owner/repo",
-          "--check-permission",
-          "",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--check-permission cannot be used with --url"),
-      );
-    });
-
-    it("should reject an empty --check-permission in environment mode", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GH_TOKEN",
-          "--check-permission",
-          " ",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "--check-permission requires a non-empty permission name",
-        ),
-      );
-    });
-
-    it("should not ignore an explicitly empty --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GH_TOKEN",
-          "--url",
-          "",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for provided URL"),
-      );
-      expect(getOutput()).not.toContain("GH_TOKEN is managed by");
-    });
-
-    it("should reject an explicit --method without --url", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--env-name",
-          "GH_TOKEN",
-          "--method",
-          "POST",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--method can only be used with --url"),
-      );
-    });
-
-    it("should reject unknown connector types without prototype matches", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.github.com/repos/owner/repo",
-          "--connector",
-          "constructor",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown connector type: constructor"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("zero connector search 'constructor'"),
-      );
-    });
-  });
-
-  describe("re-diagnose hint", () => {
-    it("should include re-diagnose hint with check-connector syntax", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "zero doctor check-connector --env-name 'GH_TOKEN'",
-      );
-    });
-
-    it("should include --check-permission in re-diagnose hint when used", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-        "--check-permission",
-        "contents:read",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "zero doctor check-connector --env-name 'GH_TOKEN' --check-permission 'contents:read'",
-      );
-    });
-  });
-
-  describe("--url mode", () => {
-    function stubConnectedUrlConnector(type: string, authMethod: string): void {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      server.use(
-        stubAvailableConnectors([type]),
-        http.get(`https://app.vm0.ai/api/zero/connectors/${type}`, () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type,
-            authMethod,
-          });
-        }),
-      );
-    }
-
-    it("should report ambiguous generated routes with explicit selection commands", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.accounts.nintendo.com/2.0.0/users/me?code=secret#private",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Multiple connectors match GET https://api.accounts.nintendo.com/2.0.0/users/me",
-        ),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "nintendo-store, nintendo-switch-parental-controls",
-        ),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "--connector 'nintendo-switch-parental-controls'",
-        ),
-      );
-      expect(mockConsoleError).not.toHaveBeenCalledWith(
-        expect.stringContaining("code=secret"),
-      );
-    });
-
-    it.each([
-      {
-        order: ["nintendo-store", "nintendo-switch-parental-controls"],
-        selected: "nintendo-store",
-        environmentName: "NINTENDO_STORE_TOKEN",
-      },
-      {
-        order: ["nintendo-switch-parental-controls", "nintendo-store"],
-        selected: "nintendo-store",
-        environmentName: "NINTENDO_STORE_TOKEN",
-      },
-      {
-        order: ["nintendo-store", "nintendo-switch-parental-controls"],
-        selected: "nintendo-switch-parental-controls",
-        environmentName: "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
-      },
-      {
-        order: ["nintendo-switch-parental-controls", "nintendo-store"],
-        selected: "nintendo-switch-parental-controls",
-        environmentName: "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
-      },
-    ])(
-      "should select $selected from compact run firewalls in either order",
-      async ({ order, selected, environmentName }) => {
-        vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-        vi.stubEnv("VM0_TOKEN", "test-token");
-        vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-        server.use(
-          stubAvailableConnectors([selected]),
-          http.get(`https://app.vm0.ai/api/zero/connectors/${selected}`, () => {
-            return HttpResponse.json({
-              ...connectedResponse,
-              type: selected,
-              authMethod: "api",
-            });
+  function getErrorOutput(): string {
+    return mockConsoleError.mock.calls.flat().join("\n");
+  }
+
+  async function expectCommandFailure(args: string[]): Promise<void> {
+    await expect(
+      checkConnectorCommand.parseAsync(["node", "cli", ...args]),
+    ).rejects.toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  }
+
+  describe("request construction and local validation", () => {
+    it("sends a sanitized URL request and preserves every selector in the re-diagnosis hint", async () => {
+      let capturedBody: unknown;
+      stubDiagnostic(
+        resolvedUrl({
+          connector: connectorIdentity({
+            connectorRef: "server-only",
+            label: "Server Only",
           }),
-          http.get(
-            "https://app.vm0.ai/api/zero/runs/run-abc-123/context",
-            () => {
-              return HttpResponse.json({
-                ...runContextResponse,
-                firewalls: order.map((name) => {
-                  return { kind: "builtin", name };
-                }),
-                networkPolicies: null,
-              });
-            },
-          ),
-        );
-
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.accounts.nintendo.com/2.0.0/users/me",
-          "--connector",
-          selected,
-        ]);
-
-        const output = getOutput();
-        expect(output).toContain(`type: ${selected}`);
-        expect(output).toContain(`Environment names: [${environmentName}]`);
-      },
-    );
-
-    it("should reject an unsafe shared route before connector diagnosis", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              { kind: "builtin", name: "nintendo-store" },
-              {
-                kind: "builtin",
-                name: "nintendo-switch-parental-controls",
-              },
-            ],
-            networkPolicies: null,
-          });
+          environmentNames: ["SERVER_ONLY_TOKEN"],
+          method: "POST",
+          base: "https://service.example.com/api",
+          relativePath: "/items",
         }),
+        (body) => {
+          capturedBody = body;
+        },
       );
-
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.accounts.nintendo.com/2.0.0/users/%2e%2e/me",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("request path contains unsafe syntax"),
-      );
-      expect(getOutput()).not.toContain("Step 2: Connector configuration");
-    });
-
-    it("should report Railway base-only ownership ambiguity", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://backboard.railway.com/graphql/v2",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("railway, railway-project"),
-      );
-    });
-
-    it.each([
-      ["railway", "RAILWAY_TOKEN"],
-      ["railway-project", "RAILWAY_PROJECT_TOKEN"],
-    ])(
-      "should select the %s base-only owner",
-      async (selected, environmentName) => {
-        stubConnectedUrlConnector(selected, "api-token");
-
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://backboard.railway.com/graphql/v2",
-          "--connector",
-          selected,
-        ]);
-
-        const output = getOutput();
-        expect(output).toContain(`type: ${selected}`);
-        expect(output).toContain(`Environment names: [${environmentName}]`);
-      },
-    );
-
-    it("should select an ambiguous connector and derive its route environment", async () => {
-      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
-      vi.stubEnv(
-        "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
-        "placeholder",
-      );
+      stubResolvedDependencies("server-only");
 
       await checkConnectorCommand.parseAsync([
         "node",
         "cli",
         "--url",
-        "https://api.accounts.nintendo.com/2.0.0/users/me",
+        "https://service.example.com/api/items?access_token=secret#private",
         "--connector",
-        "nintendo-switch-parental-controls",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "matches the Nintendo Switch Parental Controls connector",
-      );
-      expect(output).toContain(
-        "Environment names: [NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN]",
-      );
-      expect(output).toContain(
-        "Checking process.env.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN: present",
-      );
-      expect(output).toContain(
-        "--connector 'nintendo-switch-parental-controls'",
-      );
-    });
-
-    it("should derive every environment name used by a unique API route", async () => {
-      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
-      vi.stubEnv("NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE", "en-US");
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
-        "--connector",
-        "nintendo-switch-parental-controls",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "Environment names: [NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE, NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID, NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN]",
-      );
-      expect(output).toContain(
-        "Checking process.env.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE: present",
-      );
-      expect(output).toContain(
-        "These values may be non-secret connector settings or credential placeholders",
-      );
-      expect(output).toContain(
-        "Matched permissions: [nintendo-switch-parental-controls-device-credentials-read]",
-      );
-    });
-
-    it("should derive environment names from the winning API within one connector", async () => {
-      stubConnectedUrlConnector("cloudflare", "api-token");
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.cloudflare.com/client/v4/pages/assets/upload",
-        "--method",
-        "POST",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Cloudflare connector");
-      expect(output).toContain("Environment names: []");
-      expect(output).toContain(
-        "The matched API route does not use a sandbox environment name.",
-      );
-      expect(output).toContain("Matched permissions: [page.write]");
-      expect(output).not.toContain("diagnostic-api-");
-    });
-
-    it("should not guess inline environment metadata for conflicting same-base APIs", async () => {
-      stubConnectedUrlConnector("cloudflare", "api-token");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "cloudflare",
-                apis: [
-                  {
-                    base: "https://api.cloudflare.com/client",
-                    permissions: [
-                      {
-                        name: "page.write",
-                        rules: ["POST /v4/pages/assets/upload"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              cloudflare: {
-                allow: ["page.write"],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.cloudflare.com/client/v4/pages/assets/upload",
-        "--method",
-        "POST",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Environment names: unavailable");
-      expect(output).toContain(
-        "Environment metadata is unavailable for this run's sanitized firewall entry",
-      );
-      expect(output).toContain("Matched permissions: [page.write]");
-    });
-
-    it("should reject an explicit connector that does not own a unique route", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
-          "--connector",
-          "nintendo-store",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Connector nintendo-store does not own GET https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
-        ),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "the matching connector is nintendo-switch-parental-controls",
-        ),
-      );
-    });
-
-    it("should reject a base-only selector when another owner has the winning route", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "slack",
-                apis: [
-                  {
-                    base: "https://api.github.com",
-                    permissions: [],
-                  },
-                ],
-              },
-              {
-                name: "github",
-                apis: [
-                  {
-                    base: "https://api.github.com",
-                    permissions: [
-                      {
-                        name: "repository.read",
-                        rules: ["GET /repos/{owner}/{repo}"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: null,
-          });
-        }),
-      );
-
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.github.com/repos/owner/repo",
-          "--connector",
-          "slack",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("the matching connector is github"),
-      );
-    });
-
-    it("should reject a connector-owned environment from a different API route", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.accounts.nintendo.com/2.0.0/users/me",
-          "--connector",
-          "nintendo-switch-parental-controls",
-          "--env-name",
-          "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN is not used by the matched API route",
-        ),
-      );
-    });
-
-    it.each(["UNKNOWN_ROUTE_TOKEN", "SLACK_TOKEN"])(
-      "should reject URL environment selection %s outside the selected connector",
-      async (environmentName) => {
-        await expect(async () => {
-          await checkConnectorCommand.parseAsync([
-            "node",
-            "cli",
-            "--url",
-            "https://api.github.com/repos/owner/repo",
-            "--env-name",
-            environmentName,
-          ]);
-        }).rejects.toThrow("process.exit called");
-
-        expect(mockConsoleError).toHaveBeenCalledWith(
-          expect.stringContaining(
-            `${environmentName} is not an environment name for the GitHub connector`,
-          ),
-        );
-      },
-    );
-
-    it("should not fall back to generated routes when a run context exists", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [{ kind: "builtin", name: "unknown-connector" }],
-            networkPolicies: null,
-          });
-        }),
-      );
-
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://api.github.com/repos/owner/repo",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("no firewall in the current run matches"),
-      );
-    });
-
-    it("should report unavailable environment metadata for an unmatched inline API", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["github"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "github",
-                apis: [
-                  {
-                    base: "https://legacy-github.example.com",
-                    permissions: [
-                      {
-                        name: "repository.read",
-                        rules: ["GET /repos/{owner}/{repo}"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              github: {
-                allow: ["repository.read"],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://legacy-github.example.com/repos/owner/repo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Environment names: unavailable");
-      expect(output).toContain(
-        "Environment metadata is unavailable for this run's sanitized firewall entry",
-      );
-      expect(output).not.toContain("Checking process.env.GH_TOKEN");
-      expect(output).not.toContain("Checking process.env.GITHUB_TOKEN");
-      expect(output).toContain("Matched permissions: [repository.read]");
-    });
-
-    it("should resolve connector from URL and run full diagnostic", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.github.com/repos/owner/repo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the GitHub connector");
-      expect(output).toContain("Matched base URL: https://api.github.com");
-      expect(output).toContain("Relative path:    /repos/owner/repo");
-      expect(output).toContain("Environment names: [GITHUB_TOKEN]");
-      expect(output).toContain("Step 1: Sandbox environment name");
-      expect(output).toContain("Step 2: Connector configuration");
-      expect(output).toContain(
-        "Step 3: Permission policy check (auto-detected from URL)",
-      );
-      expect(output).toContain(
-        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo'",
-      );
-    });
-
-    it("should accept a sibling environment alias for the matched route", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      vi.stubEnv("GH_TOKEN", "placeholder");
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.github.com/repos/owner/repo",
+        "server-only",
         "--env-name",
-        "GH_TOKEN",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Environment names: [GH_TOKEN]");
-      expect(output).toContain("Checking process.env.GH_TOKEN: present");
-      expect(output).toContain("--env-name 'GH_TOKEN'");
-    });
-
-    it("should resolve compact built-in run context firewalls", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [{ kind: "builtin", name: "github" }],
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.github.com/repos/owner/repo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the GitHub connector");
-      expect(output).toContain("Matched base URL: https://api.github.com");
-      expect(output).toContain("Relative path:    /repos/owner/repo");
-      expect(output).toContain(
-        "The GitHub connector is configured for this run with the following base URLs:",
-      );
-      expect(output).toContain("  - https://api.github.com");
-    });
-
-    it("should resolve compact built-in run context firewalls with base URL vars", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      vi.stubEnv("ZENDESK_API_TOKEN", "zk-placeholder");
-      server.use(
-        stubAvailableConnectors(["zendesk"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/zendesk", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "zendesk",
-            authMethod: "api-token",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["zendesk"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                kind: "builtin",
-                name: "zendesk",
-                baseUrlVars: { ZENDESK_SUBDOMAIN: "acme" },
-              },
-            ],
-            networkPolicies: {
-              zendesk: {
-                allow: [],
-                deny: [],
-                ask: [],
-                unknownPolicy: "allow" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://acme.zendesk.com/api/v2/tickets.json",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Zendesk connector");
-      expect(output).toContain("Matched base URL: https://acme.zendesk.com");
-      expect(output).toContain("Relative path:    /api/v2/tickets.json");
-      expect(output).toContain("  - https://acme.zendesk.com");
-    });
-
-    it("should keep resolved run context bases for connectors without permission routes", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["altium-365"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/altium-365", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "altium-365",
-            authMethod: "api-token",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["altium-365"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                kind: "builtin",
-                name: "altium-365",
-                baseUrlVars: {
-                  ALTIUM365_WORKSPACE_URL: "https://acme.365.altium.com",
-                },
-              },
-            ],
-            networkPolicies: {
-              "altium-365": {
-                allow: [],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://acme.365.altium.com/api/v1/projects",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Altium 365 connector");
-      expect(output).toContain("Matched base URL: https://acme.365.altium.com");
-      expect(output).toContain("Relative path:    /api/v1/projects");
-      expect(output).toContain(
-        "No named permission matches GET /api/v1/projects. This request falls through to the unknown-endpoint policy.",
-      );
-      expect(output).toContain(
-        "Result: No permission matched. The unknown endpoint policy applies: deny.",
-      );
-    });
-
-    it("should reject compact built-in run context base URL vars outside host policy", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                kind: "builtin",
-                name: "jira",
-                baseUrlVars: { JIRA_DOMAIN: "attacker.example" },
-              },
-            ],
-            networkPolicies: {
-              jira: {
-                allow: [],
-                deny: [],
-                ask: [],
-                unknownPolicy: "allow" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://attacker.example/rest/api/3/project",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("host policy does not allow resolved host"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should strip query and match permissions only on the resolved API base", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["xero"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/xero", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "xero",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["xero"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                kind: "builtin",
-                name: "xero",
-              },
-            ],
-            networkPolicies: {
-              xero: {
-                allow: ["accounting.settings", "accounting.settings.read"],
-                deny: ["connections"],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://API.XERO.COM.:443/api.xro/2.0/Accounts?token=secret-token#ignored",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Xero connector");
-      expect(output).toContain(
-        "Matched base URL: https://api.xero.com/api.xro/2.0",
-      );
-      expect(output).toContain("Relative path:    /Accounts");
-      expect(output).toContain(
-        "Matched permissions: [accounting.settings.read]",
-      );
-      expect(output).not.toContain("Matched permissions: [connections");
-      expect(output).not.toContain("secret-token");
-      expect(output).not.toContain("token=");
-      expect(output).not.toContain("#ignored");
-    });
-
-    it("should shell-quote sanitized URL in re-diagnose hint", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.github.com/repos/owner/repo'$(touch-pwn)?token=secret-token#ignored",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo'\\''$(touch-pwn)'",
-      );
-      expect(output).not.toContain("secret-token");
-      expect(output).not.toContain("token=");
-      expect(output).not.toContain("#ignored");
-    });
-
-    it("should not resolve connector base paths without a segment boundary", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://slack.com/apix/chat.postMessage",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for provided URL"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should resolve parameterized connector base URLs", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "github",
-                apis: [
-                  {
-                    base: "https://raw.githubusercontent.com/{owner}/{repo}",
-                    permissions: [],
-                  },
-                ],
-              },
-            ],
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://raw.githubusercontent.com/owner/repo/main/README.md",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the GitHub connector");
-      expect(output).toContain(
-        "Matched base URL: https://raw.githubusercontent.com/{owner}/{repo}",
-      );
-      expect(output).toContain("Relative path:    /main/README.md");
-    });
-
-    it("should resolve parameterized connector host base URLs", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["alchemy"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/alchemy", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "alchemy",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["alchemy"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "alchemy",
-                apis: [
-                  {
-                    base: "https://{network}.g.alchemy.com",
-                    permissions: [],
-                  },
-                ],
-              },
-            ],
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://ETH.G.ALCHEMY.COM/v2/demo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Alchemy connector");
-      expect(output).toContain(
-        "Matched base URL: https://{network}.g.alchemy.com",
-      );
-      expect(output).toContain("Relative path:    /v2/demo");
-    });
-
-    it("should prefer static connector base URLs over wildcard host bases", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["alchemy"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/alchemy", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "alchemy",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["alchemy"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "alchemy",
-                apis: [
-                  {
-                    base: "https://{network}.g.alchemy.com",
-                    permissions: [],
-                  },
-                  {
-                    base: "https://api.g.alchemy.com",
-                    permissions: [],
-                  },
-                ],
-              },
-            ],
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.g.alchemy.com/v2/demo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Alchemy connector");
-      expect(output).toContain("Matched base URL: https://api.g.alchemy.com");
-      expect(output).toContain("Relative path:    /v2/demo");
-    });
-
-    it("should match permissions after parameterized connector base URLs", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["test-oauth"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "test-oauth",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "test-oauth",
-                apis: [
-                  {
-                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
-                    permissions: [
-                      {
-                        name: "echo",
-                        description:
-                          "Test echo endpoint used to verify token injection",
-                        rules: ["GET /echo"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              "test-oauth": {
-                allow: ["echo"],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/echo?debug=1#fragment",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("matches the Test OAuth (internal) connector");
-      expect(output).toContain(
-        "Matched base URL: https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
-      );
-      expect(output).toContain("Relative path:    /echo");
-      expect(output).toContain("Matched permissions: [echo]");
-      expect(output).toContain('Result: "echo" is in the allow list');
-    });
-
-    it("should suggest an unknown endpoint permission request for unmatched denied URLs", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["test-oauth"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "test-oauth",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "test-oauth",
-                apis: [
-                  {
-                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
-                    permissions: [
-                      {
-                        name: "echo",
-                        description:
-                          "Test echo endpoint used to verify token injection",
-                        rules: ["GET /echo"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              "test-oauth": {
-                allow: ["echo"],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/unknown",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "No named permission matches GET /unknown. This request falls through to the unknown-endpoint policy.",
-      );
-      expect(output).toContain(
-        "Result: No permission matched. The unknown endpoint policy applies: deny.",
-      );
-      expect(output).toContain(
-        "zero doctor permission-change test-oauth --permission __unknown__ --enable --duration 1h",
-      );
-    });
-
-    it("should allow matched permissions that are not denied or asked", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["test-oauth"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "test-oauth",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "test-oauth",
-                apis: [
-                  {
-                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
-                    permissions: [
-                      {
-                        name: "echo",
-                        description:
-                          "Test echo endpoint used to verify token injection",
-                        rules: ["GET /echo"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              "test-oauth": {
-                allow: [],
-                deny: [],
-                ask: [],
-                unknownPolicy: "deny" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/echo",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain("Matched permissions: [echo]");
-      expect(output).toContain(
-        'Result: "echo" is not blocked by the deny or ask list',
-      );
-      expect(output).not.toContain("unknown endpoint policy applies: deny");
-    });
-
-    it("should not describe unsafe paths as unknown endpoints", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        stubAvailableConnectors(["test-oauth"]),
-        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
-          return HttpResponse.json({
-            ...connectedResponse,
-            type: "test-oauth",
-          });
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json({
-            ...runContextResponse,
-            firewalls: [
-              {
-                name: "test-oauth",
-                apis: [
-                  {
-                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
-                    permissions: [
-                      {
-                        name: "full",
-                        rules: ["ANY /{path+}"],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-            networkPolicies: {
-              "test-oauth": {
-                allow: ["full"],
-                deny: [],
-                ask: [],
-                unknownPolicy: "allow" as const,
-              },
-            },
-          });
-        }),
-      );
-
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/users/%2e%2e/admin",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("request path contains unsafe syntax"),
-      );
-      expect(getOutput()).not.toContain("Step 2: Connector configuration");
-    });
-
-    it("should fail for unrecognized URL", async () => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync([
-          "node",
-          "cli",
-          "--url",
-          "https://unknown-service.example.com/path",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for provided URL"),
-      );
-    });
-
-    it.each([
-      ["userinfo", "https://user:pass@api.github.com/repos/owner/repo"],
-      ["raw whitespace", "https://api.github.com/foo bar"],
-      ["authority backslash", "https://api.github.com\\repos/owner/repo"],
-      ["empty host label", "https://.g.alchemy.com/v2"],
-      ["raw host braces", "https://{eth}.g.alchemy.com/v2/demo"],
-      ["raw host comma", "https://eth,mainnet.g.alchemy.com/v2/demo"],
-      [
-        "non-default port without a matching connector base",
-        "https://api.github.com:8443/repos/owner/repo",
-      ],
-      [
-        "invalid authority percent escape",
-        "https://api%zz.github.com/repos/owner/repo",
-      ],
-      [
-        "percent-encoded host comma",
-        "https://eth%2Cmainnet.g.alchemy.com/v2/demo",
-      ],
-      [
-        "percent-encoded host braces",
-        "https://%7Beth%7D.g.alchemy.com/v2/demo",
-      ],
-      [
-        "percent-encoded authority colon",
-        "https://api.github.com%3A443/repos/owner/repo",
-      ],
-      [
-        "percent-encoded authority dot",
-        "https://api%2egithub.com/repos/owner/repo",
-      ],
-      [
-        "multiple trailing host dots",
-        "https://api.github.com../repos/owner/repo",
-      ],
-    ])("should fail for URL with %s", async (_label, url) => {
-      await expect(async () => {
-        await checkConnectorCommand.parseAsync(["node", "cli", "--url", url]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for provided URL"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should include --method in re-diagnose hint when not GET", async () => {
-      vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-      vi.stubEnv("VM0_TOKEN", "test-token");
-      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-      server.use(
-        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
-          return HttpResponse.json(connectedResponse);
-        }),
-        http.get(
-          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
-        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
-          return HttpResponse.json(runContextResponse);
-        }),
-      );
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://api.github.com/repos/owner/repo",
-        "--method",
-        "POST",
-      ]);
-
-      const output = getOutput();
-      expect(output).toContain(
-        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo' --method 'POST'",
-      );
-    });
-
-    it("should preserve every URL selector while redacting query and fragment", async () => {
-      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
-
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://app.lp1.znma.srv.nintendo.net/v3/actions/device/updateDeviceLabel?access_token=secret#private",
-        "--connector",
-        "nintendo-switch-parental-controls",
-        "--env-name",
-        "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+        "SERVER_ONLY_TOKEN",
         "--method",
         "post",
       ]);
 
+      expect(capturedBody).toStrictEqual({
+        mode: "url",
+        method: "POST",
+        url: "https://service.example.com/api/items",
+        connectorRef: "server-only",
+        environmentName: "SERVER_ONLY_TOKEN",
+      } satisfies ConnectorCheckRequest);
+      expect(getOutput()).toContain(
+        "URL https://service.example.com/api/items matches the Server Only connector",
+      );
+      expect(getOutput()).toContain(
+        "zero doctor check-connector --url 'https://service.example.com/api/items' --connector 'server-only' --env-name 'SERVER_ONLY_TOKEN' --method 'POST'",
+      );
+      expect(getOutput()).not.toContain("access_token=secret");
+      expect(getOutput()).not.toContain("#private");
+      expect(getErrorOutput()).not.toContain("access_token=secret");
+    });
+
+    it("sends an environment request with the explicit permission", async () => {
+      let capturedBody: unknown;
+      stubDiagnostic(
+        resolvedEnvironment({
+          permission: { outcome: "deny", basis: "deny-list" },
+        }),
+        (body) => {
+          capturedBody = body;
+        },
+      );
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+        "--check-permission",
+        "contents:write",
+      ]);
+
+      expect(capturedBody).toStrictEqual({
+        mode: "environment",
+        environmentName: "GH_TOKEN",
+        permission: "contents:write",
+      } satisfies ConnectorCheckRequest);
+      expect(getOutput()).toContain(
+        'Checking permission: "contents:write" for the GitHub connector.',
+      );
+      expect(getOutput()).toContain(
+        'Result: "contents:write" is in the deny list — denied.',
+      );
+    });
+
+    it.each([
+      {
+        name: "requires one input mode",
+        args: [],
+        expected: "Either --env-name or --url is required",
+      },
+      {
+        name: "rejects connector without URL",
+        args: ["--env-name", "GH_TOKEN", "--connector", "github"],
+        expected: "--connector can only be used with --url",
+      },
+      {
+        name: "rejects permission with URL",
+        args: [
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--check-permission",
+          "contents:read",
+        ],
+        expected: "--check-permission cannot be used with --url",
+      },
+      {
+        name: "rejects an empty permission",
+        args: ["--env-name", "GH_TOKEN", "--check-permission", ""],
+        expected: "--check-permission requires a non-empty permission name",
+      },
+      {
+        name: "rejects method without URL",
+        args: ["--env-name", "GH_TOKEN", "--method", "POST"],
+        expected: "--method can only be used with --url",
+      },
+    ])("$name", async ({ args, expected }) => {
+      await expectCommandFailure(args);
+      expect(getErrorOutput()).toContain(expected);
+      expect(getOutput()).not.toContain("Step 1");
+    });
+  });
+
+  describe("resolved identities and local responsibilities", () => {
+    it("uses a server-only connector ref for local presence, connection, and authorization checks", async () => {
+      const serverOnlyIdentity = connectorIdentity({
+        connectorRef: "server-only",
+        label: "Server Only Connector",
+      });
+      let connectorCalls = 0;
+      let authorizationCalls = 0;
+      vi.stubEnv("SERVER_ONLY_TOKEN", "placeholder-not-a-secret");
+      stubDiagnostic(
+        resolvedEnvironment({
+          connector: serverOnlyIdentity,
+          environmentName: "SERVER_ONLY_TOKEN",
+          run: {
+            status: "configured",
+            bases: [
+              "https://one.server-only.example.com",
+              "https://two.server-only.example.com",
+            ],
+          },
+        }),
+      );
+      stubConnector("server-only", connectorResponse("server-only"), () => {
+        connectorCalls += 1;
+      });
+      stubAgentConnectors(["server-only"], () => {
+        authorizationCalls += 1;
+      });
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "SERVER_ONLY_TOKEN",
+      ]);
+
       const output = getOutput();
       expect(output).toContain(
-        "zero doctor check-connector --url 'https://app.lp1.znma.srv.nintendo.net/v3/actions/device/updateDeviceLabel' --connector 'nintendo-switch-parental-controls' --env-name 'NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN' --method 'POST'",
+        "SERVER_ONLY_TOKEN is managed by the Server Only Connector connector (type: server-only).",
       );
-      expect(output).not.toContain("access_token=secret");
-      expect(output).not.toContain("#private");
+      expect(output).toContain(
+        "Checking process.env.SERVER_ONLY_TOKEN: present",
+      );
+      expect(output).toContain(
+        "The Server Only Connector connector is connected and active.",
+      );
+      expect(output).toContain(
+        "The Server Only Connector connector is authorized for this agent.",
+      );
+      expect(output).toContain("  - https://one.server-only.example.com");
+      expect(output).toContain("  - https://two.server-only.example.com");
+      expect(output).toContain(
+        "Credentials are resolved at the network boundary for requests matching these registered base URLs.",
+      );
+      expect(output).not.toContain("Credentials resolved from:");
+      expect(connectorCalls).toBe(1);
+      expect(authorizationCalls).toBe(1);
+    });
+
+    it("reports a missing local environment value without reading a bundled binding", async () => {
+      stubDiagnostic(resolvedEnvironment());
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).toContain(
+        "Checking process.env.GH_TOKEN: not present",
+      );
+      expect(getOutput()).toContain(
+        "No value found for these environment names",
+      );
+    });
+
+    it.each([
+      {
+        name: "unavailable",
+        identity: connectorIdentity({ visibility: "unavailable" }),
+        connector: null,
+        enabledTypes: [] as string[],
+        expected: "not available for this account",
+      },
+      {
+        name: "disconnected but authorized",
+        identity: connectorIdentity(),
+        connector: null,
+        enabledTypes: ["github"],
+        expected: "authorized for this agent, but it is not connected",
+      },
+      {
+        name: "expired",
+        identity: connectorIdentity(),
+        connector: connectorResponse("github", "reconnect-required"),
+        enabledTypes: ["github"],
+        expected: "needs to be reconnected",
+      },
+      {
+        name: "connected but unauthorized",
+        identity: connectorIdentity(),
+        connector: connectorResponse("github"),
+        enabledTypes: [] as string[],
+        expected: "not authorized for this agent",
+      },
+    ])(
+      "renders $name connector state",
+      async ({ identity, connector, enabledTypes, expected }) => {
+        stubDiagnostic(resolvedEnvironment({ connector: identity }));
+        stubResolvedDependencies("github", { connector, enabledTypes });
+
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+        ]);
+
+        expect(getOutput()).toContain(expected);
+      },
+    );
+
+    it("transforms a www API origin into app links", async () => {
+      const baseUrl = "https://www.vm0.ai";
+      vi.stubEnv("VM0_API_BACKEND_URL", baseUrl);
+      stubDiagnostic(resolvedEnvironment(), undefined, baseUrl);
+      stubResolvedDependencies("github", {
+        connector: null,
+        enabledTypes: [],
+        baseUrl,
+      });
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).toContain(
+        `[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID})`,
+      );
+      expect(getOutput()).not.toContain("https://www.vm0.ai/connectors");
+    });
+
+    it.each([
+      {
+        name: "unavailable environment metadata",
+        environmentNames: null,
+        expected: "Environment metadata is unavailable",
+      },
+      {
+        name: "a route without environment names",
+        environmentNames: [] as string[],
+        expected: "does not use a sandbox environment name",
+      },
+    ])("renders $name", async ({ environmentNames, expected }) => {
+      stubDiagnostic(resolvedUrl({ environmentNames }));
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/vm0-ai/vm0",
+      ]);
+
+      expect(getOutput()).toContain(expected);
+      expect(getOutput()).not.toContain("Checking process.env.GITHUB_TOKEN");
+    });
+  });
+
+  describe("run and credential behavior", () => {
+    it.each([
+      {
+        name: "not configured",
+        run: { status: "not-configured" as const },
+        expected: "No configuration found for the GitHub connector in this run",
+      },
+      {
+        name: "not scoped",
+        run: { status: "not-scoped" as const },
+        expected: "This diagnostic is not scoped to a run",
+      },
+    ])("renders a $name run", async ({ run, expected }) => {
+      stubDiagnostic(resolvedEnvironment({ run }));
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).toContain(expected);
+    });
+
+    it("does not claim credential resolution when the server returns none", async () => {
+      stubDiagnostic(
+        resolvedEnvironment({
+          connector: connectorIdentity({ credentialResolution: "none" }),
+        }),
+      );
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      expect(getOutput()).not.toContain(
+        "Credentials are resolved at the network boundary for requests matching these registered base URLs.",
+      );
+    });
+
+    it("does not use a local dynamic-base value when the server reports it unresolved", async () => {
+      vi.stubEnv("REAP_API_BASE_URL", "https://local-only.example.com/v1");
+      stubDiagnostic({
+        outcome: "unresolved-dynamic-base",
+        connector: connectorIdentity({
+          connectorRef: "reap",
+          label: "Reap",
+        }),
+      });
+
+      await expectCommandFailure([
+        "--url",
+        "https://local-only.example.com/v1/users",
+        "--connector",
+        "reap",
+      ]);
+
+      expect(getErrorOutput()).toContain(
+        "No authoritative Reap base URL is available",
+      );
+      expect(getOutput()).not.toContain("Step 1");
+      expect(getOutput()).not.toContain("configured for this run");
+    });
+  });
+
+  describe("final policy rendering", () => {
+    interface NamedPolicyCase {
+      readonly name: string;
+      readonly policy: ConnectorCheckPolicy;
+      readonly expected: string;
+    }
+
+    const namedPolicyCases = [
+      {
+        name: "allow list",
+        policy: { outcome: "allow", basis: "allow-list" },
+        expected: '"contents:read" is in the allow list — allowed',
+      },
+      {
+        name: "not blocked",
+        policy: { outcome: "allow", basis: "not-blocked" },
+        expected: '"contents:read" is not blocked by the deny or ask list',
+      },
+      {
+        name: "no policy",
+        policy: { outcome: "allow", basis: "no-policy" },
+        expected: "No policy entry exists for this connector",
+      },
+      {
+        name: "unknown policy allow",
+        policy: { outcome: "allow", basis: "unknown-policy" },
+        expected: "server policy allows",
+      },
+      {
+        name: "deny list",
+        policy: { outcome: "deny", basis: "deny-list" },
+        expected: '"contents:read" is in the deny list — denied',
+      },
+      {
+        name: "unknown policy deny",
+        policy: { outcome: "deny", basis: "unknown-policy" },
+        expected: "unknown-endpoint policy denies",
+      },
+      {
+        name: "ask list",
+        policy: { outcome: "ask", basis: "ask-list" },
+        expected: '"contents:read" is in the ask list — blocked until approval',
+      },
+      {
+        name: "unknown policy ask",
+        policy: { outcome: "ask", basis: "unknown-policy" },
+        expected: "unknown-endpoint policy blocks",
+      },
+      {
+        name: "not run scoped",
+        policy: { outcome: "unavailable", basis: "not-run-scoped" },
+        expected: "not scoped to a run",
+      },
+      {
+        name: "policies unavailable",
+        policy: { outcome: "unavailable", basis: "policies-unavailable" },
+        expected: "Network policies are unavailable",
+      },
+      {
+        name: "connector not configured",
+        policy: {
+          outcome: "unavailable",
+          basis: "connector-not-configured",
+        },
+        expected: "connector is not configured for this run",
+      },
+    ] satisfies readonly NamedPolicyCase[];
+
+    it.each(namedPolicyCases)(
+      "renders the $name named-permission result without full policy lists",
+      async ({ policy, expected }) => {
+        stubDiagnostic(
+          resolvedEnvironment({
+            permission: policy,
+          }),
+        );
+        stubResolvedDependencies();
+
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--check-permission",
+          "contents:read",
+        ]);
+
+        expect(getOutput()).toContain(expected);
+        expect(getOutput()).not.toContain("allow list: [");
+        expect(getOutput()).not.toContain("deny list:  [");
+        expect(getOutput()).not.toContain("ask list:   [");
+      },
+    );
+
+    it("renders multiple matched URL permissions from final server outcomes", async () => {
+      stubDiagnostic(
+        resolvedUrl({
+          permission: {
+            kind: "matched",
+            permissions: [
+              {
+                name: "contents:read",
+                policy: { outcome: "allow", basis: "allow-list" },
+              },
+              {
+                name: "metadata:read",
+                policy: { outcome: "ask", basis: "ask-list" },
+              },
+            ],
+          },
+        }),
+      );
+      stubResolvedDependencies();
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/vm0-ai/vm0",
+      ]);
+
+      expect(getOutput()).toContain(
+        "Matched permissions: [contents:read, metadata:read]",
+      );
+      expect(getOutput()).toContain('"contents:read" is in the allow list');
+      expect(getOutput()).toContain('"metadata:read" is in the ask list');
+    });
+
+    interface UnknownPolicyCase {
+      readonly name: string;
+      readonly policy: ConnectorCheckPolicy;
+      readonly expected: string;
+      readonly expectsGuidance: boolean;
+    }
+
+    const unknownPolicyCases = [
+      {
+        name: "allow",
+        policy: { outcome: "allow", basis: "unknown-policy" },
+        expected: "unknown endpoint policy allows this request",
+        expectsGuidance: false,
+      },
+      {
+        name: "no policy",
+        policy: { outcome: "allow", basis: "no-policy" },
+        expected: "No policy entry exists for this connector",
+        expectsGuidance: false,
+      },
+      {
+        name: "deny",
+        policy: { outcome: "deny", basis: "unknown-policy" },
+        expected: "unknown endpoint policy denies this request",
+        expectsGuidance: true,
+      },
+      {
+        name: "ask",
+        policy: { outcome: "ask", basis: "unknown-policy" },
+        expected: "unknown endpoint policy requires approval",
+        expectsGuidance: true,
+      },
+      {
+        name: "unavailable",
+        policy: { outcome: "unavailable", basis: "policies-unavailable" },
+        expected: "Network policies are unavailable",
+        expectsGuidance: false,
+      },
+    ] satisfies readonly UnknownPolicyCase[];
+
+    it.each(unknownPolicyCases)(
+      "renders the $name unknown-endpoint result",
+      async ({ policy, expected, expectsGuidance }) => {
+        stubDiagnostic(
+          resolvedUrl({
+            permission: { kind: "unknown-endpoint", policy },
+          }),
+        );
+        stubResolvedDependencies();
+
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/not-a-known-endpoint",
+        ]);
+
+        expect(getOutput()).toContain("No named permission matches");
+        expect(getOutput()).toContain(expected);
+        if (expectsGuidance) {
+          expect(getOutput()).toContain(
+            "permission-change github --permission __unknown__ --enable --duration 1h",
+          );
+        } else {
+          expect(getOutput()).not.toContain("--permission __unknown__");
+        }
+      },
+    );
+  });
+
+  describe("explicit diagnostic outcomes", () => {
+    interface OutcomeCase {
+      readonly name: string;
+      readonly args: string[];
+      readonly result: ConnectorCheckDiagnosticResult;
+      readonly expected: string;
+    }
+
+    const outcomeCases = [
+      {
+        name: "invalid method",
+        args: [
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--method",
+          "TRACE",
+        ],
+        result: { outcome: "unsafe-input", reason: "invalid-method" },
+        expected: "requires --method to be a supported HTTP method",
+      },
+      {
+        name: "invalid URL",
+        args: ["--url", "not-a-url"],
+        result: { outcome: "unsafe-input", reason: "invalid-url" },
+        expected: "requires --url to be a valid absolute http or https URL",
+      },
+      {
+        name: "unsafe path",
+        args: ["--url", "https://api.github.com/%2e%2e/private"],
+        result: { outcome: "unsafe-input", reason: "unsafe-path" },
+        expected: "cannot diagnose unsafe URL paths",
+      },
+      {
+        name: "unknown connector",
+        args: [
+          "--url",
+          "https://service.example.com/path",
+          "--connector",
+          "missing-connector",
+        ],
+        result: { outcome: "unknown-connector" },
+        expected: "Unknown connector type: missing-connector",
+      },
+      {
+        name: "unknown environment",
+        args: ["--env-name", "UNKNOWN_CONNECTOR_VALUE"],
+        result: { outcome: "unknown-environment" },
+        expected: "Unknown environment name: UNKNOWN_CONNECTOR_VALUE",
+      },
+      {
+        name: "catalog no match",
+        args: ["--url", "https://unknown.example.com/path"],
+        result: { outcome: "no-match", scope: "catalog" },
+        expected: "no registered connector base URL matches this URL",
+      },
+      {
+        name: "run no match",
+        args: ["--url", "https://unknown.example.com/path"],
+        result: { outcome: "no-match", scope: "run" },
+        expected:
+          "no connector configured for the current run matches this URL",
+      },
+      {
+        name: "connector mismatch",
+        args: [
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--connector",
+          "slack",
+        ],
+        result: {
+          outcome: "connector-mismatch",
+          connector: connectorIdentity(),
+        },
+        expected: "the matching connector is github",
+      },
+      {
+        name: "environment not owned",
+        args: [
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--env-name",
+          "SLACK_TOKEN",
+        ],
+        result: {
+          outcome: "environment-not-owned",
+          connector: connectorIdentity(),
+        },
+        expected:
+          "SLACK_TOKEN is not an environment name for the GitHub connector",
+      },
+      {
+        name: "environment not used",
+        args: [
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--env-name",
+          "GH_TOKEN",
+        ],
+        result: {
+          outcome: "environment-not-used",
+          connector: connectorIdentity(),
+          environmentNames: ["GITHUB_TOKEN"],
+        },
+        expected: "Expected one of: GITHUB_TOKEN",
+      },
+      {
+        name: "unresolved dynamic base",
+        args: [
+          "--url",
+          "https://tenant.example.com/path",
+          "--connector",
+          "reap",
+        ],
+        result: {
+          outcome: "unresolved-dynamic-base",
+          connector: connectorIdentity({
+            connectorRef: "reap",
+            label: "Reap",
+          }),
+        },
+        expected: "No authoritative Reap base URL is available",
+      },
+      {
+        name: "run context unavailable",
+        args: ["--env-name", "GH_TOKEN"],
+        result: { outcome: "run-context-unavailable" },
+        expected: "current run context is unavailable",
+      },
+    ] satisfies readonly OutcomeCase[];
+
+    it.each(outcomeCases)(
+      "renders the $name outcome without starting resolved checks",
+      async ({ args, result, expected }) => {
+        stubDiagnostic(result);
+
+        await expectCommandFailure(args);
+
+        expect(getErrorOutput()).toContain(expected);
+        expect(getOutput()).not.toContain("Step 1");
+        expect(getOutput()).not.toContain("Step 2");
+      },
+    );
+
+    it("sorts ambiguous candidates and prints sanitized selection commands", async () => {
+      stubDiagnostic({
+        outcome: "ambiguous",
+        candidates: [
+          { connectorRef: "zeta", label: "Zeta" },
+          { connectorRef: "alpha", label: "Alpha" },
+        ],
+      });
+
+      await expectCommandFailure([
+        "--url",
+        "https://shared.example.com/path?secret=value#private",
+        "--method",
+        "post",
+      ]);
+
+      const error = getErrorOutput();
+      expect(error).toContain("alpha, zeta");
+      expect(error).toContain(
+        "--url 'https://shared.example.com/path' --connector 'alpha' --method 'POST'",
+      );
+      expect(error).toContain(
+        "--url 'https://shared.example.com/path' --connector 'zeta' --method 'POST'",
+      );
+      expect(error).not.toContain("secret=value");
+      expect(error).not.toContain("#private");
+    });
+  });
+
+  describe("endpoint and contract failures", () => {
+    it.each([
+      {
+        name: "missing endpoint",
+        status: 404,
+        body: { error: { message: "Route not found", code: "NOT_FOUND" } },
+        expected: "Route not found",
+      },
+      {
+        name: "authentication failure",
+        status: 401,
+        body: { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
+        expected: "Authentication failed",
+      },
+      {
+        name: "authorization failure",
+        status: 403,
+        body: { error: { message: "Forbidden", code: "FORBIDDEN" } },
+        expected: "403: Forbidden",
+      },
+      {
+        name: "server failure",
+        status: 500,
+        body: { error: { message: "Server failed", code: "INTERNAL" } },
+        expected: "500: Server failed",
+      },
+    ])(
+      "surfaces $name with no fallback",
+      async ({ status, body, expected }) => {
+        let secondaryCalls = 0;
+        server.use(
+          http.post(diagnosticEndpoint(), () => {
+            return HttpResponse.json(body, { status });
+          }),
+        );
+        stubConnector("github", connectorResponse("github"), () => {
+          secondaryCalls += 1;
+        });
+        stubAgentConnectors(["github"], () => {
+          secondaryCalls += 1;
+        });
+
+        await expectCommandFailure(["--env-name", "GH_TOKEN"]);
+
+        expect(getErrorOutput()).toContain(expected);
+        expect(getOutput()).not.toContain("Step 1");
+        expect(secondaryCalls).toBe(0);
+      },
+    );
+
+    it("surfaces a network failure with no fallback", async () => {
+      server.use(
+        http.post(diagnosticEndpoint(), () => {
+          return HttpResponse.error();
+        }),
+      );
+
+      await expectCommandFailure(["--env-name", "GH_TOKEN"]);
+
+      expect(getErrorOutput()).not.toBe("");
+      expect(getOutput()).not.toContain("Step 1");
+    });
+
+    it("rejects a malformed successful response at runtime", async () => {
+      server.use(
+        http.post(diagnosticEndpoint(), () => {
+          return HttpResponse.json({ outcome: "future-unsupported-outcome" });
+        }),
+      );
+
+      await expectCommandFailure(["--env-name", "GH_TOKEN"]);
+
+      expect(getErrorOutput()).not.toBe("");
+      expect(getOutput()).not.toContain("Step 1");
+      expect(getOutput()).not.toContain("configured for this run");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -66,6 +66,21 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
+function rawUrlAuthorityHasUserinfo(url: string): boolean {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd === -1) return false;
+
+  const authorityStart = schemeEnd + 3;
+  let authorityEnd = url.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const delimiterIndex = url.indexOf(delimiter, authorityStart);
+    if (delimiterIndex !== -1) {
+      authorityEnd = Math.min(authorityEnd, delimiterIndex);
+    }
+  }
+  return url.slice(authorityStart, authorityEnd).includes("@");
+}
+
 function shellQuoteArg(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -90,6 +105,10 @@ function validateCheckConnectorOptions(
   command: Command,
 ): asserts opts is ValidatedCheckConnectorOptions {
   const hasUrl = opts.url !== undefined;
+  // Reject embedded credentials before the diagnostic request leaves the client.
+  if (opts.url !== undefined && rawUrlAuthorityHasUserinfo(opts.url)) {
+    throw unsafeInputError("invalid-url");
+  }
   if (opts.connector !== undefined && !hasUrl) {
     throw new Error(
       "--connector can only be used with --url. Add --url <URL> or remove --connector.",

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1,50 +1,26 @@
 import { Command, Option } from "commander";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  getConnectorEnvBindingEntries,
-  getDiagnosticConnectorTypeForRuntimeEnvName,
-} from "@vm0/connectors/connector-utils";
-import {
-  type FirewallConnectorIntent,
-  type FirewallRequestDecision,
-  matchFirewallBaseUrl,
-  matchFirewallRequestDecision,
-  type FirewallRoutingPermissionApi,
-  type FirewallRoutingPermissionRoute,
-} from "@vm0/connectors/firewall-rule-matcher";
-import {
-  type FirewallBaseHostPolicy,
-  resolveFirewallBaseUrlTemplate,
-  UNKNOWN_PERMISSION_GRANT,
-  type NetworkPolicies,
-} from "@vm0/connectors/firewall-types";
-import {
-  FIREWALL_ROUTING_METADATA_INDEX,
-  loadFirewallRoutingMetadata,
-  type FirewallRoutingMetadata,
-} from "@vm0/connectors/firewall-metadata/routing";
-import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
-import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type {
+  ConnectorCheckDiagnosticResult,
+  ConnectorCheckPolicy,
+  ConnectorCheckRequest,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
+
 import { getApiUrl } from "../../../lib/api/config";
 import {
+  diagnoseZeroConnectorCheck,
   getZeroConnector,
-  searchZeroConnectors,
 } from "../../../lib/api/domains/zero-connectors";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
-import { getZeroRunContext } from "../../../lib/api/domains/zero-runs";
 import { withErrorHandler } from "../../../lib/command";
 import { toPlatformUrl } from "./platform-url";
-import { decodeZeroTokenPayload } from "../../../lib/api/zero-token";
 
 interface CheckConnectorOptions {
-  connector?: string;
-  envName?: string;
-  url?: string;
-  method: string;
-  checkPermission?: string;
+  readonly connector?: string;
+  readonly envName?: string;
+  readonly url?: string;
+  readonly method: string;
+  readonly checkPermission?: string;
 }
 
 type ValidatedCheckConnectorOptions = CheckConnectorOptions &
@@ -53,76 +29,32 @@ type ValidatedCheckConnectorOptions = CheckConnectorOptions &
     | { readonly url?: undefined; readonly envName: string }
   );
 
-interface DiagContext {
-  environmentNames: readonly string[] | null;
-  connectorType: ConnectorType;
-  label: string;
-  connectorAvailable: boolean;
-  platformOrigin: string;
-  agentId: string | undefined;
-}
-
-interface RunConnectorState {
-  readonly networkPolicies: NetworkPolicies | null;
-  readonly configuredForRun: boolean | null;
-}
-
-interface DiagnosticRoutingApi extends FirewallRoutingPermissionApi {
-  readonly environmentNames: readonly string[] | null;
-}
-
-interface DiagnosticRoutingConfig {
-  readonly type: ConnectorType;
-  readonly label: string;
-  readonly apis: readonly DiagnosticRoutingApi[];
-}
-
-interface DiagnosticDecisionPermission {
-  readonly name: string;
-  readonly rules: readonly string[];
-}
-
-interface DiagnosticDecisionApi {
-  readonly base: string;
-  readonly auth: Record<string, never>;
-  readonly permissions: readonly DiagnosticDecisionPermission[];
-}
-
-interface DiagnosticDecisionFirewall {
-  readonly name: string;
-  readonly apis: readonly DiagnosticDecisionApi[];
-}
-
-type SelectedFirewallRequestDecision = Extract<
-  FirewallRequestDecision,
-  { readonly kind: "allow" | "block" }
+type ResolvedDiagnostic = Extract<
+  ConnectorCheckDiagnosticResult,
+  { readonly outcome: "resolved" }
+>;
+type ResolvedUrlDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "url" }
+>;
+type ResolvedEnvironmentDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "environment" }
+>;
+type UrlDiagnosticRequest = Extract<
+  ConnectorCheckRequest,
+  { readonly mode: "url" }
 >;
 
-interface UrlDiagnosticResult {
-  readonly connectorType: ConnectorType;
-  readonly routingConfig: DiagnosticRoutingConfig;
-  readonly decision: SelectedFirewallRequestDecision;
+interface DiagContext {
   readonly environmentNames: readonly string[] | null;
-}
-
-type RunContextFirewall = RunContextResponse["firewalls"][number];
-type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
-type RunContextInlinePermission =
-  RunContextInlineFirewall["apis"][number]["permissions"] extends
-    | readonly (infer Permission)[]
-    | undefined
-    ? Permission
-    : never;
-
-function isConnectorType(type: string): type is ConnectorType {
-  return Object.hasOwn(CONNECTOR_TYPES, type);
-}
-
-async function connectorTypeIsAvailable(type: ConnectorType): Promise<boolean> {
-  const catalog = await searchZeroConnectors();
-  return catalog.connectors.some((connector) => {
-    return connector.id === type;
-  });
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+  readonly connectorAvailable: boolean;
+  readonly credentialResolution: "network-boundary" | "none";
+  readonly run: ResolvedDiagnostic["run"];
+  readonly platformOrigin: string;
+  readonly agentId: string | undefined;
 }
 
 function stripUrlQueryAndFragment(url: string): string {
@@ -138,367 +70,267 @@ function shellQuoteArg(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function routesToDecisionPermissions(
-  routes: readonly FirewallRoutingPermissionRoute[],
-): DiagnosticDecisionPermission[] {
-  const rulesByPermission = new Map<string, string[]>();
-  for (const route of routes) {
-    const rules = rulesByPermission.get(route.permissionName);
-    if (rules) {
-      rules.push(route.rule);
-    } else {
-      rulesByPermission.set(route.permissionName, [route.rule]);
-    }
+function connectorSelectionCommand(
+  url: string,
+  method: string,
+  connectorRef: string,
+): string {
+  const args = [
+    `--url ${shellQuoteArg(url)}`,
+    `--connector ${shellQuoteArg(connectorRef)}`,
+  ];
+  if (method !== "GET") {
+    args.push(`--method ${shellQuoteArg(method)}`);
+  }
+  return `zero doctor check-connector ${args.join(" ")}`;
+}
+
+function validateCheckConnectorOptions(
+  opts: CheckConnectorOptions,
+  command: Command,
+): asserts opts is ValidatedCheckConnectorOptions {
+  const hasUrl = opts.url !== undefined;
+  if (opts.connector !== undefined && !hasUrl) {
+    throw new Error(
+      "--connector can only be used with --url. Add --url <URL> or remove --connector.",
+    );
+  }
+  if (opts.checkPermission !== undefined && hasUrl) {
+    throw new Error(
+      "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
+    );
+  }
+  if (opts.checkPermission?.trim() === "") {
+    throw new Error("--check-permission requires a non-empty permission name.");
+  }
+  if (!hasUrl && command.getOptionValueSource("method") === "cli") {
+    throw new Error(
+      "--method can only be used with --url. Add --url <URL> or remove --method.",
+    );
+  }
+  if (opts.envName === undefined && !hasUrl) {
+    throw new Error(
+      "Either --env-name or --url is required. Use --help for usage.",
+    );
+  }
+}
+
+function buildDiagnosticRequest(
+  opts: ValidatedCheckConnectorOptions,
+  method: string,
+): ConnectorCheckRequest {
+  if (opts.url !== undefined) {
+    return {
+      mode: "url",
+      method,
+      url: stripUrlQueryAndFragment(opts.url),
+      ...(opts.connector !== undefined ? { connectorRef: opts.connector } : {}),
+      ...(opts.envName !== undefined ? { environmentName: opts.envName } : {}),
+    };
   }
 
-  return [...rulesByPermission.entries()].map(([name, rules]) => {
-    return { name, rules };
-  });
-}
-
-function routingConfigsToDecisionFirewalls(
-  configs: readonly DiagnosticRoutingConfig[],
-): readonly DiagnosticDecisionFirewall[] {
-  return configs.map((config) => {
-    return {
-      name: config.type,
-      apis: config.apis.map((api) => {
-        return {
-          base: api.base,
-          auth: {},
-          permissions: routesToDecisionPermissions(api.routes),
-        };
-      }),
-    };
-  });
-}
-
-interface RoutingBaseExecutionTemplate {
-  readonly credentialed: boolean;
-  readonly hostPolicy?: FirewallBaseHostPolicy;
-}
-
-function routingBaseExecutionTemplate(
-  type: ConnectorType,
-  base: string,
-): RoutingBaseExecutionTemplate {
-  const executionMetadata = getFirewallExecutionMetadata(type);
-  const template = executionMetadata?.baseUrlTemplates.find((entry) => {
-    return entry.base === base;
-  });
   return {
-    credentialed: template?.credentialed ?? true,
-    ...(template?.hostPolicy !== undefined
-      ? { hostPolicy: template.hostPolicy }
+    mode: "environment",
+    environmentName: opts.envName,
+    ...(opts.checkPermission !== undefined
+      ? { permission: opts.checkPermission }
       : {}),
   };
 }
 
-function routingConfigFromMetadata(
-  metadata: FirewallRoutingMetadata,
-  baseUrlVars: Record<string, string> | undefined,
-  resolveBaseUrlVars: boolean,
-): DiagnosticRoutingConfig {
-  return {
-    type: metadata.type,
-    label: metadata.label,
-    apis: metadata.apis.map((api) => {
-      const template = routingBaseExecutionTemplate(metadata.type, api.base);
-      return {
-        base: resolveBaseUrlVars
-          ? resolveFirewallBaseUrlTemplate({
-              serviceName: metadata.type,
-              base: api.base,
-              vars: baseUrlVars,
-              credentialed: template.credentialed,
-              ...(template.hostPolicy !== undefined
-                ? { hostPolicy: template.hostPolicy }
-                : {}),
-            })
-          : api.base,
-        routes: api.routes,
-        environmentNames: api.environmentNames,
-      };
-    }),
-  };
-}
-
-function runContextPermissionRoutes(
-  permissions: readonly RunContextInlinePermission[] | undefined,
-): FirewallRoutingPermissionApi["routes"] {
-  const routes: { permissionName: string; rule: string }[] = [];
-  const seenPermissionNames = new Set<string>();
-  for (const permission of permissions ?? []) {
-    if (seenPermissionNames.has(permission.name)) continue;
-    seenPermissionNames.add(permission.name);
-    for (const rule of permission.rules) {
-      routes.push({
-        permissionName: permission.name,
-        rule,
-      });
-    }
+function requireUrlRequest(
+  request: ConnectorCheckRequest,
+): UrlDiagnosticRequest {
+  if (request.mode !== "url") {
+    throw new Error(
+      "Connector diagnostic returned a URL-only outcome for an environment request.",
+    );
   }
-  return routes;
+  return request;
 }
 
-function inlineApiEnvironmentNames(
-  base: string,
-  metadata: FirewallRoutingMetadata | null,
-): readonly string[] | null {
-  if (!metadata) return null;
-  const [first, ...otherApis] = metadata.apis.filter((api) => {
-    return api.base === base;
-  });
-  if (!first) return null;
-  for (const api of otherApis) {
-    if (
-      api.environmentNames.length !== first.environmentNames.length ||
-      api.environmentNames.some((name, index) => {
-        return name !== first.environmentNames[index];
-      })
-    ) {
-      return null;
-    }
+function requestedEnvironmentName(request: ConnectorCheckRequest): string {
+  if (request.environmentName === undefined) {
+    throw new Error(
+      "Connector diagnostic returned an environment outcome without an environment name.",
+    );
   }
-  return first.environmentNames;
+  return request.environmentName;
 }
 
-function routingConfigFromInlineRunContext(
-  firewall: RunContextInlineFirewall,
-  connectorType: ConnectorType,
-  metadata: FirewallRoutingMetadata | null,
-): DiagnosticRoutingConfig {
-  return {
-    type: connectorType,
-    label: CONNECTOR_TYPES[connectorType].label,
-    apis: firewall.apis.map((api) => {
-      return {
-        base: api.base,
-        routes: runContextPermissionRoutes(api.permissions),
-        environmentNames: inlineApiEnvironmentNames(api.base, metadata),
-      };
-    }),
-  };
-}
-
-async function runContextFirewallRoutingConfig(
-  firewall: RunContextFirewall,
-): Promise<DiagnosticRoutingConfig | null> {
-  if ("apis" in firewall) {
-    if (!isConnectorType(firewall.name)) return null;
-    const metadata = await loadFirewallRoutingMetadata(firewall.name);
-    return routingConfigFromInlineRunContext(firewall, firewall.name, metadata);
+function unsafeInputError(
+  reason: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "unsafe-input" }
+  >["reason"],
+): Error {
+  switch (reason) {
+    case "invalid-method":
+      return new Error(
+        "check-connector requires --method to be a supported HTTP method.",
+      );
+    case "invalid-url":
+      return new Error(
+        "check-connector requires --url to be a valid absolute http or https URL.",
+      );
+    case "unsafe-path":
+      return new Error(
+        "check-connector cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
+      );
   }
-  if (!isConnectorType(firewall.name)) {
-    return null;
-  }
-  const metadata = await loadFirewallRoutingMetadata(firewall.name);
-  if (!metadata) return null;
-  return routingConfigFromMetadata(metadata, firewall.baseUrlVars, true);
-}
-
-function mergeRoutingConfigs(
-  configs: readonly DiagnosticRoutingConfig[],
-): DiagnosticRoutingConfig[] {
-  const merged = new Map<ConnectorType, DiagnosticRoutingConfig>();
-  for (const config of configs) {
-    const existing = merged.get(config.type);
-    merged.set(config.type, {
-      type: config.type,
-      label: config.label,
-      apis: existing ? [...existing.apis, ...config.apis] : config.apis,
-    });
-  }
-  return [...merged.values()];
-}
-
-async function loadRunContextRoutingConfigs(
-  runContext: RunContextResponse,
-): Promise<DiagnosticRoutingConfig[]> {
-  const configs = await Promise.all(
-    runContext.firewalls.map(async (firewall) => {
-      return await runContextFirewallRoutingConfig(firewall);
-    }),
-  );
-  return mergeRoutingConfigs(
-    configs.filter((config): config is DiagnosticRoutingConfig => {
-      return config !== null;
-    }),
-  );
-}
-
-async function loadGeneratedRoutingConfigs(
-  url: string,
-): Promise<DiagnosticRoutingConfig[]> {
-  let bestScore: number | null = null;
-  const connectorTypes = new Set<ConnectorType>();
-  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
-    for (const api of metadata.apis) {
-      const match = matchFirewallBaseUrl(url, api.base);
-      if (match === null) continue;
-      if (bestScore === null || match.score > bestScore) {
-        bestScore = match.score;
-        connectorTypes.clear();
-      }
-      if (match.score === bestScore) {
-        connectorTypes.add(metadata.type);
-      }
-    }
-  }
-
-  const configs = await Promise.all(
-    [...connectorTypes].sort().map(async (type) => {
-      const metadata = await loadFirewallRoutingMetadata(type);
-      return metadata
-        ? routingConfigFromMetadata(metadata, undefined, false)
-        : null;
-    }),
-  );
-  return configs.filter((config): config is DiagnosticRoutingConfig => {
-    return config !== null;
-  });
-}
-
-function decisionOwnerNames(
-  decision: FirewallRequestDecision,
-): readonly string[] {
-  if (decision.kind === "ambiguous") return decision.candidates;
-  if (decision.kind === "allow" || decision.kind === "block") {
-    return [decision.firewallName];
-  }
-  return [];
-}
-
-function environmentNamesForWinningApis(
-  config: DiagnosticRoutingConfig,
-  method: string,
-  url: string,
-): readonly string[] | null {
-  const apisByOwner = new Map<string, DiagnosticRoutingApi>();
-  const firewalls = config.apis.map((api, index) => {
-    const name = `diagnostic-api-${index}`;
-    apisByOwner.set(name, api);
-    return {
-      name,
-      apis: [
-        {
-          base: api.base,
-          auth: {},
-          permissions: routesToDecisionPermissions(api.routes),
-        },
-      ],
-    } satisfies DiagnosticDecisionFirewall;
-  });
-  const decision = matchFirewallRequestDecision(firewalls, method, url);
-  const names = new Set<string>();
-  let found = false;
-  for (const owner of decisionOwnerNames(decision)) {
-    const api = apisByOwner.get(owner);
-    if (!api) continue;
-    found = true;
-    if (api.environmentNames === null) return null;
-    for (const name of api.environmentNames) names.add(name);
-  }
-  return found ? [...names].sort() : null;
-}
-
-function connectorSelectionCommand(
-  url: string,
-  method: string,
-  connectorType: string,
-): string {
-  const args = [
-    `--url ${shellQuoteArg(stripUrlQueryAndFragment(url))}`,
-    `--connector ${shellQuoteArg(connectorType)}`,
-  ];
-  if (method !== "GET") args.push(`--method ${shellQuoteArg(method)}`);
-  return `zero doctor check-connector ${args.join(" ")}`;
 }
 
 function ambiguousConnectorError(
-  decision: Extract<FirewallRequestDecision, { readonly kind: "ambiguous" }>,
-  url: string,
+  request: UrlDiagnosticRequest,
+  result: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "ambiguous" }
+  >,
 ): Error {
-  const candidates = [...decision.candidates].sort();
+  const candidates = [...result.candidates].sort((left, right) => {
+    return left.connectorRef.localeCompare(right.connectorRef);
+  });
   const commands = candidates.map((candidate) => {
-    return `  ${connectorSelectionCommand(url, decision.method, candidate)}`;
+    return `  ${connectorSelectionCommand(request.url, request.method, candidate.connectorRef)}`;
   });
   return new Error(
-    `Multiple connectors match ${decision.method} ${stripUrlQueryAndFragment(url)} at the same route specificity: ${candidates.join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
+    `Multiple connectors match ${request.method} ${request.url}: ${candidates
+      .map((candidate) => {
+        return candidate.connectorRef;
+      })
+      .join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
   );
 }
 
-async function resolveUrlDiagnostic(
-  url: string,
-  method: string,
-  requestedConnector: ConnectorType | undefined,
-  runContext: RunContextResponse | null,
-): Promise<UrlDiagnosticResult> {
-  const routingConfigs = runContext
-    ? await loadRunContextRoutingConfigs(runContext)
-    : await loadGeneratedRoutingConfigs(url);
-  const connectorIntent: FirewallConnectorIntent = requestedConnector
-    ? { status: "present", value: requestedConnector }
-    : { status: "absent" };
-  const decision = matchFirewallRequestDecision(
-    routingConfigsToDecisionFirewalls(routingConfigs),
-    method,
-    url,
-    runContext?.networkPolicies,
-    connectorIntent,
-  );
-
-  if (decision.kind === "ambiguous") {
-    throw ambiguousConnectorError(decision, url);
-  }
-  if (decision.kind === "no_match") {
-    throw new Error(
-      runContext
-        ? "No connector found for provided URL — no firewall in the current run matches this URL"
-        : "No connector found for provided URL — no registered base URL matches this URL",
+function unknownConnectorError(request: ConnectorCheckRequest): Error {
+  if (request.mode === "url" && request.connectorRef !== undefined) {
+    return new Error(
+      `Unknown connector type: ${request.connectorRef}\nRun: zero connector search ${shellQuoteArg(request.connectorRef)}`,
     );
   }
-  if (decision.kind === "block" && decision.reason === "unsafe_path") {
-    throw new Error(
-      `Cannot diagnose ${method} ${stripUrlQueryAndFragment(url)} because the request path contains unsafe syntax`,
-    );
-  }
-  if (!isConnectorType(decision.firewallName)) {
-    throw new Error("The matched firewall is not a registered connector");
-  }
-  if (
-    requestedConnector !== undefined &&
-    decision.firewallName !== requestedConnector
-  ) {
-    throw new Error(
-      `Connector ${requestedConnector} does not own ${method} ${stripUrlQueryAndFragment(url)}; the matching connector is ${decision.firewallName}\nRun: ${connectorSelectionCommand(url, method, decision.firewallName)}`,
-    );
-  }
-
-  const routingConfig = routingConfigs.find((config) => {
-    return config.type === decision.firewallName;
-  });
-  if (!routingConfig) {
-    throw new Error("The matched connector routing metadata is unavailable");
-  }
-
-  return {
-    connectorType: decision.firewallName,
-    routingConfig,
-    decision,
-    environmentNames: environmentNamesForWinningApis(
-      routingConfig,
-      method,
-      url,
-    ),
-  };
+  return new Error("The requested connector is unknown.");
 }
 
-async function getCurrentRunContext(): Promise<RunContextResponse | null> {
-  const payload = decodeZeroTokenPayload();
-  const runId = payload?.runId;
-  if (!runId) return null;
-  return await getZeroRunContext(runId);
+function noMatchError(
+  result: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "no-match" }
+  >,
+): Error {
+  return new Error(
+    result.scope === "run"
+      ? "No connector found for provided URL — no connector configured for the current run matches this URL"
+      : "No connector found for provided URL — no registered connector base URL matches this URL",
+  );
+}
+
+function connectorMismatchError(
+  request: UrlDiagnosticRequest,
+  result: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "connector-mismatch" }
+  >,
+): Error {
+  const requestedRef = request.connectorRef ?? "the requested connector";
+  return new Error(
+    `Connector ${requestedRef} does not own ${request.method} ${request.url}; the matching connector is ${result.connector.connectorRef}\nRun: ${connectorSelectionCommand(request.url, request.method, result.connector.connectorRef)}`,
+  );
+}
+
+function environmentNotOwnedError(
+  request: ConnectorCheckRequest,
+  result: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "environment-not-owned" }
+  >,
+): Error {
+  const environmentName = requestedEnvironmentName(request);
+  return new Error(
+    `${environmentName} is not an environment name for the ${result.connector.label} connector. Remove --env-name to use the matched route metadata.`,
+  );
+}
+
+function environmentNotUsedError(
+  request: ConnectorCheckRequest,
+  result: Extract<
+    ConnectorCheckDiagnosticResult,
+    { readonly outcome: "environment-not-used" }
+  >,
+): Error {
+  const environmentName = requestedEnvironmentName(request);
+  return new Error(
+    `${environmentName} is not used by the matched API route. Expected one of: ${result.environmentNames.join(", ") || "none"}. Remove --env-name to use the matched route metadata.`,
+  );
+}
+
+function resolvedDiagnostic(
+  request: ConnectorCheckRequest,
+  result: ConnectorCheckDiagnosticResult,
+): ResolvedDiagnostic {
+  switch (result.outcome) {
+    case "resolved":
+      return result;
+    case "unsafe-input":
+      throw unsafeInputError(result.reason);
+    case "unknown-connector":
+      throw unknownConnectorError(request);
+    case "unknown-environment":
+      throw new Error(
+        `Unknown environment name: ${requestedEnvironmentName(request)} — not managed by any connector`,
+      );
+    case "no-match":
+      throw noMatchError(result);
+    case "ambiguous":
+      throw ambiguousConnectorError(requireUrlRequest(request), result);
+    case "connector-mismatch":
+      throw connectorMismatchError(requireUrlRequest(request), result);
+    case "environment-not-owned":
+      throw environmentNotOwnedError(request, result);
+    case "environment-not-used":
+      throw environmentNotUsedError(request, result);
+    case "unresolved-dynamic-base":
+      throw new Error(
+        `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${result.connector.connectorRef} connector configuration for the affected context and retry.`,
+      );
+    case "run-context-unavailable":
+      throw new Error(
+        "The current run context is unavailable for connector diagnosis. Retry from an active run or start a new run.",
+      );
+  }
+}
+
+function printDiagnosticSummary(
+  request: ConnectorCheckRequest,
+  result: ResolvedDiagnostic,
+): void {
+  if (result.mode === "url") {
+    const urlRequest = requireUrlRequest(request);
+    console.log(
+      `URL ${urlRequest.url} matches the ${result.connector.label} connector (type: ${result.connector.connectorRef}).`,
+    );
+    console.log(`  Matched base URL: ${result.base}`);
+    console.log(`  Relative path:    ${result.relativePath}`);
+    if (result.environmentNames === null) {
+      console.log("  Environment names: unavailable");
+    } else {
+      console.log(
+        `  Environment names: [${result.environmentNames.join(", ")}]`,
+      );
+    }
+    return;
+  }
+
+  console.log(
+    `${result.environmentName} is managed by the ${result.connector.label} connector (type: ${result.connector.connectorRef}).`,
+  );
+}
+
+function diagnosticEnvironmentNames(
+  result: ResolvedDiagnostic,
+): readonly string[] | null {
+  return result.mode === "url"
+    ? result.environmentNames
+    : [result.environmentName];
 }
 
 function printConnectorConnectionStatus(
@@ -508,7 +340,7 @@ function printConnectorConnectionStatus(
   hasPermission: boolean,
 ): void {
   console.log(
-    `### 2a: Connector status (user must configure via OAuth login or API key)`,
+    "### 2a: Connector status (user must configure via OAuth login or API key)",
   );
   console.log("");
   if (!ctx.connectorAvailable) {
@@ -518,13 +350,10 @@ function printConnectorConnectionStatus(
   } else if (!isConnected) {
     console.log(`The ${ctx.label} connector is not connected.`);
     if (ctx.agentId && hasPermission) {
-      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorRef}/connect?agentId=${ctx.agentId}`;
       console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
     } else if (!ctx.agentId) {
-      // No agentId: can't scope the authorize page, so fall back to a plain
-      // connect link. With agentId, 2b's Authorize link performs the initial
-      // OAuth connect before granting permission — one link covers both steps.
-      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorRef}/connect`;
       console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
     }
   } else if (isExpired) {
@@ -548,8 +377,6 @@ function printAgentAuthorizationStatus(
   if (!ctx.agentId) {
     console.log("ZERO_AGENT_ID is not set — cannot check agent authorization.");
   } else if (isExpired) {
-    // The /authorize page treats an expired connector as "already connected"
-    // and won't re-trigger OAuth. Defer to 2a's Reconnect link in that case.
     console.log(
       `Skipped — agent authorization can only be checked once the ${ctx.label} connector is reconnected (see 2a).`,
     );
@@ -560,7 +387,7 @@ function printAgentAuthorizationStatus(
         : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
     );
   } else {
-    const url = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/authorize?agentId=${ctx.agentId}`;
+    const url = `${ctx.platformOrigin}/connectors/${ctx.connectorRef}/authorize?agentId=${ctx.agentId}`;
     console.log(
       isConnected
         ? `The ${ctx.label} connector is not authorized for this agent (${ctx.agentId}).`
@@ -577,7 +404,7 @@ function printConnectorAuthorizationStatus(
   hasPermission: boolean,
 ): void {
   console.log(
-    `### 2b: Agent authorization (user must authorize agent to use this connector)`,
+    "### 2b: Agent authorization (user must authorize agent to use this connector)",
   );
   console.log("");
   if (!ctx.connectorAvailable) {
@@ -591,69 +418,6 @@ function printConnectorAuthorizationStatus(
     `This run uses agent-scoped connector authorization for ${ctx.label} access.`,
   );
   console.log("");
-}
-
-function connectorEnvironmentValueRefs(
-  connectorType: ConnectorType,
-  environmentName: string,
-): ReadonlySet<string> {
-  const refs = new Set<string>();
-  for (const entry of getConnectorEnvBindingEntries(connectorType)) {
-    if (entry.envName === environmentName) refs.add(entry.valueRef);
-  }
-  return refs;
-}
-
-function environmentNameSupportsRoute(
-  connectorType: ConnectorType,
-  environmentName: string,
-  routeEnvironmentNames: readonly string[],
-): boolean {
-  const explicitRefs = connectorEnvironmentValueRefs(
-    connectorType,
-    environmentName,
-  );
-  return routeEnvironmentNames.some((routeEnvironmentName) => {
-    if (routeEnvironmentName === environmentName) return true;
-    const routeRefs = connectorEnvironmentValueRefs(
-      connectorType,
-      routeEnvironmentName,
-    );
-    return [...explicitRefs].some((ref) => {
-      return routeRefs.has(ref);
-    });
-  });
-}
-
-function resolveUrlEnvironmentNames(
-  connectorType: ConnectorType,
-  routeEnvironmentNames: readonly string[] | null,
-  requestedEnvironmentName: string | undefined,
-): readonly string[] | null {
-  if (requestedEnvironmentName === undefined) return routeEnvironmentNames;
-  const ownedByConnector = getConnectorEnvBindingEntries(connectorType).some(
-    (entry) => {
-      return entry.envName === requestedEnvironmentName;
-    },
-  );
-  if (!ownedByConnector) {
-    throw new Error(
-      `${requestedEnvironmentName} is not an environment name for the ${CONNECTOR_TYPES[connectorType].label} connector. Remove --env-name to use the matched route metadata.`,
-    );
-  }
-  if (
-    routeEnvironmentNames !== null &&
-    !environmentNameSupportsRoute(
-      connectorType,
-      requestedEnvironmentName,
-      routeEnvironmentNames,
-    )
-  ) {
-    throw new Error(
-      `${requestedEnvironmentName} is not used by the matched API route. Expected one of: ${routeEnvironmentNames.join(", ") || "none"}. Remove --env-name to use the matched route metadata.`,
-    );
-  }
-  return [requestedEnvironmentName];
 }
 
 function checkEnvironmentNames(ctx: DiagContext): void {
@@ -695,9 +459,9 @@ function checkEnvironmentNames(ctx: DiagContext): void {
 }
 
 async function checkConnectorStatus(ctx: DiagContext): Promise<{
-  isConnected: boolean;
-  isExpired: boolean;
-  hasPermission: boolean;
+  readonly isConnected: boolean;
+  readonly isExpired: boolean;
+  readonly hasPermission: boolean;
 }> {
   console.log("## Step 2: Connector configuration");
   console.log("");
@@ -707,7 +471,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   console.log("");
 
   const [connector, enabledTypes] = await Promise.all([
-    getZeroConnector(ctx.connectorType),
+    getZeroConnector(ctx.connectorRef),
     ctx.agentId
       ? getZeroAgentUserConnectors(ctx.agentId)
       : Promise.resolve(null),
@@ -716,7 +480,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   const isConnected = connector !== null;
   const isExpired = connector?.connectionStatus === "reconnect-required";
   const hasPermission =
-    enabledTypes !== null && enabledTypes.includes(ctx.connectorType);
+    enabledTypes !== null && enabledTypes.includes(ctx.connectorRef);
 
   printConnectorConnectionStatus(ctx, isConnected, isExpired, hasPermission);
   printConnectorAuthorizationStatus(ctx, isConnected, isExpired, hasPermission);
@@ -724,473 +488,214 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   return { isConnected, isExpired, hasPermission };
 }
 
-async function checkConnectorDomains(
-  ctx: DiagContext,
-  preloadedRunContext?: RunContextResponse | null,
-): Promise<RunConnectorState> {
-  // 2c: Registered base URLs — connector defines which URL prefixes get credential replacement
+function checkConnectorDomains(ctx: DiagContext): boolean | null {
   console.log(
-    `### 2c: Registered base URLs (credential replacement only applies to URLs matching these prefixes)`,
+    "### 2c: Registered base URLs (credential replacement only applies to URLs matching these prefixes)",
   );
   console.log("");
 
-  const runContext =
-    preloadedRunContext === undefined
-      ? await getCurrentRunContext()
-      : preloadedRunContext;
-  if (!runContext) {
-    console.log(
-      "Cannot determine run ID from ZERO_TOKEN — skipping base URL check.",
-    );
-    console.log("");
-    return { networkPolicies: null, configuredForRun: null };
-  }
-
-  const configuredForRun = await printConnectorDomains(ctx, runContext);
-  console.log("");
-  return { networkPolicies: runContext.networkPolicies, configuredForRun };
-}
-
-async function printConnectorDomains(
-  ctx: DiagContext,
-  runContext: RunContextResponse,
-): Promise<boolean> {
-  const matchingEntry = runContext.firewalls.find((fw) => {
-    return fw.name === ctx.connectorType;
-  });
-
-  if (!matchingEntry) {
-    console.log(
-      `No configuration found for the ${ctx.label} connector in this run.`,
-    );
-    console.log(
-      "This means no base URLs are registered for credential replacement for this connector.",
-    );
-    return false;
-  }
-  const routingConfig = await runContextFirewallRoutingConfig(matchingEntry);
-  if (!routingConfig) {
-    console.log(
-      `No configuration found for the ${ctx.label} connector in this run.`,
-    );
-    console.log(
-      "This means no base URLs are registered for credential replacement for this connector.",
-    );
-    return false;
-  }
-
-  console.log(
-    `The ${ctx.label} connector is configured for this run with the following base URLs:`,
-  );
-  for (const api of routingConfig.apis) {
-    console.log(`  - ${api.base}`);
-  }
-  console.log("");
-  console.log(
-    "When the sandbox sends an HTTP request matching one of these URL prefixes, the network boundary intercepts the request and injects real credentials into the auth headers.",
-  );
-
-  const secretNames =
-    getFirewallExecutionMetadata(ctx.connectorType)?.secretPlaceholderNames ??
-    [];
-  if (secretNames.length > 0) {
-    console.log(`Credentials resolved from: ${secretNames.join(", ")}`);
-  }
-  return true;
-}
-
-function checkPermissionPolicy(
-  connectorType: ConnectorType,
-  label: string,
-  permissionName: string,
-  networkPolicies: NetworkPolicies | null,
-  configuredForRun: boolean | null,
-): void {
-  console.log("## Step 3: Permission policy check");
-  console.log("");
-  console.log(
-    `Checking permission: "${permissionName}" for the ${label} connector.`,
-  );
-  console.log(
-    `Beyond credential replacement, the ${label} connector enforces permission policies on each API path. A request either matches a named permission or falls through to the unknown-endpoint policy.`,
-  );
-  console.log("");
-
-  if (!networkPolicies) {
-    console.log(
-      "Network policies are not available for this run — cannot check permission status.",
-    );
-    console.log("");
-    return;
-  }
-
-  const connectorPolicies = networkPolicies[connectorType];
-
-  if (!connectorPolicies) {
-    if (configuredForRun === false) {
+  switch (ctx.run.status) {
+    case "not-scoped":
       console.log(
-        `No policy entry found because the ${label} connector is not configured for this run.`,
-      );
-      console.log(
-        "Requests for this connector cannot receive credentials in the current run.",
+        "This diagnostic is not scoped to a run — skipping the run base URL check.",
       );
       console.log("");
-      return;
+      return null;
+    case "not-configured":
+      console.log(
+        `No configuration found for the ${ctx.label} connector in this run.`,
+      );
+      console.log(
+        "This means no base URLs are registered for credential replacement for this connector.",
+      );
+      console.log("");
+      return false;
+    case "configured":
+      console.log(
+        `The ${ctx.label} connector is configured for this run with the following base URLs:`,
+      );
+      for (const base of ctx.run.bases) {
+        console.log(`  - ${base}`);
+      }
+      console.log("");
+      if (ctx.credentialResolution === "network-boundary") {
+        console.log(
+          "Credentials are resolved at the network boundary for requests matching these registered base URLs.",
+        );
+      }
+      console.log("");
+      return true;
+  }
+}
+
+function printUnavailablePolicy(
+  policy: Extract<
+    ConnectorCheckPolicy,
+    {
+      readonly outcome: "unavailable";
     }
-    console.log(
-      `No policy entry found for the ${label} connector in this run's network policies.`,
-    );
-    console.log(
-      "When a connector has no policy entry, all requests are fully permissive (allowed).",
-    );
-    console.log("");
-    return;
+  >,
+): void {
+  switch (policy.basis) {
+    case "not-run-scoped":
+      console.log(
+        "Result: Permission policy is unavailable because this diagnostic is not scoped to a run.",
+      );
+      return;
+    case "policies-unavailable":
+      console.log(
+        "Result: Network policies are unavailable for this run, so the permission status cannot be determined.",
+      );
+      return;
+    case "connector-not-configured":
+      console.log(
+        "Result: The connector is not configured for this run, so requests cannot receive credentials.",
+      );
+      return;
   }
+}
 
-  console.log(`Permission policies for the ${label} connector:`);
-  console.log(`  allow list: [${connectorPolicies.allow.join(", ")}]`);
-  console.log(`  deny list:  [${connectorPolicies.deny.join(", ")}]`);
-  console.log(`  ask list:   [${connectorPolicies.ask.join(", ")}]`);
-  console.log(`  unknown endpoint policy: ${connectorPolicies.unknownPolicy}`);
-  console.log("");
-
-  const isInAllow = connectorPolicies.allow.includes(permissionName);
-  const isInDeny = connectorPolicies.deny.includes(permissionName);
-  const isInAsk = connectorPolicies.ask.includes(permissionName);
-
-  if (isInDeny) {
-    console.log(
-      `Result: "${permissionName}" is in the deny list. Requests matching this permission are denied.`,
-    );
-  } else if (isInAsk) {
-    console.log(
-      `Result: "${permissionName}" is in the ask list. Requests matching this permission are blocked until approval.`,
-    );
-  } else if (isInAllow) {
-    console.log(
-      `Result: "${permissionName}" is in the allow list. Requests matching this permission are allowed.`,
-    );
-  } else {
-    console.log(
-      `Result: "${permissionName}" is not in the deny or ask list. Requests matching this permission are allowed; the unknown endpoint policy only applies when no named permission matches a request.`,
-    );
+function printNamedPolicyResult(
+  permission: string,
+  policy: ConnectorCheckPolicy,
+): void {
+  switch (policy.outcome) {
+    case "allow": {
+      switch (policy.basis) {
+        case "allow-list":
+          console.log(
+            `Result: "${permission}" is in the allow list — allowed.`,
+          );
+          return;
+        case "not-blocked":
+          console.log(
+            `Result: "${permission}" is not blocked by the deny or ask list — allowed.`,
+          );
+          return;
+        case "no-policy":
+          console.log(
+            `Result: No policy entry exists for this connector — "${permission}" is allowed.`,
+          );
+          return;
+        case "unknown-policy":
+          console.log(
+            `Result: The server policy allows "${permission}" through the unknown-endpoint policy.`,
+          );
+          return;
+      }
+      break;
+    }
+    case "deny":
+      console.log(
+        policy.basis === "deny-list"
+          ? `Result: "${permission}" is in the deny list — denied.`
+          : `Result: The unknown-endpoint policy denies "${permission}".`,
+      );
+      return;
+    case "ask":
+      console.log(
+        policy.basis === "ask-list"
+          ? `Result: "${permission}" is in the ask list — blocked until approval.`
+          : `Result: The unknown-endpoint policy blocks "${permission}" until approval.`,
+      );
+      return;
+    case "unavailable":
+      printUnavailablePolicy(policy);
+      return;
   }
-  console.log("");
 }
 
 function unknownPermissionChangeCommand(connectorRef: string): string {
-  return `zero doctor permission-change ${connectorRef} --permission ${UNKNOWN_PERMISSION_GRANT} --enable --duration 1h`;
+  return `zero doctor permission-change ${connectorRef} --permission __unknown__ --enable --duration 1h`;
 }
 
-function matchedPermissionsFromDecision(
-  decision: SelectedFirewallRequestDecision,
-): string[] {
-  if (decision.kind === "allow") {
-    return decision.permission === undefined ? [] : [decision.permission];
-  }
-  if (decision.kind === "block" && decision.reason === "permission_denied") {
-    return [...decision.permissions];
-  }
-  return [];
-}
-
-function printMatchedPermissionsSummary(
-  method: string,
-  relativePath: string,
-  decision: SelectedFirewallRequestDecision,
+function printUnknownEndpointPolicy(
+  connectorRef: string,
+  policy: ConnectorCheckPolicy,
 ): void {
-  const matchedPermissions = matchedPermissionsFromDecision(decision);
-  if (matchedPermissions.length > 0) {
-    console.log(`Matched permissions: [${matchedPermissions.join(", ")}]`);
-    return;
-  }
-
-  if (
-    decision.kind === "allow" ||
-    (decision.kind === "block" && decision.reason === "unknown_endpoint")
-  ) {
-    console.log(
-      `No named permission matches ${method} ${relativePath}. This request falls through to the unknown-endpoint policy.`,
-    );
-    return;
-  }
-
-  if (decision.reason === "malformed_firewall_config") {
-    console.log(
-      "Permission matching could not complete because the matched firewall config is malformed.",
-    );
-    return;
-  }
-
-  if (decision.reason === "malformed_network_policy") {
-    console.log(
-      "Permission matching could not complete because the matched network policy is malformed.",
-    );
-    return;
-  }
-
-  console.log(
-    "Permission matching could not complete because the request path contains unsafe path syntax.",
-  );
-}
-
-function printAllowedPermissionResult(
-  permission: string,
-  connectorPolicies: NetworkPolicies[string],
-): void {
-  if (connectorPolicies.allow.includes(permission)) {
-    console.log(`Result: "${permission}" is in the allow list — allowed.`);
-    return;
-  }
-  console.log(
-    `Result: "${permission}" is not blocked by the deny or ask list — allowed.`,
-  );
-}
-
-function printDeniedPermissionResult(
-  permission: string,
-  connectorPolicies: NetworkPolicies[string],
-): void {
-  if (connectorPolicies.deny.includes(permission)) {
-    console.log(`Result: "${permission}" is in the deny list — denied.`);
-    return;
-  }
-  if (connectorPolicies.ask.includes(permission)) {
-    console.log(`Result: "${permission}" is in the ask list — blocked.`);
-    return;
-  }
-  console.log(`Result: "${permission}" is blocked by permission policy.`);
-}
-
-function printFirewallDecisionResult(
-  connectorType: ConnectorType,
-  decision: SelectedFirewallRequestDecision,
-  connectorPolicies: NetworkPolicies[string],
-): void {
-  if (decision.kind === "allow") {
-    if (decision.permission === undefined) {
+  switch (policy.outcome) {
+    case "allow":
       console.log(
-        "Result: No permission matched. The unknown endpoint policy applies: allow.",
+        policy.basis === "no-policy"
+          ? "Result: No policy entry exists for this connector, so the request is allowed."
+          : "Result: No permission matched. The unknown endpoint policy allows this request.",
       );
       return;
-    }
-    printAllowedPermissionResult(decision.permission, connectorPolicies);
-    return;
-  }
-
-  switch (decision.reason) {
-    case "permission_denied":
-      for (const permission of decision.permissions) {
-        printDeniedPermissionResult(permission, connectorPolicies);
-      }
-      return;
-    case "unknown_endpoint":
+    case "deny":
       console.log(
-        `Result: No permission matched. The unknown endpoint policy applies: ${connectorPolicies.unknownPolicy}.`,
+        "Result: No permission matched. The unknown endpoint policy denies this request.",
       );
       console.log(
-        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorType)}`,
+        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorRef)}`,
       );
       return;
-    case "malformed_firewall_config":
+    case "ask":
       console.log(
-        "Result: The matched firewall config is malformed, so the request is blocked.",
+        "Result: No permission matched. The unknown endpoint policy requires approval.",
+      );
+      console.log(
+        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorRef)}`,
       );
       return;
-    case "malformed_network_policy":
-      console.log(
-        "Result: The matched network policy is malformed, so the request is blocked.",
-      );
-      return;
-    case "unsafe_path":
-      console.log(
-        "Result: The request path contains unsafe path syntax, so the request is blocked.",
-      );
+    case "unavailable":
+      printUnavailablePolicy(policy);
       return;
   }
 }
 
-function resolvePermissionFromUrl(
-  connectorType: ConnectorType,
-  label: string,
-  method: string,
-  relativePath: string,
-  matchedBase: string,
-  decision: SelectedFirewallRequestDecision,
-  networkPolicies: NetworkPolicies | null,
-  configuredForRun: boolean | null,
-): void {
+function printUrlPermissionDiagnostic(result: ResolvedUrlDiagnostic): void {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
   console.log("");
   console.log(
-    `Matching ${method} ${relativePath} (relative to base URL ${matchedBase}) against the ${label} connector's permission rules.`,
+    `Matching ${result.method} ${result.relativePath} (relative to base URL ${result.base}) against the ${result.connector.label} connector's permission rules.`,
   );
   console.log("");
 
-  printMatchedPermissionsSummary(method, relativePath, decision);
-  console.log("");
-
-  if (!networkPolicies) {
+  if (result.permission.kind === "matched") {
     console.log(
-      "Network policies are not available for this run — cannot check allow/deny status.",
+      `Matched permissions: [${result.permission.permissions
+        .map((permission) => {
+          return permission.name;
+        })
+        .join(", ")}]`,
     );
     console.log("");
-    return;
-  }
-
-  const connectorPolicies = networkPolicies[connectorType];
-
-  if (!connectorPolicies) {
-    if (configuredForRun === false) {
-      console.log(
-        `No policy entry found because the ${label} connector is not configured for this run.`,
-      );
-      console.log(
-        "Requests for this connector cannot receive credentials in the current run.",
-      );
-      console.log("");
-      return;
+    for (const permission of result.permission.permissions) {
+      printNamedPolicyResult(permission.name, permission.policy);
     }
-    console.log(
-      `No policy entry found for the ${label} connector. All requests are fully permissive (allowed).`,
-    );
-    console.log("");
-    return;
-  }
-
-  console.log(`Permission policies for the ${label} connector:`);
-  console.log(`  allow list: [${connectorPolicies.allow.join(", ")}]`);
-  console.log(`  deny list:  [${connectorPolicies.deny.join(", ")}]`);
-  console.log(`  ask list:   [${connectorPolicies.ask.join(", ")}]`);
-  console.log(`  unknown endpoint policy: ${connectorPolicies.unknownPolicy}`);
-  console.log("");
-
-  printFirewallDecisionResult(connectorType, decision, connectorPolicies);
-  console.log("");
-}
-
-type ResolvedCheckConnectorInput =
-  | {
-      readonly mode: "url";
-      readonly method: string;
-      readonly connectorType: ConnectorType;
-      readonly environmentNames: readonly string[] | null;
-      readonly urlDiagnostic: UrlDiagnosticResult;
-      readonly runContext: RunContextResponse | null;
-    }
-  | {
-      readonly mode: "environment";
-      readonly method: string;
-      readonly connectorType: ConnectorType;
-      readonly environmentNames: readonly string[];
-    };
-
-function validateCheckConnectorOptions(
-  opts: CheckConnectorOptions,
-  command: Command,
-): asserts opts is ValidatedCheckConnectorOptions {
-  const hasUrl = opts.url !== undefined;
-  if (opts.connector !== undefined && !hasUrl) {
-    throw new Error(
-      "--connector can only be used with --url. Add --url <URL> or remove --connector.",
-    );
-  }
-  if (opts.checkPermission !== undefined && hasUrl) {
-    throw new Error(
-      "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
-    );
-  }
-  if (opts.checkPermission?.trim() === "") {
-    throw new Error("--check-permission requires a non-empty permission name.");
-  }
-  if (!hasUrl && command.getOptionValueSource("method") === "cli") {
-    throw new Error(
-      "--method can only be used with --url. Add --url <URL> or remove --method.",
-    );
-  }
-  if (opts.envName === undefined && !hasUrl) {
-    throw new Error(
-      "Either --env-name or --url is required. Use --help for usage.",
-    );
-  }
-}
-
-function requestedConnectorType(
-  value: string | undefined,
-): ConnectorType | undefined {
-  if (value === undefined) return undefined;
-  if (!isConnectorType(value)) {
-    throw new Error(
-      `Unknown connector type: ${value}\nRun: zero connector search ${shellQuoteArg(value)}`,
-    );
-  }
-  return value;
-}
-
-function printUrlDiagnosticSummary(
-  url: string,
-  diagnostic: UrlDiagnosticResult,
-  environmentNames: readonly string[] | null,
-): void {
-  const { connectorType, decision } = diagnostic;
-  console.log(
-    `URL ${stripUrlQueryAndFragment(url)} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
-  );
-  console.log(`  Matched base URL: ${decision.base}`);
-  console.log(`  Relative path:    ${decision.relativePath}`);
-  if (environmentNames === null) {
-    console.log("  Environment names: unavailable");
   } else {
-    console.log(`  Environment names: [${environmentNames.join(", ")}]`);
+    console.log(
+      `No named permission matches ${result.method} ${result.relativePath}. This request falls through to the unknown-endpoint policy.`,
+    );
+    console.log("");
+    printUnknownEndpointPolicy(
+      result.connector.connectorRef,
+      result.permission.policy,
+    );
   }
+  console.log("");
 }
 
-async function resolveCheckConnectorInput(
-  opts: ValidatedCheckConnectorOptions,
-): Promise<ResolvedCheckConnectorInput> {
-  const method = opts.method.toUpperCase();
-  if (opts.url !== undefined) {
-    const requestedConnector = requestedConnectorType(opts.connector);
-    const runContext = await getCurrentRunContext();
-    const urlDiagnostic = await resolveUrlDiagnostic(
-      opts.url,
-      method,
-      requestedConnector,
-      runContext,
-    );
-    const environmentNames = resolveUrlEnvironmentNames(
-      urlDiagnostic.connectorType,
-      urlDiagnostic.environmentNames,
-      opts.envName,
-    );
-    printUrlDiagnosticSummary(opts.url, urlDiagnostic, environmentNames);
-    return {
-      mode: "url",
-      method,
-      connectorType: urlDiagnostic.connectorType,
-      environmentNames,
-      urlDiagnostic,
-      runContext,
-    };
+function printEnvironmentPermissionDiagnostic(
+  result: ResolvedEnvironmentDiagnostic,
+  permissionName: string | undefined,
+): void {
+  if (result.permission === null) {
+    return;
   }
-
-  const environmentName = opts.envName;
-  const connectorType =
-    getDiagnosticConnectorTypeForRuntimeEnvName(environmentName);
-  if (!connectorType) {
+  if (permissionName === undefined) {
     throw new Error(
-      `Unknown environment name: ${environmentName} — not managed by any connector`,
+      "Connector diagnostic returned a permission outcome without a requested permission.",
     );
   }
+  console.log("## Step 3: Permission policy check");
+  console.log("");
   console.log(
-    `${environmentName} is managed by the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
+    `Checking permission: "${permissionName}" for the ${result.connector.label} connector.`,
   );
-  return {
-    mode: "environment",
-    method,
-    connectorType,
-    environmentNames: [environmentName],
-  };
+  console.log("");
+  printNamedPolicyResult(permissionName, result.permission);
+  console.log("");
 }
 
 function printRediagnoseHint(
@@ -1276,22 +781,22 @@ How connectors work:
   .action(
     withErrorHandler(async (opts: CheckConnectorOptions, command: Command) => {
       validateCheckConnectorOptions(opts, command);
-      const input = await resolveCheckConnectorInput(opts);
+      const method = opts.method.toUpperCase();
+      const request = buildDiagnosticRequest(opts, method);
+      const diagnostic = await diagnoseZeroConnectorCheck(request);
+      const result = resolvedDiagnostic(request, diagnostic);
+
+      printDiagnosticSummary(request, result);
       console.log("");
 
-      const { connectorType, environmentNames, method } = input;
-      const { label } = CONNECTOR_TYPES[connectorType];
-      const [apiUrl, connectorAvailable] = await Promise.all([
-        getApiUrl(),
-        connectorTypeIsAvailable(connectorType),
-      ]);
-      const platformUrl = toPlatformUrl(apiUrl);
-
+      const platformUrl = toPlatformUrl(await getApiUrl());
       const ctx: DiagContext = {
-        environmentNames,
-        connectorType,
-        label,
-        connectorAvailable,
+        environmentNames: diagnosticEnvironmentNames(result),
+        connectorRef: result.connector.connectorRef,
+        label: result.connector.label,
+        connectorAvailable: result.connector.visibility === "available",
+        credentialResolution: result.connector.credentialResolution,
+        run: result.run,
         platformOrigin: platformUrl.origin,
         agentId: process.env.ZERO_AGENT_ID || undefined,
       };
@@ -1299,40 +804,25 @@ How connectors work:
       checkEnvironmentNames(ctx);
       const { isConnected, isExpired, hasPermission } =
         await checkConnectorStatus(ctx);
-      const { networkPolicies, configuredForRun } = await checkConnectorDomains(
-        ctx,
-        input.mode === "url" ? input.runContext : undefined,
-      );
+      const configuredForRun = checkConnectorDomains(ctx);
 
       if (configuredForRun === false) {
         console.log(
-          `Steps 1-2 summary: The ${label} connector is not configured for this run. Check the agent authorization settings, then start a new run after updating them.`,
+          `Steps 1-2 summary: The ${ctx.label} connector is not configured for this run. Check the agent authorization settings, then start a new run after updating them.`,
         );
       } else if (isConnected && !isExpired && hasPermission) {
         console.log(
-          `Steps 1-2 summary: The ${label} connector is connected, active, and authorized. Outbound requests to the registered base URLs will have credentials injected at the network boundary.`,
+          `Steps 1-2 summary: The ${ctx.label} connector is connected, active, and authorized. Outbound requests to the registered base URLs will have credentials injected at the network boundary.`,
         );
       }
       console.log("");
 
-      if (input.mode === "url") {
-        resolvePermissionFromUrl(
-          connectorType,
-          label,
-          method,
-          input.urlDiagnostic.decision.relativePath,
-          input.urlDiagnostic.decision.base,
-          input.urlDiagnostic.decision,
-          networkPolicies,
-          configuredForRun,
-        );
-      } else if (opts.checkPermission !== undefined) {
-        checkPermissionPolicy(
-          connectorType,
-          label,
-          opts.checkPermission,
-          networkPolicies,
-          configuredForRun,
+      if (result.mode === "url") {
+        printUrlPermissionDiagnostic(result);
+      } else {
+        printEnvironmentPermissionDiagnostic(
+          result,
+          request.mode === "environment" ? request.permission : undefined,
         );
       }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -7,8 +7,6 @@ import {
   zeroConnectorManualGrantContract,
   zeroConnectorsByTypeContract,
   zeroConnectorsMainContract,
-  zeroConnectorsSearchContract,
-  type ConnectorSearchResponse,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
@@ -16,6 +14,11 @@ import {
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  zeroConnectorCheckContract,
+  type ConnectorCheckDiagnosticResult,
+  type ConnectorCheckRequest,
+} from "@vm0/api-contracts/contracts/zero-connector-check";
 import {
   zeroConnectorPermissionDenyContract,
   type ConnectorPermissionDenyDiagnosticResult,
@@ -45,28 +48,6 @@ export async function listZeroConnectors(): Promise<ConnectorListResponse> {
   }
 
   handleError(result, "Failed to list connectors");
-}
-
-/**
- * Search available connector definitions for the authenticated user.
- * Omitting the keyword returns the server-side visible connector catalog.
- */
-export async function searchZeroConnectors(
-  keyword?: string,
-): Promise<ConnectorSearchResponse> {
-  const config = await getClientConfig();
-  const client = initClient(zeroConnectorsSearchContract, config);
-
-  const result = await client.search({
-    headers: {},
-    query: keyword ? { keyword } : {},
-  });
-
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  handleError(result, "Failed to search connectors");
 }
 
 export async function listZeroConnectorCatalog(): Promise<PublicConnectorCatalogListResponse> {
@@ -122,6 +103,24 @@ export async function getZeroConnectorCatalogPermissions(
     result,
     `Failed to get connector permission metadata for "${connectorRef}"`,
   );
+}
+
+export async function diagnoseZeroConnectorCheck(
+  request: ConnectorCheckRequest,
+): Promise<ConnectorCheckDiagnosticResult> {
+  const config = await getClientConfig();
+  const client = initClient(zeroConnectorCheckContract, {
+    ...config,
+    validateResponse: true,
+  });
+
+  const result = await client.check({ body: request });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to diagnose connector");
 }
 
 export async function diagnoseZeroConnectorPermissionDeny(

--- a/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
@@ -1,10 +1,6 @@
 import { initClient } from "@vm0/api-contracts/contracts/trpc-contract";
-import {
-  zeroRunAgentEventsContract,
-  zeroRunContextContract,
-} from "@vm0/api-contracts/contracts/zero-runs";
+import { zeroRunAgentEventsContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type { AgentEventsResponse } from "@vm0/api-contracts/contracts/runs";
-import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { getClientConfig, handleError } from "../core/client-factory";
 
 interface LogPaginationOptions {
@@ -33,14 +29,4 @@ export async function getZeroRunAgentEvents(
   });
   if (result.status === 200) return result.body;
   handleError(result, `Failed to get zero run events for "${id}"`);
-}
-
-export async function getZeroRunContext(
-  id: string,
-): Promise<RunContextResponse> {
-  const config = await getClientConfig();
-  const client = initClient(zeroRunContextContract, config);
-  const result = await client.getContext({ params: { id } });
-  if (result.status === 200) return result.body;
-  handleError(result, `Failed to get zero run context for "${id}"`);
 }

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -30,24 +30,6 @@ function isConnectorAuthMethodId(
   return connectorAuthMethodIdSchema.safeParse(value).success;
 }
 
-function defaultAvailableConnectors() {
-  return CONNECTOR_TYPE_KEYS.map((type) => {
-    const authMethods = getAvailableConnectorAuthMethodIds(type, {});
-    return { type, authMethods };
-  })
-    .filter((item) => {
-      return item.authMethods.length > 0;
-    })
-    .map(({ type, authMethods }) => {
-      return {
-        id: type,
-        label: CONNECTOR_TYPES[type].label,
-        description: CONNECTOR_TYPES[type].helpText,
-        authMethods,
-      };
-    });
-}
-
 function defaultPermissionSummary() {
   return {
     hasPermissions: false,
@@ -342,26 +324,6 @@ export const apiHandlers = [
       );
     },
   ),
-
-  // GET /api/zero/connectors/search - searchZeroConnectors
-  http.get("http://localhost:3000/api/zero/connectors/search", () => {
-    return HttpResponse.json(
-      { connectors: defaultAvailableConnectors() },
-      { status: 200 },
-    );
-  }),
-  http.get("https://app.vm0.ai/api/zero/connectors/search", () => {
-    return HttpResponse.json(
-      { connectors: defaultAvailableConnectors() },
-      { status: 200 },
-    );
-  }),
-  http.get("https://www.vm0.ai/api/zero/connectors/search", () => {
-    return HttpResponse.json(
-      { connectors: defaultAvailableConnectors() },
-      { status: 200 },
-    );
-  }),
 
   // GET /api/zero/org - getZeroOrg
   http.get("http://localhost:3000/api/zero/org", () => {


### PR DESCRIPTION
## Summary

- route `zero doctor check-connector` through the typed, runtime-validating connector diagnostic API
- render server-owned connector identity, route ownership, run bases, and final policy outcomes while retaining local environment-presence, connection, and agent-authorization checks
- remove the obsolete CLI catalog-search and run-context clients and their unused default handlers

## Behavior changes

- server-only connector refs now work without a bundled enum or label lookup
- URL query strings and fragments are removed before transport, display, and remediation commands
- URLs with embedded userinfo credentials are rejected locally before credentials can cross the client boundary or reach output
- dynamic bases are accepted only from the authoritative server result; local environment values are not used as a fallback
- credential output is generic network-boundary guidance, and policy output contains only the final result returned for the diagnosed request
- endpoint, authentication, network, and malformed-response failures stop before secondary connector or agent requests and never fall back to bundled metadata

## Exclusions

- no API contract, server route, runner, frontend, R2-loading, or permission-deny changes
- no legacy response adapter or bundled diagnostic fallback

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm -F @vm0/cli build`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts` (57 passed)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` against a fresh migrated database (7,446 passed; 1 existing benchmark skipped)
- `pnpm knip`

Closes #21220

Parent delivery issue: #21140
