### PR TITLE
refactor: reduce fallback slop in messaging mock contracts

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/test-slack-mock.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-mock.ts
@@ -29,7 +29,7 @@ export const SLACK_E2E_SCOPES = [
   "users:read.email",
 ] as const;
 
-const slackMockRequestBodySchema = z.unknown().optional();
+const slackMockRequestBodySchema = z.record(z.string(), z.unknown()).optional();
 const slackMockNotFoundSchema = z.string();
 
 export const testSlackMockOkResponseSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/test-teams-mock.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-teams-mock.ts
@@ -4,7 +4,7 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-const teamsMockBodySchema = z.unknown().optional();
+const teamsMockBodySchema = z.record(z.string(), z.unknown()).optional();
 const teamsMockOkSchema = z.object({ ok: z.literal(true) });
 const teamsMockTokenResponseSchema = z.object({
   access_token: z.string(),

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-mock.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-mock.ts
@@ -24,7 +24,7 @@ export const testTelegramMockContract = c.router({
     method: "POST",
     path: "/api/test/telegram-mock/:botToken/:method",
     pathParams: testTelegramMockPathParamsSchema,
-    body: z.unknown().optional(),
+    body: z.record(z.string(), z.unknown()).optional(),
     responses: {
       200: testTelegramMockSuccessResponseSchema,
       404: z.union([z.string(), testTelegramMockErrorResponseSchema]),


### PR DESCRIPTION
## Summary

- Tighten Slack, Teams, and Telegram E2E mock request bodies from unconstrained optional values to optional string-keyed records.
- Preserve empty-body support while rejecting scalar and array payloads that the mock handlers do not consume as valid API request bodies.

## Scan

- Timestamp: `2026-07-13T20:02:04.182Z`
- Base commit: `3aff0819589c8892cb760b3a6c8db314aabd692f`
- Files scanned: 4,190
- Raw matches: 19,663
- Scanner actionable matches (medium/high confidence): 4,540
- `actionable_total` used for the initial budget: 238 high-confidence production signals
- `edit_budget`: 12
- Candidates changed: 3

Total matches by category:

- `nullish`: 5,924
- `nullish-chain`: 135
- `field-fallback-chain`: 110
- `optional-prop`: 6,155
- `zod-optional`: 2,276
- `zod-loose-optional`: 5
- `loose-record`: 1,195
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 33
- `empty-fallback`: 687
- `string-fallback`: 741
- `null-undefined-fallback`: 1,614
- `empty-catch`: 3
- `promise-catch-swallow`: 14
- `rust-unwrap-or`: 626
- `rust-ok-discard`: 142

## Safety of changes

- `test-slack-mock.ts`: Slack mock calls carry keyed JSON or form fields; the handler already parses both representations into records.
- `test-teams-mock.ts`: Bot Framework and token mock requests use keyed bodies, and downstream tenant extraction only reads object fields.
- `test-telegram-mock.ts`: Supported Telegram mock methods read keyed fields such as `chat_id`, `text`, and `file_id`; absent bodies remain accepted for bodyless methods.

## Verification

- `git diff --check`
- Re-ran the fallback scanner; `zod-loose-optional` decreased from 5 to 2 and high-confidence production signals decreased from 238 to 235.
- Package lint and type checks were not run because this fresh checkout has no installed dependencies; the PR pipeline will run the repository checks.

This workflow intentionally leaves the remaining candidates for later daily runs.
