### PR TITLE
feat: default new organizations to gpt-5.6 luna with ultra reasoning

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -185,6 +185,7 @@ pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'
     match bare {
         "gpt-5.6-sol" => Some("xhigh"),
         "gpt-5.6-terra" => Some("low"),
+        "gpt-5.6-luna" => Some("ultra"),
         "gpt-5.5" => Some("xhigh"),
         _ => None,
     }
@@ -685,14 +686,19 @@ mod tests {
     }
 
     #[test]
+    fn build_codex_args_gpt_5_6_luna_defaults_reasoning_effort_ultra() {
+        for model in ["gpt-5.6-luna", "openai/gpt-5.6-luna"] {
+            let args = build_codex_args_for_test(model, "", "p");
+            assert!(codex_args_have_config(
+                &args,
+                "model_reasoning_effort=ultra"
+            ));
+        }
+    }
+
+    #[test]
     fn build_codex_args_models_without_overrides_omit_reasoning_effort() {
-        for model in [
-            "gpt-5.6-luna",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "openai/gpt-5.4",
-            "",
-        ] {
+        for model in ["gpt-5.4", "gpt-5.4-mini", "openai/gpt-5.4", ""] {
             let args = build_codex_args_for_test(model, "", "p");
             assert!(
                 !args

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3746,7 +3746,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
   });
 
-  it("defaults limited-free runs to Terra, allows Luna, and rejects Sol", async () => {
+  it("defaults limited-free runs to Luna, allows Terra, and rejects Sol", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -446,8 +446,8 @@ describe("model-first canonical catalog", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
     ]);
-    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("gpt-5.6-terra");
-    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("gpt-5.6-terra");
+    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("gpt-5.6-luna");
+    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("gpt-5.6-luna");
     expect(getDefaultModel("vm0")).toBe(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL);
     expect(getDefaultOrgModelPolicySeed()).toEqual(
       DEFAULT_ORG_MODEL_POLICY_MODELS.map((model) => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -223,10 +223,10 @@ export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
 ] as const satisfies readonly SupportedRunModel[];
 
 export const DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL =
-  "gpt-5.6-terra" as const satisfies SupportedRunModel;
+  "gpt-5.6-luna" as const satisfies SupportedRunModel;
 
 export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
-  "gpt-5.6-terra" as const satisfies SupportedRunModel;
+  "gpt-5.6-luna" as const satisfies SupportedRunModel;
 
 export const supportedRunModelSchema = z.enum(SUPPORTED_RUN_MODELS);
 


### PR DESCRIPTION
## Summary

- configure GPT-5.6 Luna Codex runs to use `model_reasoning_effort=ultra` for canonical and `openai/`-prefixed model IDs
- make GPT-5.6 Luna the seeded default for new standard and limited-free organizations
- update focused model-policy and guest-agent coverage for the new defaults

## User-visible impact

New organizations start with GPT-5.6 Luna selected, including limited-free workspaces. Luna-backed Codex runs use ultra reasoning by default. Existing eligible Terra policies remain available and are not globally backfilled.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent build_codex_args_gpt_5_6_luna_defaults_reasoning_effort_ultra` (1 passed)
- `pnpm exec prettier --check packages/api-contracts/src/contracts/model-providers.ts packages/api-contracts/src/contracts/__tests__/model-providers.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm exec vitest run packages/api-contracts/src/contracts/__tests__/model-providers.test.ts` (174 passed)
- `git diff --check`
