### PR TITLE
fix(platform): reduce thinking indicator line pause to one second

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3148,7 +3148,7 @@ function createCancelRunWithQueuedRecall({
 // ---------------------------------------------------------------------------
 
 const THINKING_TYPEWRITER_INTERVAL_MS = 100;
-const THINKING_TYPEWRITER_LINE_PAUSE_MS = 3000;
+const THINKING_TYPEWRITER_LINE_PAUSE_MS = 1000;
 const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
   ? 1
   : Math.ceil(


### PR DESCRIPTION
## Summary

- reduce the completed thinking line pause from 3 seconds to 1 second
- make follow-up thinking lines appear sooner while preserving the existing 100 ms typewriter cadence and responsive character stepping

## Verification

- `git diff --check`
- full local Vitest was not run; the PR pipeline will validate the change