### PR TITLE
fix(sandbox-fc): gate startup on guest dns readiness

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1064,6 +1064,25 @@ jobs:
           [ -z "$SANDBOX_ID" ] && fail "control socket not found after 60s"
           echo "Found sandbox: $SANDBOX_ID"
 
+          # The provider must prove the attached guest DNS path before it
+          # publishes the Running state or exposes runner exec.
+          SANDBOX_LOGS=$(sudo journalctl --no-pager --lines 500 \
+            "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+            || fail "failed to read sandbox startup logs"
+          GUEST_DNS_READY_LINE=$(printf '%s\n' "$SANDBOX_LOGS" \
+            | grep -n -F "guest DNS readiness probe succeeded" \
+            | grep -F "id=$SANDBOX_ID" | head -1 | cut -d: -f1)
+          SANDBOX_STARTED_LINE=$(printf '%s\n' "$SANDBOX_LOGS" \
+            | grep -n -F "sandbox started" \
+            | grep -F "id=$SANDBOX_ID" | head -1 | cut -d: -f1)
+          [ -n "$GUEST_DNS_READY_LINE" ] \
+            || fail "guest DNS readiness was not logged for sandbox $SANDBOX_ID"
+          [ -n "$SANDBOX_STARTED_LINE" ] \
+            || fail "sandbox start was not logged for sandbox $SANDBOX_ID"
+          [ "$GUEST_DNS_READY_LINE" -lt "$SANDBOX_STARTED_LINE" ] \
+            || fail "sandbox started before guest DNS readiness"
+          echo "PASS: guest DNS readiness precedes sandbox start"
+
           # Test 1: privilege boundary
           echo "--- Test: privilege boundary ---"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- id -u) || \

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -278,6 +278,9 @@ check_required_executable "/usr/bin/date" "date"
 check_required_executable "/usr/bin/ln" "ln"
 check_required_executable "/usr/bin/sed" "sed"
 
+# Firecracker startup validates runner-managed DNS through the guest resolver.
+check_required_executable "/usr/bin/getent" "getent"
+
 # Storage manifest cleanup and Codex session cleanup helpers.
 check_required_executable "/usr/bin/rm" "rm"
 check_required_executable "/usr/bin/find" "find"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -552,6 +552,7 @@ exit 1
                 "guest state runtime",
                 &["/usr/bin/date", "/usr/bin/ln", "/usr/bin/sed"][..],
             ),
+            ("guest DNS readiness runtime", &["/usr/bin/getent"][..]),
             (
                 "storage and Codex cleanup runtime",
                 &[

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -804,23 +804,17 @@ async fn create_started_sandbox(
             Some(SANDBOX_START_FAILED),
         );
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        let unregister_succeeded =
-            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
-                Ok(()) => true,
-                Err(unregister_error) => {
-                    warn!(
-                        run_id = %context.run_id,
-                        error = %unregister_error,
-                        "failed to unregister VM from proxy after sandbox start failure"
-                    );
-                    false
-                }
-            };
-        network_log_session
-            .close_for_upload(context.run_id, &config.network_log_drain)
-            .await;
-        let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
-        let error = if unregister_succeeded && destroy_succeeded {
+        let cleanup_succeeded = cleanup_failed_sandbox_preparation(
+            factory,
+            sandbox,
+            network_log_session,
+            config,
+            context,
+            &source_ip,
+            "sandbox_start",
+        )
+        .await;
+        let error = if cleanup_succeeded {
             SandboxPrepareError::from_start(e)
         } else {
             SandboxPrepareError::fatal(e.into())
@@ -843,23 +837,17 @@ async fn create_started_sandbox(
             false,
             Some(&e.to_string()),
         );
-        let unregister_succeeded =
-            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
-                Ok(()) => true,
-                Err(unregister_error) => {
-                    warn!(
-                        run_id = %context.run_id,
-                        error = %unregister_error,
-                        "failed to unregister VM from proxy after workspace mount failure"
-                    );
-                    false
-                }
-            };
-        network_log_session
-            .close_for_upload(context.run_id, &config.network_log_drain)
-            .await;
-        let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
-        let error = if unregister_succeeded && destroy_succeeded {
+        let cleanup_succeeded = cleanup_failed_sandbox_preparation(
+            factory,
+            sandbox,
+            network_log_session,
+            config,
+            context,
+            &source_ip,
+            "workspace_mount",
+        )
+        .await;
+        let error = if cleanup_succeeded {
             SandboxPrepareError::retry_without_workspace_image(e)
         } else {
             SandboxPrepareError::fatal(e)
@@ -912,6 +900,35 @@ pub(super) async fn destroy_sandbox_panic_safe(
         return false;
     }
     true
+}
+
+async fn cleanup_failed_sandbox_preparation(
+    factory: &dyn SandboxFactory,
+    sandbox: Box<dyn Sandbox>,
+    network_log_session: NetworkLogSession,
+    config: &ExecutorConfig,
+    context: &ExecutionContext,
+    source_ip: &str,
+    failure_stage: &'static str,
+) -> bool {
+    let unregister_succeeded =
+        match unregister_proxy_registry(config, source_ip, context.run_id).await {
+            Ok(()) => true,
+            Err(unregister_error) => {
+                warn!(
+                    run_id = %context.run_id,
+                    failure_stage,
+                    error = %unregister_error,
+                    "failed to unregister VM from proxy after sandbox preparation failure"
+                );
+                false
+            }
+        };
+    network_log_session
+        .close_for_upload(context.run_id, &config.network_log_drain)
+        .await;
+    let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
+    unregister_succeeded && destroy_succeeded
 }
 
 /// Run a job inside a reused (kept-alive) sandbox.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -111,6 +111,8 @@ const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_MULTIPLE: &str =
     "runner_fresh_sandbox_factory_nbd_size_zero_retries_multiple";
 const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_register";
 const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
+const RUNNER_FRESH_SANDBOX_RETRY_AFTER_START_READINESS: &str =
+    "runner_fresh_sandbox_retry_after_start_readiness";
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
     "runner_fresh_sandbox_retry_without_workspace_image";
 
@@ -338,91 +340,108 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         telemetry,
     )
     .await;
-    let prepared = match create_started_sandbox(
-        factory,
-        context,
-        sandbox_id,
-        config,
-        params,
-        telemetry,
-        StartSandboxOptions {
-            workspace_image: workspace_image.as_ref(),
-            sandbox_prepared,
-        },
-    )
-    .await
-    {
-        Ok(prepared) => prepared,
-        Err(e)
-            if e.retry_without_workspace_image
-                && workspace_image
-                    .as_ref()
-                    .is_some_and(WorkspaceImageLease::is_cache_hit) =>
-        {
-            let error = e.error;
-            invalidate_workspace_cache_hit(
-                workspace_image.as_ref(),
-                context.run_id,
-                "sandbox_prepare_failed",
-            )
-            .await;
-            warn!(
-                run_id = %context.run_id,
-                sandbox_id = %sandbox_id,
-                error = %error,
-                "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
-            );
-            telemetry.record(
-                RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE,
-                Duration::ZERO,
-                true,
-                None,
-            );
-            workspace_image = None;
-            controls.session_history_restore_plan =
-                discard_local_sidecar_restore_plan_for_workspace_retry(
-                    std::mem::take(&mut controls.session_history_restore_plan),
-                    context,
-                    config,
-                    controls.cancel.clone(),
-                    telemetry,
-                );
-            match create_started_sandbox(
-                factory,
-                context,
-                sandbox_id,
-                config,
-                params,
-                telemetry,
-                StartSandboxOptions {
-                    workspace_image: None,
-                    sandbox_prepared,
-                },
-            )
-            .await
+    let mut fresh_sandbox_retry_available = true;
+    let prepared = loop {
+        let result = create_started_sandbox(
+            factory,
+            context,
+            sandbox_id,
+            config,
+            params,
+            telemetry,
+            StartSandboxOptions {
+                workspace_image: workspace_image.as_ref(),
+                sandbox_prepared,
+            },
+        )
+        .await;
+        match result {
+            Ok(prepared) => break prepared,
+            Err(e)
+                if matches!(e.retry, SandboxPrepareRetry::FreshSandbox)
+                    && fresh_sandbox_retry_available =>
             {
-                Ok(prepared) => prepared,
-                Err(e) => {
-                    let error = e.error;
-                    telemetry.record(
-                        "runner_fresh_sandbox_prepare",
-                        prepare_started.elapsed(),
-                        false,
-                        Some(&error.to_string()),
-                    );
-                    return Err(error);
+                fresh_sandbox_retry_available = false;
+                let error = e.error;
+                let discard_workspace_image = workspace_image
+                    .as_ref()
+                    .is_some_and(WorkspaceImageLease::is_cache_hit);
+                if discard_workspace_image {
+                    invalidate_workspace_cache_hit(
+                        workspace_image.as_ref(),
+                        context.run_id,
+                        "sandbox_start_readiness_failed",
+                    )
+                    .await;
+                    workspace_image = None;
+                    controls.session_history_restore_plan =
+                        discard_local_sidecar_restore_plan_for_workspace_retry(
+                            std::mem::take(&mut controls.session_history_restore_plan),
+                            context,
+                            config,
+                            controls.cancel.clone(),
+                            telemetry,
+                        );
                 }
+                warn!(
+                    run_id = %context.run_id,
+                    sandbox_id = %sandbox_id,
+                    discarded_workspace_image = discard_workspace_image,
+                    error = %error,
+                    "sandbox start readiness failed; retrying with a fresh sandbox"
+                );
+                telemetry.record(
+                    RUNNER_FRESH_SANDBOX_RETRY_AFTER_START_READINESS,
+                    Duration::ZERO,
+                    true,
+                    None,
+                );
             }
-        }
-        Err(e) => {
-            let error = e.error;
-            telemetry.record(
-                "runner_fresh_sandbox_prepare",
-                prepare_started.elapsed(),
-                false,
-                Some(&error.to_string()),
-            );
-            return Err(error);
+            Err(e)
+                if matches!(e.retry, SandboxPrepareRetry::WithoutWorkspaceImage)
+                    && workspace_image
+                        .as_ref()
+                        .is_some_and(WorkspaceImageLease::is_cache_hit) =>
+            {
+                let error = e.error;
+                invalidate_workspace_cache_hit(
+                    workspace_image.as_ref(),
+                    context.run_id,
+                    "sandbox_prepare_failed",
+                )
+                .await;
+                warn!(
+                    run_id = %context.run_id,
+                    sandbox_id = %sandbox_id,
+                    error = %error,
+                    "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
+                );
+                telemetry.record(
+                    RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE,
+                    Duration::ZERO,
+                    true,
+                    None,
+                );
+                workspace_image = None;
+                controls.session_history_restore_plan =
+                    discard_local_sidecar_restore_plan_for_workspace_retry(
+                        std::mem::take(&mut controls.session_history_restore_plan),
+                        context,
+                        config,
+                        controls.cancel.clone(),
+                        telemetry,
+                    );
+            }
+            Err(e) => {
+                let error = e.error;
+                telemetry.record(
+                    "runner_fresh_sandbox_prepare",
+                    prepare_started.elapsed(),
+                    false,
+                    Some(&error.to_string()),
+                );
+                return Err(error);
+            }
         }
     };
     telemetry.record(
@@ -459,7 +478,14 @@ pub(super) struct PreparedSandboxRun {
 
 pub(super) struct SandboxPrepareError {
     error: RunnerError,
-    retry_without_workspace_image: bool,
+    retry: SandboxPrepareRetry,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SandboxPrepareRetry {
+    None,
+    WithoutWorkspaceImage,
+    FreshSandbox,
 }
 
 pub(super) struct NewSandboxHooks<'a> {
@@ -473,17 +499,32 @@ struct StartSandboxOptions<'a> {
 }
 
 impl SandboxPrepareError {
-    fn retry(error: RunnerError) -> Self {
+    fn retry_without_workspace_image(error: RunnerError) -> Self {
         Self {
             error,
-            retry_without_workspace_image: true,
+            retry: SandboxPrepareRetry::WithoutWorkspaceImage,
+        }
+    }
+
+    fn from_start(error: sandbox::SandboxError) -> Self {
+        let retry = if matches!(
+            error,
+            sandbox::SandboxError::StartRequiresFreshSandbox { .. }
+        ) {
+            SandboxPrepareRetry::FreshSandbox
+        } else {
+            SandboxPrepareRetry::WithoutWorkspaceImage
+        };
+        Self {
+            error: error.into(),
+            retry,
         }
     }
 
     fn fatal(error: RunnerError) -> Self {
         Self {
             error,
-            retry_without_workspace_image: false,
+            retry: SandboxPrepareRetry::None,
         }
     }
 }
@@ -710,7 +751,7 @@ async fn create_started_sandbox(
                 Some(SANDBOX_FACTORY_CREATE_FAILED),
             );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-            return Err(SandboxPrepareError::retry(e.into()));
+            return Err(SandboxPrepareError::retry_without_workspace_image(e.into()));
         }
     };
 
@@ -776,7 +817,7 @@ async fn create_started_sandbox(
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::retry(e.into()));
+        return Err(SandboxPrepareError::from_start(e));
     }
     telemetry.record(
         RUNNER_FRESH_SANDBOX_START,
@@ -807,7 +848,7 @@ async fn create_started_sandbox(
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::retry(e));
+        return Err(SandboxPrepareError::retry_without_workspace_image(e));
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
     if let Some(notifier) = sandbox_prepared {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -790,7 +790,7 @@ async fn create_started_sandbox(
                 &e.to_string(),
             );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-            destroy_sandbox_panic_safe(factory, sandbox).await;
+            let _ = destroy_sandbox_panic_safe(factory, sandbox).await;
             return Err(SandboxPrepareError::fatal(e));
         }
     };
@@ -816,8 +816,13 @@ async fn create_started_sandbox(
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
-        destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::from_start(e));
+        let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
+        let error = if destroy_succeeded {
+            SandboxPrepareError::from_start(e)
+        } else {
+            SandboxPrepareError::fatal(e.into())
+        };
+        return Err(error);
     }
     telemetry.record(
         RUNNER_FRESH_SANDBOX_START,
@@ -847,8 +852,13 @@ async fn create_started_sandbox(
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
-        destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::retry_without_workspace_image(e));
+        let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
+        let error = if destroy_succeeded {
+            SandboxPrepareError::retry_without_workspace_image(e)
+        } else {
+            SandboxPrepareError::fatal(e)
+        };
+        return Err(error);
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
     if let Some(notifier) = sandbox_prepared {
@@ -886,14 +896,16 @@ pub(super) async fn invalidate_workspace_cache_hit(
 pub(super) async fn destroy_sandbox_panic_safe(
     factory: &dyn SandboxFactory,
     sandbox: Box<dyn Sandbox>,
-) {
+) -> bool {
     if AssertUnwindSafe(factory.destroy(sandbox))
         .catch_unwind()
         .await
         .is_err()
     {
-        warn!("sandbox destroy panicked after start failure");
+        warn!("sandbox destroy panicked after preparation failure");
+        return false;
     }
+    true
 }
 
 /// Run a job inside a reused (kept-alive) sandbox.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -804,20 +804,23 @@ async fn create_started_sandbox(
             Some(SANDBOX_START_FAILED),
         );
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        if let Err(unregister_error) =
-            unregister_proxy_registry(config, &source_ip, context.run_id).await
-        {
-            warn!(
-                run_id = %context.run_id,
-                error = %unregister_error,
-                "failed to unregister VM from proxy after sandbox start failure"
-            );
-        }
+        let unregister_succeeded =
+            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
+                Ok(()) => true,
+                Err(unregister_error) => {
+                    warn!(
+                        run_id = %context.run_id,
+                        error = %unregister_error,
+                        "failed to unregister VM from proxy after sandbox start failure"
+                    );
+                    false
+                }
+            };
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
-        let error = if destroy_succeeded {
+        let error = if unregister_succeeded && destroy_succeeded {
             SandboxPrepareError::from_start(e)
         } else {
             SandboxPrepareError::fatal(e.into())
@@ -840,20 +843,23 @@ async fn create_started_sandbox(
             false,
             Some(&e.to_string()),
         );
-        if let Err(unregister_error) =
-            unregister_proxy_registry(config, &source_ip, context.run_id).await
-        {
-            warn!(
-                run_id = %context.run_id,
-                error = %unregister_error,
-                "failed to unregister VM from proxy after workspace mount failure"
-            );
-        }
+        let unregister_succeeded =
+            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
+                Ok(()) => true,
+                Err(unregister_error) => {
+                    warn!(
+                        run_id = %context.run_id,
+                        error = %unregister_error,
+                        "failed to unregister VM from proxy after workspace mount failure"
+                    );
+                    false
+                }
+            };
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
         let destroy_succeeded = destroy_sandbox_panic_safe(factory, sandbox).await;
-        let error = if destroy_succeeded {
+        let error = if unregister_succeeded && destroy_succeeded {
             SandboxPrepareError::retry_without_workspace_image(e)
         } else {
             SandboxPrepareError::fatal(e)

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -514,6 +514,135 @@ async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
 }
 
 #[tokio::test]
+async fn execute_new_sandbox_replaces_once_after_start_readiness_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "guest DNS readiness failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let sandbox_id = SandboxId::new_v4();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: sandbox_id,
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    let create_configs = overrides.create_configs();
+    assert_eq!(create_configs.len(), 2);
+    assert!(create_configs.iter().all(|config| config.id == sandbox_id));
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+        true,
+        None,
+    );
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_stops_after_second_start_readiness_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "first guest DNS readiness failure".into(),
+    }));
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "second guest DNS readiness failure".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert!(
+        error
+            .to_string()
+            .contains("second guest DNS readiness failure"),
+        "got: {error}"
+    );
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 2);
+    assert!(overrides.start_process_calls().is_empty());
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+        true,
+        None,
+    );
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_does_not_replace_after_ordinary_start_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::Start {
+        message: "boot failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert!(error.to_string().contains("boot failed"), "got: {error}");
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+    );
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
 async fn execute_job_wraps_execute_inner() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -451,15 +451,15 @@ async fn execute_inner_create_failure_returns_error() {
 }
 
 #[tokio::test]
-async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
+async fn execute_new_sandbox_does_not_replace_when_failed_sandbox_destroy_panics() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_result(Err(SandboxError::Start {
-        message: "boot failed".into(),
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "guest DNS readiness failed".into(),
     }));
     let factory = DestroyPanicFactory {
-        inner: MockSandboxFactory::with_overrides(overrides),
+        inner: MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
     };
 
     let ctx = minimal_context();
@@ -481,7 +481,15 @@ async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
 
     assert!(result.is_err(), "start failure must return an error");
     let err = result.err().unwrap();
-    assert!(err.to_string().contains("boot failed"), "got: {err}");
+    assert!(
+        err.to_string().contains("guest DNS readiness failed"),
+        "got: {err}"
+    );
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+    );
     assert_proxy_registry_empty(dir.path()).await;
     assert!(
         !config

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -14,6 +14,38 @@ fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
         .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
     assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
 }
+
+struct RemoveRegistryBeforeStartFactory {
+    inner: MockSandboxFactory,
+    registry_path: PathBuf,
+}
+
+#[async_trait::async_trait]
+impl SandboxFactory for RemoveRegistryBeforeStartFactory {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn config_hash(&self) -> String {
+        self.inner.config_hash()
+    }
+
+    async fn create(&self, config: sandbox::SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+        let sandbox = self.inner.create(config).await?;
+        Ok(Box::new(
+            QueuedCopyFileSandbox::new(sandbox, Vec::new())
+                .with_remove_path_before_start(self.registry_path.clone()),
+        ))
+    }
+
+    async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
+        self.inner.destroy(sandbox).await;
+    }
+
+    async fn shutdown(&mut self) {
+        self.inner.shutdown().await;
+    }
+}
 #[test]
 fn proxy_register_fast_success_logs_info() {
     let events = capture_proxy_register_events(|| {
@@ -124,6 +156,50 @@ async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_
         "agent must not start when proxy registry registration fails"
     );
 }
+
+#[tokio::test]
+async fn execute_new_sandbox_does_not_retry_when_proxy_unregister_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "guest DNS readiness failed".into(),
+    }));
+    let factory = RemoveRegistryBeforeStartFactory {
+        inner: MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
+        registry_path: dir.path().join("proxy-registry.json"),
+    };
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let error = result.err().unwrap();
+    assert!(
+        error.to_string().contains("guest DNS readiness failed"),
+        "got: {error}"
+    );
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+    );
+}
+
 #[tokio::test]
 async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_agent_start() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -88,6 +88,80 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
 }
 
 #[tokio::test]
+async fn execute_inner_discards_consumed_cache_when_replacing_dns_unready_sandbox() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::StartRequiresFreshSandbox {
+        message: "guest DNS readiness failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-dns-retry".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let expected_seed =
+        seed_workspace_image_cache(&cache, &runner_paths, "sess-dns-retry", 16).await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert!(outcome.workspace_image.is_none());
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 2);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                expected_seed.clone(),
+            )),
+        })
+    );
+    assert_eq!(
+        configs[1].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: None,
+        })
+    );
+    assert!(!expected_seed.exists());
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_after_start_readiness",
+        true,
+        None,
+    );
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_uses_workspace_cache_when_configured() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -337,6 +337,7 @@ impl Sandbox for CancelAfterWaitSandbox {
 pub(in crate::executor::tests) struct QueuedCopyFileSandbox {
     inner: Box<dyn Sandbox>,
     copy_file_results: Mutex<VecDeque<Vec<u8>>>,
+    remove_path_before_start: Option<std::path::PathBuf>,
     remove_path_before_copy: Option<std::path::PathBuf>,
 }
 
@@ -348,8 +349,17 @@ impl QueuedCopyFileSandbox {
         Self {
             inner,
             copy_file_results: Mutex::new(VecDeque::from(copy_file_results)),
+            remove_path_before_start: None,
             remove_path_before_copy: None,
         }
+    }
+
+    pub(in crate::executor::tests) fn with_remove_path_before_start(
+        mut self,
+        path: std::path::PathBuf,
+    ) -> Self {
+        self.remove_path_before_start = Some(path);
+        self
     }
 
     pub(in crate::executor::tests) fn with_remove_path_before_copy(
@@ -376,6 +386,9 @@ impl Sandbox for QueuedCopyFileSandbox {
     }
 
     async fn start(&mut self) -> sandbox::Result<()> {
+        if let Some(path) = self.remove_path_before_start.take() {
+            std::fs::remove_file(path)?;
+        }
         self.inner.start().await
     }
 

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -19,6 +19,7 @@ const EXPECTED_TRANSIENT_EXIT_CODES: &[i32] = &[2];
 const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
     total_timeout: Duration::from_secs(30),
     retry_interval: Duration::from_secs(1),
+    operation_wait_timeout: OPERATION_WAIT_TIMEOUT,
     max_attempts: 30,
 };
 
@@ -26,6 +27,7 @@ const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
 struct ReadinessPolicy {
     total_timeout: Duration,
     retry_interval: Duration,
+    operation_wait_timeout: Duration,
     max_attempts: u16,
 }
 
@@ -64,10 +66,7 @@ impl GuestDnsReadinessFailure {
     fn retryable(self) -> bool {
         matches!(
             self,
-            Self::TimedOut
-                | Self::Transport(io::ErrorKind::TimedOut)
-                | Self::ExitNonZero(2)
-                | Self::UnexpectedAnswer
+            Self::TimedOut | Self::ExitNonZero(2) | Self::UnexpectedAnswer
         )
     }
 }
@@ -127,7 +126,7 @@ async fn wait_for_guest_dns_readiness_with_policy(
             stderr_limit_bytes: STDERR_LIMIT_BYTES,
             expected_exit_codes: EXPECTED_TRANSIENT_EXIT_CODES,
             stdin_bytes: None,
-            wait_timeout: remaining.min(OPERATION_WAIT_TIMEOUT),
+            wait_timeout: remaining.min(policy.operation_wait_timeout),
         };
         let failure = match timeout_at(deadline, guest.exec_operation_capture(request)).await {
             Ok(Ok(result)) => match validate_result(result) {
@@ -233,6 +232,7 @@ mod tests {
     const TEST_POLICY: ReadinessPolicy = ReadinessPolicy {
         total_timeout: Duration::from_secs(1),
         retry_interval: Duration::ZERO,
+        operation_wait_timeout: OPERATION_WAIT_TIMEOUT,
         max_attempts: 3,
     };
 
@@ -470,6 +470,30 @@ mod tests {
             error.last_failure,
             GuestDnsReadinessFailure::Transport(_)
         ));
+        assert_eq!(error.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_does_not_retry_after_host_wait_timeout() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                ReadinessPolicy {
+                    operation_wait_timeout: Duration::from_millis(10),
+                    ..TEST_POLICY
+                },
+            )
+            .await
+        });
+        let request = read_message(&mut guest).await;
+        assert_readiness_request(&request);
+
+        let error = task.await.unwrap().unwrap_err();
+        assert_eq!(
+            error.last_failure,
+            GuestDnsReadinessFailure::Transport(io::ErrorKind::TimedOut)
+        );
         assert_eq!(error.attempts, 1);
     }
 }

--- a/crates/sandbox-fc/src/guest_dns_readiness.rs
+++ b/crates/sandbox-fc/src/guest_dns_readiness.rs
@@ -1,0 +1,475 @@
+use std::fmt;
+use std::io;
+use std::time::Duration;
+
+use tokio::time::{Instant, sleep_until, timeout_at};
+use vsock_host::{ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput, VsockHost};
+use vsock_proto::ExecTermination;
+
+use crate::network::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
+
+const RESOLVER_ENV: &[(&str, &str)] = &[("RES_OPTIONS", "attempts:1 timeout:1")];
+const LABEL: &str = "guest-dns-readiness";
+const PROCESS_TIMEOUT_MS: u32 = 2_000;
+const OPERATION_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
+const STDOUT_LIMIT_BYTES: u32 = 1_024;
+const STDERR_LIMIT_BYTES: u32 = 512;
+const EXPECTED_TRANSIENT_EXIT_CODES: &[i32] = &[2];
+
+const PRODUCTION_POLICY: ReadinessPolicy = ReadinessPolicy {
+    total_timeout: Duration::from_secs(30),
+    retry_interval: Duration::from_secs(1),
+    max_attempts: 30,
+};
+
+#[derive(Clone, Copy)]
+struct ReadinessPolicy {
+    total_timeout: Duration,
+    retry_interval: Duration,
+    max_attempts: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GuestDnsReadinessFailure {
+    Deadline,
+    Transport(io::ErrorKind),
+    TimedOut,
+    Cancelled,
+    StartFailed,
+    WaitFailed,
+    ExitNonZero(i32),
+    OutputTruncated,
+    InvalidOutput,
+    UnexpectedAnswer,
+}
+
+impl fmt::Display for GuestDnsReadinessFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Deadline => f.write_str("deadline"),
+            Self::Transport(kind) => write!(f, "transport_{kind:?}"),
+            Self::TimedOut => f.write_str("process_timeout"),
+            Self::Cancelled => f.write_str("process_cancelled"),
+            Self::StartFailed => f.write_str("process_start_failed"),
+            Self::WaitFailed => f.write_str("process_wait_failed"),
+            Self::ExitNonZero(exit_code) => write!(f, "exit_nonzero_{exit_code}"),
+            Self::OutputTruncated => f.write_str("output_truncated"),
+            Self::InvalidOutput => f.write_str("invalid_output"),
+            Self::UnexpectedAnswer => f.write_str("unexpected_answer"),
+        }
+    }
+}
+
+impl GuestDnsReadinessFailure {
+    fn retryable(self) -> bool {
+        matches!(
+            self,
+            Self::TimedOut
+                | Self::Transport(io::ErrorKind::TimedOut)
+                | Self::ExitNonZero(2)
+                | Self::UnexpectedAnswer
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GuestDnsReadinessReport {
+    pub(crate) attempts: u16,
+    pub(crate) elapsed: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GuestDnsReadinessError {
+    pub(crate) attempts: u16,
+    pub(crate) elapsed: Duration,
+    pub(crate) last_failure: GuestDnsReadinessFailure,
+}
+
+impl fmt::Display for GuestDnsReadinessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "outcome={} attempts={} elapsed_ms={}",
+            self.last_failure,
+            self.attempts,
+            self.elapsed.as_millis()
+        )
+    }
+}
+
+impl std::error::Error for GuestDnsReadinessError {}
+
+pub(crate) async fn wait_for_guest_dns_readiness(
+    guest: &VsockHost,
+) -> Result<GuestDnsReadinessReport, GuestDnsReadinessError> {
+    wait_for_guest_dns_readiness_with_policy(guest, PRODUCTION_POLICY).await
+}
+
+async fn wait_for_guest_dns_readiness_with_policy(
+    guest: &VsockHost,
+    policy: ReadinessPolicy,
+) -> Result<GuestDnsReadinessReport, GuestDnsReadinessError> {
+    let started = Instant::now();
+    let deadline = started + policy.total_timeout;
+    let command = format!("/usr/bin/getent ahostsv4 {DNS_READINESS_HOSTNAME}");
+    let mut attempts = 0;
+
+    loop {
+        attempts += 1;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let request = ExecCaptureRequest {
+            timeout_ms: PROCESS_TIMEOUT_MS,
+            command: &command,
+            env: RESOLVER_ENV,
+            sudo: false,
+            label: LABEL,
+            stdout_limit_bytes: STDOUT_LIMIT_BYTES,
+            stderr_limit_bytes: STDERR_LIMIT_BYTES,
+            expected_exit_codes: EXPECTED_TRANSIENT_EXIT_CODES,
+            stdin_bytes: None,
+            wait_timeout: remaining.min(OPERATION_WAIT_TIMEOUT),
+        };
+        let failure = match timeout_at(deadline, guest.exec_operation_capture(request)).await {
+            Ok(Ok(result)) => match validate_result(result) {
+                Ok(()) => {
+                    return Ok(GuestDnsReadinessReport {
+                        attempts,
+                        elapsed: started.elapsed(),
+                    });
+                }
+                Err(failure) => failure,
+            },
+            Ok(Err(error)) => GuestDnsReadinessFailure::Transport(error.kind()),
+            Err(_) => GuestDnsReadinessFailure::Deadline,
+        };
+
+        if !failure.retryable() || attempts >= policy.max_attempts || Instant::now() >= deadline {
+            return Err(GuestDnsReadinessError {
+                attempts,
+                elapsed: started.elapsed(),
+                last_failure: failure,
+            });
+        }
+
+        let retry_at = (Instant::now() + policy.retry_interval).min(deadline);
+        sleep_until(retry_at).await;
+        if Instant::now() >= deadline {
+            return Err(GuestDnsReadinessError {
+                attempts,
+                elapsed: started.elapsed(),
+                last_failure: failure,
+            });
+        }
+    }
+}
+
+fn validate_result(result: ExecOperationResult) -> Result<(), GuestDnsReadinessFailure> {
+    let ExecOperationResult {
+        termination,
+        stdout,
+        stderr,
+        stream_overflowed,
+        ..
+    } = result;
+
+    match termination {
+        ExecTermination::Exited { exit_code: 0 } => {}
+        ExecTermination::Exited { exit_code } => {
+            return Err(GuestDnsReadinessFailure::ExitNonZero(exit_code));
+        }
+        ExecTermination::TimedOut => return Err(GuestDnsReadinessFailure::TimedOut),
+        ExecTermination::Cancelled => return Err(GuestDnsReadinessFailure::Cancelled),
+        ExecTermination::StartFailed => return Err(GuestDnsReadinessFailure::StartFailed),
+        ExecTermination::WaitFailed => return Err(GuestDnsReadinessFailure::WaitFailed),
+    }
+
+    if stream_overflowed {
+        return Err(GuestDnsReadinessFailure::OutputTruncated);
+    }
+    let stdout = captured_output(stdout)?;
+    let stderr = captured_output(stderr)?;
+    if stdout.1 || stderr.1 {
+        return Err(GuestDnsReadinessFailure::OutputTruncated);
+    }
+
+    let expected = DNS_READINESS_IPV4.to_string();
+    if stdout
+        .0
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| {
+            line.split(|byte| byte.is_ascii_whitespace())
+                .find(|field| !field.is_empty())
+        })
+        .any(|address| address == expected.as_bytes())
+    {
+        Ok(())
+    } else {
+        Err(GuestDnsReadinessFailure::UnexpectedAnswer)
+    }
+}
+
+fn captured_output(
+    output: ExecOwnedCapturedOutput,
+) -> Result<(Vec<u8>, bool), GuestDnsReadinessFailure> {
+    match output {
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        ExecOwnedCapturedOutput::Discarded => Err(GuestDnsReadinessFailure::InvalidOutput),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+    use vsock_proto::{
+        ExecCapturedOutput, ExecOutputPolicy, ExecTimeoutPolicy, HEADER_SIZE, MAX_MESSAGE_SIZE,
+        MIN_BODY_SIZE, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
+    };
+
+    use super::*;
+
+    const TEST_POLICY: ReadinessPolicy = ReadinessPolicy {
+        total_timeout: Duration::from_secs(1),
+        retry_interval: Duration::ZERO,
+        max_attempts: 3,
+    };
+
+    async fn read_message(stream: &mut UnixStream) -> RawMessage {
+        let mut header = [0u8; HEADER_SIZE];
+        tokio::time::timeout(Duration::from_secs(1), stream.read_exact(&mut header))
+            .await
+            .unwrap()
+            .unwrap();
+        let body_len = u32::from_be_bytes(header) as usize;
+        assert!((MIN_BODY_SIZE..=MAX_MESSAGE_SIZE).contains(&body_len));
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).await.unwrap();
+        RawMessage {
+            msg_type: body[0],
+            seq: u32::from_be_bytes(body[1..MIN_BODY_SIZE].try_into().unwrap()),
+            payload: body[MIN_BODY_SIZE..].to_vec(),
+        }
+    }
+
+    async fn connect_mock_guest(vsock_path: &str) -> UnixStream {
+        let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match UnixStream::connect(&listener_path).await {
+                Ok(stream) => return stream,
+                Err(error)
+                    if error.kind() == io::ErrorKind::NotFound && Instant::now() < deadline =>
+                {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => panic!("connect mock guest: {error}"),
+            }
+        }
+    }
+
+    async fn setup_host_and_guest() -> (Arc<VsockHost>, UnixStream) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let vsock_path = temp_dir
+            .path()
+            .join("guest-dns-readiness")
+            .to_string_lossy()
+            .into_owned();
+        let wait_path = vsock_path.clone();
+        let host_task = tokio::spawn(async move {
+            VsockHost::wait_for_connection(&wait_path, Duration::from_secs(1))
+                .await
+                .unwrap()
+        });
+        let mut guest = connect_mock_guest(&vsock_path).await;
+        guest
+            .write_all(&vsock_proto::encode(MSG_READY, 0, &[]).unwrap())
+            .await
+            .unwrap();
+        let ping = read_message(&mut guest).await;
+        assert_eq!(ping.msg_type, MSG_PING);
+        guest
+            .write_all(&vsock_proto::encode(MSG_PONG, ping.seq, &[]).unwrap())
+            .await
+            .unwrap();
+        (Arc::new(host_task.await.unwrap()), guest)
+    }
+
+    fn assert_readiness_request(message: &RawMessage) {
+        assert_eq!(message.msg_type, MSG_EXEC_START);
+        let request = vsock_proto::decode_exec_start(&message.payload).unwrap();
+        assert_eq!(
+            request.timeout,
+            ExecTimeoutPolicy::Duration {
+                timeout_ms: PROCESS_TIMEOUT_MS
+            }
+        );
+        assert_eq!(
+            request.command,
+            format!("/usr/bin/getent ahostsv4 {DNS_READINESS_HOSTNAME}")
+        );
+        assert_eq!(request.env, RESOLVER_ENV);
+        assert!(!request.sudo);
+        assert_eq!(request.label, LABEL);
+        assert_eq!(
+            request.stdout,
+            ExecOutputPolicy::Capture {
+                limit_bytes: STDOUT_LIMIT_BYTES
+            }
+        );
+        assert_eq!(
+            request.stderr,
+            ExecOutputPolicy::Capture {
+                limit_bytes: STDERR_LIMIT_BYTES
+            }
+        );
+        assert_eq!(request.expected_exit_codes, EXPECTED_TRANSIENT_EXIT_CODES);
+        assert!(request.stdin_bytes.is_none());
+    }
+
+    async fn send_result(
+        guest: &mut UnixStream,
+        request: &RawMessage,
+        termination: ExecTermination,
+        stdout: &[u8],
+        stdout_truncated: bool,
+    ) {
+        let payload = vsock_proto::encode_exec_result(
+            termination,
+            1,
+            ExecCapturedOutput::Captured {
+                bytes: stdout,
+                truncated: stdout_truncated,
+            },
+            ExecCapturedOutput::Captured {
+                bytes: b"",
+                truncated: false,
+            },
+            "",
+        )
+        .unwrap();
+        guest
+            .write_all(&vsock_proto::encode(MSG_EXEC_RESULT, request.seq, &payload).unwrap())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_uses_fixed_guest_resolver_request() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+        });
+        let request = read_message(&mut guest).await;
+        assert_readiness_request(&request);
+        send_result(
+            &mut guest,
+            &request,
+            ExecTermination::Exited { exit_code: 0 },
+            b"192.0.2.1 STREAM vm0-readiness.invalid\n",
+            false,
+        )
+        .await;
+
+        let report = task.await.unwrap().unwrap();
+        assert_eq!(report.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_recovers_after_transient_failure() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+        });
+        let first = read_message(&mut guest).await;
+        send_result(
+            &mut guest,
+            &first,
+            ExecTermination::Exited { exit_code: 2 },
+            b"",
+            false,
+        )
+        .await;
+        let second = read_message(&mut guest).await;
+        send_result(
+            &mut guest,
+            &second,
+            ExecTermination::Exited { exit_code: 0 },
+            b"192.0.2.1 DGRAM vm0-readiness.invalid\n",
+            false,
+        )
+        .await;
+
+        let report = task.await.unwrap().unwrap();
+        assert_eq!(report.attempts, 2);
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_stops_at_attempt_limit() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+        });
+        for _ in 0..TEST_POLICY.max_attempts {
+            let request = read_message(&mut guest).await;
+            send_result(
+                &mut guest,
+                &request,
+                ExecTermination::Exited { exit_code: 0 },
+                b"203.0.113.1 STREAM vm0-readiness.invalid\n",
+                false,
+            )
+            .await;
+        }
+
+        let error = task.await.unwrap().unwrap_err();
+        assert_eq!(error.attempts, TEST_POLICY.max_attempts);
+        assert_eq!(
+            error.last_failure,
+            GuestDnsReadinessFailure::UnexpectedAnswer
+        );
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_rejects_truncated_output() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+        });
+        let request = read_message(&mut guest).await;
+        send_result(
+            &mut guest,
+            &request,
+            ExecTermination::Exited { exit_code: 0 },
+            b"192.0.2.1 STREAM vm0-readiness.invalid\n",
+            true,
+        )
+        .await;
+
+        let error = task.await.unwrap().unwrap_err();
+        assert_eq!(
+            error.last_failure,
+            GuestDnsReadinessFailure::OutputTruncated
+        );
+        assert_eq!(error.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn guest_dns_readiness_reports_transport_failure() {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+        });
+        let request = read_message(&mut guest).await;
+        assert_readiness_request(&request);
+        drop(guest);
+
+        let error = task.await.unwrap().unwrap_err();
+        assert!(matches!(
+            error.last_failure,
+            GuestDnsReadinessFailure::Transport(_)
+        ));
+        assert_eq!(error.attempts, 1);
+    }
+}

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -33,6 +33,7 @@ mod cow_pool;
 mod duration;
 mod exec_operation_result;
 mod factory;
+mod guest_dns_readiness;
 mod guest_operations;
 mod leaked_resources;
 mod network;

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -149,7 +149,7 @@ enum AcquirePlan {
 struct ReleasePlan {
     info: NetnsInfo,
     kind: NetnsKind,
-    active_at_prepare: bool,
+    reusable_at_prepare: bool,
     ops: NetnsLifecycleOps,
 }
 
@@ -784,7 +784,9 @@ impl NetnsPoolState {
         }
 
         let kind = self.active_kind();
-        let reusable = self.active && !self.non_reusable.contains(active_lease.name());
+        let reusable = self.active
+            && active_lease.reuse_eligible()
+            && !self.non_reusable.contains(active_lease.name());
         if reusable
             && self
                 .target_queue(kind)
@@ -804,7 +806,7 @@ impl NetnsPoolState {
         Ok(ReleasePlan {
             info: active_lease.info().clone(),
             kind,
-            active_at_prepare: reusable,
+            reusable_at_prepare: reusable,
             ops: self.ops.clone(),
         })
     }
@@ -1042,13 +1044,13 @@ impl NetnsPoolInner {
                 Ok(plan) => plan,
                 Err(message) => return NetnsReleaseOutcome::InvalidLease(message),
             };
-            if plan.active_at_prepare {
+            if plan.reusable_at_prepare {
                 state.mark_non_reusable(&plan);
             }
             plan
         };
 
-        let can_requeue = if plan.active_at_prepare {
+        let can_requeue = if plan.reusable_at_prepare {
             (plan.ops.flush_conntrack)(plan.info.peer_ip.clone())
                 .await
                 .is_trusted()
@@ -1355,6 +1357,7 @@ mod tests {
 
     struct CountedLifecycle {
         ops: NetnsLifecycleOps,
+        flush_count: Arc<AtomicUsize>,
         delete_count: Arc<AtomicUsize>,
     }
 
@@ -1426,11 +1429,19 @@ mod tests {
         flush_outcome: ConntrackFlushOutcome,
         delete_outcome: NamespaceDeleteOutcome,
     ) -> CountedLifecycle {
+        let flush_count = Arc::new(AtomicUsize::new(0));
         let delete_count = Arc::new(AtomicUsize::new(0));
+        let flush_count_for_ops = Arc::clone(&flush_count);
         let delete_count_for_ops = Arc::clone(&delete_count);
         CountedLifecycle {
             ops: NetnsLifecycleOps {
-                flush_conntrack: Arc::new(move |_| Box::pin(async move { flush_outcome })),
+                flush_conntrack: Arc::new(move |_| {
+                    let flush_count = Arc::clone(&flush_count_for_ops);
+                    Box::pin(async move {
+                        flush_count.fetch_add(1, Ordering::SeqCst);
+                        flush_outcome
+                    })
+                }),
                 delete_namespace: Arc::new(move |_| {
                     let delete_count = Arc::clone(&delete_count_for_ops);
                     Box::pin(async move {
@@ -1439,6 +1450,7 @@ mod tests {
                     })
                 }),
             },
+            flush_count,
             delete_count,
         }
     }
@@ -2025,6 +2037,7 @@ mod tests {
         let CountedLifecycle {
             ops,
             delete_count: deleted,
+            ..
         } = counted_deleted_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.ops = ops;
@@ -2047,6 +2060,7 @@ mod tests {
         let CountedLifecycle {
             ops,
             delete_count: deleted,
+            ..
         } = counted_deleted_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
@@ -2117,6 +2131,7 @@ mod tests {
         let CountedLifecycle {
             ops,
             delete_count: deleted,
+            ..
         } = counted_deleted_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.ops = ops;
@@ -2143,7 +2158,9 @@ mod tests {
     #[tokio::test]
     async fn cleanup_rejects_acquire_and_deletes_late_completion() {
         let release = Arc::new(tokio::sync::Notify::new());
-        let CountedLifecycle { ops, delete_count } = counted_deleted_lifecycle();
+        let CountedLifecycle {
+            ops, delete_count, ..
+        } = counted_deleted_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
         pool.ops = ops;
@@ -2395,8 +2412,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lease_marked_non_reusable_is_deleted_without_conntrack_flush() {
+        let CountedLifecycle {
+            ops,
+            flush_count,
+            delete_count,
+        } = counted_deleted_lifecycle();
+        let mut pool = NetnsPoolState::inactive_for_test();
+        pool.active = true;
+        pool.ops = ops;
+        pool.plain_queue.push_back(test_info("healthy-ns"));
+        let mut lease = pool.checkout(test_info("failed-ns")).unwrap();
+        lease.mark_non_reusable();
+        let mut lease = Some(lease);
+        let handle = NetnsPoolHandle::from_state_for_test(pool);
+
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Deleted));
+        assert!(lease.is_none());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 0);
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        let pool = handle.inner.state.lock().await;
+        assert!(!pool.in_flight.contains("failed-ns"));
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert_eq!(pool.plain_queue.front().unwrap().name(), "healthy-ns");
+    }
+
+    #[tokio::test]
+    async fn lease_reapproved_after_readiness_uses_normal_release_path() {
+        let CountedLifecycle {
+            ops,
+            flush_count,
+            delete_count,
+        } = counted_deleted_lifecycle();
+        let mut pool = NetnsPoolState::inactive_for_test();
+        pool.active = true;
+        pool.ops = ops;
+        let mut lease = pool.checkout(test_info("ready-ns")).unwrap();
+        lease.mark_non_reusable();
+        lease.mark_reusable();
+        let mut lease = Some(lease);
+        let handle = NetnsPoolHandle::from_state_for_test(pool);
+
+        let outcome = handle.release(&mut lease).await;
+
+        assert!(matches!(outcome, NetnsReleaseOutcome::Released));
+        assert!(lease.is_none());
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        assert_eq!(delete_count.load(Ordering::SeqCst), 0);
+        let pool = handle.inner.state.lock().await;
+        assert!(pool.in_flight.is_empty());
+        assert_eq!(pool.plain_queue.len(), 1);
+        assert_eq!(pool.plain_queue.front().unwrap().name(), "ready-ns");
+    }
+
+    #[tokio::test]
     async fn untrusted_conntrack_flush_deletes_without_requeue() {
-        let CountedLifecycle { ops, delete_count } = untrusted_flush_counted_deleted_lifecycle();
+        let CountedLifecycle {
+            ops, delete_count, ..
+        } = untrusted_flush_counted_deleted_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
         pool.ops = ops;
@@ -2691,8 +2766,9 @@ mod tests {
 
     #[tokio::test]
     async fn release_abandoned_delete_consumes_lease_and_clears_tracking() {
-        let CountedLifecycle { ops, delete_count } =
-            untrusted_flush_counted_abandoned_delete_lifecycle();
+        let CountedLifecycle {
+            ops, delete_count, ..
+        } = untrusted_flush_counted_abandoned_delete_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
         pool.ops = ops;
@@ -2839,8 +2915,9 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_removes_queued_namespace_after_abandoned_delete() {
-        let CountedLifecycle { ops, delete_count } =
-            trusted_flush_counted_abandoned_delete_lifecycle();
+        let CountedLifecycle {
+            ops, delete_count, ..
+        } = trusted_flush_counted_abandoned_delete_lifecycle();
         let mut pool = NetnsPoolState::inactive_for_test();
         pool.active = true;
         pool.plain_queue.push_back(test_info("test-ns"));

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -44,6 +44,9 @@ impl NetnsInfo {
 
 /// Non-cloneable release authority for a checked-out namespace.
 ///
+/// The lease also carries the sandbox's reuse disposition so an unproven or
+/// failed VM attachment follows the pool's deletion path on every cleanup route.
+///
 /// Dropping a live lease only emits a warning. Call `NetnsPool::release` so
 /// the namespace is either recycled into the pool or deleted during shutdown.
 #[derive(Debug)]
@@ -52,6 +55,7 @@ pub struct NetnsLease {
     info: NetnsInfo,
     pool_instance_id: u64,
     active: bool,
+    reuse_eligible: bool,
 }
 
 impl NetnsLease {
@@ -60,6 +64,7 @@ impl NetnsLease {
             info,
             pool_instance_id,
             active: true,
+            reuse_eligible: true,
         }
     }
 
@@ -88,6 +93,18 @@ impl NetnsLease {
 
     pub(super) fn pool_instance_id(&self) -> u64 {
         self.pool_instance_id
+    }
+
+    pub(crate) fn mark_non_reusable(&mut self) {
+        self.reuse_eligible = false;
+    }
+
+    pub(crate) fn mark_reusable(&mut self) {
+        self.reuse_eligible = true;
+    }
+
+    pub(super) fn reuse_eligible(&self) -> bool {
+        self.reuse_eligible
     }
 
     pub(super) fn into_info(mut self) -> NetnsInfo {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1582,7 +1582,7 @@ impl Sandbox for FirecrackerSandbox {
                     );
                     self.guest.lock().await.take();
                     self.runtime.kill_process().await;
-                    return Err(SandboxError::Start {
+                    return Err(SandboxError::StartRequiresFreshSandbox {
                         message: format!(
                             "guest DNS readiness for namespace {}: {error}",
                             self.network.name()

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -37,6 +37,7 @@ use crate::exec_operation_result::{
     validate_exec_capture_timeout,
 };
 use crate::factory::InvariantConfig;
+use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::leaked_resources::LeakedResources;
 use crate::network::{NetnsInfo, NetnsLease};
@@ -1484,6 +1485,16 @@ impl Sandbox for FirecrackerSandbox {
             });
         }
 
+        let requires_guest_dns_readiness = self.factory_config.dns_port.is_some();
+        if requires_guest_dns_readiness {
+            let Some(lease) = self.network.lease_mut().as_mut() else {
+                return Err(SandboxError::Start {
+                    message: "network lease missing before guest DNS readiness".into(),
+                });
+            };
+            lease.mark_non_reusable();
+        }
+
         let runtime_cancel = CancellationToken::new();
 
         // Start the vsock listener BEFORE launching Firecracker.
@@ -1536,7 +1547,50 @@ impl Sandbox for FirecrackerSandbox {
             }
         };
 
-        *self.guest.lock().await = Some(Arc::new(vsock_guest));
+        let vsock_guest = Arc::new(vsock_guest);
+        *self.guest.lock().await = Some(Arc::clone(&vsock_guest));
+
+        if requires_guest_dns_readiness {
+            match wait_for_guest_dns_readiness(&vsock_guest).await {
+                Ok(report) => {
+                    let Some(lease) = self.network.lease_mut().as_mut() else {
+                        self.guest.lock().await.take();
+                        self.runtime.kill_process().await;
+                        return Err(SandboxError::Start {
+                            message: "network lease missing after guest DNS readiness".into(),
+                        });
+                    };
+                    lease.mark_reusable();
+                    info!(
+                        id = %self.id,
+                        namespace = %self.network.name(),
+                        stage = "guest_dns_readiness",
+                        attempts = report.attempts,
+                        elapsed_ms = duration_ms(report.elapsed),
+                        "guest DNS readiness probe succeeded"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        id = %self.id,
+                        namespace = %self.network.name(),
+                        stage = "guest_dns_readiness",
+                        outcome = %error.last_failure,
+                        attempts = error.attempts,
+                        elapsed_ms = duration_ms(error.elapsed),
+                        "guest DNS readiness probe failed"
+                    );
+                    self.guest.lock().await.take();
+                    self.runtime.kill_process().await;
+                    return Err(SandboxError::Start {
+                        message: format!(
+                            "guest DNS readiness for namespace {}: {error}",
+                            self.network.name()
+                        ),
+                    });
+                }
+            }
+        }
 
         let control_sock_path = self.sock_paths.control_sock();
         let Some(termination_handle) = self

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -29,6 +29,11 @@ pub enum SandboxError {
     #[error("sandbox start failed: {message}")]
     Start { message: String },
 
+    /// A created sandbox failed because an isolated sandbox resource was not
+    /// ready. The current sandbox must be destroyed before creating a replacement.
+    #[error("sandbox start failed: {message}")]
+    StartRequiresFreshSandbox { message: String },
+
     /// The requested action is invalid for the current runtime, factory, or
     /// sandbox state.
     #[error("invalid state for {context} (state: {state}): {message}")]


### PR DESCRIPTION
## Summary

- gate DNS-managed Firecracker startup on a deterministic resolver check from the attached guest before exposing the control socket or `Running` state
- carry reuse eligibility on the network namespace lease so failed or cancelled startup deletes the namespace instead of returning it to the pool
- destroy a DNS-unready sandbox and create exactly one fresh replacement so isolated bad attachment state does not fail the user run when healthy capacity is available
- require `getent` in runner rootfs verification and assert guest DNS readiness ordering in the metal-host runner workflow

## Behavior and bounds

- resolves the runner-owned `vm0-readiness.invalid` record and requires the fixed `192.0.2.1` answer
- bounds each readiness window to 30 seconds, 30 attempts, a two-second guest process timeout, and a separately bounded host wait
- permits one replacement sandbox after the first readiness failure; a second failure is cleaned up and returned without another replacement
- retries only after proxy unregister, network-log closure, and sandbox destroy complete successfully; cleanup failures stop recovery rather than overlapping resources
- preserves reusable workspace image sources, but invalidates a consumed cache hit and retries with a fresh workspace because its `Move` seed no longer exists
- retries terminal DNS-specific failures within one attachment while failing abandoned host waits and non-recoverable protocol, process-start, and malformed-output failures immediately
- keeps snapshot creation and benchmark runtimes unchanged because they do not configure runner-managed DNS

## Exclusions

- does not claim a specific kernel, TAP, NAT, or dnsmasq root cause for the intermittent outage
- does not add a public endpoint, general provider invalidation method, persisted state, or new vsock protocol message
- does not replace the existing namespace-creation readiness gate

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p sandbox -p sandbox-fc -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox -p sandbox-fc -p runner --no-deps`
- `cargo test -p sandbox` (32 passed)
- `cargo test -p sandbox-fc` (712 passed)
- `cargo test -p runner executor::tests::sandbox_run_tests` (79 passed)
- `cargo test -p runner cmd::build::scripts::tests` (24 passed)
- `bash -n crates/runner/scripts/verify-rootfs.sh`
- `bash -n` on the `runner-exec` remote workflow script
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/crates.yml`
- repository pre-commit and commit-message hooks

Closes #21315
