### PR TITLE
fix(runner): reject conflicting build modes

### DIFF
--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -104,10 +104,10 @@ pub struct BuildArgs {
     /// Profile to build (determines VM resources and disk sizes)
     #[arg(long)]
     pub profile: String,
-    /// Compute and print the image hash without building
-    #[arg(long)]
+    /// Print rootfs_hash and snapshot_hash without building (incompatible with --warm-rootfs-cache)
+    #[arg(long, conflicts_with = "warm_rootfs_cache")]
     pub dry_run: bool,
-    /// Build or upload only the shared R2 template cache, without creating a snapshot
+    /// Populate only the shared R2 template cache; prints no image hashes (incompatible with --dry-run)
     #[arg(long)]
     pub warm_rootfs_cache: bool,
 }

--- a/crates/runner/src/cmd/build/tests/cli.rs
+++ b/crates/runner/src/cmd/build/tests/cli.rs
@@ -32,6 +32,31 @@ fn build_args_parse_warm_rootfs_cache_without_guest_binaries() {
 }
 
 #[test]
+fn build_args_reject_dry_run_with_warm_rootfs_cache() {
+    let mut args = build_args();
+    args.extend(["--dry-run".to_string(), "--warm-rootfs-cache".to_string()]);
+
+    let error = <TestBuildCli as clap::Parser>::try_parse_from(args)
+        .err()
+        .expect("combined flags should fail");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn build_help_describes_dry_run_and_warm_cache_output() {
+    let help = TestBuildCli::command().render_help().to_string();
+    let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(normalized_help.contains(
+        "Print rootfs_hash and snapshot_hash without building (incompatible with --warm-rootfs-cache)"
+    ));
+    assert!(normalized_help.contains(
+        "Populate only the shared R2 template cache; prints no image hashes (incompatible with --dry-run)"
+    ));
+}
+
+#[test]
 fn guest_cli_flags_match_inventory() {
     let command = TestBuildCli::command();
     let actual: BTreeSet<_> = command


### PR DESCRIPTION
## Summary

- reject `runner build --dry-run --warm-rootfs-cache` during Clap parsing instead of succeeding with empty stdout and no cache work
- clarify that full-image dry runs print `rootfs_hash` and `snapshot_hash`, while warm-cache mode prints no image hashes
- cover the argument conflict and generated help through the production `BuildArgs` parser

## Scope

- preserves standalone full-image dry runs and actual warm-cache runs
- does not expose the internal `template_hash`
- does not change hash computation, stdout writes, R2 behavior, workflows, Ansible, protocols, or persisted state

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::tests::cli --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps --all-features`
- pre-commit hooks: file-size check, generated connector firewall check, Cargo fmt, Cargo doc, Cargo Clippy, and commitlint

Closes #21304
