### PR TITLE
fix(mitm-addon): preserve with item binding order

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -745,10 +745,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for item in node.items:
             self._record_metadata_merge_key_violations(item.context_expr)
             self.visit(item.context_expr)
+            self._discard_alias_target(item.optional_vars)
         body_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(body_aliases)
-        for item in node.items:
-            self._discard_alias_target(item.optional_vars)
         exception_state = _ExceptionAliasState()
         self._exception_alias_scopes.append(exception_state)
         body_falls_through = self._visit_current_scope_body(node.body)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/with_item_bindings.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/with_item_bindings.base.py.txt
@@ -1,0 +1,39 @@
+def sync_later_context_uses_shadowed_name(flow, first, second):
+    metadata = flow.metadata
+    with (
+        first() as metadata,
+        second(metadata["vm_run_id"]),
+    ):
+        body_value = metadata["vm_run_id"]
+    after_value = metadata["vm_run_id"]
+    return body_value, after_value
+
+async def async_later_context_uses_shadowed_name(flow, first, second):
+    metadata = flow.metadata
+    async with (
+        first() as metadata,
+        second(metadata["vm_run_id"]),
+    ):
+        body_value = metadata["vm_run_id"]
+    after_value = metadata["vm_run_id"]
+    return body_value, after_value
+
+def sync_current_context_uses_alias_before_binding(flow, first, second):
+    metadata = flow.metadata
+    with (
+        first(metadata["vm_run_id"]) as metadata,
+        second(metadata["vm_run_id"]),
+    ):
+        body_value = metadata["vm_run_id"]
+    after_value = metadata["vm_run_id"]
+    return body_value, after_value
+
+async def async_current_context_uses_alias_before_binding(flow, first, second):
+    metadata = flow.metadata
+    async with (
+        first(metadata["vm_run_id"]) as metadata,
+        second(metadata["vm_run_id"]),
+    ):
+        body_value = metadata["vm_run_id"]
+    after_value = metadata["vm_run_id"]
+    return body_value, after_value

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/with_item_bindings.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/with_item_bindings.expected.txt
@@ -1,0 +1,2 @@
+with_item_bindings.py:24: use metadata_keys.VM_RUN_ID for flow.metadata access
+with_item_bindings.py:34: use metadata_keys.VM_RUN_ID for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -159,6 +159,17 @@ def test_registered_flow_metadata_guard_tracks_context_manager_exception_paths(t
     )
 
 
+def test_registered_flow_metadata_guard_tracks_with_item_binding_order(tmp_path):
+    source_path = tmp_path / "with_item_bindings.py"
+    _write_python_source(source_path, "with_item_bindings.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "with_item_bindings.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_respects_python_source_encoding(tmp_path):
     source_path = tmp_path / "latin1.py"
     source_path.write_bytes(b'# coding: latin-1\nflow.metadata["vm_run_id"] = "caf\xe9"\n')


### PR DESCRIPTION
## Summary

- analyze each `with` item before applying its own `as` binding, then carry that binding into later items
- share the ordering logic between synchronous and asynchronous context statements
- add a focused public-API fixture that preserves pre-binding diagnostics while rejecting later-item false positives

## Scope

This changes only the repository flow-metadata static analyzer and its integration contract. It does not change mitmproxy runtime behavior, schemas, persisted data, APIs, protocols, deployment compatibility, or feature switches.

## Validation

- `python3 -m pytest tests/test_flow_metadata_key_contract.py -v` (11 passed)
- `./scripts/check-flow-metadata-keys.py`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/ -v` (3918 passed)
- pre-commit Ruff checks and commitlint

Closes #21309

