### PR TITLE
fix(vsock-host): bound lifecycle request timeout

### DIFF
--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -557,8 +557,12 @@ async fn request_on_shared(
     payload: &[u8],
     timeout: Duration,
 ) -> io::Result<RawMessage> {
+    if timeout.is_zero() {
+        return Err(request_timeout_error());
+    }
+    let deadline = deadline_after(timeout, "request timeout overflowed")?;
     let seq = shared.next_seq();
-    request_raw_on_shared(shared, msg_type, seq, payload, timeout).await
+    request_raw_on_shared(shared, msg_type, seq, payload, deadline).await
 }
 
 async fn write_request_frame(
@@ -641,7 +645,7 @@ async fn write_registered_request_and_wait(
     shared: &Arc<Shared>,
     seq: u32,
     data: &[u8],
-    timeout: Duration,
+    deadline: Instant,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
@@ -651,16 +655,18 @@ async fn write_registered_request_and_wait(
     // or cancellation before reader_loop dispatches a response. The write
     // helper separately poisons the connection if cancellation interrupts an
     // in-progress frame write.
-    write_request_frame(shared, data, before_write).await?;
+    time::timeout_at(deadline, write_request_frame(shared, data, before_write))
+        .await
+        .map_err(|_| request_timeout_error())??;
 
-    await_pending_response(rx, timeout).await
+    await_pending_response(rx, deadline).await
 }
 
 async fn write_registered_request_and_wait_with_frame_builder(
     shared: &Arc<Shared>,
     seq: u32,
     build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
-    timeout: Duration,
+    response_timeout: Duration,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
@@ -668,12 +674,13 @@ async fn write_registered_request_and_wait_with_frame_builder(
 
     write_request_frame_with_builder(shared, seq, build_frame, before_write).await?;
 
-    await_pending_response(rx, timeout).await
+    let response_deadline = deadline_after(response_timeout, "request timeout overflowed")?;
+    await_pending_response(rx, response_deadline).await
 }
 
 async fn await_pending_response(
     rx: oneshot::Receiver<RawMessage>,
-    timeout: Duration,
+    deadline: Instant,
 ) -> io::Result<RawMessage> {
     // `rx` returns `Ok(msg)` when the reader dispatches a response and
     // `Err(RecvError)` when `close()` drops the `Connected` variant. The
@@ -686,10 +693,14 @@ async fn await_pending_response(
                 "connection closed",
             ))
         }
-        _ = tokio::time::sleep(timeout) => {
-            Err(io::Error::new(io::ErrorKind::TimedOut, "request timeout"))
+        _ = time::sleep_until(deadline) => {
+            Err(request_timeout_error())
         }
     }
+}
+
+fn request_timeout_error() -> io::Error {
+    io::Error::new(io::ErrorKind::TimedOut, "request timeout")
 }
 
 /// Send a request with a pre-allocated sequence number.
@@ -698,7 +709,7 @@ async fn request_raw_on_shared(
     msg_type: u8,
     seq: u32,
     payload: &[u8],
-    timeout: Duration,
+    deadline: Instant,
 ) -> io::Result<RawMessage> {
     let data = encode_request_frame(msg_type, seq, payload)?;
     let rx = register_pending_response(shared, seq, |tx| {
@@ -709,7 +720,7 @@ async fn request_raw_on_shared(
         })
     })?;
 
-    write_registered_request_and_wait(shared, seq, &data, timeout, || Ok(()), rx).await
+    write_registered_request_and_wait(shared, seq, &data, deadline, || Ok(()), rx).await
 }
 
 async fn normal_request_on_shared_with_write_observer_frame_builder(
@@ -1075,6 +1086,8 @@ impl VsockHost {
     /// This does not fence host-side normal operations. Callers that need a
     /// no-new-normal-operation boundary must hold a
     /// [`NormalOperationFence`] before sending this lifecycle request.
+    /// The timeout covers waiting for the shared writer, writing the request,
+    /// and waiting for the response.
     pub async fn quiesce_operations(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_QUIESCE_OPERATIONS,
@@ -1086,6 +1099,9 @@ impl VsockHost {
     }
 
     /// Resume guest operations after a failed or aborted quiesce attempt.
+    ///
+    /// The timeout covers waiting for the shared writer, writing the request,
+    /// and waiting for the response.
     pub async fn resume_operations(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_RESUME_OPERATIONS,
@@ -1162,7 +1178,10 @@ impl VsockHost {
 
     /// Request graceful shutdown from guest.
     ///
-    /// Returns `true` if guest acknowledged, `false` on timeout.
+    /// The timeout covers waiting for the shared writer, writing the request,
+    /// and waiting for the acknowledgement. Returns `true` if the guest
+    /// acknowledges, and `false` on timeout, request failure, or an unexpected
+    /// response.
     pub async fn shutdown(&self, timeout: Duration) -> bool {
         let result = self.request(MSG_SHUTDOWN, &[], timeout).await;
         matches!(result, Ok(ref m) if m.msg_type == MSG_SHUTDOWN_ACK)

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -10,8 +10,8 @@ use vsock_proto::{
 use super::support::{
     MockGuest, await_mock_guest, captured_output_bytes, drop_idle_request_write_guard,
     drop_started_request_write_guard, exec_capture_default, fence_normal_operations,
-    host_from_stream, is_connected, make_pair, normal_operation_readiness, poison_connection,
-    setup_host_and_mock_guest,
+    host_from_stream, is_connected, make_pair, normal_operation_readiness, pending_request_count,
+    poison_connection, setup_host_and_mock_guest,
 };
 use crate::{
     NormalOperationFenceRejection, VsockHost, operation_tracker::NormalOperationReadiness,
@@ -351,56 +351,89 @@ async fn quiesce_operations_rejects_non_empty_ack_payload() {
 
 #[tokio::test]
 async fn quiesce_operations_times_out_and_late_ack_is_ignored() {
-    let (host_stream, guest) = make_pair();
-    let (quiesce_seen_tx, quiesce_seen_rx) = tokio::sync::oneshot::channel();
-    let (send_late_ack, receive_late_ack) = tokio::sync::oneshot::channel();
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_millis(100)).await })
+    };
 
-    let mut guest_task = tokio::spawn(async move {
-        let mut guest = MockGuest::new(guest);
-        guest.complete_handshake().await;
-
-        let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
-        quiesce_seen_tx.send(()).unwrap();
-
-        receive_late_ack.await.unwrap();
-        guest
-            .send_empty_response(MSG_OPERATIONS_QUIESCED, quiesce.seq)
-            .await;
-
-        let resume = guest.expect_message(MSG_RESUME_OPERATIONS).await;
-        guest
-            .send_empty_response(MSG_OPERATIONS_RESUMED, resume.seq)
-            .await;
-    });
-
-    let host = host_from_stream(host_stream).await.unwrap();
-    let err = host.quiesce_operations(Duration::ZERO).await.unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
-
-    tokio::select! {
-        result = tokio::time::timeout(Duration::from_secs(2), quiesce_seen_rx) => {
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(_)) => {
-                    match (&mut guest_task).await {
-                        Ok(()) => panic!("mock guest finished before quiesce request"),
-                        Err(err) => panic!("mock guest task panicked before quiesce request: {err}"),
-                    }
-                }
-                Err(_) => panic!("guest should receive quiesce request before late ack"),
-            }
-        }
-        result = &mut guest_task => {
-            result.expect("mock guest task panicked before quiesce request");
-            panic!("mock guest finished before quiesce request");
-        }
-    }
-    assert!(is_connected(&host));
-    send_late_ack.send(()).unwrap();
-    host.resume_operations(Duration::from_secs(2))
+    let quiesce = guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+    let err = tokio::time::timeout(Duration::from_secs(2), quiesce_task)
         .await
-        .unwrap();
-    await_mock_guest(guest_task).await;
+        .expect("quiesce should respect its response timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+
+    guest
+        .send_empty_response(MSG_OPERATIONS_QUIESCED, quiesce.seq)
+        .await;
+    let resume_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.resume_operations(Duration::from_secs(2)).await })
+    };
+    let resume = guest.expect_message(MSG_RESUME_OPERATIONS).await;
+    guest
+        .send_empty_response(MSG_OPERATIONS_RESUMED, resume.seq)
+        .await;
+    resume_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn lifecycle_request_zero_timeout_does_not_send_frame() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+
+    let err = host.quiesce_operations(Duration::ZERO).await.unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(pending_request_count(&host), 0);
+    assert!(is_connected(&host));
+    match guest.stream_mut().try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("zero-timeout lifecycle request must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after zero-timeout request: {err}"),
+    }
+}
+
+#[tokio::test]
+async fn lifecycle_request_times_out_while_waiting_for_writer() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let quiesce_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_millis(50)).await })
+    };
+
+    let err = tokio::time::timeout(Duration::from_secs(2), quiesce_task)
+        .await
+        .expect("quiesce should time out while waiting for the writer")
+        .unwrap()
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(pending_request_count(&host), 0);
+    assert!(is_connected(&host));
+
+    drop(writer_guard);
+    match guest.stream_mut().try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out lifecycle request must not send later; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after writer timeout: {err}"),
+    }
+
+    let resume_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.resume_operations(Duration::from_secs(2)).await })
+    };
+    let resume = guest.expect_message(MSG_RESUME_OPERATIONS).await;
+    guest
+        .send_empty_response(MSG_OPERATIONS_RESUMED, resume.seq)
+        .await;
+    resume_task.await.unwrap().unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- apply one total deadline to lifecycle writer-lock acquisition, frame writing, and response waiting
- preserve pending cleanup before write-start and fail-closed connection poisoning after write-start
- make zero-timeout lifecycle requests side-effect free while retaining positive-timeout late-response coverage

## Scope

- updates only the plain request path used by shutdown, quiesce, and resume
- does not change frame-builder file-write or exec-control timeout contracts
- does not change guest protocol messages, persisted state, or deployment compatibility

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host lifecycle_request_ -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::connection`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- repeated the held-writer and late-ack timeout tests five times each
- pre-commit hooks: workspace cargo fmt, Clippy, rustdoc, file-size, and generated-file checks

Closes #21310
