### PR TITLE
feat: route image editing actions to dedicated transform models

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
@@ -75,7 +75,12 @@ export type ImageEditRegionComment = {
   region: ImageEditRegion;
 };
 
-const IMAGE_EDIT_MODEL = "nano-banana-2";
+const IMAGE_EDIT_MODEL_BY_OPERATION = {
+  removeBackground: "birefnet",
+  enhance: "clarity-upscaler",
+  editRegion: "nano-banana-2",
+  styleTransfer: "nano-banana-2",
+} as const satisfies Record<ImageEditOperation, string>;
 // Region editing runs in two steps. First a multimodal model interprets a copy
 // of the source image with numbered marks drawn on each selected region,
 // turning each mark + user comment into a disambiguated, self-contained edit
@@ -100,16 +105,6 @@ const POLL_TIMEOUT_MS = 90_000;
 // (and its "Working"/Send-disabled flag) forever; the poll path is likewise
 // time-boxed via POLL_TIMEOUT_MS.
 const IMAGE_LOAD_TIMEOUT_MS = 30_000;
-
-const IMAGE_EDIT_PROMPTS = {
-  removeBackground:
-    "Remove the background completely. Keep only the main subject on a plain solid white background. Do not alter the subject.",
-  enhance:
-    "Enhance this image to high definition. Increase sharpness, clarity and fine detail while faithfully preserving the original content, composition and colors.",
-} as const satisfies Record<
-  Exclude<ImageEditOperation, "editRegion" | "styleTransfer">,
-  string
->;
 
 const IMAGE_EDIT_LOADING_TOAST = {
   removeBackground: "Removing background...",
@@ -473,13 +468,11 @@ function imageEditPrompt(args: {
   operation: ImageEditOperation;
   regionEdits?: readonly ResolvedRegionEdit[];
   stylePrompt?: string;
-}): string {
+}): string | undefined {
   switch (args.operation) {
-    case "removeBackground": {
-      return IMAGE_EDIT_PROMPTS.removeBackground;
-    }
+    case "removeBackground":
     case "enhance": {
-      return IMAGE_EDIT_PROMPTS.enhance;
+      return undefined;
     }
     case "editRegion": {
       return editRegionPrompt(args.regionEdits ?? []);
@@ -737,7 +730,7 @@ async function startImageEditGeneration({
   const accepted = await accept(
     generateClient.post({
       body: {
-        model: IMAGE_EDIT_MODEL,
+        model: IMAGE_EDIT_MODEL_BY_OPERATION[operation],
         outputFormat: regionEdit ? "png" : undefined,
         prompt: imageEditPrompt({
           operation,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -635,7 +635,14 @@ async function createRegionComment(
 describe("image editing", () => {
   it("adds a remove-background result for the selected canvas image", async () => {
     const user = userEvent.setup({ delay: null });
-    mockImageEditGeneration();
+    const requests: {
+      model?: string;
+      prompt?: string;
+      sourceImageUrls?: readonly string[];
+    }[] = [];
+    mockImageEditGeneration((body) => {
+      requests.push(body);
+    });
     setupChatThread({
       featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
     });
@@ -735,6 +742,42 @@ describe("image editing", () => {
         screen.getByTestId("artifact-sidebar-body-image-copy"),
       ).toHaveAttribute("src", EDITED_IMAGE_URL);
     });
+    expect(requests).toStrictEqual([
+      {
+        model: "birefnet",
+        sourceImageUrls: [SOURCE_IMAGE_URL],
+      },
+    ]);
+  });
+
+  it("uses the dedicated promptless upscaler when enhancing an image", async () => {
+    const user = userEvent.setup({ delay: null });
+    const requests: {
+      model?: string;
+      prompt?: string;
+      sourceImageUrls?: readonly string[];
+    }[] = [];
+    mockImageEditGeneration((body) => {
+      requests.push(body);
+    });
+    setupChatThread({
+      featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
+    });
+
+    await openSelectedImageEditToolbar(user);
+    await user.click(screen.getByTestId("image-edit-enhance"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("artifact-sidebar-body-image-copy"),
+      ).toHaveAttribute("src", EDITED_IMAGE_URL);
+    });
+    expect(requests).toStrictEqual([
+      {
+        model: "clarity-upscaler",
+        sourceImageUrls: [SOURCE_IMAGE_URL],
+      },
+    ]);
   });
 
   it("restores a generated image after exiting and reopening image edit mode", async () => {


### PR DESCRIPTION
## Summary

- Route **Remove background** to the dedicated `birefnet` transform for transparent cutouts.
- Route **Enhance** to the dedicated `clarity-upscaler` transform for real upscaling.
- Keep region editing and style transfer on `nano-banana-2`.
- Omit prompts for the two promptless transform models and cover both request shapes with UI tests.

## Billing

Production pricing is already configured for both transform models. Selecting these model aliases routes results through the existing image usage pipeline:

- `birefnet` records one `output_image` usage unit.
- `clarity-upscaler` records `output_megapixel` usage based on the returned image dimensions.
- Usage events are settled through the existing credit processor; requests fail closed if the required pricing category is unavailable.

No production pricing values are added to the public repository.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/zero-page/zero-image-edit.ts apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx`
- `pnpm turbo run lint --filter=@vm0/app --log-order grouped`
- `pnpm turbo run check-types --filter=@vm0/app --log-order grouped`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-image-edit.test.tsx` — 31 passed
- `git diff --check`

Full local Vitest and the dev server were not run; the PR pipeline ran the broader checks successfully.