### PR TITLE
fix(mitm-addon): preserve suppressed exception metadata paths

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from typing import TypeGuard
 
 
@@ -359,31 +360,90 @@ def _pattern_is_exhaustive(pattern: ast.pattern) -> bool:
     return False
 
 
-def _body_can_fall_through(body: list[ast.stmt]) -> bool:
-    return all(_statement_can_fall_through(statement) for statement in body)
+@dataclass(frozen=True)
+class _FlowSummary:
+    """Syntactic exits used by reachability; ``raises`` covers explicit ``raise`` only."""
+
+    falls_through: bool
+    raises: bool
+
+
+def _body_flow(body: list[ast.stmt]) -> _FlowSummary:
+    falls_through = True
+    raises = False
+    for statement in body:
+        if not falls_through:
+            break
+        statement_flow = _statement_flow(statement)
+        falls_through = statement_flow.falls_through
+        raises = raises or statement_flow.raises
+    return _FlowSummary(falls_through=falls_through, raises=raises)
 
 
 def _is_try_statement(statement: ast.stmt) -> TypeGuard[ast.Try]:
     return isinstance(statement, ast.Try) or statement.__class__.__name__ == "TryStar"
 
 
-def _statement_can_fall_through(statement: ast.stmt) -> bool:
-    if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
-        return False
+def _try_statement_flow(statement: ast.Try) -> _FlowSummary:
+    body_flow = _body_flow(statement.body)
+    normal_path_falls_through = body_flow.falls_through
+    raises = body_flow.raises and not any(handler.type is None for handler in statement.handlers)
+    if normal_path_falls_through and statement.orelse:
+        orelse_flow = _body_flow(statement.orelse)
+        normal_path_falls_through = orelse_flow.falls_through
+        raises = raises or orelse_flow.raises
+    handler_flows = [_body_flow(handler.body) for handler in statement.handlers]
+    falls_through = normal_path_falls_through or any(flow.falls_through for flow in handler_flows)
+    raises = raises or any(flow.raises for flow in handler_flows)
+    if not statement.finalbody:
+        return _FlowSummary(falls_through=falls_through, raises=raises)
+    finalbody_flow = _body_flow(statement.finalbody)
+    return _FlowSummary(
+        falls_through=falls_through and finalbody_flow.falls_through,
+        raises=finalbody_flow.raises or (raises and finalbody_flow.falls_through),
+    )
+
+
+def _statement_flow(statement: ast.stmt) -> _FlowSummary:
+    if isinstance(statement, ast.Raise):
+        return _FlowSummary(falls_through=False, raises=True)
+    if isinstance(statement, (ast.Return, ast.Break, ast.Continue)):
+        return _FlowSummary(falls_through=False, raises=False)
     if isinstance(statement, ast.If):
-        if not statement.orelse:
-            return True
-        return _body_can_fall_through(statement.body) or _body_can_fall_through(statement.orelse)
-    if isinstance(statement, (ast.With, ast.AsyncWith)):
-        return _body_can_fall_through(statement.body)
-    if _is_try_statement(statement):
-        if statement.finalbody and not _body_can_fall_through(statement.finalbody):
-            return False
-        normal_path_falls_through = _body_can_fall_through(statement.body)
-        if normal_path_falls_through and statement.orelse:
-            normal_path_falls_through = _body_can_fall_through(statement.orelse)
-        handler_path_falls_through = any(
-            _body_can_fall_through(handler.body) for handler in statement.handlers
+        body_flow = _body_flow(statement.body)
+        orelse_flow = (
+            _body_flow(statement.orelse)
+            if statement.orelse
+            else _FlowSummary(falls_through=True, raises=False)
         )
-        return normal_path_falls_through or handler_path_falls_through
-    return True
+        return _FlowSummary(
+            falls_through=body_flow.falls_through or orelse_flow.falls_through,
+            raises=body_flow.raises or orelse_flow.raises,
+        )
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        body_flow = _body_flow(statement.body)
+        return _FlowSummary(
+            falls_through=body_flow.falls_through or body_flow.raises,
+            raises=body_flow.raises,
+        )
+    if _is_try_statement(statement):
+        return _try_statement_flow(statement)
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        body_flow = _body_flow(statement.body)
+        orelse_flow = _body_flow(statement.orelse)
+        return _FlowSummary(
+            falls_through=True,
+            raises=body_flow.raises or orelse_flow.raises,
+        )
+    if isinstance(statement, ast.Match):
+        return _FlowSummary(
+            falls_through=True,
+            raises=any(_body_flow(case.body).raises for case in statement.cases),
+        )
+    if isinstance(statement, ast.ClassDef):
+        return _body_flow(statement.body)
+    return _FlowSummary(falls_through=True, raises=False)
+
+
+def _statement_can_fall_through(statement: ast.stmt) -> bool:
+    return _statement_flow(statement).falls_through

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -437,6 +437,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._class_nested_scope_alias_scopes.pop()
         self._exception_alias_scopes.pop()
         if class_exception_state.may_raise:
+            outer_visible_names = (
+                (class_failure_aliases | class_exception_state.aliases)
+                - class_body_bound_names
+                - class_body_global_names
+                - type_param_names
+            )
+            class_failure_aliases.difference_update(outer_visible_names)
+            class_failure_aliases.update(class_exception_state.aliases & outer_visible_names)
             self._record_exception_aliases(class_failure_aliases)
         self._metadata_aliases.discard(node.name)
 

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -62,6 +62,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.violations: list[str] = []
         self._violation_messages: set[str] = set()
         self._metadata_alias_scopes: list[set[str]] = [set()]
+        self._exception_alias_scopes: list[set[str]] = []
         self._class_nested_scope_alias_scopes: list[set[str]] = []
         self._metadata_key_checked_node_ids: set[int] = set()
         self._named_expr_target_scope_indexes: list[int] = []
@@ -201,6 +202,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_aliases.clear()
         self._metadata_aliases.update(aliases)
 
+    def _record_exception_aliases(self, aliases: set[str] | None = None) -> None:
+        if not self._exception_alias_scopes:
+            return
+        self._exception_alias_scopes[-1].update(
+            self._metadata_aliases if aliases is None else aliases
+        )
+
     def _visit_definition_expression(
         self,
         node: ast.AST,
@@ -237,6 +245,15 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.pop()
         return result, falls_through
 
+    def _visit_branch_body_capturing_exceptions(
+        self, body: list[ast.stmt], aliases: set[str]
+    ) -> tuple[set[str], bool, set[str]]:
+        exception_aliases: set[str] = set()
+        self._exception_alias_scopes.append(exception_aliases)
+        result_aliases, falls_through = self._visit_branch_body(body, aliases)
+        self._exception_alias_scopes.pop()
+        return result_aliases, falls_through, exception_aliases
+
     def _visit_branch_body_state_only(
         self, body: list[ast.stmt], aliases: set[str]
     ) -> tuple[set[str], bool]:
@@ -262,6 +279,17 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         result = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
         return result, falls_through
+
+    def _visit_except_handler_branch_capturing_exceptions(
+        self, handler: ast.ExceptHandler, aliases: set[str]
+    ) -> tuple[set[str], bool, set[str]]:
+        exception_aliases: set[str] = set()
+        self._exception_alias_scopes.append(exception_aliases)
+        result_aliases, falls_through = self._visit_except_handler_branch(handler, aliases)
+        self._exception_alias_scopes.pop()
+        if handler.name is not None:
+            exception_aliases.discard(handler.name)
+        return result_aliases, falls_through, exception_aliases
 
     def _visit_scoped_body(
         self,
@@ -335,7 +363,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         body_base_aliases = self._nested_function_base_aliases()
         body_base_aliases.difference_update(body_global_names)
         body_base_aliases.update(self._metadata_alias_scopes[0] & body_global_names)
+        self._exception_alias_scopes.append(set())
         self._visit_scoped_body(node.body, shadowed_names, metadata_defaults, body_base_aliases)
+        self._exception_alias_scopes.pop()
         self._metadata_aliases.discard(node.name)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -349,12 +379,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
+        self._exception_alias_scopes.append(set())
         self._visit_scoped_expression(
             node.body,
             (_argument_names(node.args) | _expression_bound_names(node.body)) - metadata_defaults,
             metadata_defaults,
             self._nested_function_base_aliases(),
         )
+        self._exception_alias_scopes.pop()
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for decorator in node.decorator_list:
@@ -376,9 +408,15 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         class_body_aliases.update(
             self._metadata_alias_scopes[0] & (class_body_bound_names | class_body_global_names)
         )
+        class_failure_aliases = set(self._metadata_aliases)
+        class_exception_aliases: set[str] = set()
+        self._exception_alias_scopes.append(class_exception_aliases)
         self._class_nested_scope_alias_scopes.append(outer_aliases)
         self._visit_scoped_body(node.body, base_aliases=class_body_aliases)
         self._class_nested_scope_alias_scopes.pop()
+        self._exception_alias_scopes.pop()
+        if class_exception_aliases:
+            self._record_exception_aliases(class_failure_aliases)
         self._metadata_aliases.discard(node.name)
 
     def visit_TypeAlias(self, node: ast.AST) -> None:
@@ -582,6 +620,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._record_metadata_merge_key_violations(node.exc)
         self._record_metadata_merge_key_violations(node.cause)
         self.generic_visit(node)
+        self._record_exception_aliases()
 
     def visit_Yield(self, node: ast.Yield) -> None:
         self._record_metadata_merge_key_violations(node.value)
@@ -673,7 +712,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         )
         self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
-    def visit_With(self, node: ast.With) -> None:
+    def _visit_with_statement(self, node: ast.With | ast.AsyncWith) -> None:
         for item in node.items:
             self._record_metadata_merge_key_violations(item.context_expr)
             self.visit(item.context_expr)
@@ -681,23 +720,22 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
+        exception_aliases: set[str] = set()
+        self._exception_alias_scopes.append(exception_aliases)
         body_falls_through = self._visit_current_scope_body(node.body)
+        self._exception_alias_scopes.pop()
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
-        self._replace_current_aliases(body_result_aliases if body_falls_through else set())
+        exit_aliases = body_result_aliases if body_falls_through else set()
+        exit_aliases.update(exception_aliases)
+        self._replace_current_aliases(exit_aliases)
+        self._record_exception_aliases(exception_aliases)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with_statement(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
-        for item in node.items:
-            self._record_metadata_merge_key_violations(item.context_expr)
-            self.visit(item.context_expr)
-        body_aliases = set(self._metadata_aliases)
-        self._metadata_alias_scopes.append(body_aliases)
-        for item in node.items:
-            self._discard_alias_target(item.optional_vars)
-        body_falls_through = self._visit_current_scope_body(node.body)
-        body_result_aliases = set(self._metadata_aliases)
-        self._metadata_alias_scopes.pop()
-        self._replace_current_aliases(body_result_aliases if body_falls_through else set())
+        self._visit_with_statement(node)
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if node.type is not None:
@@ -714,43 +752,66 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _visit_try_statement(self, node: ast.Try) -> None:
         base_aliases = set(self._metadata_aliases)
-        body_aliases, body_falls_through = self._visit_branch_body(node.body, base_aliases)
-        handler_start_aliases = base_aliases | body_aliases
+        body_aliases, body_falls_through, body_exception_aliases = (
+            self._visit_branch_body_capturing_exceptions(node.body, base_aliases)
+        )
+        handler_start_aliases = base_aliases | body_aliases | body_exception_aliases
         handler_results = [
-            self._visit_except_handler_branch(handler, handler_start_aliases)
+            self._visit_except_handler_branch_capturing_exceptions(handler, handler_start_aliases)
             for handler in node.handlers
         ]
         exit_aliases: set[str] = set()
+        exception_aliases: set[str] = set()
+        if not any(handler.type is None for handler in node.handlers):
+            exception_aliases.update(body_exception_aliases)
         if body_falls_through:
             if node.orelse:
-                orelse_aliases, orelse_falls_through = self._visit_branch_body(
-                    node.orelse, body_aliases
+                orelse_aliases, orelse_falls_through, orelse_exception_aliases = (
+                    self._visit_branch_body_capturing_exceptions(node.orelse, body_aliases)
                 )
+                exception_aliases.update(orelse_exception_aliases)
                 if orelse_falls_through:
                     exit_aliases.update(orelse_aliases)
             else:
                 exit_aliases.update(body_aliases)
-        for aliases, falls_through in handler_results:
+        for aliases, falls_through, handler_exception_aliases in handler_results:
+            exception_aliases.update(handler_exception_aliases)
             if falls_through:
                 exit_aliases.update(aliases)
         if node.finalbody:
-            finalbody_scan_aliases = base_aliases | body_aliases
-            for aliases, _falls_through in handler_results:
+            finalbody_scan_aliases = (
+                base_aliases
+                | body_aliases
+                | body_exception_aliases
+                | exit_aliases
+                | exception_aliases
+            )
+            for aliases, _falls_through, handler_exception_aliases in handler_results:
                 finalbody_scan_aliases.update(aliases)
+                finalbody_scan_aliases.update(handler_exception_aliases)
+            finalbody_exception_aliases: set[str] = set()
+            self._exception_alias_scopes.append(finalbody_exception_aliases)
+            finalbody_scan_result, finalbody_falls_through = self._visit_branch_body(
+                node.finalbody, finalbody_scan_aliases
+            )
             if finalbody_scan_aliases == exit_aliases:
-                exit_aliases, finalbody_falls_through = self._visit_branch_body(
-                    node.finalbody, exit_aliases
+                exit_aliases = finalbody_scan_result
+            elif exit_aliases:
+                exit_aliases = self._visit_branch_body_state_only(node.finalbody, exit_aliases)[0]
+            if exception_aliases and finalbody_falls_through:
+                exception_aliases = (
+                    finalbody_scan_result
+                    if finalbody_scan_aliases == exception_aliases
+                    else self._visit_branch_body_state_only(node.finalbody, exception_aliases)[0]
                 )
             else:
-                self._visit_branch_body(node.finalbody, finalbody_scan_aliases)
-                exit_aliases, finalbody_falls_through = (
-                    self._visit_branch_body_state_only(node.finalbody, exit_aliases)
-                    if exit_aliases
-                    else (set(), True)
-                )
+                exception_aliases = set()
+            self._exception_alias_scopes.pop()
             if not finalbody_falls_through:
                 exit_aliases = set()
+            exception_aliases.update(finalbody_exception_aliases)
         self._replace_current_aliases(exit_aliases)
+        self._record_exception_aliases(exception_aliases)
 
     def visit_Try(self, node: ast.Try) -> None:
         self._visit_try_statement(node)

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from flow_metadata_linter.ast_helpers import (
@@ -40,6 +41,22 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
 
 
+@dataclass
+class _ExceptionAliasState:
+    """Whether exception paths exist and aliases that may hold on those paths."""
+
+    may_raise: bool = False
+    aliases: set[str] = field(default_factory=set)
+
+    def record(self, aliases: set[str]) -> None:
+        self.may_raise = True
+        self.aliases.update(aliases)
+
+    def merge(self, other: _ExceptionAliasState) -> None:
+        if other.may_raise:
+            self.record(other.aliases)
+
+
 def _metadata_match_pattern_alias_names(pattern: ast.pattern) -> set[str]:
     if isinstance(pattern, ast.MatchAs):
         names = set() if pattern.name is None else {pattern.name}
@@ -62,7 +79,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.violations: list[str] = []
         self._violation_messages: set[str] = set()
         self._metadata_alias_scopes: list[set[str]] = [set()]
-        self._exception_alias_scopes: list[set[str]] = []
+        self._exception_alias_scopes: list[_ExceptionAliasState] = []
         self._class_nested_scope_alias_scopes: list[set[str]] = []
         self._metadata_key_checked_node_ids: set[int] = set()
         self._named_expr_target_scope_indexes: list[int] = []
@@ -205,9 +222,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def _record_exception_aliases(self, aliases: set[str] | None = None) -> None:
         if not self._exception_alias_scopes:
             return
-        self._exception_alias_scopes[-1].update(
+        self._exception_alias_scopes[-1].record(
             self._metadata_aliases if aliases is None else aliases
         )
+
+    def _record_exception_state(self, state: _ExceptionAliasState) -> None:
+        if state.may_raise:
+            self._record_exception_aliases(state.aliases)
 
     def _visit_definition_expression(
         self,
@@ -247,12 +268,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _visit_branch_body_capturing_exceptions(
         self, body: list[ast.stmt], aliases: set[str]
-    ) -> tuple[set[str], bool, set[str]]:
-        exception_aliases: set[str] = set()
-        self._exception_alias_scopes.append(exception_aliases)
+    ) -> tuple[set[str], bool, _ExceptionAliasState]:
+        exception_state = _ExceptionAliasState()
+        self._exception_alias_scopes.append(exception_state)
         result_aliases, falls_through = self._visit_branch_body(body, aliases)
         self._exception_alias_scopes.pop()
-        return result_aliases, falls_through, exception_aliases
+        return result_aliases, falls_through, exception_state
 
     def _visit_branch_body_state_only(
         self, body: list[ast.stmt], aliases: set[str]
@@ -282,14 +303,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _visit_except_handler_branch_capturing_exceptions(
         self, handler: ast.ExceptHandler, aliases: set[str]
-    ) -> tuple[set[str], bool, set[str]]:
-        exception_aliases: set[str] = set()
-        self._exception_alias_scopes.append(exception_aliases)
+    ) -> tuple[set[str], bool, _ExceptionAliasState]:
+        exception_state = _ExceptionAliasState()
+        self._exception_alias_scopes.append(exception_state)
         result_aliases, falls_through = self._visit_except_handler_branch(handler, aliases)
         self._exception_alias_scopes.pop()
         if handler.name is not None:
-            exception_aliases.discard(handler.name)
-        return result_aliases, falls_through, exception_aliases
+            exception_state.aliases.discard(handler.name)
+        return result_aliases, falls_through, exception_state
 
     def _visit_scoped_body(
         self,
@@ -363,7 +384,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         body_base_aliases = self._nested_function_base_aliases()
         body_base_aliases.difference_update(body_global_names)
         body_base_aliases.update(self._metadata_alias_scopes[0] & body_global_names)
-        self._exception_alias_scopes.append(set())
+        self._exception_alias_scopes.append(_ExceptionAliasState())
         self._visit_scoped_body(node.body, shadowed_names, metadata_defaults, body_base_aliases)
         self._exception_alias_scopes.pop()
         self._metadata_aliases.discard(node.name)
@@ -379,7 +400,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
-        self._exception_alias_scopes.append(set())
+        self._exception_alias_scopes.append(_ExceptionAliasState())
         self._visit_scoped_expression(
             node.body,
             (_argument_names(node.args) | _expression_bound_names(node.body)) - metadata_defaults,
@@ -409,13 +430,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self._metadata_alias_scopes[0] & (class_body_bound_names | class_body_global_names)
         )
         class_failure_aliases = set(self._metadata_aliases)
-        class_exception_aliases: set[str] = set()
-        self._exception_alias_scopes.append(class_exception_aliases)
+        class_exception_state = _ExceptionAliasState()
+        self._exception_alias_scopes.append(class_exception_state)
         self._class_nested_scope_alias_scopes.append(outer_aliases)
         self._visit_scoped_body(node.body, base_aliases=class_body_aliases)
         self._class_nested_scope_alias_scopes.pop()
         self._exception_alias_scopes.pop()
-        if class_exception_aliases:
+        if class_exception_state.may_raise:
             self._record_exception_aliases(class_failure_aliases)
         self._metadata_aliases.discard(node.name)
 
@@ -720,16 +741,16 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
-        exception_aliases: set[str] = set()
-        self._exception_alias_scopes.append(exception_aliases)
+        exception_state = _ExceptionAliasState()
+        self._exception_alias_scopes.append(exception_state)
         body_falls_through = self._visit_current_scope_body(node.body)
         self._exception_alias_scopes.pop()
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
         exit_aliases = body_result_aliases if body_falls_through else set()
-        exit_aliases.update(exception_aliases)
+        exit_aliases.update(exception_state.aliases)
         self._replace_current_aliases(exit_aliases)
-        self._record_exception_aliases(exception_aliases)
+        self._record_exception_state(exception_state)
 
     def visit_With(self, node: ast.With) -> None:
         self._visit_with_statement(node)
@@ -752,66 +773,72 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _visit_try_statement(self, node: ast.Try) -> None:
         base_aliases = set(self._metadata_aliases)
-        body_aliases, body_falls_through, body_exception_aliases = (
+        body_aliases, body_falls_through, body_exception_state = (
             self._visit_branch_body_capturing_exceptions(node.body, base_aliases)
         )
-        handler_start_aliases = base_aliases | body_aliases | body_exception_aliases
+        handler_start_aliases = base_aliases | body_aliases | body_exception_state.aliases
         handler_results = [
             self._visit_except_handler_branch_capturing_exceptions(handler, handler_start_aliases)
             for handler in node.handlers
         ]
         exit_aliases: set[str] = set()
-        exception_aliases: set[str] = set()
+        has_normal_exit = False
+        exception_state = _ExceptionAliasState()
         if not any(handler.type is None for handler in node.handlers):
-            exception_aliases.update(body_exception_aliases)
+            exception_state.merge(body_exception_state)
         if body_falls_through:
             if node.orelse:
-                orelse_aliases, orelse_falls_through, orelse_exception_aliases = (
+                orelse_aliases, orelse_falls_through, orelse_exception_state = (
                     self._visit_branch_body_capturing_exceptions(node.orelse, body_aliases)
                 )
-                exception_aliases.update(orelse_exception_aliases)
+                exception_state.merge(orelse_exception_state)
                 if orelse_falls_through:
                     exit_aliases.update(orelse_aliases)
+                    has_normal_exit = True
             else:
                 exit_aliases.update(body_aliases)
-        for aliases, falls_through, handler_exception_aliases in handler_results:
-            exception_aliases.update(handler_exception_aliases)
+                has_normal_exit = True
+        for aliases, falls_through, handler_exception_state in handler_results:
+            exception_state.merge(handler_exception_state)
             if falls_through:
                 exit_aliases.update(aliases)
+                has_normal_exit = True
         if node.finalbody:
             finalbody_scan_aliases = (
                 base_aliases
                 | body_aliases
-                | body_exception_aliases
+                | body_exception_state.aliases
                 | exit_aliases
-                | exception_aliases
+                | exception_state.aliases
             )
-            for aliases, _falls_through, handler_exception_aliases in handler_results:
+            for aliases, _falls_through, handler_exception_state in handler_results:
                 finalbody_scan_aliases.update(aliases)
-                finalbody_scan_aliases.update(handler_exception_aliases)
-            finalbody_exception_aliases: set[str] = set()
-            self._exception_alias_scopes.append(finalbody_exception_aliases)
+                finalbody_scan_aliases.update(handler_exception_state.aliases)
+            finalbody_exception_state = _ExceptionAliasState()
+            self._exception_alias_scopes.append(finalbody_exception_state)
             finalbody_scan_result, finalbody_falls_through = self._visit_branch_body(
                 node.finalbody, finalbody_scan_aliases
             )
             if finalbody_scan_aliases == exit_aliases:
                 exit_aliases = finalbody_scan_result
-            elif exit_aliases:
+            elif has_normal_exit:
                 exit_aliases = self._visit_branch_body_state_only(node.finalbody, exit_aliases)[0]
-            if exception_aliases and finalbody_falls_through:
-                exception_aliases = (
+            if exception_state.may_raise and finalbody_falls_through:
+                exception_state.aliases = (
                     finalbody_scan_result
-                    if finalbody_scan_aliases == exception_aliases
-                    else self._visit_branch_body_state_only(node.finalbody, exception_aliases)[0]
+                    if finalbody_scan_aliases == exception_state.aliases
+                    else self._visit_branch_body_state_only(
+                        node.finalbody, exception_state.aliases
+                    )[0]
                 )
             else:
-                exception_aliases = set()
+                exception_state = _ExceptionAliasState()
             self._exception_alias_scopes.pop()
             if not finalbody_falls_through:
                 exit_aliases = set()
-            exception_aliases.update(finalbody_exception_aliases)
+            exception_state.merge(finalbody_exception_state)
         self._replace_current_aliases(exit_aliases)
-        self._record_exception_aliases(exception_aliases)
+        self._record_exception_state(exception_state)
 
     def visit_Try(self, node: ast.Try) -> None:
         self._visit_try_statement(node)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
@@ -1,0 +1,149 @@
+from contextlib import suppress
+
+
+def sync_alias_before_raise(flow):
+    metadata = flow.metadata
+    with suppress(RuntimeError):
+        raise RuntimeError()
+    return metadata["vm_run_id"]
+
+
+def sync_direct_after_raise(flow):
+    with suppress(RuntimeError):
+        raise RuntimeError()
+    return flow.metadata["firewall_name"]
+
+
+async def async_alias_before_raise(flow, manager):
+    metadata = flow.metadata
+    async with manager:
+        raise RuntimeError()
+    return metadata["original_url"]
+
+
+def branch_alias_on_raise(flow, manager, condition):
+    metadata = {}
+    with manager:
+        if condition:
+            metadata = flow.metadata
+            raise RuntimeError()
+        metadata = {}
+    return metadata["vm_proxy_log_path"]
+
+
+def branch_entry_alias_on_raise(flow, manager, condition):
+    metadata = flow.metadata
+    with manager:
+        if condition:
+            raise RuntimeError()
+        metadata = {}
+    return metadata["capture_body"]
+
+
+def rebind_before_raise(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        metadata = {}
+        raise RuntimeError()
+    return metadata["vm_run_id"]
+
+
+def return_is_terminal(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        return None
+    return metadata["vm_run_id"]
+
+
+def break_is_terminal(flow, manager, rows):
+    metadata = flow.metadata
+    for _row in rows:
+        with manager:
+            break
+        metadata["vm_run_id"]
+
+
+def continue_is_terminal(flow, manager, rows):
+    metadata = flow.metadata
+    for _row in rows:
+        with manager:
+            continue
+        metadata["vm_run_id"]
+
+
+def with_target_rebinds_to_external(flow, manager):
+    metadata = flow.metadata
+    with manager as metadata:
+        pass
+    return metadata["vm_run_id"]
+
+
+def nested_function_raise_is_deferred(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        def inner():
+            raise RuntimeError()
+
+        return None
+    return metadata["vm_run_id"]
+
+
+def nested_managers_may_defer_suppression(flow, outer_manager, inner_manager):
+    metadata = flow.metadata
+    with outer_manager:
+        with inner_manager:
+            raise RuntimeError()
+        metadata = {}
+    return metadata["firewall_base"]
+
+
+def bare_handler_return_is_terminal(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        try:
+            raise RuntimeError()
+        except:
+            return None
+    return metadata["vm_run_id"]
+
+
+def typed_handler_may_not_catch(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        try:
+            raise RuntimeError()
+        except ValueError:
+            return None
+    return metadata["auth_refreshed_connectors"]
+
+
+def terminal_finally_overrides_raise(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        try:
+            raise RuntimeError()
+        finally:
+            return None
+    return metadata["vm_run_id"]
+
+
+def raising_finally_may_be_suppressed(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        try:
+            return None
+        finally:
+            raise RuntimeError()
+    return metadata["auth_resolved_secrets"]
+
+
+def class_body_raise_may_be_suppressed(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        class Broken:
+            raise RuntimeError()
+
+        metadata = {}
+    return metadata["connector_diagnostic_base"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
@@ -182,3 +182,27 @@ def finally_updates_empty_normal_path_before_raise(flow, manager):
             metadata = flow.metadata
         raise RuntimeError()
     return metadata["firewall_action"]
+
+
+def class_nonlocal_adds_alias_before_failure(flow, manager):
+    metadata = {}
+    with manager:
+
+        class Broken:
+            nonlocal metadata
+            metadata = flow.metadata
+            raise RuntimeError()
+
+    return metadata["firewall_billable"]
+
+
+def class_nonlocal_removes_alias_before_failure(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        class Broken:
+            nonlocal metadata
+            metadata = {}
+            raise RuntimeError()
+
+    return metadata["firewall_error"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
@@ -147,3 +147,38 @@ def class_body_raise_may_be_suppressed(flow, manager):
 
         metadata = {}
     return metadata["connector_diagnostic_base"]
+
+
+def finally_creates_alias_on_pending_exception(flow, manager):
+    metadata = {}
+    with manager:
+        try:
+            raise RuntimeError()
+        finally:
+            metadata = flow.metadata
+    return metadata["firewall_permission"]
+
+
+def class_local_shadow_preserves_outer_failure_state(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        class Broken:
+            metadata = {}
+            raise RuntimeError()
+
+    return metadata["firewall_rule_match"]
+
+
+def finally_updates_empty_normal_path_before_raise(flow, manager):
+    metadata = {}
+    with manager:
+        try:
+            pass
+        except RuntimeError:
+            other = flow.metadata
+            return other
+        finally:
+            metadata = flow.metadata
+        raise RuntimeError()
+    return metadata["firewall_action"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
@@ -10,3 +10,4 @@ context_manager_flow.py:149: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flo
 context_manager_flow.py:159: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
 context_manager_flow.py:170: use metadata_keys.FIREWALL_RULE_MATCH for flow.metadata access
 context_manager_flow.py:184: use metadata_keys.FIREWALL_ACTION for flow.metadata access
+context_manager_flow.py:196: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
@@ -7,3 +7,6 @@ context_manager_flow.py:98: use metadata_keys.FIREWALL_BASE for flow.metadata ac
 context_manager_flow.py:118: use metadata_keys.AUTH_REFRESHED_CONNECTORS for flow.metadata access
 context_manager_flow.py:138: use metadata_keys.AUTH_RESOLVED_SECRETS for flow.metadata access
 context_manager_flow.py:149: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access
+context_manager_flow.py:159: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
+context_manager_flow.py:170: use metadata_keys.FIREWALL_RULE_MATCH for flow.metadata access
+context_manager_flow.py:184: use metadata_keys.FIREWALL_ACTION for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
@@ -1,0 +1,9 @@
+context_manager_flow.py:8: use metadata_keys.VM_RUN_ID for flow.metadata access
+context_manager_flow.py:14: use metadata_keys.FIREWALL_NAME for flow.metadata access
+context_manager_flow.py:21: use metadata_keys.ORIGINAL_URL for flow.metadata access
+context_manager_flow.py:31: use metadata_keys.VM_PROXY_LOG_PATH for flow.metadata access
+context_manager_flow.py:40: use metadata_keys.CAPTURE_BODY for flow.metadata access
+context_manager_flow.py:98: use metadata_keys.FIREWALL_BASE for flow.metadata access
+context_manager_flow.py:118: use metadata_keys.AUTH_REFRESHED_CONNECTORS for flow.metadata access
+context_manager_flow.py:138: use metadata_keys.AUTH_RESOLVED_SECRETS for flow.metadata access
+context_manager_flow.py:149: use metadata_keys.CONNECTOR_DIAGNOSTIC_BASE for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -148,6 +148,17 @@ def test_registered_flow_metadata_guard_flags_literals_after_dynamic_star_args(t
     )
 
 
+def test_registered_flow_metadata_guard_tracks_context_manager_exception_paths(tmp_path):
+    source_path = tmp_path / "context_manager_flow.py"
+    _write_python_source(source_path, "context_manager_flow.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "context_manager_flow.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_respects_python_source_encoding(tmp_path):
     source_path = tmp_path / "latin1.py"
     source_path.write_bytes(b'# coding: latin-1\nflow.metadata["vm_run_id"] = "caf\xe9"\n')


### PR DESCRIPTION
## Summary

- distinguish explicit exception exits from return, break, and continue in metadata-linter reachability
- track exception-path existence independently from alias membership so empty states survive `finally`
- preserve outer-visible alias changes across suppressible sync/async context managers and failed class execution
- add a public-API regression matrix for branches, nested scopes and managers, handlers, `finally`, and `nonlocal`

## Scope

- repository-only flow-metadata lint tooling and tests
- no runtime addon, API, persisted-data, dependency, or deployment changes

## Validation

- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_flow_metadata_key_contract.py -q` (10 passed)
- `python3 scripts/check-flow-metadata-keys.py`
- `python3 -m pytest tests/ -q` (3902 passed)

Closes #21307
