### PR TITLE
perf(runner): attribute history hash transitions

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1047,7 +1047,9 @@ mod tests {
     use crate::network_log_drain::NetworkLogDrainCoordinator;
     use crate::provider::CompletionAuth;
     use crate::resource_budget::ResourceBudget;
-    use crate::restored_session_identity::RestoredSessionFramework;
+    use crate::restored_session_identity::{
+        RestoredSessionFramework, RestoredSessionHistoryHashSizeRelationship,
+    };
     use crate::status::IdleVm;
     use crate::test_fixtures::execution_context_for_test;
     use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
@@ -1110,6 +1112,24 @@ mod tests {
             },
         });
         context
+    }
+
+    fn final_metadata_identity(history_hash: String, size: u64) -> RestoredSessionIdentity {
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"sess-restore-plan")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            size,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap();
+        RestoredSessionIdentity::from_final_metadata(
+            metadata,
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
+            "/home/user/.vm0/guest-agent/runs/previous",
+        )
+        .expect("checkpointed final identity")
     }
 
     async fn reusable_sandbox_with_identity(
@@ -1557,7 +1577,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_plan_falls_back_when_reused_identity_mismatches() {
+    async fn restore_plan_classifies_history_hash_size_relationships() {
+        let http = test_http_client();
+        let requested_hash = "a".repeat(64);
+        let restored_hash = "b".repeat(64);
+        let cases = [
+            (
+                11,
+                RestoredSessionHistoryHashSizeRelationship::RequestedSmaller,
+            ),
+            (
+                12,
+                RestoredSessionHistoryHashSizeRelationship::RequestedEqual,
+            ),
+            (
+                13,
+                RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
+            ),
+            (0, RestoredSessionHistoryHashSizeRelationship::SizeUnknown),
+            (
+                api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES + 1,
+                RestoredSessionHistoryHashSizeRelationship::SizeUnknown,
+            ),
+        ];
+
+        for (requested_size, expected_relationship) in cases {
+            let context = context_with_history_ref_and_size(&requested_hash, requested_size);
+            let restored_identity = final_metadata_identity(restored_hash.clone(), 12);
+            let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+            let cancel = RunCancellationHandle::new();
+            let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+            let plan = build_session_history_restore_plan(
+                &http,
+                &SessionHistoryCpuPool::with_capacity(1),
+                &context,
+                &cancel,
+                SessionHistoryRestoreReuse {
+                    entry: Some(&reusable_sandbox),
+                    result: SandboxReuseResult::Reused,
+                },
+                &mut timing,
+                None,
+            );
+
+            match plan {
+                SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                    assert_eq!(
+                        fallback,
+                        Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                            RestoredSessionIdentityMismatchReason::HistoryHash(
+                                expected_relationship
+                            )
+                        )))
+                    );
+                }
+                _ => panic!("history hash mismatch should keep the prestarted restore plan"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_classifies_unverified_history_hash_size_as_unknown() {
         let http = test_http_client();
         let context = context_with_history_ref("history-hash-a");
         let restored_identity = RestoredSessionIdentity::claude_code_for_test("history-hash-b");
@@ -1583,11 +1664,13 @@ mod tests {
                 assert_eq!(
                     fallback,
                     Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
-                        RestoredSessionIdentityMismatchReason::HistoryHash
+                        RestoredSessionIdentityMismatchReason::HistoryHash(
+                            RestoredSessionHistoryHashSizeRelationship::SizeUnknown
+                        )
                     )))
                 );
             }
-            _ => panic!("mismatched reused identity should fall back to restore"),
+            _ => panic!("unverified history hash mismatch should fall back to restore"),
         }
     }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -214,6 +214,9 @@ fn record_session_history_identity_mismatch_reason(
     reason: RestoredSessionIdentityMismatchReason,
 ) {
     telemetry.record(reason.action_type(), Duration::ZERO, true, None);
+    if let Some(action_type) = reason.history_hash_size_relationship_action_type() {
+        telemetry.record(action_type, Duration::ZERO, true, None);
+    }
 }
 
 fn record_session_history_download_timings(

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -2448,10 +2448,31 @@ async fn run_in_sandbox_records_mismatch_fallback_and_restores_prestarted_histor
     let cases = [
         (
             RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::RequestedSmaller,
+            ),
+            "session_history_identity_mismatch_history_hash",
+            Some("session_history_identity_mismatch_history_hash_requested_smaller"),
+        ),
+        (
+            RestoredSessionIdentityMismatchReason::HistoryHash(
                 RestoredSessionHistoryHashSizeRelationship::RequestedEqual,
             ),
             "session_history_identity_mismatch_history_hash",
             Some("session_history_identity_mismatch_history_hash_requested_equal"),
+        ),
+        (
+            RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
+            ),
+            "session_history_identity_mismatch_history_hash",
+            Some("session_history_identity_mismatch_history_hash_requested_larger"),
+        ),
+        (
+            RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::SizeUnknown,
+            ),
+            "session_history_identity_mismatch_history_hash",
+            Some("session_history_identity_mismatch_history_hash_size_unknown"),
         ),
         (
             RestoredSessionIdentityMismatchReason::SessionIdentity,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -52,7 +52,9 @@ use super::support::{
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
-use crate::restored_session_identity::RestoredSessionIdentityMismatchReason;
+use crate::restored_session_identity::{
+    RestoredSessionHistoryHashSizeRelationship, RestoredSessionIdentityMismatchReason,
+};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::telemetry::SessionHistoryTelemetrySnapshot;
 use crate::test_fixtures::OneShotSessionHistoryServer;
@@ -2436,92 +2438,126 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
 }
 
 #[tokio::test]
-async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-fallback-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                encoding: None,
-                raw_size: history.len() as u64,
-                encoded_size: history.len() as u64,
-                download_source: None,
+async fn run_in_sandbox_records_mismatch_fallback_and_restores_prestarted_history() {
+    const RELATIONSHIP_ACTIONS: [&str; 4] = [
+        "session_history_identity_mismatch_history_hash_requested_smaller",
+        "session_history_identity_mismatch_history_hash_requested_equal",
+        "session_history_identity_mismatch_history_hash_requested_larger",
+        "session_history_identity_mismatch_history_hash_size_unknown",
+    ];
+    let cases = [
+        (
+            RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::RequestedEqual,
+            ),
+            "session_history_identity_mismatch_history_hash",
+            Some("session_history_identity_mismatch_history_hash_requested_equal"),
+        ),
+        (
+            RestoredSessionIdentityMismatchReason::SessionIdentity,
+            "session_history_identity_mismatch_session_identity",
+            None,
+        ),
+    ];
+
+    for (reason, aggregate_action, expected_relationship_action) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let sandbox = sandbox_mock::MockSandbox::new("test");
+        let history = br#"{"type":"init"}"#;
+        let server = MockServer::start_async().await;
+        let history_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/history.blob");
+                then.status(200).body(history);
+            })
+            .await;
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            cli_agent_session_id: "sess-fallback-123".into(),
+            history: ResumeSessionHistory::Ref {
+                history_ref: ResumeSessionHistoryRef {
+                    kind: ResumeSessionHistoryRefKind::Blob,
+                    hash: hex::encode(Sha256::digest(history)),
+                    url: server.url("/history.blob?token=secret"),
+                    encoding: None,
+                    raw_size: history.len() as u64,
+                    encoded_size: history.len() as u64,
+                    download_source: None,
+                },
             },
-        },
-    });
-    sandbox.push_read_file_result(Ok(None));
-    let materializer = SessionHistoryMaterializer::start_cancellable(
-        &config.http,
-        &config.session_history_cpu,
-        ctx.resume_session.as_ref(),
-        effective_cli_framework(&ctx.cli_agent_type),
-        tokio_util::sync::CancellationToken::new(),
-        None,
-    );
-    let mut telemetry = test_telemetry(&config, &ctx);
+        });
+        sandbox.push_read_file_result(Ok(None));
+        let materializer = SessionHistoryMaterializer::start_cancellable(
+            &config.http,
+            &config.session_history_cpu,
+            ctx.resume_session.as_ref(),
+            effective_cli_framework(&ctx.cli_agent_type),
+            tokio_util::sync::CancellationToken::new(),
+            None,
+        );
+        let mut telemetry = test_telemetry(&config, &ctx);
 
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
-                materializer,
-                fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
-                    RestoredSessionIdentityMismatchReason::HistoryHash,
-                ))),
-            }),
-    )
-    .await
-    .unwrap();
+        let result = run_in_sandbox(
+            &sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::Reused,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+                .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                    materializer,
+                    fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        reason,
+                    ))),
+                }),
+        )
+        .await
+        .unwrap();
 
-    assert!(result.failure.is_none());
-    assert!(result.reusable_session_identity.is_none());
-    history_mock.assert_calls_async(1).await;
-    let writes = sandbox.write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(
-        writes[0].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-fallback-123.jsonl"
-    );
-    assert_eq!(writes[0].content, history);
-    let ops = telemetry.pending_ops_snapshot();
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_restore_fallback_identity_mismatch" && op.1),
-        "expected fallback telemetry, got: {ops:?}"
-    );
-    assert_successful_action(&ops, "session_history_identity_mismatch_history_hash");
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_download" && op.1),
-        "expected download telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter().any(|op| op.0 == "session_restore" && op.1),
-        "expected restore telemetry, got: {ops:?}"
-    );
-    assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
+        assert!(result.failure.is_none());
+        assert!(result.reusable_session_identity.is_none());
+        history_mock.assert_calls_async(1).await;
+        let writes = sandbox.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(
+            writes[0].path,
+            "/home/user/.claude/projects/-home-user-workspace/sess-fallback-123.jsonl"
+        );
+        assert_eq!(writes[0].content, history);
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter()
+                .any(|op| op.0 == "session_history_restore_fallback_identity_mismatch" && op.1),
+            "expected fallback telemetry, got: {ops:?}"
+        );
+        assert_successful_action(&ops, aggregate_action);
+        for action in RELATIONSHIP_ACTIONS {
+            let expected_count = usize::from(expected_relationship_action == Some(action));
+            assert_eq!(
+                ops.iter().filter(|op| op.0 == action).count(),
+                expected_count,
+                "unexpected relationship telemetry for {reason:?}: {ops:?}"
+            );
+            if expected_count == 1 {
+                assert_successful_action(&ops, action);
+            }
+        }
+        assert!(
+            ops.iter()
+                .any(|op| op.0 == "session_history_download" && op.1),
+            "expected download telemetry, got: {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|op| op.0 == "session_restore" && op.1),
+            "expected restore telemetry, got: {ops:?}"
+        );
+        assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -1,5 +1,7 @@
+use std::cmp::Ordering;
 use std::fmt;
 
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
@@ -32,7 +34,7 @@ pub(crate) enum RestoredSessionIdentityMismatchReason {
     RestoreFormatVersion,
     SessionIdentity,
     HistoryRefKind,
-    HistoryHash,
+    HistoryHash(RestoredSessionHistoryHashSizeRelationship),
     HistorySize,
     MissingRequestedIdentity,
 }
@@ -46,11 +48,43 @@ impl RestoredSessionIdentityMismatchReason {
             }
             Self::SessionIdentity => "session_history_identity_mismatch_session_identity",
             Self::HistoryRefKind => "session_history_identity_mismatch_history_ref_kind",
-            Self::HistoryHash => "session_history_identity_mismatch_history_hash",
+            Self::HistoryHash(_) => "session_history_identity_mismatch_history_hash",
             Self::HistorySize => "session_history_identity_mismatch_history_size",
             Self::MissingRequestedIdentity => {
                 "session_history_identity_mismatch_missing_requested_identity"
             }
+        }
+    }
+
+    pub(crate) const fn history_hash_size_relationship_action_type(self) -> Option<&'static str> {
+        match self {
+            Self::HistoryHash(relationship) => Some(relationship.action_type()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RestoredSessionHistoryHashSizeRelationship {
+    RequestedSmaller,
+    RequestedEqual,
+    RequestedLarger,
+    SizeUnknown,
+}
+
+impl RestoredSessionHistoryHashSizeRelationship {
+    const fn action_type(self) -> &'static str {
+        match self {
+            Self::RequestedSmaller => {
+                "session_history_identity_mismatch_history_hash_requested_smaller"
+            }
+            Self::RequestedEqual => {
+                "session_history_identity_mismatch_history_hash_requested_equal"
+            }
+            Self::RequestedLarger => {
+                "session_history_identity_mismatch_history_hash_requested_larger"
+            }
+            Self::SizeUnknown => "session_history_identity_mismatch_history_hash_size_unknown",
         }
     }
 }
@@ -233,7 +267,9 @@ impl RestoredSessionIdentity {
             return Some(RestoredSessionIdentityMismatchReason::HistoryRefKind);
         }
         if self.history_hash != requested.history_hash {
-            return Some(RestoredSessionIdentityMismatchReason::HistoryHash);
+            return Some(RestoredSessionIdentityMismatchReason::HistoryHash(
+                self.history_hash_size_relationship_for_request(requested),
+            ));
         }
         if let Some(requested_size) = requested.history_size_bytes
             && self.history_size_bytes != Some(requested_size)
@@ -241,6 +277,30 @@ impl RestoredSessionIdentity {
             return Some(RestoredSessionIdentityMismatchReason::HistorySize);
         }
         None
+    }
+
+    fn history_hash_size_relationship_for_request(
+        &self,
+        requested: &Self,
+    ) -> RestoredSessionHistoryHashSizeRelationship {
+        let Some(restored_size) = self
+            .final_metadata_verification()
+            .map(|verification| verification.history_size_bytes)
+        else {
+            return RestoredSessionHistoryHashSizeRelationship::SizeUnknown;
+        };
+        let Some(requested_size) = requested
+            .history_size_bytes
+            .filter(|size| (1..=RESUME_SESSION_HISTORY_MAX_BYTES).contains(size))
+        else {
+            return RestoredSessionHistoryHashSizeRelationship::SizeUnknown;
+        };
+
+        match requested_size.cmp(&restored_size) {
+            Ordering::Less => RestoredSessionHistoryHashSizeRelationship::RequestedSmaller,
+            Ordering::Equal => RestoredSessionHistoryHashSizeRelationship::RequestedEqual,
+            Ordering::Greater => RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- classify reusable-session history-hash mismatches as requested smaller, equal, larger, or size unknown using verifier-backed local final metadata
- carry the fixed relationship through the existing mismatch fallback and emit one additive low-cardinality action while preserving the aggregate actions
- cover all relationship categories, untrusted size boundaries, non-hash mismatches, exact reuse, materialization, download, and guest restore behavior

## Compatibility

This is additive runner telemetry only. It does not change restore selection, history content handling, database schema, persisted state, API or queue payloads, runner/backend protocol, guest protocol, or deployment ordering.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p runner`

Closes #21349

Parent context: #18746
