### PR TITLE
perf(python): index credentialed firewall authorities for tls admission

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -128,6 +128,7 @@ class _CompiledApiCore(NamedTuple):
     rule_index: _CompiledRuleIndex
     base_malformed: bool
     auth_malformed: bool
+    injects_ordinary_upstream_credentials: bool
     routing_identity: str | None
     # True when API compilation encountered malformed permissions/rules config.
     has_malformed_rules: bool
@@ -156,6 +157,10 @@ class _CompiledApi(NamedTuple):
     @property
     def auth_malformed(self) -> bool:
         return self.core.auth_malformed
+
+    @property
+    def injects_ordinary_upstream_credentials(self) -> bool:
+        return self.core.injects_ordinary_upstream_credentials
 
     @property
     def routing_identity(self) -> str | None:
@@ -208,14 +213,28 @@ class _CompiledApiIndex(NamedTuple):
     static_roots: Mapping[tuple[str, str], _CompiledApiTrieNode]
 
 
+class _CompiledOrdinaryCredentialAuthorityIndex(NamedTuple):
+    static_authorities: frozenset[str]
+    parameterized_bases: tuple[_CompiledBase, ...]
+
+
 @dataclass(frozen=True, init=False, slots=True, eq=False, repr=False)
 class CompiledFirewallSet:
     firewalls: tuple[_CompiledFirewall, ...]
     _api_index: _CompiledApiIndex = field(compare=False, repr=False)
+    _ordinary_credential_authority_index: _CompiledOrdinaryCredentialAuthorityIndex = field(
+        compare=False,
+        repr=False,
+    )
 
     def __init__(self, firewalls: tuple[_CompiledFirewall, ...]) -> None:
         object.__setattr__(self, "firewalls", firewalls)
         object.__setattr__(self, "_api_index", _compile_api_candidate_index(firewalls))
+        object.__setattr__(
+            self,
+            "_ordinary_credential_authority_index",
+            _compile_ordinary_credential_authority_index(firewalls),
+        )
 
     def __bool__(self) -> bool:
         return bool(self.firewalls)
@@ -230,10 +249,12 @@ class CompiledFirewallSet:
         url_parts = _split_https_authority_parts(host, port)
         if url_parts is None:
             return False
+        authority_index = self._ordinary_credential_authority_index
+        if url_parts.authority.lower() in authority_index.static_authorities:
+            return True
         return any(
-            _api_matches_ordinary_credential_authority(candidate.api, url_parts)
-            for candidate in self._api_index.all_candidates
-            if not candidate.firewall.name_malformed
+            _match_compiled_base_authority(url_parts, base)
+            for base in authority_index.parameterized_bases
         )
 
 
@@ -444,19 +465,35 @@ def _path_specificity(
     )
 
 
-def _api_matches_ordinary_credential_authority(
-    api_entry: _CompiledApi,
-    url_parts: _BaseUrlParts,
-) -> bool:
-    if (
-        api_entry.base_malformed
-        or api_entry.auth_malformed
-        or api_entry.base.parts.scheme.lower() != "https"
-    ):
-        return False
-    if not auth_config_injects_ordinary_upstream_credentials(api_entry.raw_api_entry.get("auth")):
-        return False
-    return _match_compiled_base_authority(url_parts, api_entry.base)
+def _compiled_base_authority_has_params(base: _CompiledBase) -> bool:
+    return base.has_params and any(
+        not isinstance(segment, SegmentLiteral) for segment in base.host_segments
+    )
+
+
+def _compile_ordinary_credential_authority_index(
+    firewalls: tuple[_CompiledFirewall, ...],
+) -> _CompiledOrdinaryCredentialAuthorityIndex:
+    static_authorities: set[str] = set()
+    parameterized_bases: list[_CompiledBase] = []
+    for firewall in firewalls:
+        if firewall.name_malformed:
+            continue
+        for api in firewall.apis:
+            if (
+                api.base_malformed
+                or not api.injects_ordinary_upstream_credentials
+                or api.base.parts.scheme.lower() != "https"
+            ):
+                continue
+            if _compiled_base_authority_has_params(api.base):
+                parameterized_bases.append(api.base)
+            else:
+                static_authorities.add(api.base.parts.authority.lower())
+    return _CompiledOrdinaryCredentialAuthorityIndex(
+        frozenset(static_authorities),
+        tuple(parameterized_bases),
+    )
 
 
 def _path_index_key(path: str) -> tuple[str, ...]:
@@ -796,6 +833,10 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
         base = compiled_config_base.base
         base_malformed = compiled_config_base.malformed
         auth_malformed = not _auth_config_is_valid(api_entry)
+        injects_ordinary_upstream_credentials = (
+            not auth_malformed
+            and auth_config_injects_ordinary_upstream_credentials(api_entry.get("auth"))
+        )
         routing_identity = _api_routing_identity(api_entry)
 
         compiled_permissions: list[_CompiledPermission] = []
@@ -850,6 +891,7 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
                 _compile_rule_index(compiled_permissions_tuple),
                 base_malformed,
                 auth_malformed,
+                injects_ordinary_upstream_credentials,
                 routing_identity,
                 has_malformed_rules,
             )

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -396,10 +396,9 @@ def _server_connect_binding_kinds(
     hostname: str,
     port: int,
     compiled_firewalls: matching.CompiledFirewallSet | None,
-    api_url: str,
+    is_api_host: bool,
 ) -> frozenset[upstream_destination_binding.BindingKind]:
     kinds: set[upstream_destination_binding.BindingKind] = set()
-    is_api_host = api_hostname_matches(api_url, hostname)
     if is_api_host:
         kinds.add("api_allow")
     if (
@@ -446,12 +445,24 @@ def _bind_privileged_upstream_destination(
     if address is None:
         return
     _original_host, port = address
+    is_api_host = api_hostname_matches(api_url, hostname)
+    reusable_kind: upstream_destination_binding.BindingKind = (
+        "api_allow" if is_api_host else "connector_auth"
+    )
+    if upstream_destination_binding.reuse_server_binding_kind_if_matching(
+        server,
+        client=client,
+        host=hostname,
+        port=port,
+        kind=reusable_kind,
+    ):
+        return
 
     kinds = _server_connect_binding_kinds(
         hostname=hostname,
         port=port,
         compiled_firewalls=registry_state.compiled_firewalls.get(client_ip),
-        api_url=api_url,
+        is_api_host=is_api_host,
     )
     if not kinds:
         return

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -39,6 +39,7 @@ __all__ = (
     "record_server_binding",
     "refresh_server_binding_connected_address_if_matching",
     "reset_for_tests",
+    "reuse_server_binding_kind_if_matching",
     "server_binding_original_address",
 )
 
@@ -143,6 +144,45 @@ def record_server_binding(
     _associate_server_with_client(server_id, client)
 
 
+def _matching_server_binding(
+    server: object,
+    *,
+    host: str,
+    port: int,
+) -> tuple[str, UpstreamDestinationBinding] | None:
+    server_id = _connection_id(server)
+    if server_id is None:
+        return None
+    binding = _bindings_by_server_id.get(server_id)
+    if binding is None:
+        return None
+    normalized_host = normalize_trusted_hostname(host)
+    if binding.host != normalized_host or binding.port != port:
+        return None
+    if not _server_binding_matches_current_destination(server, binding):
+        return None
+    return server_id, binding
+
+
+def reuse_server_binding_kind_if_matching(
+    server: object,
+    *,
+    client: object | None = None,
+    host: str,
+    port: int,
+    kind: BindingKind,
+) -> bool:
+    """Reuse an existing binding kind without authorizing a missing kind."""
+    matched = _matching_server_binding(server, host=host, port=port)
+    if matched is None:
+        return False
+    server_id, binding = matched
+    if kind not in binding.kinds:
+        return False
+    _associate_server_with_client(server_id, client)
+    return True
+
+
 def add_server_binding_kind_if_matching(
     server: object,
     *,
@@ -152,17 +192,10 @@ def add_server_binding_kind_if_matching(
     kind: BindingKind,
 ) -> bool:
     """Add a binding kind only if the current server destination still matches."""
-    server_id = _connection_id(server)
-    if server_id is None:
+    matched = _matching_server_binding(server, host=host, port=port)
+    if matched is None:
         return False
-    binding = _bindings_by_server_id.get(server_id)
-    if binding is None:
-        return False
-    normalized_host = normalize_trusted_hostname(host)
-    if binding.host != normalized_host or binding.port != port:
-        return False
-    if not _server_binding_matches_current_destination(server, binding):
-        return False
+    server_id, binding = matched
     if kind not in binding.kinds:
         _bindings_by_server_id[server_id] = UpstreamDestinationBinding(
             host=binding.host,

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
@@ -418,6 +418,16 @@ def test_compiled_ordinary_credential_authority_index_skips_static_candidates(mo
                 "auth": {"headers": {"Authorization": "Bearer token"}},
                 "permissions": [{"name": "read", "rules": ["GET /items"]}],
             },
+            {
+                "base": "http://{subdomain}.insecure.example.com/items",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            },
+            {
+                "base": "https://{subdomain}.auth-base.example.com/items",
+                "auth": {"base": "${{ secrets.WEBHOOK_URL }}"},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            },
         ]
     )
     raw_auth_check_count = 0

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
@@ -257,9 +257,13 @@ def test_compiled_matches_parameterized_host_nonstandard_port_rejection():
     [
         ("https://api.github.com", "api.github.com", 443),
         ("https://api.github.com:8443", "api.github.com", 8443),
+        ("https://api.github.com/v1", "api.github.com", 443),
+        ("https://api.github.com/repos/{owner}", "api.github.com", 443),
         ("https://{sub}.github.com", "api.github.com", 443),
         ("https://{deployment+}.bentoml.ai", "team.prod.bentoml.ai", 443),
         ("https://api.github.com.", "api.github.com", 443),
+        ("https://例子.测试", "xn--fsqu00a.xn--0zwm56d", 443),
+        ("https://[2001:0db8::1]", "[2001:db8::1]", 443),
     ],
 )
 def test_compiled_matches_ordinary_credential_authority(base, host, port):
@@ -277,6 +281,33 @@ def test_compiled_matches_ordinary_credential_authority(base, host, port):
     )
 
     assert compile_firewalls_or_fail(fws).matches_ordinary_credential_authority(host, port)
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        {"headers": {"Authorization": "Bearer token"}},
+        {"query": {"api_key": "token"}},
+        {"awsSigv4": {"accessKeyId": "key", "secretAccessKey": "secret"}},
+    ],
+    ids=["headers", "query", "aws-sigv4"],
+)
+def test_compiled_matches_ordinary_credential_authority_auth_kinds(auth):
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.github.com",
+                "auth": auth,
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            }
+        ],
+        name="example",
+    )
+
+    assert compile_firewalls_or_fail(fws).matches_ordinary_credential_authority(
+        "api.github.com",
+        443,
+    )
 
 
 @pytest.mark.parametrize(
@@ -302,8 +333,25 @@ def test_compiled_matches_ordinary_credential_authority(base, host, port):
             "auth": {"headers": None},
             "permissions": [{"name": "read", "rules": ["GET /items"]}],
         },
+        {
+            "base": "https://api.github.com?source=malformed",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+        },
+        {
+            "base": "https://api.github.com",
+            "auth": {"awsSigv4": {"accessKeyId": "key"}},
+            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+        },
     ],
-    ids=["http", "auth-base-only", "empty-headers", "malformed-auth"],
+    ids=[
+        "http",
+        "auth-base-only",
+        "empty-headers",
+        "malformed-auth",
+        "malformed-base",
+        "malformed-aws-sigv4",
+    ],
 )
 def test_compiled_skips_non_ordinary_credential_authority_candidates(api_entry):
     fws = wrap_firewalls([api_entry], name="example")
@@ -329,3 +377,78 @@ def test_compiled_ordinary_credential_authority_respects_nondefault_port():
 
     assert compiled.matches_ordinary_credential_authority("api.github.com", 8443)
     assert not compiled.matches_ordinary_credential_authority("api.github.com", 443)
+
+
+def test_compiled_skips_malformed_firewall_name_ordinary_credential_authority():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            }
+        ],
+        name="",
+    )
+
+    assert not compile_firewalls_or_fail(fws).matches_ordinary_credential_authority(
+        "api.github.com",
+        443,
+    )
+
+
+def test_compiled_ordinary_credential_authority_index_skips_static_candidates(monkeypatch):
+    apis = [
+        {
+            "base": f"https://api-{index}.example.com/items",
+            "auth": {"headers": {"Authorization": "Bearer token"}},
+            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+        }
+        for index in range(500)
+    ]
+    apis.extend(
+        [
+            {
+                "base": "https://path.example.com/items/{item_id}",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            },
+            {
+                "base": "https://{subdomain}.parameterized.example.com/items",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            },
+        ]
+    )
+    raw_auth_check_count = 0
+    original_auth_check = matching.auth_config_injects_ordinary_upstream_credentials
+
+    def counting_auth_check(auth_config):
+        nonlocal raw_auth_check_count
+        raw_auth_check_count += 1
+        return original_auth_check(auth_config)
+
+    monkeypatch.setattr(
+        matching,
+        "auth_config_injects_ordinary_upstream_credentials",
+        counting_auth_check,
+    )
+    compiled = compile_firewalls_or_fail(wrap_firewalls(apis, name="example"))
+    compiled_auth_check_count = raw_auth_check_count
+    parameterized_match_count = 0
+    original_authority_match = matching._match_compiled_base_authority
+
+    def counting_authority_match(url_parts, base):
+        nonlocal parameterized_match_count
+        parameterized_match_count += 1
+        return original_authority_match(url_parts, base)
+
+    monkeypatch.setattr(
+        matching,
+        "_match_compiled_base_authority",
+        counting_authority_match,
+    )
+
+    assert not compiled.matches_ordinary_credential_authority("unrelated.example.net", 443)
+    assert raw_auth_check_count == compiled_auth_check_count
+    assert parameterized_match_count == 1

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -6,6 +6,8 @@ import threading
 import uuid
 from unittest.mock import patch
 
+import pytest
+
 import matching
 import mitm_addon
 import upstream_admission
@@ -17,6 +19,28 @@ from tests.request_handler_helpers import (
 )
 
 _API_ADDRINFO = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))]
+
+
+def _record_authority_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, int]]:
+    calls: list[tuple[str, int]] = []
+    original = matching.CompiledFirewallSet.matches_ordinary_credential_authority
+
+    def counting_authority_check(
+        compiled_firewalls: matching.CompiledFirewallSet,
+        host: str,
+        port: int,
+    ) -> bool:
+        calls.append((host, port))
+        return original(compiled_firewalls, host, port)
+
+    monkeypatch.setattr(
+        matching.CompiledFirewallSet,
+        "matches_ordinary_credential_authority",
+        counting_authority_check,
+    )
+    return calls
 
 
 class _Server:
@@ -145,26 +169,14 @@ async def test_server_connect_reuses_clienthello_binding_without_rechecking_auth
         sni="api.github.com",
     )
     data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
-    authority_check_count = 0
-    original_authority_check = matching.CompiledFirewallSet.matches_ordinary_credential_authority
-
-    def counting_authority_check(compiled_firewalls, host, port):
-        nonlocal authority_check_count
-        authority_check_count += 1
-        return original_authority_check(compiled_firewalls, host, port)
-
-    monkeypatch.setattr(
-        matching.CompiledFirewallSet,
-        "matches_ordinary_credential_authority",
-        counting_authority_check,
-    )
+    authority_checks = _record_authority_checks(monkeypatch)
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         mitm_addon.tls_clienthello(tls_data)
         await mitm_addon.server_connect(data)
 
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
-    assert authority_check_count == 1
+    assert authority_checks == [("api.github.com", 443)]
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("203.0.113.10", 443)
@@ -183,19 +195,7 @@ async def test_server_connect_wrong_kind_binding_still_checks_current_authority(
         sni="api.github.com",
     )
     data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
-    authority_check_count = 0
-    original_authority_check = matching.CompiledFirewallSet.matches_ordinary_credential_authority
-
-    def counting_authority_check(compiled_firewalls, host, port):
-        nonlocal authority_check_count
-        authority_check_count += 1
-        return original_authority_check(compiled_firewalls, host, port)
-
-    monkeypatch.setattr(
-        matching.CompiledFirewallSet,
-        "matches_ordinary_credential_authority",
-        counting_authority_check,
-    )
+    authority_checks = _record_authority_checks(monkeypatch)
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.github.com"):
         mitm_addon.tls_clienthello(tls_data)
@@ -207,7 +207,7 @@ async def test_server_connect_wrong_kind_binding_still_checks_current_authority(
         await mitm_addon.server_connect(data)
 
     connector_binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
-    assert authority_check_count == 1
+    assert authority_checks == [("api.github.com", 443)]
     assert connector_binding.kinds == frozenset(("api_allow", "connector_auth"))
 
 
@@ -215,6 +215,7 @@ async def test_server_connect_does_not_overwrite_clienthello_binding_after_addre
     tmp_path,
     mitm_ctx,
     make_tls_data,
+    monkeypatch,
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     tls_data = make_tls_data(
@@ -223,6 +224,7 @@ async def test_server_connect_does_not_overwrite_clienthello_binding_after_addre
         sni="api.github.com",
     )
     data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
+    authority_checks = _record_authority_checks(monkeypatch)
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         mitm_addon.tls_clienthello(tls_data)
@@ -230,6 +232,10 @@ async def test_server_connect_does_not_overwrite_clienthello_binding_after_addre
         await mitm_addon.server_connect(data)
 
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert authority_checks == [
+        ("api.github.com", 443),
+        ("api.github.com", 443),
+    ]
     assert data.server.address == ("203.0.113.99", 443)
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -6,6 +6,7 @@ import threading
 import uuid
 from unittest.mock import patch
 
+import matching
 import mitm_addon
 import upstream_admission
 import upstream_destination_binding
@@ -129,6 +130,85 @@ async def test_server_connect_preserves_clienthello_original_address(
     assert binding.host == "api.github.com"
     assert binding.kinds == frozenset(("connector_auth",))
     assert binding.original_address == ("203.0.113.10", 443)
+
+
+async def test_server_connect_reuses_clienthello_binding_without_rechecking_authority(
+    tmp_path,
+    mitm_ctx,
+    make_tls_data,
+    monkeypatch,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    tls_data = make_tls_data(
+        client_ip="10.200.0.5",
+        client_sni="",
+        sni="api.github.com",
+    )
+    data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
+    authority_check_count = 0
+    original_authority_check = matching.CompiledFirewallSet.matches_ordinary_credential_authority
+
+    def counting_authority_check(compiled_firewalls, host, port):
+        nonlocal authority_check_count
+        authority_check_count += 1
+        return original_authority_check(compiled_firewalls, host, port)
+
+    monkeypatch.setattr(
+        matching.CompiledFirewallSet,
+        "matches_ordinary_credential_authority",
+        counting_authority_check,
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        await mitm_addon.server_connect(data)
+
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert authority_check_count == 1
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("connector_auth",))
+    assert binding.original_address == ("203.0.113.10", 443)
+
+
+async def test_server_connect_wrong_kind_binding_still_checks_current_authority(
+    tmp_path,
+    mitm_ctx,
+    make_tls_data,
+    monkeypatch,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    tls_data = make_tls_data(
+        client_ip="10.200.0.5",
+        client_sni="",
+        sni="api.github.com",
+    )
+    data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
+    authority_check_count = 0
+    original_authority_check = matching.CompiledFirewallSet.matches_ordinary_credential_authority
+
+    def counting_authority_check(compiled_firewalls, host, port):
+        nonlocal authority_check_count
+        authority_check_count += 1
+        return original_authority_check(compiled_firewalls, host, port)
+
+    monkeypatch.setattr(
+        matching.CompiledFirewallSet,
+        "matches_ordinary_credential_authority",
+        counting_authority_check,
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.github.com"):
+        mitm_addon.tls_clienthello(tls_data)
+
+    api_binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert api_binding.kinds == frozenset(("api_allow",))
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.server_connect(data)
+
+    connector_binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert authority_check_count == 1
+    assert connector_binding.kinds == frozenset(("api_allow", "connector_auth"))
 
 
 async def test_server_connect_does_not_overwrite_clienthello_binding_after_address_changes(


### PR DESCRIPTION
## Summary

- compile ordinary-credential eligibility once and index exact HTTPS authorities in each immutable firewall snapshot
- retain authority matching only for eligible parameterized hosts, preserving existing normalization and auth semantics
- reuse a verified ClientHello destination binding during `server_connect` only when host, port, current destination, and binding kind still match

## Scope

- keeps request matching, registry reload behavior, and downstream request-time authorization unchanged
- does not change APIs, persisted schemas, runner protocols, or migrations

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_compiled_firewall_authority_normalization.py tests/test_server_connect_hook.py` (120 passed)
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/` (3914 passed)

Closes #21314
