### PR TITLE
perf(mitm-addon): stop buffering firewall rule matches

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -33,6 +33,7 @@ from firewall_matching.base_url import (
 from firewall_matching.patterns import (
     SegmentError,
     SegmentLiteral,
+    _compiled_path_segments_match,
     _match_compiled_path_segments,
     _split_path_segments,
 )
@@ -1076,32 +1077,26 @@ class _MatchedApi(NamedTuple):
     block_match: _BlockMatch
 
 
-class _MatchedRule(NamedTuple):
-    api_match: _MatchedApi
-    entry: _CompiledRuleEntry
-    params: dict[str, str]
-
-
 class _FirewallMatchCollection:
-    """Winning base and rule records collected before policy evaluation."""
+    """Winning base matches and rule-route summary collected before policy evaluation."""
 
     __slots__ = (
         "api_matches",
         "best_base_specificity",
         "best_rule_specificity",
-        "rule_matches",
+        "winning_rule_api_orders",
     )
 
     api_matches: list[_MatchedApi]
     best_base_specificity: int | None
     best_rule_specificity: _PathSpecificity | None
-    rule_matches: list[_MatchedRule]
+    winning_rule_api_orders: set[int]
 
     def __init__(self) -> None:
         self.api_matches = []
         self.best_base_specificity = None
         self.best_rule_specificity = None
-        self.rule_matches = []
+        self.winning_rule_api_orders = set()
 
     def accept_api(self, match: _MatchedApi) -> bool:
         specificity = match.api.base.specificity
@@ -1109,7 +1104,7 @@ class _FirewallMatchCollection:
             self.best_base_specificity = specificity
             self.best_rule_specificity = None
             self.api_matches = []
-            self.rule_matches = []
+            self.winning_rule_api_orders = set()
         elif specificity < self.best_base_specificity:
             return False
 
@@ -1119,18 +1114,17 @@ class _FirewallMatchCollection:
     def can_rule_affect_collection(self, specificity: _PathSpecificity) -> bool:
         return self.best_rule_specificity is None or specificity >= self.best_rule_specificity
 
-    def record_rule(self, match: _MatchedRule) -> None:
-        specificity = match.entry.rule.specificity
+    def record_rule_route(self, api_order: int, specificity: _PathSpecificity) -> None:
         if self.best_rule_specificity is None or specificity > self.best_rule_specificity:
             self.best_rule_specificity = specificity
-            self.rule_matches = []
+            self.winning_rule_api_orders = set()
         elif specificity < self.best_rule_specificity:
             return
-        self.rule_matches.append(match)
+        self.winning_rule_api_orders.add(api_order)
 
 
 class _FirewallDecisionState:
-    """Mutable decision state for the single-pass compiled firewall matcher."""
+    """Mutable decision state for selected-owner policy reduction."""
 
     __slots__ = (
         "allowed_match",
@@ -1311,12 +1305,11 @@ def _resolve_firewall_decision(
     )
 
 
-def _collect_rule_entries(
+def _collect_rule_routes(
     *,
     collection: _FirewallMatchCollection,
     api_match: _MatchedApi,
     rel_path_segs: list[str],
-    base_params: dict[str, str],
     upper_method: str,
     rule_entries: tuple[_CompiledRuleEntry, ...],
 ) -> None:
@@ -1327,37 +1320,26 @@ def _collect_rule_entries(
         if not collection.can_rule_affect_collection(rule.specificity):
             continue
 
-        params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
-        if params is None:
+        if not _compiled_path_segments_match(rel_path_segs, rule.path.segments):
             continue
-        collection.record_rule(
-            _MatchedRule(
-                api_match,
-                entry,
-                {**base_params, **params},
-            )
-        )
+        collection.record_rule_route(api_match.order, rule.specificity)
 
 
-def _winning_owner_records(
+def _winning_api_matches(
     collection: _FirewallMatchCollection,
-) -> tuple[_MatchedRule | _MatchedApi, ...]:
-    if collection.rule_matches:
-        return tuple(collection.rule_matches)
-    return tuple(collection.api_matches)
+) -> tuple[_MatchedApi, ...]:
+    if collection.best_rule_specificity is None:
+        return tuple(collection.api_matches)
+    return tuple(
+        match
+        for match in collection.api_matches
+        if match.order in collection.winning_rule_api_orders
+    )
 
 
 def _winning_owner_names(collection: _FirewallMatchCollection) -> tuple[str, ...]:
-    records = _winning_owner_records(collection)
-    names = {
-        record.api_match.firewall.name if isinstance(record, _MatchedRule) else record.firewall.name
-        for record in records
-        if not (
-            record.api_match.firewall.name_malformed
-            if isinstance(record, _MatchedRule)
-            else record.firewall.name_malformed
-        )
-    }
+    matches = _winning_api_matches(collection)
+    names = {match.firewall.name for match in matches if not match.firewall.name_malformed}
     return tuple(sorted(names))
 
 
@@ -1397,16 +1379,9 @@ def _selected_source_api_matches(
     collection: _FirewallMatchCollection,
     selected_name: str,
 ) -> list[_MatchedApi]:
-    records = _winning_owner_records(collection)
-    result: list[_MatchedApi] = []
-    seen_orders: set[int] = set()
-    for record in records:
-        api_match = record.api_match if isinstance(record, _MatchedRule) else record
-        if api_match.firewall.name != selected_name or api_match.order in seen_orders:
-            continue
-        seen_orders.add(api_match.order)
-        result.append(api_match)
-    return result
+    return [
+        match for match in _winning_api_matches(collection) if match.firewall.name == selected_name
+    ]
 
 
 def _conflicting_selected_api_block(
@@ -1445,12 +1420,60 @@ def _conflicting_selected_api_block(
     )
 
 
+def _evaluate_selected_rule_entries(
+    *,
+    decision: _FirewallDecisionState,
+    api_match: _MatchedApi,
+    policy: _CompiledNetworkPolicy | None,
+    rel_path_segs: list[str],
+    upper_method: str,
+    winning_specificity: _PathSpecificity,
+    rule_entries: tuple[_CompiledRuleEntry, ...],
+) -> None:
+    for entry in rule_entries:
+        rule = entry.rule
+        if rule.method not in ("ANY", upper_method):
+            continue
+        if rule.specificity != winning_specificity:
+            continue
+
+        permission_blocked = policy is not None and entry.permission in policy.blocked_permissions
+        if permission_blocked:
+            if not _compiled_path_segments_match(rel_path_segs, rule.path.segments):
+                continue
+            if not decision.accept_rule_specificity(rule.specificity):
+                continue
+            decision.record_denied_rule(api_match.block_match, entry.permission)
+            continue
+
+        params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
+        if params is None:
+            continue
+        if not decision.accept_rule_specificity(rule.specificity):
+            continue
+        decision.record_allowed_rule(
+            _AllowedRuleMatch(
+                api_match.api.raw_api_entry,
+                api_match.firewall.name,
+                api_match.rel_path,
+                _CompiledRuleCandidate(
+                    entry.permission,
+                    rule.raw,
+                    rule.specificity,
+                    {**api_match.base_params, **params},
+                ),
+            )
+        )
+        return
+
+
 def _reduce_selected_owner(
     collection: _FirewallMatchCollection,
     *,
     selected_name: str | None,
     compiled_network_policies: CompiledNetworkPolicies,
     upper_method: str,
+    indexed_rules: bool,
 ) -> FirewallAllow | FirewallBlock | None:
     if selected_name is not None:
         conflicting_block = _conflicting_selected_api_block(collection, selected_name)
@@ -1498,32 +1521,37 @@ def _reduce_selected_owner(
             continue
         evaluable_api_orders.add(api_match.order)
 
-    for rule_match in collection.rule_matches:
-        api_match = rule_match.api_match
+    winning_specificity = collection.best_rule_specificity
+    if winning_specificity is None:
+        return _resolve_firewall_decision(
+            decision,
+            compiled_network_policies=compiled_network_policies,
+            upper_method=upper_method,
+        )
+
+    for api_match in collection.api_matches:
+        if decision.allowed_match is not None:
+            break
         if api_match.order not in evaluable_api_orders:
             continue
         fw_entry = api_match.firewall
         if selected_name is not None and fw_entry.name != selected_name:
             continue
         policy = compiled_network_policies.policies.get(fw_entry.name)
-        entry = rule_match.entry
-        if not decision.accept_rule_specificity(entry.rule.specificity):
-            continue
-        if policy is not None and entry.permission in policy.blocked_permissions:
-            decision.record_denied_rule(api_match.block_match, entry.permission)
-            continue
-        decision.record_allowed_rule(
-            _AllowedRuleMatch(
-                api_match.api.raw_api_entry,
-                fw_entry.name,
-                api_match.rel_path,
-                _CompiledRuleCandidate(
-                    entry.permission,
-                    entry.rule.raw,
-                    entry.rule.specificity,
-                    rule_match.params,
-                ),
-            )
+        rel_path_segs = _split_path_segments(api_match.rel_path)
+        rule_entries = (
+            _indexed_rule_candidates(api_match.api, upper_method, rel_path_segs)
+            if indexed_rules
+            else api_match.api.rule_index.all_rules
+        )
+        _evaluate_selected_rule_entries(
+            decision=decision,
+            api_match=api_match,
+            policy=policy,
+            rel_path_segs=rel_path_segs,
+            upper_method=upper_method,
+            winning_specificity=winning_specificity,
+            rule_entries=rule_entries,
         )
 
     return _resolve_firewall_decision(
@@ -1594,11 +1622,10 @@ def _match_compiled_firewall_request_with_api_candidates(
             if indexed_rules
             else api_entry.rule_index.all_rules
         )
-        _collect_rule_entries(
+        _collect_rule_routes(
             collection=collection,
             api_match=api_match,
             rel_path_segs=rel_path_segs,
-            base_params=base_params,
             upper_method=upper_method,
             rule_entries=rule_entries,
         )
@@ -1616,6 +1643,7 @@ def _match_compiled_firewall_request_with_api_candidates(
         selected_name=selected_name,
         compiled_network_policies=compiled_network_policies,
         upper_method=upper_method,
+        indexed_rules=indexed_rules,
     )
 
 

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1532,6 +1532,8 @@ def _reduce_selected_owner(
     for api_match in collection.api_matches:
         if decision.allowed_match is not None:
             break
+        if api_match.order not in collection.winning_rule_api_orders:
+            continue
         if api_match.order not in evaluable_api_orders:
             continue
         fw_entry = api_match.firewall

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1130,7 +1130,6 @@ class _FirewallDecisionState:
         "allowed_match",
         "base_match",
         "best_base_specificity",
-        "best_rule_specificity",
         "denied_match",
         "denied_permission_names",
         "malformed_config_match",
@@ -1140,7 +1139,6 @@ class _FirewallDecisionState:
     allowed_match: _AllowedRuleMatch | None
     base_match: _BaseMatch | None
     best_base_specificity: int | None
-    best_rule_specificity: _PathSpecificity | None
     denied_match: _BlockMatch | None
     # Dict keys act as an ordered set of first-seen denied permission names.
     denied_permission_names: dict[str, None]
@@ -1151,7 +1149,6 @@ class _FirewallDecisionState:
         self.allowed_match = None
         self.base_match = None
         self.best_base_specificity = None
-        self.best_rule_specificity = None
         self.denied_match = None
         self.denied_permission_names = {}
         self.malformed_config_match = None
@@ -1170,7 +1167,6 @@ class _FirewallDecisionState:
             or api_entry.base.specificity > self.best_base_specificity
         ):
             self.best_base_specificity = api_entry.base.specificity
-            self.best_rule_specificity = None
             self.allowed_match = None
             self.base_match = None
             self.denied_match = None
@@ -1197,17 +1193,6 @@ class _FirewallDecisionState:
     def record_malformed_policy(self, match: _BlockMatch) -> None:
         if self.malformed_policy_match is None:
             self.malformed_policy_match = match
-
-    def accept_rule_specificity(self, specificity: _PathSpecificity) -> bool:
-        if self.best_rule_specificity is None or specificity > self.best_rule_specificity:
-            self.best_rule_specificity = specificity
-            self.allowed_match = None
-            self.denied_match = None
-            self.denied_permission_names = {}
-        elif specificity < self.best_rule_specificity:
-            return False
-
-        return True
 
     def record_allowed_rule(self, match: _AllowedRuleMatch) -> None:
         if self.allowed_match is None:
@@ -1441,15 +1426,11 @@ def _evaluate_selected_rule_entries(
         if permission_blocked:
             if not _compiled_path_segments_match(rel_path_segs, rule.path.segments):
                 continue
-            if not decision.accept_rule_specificity(rule.specificity):
-                continue
             decision.record_denied_rule(api_match.block_match, entry.permission)
             continue
 
         params = _match_compiled_path_segments(rel_path_segs, rule.path.segments)
         if params is None:
-            continue
-        if not decision.accept_rule_specificity(rule.specificity):
             continue
         decision.record_allowed_rule(
             _AllowedRuleMatch(

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
@@ -1,5 +1,7 @@
 """Indexed compiled firewall matcher compatibility and scan guardrails."""
 
+import pytest
+
 import connector_intent
 import matching
 from tests.firewall_helpers import (
@@ -338,6 +340,64 @@ def test_indexed_matching_skips_unrelated_literal_rule_path_checks(monkeypatch):
     assert isinstance(result, matching.FirewallAllow)
     assert result.permission == "target"
     assert path_match_count == 1
+
+
+@pytest.mark.parametrize(
+    ("blocked", "expected_capture_count"),
+    [
+        (True, 0),
+        (False, 1),
+    ],
+)
+def test_indexed_matching_bounds_param_capture_for_same_specificity_fallbacks(
+    monkeypatch,
+    blocked,
+    expected_capture_count,
+):
+    repeated_rule = "GET /{path+}"
+    firewalls = wrap_firewalls(
+        [
+            firewall_api(
+                "https://api.example.com",
+                [firewall_permission("files-read", *([repeated_rule] * 128))],
+            )
+        ],
+        name="large",
+    )
+    policies = {
+        "large": network_policy(
+            allow=[] if blocked else ["files-read"],
+            deny=["files-read"] if blocked else [],
+        )
+    }
+    compiled = compile_firewalls_or_fail(firewalls)
+    capture_count = 0
+    original_capture_match = matching._match_compiled_path_segments
+
+    # Narrow performance-contract guard: the public decision does not reveal
+    # whether route discovery retained params for every matching fallback.
+    def counting_capture_match(path_segs, pattern_segs):
+        nonlocal capture_count
+        capture_count += 1
+        return original_capture_match(path_segs, pattern_segs)
+
+    monkeypatch.setattr(matching, "_match_compiled_path_segments", counting_capture_match)
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com/a/b/c",
+        "GET",
+        compiled,
+        policies,
+    )
+
+    if blocked:
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ("files-read",)
+    else:
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "files-read"
+        assert result.params == {"path": "a/b/c"}
+    assert capture_count == expected_capture_count
 
 
 def test_indexed_matches_linear_for_root_static_base_with_long_path():

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
@@ -354,13 +354,18 @@ def test_indexed_matching_bounds_param_capture_for_same_specificity_fallbacks(
     blocked,
     expected_capture_count,
 ):
-    repeated_rule = "GET /{path+}"
+    nonmatching_rule = "GET /{prefix}-nope/{path+}"
+    repeated_rule = "GET /{prefix}-good/{path+}"
     firewalls = wrap_firewalls(
         [
             firewall_api(
                 "https://api.example.com",
+                [firewall_permission("irrelevant", *([nonmatching_rule] * 128))],
+            ),
+            firewall_api(
+                "https://api.example.com",
                 [firewall_permission("files-read", *([repeated_rule] * 128))],
-            )
+            ),
         ],
         name="large",
     )
@@ -384,7 +389,7 @@ def test_indexed_matching_bounds_param_capture_for_same_specificity_fallbacks(
     monkeypatch.setattr(matching, "_match_compiled_path_segments", counting_capture_match)
 
     result = matching.match_compiled_firewall_request(
-        "https://api.example.com/a/b/c",
+        "https://api.example.com/a-good/b/c",
         "GET",
         compiled,
         policies,
@@ -396,7 +401,7 @@ def test_indexed_matching_bounds_param_capture_for_same_specificity_fallbacks(
     else:
         assert isinstance(result, matching.FirewallAllow)
         assert result.permission == "files-read"
-        assert result.params == {"path": "a/b/c"}
+        assert result.params == {"prefix": "a", "path": "b/c"}
     assert capture_count == expected_capture_count
 
 


### PR DESCRIPTION
## Summary

- discover globally winning firewall routes without retaining one match object and captured-parameter dictionary per rule
- rescan only the selected connector owner, avoiding parameter capture for denied rules and stopping after the first allowed rule
- add a deterministic same-specificity fallback test that bounds parameter capture without wall-clock assertions

## Compatibility

- preserves base and rule specificity, owner selection, connector-intent ambiguity, routing-identity conflicts, malformed input precedence, denied-permission ordering, and indexed-versus-linear behavior
- leaves the TypeScript matcher, API and runner protocols, and persisted state unchanged
- keeps the existing candidate-index allocation outside this change

## Validation

- Ruff formatting: 234 files unchanged
- Ruff lint: passed
- BasedPyright: 0 errors, 0 warnings, 0 notes
- focused matcher matrix: 249 passed
- full mitm-addon pytest suite: 3903 passed

Closes #21313
