### PR TITLE
fix(runner): prevent dnsmasq stalls during namespace churn

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -998,6 +998,8 @@ jobs:
           SVC="${JOB_REF}-exec"
           GROUP="vm0/exec-${JOB_REF}"
           SUBMIT_PID=""
+          DNS_ISOLATION_NS=""
+          DNS_ISOLATION_HOST_IF=""
 
           fail() { echo "FAIL: $1"; exit 1; }
 
@@ -1012,6 +1014,12 @@ jobs:
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
             cleanup_submit_pid "$SUBMIT_PID"
+            if [ -n "$DNS_ISOLATION_NS" ]; then
+              sudo ip netns delete "$DNS_ISOLATION_NS" 2>/dev/null || true
+            fi
+            if [ -n "$DNS_ISOLATION_HOST_IF" ]; then
+              sudo ip link delete "$DNS_ISOLATION_HOST_IF" 2>/dev/null || true
+            fi
           }
           trap cleanup EXIT
 
@@ -1288,6 +1296,20 @@ jobs:
           DNS_PORT=$(sudo jq -r '.dns_port // empty' "$RUNNER_DIR/status.json")
           [ -n "$PROXY_PORT" ] || fail "proxy port missing from runner status"
           [ -n "$DNS_PORT" ] || fail "DNS port missing from runner status"
+
+          DNS_LISTENERS=$(sudo ss -H -luntp \
+            | grep -E ":${DNS_PORT}[[:space:]]" || true)
+          DNS_LISTENER_COUNT=$(printf '%s\n' "$DNS_LISTENERS" \
+            | grep -c . || true)
+          [ "$DNS_LISTENER_COUNT" -ge 2 ] \
+            || fail "expected UDP/TCP dnsmasq wildcard listeners, found $DNS_LISTENER_COUNT"
+          [ "$DNS_LISTENER_COUNT" -le 4 ] \
+            || fail "dnsmasq created per-address listeners: $DNS_LISTENERS"
+          if printf '%s\n' "$DNS_LISTENERS" \
+            | grep -E '10\.200\.|%vm0-ve-' >/dev/null; then
+            fail "dnsmasq listener set contains VM interface addresses: $DNS_LISTENERS"
+          fi
+
           NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
           FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
 
@@ -1311,10 +1333,116 @@ jobs:
           printf '%s\n' "$FILTER_RULES" \
             | grep -E -- "-A FORWARD .* -p tcp .*--dport 853 .* -j DROP" >/dev/null \
             || fail "TCP/853 FORWARD drop rule not found"
+
+          DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
+            | grep -E -- "-A INPUT .*--dport ${DNS_PORT} .*--comment vm0-ns-[0-9a-f]{2}-dns.*-j REJECT" \
+            | sed -nE 's/.*--comment "?([^ " ]+)"?.*/\1/p' \
+            | head -n 1)
+          [ -n "$DNS_FILTER_COMMENT" ] || fail "DNS INPUT filter comment missing"
+
+          # Default dnsmasq wildcard sockets must still reject requests that
+          # arrive through a non-runner interface before a TCP handshake or
+          # DNS response reaches the process. Exercise IPv4/IPv6 and UDP/TCP
+          # through a temporary, deliberately non-matching veth.
+          DNS_ISOLATION_NS="dns-isolation-$$"
+          DNS_ISOLATION_HOST_IF="vmdh$$"
+          DNS_ISOLATION_PEER_IF="vmdp$$"
+          DNS_ISOLATION_HASH=$(printf '%s' "$SVC" | cksum | awk '{print $1}')
+          DNS_ISOLATION_SECOND=$((18 + DNS_ISOLATION_HASH % 2))
+          DNS_ISOLATION_THIRD=$(((DNS_ISOLATION_HASH / 2) % 256))
+          DNS_ISOLATION_BASE=$((((DNS_ISOLATION_HASH / 512) % 64) * 4))
+          DNS_ISOLATION_HOST_IP="198.${DNS_ISOLATION_SECOND}.${DNS_ISOLATION_THIRD}.$((DNS_ISOLATION_BASE + 1))"
+          DNS_ISOLATION_PEER_IP="198.${DNS_ISOLATION_SECOND}.${DNS_ISOLATION_THIRD}.$((DNS_ISOLATION_BASE + 2))"
+          DNS_ISOLATION_IPV6_HEXTET=$(printf '%x' "$((DNS_ISOLATION_HASH % 65535 + 1))")
+          DNS_ISOLATION_HOST_IPV6="fd00:198:18:${DNS_ISOLATION_IPV6_HEXTET}::1"
+          DNS_ISOLATION_PEER_IPV6="fd00:198:18:${DNS_ISOLATION_IPV6_HEXTET}::2"
+
+          sudo ip netns add "$DNS_ISOLATION_NS" \
+            || fail "failed to create DNS isolation namespace"
+          sudo ip link add "$DNS_ISOLATION_HOST_IF" type veth \
+            peer name "$DNS_ISOLATION_PEER_IF" \
+            || fail "failed to create DNS isolation veth"
+          sudo ip link set "$DNS_ISOLATION_PEER_IF" netns "$DNS_ISOLATION_NS"
+          sudo ip address add "${DNS_ISOLATION_HOST_IP}/30" \
+            dev "$DNS_ISOLATION_HOST_IF"
+          sudo ip -6 address add "${DNS_ISOLATION_HOST_IPV6}/64" \
+            dev "$DNS_ISOLATION_HOST_IF" nodad
+          sudo ip link set "$DNS_ISOLATION_HOST_IF" up
+          sudo ip -n "$DNS_ISOLATION_NS" address add \
+            "${DNS_ISOLATION_PEER_IP}/30" dev "$DNS_ISOLATION_PEER_IF"
+          sudo ip -n "$DNS_ISOLATION_NS" -6 address add \
+            "${DNS_ISOLATION_PEER_IPV6}/64" dev "$DNS_ISOLATION_PEER_IF" nodad
+          sudo ip -n "$DNS_ISOLATION_NS" link set lo up
+          sudo ip -n "$DNS_ISOLATION_NS" link set "$DNS_ISOLATION_PEER_IF" up
+          sudo ip netns exec "$DNS_ISOLATION_NS" \
+            ping -c 1 -W 1 "$DNS_ISOLATION_HOST_IP" >/dev/null \
+            || fail "temporary non-runner veth cannot reach its host peer"
+          sudo ip netns exec "$DNS_ISOLATION_NS" \
+            ping -6 -c 1 -W 1 "$DNS_ISOLATION_HOST_IPV6" >/dev/null \
+            || fail "temporary non-runner veth cannot reach its IPv6 host peer"
+
+          if ! sudo ip netns exec "$DNS_ISOLATION_NS" \
+            python3 - "$DNS_ISOLATION_HOST_IP" "$DNS_ISOLATION_HOST_IPV6" "$DNS_PORT" <<'PY'
+          import socket
+          import sys
+
+          hosts = sys.argv[1:3]
+          port = int(sys.argv[3])
+          query = bytes.fromhex(
+              "123401000001000000000000"
+              "0d766d302d72656164696e657373"
+              "07696e76616c69640000010001"
+          )
+
+          for host in hosts:
+              address = (host, port)
+              family = socket.AF_INET6 if ":" in host else socket.AF_INET
+              udp = socket.socket(family, socket.SOCK_DGRAM)
+              udp.settimeout(1)
+              udp.sendto(query, address)
+              try:
+                  response, _ = udp.recvfrom(4096)
+              except (ConnectionError, TimeoutError):
+                  pass
+              else:
+                  if response:
+                      raise SystemExit(
+                          f"dnsmasq answered UDP on non-runner address {host}"
+                      )
+              finally:
+                  udp.close()
+
+              try:
+                  tcp = socket.create_connection(address, timeout=1)
+              except OSError:
+                  pass
+              else:
+                  tcp.close()
+                  raise SystemExit(
+                      f"dnsmasq TCP port reachable on non-runner address {host}"
+                  )
+          PY
+          then
+            fail "dnsmasq accepted a query from a non-runner interface"
+          fi
+
+          sudo ip netns delete "$DNS_ISOLATION_NS" \
+            || fail "failed to remove DNS isolation namespace"
+          sudo ip link delete "$DNS_ISOLATION_HOST_IF" 2>/dev/null || true
+          DNS_ISOLATION_NS=""
+          DNS_ISOLATION_HOST_IF=""
           echo "PASS: DNS resolution"
 
           # Stop transient service (kills sandbox, submit terminates naturally)
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          if sudo iptables-save -t filter \
+            | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
+            fail "IPv4 DNS INPUT filter leaked after runner stop"
+          fi
+          if sudo ip6tables-save -t filter \
+            | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
+            fail "IPv6 DNS INPUT filter leaked after runner stop"
+          fi
           cleanup_submit_pid "$SUBMIT_PID"
           SUBMIT_PID=""
           trap - EXIT

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1000,6 +1000,7 @@ jobs:
           SUBMIT_PID=""
           DNS_ISOLATION_NS=""
           DNS_ISOLATION_HOST_IF=""
+          DNS_ISOLATION_LOCK_FD=""
 
           fail() { echo "FAIL: $1"; exit 1; }
 
@@ -1019,6 +1020,9 @@ jobs:
             fi
             if [ -n "$DNS_ISOLATION_HOST_IF" ]; then
               sudo ip link delete "$DNS_ISOLATION_HOST_IF" 2>/dev/null || true
+            fi
+            if [ -n "$DNS_ISOLATION_LOCK_FD" ]; then
+              exec {DNS_ISOLATION_LOCK_FD}>&-
             fi
           }
           trap cleanup EXIT
@@ -1344,6 +1348,10 @@ jobs:
           # arrive through a non-runner interface before a TCP handshake or
           # DNS response reaches the process. Exercise IPv4/IPv6 and UDP/TCP
           # through a temporary, deliberately non-matching veth.
+          exec {DNS_ISOLATION_LOCK_FD}>/tmp/vm0-runner-exec-dns-isolation.lock \
+            || fail "failed to open DNS isolation lock"
+          flock -w 30 "$DNS_ISOLATION_LOCK_FD" \
+            || fail "timed out waiting for DNS isolation lock"
           DNS_ISOLATION_NS="dns-isolation-$$"
           DNS_ISOLATION_HOST_IF="vmdh$$"
           DNS_ISOLATION_PEER_IF="vmdp$$"
@@ -1431,6 +1439,8 @@ jobs:
           sudo ip link delete "$DNS_ISOLATION_HOST_IF" 2>/dev/null || true
           DNS_ISOLATION_NS=""
           DNS_ISOLATION_HOST_IF=""
+          exec {DNS_ISOLATION_LOCK_FD}>&-
+          DNS_ISOLATION_LOCK_FD=""
           echo "PASS: DNS resolution"
 
           # Stop transient service (kills sandbox, submit terminates naturally)

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1348,7 +1348,7 @@ jobs:
           # arrive through a non-runner interface before a TCP handshake or
           # DNS response reaches the process. Exercise IPv4/IPv6 and UDP/TCP
           # through a temporary, deliberately non-matching veth.
-          exec {DNS_ISOLATION_LOCK_FD}>/tmp/vm0-runner-exec-dns-isolation.lock \
+          exec {DNS_ISOLATION_LOCK_FD}<>/tmp/vm0-runner-exec-dns-isolation.lock \
             || fail "failed to open DNS isolation lock"
           flock -w 30 "$DNS_ISOLATION_LOCK_FD" \
             || fail "timed out waiting for DNS isolation lock"

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -34,10 +34,12 @@ const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
-const START_SYSTEM_DEPENDENCIES: [&str; 7] = [
+const START_SYSTEM_DEPENDENCIES: [&str; 9] = [
     "ip",
     "iptables",
     "iptables-save",
+    "ip6tables",
+    "ip6tables-save",
     "sysctl",
     "dnsmasq",
     "mkfs.ext4",
@@ -1224,6 +1226,13 @@ mod tests {
     fn runner_start_dependencies_include_openssl_for_proxy_ca_validation() {
         assert!(START_SYSTEM_DEPENDENCIES.contains(&"openssl"));
         assert!(!OTHER_COMMAND_SYSTEM_DEPENDENCIES.contains(&"openssl"));
+    }
+
+    #[test]
+    fn runner_start_dependencies_include_dual_stack_firewall_tools() {
+        for dependency in ["iptables", "iptables-save", "ip6tables", "ip6tables-save"] {
+            assert!(START_SYSTEM_DEPENDENCIES.contains(&dependency));
+        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -21,6 +21,10 @@ use crate::paths::HomePaths;
 pub(super) type SharedFactory = Arc<Box<dyn SandboxFactory>>;
 
 /// Build one sandbox factory per configured profile.
+///
+/// On failure, already-created factories are stopped, but shared runtime
+/// resources remain owned by the caller so dependent services can stop before
+/// the runtime removes their network isolation.
 pub(super) async fn start_factories(
     profiles: &BTreeMap<String, ProfileConfig>,
     firecracker: &config::FirecrackerConfig,
@@ -42,7 +46,7 @@ pub(super) async fn start_factories(
         let factory = match factory_result {
             Ok(factory) => factory,
             Err(e) => {
-                shutdown_factories(&mut factories, runtime, None).await;
+                shutdown_factory_instances(&mut factories, None).await;
                 return Err(e.into());
             }
         };
@@ -55,10 +59,9 @@ pub(super) async fn start_factories(
     Ok(factories)
 }
 
-/// Shut down all factories, then release shared runtime resources.
-pub(super) async fn shutdown_factories(
+/// Shut down all factory-owned sandboxes while retaining shared runtime resources.
+pub(super) async fn shutdown_factory_instances(
     factories: &mut BTreeMap<String, (SharedFactory, bool)>,
-    runtime: &mut dyn SandboxRuntime,
     teardown: Option<&TeardownTimer>,
 ) {
     for (name, (factory, _)) in std::mem::take(factories) {
@@ -88,6 +91,13 @@ pub(super) async fn shutdown_factories(
             Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
         }
     }
+}
+
+/// Release runtime-owned shared resources after their dependent services stop.
+pub(super) async fn shutdown_runtime(
+    runtime: &mut dyn SandboxRuntime,
+    teardown: Option<&TeardownTimer>,
+) {
     // Clean up runtime-owned shared resources (netns and NBD device pools).
     let phase = teardown.map(|timer| timer.phase_start("runtime_shutdown"));
     runtime.shutdown().await;
@@ -210,11 +220,11 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 2);
         assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 1);
-        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
-    async fn start_factories_shuts_down_runtime_after_first_factory_create_error() {
+    async fn start_factories_retains_runtime_after_first_factory_create_error() {
         let temp = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(temp.path().join("home"));
         let base_dir = temp.path().join("base");
@@ -232,11 +242,11 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 1);
         assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 0);
-        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
-    async fn shutdown_factories_skips_factories_that_are_still_referenced() {
+    async fn split_shutdown_skips_referenced_factories_and_releases_runtime() {
         let mut runtime = RecordingRuntime::new(usize::MAX);
         let factory_shutdowns = Arc::clone(&runtime.factory_shutdowns);
         let retained_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
@@ -245,7 +255,8 @@ mod tests {
         let mut factories = BTreeMap::new();
         factories.insert("vm0/first".into(), (Arc::clone(&retained_factory), false));
 
-        shutdown_factories(&mut factories, &mut runtime, None).await;
+        shutdown_factory_instances(&mut factories, None).await;
+        shutdown_runtime(&mut runtime, None).await;
 
         assert!(factories.is_empty());
         assert_eq!(factory_shutdowns.load(Ordering::SeqCst), 0);

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -83,7 +83,7 @@ mod sandbox_finalization;
 mod signals;
 
 use active_sessions::new_active_cli_agent_sessions;
-use factory_lifecycle::{shutdown_factories, start_factories};
+use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeldSessionStateSnapshot,
     collect_heartbeat_state, refresh_workspace_cache_held_session_snapshot, send_heartbeat,
@@ -207,12 +207,12 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
         Err(e) => {
             resources.memory_prefetch.cancel();
             resources.provider.shutdown().await;
+            resources.dns_handle.stop().await;
             resources.runtime.shutdown().await;
             if let Err(kill_error) = resources.mitm.kill_now().await {
                 warn!(error = %kill_error, "failed to kill proxy after live runner instance publish failed");
             }
             resources.kmsg_handle.stop().await;
-            resources.dns_handle.stop().await;
             resources.memory_prefetch.drain().await;
             resources.status.set_mode(RunnerMode::Stopped).await;
             Err(e)
@@ -226,6 +226,7 @@ async fn shutdown_startup_resources_after_startup_failure(
 ) {
     resources.memory_prefetch.cancel();
     resources.provider.shutdown().await;
+    resources.dns_handle.stop().await;
     if let Some(runtime) = resources.runtime {
         runtime.shutdown().await;
     }
@@ -233,7 +234,6 @@ async fn shutdown_startup_resources_after_startup_failure(
         warn!(error = %e, context, "failed to kill proxy after startup failed");
     }
     resources.kmsg_handle.stop().await;
-    resources.dns_handle.stop().await;
     resources.memory_prefetch.drain().await;
     resources.status.set_mode(RunnerMode::Stopped).await;
 }
@@ -1243,7 +1243,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             shutdown_startup_resources_after_startup_failure(
                 StartupFailureResources {
                     provider: provider_state.provider.as_ref(),
-                    runtime: None,
+                    runtime: Some(runtime.as_mut()),
                     mitm: &mut mitm,
                     kmsg_handle,
                     dns_handle,
@@ -1765,9 +1765,18 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
 
     info!("shutting down factories");
-    let phase = teardown.phase_start("shutdown_factories");
-    shutdown_factories(&mut factories, runtime.as_mut(), Some(&teardown)).await;
-    teardown.phase_complete("shutdown_factories", phase);
+    let phase = teardown.phase_start("shutdown_factory_instances");
+    shutdown_factory_instances(&mut factories, Some(&teardown)).await;
+    teardown.phase_complete("shutdown_factory_instances", phase);
+
+    // Keep the pool-scoped INPUT filters installed until dnsmasq is gone.
+    // Runtime shutdown owns those filters, so it must follow DNS shutdown to
+    // avoid exposing the wildcard listener between the two cleanup phases.
+    let phase = teardown.phase_start("dns_stop");
+    dns_handle.stop().await;
+    teardown.phase_complete("dns_stop", phase);
+
+    shutdown_runtime(runtime.as_mut(), Some(&teardown)).await;
 
     // Wait for buffered and pending usage reports before stopping the proxy.
     // The runner writes a shutdown request marker, then the addon replies with
@@ -1825,10 +1834,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let phase = teardown.phase_start("kmsg_stop");
     kmsg_handle.stop().await;
     teardown.phase_complete("kmsg_stop", phase);
-    let phase = teardown.phase_start("dns_stop");
-    dns_handle.stop().await;
-    teardown.phase_complete("dns_stop", phase);
-
     let phase = teardown.phase_start("memory_prefetch_drain");
     memory_prefetch.drain().await;
     teardown.phase_complete("memory_prefetch_drain", phase);

--- a/crates/runner/src/dns/mod.rs
+++ b/crates/runner/src/dns/mod.rs
@@ -7,8 +7,10 @@
 //! Defense-in-depth:
 //! - Layer 1: iptables REDIRECT → dnsmasq port (working path, preserves source IP)
 //! - Layer 2: iptables DROP external UDP/TCP 53 and TCP 853 (bypass prevention)
-//! - Layer 3: dnsmasq binds to VM-facing veth interfaces instead of external
-//!   host interfaces (listener restriction)
+//! - Layer 3: IPv4/IPv6 INPUT filters reject direct access to dnsmasq's wildcard
+//!   port from interfaces outside the runner's netns pool
+//! - Layer 4: dnsmasq validates each request against the runner's VM-facing
+//!   veth interface pattern (listener access control)
 //!
 //! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
 //! target. The REDIRECT rules in PREROUTING intercept UDP and TCP 53 from the

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -113,11 +113,24 @@ async fn try_start(
     interface_pattern: &str,
     network_log_manager: NetworkLogManager,
 ) -> std::io::Result<DnsProxy> {
-    let mut child = tokio::process::Command::new("dnsmasq")
+    let mut command = tokio::process::Command::new("dnsmasq");
+    command
         .args(dnsmasq_args(port, interface_pattern))
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()?;
+        .stderr(Stdio::piped());
+
+    // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)`, which is
+    // async-signal-safe. This prevents a wildcard dnsmasq listener from
+    // surviving a SIGKILL or crash of its parent runner and outliving the
+    // pool-scoped firewall rules that protect it.
+    unsafe {
+        command.pre_exec(|| {
+            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
+                .map_err(std::io::Error::from)
+        });
+    }
+
+    let mut child = command.spawn()?;
 
     // Give dnsmasq a moment to bind, then verify it's still running.
     // Catches port-already-in-use, missing binary (spawn itself errors),
@@ -199,9 +212,10 @@ fn dnsmasq_args(port: u16, interface_pattern: &str) -> Vec<String> {
         "--no-resolv".into(),
         "--port".into(),
         port.to_string(),
-        // VM host-side veth devices are created after dnsmasq starts.
+        // Keep dnsmasq's default wildcard sockets so VM host-side veth churn
+        // cannot rebuild a per-address listener set in its query event loop.
+        // --interface still validates the arrival interface for every request.
         format!("--interface={interface_pattern}"),
-        "--bind-dynamic".into(),
         format!("--address=/{DNS_READINESS_HOSTNAME}/{DNS_READINESS_IPV4}"),
         format!("--local=/{DNS_READINESS_HOSTNAME}/"),
         "--server".into(),
@@ -218,11 +232,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dnsmasq_args_restrict_listener_to_vm_interface_pattern() {
+    fn dnsmasq_args_use_wildcard_sockets_with_vm_interface_access_control() {
         let args = dnsmasq_args(5353, "vm0-ve-0a-*");
 
         assert!(args.contains(&"--interface=vm0-ve-0a-*".to_string()));
-        assert!(args.contains(&"--bind-dynamic".to_string()));
+        assert!(!args.contains(&"--bind-dynamic".to_string()));
+        assert!(!args.contains(&"--bind-interfaces".to_string()));
     }
 
     #[test]
@@ -237,7 +252,6 @@ mod tests {
                 "--port",
                 "5353",
                 "--interface=vm0-ve-0a-*",
-                "--bind-dynamic",
                 "--address=/vm0-readiness.invalid/192.0.2.1",
                 "--local=/vm0-readiness.invalid/",
                 "--server",

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -113,20 +113,26 @@ async fn try_start(
     interface_pattern: &str,
     network_log_manager: NetworkLogManager,
 ) -> std::io::Result<DnsProxy> {
+    let expected_parent = nix::unistd::getpid();
     let mut command = tokio::process::Command::new("dnsmasq");
     command
         .args(dnsmasq_args(port, interface_pattern))
         .stdout(Stdio::null())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
 
-    // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)`, which is
-    // async-signal-safe. This prevents a wildcard dnsmasq listener from
-    // surviving a SIGKILL or crash of its parent runner and outliving the
-    // pool-scoped firewall rules that protect it.
+    // SAFETY: `set_pdeathsig` and `getppid` are async-signal-safe. Checking the
+    // parent after installing the signal closes the fork-to-prctl race: if the
+    // runner already exited, the child fails before exec instead of creating an
+    // unowned wildcard listener.
     unsafe {
-        command.pre_exec(|| {
+        command.pre_exec(move || {
             nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
-                .map_err(std::io::Error::from)
+                .map_err(std::io::Error::from)?;
+            if nix::unistd::getppid() != expected_parent {
+                return Err(std::io::Error::from_raw_os_error(nix::libc::ESRCH));
+            }
+            Ok(())
         });
     }
 

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -18,7 +18,7 @@ use super::super::error::{NetworkError, Result};
 use super::super::{GUEST_NETWORK, GuestNetwork};
 use super::naming::{
     MAX_NAMESPACES, MAX_POOLS, NS_PREFIX, format_hex_index, generate_veth_ip_pair,
-    make_host_device, make_ns_name, parse_netns_name,
+    make_host_device, make_host_device_iptables_pattern, make_ns_name, parse_netns_name,
 };
 use super::types::NetnsInfo;
 
@@ -102,6 +102,61 @@ async fn exec_ip(args: &[&str]) -> Result<()> {
 async fn exec_iptables(args: &[&str]) -> Result<()> {
     exec_status_with_timeout("iptables", args, NETNS_COMMAND_TIMEOUT).await?;
     Ok(())
+}
+
+/// Restrict the runner-managed DNS port to this pool's VM-facing veths.
+///
+/// dnsmasq's default socket mode avoids per-address listener churn by using
+/// wildcard sockets. These INPUT rules preserve the old kernel-level listener
+/// isolation: public, management, and other runners' interfaces see the port as
+/// unreachable, while REDIRECT traffic arriving on this pool's veths proceeds
+/// to dnsmasq. Both address families are covered because dnsmasq can create
+/// IPv4 and IPv6 wildcard sockets.
+pub(super) async fn setup_dns_input_filter(pool_index: u32, dns_port: u16) -> Result<String> {
+    let pool_idx = format_hex_index(pool_index);
+    let interface = make_host_device_iptables_pattern(&pool_idx);
+    let comment = format!("{NS_PREFIX}{pool_idx}-dns");
+    let port = dns_port.to_string();
+
+    for program in ["iptables", "ip6tables"] {
+        for protocol in ["udp", "tcp"] {
+            let args = [
+                "-I",
+                "INPUT",
+                "1",
+                "!",
+                "-i",
+                &interface,
+                "-p",
+                protocol,
+                "--dport",
+                &port,
+                "-m",
+                "comment",
+                "--comment",
+                &comment,
+                "-j",
+                "REJECT",
+            ];
+            if let Err(error) =
+                exec_status_with_timeout(program, &args, NETNS_COMMAND_TIMEOUT).await
+            {
+                if matches!(
+                    delete_pool_firewall_rules_by_comment(&comment).await,
+                    NamespaceDeleteOutcome::Abandoned
+                ) {
+                    warn!(
+                        comment,
+                        "failed to roll back partial DNS input filter; startup orphan reconciliation will retry"
+                    );
+                }
+                return Err(error.into());
+            }
+        }
+    }
+
+    info!(dns_port, interface, comment, "DNS input filter installed");
+    Ok(comment)
 }
 
 pub(super) async fn enable_host_ip_forwarding() -> Result<()> {
@@ -457,11 +512,11 @@ pub(super) async fn get_default_interface() -> Result<String> {
     Ok(iface)
 }
 
-/// Delete iptables rules that contain `comment` in nat and filter tables.
+/// Delete IPv4 iptables rules that contain `comment`.
 async fn delete_iptables_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
     let (nat, filter) = tokio::join!(
-        delete_iptables_from_table("nat", comment),
-        delete_iptables_from_table("filter", comment),
+        delete_firewall_rules_from_table("iptables", "iptables-save", "nat", comment),
+        delete_firewall_rules_from_table("iptables", "iptables-save", "filter", comment),
     );
     if matches!(nat, NamespaceDeleteOutcome::Deleted)
         && matches!(filter, NamespaceDeleteOutcome::Deleted)
@@ -472,15 +527,35 @@ async fn delete_iptables_rules_by_comment(comment: &str) -> NamespaceDeleteOutco
     }
 }
 
-async fn delete_iptables_from_table(table: &str, comment: &str) -> NamespaceDeleteOutcome {
-    let output =
-        match exec_with_timeout("iptables-save", &["-t", table], NETNS_COMMAND_TIMEOUT).await {
-            Ok(output) => output,
-            Err(e) => {
-                warn!(table, error = %e, "failed to read iptables rules, skipping cleanup");
-                return NamespaceDeleteOutcome::Abandoned;
-            }
-        };
+/// Delete pool-scoped IPv4 and IPv6 firewall rules that contain `comment`.
+pub(super) async fn delete_pool_firewall_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
+    let (ipv4, ipv6_filter) = tokio::join!(
+        delete_iptables_rules_by_comment(comment),
+        delete_firewall_rules_from_table("ip6tables", "ip6tables-save", "filter", comment),
+    );
+    if matches!(ipv4, NamespaceDeleteOutcome::Deleted)
+        && matches!(ipv6_filter, NamespaceDeleteOutcome::Deleted)
+    {
+        NamespaceDeleteOutcome::Deleted
+    } else {
+        NamespaceDeleteOutcome::Abandoned
+    }
+}
+
+async fn delete_firewall_rules_from_table(
+    command: &str,
+    save_command: &str,
+    table: &str,
+    comment: &str,
+) -> NamespaceDeleteOutcome {
+    let output = match exec_with_timeout(save_command, &["-t", table], NETNS_COMMAND_TIMEOUT).await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            warn!(save_command, table, error = %e, "failed to read firewall rules, skipping cleanup");
+            return NamespaceDeleteOutcome::Abandoned;
+        }
+    };
     // Sequential: xtables lock serializes writes to the same table anyway.
     // Note: split_whitespace + trim_matches('"') is safe because namespace
     // comment values (e.g. "vm0-ns-00-0a") never contain spaces. If they
@@ -494,8 +569,7 @@ async fn delete_iptables_from_table(table: &str, comment: &str) -> NamespaceDele
         let rule = line.replacen("-A ", "-D ", 1);
         let mut args: Vec<&str> = vec!["-t", table];
         args.extend(rule.split_whitespace().map(|t| t.trim_matches('"')));
-        outcomes
-            .push(exec_ignore_errors_with_timeout("iptables", &args, NETNS_COMMAND_TIMEOUT).await);
+        outcomes.push(exec_ignore_errors_with_timeout(command, &args, NETNS_COMMAND_TIMEOUT).await);
     }
     NamespaceDeleteOutcome::from_best_effort(outcomes)
 }
@@ -740,7 +814,7 @@ async fn cleanup_namespaces_by_index(index: u32) {
     //    The Rust-side `contains()` does substring matching, so the prefix matches
     //    all namespaces in this pool. This catches rules left behind even if the
     //    namespace itself was already deleted.
-    let iptables = delete_iptables_rules_by_comment(&prefix).await;
+    let iptables = delete_pool_firewall_rules_by_comment(&prefix).await;
 
     // 2. Discover and delete any remaining namespaces (+ their veth devices).
     let Ok(output) = exec_with_timeout("ip", &["netns", "list"], NETNS_COMMAND_TIMEOUT).await

--- a/crates/sandbox-fc/src/network/pool/naming.rs
+++ b/crates/sandbox-fc/src/network/pool/naming.rs
@@ -35,6 +35,14 @@ pub(super) fn make_host_device(pool_idx: &str, ns_idx: &str) -> String {
     format!("{HOST_PREFIX}{pool_idx}-{ns_idx}")
 }
 
+pub(super) fn make_host_device_dnsmasq_pattern(pool_idx: &str) -> String {
+    format!("{HOST_PREFIX}{pool_idx}-*")
+}
+
+pub(super) fn make_host_device_iptables_pattern(pool_idx: &str) -> String {
+    format!("{HOST_PREFIX}{pool_idx}-+")
+}
+
 /// Generate a unique /30 IP pair for a veth link.
 ///
 /// Each namespace gets a /30 subnet from the `10.200.0.0/16` range:

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -25,9 +25,10 @@ use super::super::readiness::{
 use super::host::ConntrackFlushOutcome;
 use super::host::{
     NamespaceDeleteOutcome, NetnsLifecycleOps, acquire_pool_lock, create_single_namespace,
-    enable_host_ip_forwarding, get_default_interface, reconcile_orphan_namespaces,
+    delete_pool_firewall_rules_by_comment, enable_host_ip_forwarding, get_default_interface,
+    reconcile_orphan_namespaces, setup_dns_input_filter,
 };
-use super::naming::{MAX_NAMESPACES, format_hex_index};
+use super::naming::{MAX_NAMESPACES, format_hex_index, make_host_device_dnsmasq_pattern};
 use super::types::{
     CheckedNetnsPoolConfig, NetnsInfo, NetnsLease, NetnsPoolConfig, NetnsReleaseOutcome,
 };
@@ -157,6 +158,7 @@ struct CleanupPlan {
     namespaces: Vec<NetnsInfo>,
     ops: NetnsLifecycleOps,
     wait_for_pending: Option<watch::Receiver<u64>>,
+    dns_input_filter_comment: Option<String>,
     done: bool,
 }
 
@@ -190,6 +192,11 @@ struct NetnsPoolState {
     dns_readiness_state: DnsReadinessState,
     dns_readiness_probe: DnsReadinessProbe,
     dns_readiness_timeout: Duration,
+    /// Comment shared by the pool-wide IPv4/IPv6 DNS INPUT rules.
+    ///
+    /// Cleanup keeps this ownership marker until the bounded firewall delete
+    /// completes so cancellation cannot silently orphan the rules.
+    dns_input_filter_comment: Option<String>,
     creation_failure: Option<NetworkError>,
     default_iface: String,
     ops: NetnsLifecycleOps,
@@ -248,6 +255,7 @@ impl NetnsPoolState {
             dns_readiness_state: DnsReadinessState::NotRequired,
             dns_readiness_probe: production_dns_readiness_probe(),
             dns_readiness_timeout: DNS_READINESS_OPERATION_TIMEOUT,
+            dns_input_filter_comment: None,
             creation_failure: None,
             default_iface: "test0".into(),
             ops: NetnsLifecycleOps::trusted_for_test(),
@@ -286,6 +294,10 @@ impl NetnsPoolState {
         reconcile_orphan_namespaces(&lock_paths, index, &lock).await;
 
         let default_iface = get_default_interface().await?;
+        let dns_input_filter_comment = match config.dns_port {
+            Some(dns_port) => Some(setup_dns_input_filter(index, dns_port).await?),
+            None => None,
+        };
         let (completion_tx, completion_rx, completion_generation, completion_wake_tx) =
             Self::completion_state();
 
@@ -318,6 +330,7 @@ impl NetnsPoolState {
             },
             dns_readiness_probe: production_dns_readiness_probe(),
             dns_readiness_timeout: DNS_READINESS_OPERATION_TIMEOUT,
+            dns_input_filter_comment,
             creation_failure: None,
             default_iface,
             ops: NetnsLifecycleOps::default(),
@@ -361,7 +374,7 @@ impl NetnsPoolState {
 
     fn host_device_pattern(&self) -> String {
         let pool_idx = format_hex_index(self.pool_index);
-        format!("vm0-ve-{pool_idx}-*")
+        make_host_device_dnsmasq_pattern(&pool_idx)
     }
 
     fn creation_notifier(&self) -> CreationNotifier {
@@ -924,11 +937,25 @@ impl NetnsPoolState {
                 .chain(self.proxy_queue.iter())
                 .cloned(),
         );
+        let dns_input_filter_comment = if namespaces.is_empty() && wait_for_pending.is_none() {
+            self.dns_input_filter_comment.clone()
+        } else {
+            None
+        };
         CleanupPlan {
-            done: namespaces.is_empty() && wait_for_pending.is_none(),
+            done: namespaces.is_empty()
+                && wait_for_pending.is_none()
+                && dns_input_filter_comment.is_none(),
             namespaces,
             ops: self.ops.clone(),
             wait_for_pending,
+            dns_input_filter_comment,
+        }
+    }
+
+    fn commit_dns_input_filter_cleanup(&mut self, comment: &str) {
+        if self.dns_input_filter_comment.as_deref() == Some(comment) {
+            self.dns_input_filter_comment = None;
         }
     }
 
@@ -954,12 +981,18 @@ impl Drop for NetnsPoolState {
     fn drop(&mut self) {
         let queued = self.plain_queue.len() + self.proxy_queue.len();
         let pending = self.pending_plain.len() + self.pending_proxy.len();
-        if self.active || queued != 0 || pending != 0 || !self.in_flight.is_empty() {
+        if self.active
+            || queued != 0
+            || pending != 0
+            || !self.in_flight.is_empty()
+            || self.dns_input_filter_comment.is_some()
+        {
             warn!(
                 active = self.active,
                 queued,
                 pending,
                 in_flight = self.in_flight.len(),
+                dns_input_filter = self.dns_input_filter_comment.is_some(),
                 "NetnsPool dropped without calling cleanup()"
             );
         }
@@ -1086,6 +1119,18 @@ impl NetnsPoolInner {
             {
                 let mut state = self.state.lock().await;
                 state.remove_queued_namespaces(&names);
+            }
+
+            if let Some(comment) = plan.dns_input_filter_comment {
+                let outcome = delete_pool_firewall_rules_by_comment(&comment).await;
+                if matches!(outcome, NamespaceDeleteOutcome::Abandoned) {
+                    warn!(
+                        comment,
+                        "DNS input filter cleanup did not complete cleanly; startup orphan reconciliation will retry"
+                    );
+                }
+                let mut state = self.state.lock().await;
+                state.commit_dns_input_filter_cleanup(&comment);
             }
 
             if let Some(mut waiter) = plan.wait_for_pending

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -135,7 +135,7 @@ pub(crate) struct CheckedNetnsPoolConfig {
 impl NetnsPoolConfig {
     /// Validate host tools required by [`NetnsPool::create`].
     pub(crate) fn into_checked(self) -> std::result::Result<CheckedNetnsPoolConfig, SandboxError> {
-        crate::prerequisites::check_network_prerequisites()?;
+        crate::prerequisites::check_network_prerequisites(self.dns_port.is_some())?;
         Ok(CheckedNetnsPoolConfig { inner: self })
     }
 }

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -60,7 +60,14 @@ const SNAPSHOT_CREATE_COMMAND_GROUPS: &[&[&str]] = &[
     SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
 ];
 
-const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
+const NETWORK_COMMANDS: &[&str] = &[
+    "ip",
+    "iptables",
+    "iptables-save",
+    "ip6tables",
+    "ip6tables-save",
+    "sysctl",
+];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
 const COW_POOL_SNAPSHOT_RESTORE_COMMANDS: &[&str] = &["cp"];
@@ -458,7 +465,15 @@ mod tests {
         let mode = PrerequisiteMode::FactoryFresh;
         assert_eq!(
             required_commands(mode),
-            vec!["ip", "iptables", "iptables-save", "sysctl", "mkfs.ext4"]
+            vec![
+                "ip",
+                "iptables",
+                "iptables-save",
+                "ip6tables",
+                "ip6tables-save",
+                "sysctl",
+                "mkfs.ext4",
+            ]
         );
     }
 
@@ -475,6 +490,8 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
+                "ip6tables",
+                "ip6tables-save",
                 "sysctl",
                 "cp",
                 "mkfs.ext4",
@@ -497,6 +514,8 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
+                "ip6tables",
+                "ip6tables-save",
                 "sysctl",
                 "mkfs.ext4",
                 "unshare",
@@ -544,7 +563,14 @@ mod tests {
     fn network_prerequisites_use_network_command_set() {
         assert_eq!(
             required_commands_for_groups(&[NETWORK_COMMANDS]),
-            vec!["ip", "iptables", "iptables-save", "sysctl"]
+            vec![
+                "ip",
+                "iptables",
+                "iptables-save",
+                "ip6tables",
+                "ip6tables-save",
+                "sysctl",
+            ]
         );
     }
 

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -60,14 +60,8 @@ const SNAPSHOT_CREATE_COMMAND_GROUPS: &[&[&str]] = &[
     SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS,
 ];
 
-const NETWORK_COMMANDS: &[&str] = &[
-    "ip",
-    "iptables",
-    "iptables-save",
-    "ip6tables",
-    "ip6tables-save",
-    "sysctl",
-];
+const NETWORK_COMMANDS: &[&str] = &["ip", "iptables", "iptables-save", "sysctl"];
+const DNS_INPUT_FILTER_COMMANDS: &[&str] = &["ip6tables", "ip6tables-save"];
 const SNAPSHOT_PRIVATE_MOUNT_CREATE_COMMANDS: &[&str] = &["unshare", "bash", "mount"];
 const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "mount", "umount"];
 const COW_POOL_SNAPSHOT_RESTORE_COMMANDS: &[&str] = &["cp"];
@@ -93,9 +87,12 @@ pub(crate) async fn check_prerequisites(
 }
 
 /// Verify host network tools before creating network namespaces.
-pub(crate) fn check_network_prerequisites() -> Result<(), SandboxError> {
+pub(crate) fn check_network_prerequisites(
+    require_dns_input_filter: bool,
+) -> Result<(), SandboxError> {
     let mut errors = Vec::new();
-    check_required_commands(NETWORK_COMMANDS, &mut errors);
+    let commands = network_commands(require_dns_input_filter);
+    check_required_commands(&commands, &mut errors);
     prerequisite_result(errors)
 }
 
@@ -283,6 +280,14 @@ fn required_commands(mode: PrerequisiteMode<'_>) -> Vec<&'static str> {
     required_commands_for_groups(mode.command_groups())
 }
 
+fn network_commands(require_dns_input_filter: bool) -> Vec<&'static str> {
+    if require_dns_input_filter {
+        required_commands_for_groups(&[NETWORK_COMMANDS, DNS_INPUT_FILTER_COMMANDS])
+    } else {
+        required_commands_for_groups(&[NETWORK_COMMANDS])
+    }
+}
+
 fn required_commands_for_groups<'a>(command_groups: &[&'a [&'a str]]) -> Vec<&'a str> {
     let mut commands = Vec::new();
     for group in command_groups {
@@ -465,15 +470,7 @@ mod tests {
         let mode = PrerequisiteMode::FactoryFresh;
         assert_eq!(
             required_commands(mode),
-            vec![
-                "ip",
-                "iptables",
-                "iptables-save",
-                "ip6tables",
-                "ip6tables-save",
-                "sysctl",
-                "mkfs.ext4",
-            ]
+            vec!["ip", "iptables", "iptables-save", "sysctl", "mkfs.ext4"]
         );
     }
 
@@ -490,8 +487,6 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
-                "ip6tables",
-                "ip6tables-save",
                 "sysctl",
                 "cp",
                 "mkfs.ext4",
@@ -514,8 +509,6 @@ mod tests {
                 "ip",
                 "iptables",
                 "iptables-save",
-                "ip6tables",
-                "ip6tables-save",
                 "sysctl",
                 "mkfs.ext4",
                 "unshare",
@@ -560,16 +553,20 @@ mod tests {
     }
 
     #[test]
-    fn network_prerequisites_use_network_command_set() {
+    fn network_prerequisites_only_require_ipv6_tools_for_dns_filter() {
         assert_eq!(
-            required_commands_for_groups(&[NETWORK_COMMANDS]),
+            network_commands(false),
+            vec!["ip", "iptables", "iptables-save", "sysctl"]
+        );
+        assert_eq!(
+            network_commands(true),
             vec![
                 "ip",
                 "iptables",
                 "iptables-save",
+                "sysctl",
                 "ip6tables",
                 "ip6tables-save",
-                "sysctl",
             ]
         );
     }


### PR DESCRIPTION
## Summary

- replace dnsmasq `--bind-dynamic` with its default wildcard sockets so veth address churn cannot rebuild a per-address listener set in the query event loop
- preserve listener isolation with pool-scoped IPv4 and IPv6 INPUT filters plus dnsmasq interface validation
- keep filters installed until dnsmasq exits, reconcile orphaned rules, and terminate dnsmasq when its runner parent dies
- add permanent metal regression coverage for listener cardinality, dual-stack access isolation, and filter cleanup

## Root cause

[Crates run 29316881674, job 87033798293](https://github.com/vm0-ai/vm0/actions/runs/29316881674/job/87033798293) showed a host-wide dnsmasq event-loop stall rather than a guest-only resolver failure:

- guest link, route, and gateway-neighbor state were healthy
- a host-namespace query failed concurrently
- many namespaces stalled together, then dnsmasq processed their fixed-record queries in a burst
- `--bind-dynamic` had expanded one resolver to more than 200 per-address UDP/TCP IPv4/IPv6 descriptors and synchronously maintained them during veth churn

Using constant wildcard sockets avoids listener-set rebuilds. Three same-pool metal stress attempts with 192 attachments each completed with zero DNS failures and four dnsmasq listeners throughout: [attempt 1](https://github.com/vm0-ai/vm0/actions/runs/29323997820/job/87056547131), [attempt 2](https://github.com/vm0-ai/vm0/actions/runs/29323997820/job/87057225858), [attempt 3](https://github.com/vm0-ai/vm0/actions/runs/29323997820/job/87057901213).

## Security and lifecycle

- public, management, other-pool, and non-matching veth interfaces cannot reach the private wildcard DNS port over IPv4 or IPv6
- firewall rules are installed before dnsmasq starts and removed only after dnsmasq exits
- orphaned rules are reconciled during startup and cleanup
- `PR_SET_PDEATHSIG` plus a post-install parent check closes the runner-parent exit race
- cancellation before `DnsProxy` ownership transfer kills the partially started dnsmasq child
- IPv6 tooling is required only for configurations that enable the runner-managed DNS service
- no API, schema, persisted state, queue payload, or cross-version protocol changes are introduced

## Validation

Current head: `31336d90d9`

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --no-deps`
- `cargo test -p runner` (2676 passed, 9 ignored)
- `cargo test -p sandbox-fc` (704 passed)
- `pnpm prettier --check ../.github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml`
- extracted `runner-exec` remote script checked with `bash -n`

Part of #21343

Diagnostic follow-up: #21366