### PR TITLE
fix(platform): align standalone viewport with software keyboard

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -1,17 +1,20 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
+import { createDeferredPromise } from "../../signals/utils.ts";
 import { setupVisualViewportKeyboardState } from "../visual-viewport-keyboard.ts";
 
 class MockVisualViewport extends EventTarget {
   height: number;
   offsetTop = 0;
+  scale = 1;
 
   constructor(height: number) {
     super();
     this.height = height;
   }
 
-  resizeTo(height: number): void {
+  resizeTo(height: number, offsetTop = this.offsetTop): void {
     this.height = height;
+    this.offsetTop = offsetTop;
     this.dispatchEvent(new Event("resize"));
   }
 }
@@ -37,9 +40,36 @@ function focusTextEntry(): HTMLTextAreaElement {
   return textarea;
 }
 
+function waitForAnimationFrames(frameCount = 2): Promise<void> {
+  const viewportUpdated = createDeferredPromise<void>(AbortSignal.any([]));
+  let remainingFrameCount = frameCount;
+  const handleAnimationFrame = () => {
+    remainingFrameCount -= 1;
+    if (remainingFrameCount === 0) {
+      viewportUpdated.resolve();
+      return;
+    }
+    window.requestAnimationFrame(handleAnimationFrame);
+  };
+  window.requestAnimationFrame(handleAnimationFrame);
+  return viewportUpdated.promise;
+}
+
+function startViewportKeyboardState(): () => void {
+  const cleanup = setupVisualViewportKeyboardState();
+  onTestFinished(cleanup);
+  return cleanup;
+}
+
 afterEach(() => {
   document.body.replaceChildren();
   delete document.documentElement.dataset.keyboardOpen;
+  document.documentElement.style.removeProperty(
+    "--zero-keyboard-viewport-height",
+  );
+  document.documentElement.style.removeProperty(
+    "--zero-keyboard-viewport-offset-top",
+  );
   Object.defineProperty(window, "visualViewport", {
     configurable: true,
     value: undefined,
@@ -47,60 +77,178 @@ afterEach(() => {
 });
 
 describe("visual viewport keyboard state", () => {
-  it("keeps the safe-area state when text entry is focused without viewport shrink", () => {
+  it("keeps the safe-area state when text entry is focused without viewport shrink", async () => {
     const viewport = new MockVisualViewport(844);
     setInnerHeight(844);
     installVisualViewport(viewport);
 
-    const cleanup = setupVisualViewportKeyboardState();
+    startViewportKeyboardState();
     focusTextEntry();
     viewport.resizeTo(844);
+    await waitForAnimationFrames();
 
     expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
-
-    cleanup();
   });
 
-  it("marks the keyboard open only while a focused text entry occludes the viewport", () => {
+  it("marks the keyboard open only while a focused text entry occludes the viewport", async () => {
     const viewport = new MockVisualViewport(844);
     setInnerHeight(844);
     installVisualViewport(viewport);
 
-    const cleanup = setupVisualViewportKeyboardState();
+    startViewportKeyboardState();
     focusTextEntry();
 
     viewport.resizeTo(520);
+    await waitForAnimationFrames();
     expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-height",
+      ),
+    ).toBe("520px");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-offset-top",
+      ),
+    ).toBe("0px");
 
     viewport.resizeTo(844);
+    await waitForAnimationFrames();
     expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
-
-    cleanup();
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-height",
+      ),
+    ).toBe("");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-offset-top",
+      ),
+    ).toBe("");
   });
 
-  it("clears the keyboard state when focus leaves the text entry", () => {
+  it("marks the keyboard open when a standalone viewport also shifts down", async () => {
     const viewport = new MockVisualViewport(844);
     setInnerHeight(844);
     installVisualViewport(viewport);
 
-    const cleanup = setupVisualViewportKeyboardState();
+    startViewportKeyboardState();
+    focusTextEntry();
+
+    viewport.resizeTo(520, 324);
+    await waitForAnimationFrames();
+    expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-height",
+      ),
+    ).toBe("520px");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-offset-top",
+      ),
+    ).toBe("324px");
+  });
+
+  it("reads viewport metrics after standalone layout settles", async () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    startViewportKeyboardState();
+    focusTextEntry();
+
+    viewport.resizeTo(844);
+    window.requestAnimationFrame(() => {
+      viewport.resizeTo(844);
+      window.requestAnimationFrame(() => {
+        viewport.height = 520;
+        viewport.offsetTop = 324;
+      });
+    });
+    await waitForAnimationFrames(3);
+
+    expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+  });
+
+  it("does not treat visual viewport zoom as keyboard occlusion", async () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    startViewportKeyboardState();
+    focusTextEntry();
+
+    viewport.scale = 2;
+    viewport.resizeTo(422);
+    await waitForAnimationFrames();
+
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+  });
+
+  it("detects keyboard occlusion while the focused viewport is zoomed", async () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    startViewportKeyboardState();
+    focusTextEntry();
+
+    viewport.scale = 1.066;
+    viewport.resizeTo(488, 356);
+    await waitForAnimationFrames();
+
+    expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-height",
+      ),
+    ).toBe("488px");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--zero-keyboard-viewport-offset-top",
+      ),
+    ).toBe("356px");
+  });
+
+  it("resets the baseline after orientation metrics settle", async () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    startViewportKeyboardState();
+    focusTextEntry();
+
+    window.dispatchEvent(new Event("orientationchange"));
+    window.requestAnimationFrame(() => {
+      setInnerHeight(390);
+      viewport.height = 390;
+    });
+    await waitForAnimationFrames();
+
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+  });
+
+  it("clears the keyboard state when focus leaves the text entry", async () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    startViewportKeyboardState();
     const textarea = focusTextEntry();
     viewport.resizeTo(520);
+    await waitForAnimationFrames();
 
     textarea.blur();
     expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
-
-    cleanup();
   });
 
   it("does not mark keyboard state without visualViewport support", () => {
     setInnerHeight(844);
 
-    const cleanup = setupVisualViewportKeyboardState();
+    startViewportKeyboardState();
     focusTextEntry();
 
     expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
-
-    cleanup();
   });
 });

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,5 +1,8 @@
 const KEYBOARD_SHRINK_RATIO = 0.15;
 const MIN_KEYBOARD_SHRINK_PX = 120;
+const KEYBOARD_VIEWPORT_HEIGHT_PROPERTY = "--zero-keyboard-viewport-height";
+const KEYBOARD_VIEWPORT_OFFSET_TOP_PROPERTY =
+  "--zero-keyboard-viewport-offset-top";
 
 const TEXT_ENTRY_SELECTOR =
   "textarea, select, [contenteditable]:not([contenteditable='false'])";
@@ -48,8 +51,7 @@ function viewportHasKeyboardOcclusion(
   baselineHeight: number,
   viewport: VisualViewport,
 ): boolean {
-  const visibleBottom = viewport.height + viewport.offsetTop;
-  const occludedHeight = baselineHeight - visibleBottom;
+  const occludedHeight = baselineHeight - viewport.height * viewport.scale;
   const threshold = Math.max(
     MIN_KEYBOARD_SHRINK_PX,
     baselineHeight * KEYBOARD_SHRINK_RATIO,
@@ -58,12 +60,24 @@ function viewportHasKeyboardOcclusion(
   return occludedHeight > threshold;
 }
 
-function setKeyboardOpen(open: boolean): void {
-  if (open) {
-    document.documentElement.dataset.keyboardOpen = "true";
-  } else {
-    delete document.documentElement.dataset.keyboardOpen;
-  }
+function setKeyboardOpen(viewport: VisualViewport): void {
+  const root = document.documentElement;
+  root.dataset.keyboardOpen = "true";
+  root.style.setProperty(
+    KEYBOARD_VIEWPORT_HEIGHT_PROPERTY,
+    `${viewport.height}px`,
+  );
+  root.style.setProperty(
+    KEYBOARD_VIEWPORT_OFFSET_TOP_PROPERTY,
+    `${viewport.offsetTop}px`,
+  );
+}
+
+function setKeyboardClosed(): void {
+  const root = document.documentElement;
+  delete root.dataset.keyboardOpen;
+  root.style.removeProperty(KEYBOARD_VIEWPORT_HEIGHT_PROPERTY);
+  root.style.removeProperty(KEYBOARD_VIEWPORT_OFFSET_TOP_PROPERTY);
 }
 
 export function setupVisualViewportKeyboardState(): () => void {
@@ -71,12 +85,14 @@ export function setupVisualViewportKeyboardState(): () => void {
 
   if (!viewport) {
     return () => {
-      setKeyboardOpen(false);
+      setKeyboardClosed();
     };
   }
 
   let baselineHeight = readLayoutViewportHeight(viewport);
   let keyboardOpen = false;
+  let resetBaselineAfterLayout = false;
+  let scheduledFrameId: number | null = null;
 
   const update = () => {
     const activeTextEntry = isTextEntryElement(document.activeElement);
@@ -84,7 +100,7 @@ export function setupVisualViewportKeyboardState(): () => void {
     if (!activeTextEntry) {
       keyboardOpen = false;
       baselineHeight = readLayoutViewportHeight(viewport);
-      setKeyboardOpen(false);
+      setKeyboardClosed();
       return;
     }
 
@@ -96,27 +112,50 @@ export function setupVisualViewportKeyboardState(): () => void {
     }
 
     keyboardOpen = viewportHasKeyboardOcclusion(baselineHeight, viewport);
-    setKeyboardOpen(keyboardOpen);
+    if (keyboardOpen) {
+      setKeyboardOpen(viewport);
+    } else {
+      setKeyboardClosed();
+    }
   };
 
-  const resetBaseline = () => {
-    baselineHeight = readLayoutViewportHeight(viewport);
-    update();
+  const scheduleUpdate = () => {
+    if (scheduledFrameId !== null) {
+      window.cancelAnimationFrame(scheduledFrameId);
+    }
+    scheduledFrameId = window.requestAnimationFrame(() => {
+      scheduledFrameId = window.requestAnimationFrame(() => {
+        scheduledFrameId = null;
+        if (resetBaselineAfterLayout) {
+          baselineHeight = readLayoutViewportHeight(viewport);
+          resetBaselineAfterLayout = false;
+        }
+        update();
+      });
+    });
   };
 
-  viewport.addEventListener("resize", update);
-  viewport.addEventListener("scroll", update);
-  window.addEventListener("orientationchange", resetBaseline);
+  const scheduleBaselineReset = () => {
+    resetBaselineAfterLayout = true;
+    scheduleUpdate();
+  };
+
+  viewport.addEventListener("resize", scheduleUpdate);
+  viewport.addEventListener("scroll", scheduleUpdate);
+  window.addEventListener("orientationchange", scheduleBaselineReset);
   document.addEventListener("focusin", update);
   document.addEventListener("focusout", update);
   update();
 
   return () => {
-    viewport.removeEventListener("resize", update);
-    viewport.removeEventListener("scroll", update);
-    window.removeEventListener("orientationchange", resetBaseline);
+    viewport.removeEventListener("resize", scheduleUpdate);
+    viewport.removeEventListener("scroll", scheduleUpdate);
+    window.removeEventListener("orientationchange", scheduleBaselineReset);
     document.removeEventListener("focusin", update);
     document.removeEventListener("focusout", update);
-    setKeyboardOpen(false);
+    if (scheduledFrameId !== null) {
+      window.cancelAnimationFrame(scheduledFrameId);
+    }
+    setKeyboardClosed();
   };
 }

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -76,14 +76,18 @@ describe("platform entrypoint safe area behavior", () => {
 
     expect(globalCss).toMatch(/--zero-viewport-height:\s*100dvh;/);
     expect(globalCss).toMatch(/--zero-viewport-height:\s*100lvh;/);
+    expect(globalCss).toMatch(/--zero-viewport-offset-top:\s*0px;/);
     expect(globalCss).toMatch(
-      /:root\[data-keyboard-open="true"\]\s*{\s*--zero-viewport-height:\s*100dvh;\s*}/,
+      /:root\[data-keyboard-open="true"\]\s*{[\s\S]*?--zero-viewport-height:\s*var\(--zero-keyboard-viewport-height,\s*100dvh\);/,
+    );
+    expect(globalCss).toMatch(
+      /--zero-viewport-offset-top:\s*var\(\s*--zero-keyboard-viewport-offset-top,\s*0px\s*\);/,
     );
     expect(globalCss).toMatch(
       /html,\s*body,\s*#root\s*{[\s\S]*overflow:\s*hidden;[\s\S]*overscroll-behavior:\s*none;/,
     );
     expect(globalCss).toMatch(
-      /#root\s*{[\s\S]*position:\s*fixed;[\s\S]*top:\s*0;[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
+      /#root\s*{[\s\S]*position:\s*fixed;[\s\S]*top:\s*var\(--zero-viewport-offset-top\);[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
     );
     expect(globalCss).toMatch(
       /#root\s*{[\s\S]*box-sizing:\s*border-box;[\s\S]*background-color:\s*hsl\(var\(--background\)\);[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab\)\s+var\(--sal\);/,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -60,6 +60,7 @@
   --sab: var(--sab-raw);
   --sal: env(safe-area-inset-left, 0px);
   --zero-viewport-height: 100dvh;
+  --zero-viewport-offset-top: 0px;
   --zero-desktop-titlebar-height: 48px;
 }
 
@@ -75,11 +76,10 @@
   --sab: 0px;
 }
 
-@supports (height: 100lvh) {
-  @media (display-mode: standalone) {
-    :root[data-keyboard-open="true"] {
-      --zero-viewport-height: 100dvh;
-    }
+@media (display-mode: standalone) {
+  :root[data-keyboard-open="true"] {
+    --zero-viewport-height: var(--zero-keyboard-viewport-height, 100dvh);
+    --zero-viewport-offset-top: var(--zero-keyboard-viewport-offset-top, 0px);
   }
 }
 
@@ -100,7 +100,7 @@ body {
 #root {
   box-sizing: border-box;
   position: fixed;
-  top: 0;
+  top: var(--zero-viewport-offset-top);
   right: 0;
   left: 0;
   /* Keep the root-owned safe-area padding opaque behind translucent iOS chrome. */


### PR DESCRIPTION
## Summary

- Detect software-keyboard occlusion from settled VisualViewport geometry with scale-aware measurements.
- Size and offset the standalone PWA root to the exact visible viewport while the keyboard is open, then clear the overrides on close.
- Add regression coverage for shifted and delayed viewport metrics, zoom, orientation changes, and cleanup.

## Validation

- Prettier check passed for all changed files.
- Platform lint and TypeScript checks passed.
- Targeted VisualViewport and safe-area tests passed: 14/14.
- Platform Knip check passed.
- Installed standalone PWA on iPhone 17 / iOS 26.5 Simulator passed 10 consecutive software-keyboard open/close cycles with the header, composer, and caret aligned.
- Full platform Vitest run passed 1000/1003 tests; the remaining 3 were intermittent unrelated UI failures in chat-composer-models-and-templates and zero-sidebar-account-menu, with isolated reruns passing or failing different cases.