### PR TITLE
fix(platform): download zip artifacts from the artifacts menu

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -795,6 +795,41 @@ describe("artifacts page", () => {
     ).toHaveAttribute("href", cdnImageUrl);
   });
 
+  it("downloads zip artifacts from the actions menu", async () => {
+    setupTeam();
+    const scope = testAuthScope("download-zip");
+    const artifact = createArtifact({
+      filename: "launch-assets.zip",
+      contentType: "application/zip",
+      url: "https://artifacts.example.com/launch-assets.zip",
+      artifactKind: undefined,
+    });
+    const downloads = context.mocks.browser.blobDownload();
+    context.mocks.http.get(artifact.url, () => {
+      return new Response("zip contents", {
+        headers: { "Content-Type": "application/zip" },
+      });
+    });
+    mockArtifacts([artifact]);
+
+    setupArtifactsPage({ scope });
+
+    await screen.findByText("launch-assets.zip");
+    click(buttonByLabel("More actions for launch-assets.zip"));
+    const downloadItem = screen
+      .getByText("Download")
+      .closest("[role=menuitem]");
+    expect(downloadItem).not.toBeNull();
+    expect(downloadItem?.querySelector(".tabler-icon-download")).not.toBeNull();
+    expect(screen.queryByText("Open a new tab")).not.toBeInTheDocument();
+
+    click(screen.getByText("Download"));
+    await waitFor(() => {
+      expect(downloads.downloads).toHaveLength(1);
+    });
+    expect(downloads.downloads[0]?.filename).toBe("launch-assets.zip");
+  });
+
   it("opens previewable artifacts in the lightbox without split view", async () => {
     setupTeam();
     const scope = testAuthScope("preview-lightbox");

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -795,40 +795,45 @@ describe("artifacts page", () => {
     ).toHaveAttribute("href", cdnImageUrl);
   });
 
-  it("downloads zip artifacts from the actions menu", async () => {
-    setupTeam();
-    const scope = testAuthScope("download-zip");
-    const artifact = createArtifact({
-      filename: "launch-assets.zip",
-      contentType: "application/zip",
-      url: "https://artifacts.example.com/launch-assets.zip",
-      artifactKind: undefined,
-    });
-    const downloads = context.mocks.browser.blobDownload();
-    context.mocks.http.get(artifact.url, () => {
-      return new Response("zip contents", {
-        headers: { "Content-Type": "application/zip" },
+  it.each(["application/zip", "application/x-zip-compressed"])(
+    "downloads %s artifacts from the actions menu",
+    async (contentType) => {
+      setupTeam();
+      const scope = testAuthScope("download-zip");
+      const artifact = createArtifact({
+        filename: "launch-assets.zip",
+        contentType,
+        url: "https://artifacts.example.com/launch-assets.zip",
+        artifactKind: undefined,
       });
-    });
-    mockArtifacts([artifact]);
+      const downloads = context.mocks.browser.blobDownload();
+      context.mocks.http.get(artifact.url, () => {
+        return new Response("zip contents", {
+          headers: { "Content-Type": contentType },
+        });
+      });
+      mockArtifacts([artifact]);
 
-    setupArtifactsPage({ scope });
+      setupArtifactsPage({ scope });
 
-    await screen.findByText("launch-assets.zip");
-    click(buttonByLabel("More actions for launch-assets.zip"));
-    const downloadItem = screen
-      .getByText("Download")
-      .closest("[role=menuitem]");
-    expect(downloadItem).not.toBeNull();
-    expect(downloadItem?.querySelector(".tabler-icon-download")).not.toBeNull();
-    expect(screen.queryByText("Open a new tab")).not.toBeInTheDocument();
+      await screen.findByText("launch-assets.zip");
+      click(buttonByLabel("More actions for launch-assets.zip"));
+      const downloadItem = screen
+        .getByText("Download")
+        .closest("[role=menuitem]");
+      expect(downloadItem).not.toBeNull();
+      expect(
+        downloadItem?.querySelector(".tabler-icon-download"),
+      ).not.toBeNull();
+      expect(screen.queryByText("Open a new tab")).not.toBeInTheDocument();
 
-    click(screen.getByText("Download"));
-    await waitFor(() => {
-      expect(downloads.downloads).toHaveLength(1);
-    });
-    expect(downloads.downloads[0]?.filename).toBe("launch-assets.zip");
-  });
+      click(screen.getByText("Download"));
+      await waitFor(() => {
+        expect(downloads.downloads).toHaveLength(1);
+      });
+      expect(downloads.downloads[0]?.filename).toBe("launch-assets.zip");
+    },
+  );
 
   it("opens previewable artifacts in the lightbox without split view", async () => {
     setupTeam();

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -9,6 +9,7 @@ import {
   IconAlertTriangle,
   IconCarambola,
   IconCarambolaFilled,
+  IconDownload,
   IconDots,
   IconExternalLink,
   IconHistory,
@@ -98,7 +99,10 @@ import {
   FilePreviewIcon,
   getFilePreviewAccentClass,
 } from "../zero-page/zero-file-preview-icon.tsx";
-import { publicAttachmentUrl } from "../zero-page/zero-attachment-url.ts";
+import {
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "../zero-page/zero-attachment-url.ts";
 
 type ArtifactPreviewKind = "image" | "html" | "pdf" | "video" | "file";
 type ArtifactTypeIconKind = "presentation" | "html" | "image" | "video";
@@ -673,17 +677,32 @@ function ArtifactCardActions({
             <IconHistory size={14} stroke={1.7} aria-hidden />
             View creation chat
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <a
-              href={previewUrl}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={`Open preview for ${item.filename}`}
+          {item.contentType === "application/zip" ? (
+            <DropdownMenuItem
+              onClick={() => {
+                detach(
+                  downloadAttachmentUrl(item.url, undefined, item.filename),
+                  Reason.DomCallback,
+                  "artifact download",
+                );
+              }}
             >
-              <IconExternalLink size={14} stroke={1.7} aria-hidden />
-              Open a new tab
-            </a>
-          </DropdownMenuItem>
+              <IconDownload size={14} stroke={1.7} aria-hidden />
+              Download
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem asChild>
+              <a
+                href={previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`Open preview for ${item.filename}`}
+              >
+                <IconExternalLink size={14} stroke={1.7} aria-hidden />
+                Open a new tab
+              </a>
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -168,6 +168,13 @@ function artifactPreviewKind(item: ArtifactItem): ArtifactPreviewKind {
   return "file";
 }
 
+function isZipArtifact(item: ArtifactItem): boolean {
+  return (
+    item.contentType === "application/zip" ||
+    item.contentType === "application/x-zip-compressed"
+  );
+}
+
 function artifactCardImageSupportsTransform(item: ArtifactItem): boolean {
   const extension = item.filename.split(".").pop()?.toLowerCase();
   return (
@@ -677,7 +684,7 @@ function ArtifactCardActions({
             <IconHistory size={14} stroke={1.7} aria-hidden />
             View creation chat
           </DropdownMenuItem>
-          {item.contentType === "application/zip" ? (
+          {isZipArtifact(item) ? (
             <DropdownMenuItem
               onClick={() => {
                 detach(


### PR DESCRIPTION
## Summary

- replace the ZIP artifact menu action from "Open a new tab" to "Download"
- use the download icon and the existing blob download path to preserve the ZIP filename
- keep the existing new-tab action unchanged for non-ZIP artifacts

## Verification

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx --silent=passed-only` (24 tests passed)
- Browser verification unavailable because the local platform environment is missing `VITE_CLERK_PUBLISHABLE_KEY`
