### PR TITLE
test(mitm-addon): assert response-error usage quantity

### DIFF
--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -59,7 +59,9 @@ class TestUsageReportingIdempotency:
             usage.flush_usage_events(trigger="test")
 
         events = webhook.usage_events()
-        assert [event["category"] for event in events] == ["tokens.output"]
+        assert [(event["category"], event["quantity"]) for event in events] == [
+            ("tokens.output", 20)
+        ]
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         if jsonl_exists_after_flush(proxy_log):
             entries = read_jsonl_entries_after_flush(proxy_log)


### PR DESCRIPTION
## Summary

- assert the delivered model usage category and quantity together in the response/error idempotency test
- make duplicate same-category aggregation visible as a test failure

## Scope

- test-only change in the mitmproxy addon
- no production code, schema, API, configuration, or documentation changes

## Validation

- `.venv/bin/ruff format --check tests/test_usage_reporting_idempotency.py`
- `.venv/bin/ruff check tests/test_usage_reporting_idempotency.py`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest -q tests/test_usage_reporting_idempotency.py` (`4 passed`)
- `.venv/bin/python -m pytest -q tests/` (`3917 passed`)
- mutation check: forced both lifecycle observations to aggregate and confirmed the assertion failed with quantity `40`; mutation was reverted

Closes #21354
