### PR TITLE
fix(ably-subscriber): enforce clean websocket shutdown

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -19,8 +19,8 @@ use super::message::{decode_data, message_targets_channel};
 use super::session::{SessionState, TokenRenewalFailure};
 use super::state::{ChannelLifecycleState, reconnect_spacing_delay, retry_delay};
 use super::transport::{
-    WsRead, WsTransport, WsWrite, connect_and_split, websocket_close_frame_reason,
-    websocket_close_reason, websocket_error_reason,
+    WsTransport, connect_pending, websocket_close_frame_reason, websocket_close_reason,
+    websocket_error_reason,
 };
 use crate::Error;
 use crate::protocol::{
@@ -158,8 +158,8 @@ async fn send_close_message(p: &mut EventLoopState) {
     p.session.mark_closed();
 }
 
-// Reconnect paths should only close the current WebSocket transport. Sending
-// Ably CLOSE here would terminate the resumable connection state on the server.
+// Transport-only shutdown paths must not send Ably CLOSE, which would terminate
+// resumable connection state or duplicate a server-declared CLOSED transition.
 //
 // The transport is detached synchronously so status events and reconnects are
 // not delayed by a slow close handshake. The bounded background close still
@@ -168,24 +168,7 @@ fn close_websocket_transport(p: &mut EventLoopState) {
     let Some(transport) = p.transport.take() else {
         return;
     };
-    let WsTransport {
-        ws_read: _ws_read,
-        mut ws_write,
-    } = transport;
-    let close_timeout = p.timing.close_timeout;
-    let close_task = tokio::spawn(async move {
-        let result = tokio::time::timeout(close_timeout, async move {
-            let _ = ws_write.close().await;
-        })
-        .await;
-        if result.is_err() {
-            tracing::warn!(
-                timeout_ms = close_timeout.as_millis(),
-                "Timed out while closing websocket transport"
-            );
-        }
-    });
-    drop(close_task);
+    transport.close_in_background(p.timing.close_timeout);
 }
 
 async fn send_status_event(
@@ -533,8 +516,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     connected_msg,
                     channel_serial,
                     token,
-                    ws_read,
-                    ws_write,
+                    transport,
                 }) => {
                     p.session.commit_reconnect_attached(
                         &connected_msg,
@@ -542,7 +524,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                         token,
                         p.timing.token_renewal_margin,
                     );
-                    p.transport = Some(WsTransport::new(ws_read, ws_write));
+                    p.transport = Some(transport);
                     if !send_status_event(&mut p, &mut close_rx, Event::Connected, "connected")
                         .await
                     {
@@ -553,8 +535,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 Ok(ReconnectOutcome::ChannelSuspended {
                     connected_msg,
                     token,
-                    ws_read,
-                    ws_write,
+                    transport,
                 }) => {
                     p.session.commit_reconnect_channel_suspended(
                         &connected_msg,
@@ -562,7 +543,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                         p.timing.token_renewal_margin,
                         p.timing.channel_retry_timeout,
                     );
-                    p.transport = Some(WsTransport::new(ws_read, ws_write));
+                    p.transport = Some(transport);
                     continue 'outer;
                 }
                 Ok(ReconnectOutcome::Closed) => {
@@ -615,14 +596,12 @@ enum ReconnectOutcome {
         connected_msg: ProtocolMessage,
         channel_serial: Option<String>,
         token: Option<TokenDetails>,
-        ws_read: WsRead,
-        ws_write: WsWrite,
+        transport: WsTransport,
     },
     ChannelSuspended {
         connected_msg: ProtocolMessage,
         token: Option<TokenDetails>,
-        ws_read: WsRead,
-        ws_write: WsWrite,
+        transport: WsTransport,
     },
     Closed,
 }
@@ -846,6 +825,7 @@ async fn handle_message(
         action::CLOSED => {
             tracing::info!("Connection closed by server");
             p.session.mark_closed();
+            close_websocket_transport(p);
             return LoopAction::Stop;
         }
         action::AUTH => {
@@ -966,7 +946,7 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 /// caller moves the channel into suspended retry, matching ably-js.
 async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, Error> {
     let reconnect_timeout = p.timing.reconnect_timeout;
-    let (connected_msg, mut ws_read, mut ws_write, new_token) =
+    let (connected_msg, mut transport, new_token) =
         tokio::time::timeout(reconnect_timeout, async {
             let use_resume = p.session.can_resume();
 
@@ -990,9 +970,9 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             };
 
             let ws_url = build_ws_url(&p.realtime_host, &active_token, resume.as_deref())?;
-            let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
+            let mut transport = connect_pending(&ws_url, p.timing.close_timeout).await?;
 
-            let connected_msg = wait_for_connected(&mut ws_read).await?;
+            let connected_msg = wait_for_connected(transport.read_mut()?).await?;
 
             let resumed = use_resume
                 && connected_msg.connection_id.as_deref() == p.session.connection_id()
@@ -1021,11 +1001,12 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
                 p.session.channel_serial(),
                 p.session.attach_mode(),
             )?;
-            ws_write
+            transport
+                .write_mut()?
                 .send(tungstenite::Message::Binary(data.into()))
                 .await?;
 
-            Ok::<_, Error>((connected_msg, ws_read, ws_write, new_token))
+            Ok::<_, Error>((connected_msg, transport, new_token))
         })
         .await
         .map_err(|_| Error::Protocol {
@@ -1035,7 +1016,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
 
     let attach_outcome = match tokio::time::timeout(p.timing.realtime_request_timeout, async {
         loop {
-            match wait_for_attach_outcome(&mut ws_read, &p.channel).await? {
+            match wait_for_attach_outcome(transport.read_mut()?, &p.channel).await? {
                 AttachOutcome::RetryAttach(err) => {
                     tracing::warn!(
                         code = err.code,
@@ -1048,7 +1029,8 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
                         p.session.channel_serial(),
                         p.session.attach_mode(),
                     )?;
-                    ws_write
+                    transport
+                        .write_mut()?
                         .send(tungstenite::Message::Binary(data.into()))
                         .await?;
                 }
@@ -1068,8 +1050,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             connected_msg,
             channel_serial,
             token: new_token,
-            ws_read,
-            ws_write,
+            transport: transport.into_transport()?,
         },
         AttachOutcome::Detached(err) => {
             tracing::warn!(
@@ -1079,8 +1060,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             ReconnectOutcome::ChannelSuspended {
                 connected_msg,
                 token: new_token,
-                ws_read,
-                ws_write,
+                transport: transport.into_transport()?,
             }
         }
         AttachOutcome::RetryAttach(err) => {
@@ -1105,8 +1085,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
             ReconnectOutcome::ChannelSuspended {
                 connected_msg,
                 token: new_token,
-                ws_read,
-                ws_write,
+                transport: transport.into_transport()?,
             }
         }
     })

--- a/crates/ably-subscriber/src/connection/handshake.rs
+++ b/crates/ably-subscriber/src/connection/handshake.rs
@@ -14,7 +14,7 @@ use super::errors::{
     channel_detached_message, error_or_unknown, protocol_disconnect_reason, protocol_error_message,
 };
 use super::state::ConnState;
-use super::transport::{WsRead, WsWrite, connect_and_split};
+use super::transport::{WsRead, WsTransport, connect_pending};
 
 pub(super) async fn wait_for_connected(ws_read: &mut WsRead) -> Result<ProtocolMessage, Error> {
     while let Some(frame) = ws_read.next().await {
@@ -171,15 +171,16 @@ pub(crate) async fn connect_and_attach(
     channel: &str,
     channel_params: Option<&HashMap<String, String>>,
     timing: &TimingConfig,
-) -> Result<(WsWrite, WsRead, ConnState), Error> {
+) -> Result<(WsTransport, ConnState), Error> {
     let ws_url = build_ws_url(realtime_host, &token.token, None)?;
-    let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
-    let connected_msg = wait_for_connected(&mut ws_read).await?;
+    let mut transport = connect_pending(&ws_url, timing.close_timeout).await?;
+    let connected_msg = wait_for_connected(transport.read_mut()?).await?;
     let mut conn_state = ConnState::from_connected(&connected_msg, token, timing);
     let encoded = encode_attach_for_channel(channel, channel_params, None, AttachMode::Clean)?;
-    ws_write
+    transport
+        .write_mut()?
         .send(tungstenite::Message::Binary(encoded.into()))
         .await?;
-    conn_state.channel_serial = wait_for_attached(&mut ws_read, channel).await?;
-    Ok((ws_write, ws_read, conn_state))
+    conn_state.channel_serial = wait_for_attached(transport.read_mut()?, channel).await?;
+    Ok((transport.into_transport()?, conn_state))
 }

--- a/crates/ably-subscriber/src/connection/mod.rs
+++ b/crates/ably-subscriber/src/connection/mod.rs
@@ -15,4 +15,3 @@ pub(crate) use endpoint::{DEFAULT_REALTIME_HOST, rest_host};
 pub(crate) use event_loop::{DropWarningState, EventLoopState, run_event_loop};
 pub(crate) use handshake::connect_and_attach;
 pub(crate) use session::SessionState;
-pub(crate) use transport::WsTransport;

--- a/crates/ably-subscriber/src/connection/transport.rs
+++ b/crates/ably-subscriber/src/connection/transport.rs
@@ -2,13 +2,14 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures_util::{Stream, StreamExt};
+use futures_util::{SinkExt, Stream, StreamExt};
 use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 use super::state::idle_deadline;
 use crate::Error;
+use crate::protocol::error_code;
 use crate::types::redact_access_token;
 
 type WsStream =
@@ -55,21 +56,96 @@ impl Stream for WsRead {
     }
 }
 
-pub(super) async fn connect_and_split(url: &str) -> Result<(WsWrite, WsRead), Error> {
-    let (ws, _resp) = tokio_tungstenite::connect_async(url).await?;
-    let (ws_write, ws_read) = ws.split();
-    Ok((ws_write, WsRead::new(ws_read)))
-}
-
 pub(crate) struct WsTransport {
     pub(super) ws_read: WsRead,
     pub(super) ws_write: WsWrite,
 }
 
 impl WsTransport {
-    pub(crate) fn new(ws_read: WsRead, ws_write: WsWrite) -> Self {
+    fn new(ws_read: WsRead, ws_write: WsWrite) -> Self {
         Self { ws_read, ws_write }
     }
+
+    pub(super) fn close_in_background(self, close_timeout: Duration) {
+        let Self {
+            ws_read,
+            mut ws_write,
+        } = self;
+        drop(ws_read);
+        let close_task = tokio::spawn(async move {
+            let result = tokio::time::timeout(close_timeout, async move {
+                let _ = ws_write.close().await;
+            })
+            .await;
+            if result.is_err() {
+                tracing::warn!(
+                    timeout_ms = close_timeout.as_millis(),
+                    "Timed out while closing websocket transport"
+                );
+            }
+        });
+        drop(close_task);
+    }
+}
+
+/// Owns a connected transport until setup commits it as active.
+///
+/// Dropping a setup future drops this guard and schedules bounded transport
+/// cleanup, so cancellation cannot silently abandon an established WebSocket.
+pub(super) struct PendingWsTransport {
+    transport: Option<WsTransport>,
+    close_timeout: Duration,
+}
+
+impl PendingWsTransport {
+    fn new(transport: WsTransport, close_timeout: Duration) -> Self {
+        Self {
+            transport: Some(transport),
+            close_timeout,
+        }
+    }
+
+    fn transport_mut(&mut self) -> Result<&mut WsTransport, Error> {
+        self.transport.as_mut().ok_or_else(|| Error::Protocol {
+            code: error_code::FAILED,
+            message: "Pending WebSocket transport is unavailable".to_string(),
+        })
+    }
+
+    pub(super) fn read_mut(&mut self) -> Result<&mut WsRead, Error> {
+        Ok(&mut self.transport_mut()?.ws_read)
+    }
+
+    pub(super) fn write_mut(&mut self) -> Result<&mut WsWrite, Error> {
+        Ok(&mut self.transport_mut()?.ws_write)
+    }
+
+    pub(super) fn into_transport(mut self) -> Result<WsTransport, Error> {
+        self.transport.take().ok_or_else(|| Error::Protocol {
+            code: error_code::FAILED,
+            message: "Pending WebSocket transport is unavailable".to_string(),
+        })
+    }
+}
+
+impl Drop for PendingWsTransport {
+    fn drop(&mut self) {
+        if let Some(transport) = self.transport.take() {
+            transport.close_in_background(self.close_timeout);
+        }
+    }
+}
+
+pub(super) async fn connect_pending(
+    url: &str,
+    close_timeout: Duration,
+) -> Result<PendingWsTransport, Error> {
+    let (ws, _resp) = tokio_tungstenite::connect_async(url).await?;
+    let (ws_write, ws_read) = ws.split();
+    Ok(PendingWsTransport::new(
+        WsTransport::new(WsRead::new(ws_read), ws_write),
+        close_timeout,
+    ))
 }
 
 pub(super) fn websocket_close_reason(frame: Option<&CloseFrame>) -> String {

--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -3,8 +3,8 @@
 use tokio::sync::{mpsc, oneshot};
 
 use crate::connection::{
-    DEFAULT_REALTIME_HOST, DropWarningState, EventLoopState, SessionState, WsTransport,
-    connect_and_attach, exchange_token, rest_host, run_event_loop,
+    DEFAULT_REALTIME_HOST, DropWarningState, EventLoopState, SessionState, connect_and_attach,
+    exchange_token, rest_host, run_event_loop,
 };
 use crate::protocol::error_code;
 use crate::types::{Error, Event, SubscribeConfig};
@@ -78,7 +78,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
     let token = exchange_token(&http, &token_request, &rest).await?;
 
     // Connect, handshake, and attach with timeout
-    let (ws_write, ws_read, conn_state) = tokio::time::timeout(
+    let (transport, conn_state) = tokio::time::timeout(
         timing.connect_timeout,
         connect_and_attach(
             &realtime_host,
@@ -99,7 +99,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
     // Spawn background event loop
     tokio::spawn(run_event_loop(
         EventLoopState {
-            transport: Some(WsTransport::new(ws_read, ws_write)),
+            transport: Some(transport),
             event_tx,
             session: SessionState::connected(conn_state),
             channel: config.channel,

--- a/crates/ably-subscriber/tests/integration/close_drop.rs
+++ b/crates/ably-subscriber/tests/integration/close_drop.rs
@@ -6,8 +6,40 @@ use ably_subscriber::{Event, TimingConfig, subscribe};
 use futures_util::{SinkExt, StreamExt};
 use httpmock::prelude::*;
 use std::time::Duration;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_tungstenite::tungstenite;
+
+#[tokio::test]
+async fn websocket_close_assertion_preserves_protocol_error() {
+    let ws = MockAblyServer::start().await.unwrap();
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_raw().await.unwrap();
+        let error = expect_websocket_closed(&mut conn).await.unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<tungstenite::Error>(),
+                Some(tungstenite::Error::Protocol(
+                    tungstenite::error::ProtocolError::UnmaskedFrameFromClient
+                ))
+            ),
+            "expected original unmasked-frame protocol error, got {error:?}"
+        );
+    });
+
+    let tcp = tokio::net::TcpStream::connect(("127.0.0.1", ws_port))
+        .await
+        .unwrap();
+    let (client, _) = tokio_tungstenite::client_async(format!("ws://127.0.0.1:{ws_port}"), tcp)
+        .await
+        .unwrap();
+    let mut tcp = client.into_inner();
+    tcp.write_all(&[0x81, 0x00]).await.unwrap();
+
+    join_server_task(server_task, "invalid websocket frame server")
+        .await
+        .unwrap();
+}
 
 #[tokio::test]
 async fn close_subscription() {

--- a/crates/ably-subscriber/tests/integration/connection_messages.rs
+++ b/crates/ably-subscriber/tests/integration/connection_messages.rs
@@ -396,6 +396,66 @@ async fn message_with_json_encoding() {
 }
 
 #[tokio::test]
+async fn closed_during_initial_attach_closes_websocket() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_raw().await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-1".into()),
+            connection_key: Some("conn-1!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-1!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&connected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let attach = expect_protocol_msg(&mut conn, "initial ATTACH")
+            .await
+            .unwrap();
+        assert_eq!(attach.action, action::ATTACH);
+        assert_eq!(attach.channel.as_deref(), Some("ch"));
+
+        let closed = ProtocolMessage {
+            action: action::CLOSED,
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&closed).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        expect_websocket_closed(&mut conn).await.unwrap();
+    });
+
+    let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
+    match result {
+        Err(ably_subscriber::Error::Protocol { code, message }) => {
+            assert_eq!(code, error_code::FAILED);
+            assert_eq!(message, "Connection closed by server");
+        }
+        Err(other) => panic!("expected Protocol error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+
+    join_server_task(server_task, "initial attach CLOSED server")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn server_error_during_handshake() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration/support/websocket.rs
+++ b/crates/ably-subscriber/tests/integration/support/websocket.rs
@@ -61,7 +61,8 @@ pub(crate) async fn expect_websocket_closed(
         .await
         .map_err(|_| std::io::Error::other("timed out waiting for websocket to close"))?;
     match frame {
-        None | Some(Err(_)) | Some(Ok(tungstenite::Message::Close(_))) => Ok(()),
+        None | Some(Ok(tungstenite::Message::Close(_))) => Ok(()),
+        Some(Err(error)) => Err(error.into()),
         Some(Ok(frame)) => {
             Err(std::io::Error::other(format!("expected websocket close, got {frame:?}")).into())
         }


### PR DESCRIPTION
## Summary

- close active WebSocket transports after an Ably `CLOSED` message
- make initial and reconnect setup cancellation-safe by retaining pending transport ownership until handoff
- tighten integration assertions so protocol errors cannot masquerade as clean WebSocket shutdowns
- cover initial-attach `CLOSED`, reconnect cancellation, and assertion error propagation

## Scope

This changes only `ably-subscriber` transport shutdown behavior and its integration tests. It does not change the public API, reconnect/resume policy, or Ably protocol error mapping.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --all-features`
- `git diff --check`

Closes #21353
