### PR TITLE
feat: move template categories into a responsive sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -3286,6 +3286,9 @@ describe("chat composer templates", () => {
   });
 
   it("opens the template picker with responsive category navigation", async () => {
+    const user = userEvent.setup({ delay: null });
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const videoTemplate = VIDEO_TEMPLATE_ITEMS[0]!;
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     detachedSetupPage({
@@ -3314,17 +3317,68 @@ describe("chat composer templates", () => {
     expect(tabByText("Presentation")).toHaveClass("bg-card");
     expect(tabByText("Presentation")).toHaveClass("text-foreground");
     expect(tabByText("Illustration")).toHaveClass("text-muted-foreground");
-    expect(
-      screen.getByRole("combobox", { name: "Template category" }),
-    ).toBeInTheDocument();
+    const categorySelect = screen.getByRole("combobox", {
+      name: "Template category",
+    });
+    expect(categorySelect).toBeInTheDocument();
 
-    const categorySidebar = document.querySelector(
-      "[data-template-picker-sidebar]",
-    );
+    const categorySidebar = screen.getByRole("tablist", {
+      name: "Template categories",
+    });
     expect(categorySidebar).toBeInstanceOf(HTMLElement);
+    expect(categorySidebar).toHaveAttribute("aria-orientation", "vertical");
     expect(categorySidebar).toHaveClass("hidden");
     expect(categorySidebar).toHaveClass("sm:flex");
     expect(categorySidebar).toHaveClass("bg-gray-50");
+
+    await user.click(categorySelect);
+    await user.click(
+      await screen.findByRole("option", { name: "Illustration" }),
+    );
+
+    await waitFor(() => {
+      expect(categorySelect).toHaveTextContent("Illustration");
+      expect(tabByText("Illustration")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
+    });
+
+    tabByText("Illustration").focus();
+    fireEvent.keyDown(tabByText("Illustration"), { key: "ArrowDown" });
+    await waitFor(() => {
+      expect(tabByText("Video")).toHaveFocus();
+      expect(tabByText("Video")).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByLabelText(`Select video template ${videoTemplate.title}`),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(tabByText("Video"), { key: "ArrowUp" });
+    await waitFor(() => {
+      expect(tabByText("Illustration")).toHaveFocus();
+      expect(tabByText("Illustration")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    fireEvent.keyDown(tabByText("Illustration"), { key: "End" });
+    await waitFor(() => {
+      expect(tabByText("Workflow")).toHaveFocus();
+      expect(tabByText("Workflow")).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByLabelText("Search connectors")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(tabByText("Workflow"), { key: "Home" });
+    await waitFor(() => {
+      expect(tabByText("Presentation")).toHaveFocus();
+      expect(tabByText("Presentation")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
   });
 
   it("selects a presentation template from the picker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -3285,7 +3285,7 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("opens the template picker without focusing the tabs on small screens", async () => {
+  it("opens the template picker with responsive category navigation", async () => {
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     detachedSetupPage({
@@ -3310,14 +3310,21 @@ describe("chat composer templates", () => {
     expect(tabByText("Video")).toBeInTheDocument();
     expect(screen.queryByText("Website")).not.toBeInTheDocument();
     expect(document.activeElement).not.toBe(tabByText("Presentation"));
+    expect(tabByText("Presentation")).toHaveAttribute("aria-selected", "true");
+    expect(tabByText("Presentation")).toHaveClass("bg-card");
+    expect(tabByText("Presentation")).toHaveClass("text-foreground");
+    expect(tabByText("Illustration")).toHaveClass("text-muted-foreground");
+    expect(
+      screen.getByRole("combobox", { name: "Template category" }),
+    ).toBeInTheDocument();
 
-    const tabScroller = document.querySelector(
-      "[data-template-picker-tabs-scroll]",
+    const categorySidebar = document.querySelector(
+      "[data-template-picker-sidebar]",
     );
-    expect(tabScroller).toBeInstanceOf(HTMLElement);
-    expect(tabScroller).toHaveClass("overflow-x-auto");
-    expect(tabScroller).toHaveClass("sm:overflow-visible");
-    expect(tabScroller).toHaveClass("[scrollbar-width:thin]");
+    expect(categorySidebar).toBeInstanceOf(HTMLElement);
+    expect(categorySidebar).toHaveClass("hidden");
+    expect(categorySidebar).toHaveClass("sm:flex");
+    expect(categorySidebar).toHaveClass("bg-gray-50");
   });
 
   it("selects a presentation template from the picker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -61,9 +61,11 @@ import {
   PopoverClose,
   PopoverContent,
   PopoverTrigger,
-  Tabs,
-  TabsList,
-  TabsTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -4504,7 +4506,37 @@ function resolveTemplatePickerCategory({
   return categories.includes(category) ? category : defaultCategory;
 }
 
-function TemplatePickerTabs({
+const TEMPLATE_PICKER_CATEGORY_META: Readonly<
+  Record<string, { title: string }>
+> = {
+  slides: {
+    title: "Presentation",
+  },
+  website: {
+    title: "Website",
+  },
+  illustration: {
+    title: "Illustration",
+  },
+  video: {
+    title: "Video",
+  },
+  workflow: {
+    title: "Workflow",
+  },
+};
+
+function templatePickerCategoryMeta(category: string): {
+  title: string;
+} {
+  return (
+    TEMPLATE_PICKER_CATEGORY_META[category] ?? {
+      title: "Template",
+    }
+  );
+}
+
+function TemplatePickerCategoryNav({
   selectedCategory,
   hasPptTab,
   hasWebsiteTab,
@@ -4521,129 +4553,191 @@ function TemplatePickerTabs({
   hasWorkflowTab: boolean;
   onChange: (value: string) => void;
 }) {
+  const categoryOptions: {
+    value: string;
+    label: string;
+    Icon: typeof IconPresentation;
+  }[] = [];
+  if (hasPptTab) {
+    categoryOptions.push({
+      value: "slides",
+      label: "Presentation",
+      Icon: IconPresentation,
+    });
+  }
+  if (hasWebsiteTab) {
+    categoryOptions.push({
+      value: "website",
+      label: "Website",
+      Icon: IconWorld,
+    });
+  }
+  if (hasIllustrationTab) {
+    categoryOptions.push({
+      value: "illustration",
+      label: "Illustration",
+      Icon: IconPhoto,
+    });
+  }
+  if (hasVideoTab) {
+    categoryOptions.push({
+      value: "video",
+      label: "Video",
+      Icon: IconVideo,
+    });
+  }
+  if (hasWorkflowTab) {
+    categoryOptions.push({
+      value: "workflow",
+      label: "Workflow",
+      Icon: IconRoute,
+    });
+  }
+
   return (
-    <div
-      data-template-picker-tabs-scroll=""
-      className="-mx-5 w-[calc(100%+2.5rem)] overflow-x-auto px-5 pb-1 [scrollbar-color:hsl(var(--muted-foreground)/0.24)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/25 [&::-webkit-scrollbar-track]:bg-transparent sm:mx-0 sm:w-auto sm:overflow-visible sm:px-0 sm:pb-0 sm:[scrollbar-color:auto] sm:[scrollbar-width:auto] sm:[&::-webkit-scrollbar]:hidden"
-    >
-      <Tabs
-        value={selectedCategory}
-        onValueChange={onChange}
-        className="-mb-px min-w-max"
+    <>
+      <div className="shrink-0 border-b border-border bg-gray-50 px-4 pb-4 pr-14 pt-4 sm:hidden">
+        <Select value={selectedCategory} onValueChange={onChange}>
+          <SelectTrigger
+            aria-label="Template category"
+            className="h-9 w-full bg-card"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {categoryOptions.map(({ value, label, Icon }) => {
+              return (
+                <SelectItem key={value} value={value}>
+                  <span className="flex items-center gap-2">
+                    <Icon className="h-4 w-4" stroke={1.8} />
+                    {label}
+                  </span>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+      <nav
+        role="tablist"
+        aria-label="Template categories"
+        data-template-picker-sidebar=""
+        className="hidden w-52 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-gray-50 p-3 sm:flex"
       >
-        <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
-          {hasPptTab && (
-            <TabsTrigger
-              value="slides"
+        <div className="flex min-h-[50px] items-center px-2">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            Template
+          </h2>
+        </div>
+        {categoryOptions.map(({ value, label, Icon }, categoryIndex) => {
+          const selected = value === selectedCategory;
+          return (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => {
+                onChange(value);
+              }}
+              onKeyDown={(event) => {
+                let nextIndex: number | null = null;
+                if (event.key === "ArrowDown") {
+                  nextIndex = (categoryIndex + 1) % categoryOptions.length;
+                } else if (event.key === "ArrowUp") {
+                  nextIndex =
+                    (categoryIndex - 1 + categoryOptions.length) %
+                    categoryOptions.length;
+                } else if (event.key === "Home") {
+                  nextIndex = 0;
+                } else if (event.key === "End") {
+                  nextIndex = categoryOptions.length - 1;
+                }
+                if (nextIndex === null) {
+                  return;
+                }
+                event.preventDefault();
+                const nextTab = event.currentTarget.parentElement
+                  ?.querySelectorAll<HTMLElement>("[role=tab]")
+                  .item(nextIndex);
+                nextTab?.focus();
+                onChange(categoryOptions[nextIndex]?.value ?? value);
+              }}
               className={cn(
-                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-                selectedCategory === "slides"
-                  ? "border-foreground text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
+                "flex h-9 w-full items-center gap-2 rounded-lg border px-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                selected
+                  ? "border-border bg-card font-medium text-foreground"
+                  : "border-transparent text-muted-foreground hover:bg-card hover:text-foreground focus-visible:bg-card focus-visible:text-foreground",
               )}
             >
-              <IconPresentation
+              <Icon
                 className={cn(
-                  "h-5 w-5",
-                  selectedCategory === "slides"
-                    ? "text-blue-500"
-                    : "text-muted-foreground",
+                  "h-4 w-4 shrink-0",
+                  selected ? "text-primary" : "text-muted-foreground",
                 )}
                 stroke={1.8}
               />
-              Presentation
-            </TabsTrigger>
-          )}
-          {hasWebsiteTab && (
-            <TabsTrigger
-              value="website"
-              className={cn(
-                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-                selectedCategory === "website"
-                  ? "border-foreground text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconWorld
-                className={cn(
-                  "h-5 w-5",
-                  selectedCategory === "website"
-                    ? "text-cyan-500"
-                    : "text-muted-foreground",
-                )}
-                stroke={1.8}
-              />
-              Website
-            </TabsTrigger>
-          )}
-          {hasIllustrationTab && (
-            <TabsTrigger
-              value="illustration"
-              className={cn(
-                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-                selectedCategory === "illustration"
-                  ? "border-foreground text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconPhoto
-                className={cn(
-                  "h-5 w-5",
-                  selectedCategory === "illustration"
-                    ? "text-emerald-500"
-                    : "text-muted-foreground",
-                )}
-                stroke={1.8}
-              />
-              Illustration
-            </TabsTrigger>
-          )}
-          {hasVideoTab && (
-            <TabsTrigger
-              value="video"
-              className={cn(
-                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-                selectedCategory === "video"
-                  ? "border-foreground text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconVideo
-                className={cn(
-                  "h-5 w-5",
-                  selectedCategory === "video"
-                    ? "text-purple-500"
-                    : "text-muted-foreground",
-                )}
-                stroke={1.8}
-              />
-              Video
-            </TabsTrigger>
-          )}
-          {hasWorkflowTab && (
-            <TabsTrigger
-              value="workflow"
-              className={cn(
-                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-                selectedCategory === "workflow"
-                  ? "border-foreground text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <IconRoute
-                className={cn(
-                  "h-5 w-5",
-                  selectedCategory === "workflow"
-                    ? "text-sky-500"
-                    : "text-muted-foreground",
-                )}
-                stroke={1.8}
-              />
-              Workflow
-            </TabsTrigger>
-          )}
-        </TabsList>
-      </Tabs>
+              <span className="truncate">{label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </>
+  );
+}
+
+function TemplatePickerCategoryHeader({
+  selectedCategory,
+}: {
+  selectedCategory: string;
+}) {
+  const meta = templatePickerCategoryMeta(selectedCategory);
+  return (
+    <header
+      className={cn(
+        "hidden min-h-[74px] shrink-0 items-center border-b border-border px-5 py-4 sm:flex",
+        selectedCategory === "workflow" ? "pr-[21rem]" : "pr-14",
+      )}
+    >
+      <div className="min-w-0">
+        <h2 className="truncate text-lg font-semibold tracking-tight text-foreground">
+          {meta.title}
+        </h2>
+      </div>
+    </header>
+  );
+}
+
+function TemplatePickerWorkflowSearch({
+  selectedCategory,
+  search,
+  onSearchChange,
+}: {
+  selectedCategory: string;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) {
+  if (selectedCategory !== "workflow") {
+    return null;
+  }
+  return (
+    <div className="shrink-0 border-b border-border px-4 py-3 sm:absolute sm:right-14 sm:top-[21px] sm:z-10 sm:w-64 sm:border-0 sm:p-0">
+      <div className="relative">
+        <IconSearch
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          stroke={1.8}
+        />
+        <Input
+          aria-label="Search connectors"
+          className="h-9 pl-9 text-sm sm:h-8"
+          value={search}
+          onChange={(event) => {
+            onSearchChange(event.target.value);
+          }}
+          placeholder="Search connector..."
+        />
+      </div>
     </div>
   );
 }
@@ -4761,13 +4855,9 @@ function TemplatePickerDialog({
   const isPreviewing = Boolean(previewItem);
   const dialogContentClassName = cn(
     "gap-0 overflow-hidden p-0 focus:outline-none focus-visible:outline-none focus-visible:ring-0",
-    // The auto-rendered close button defaults to top-4, which is tuned for the
-    // default p-6 dialog. This dialog uses a custom py-4 header, so re-center the
-    // 36px (size-9) close button within the 50px header.
-    "[&>button[aria-label=Close]]:top-[7px]",
     isPreviewing
-      ? "flex h-[min(90dvh,760px)] max-w-6xl flex-col sm:h-auto"
-      : "flex h-[min(82vh,760px)] max-w-4xl flex-col",
+      ? "flex h-[min(90dvh,760px)] max-w-6xl flex-col sm:h-auto [&>button[aria-label=Close]]:top-[7px]"
+      : "flex h-[min(82vh,760px)] max-w-6xl flex-col [&>button[aria-label=Close]]:top-[7px] sm:[&>button[aria-label=Close]]:top-[19px]",
   );
   const filteredPptItems = presentationItems;
   const filteredIllustrationItems = ILLUSTRATION_TEMPLATE_ITEMS;
@@ -5012,11 +5102,11 @@ function TemplatePickerDialog({
           />
         ) : (
           <>
-            <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
-              <DialogTitle>Create with template</DialogTitle>
+            <DialogHeader className="shrink-0 border-b border-border px-5 py-4 sm:hidden">
+              <DialogTitle>Template</DialogTitle>
             </DialogHeader>
-            <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-center sm:justify-between">
-              <TemplatePickerTabs
+            <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+              <TemplatePickerCategoryNav
                 selectedCategory={selectedCategory}
                 hasPptTab={hasPptTab}
                 hasWebsiteTab={hasWebsiteTab}
@@ -5025,60 +5115,44 @@ function TemplatePickerDialog({
                 hasWorkflowTab={hasWorkflowTab}
                 onChange={handleCategoryChange}
               />
-              <div
-                className={cn(
-                  "pb-3 pt-2 sm:w-64",
-                  selectedCategory === "workflow"
-                    ? "w-full"
-                    : "hidden sm:block",
-                )}
-              >
-                {selectedCategory === "workflow" ? (
-                  <div className="relative">
-                    <IconSearch
-                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                      stroke={1.8}
-                    />
-                    <Input
-                      aria-label="Search connectors"
-                      className="h-8 pl-9 text-sm"
-                      value={search}
-                      onChange={(event) => {
-                        handleSearchChange(event.target.value);
-                      }}
-                      placeholder="Search connector..."
-                    />
-                  </div>
-                ) : (
-                  <div aria-hidden="true" className="h-8" />
-                )}
+              <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+                <TemplatePickerCategoryHeader
+                  selectedCategory={selectedCategory}
+                />
+                <TemplatePickerWorkflowSearch
+                  selectedCategory={selectedCategory}
+                  search={search}
+                  onSearchChange={handleSearchChange}
+                />
+                <TemplatePickerCategoryContent
+                  selectedCategory={selectedCategory}
+                  hasPptTab={hasPptTab}
+                  hasWebsiteTab={hasWebsiteTab}
+                  hasVideoTab={hasVideoTab}
+                  hasWorkflowTab={hasWorkflowTab}
+                  filteredPptItems={filteredPptItems}
+                  filteredWebsiteItems={filteredWebsiteItems}
+                  filteredIllustrationItems={filteredIllustrationItems}
+                  filteredVideoItems={filteredVideoItems}
+                  workflowCatalog={workflowCatalog}
+                  value={value}
+                  illustrationVariantIndex={illustrationVariantIndex}
+                  onPresentationScroll={setPresentationGridScrollTop}
+                  onRestorePresentationScroll={
+                    restorePresentationGridScrollNode
+                  }
+                  onSelectPresentation={handleSelectPresentation}
+                  onPreviewPresentation={handlePreview}
+                  onSelectWebsite={handleSelectWebsite}
+                  onPreviewWebsite={handlePreviewWebsite}
+                  onSelectIllustration={handleSelectIllustration}
+                  onIllustrationVariantChange={setIllustrationVariantIndex}
+                  onSelectVideo={handleSelectVideo}
+                  onWorkflowCategoryChange={setWorkflowCategoryFilter}
+                  onSelectWorkflow={handleSelectWorkflow}
+                />
               </div>
             </div>
-            <TemplatePickerCategoryContent
-              selectedCategory={selectedCategory}
-              hasPptTab={hasPptTab}
-              hasWebsiteTab={hasWebsiteTab}
-              hasVideoTab={hasVideoTab}
-              hasWorkflowTab={hasWorkflowTab}
-              filteredPptItems={filteredPptItems}
-              filteredWebsiteItems={filteredWebsiteItems}
-              filteredIllustrationItems={filteredIllustrationItems}
-              filteredVideoItems={filteredVideoItems}
-              workflowCatalog={workflowCatalog}
-              value={value}
-              illustrationVariantIndex={illustrationVariantIndex}
-              onPresentationScroll={setPresentationGridScrollTop}
-              onRestorePresentationScroll={restorePresentationGridScrollNode}
-              onSelectPresentation={handleSelectPresentation}
-              onPreviewPresentation={handlePreview}
-              onSelectWebsite={handleSelectWebsite}
-              onPreviewWebsite={handlePreviewWebsite}
-              onSelectIllustration={handleSelectIllustration}
-              onIllustrationVariantChange={setIllustrationVariantIndex}
-              onSelectVideo={handleSelectVideo}
-              onWorkflowCategoryChange={setWorkflowCategoryFilter}
-              onSelectWorkflow={handleSelectWorkflow}
-            />
           </>
         )}
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4621,6 +4621,7 @@ function TemplatePickerCategoryNav({
       <nav
         role="tablist"
         aria-label="Template categories"
+        aria-orientation="vertical"
         data-template-picker-sidebar=""
         className="hidden w-52 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-gray-50 p-3 sm:flex"
       >


### PR DESCRIPTION
## Summary

- replace the colorful horizontal template tabs with a neutral desktop sidebar that uses existing foreground and muted tokens, with Zero orange reserved for the active icon
- add category-specific content headings while preserving template selection, preview, connector search, and scroll behavior
- use the existing Select component for compact mobile category navigation and keep the sidebar keyboard-accessible

## User impact

The template picker now has a calmer hierarchy and easier-to-scan categories without five competing active colors. Mobile users get a compact category selector while desktop users can switch categories from a persistent left rail.

## Design reference

- [Template picker UI exploration](https://zero-template-picker-ui-715f6d07-dd2a3f11.sites.vm0.io) — variant 1

## Verification

- `pnpm exec prettier --write src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx` (74 passed)

Local dev server and browser preview were not started per the vm0 PR verification preference; the PR pipeline and preview will provide integration validation.
