### PR TITLE
docs(mitm-addon): document anthropic sse extractor lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -70,8 +70,13 @@ def create_anthropic_messages_sse_usage_extractor(
       ``message.model`` identifies the model.
     - ``message_delta`` — ``usage`` contains the final ``output_tokens`` count.
 
-    Returns ``(parse_chunk, usage)`` where *parse_chunk* processes raw bytes
-    incrementally and *usage* is a dict that accumulates extracted fields.
+    Returns ``(scanner, usage)``. The callable *scanner* is an
+    ``SseUsageScanner``; callers pass arbitrary content-decoded byte chunks
+    that still contain SSE framing to *scanner* (or its ``feed()`` method) and
+    retain *usage* as a live mutable accumulator. Usage extracted at a complete
+    event boundary updates that same dict in place. After all decoded bytes
+    have been fed, callers must invoke ``scanner.finish()`` to flush a trailing
+    event without a blank-line terminator.
     """
     usage: dict = {}
     parser = SseUsageScanner(


### PR DESCRIPTION
## Summary

- document that the Anthropic SSE usage factory returns a callable scanner and live usage accumulator
- document content-decoded SSE input, event-boundary updates, and required finalization
- explain that `scanner.finish()` flushes a trailing event without a blank-line terminator

## Behavior and exclusions

- documentation only; no runtime parsing or billing behavior changes
- no public type, API, schema, persisted data, protocol, configuration, or deployment compatibility changes
- no test changes; existing focused and production-path coverage already exercises the documented lifecycle

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_anthropic_messages.py -v` (`43 passed`)
- `.venv/bin/python -m pytest tests/ -v` (`3917 passed`)

Closes #21355
