### PR TITLE
test(mitm-addon): assert dns waiter cancellation

### DIFF
--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -600,7 +600,8 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
         await asyncio.sleep(0)
         cancelled_task.cancel()
         release_lookup.set()
-        await asyncio.gather(cancelled_task, return_exceptions=True)
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_task
         _ = await completed_task
 
     assert calls == [("pr-test-api.vm6.ai", 443)]

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -601,7 +601,7 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
         cancelled_task.cancel()
         release_lookup.set()
         with pytest.raises(asyncio.CancelledError):
-            await cancelled_task
+            _ = await cancelled_task
         _ = await completed_task
 
     assert calls == [("pr-test-api.vm6.ai", 443)]


### PR DESCRIPTION
## Summary

- assert that a cancelled `server_connect()` waiter propagates `asyncio.CancelledError`
- preserve coverage that the shielded shared DNS lookup runs once and completes for the surviving waiter
- keep the change test-only; production cancellation behavior is unchanged

## Validation

- `python3 -m pytest tests/test_server_connect_hook.py::test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup -q` — 1 passed
- `python3 -m pytest tests/test_server_connect_hook.py -q` — 27 passed
- `ruff check .` — passed
- `ruff format --check .` — 234 files already formatted
- `basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `python3 -m pytest tests/ -q` — 3917 passed

Closes #21356
