### PR TITLE
fix(platform): show mixed permission category durations

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
@@ -14,7 +14,6 @@ import {
   materializePermissionDraftForLegacySave,
   permissionDraftInitialPolicyKey,
   resolvePermissionDraftExpiration,
-  resolvePermissionDraftGroupConfiguration,
   resolvePermissionDraftUnknownPolicy,
   restorePermissionDraftPermission,
   restorePermissionDraftUnknown,
@@ -181,17 +180,6 @@ describe("permission draft intent materialization", () => {
         permissionName: "bookmarks:read",
       }),
     ).toBeUndefined();
-    expect(
-      resolvePermissionDraftGroupConfiguration({
-        context,
-        draft,
-        permissions: READ_PERMISSIONS,
-        explicitGrants: new Map(),
-      }),
-    ).toStrictEqual({
-      policy: "allow",
-      expiration: { kind: "mixed" },
-    });
 
     const materialized = materializePermissionDraftForLegacySave({
       context,
@@ -271,15 +259,6 @@ describe("permission draft intent row duration overrides", () => {
       draft,
       permissionName: "bookmarks:read",
     });
-
-    expect(
-      resolvePermissionDraftGroupConfiguration({
-        context,
-        draft,
-        permissions: READ_PERMISSIONS,
-        explicitGrants: new Map(),
-      }),
-    ).toStrictEqual({ policy: "mixed" });
 
     const materialized = materializePermissionDraftForLegacySave({
       context,
@@ -398,17 +377,6 @@ describe("permission draft intent group duration", () => {
         permissionName: "bookmarks:read",
       }),
     ).toBe("7d");
-    expect(
-      resolvePermissionDraftGroupConfiguration({
-        context,
-        draft,
-        permissions: READ_PERMISSIONS,
-        explicitGrants: new Map(),
-      }),
-    ).toStrictEqual({
-      policy: "allow",
-      expiration: { kind: "selected", expiresIn: "7d" },
-    });
   });
 
   it("keeps cleared group members detached when allowing a group", () => {
@@ -547,18 +515,6 @@ describe("permission draft intent allow always selection", () => {
       policy: "allow",
     });
 
-    expect(
-      resolvePermissionDraftGroupConfiguration({
-        context,
-        draft,
-        permissions: READ_PERMISSIONS,
-        explicitGrants,
-      }),
-    ).toStrictEqual({
-      policy: "allow",
-      expiration: { kind: "mixed" },
-    });
-
     draft = setPermissionDraftGroupAllowExpiration({
       draft,
       category: "Read",
@@ -581,17 +537,6 @@ describe("permission draft intent allow always selection", () => {
         permissionName: "channels:read",
       }),
     ).toBeUndefined();
-    expect(
-      resolvePermissionDraftGroupConfiguration({
-        context,
-        draft,
-        permissions: READ_PERMISSIONS,
-        explicitGrants,
-      }),
-    ).toStrictEqual({
-      policy: "allow",
-      expiration: { kind: "always" },
-    });
     expect(
       materializePermissionDraftForLegacySave({
         context,

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
@@ -14,7 +14,7 @@ import {
   materializePermissionDraftForLegacySave,
   permissionDraftInitialPolicyKey,
   resolvePermissionDraftExpiration,
-  resolvePermissionDraftGroupExpiration,
+  resolvePermissionDraftGroupConfiguration,
   resolvePermissionDraftUnknownPolicy,
   restorePermissionDraftPermission,
   restorePermissionDraftUnknown,
@@ -182,13 +182,16 @@ describe("permission draft intent materialization", () => {
       }),
     ).toBeUndefined();
     expect(
-      resolvePermissionDraftGroupExpiration({
+      resolvePermissionDraftGroupConfiguration({
         context,
         draft,
-        category: "Read",
         permissions: READ_PERMISSIONS,
+        explicitGrants: new Map(),
       }),
-    ).toBeUndefined();
+    ).toStrictEqual({
+      policy: "allow",
+      expiration: { kind: "mixed" },
+    });
 
     const materialized = materializePermissionDraftForLegacySave({
       context,
@@ -270,13 +273,13 @@ describe("permission draft intent row duration overrides", () => {
     });
 
     expect(
-      resolvePermissionDraftGroupExpiration({
+      resolvePermissionDraftGroupConfiguration({
         context,
         draft,
-        category: "Read",
         permissions: READ_PERMISSIONS,
+        explicitGrants: new Map(),
       }),
-    ).toBeUndefined();
+    ).toStrictEqual({ policy: "mixed" });
 
     const materialized = materializePermissionDraftForLegacySave({
       context,
@@ -396,13 +399,16 @@ describe("permission draft intent group duration", () => {
       }),
     ).toBe("7d");
     expect(
-      resolvePermissionDraftGroupExpiration({
+      resolvePermissionDraftGroupConfiguration({
         context,
         draft,
-        category: "Read",
         permissions: READ_PERMISSIONS,
+        explicitGrants: new Map(),
       }),
-    ).toBe("7d");
+    ).toStrictEqual({
+      policy: "allow",
+      expiration: { kind: "selected", expiresIn: "7d" },
+    });
   });
 
   it("keeps cleared group members detached when allowing a group", () => {
@@ -541,6 +547,18 @@ describe("permission draft intent allow always selection", () => {
       policy: "allow",
     });
 
+    expect(
+      resolvePermissionDraftGroupConfiguration({
+        context,
+        draft,
+        permissions: READ_PERMISSIONS,
+        explicitGrants,
+      }),
+    ).toStrictEqual({
+      policy: "allow",
+      expiration: { kind: "mixed" },
+    });
+
     draft = setPermissionDraftGroupAllowExpiration({
       draft,
       category: "Read",
@@ -564,13 +582,16 @@ describe("permission draft intent allow always selection", () => {
       }),
     ).toBeUndefined();
     expect(
-      resolvePermissionDraftGroupExpiration({
+      resolvePermissionDraftGroupConfiguration({
         context,
         draft,
-        category: "Read",
         permissions: READ_PERMISSIONS,
+        explicitGrants,
       }),
-    ).toBeUndefined();
+    ).toStrictEqual({
+      policy: "allow",
+      expiration: { kind: "always" },
+    });
     expect(
       materializePermissionDraftForLegacySave({
         context,

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.ts
@@ -61,6 +61,26 @@ interface ExpirationResolutionParams {
   readonly permissionName: string;
 }
 
+type PermissionDraftGroupUniformAllowExpiration =
+  | { readonly kind: "always" }
+  | {
+      readonly kind: "selected";
+      readonly expiresIn: Exclude<UserPermissionGrantExpiresIn, "always">;
+    }
+  | { readonly kind: "persisted"; readonly expiresAt: string };
+
+type PermissionDraftGroupAllowExpiration =
+  | PermissionDraftGroupUniformAllowExpiration
+  | { readonly kind: "mixed" };
+
+type PermissionDraftGroupConfiguration =
+  | { readonly policy: "mixed" }
+  | { readonly policy: Exclude<FirewallPolicyValue, "allow"> }
+  | {
+      readonly policy: "allow";
+      readonly expiration: PermissionDraftGroupAllowExpiration;
+    };
+
 function firewallPolicyToOverlay(
   policy: FirewallPolicy | undefined,
 ): FirewallMetadataPolicyOverlay | undefined {
@@ -412,53 +432,127 @@ export function resolvePermissionDraftExpiration(
   return category ? params.draft.groupExpirations[category] : undefined;
 }
 
-export function resolvePermissionDraftGroupExpiration({
+function resolvePermissionDraftGroupAllowExpiration({
   context,
   draft,
-  category,
-  permissions,
+  permissionName,
+  grant,
 }: {
   readonly context: PermissionDraftContext;
   readonly draft: PermissionDraftIntent;
-  readonly category: string;
-  readonly permissions: readonly PermissionLike[];
-}): UserPermissionGrantExpiresIn | undefined {
-  const groupExpiration = draft.groupExpirations[category];
-  if (groupExpiration !== undefined) {
-    for (const permission of permissions) {
-      const current = resolvePermissionDraftExpiration({
-        context,
-        draft,
-        permissionName: permission.name,
-      });
-      if (current !== groupExpiration) {
-        return undefined;
-      }
-    }
-    return groupExpiration;
-  }
-  if (permissions.length === 0) {
-    return undefined;
-  }
-  const first = resolvePermissionDraftExpiration({
+  readonly permissionName: string;
+  readonly grant: UserPermissionGrantResponse | undefined;
+}): PermissionDraftGroupUniformAllowExpiration {
+  const selected = resolvePermissionDraftExpiration({
     context,
     draft,
-    permissionName: permissions[0].name,
+    permissionName,
   });
-  if (first === undefined) {
-    return undefined;
+  if (selected === "always") {
+    return { kind: "always" };
   }
-  for (let i = 1; i < permissions.length; i++) {
-    const current = resolvePermissionDraftExpiration({
-      context,
-      draft,
-      permissionName: permissions[i].name,
-    });
-    if (current !== first) {
-      return undefined;
+  if (selected !== undefined) {
+    return { kind: "selected", expiresIn: selected };
+  }
+  if (grant?.action === "allow" && grant.expiresAt) {
+    return { kind: "persisted", expiresAt: grant.expiresAt };
+  }
+  return { kind: "always" };
+}
+
+function permissionDraftGroupAllowExpirationsEqual(
+  first: PermissionDraftGroupUniformAllowExpiration,
+  second: PermissionDraftGroupUniformAllowExpiration,
+): boolean {
+  if (first.kind !== second.kind) {
+    return false;
+  }
+  switch (first.kind) {
+    case "always": {
+      return true;
+    }
+    case "selected": {
+      return second.kind === "selected" && first.expiresIn === second.expiresIn;
+    }
+    case "persisted": {
+      return (
+        second.kind === "persisted" && first.expiresAt === second.expiresAt
+      );
     }
   }
-  return first;
+}
+
+export function resolvePermissionDraftGroupConfiguration({
+  context,
+  draft,
+  permissions,
+  explicitGrants,
+}: {
+  readonly context: PermissionDraftContext;
+  readonly draft: PermissionDraftIntent;
+  readonly permissions: readonly PermissionLike[];
+  readonly explicitGrants: ReadonlyMap<string, UserPermissionGrantResponse>;
+}): PermissionDraftGroupConfiguration {
+  if (permissions.length === 0) {
+    return { policy: "allow", expiration: { kind: "always" } };
+  }
+
+  const firstPermission = permissions[0];
+  const firstPolicy = resolvePermissionDraftPolicy({
+    context,
+    draft,
+    permissionName: firstPermission.name,
+  });
+  if (firstPolicy !== "allow") {
+    for (let i = 1; i < permissions.length; i++) {
+      const currentPolicy = resolvePermissionDraftPolicy({
+        context,
+        draft,
+        permissionName: permissions[i].name,
+      });
+      if (currentPolicy !== firstPolicy) {
+        return { policy: "mixed" };
+      }
+    }
+    return { policy: firstPolicy };
+  }
+
+  const firstExpiration = resolvePermissionDraftGroupAllowExpiration({
+    context,
+    draft,
+    permissionName: firstPermission.name,
+    grant: explicitGrants.get(firstPermission.name),
+  });
+  let expirationMixed = false;
+  for (let i = 1; i < permissions.length; i++) {
+    const permission = permissions[i];
+    const currentPolicy = resolvePermissionDraftPolicy({
+      context,
+      draft,
+      permissionName: permission.name,
+    });
+    if (currentPolicy !== "allow") {
+      return { policy: "mixed" };
+    }
+    const currentExpiration = resolvePermissionDraftGroupAllowExpiration({
+      context,
+      draft,
+      permissionName: permission.name,
+      grant: explicitGrants.get(permission.name),
+    });
+    if (
+      !permissionDraftGroupAllowExpirationsEqual(
+        firstExpiration,
+        currentExpiration,
+      )
+    ) {
+      expirationMixed = true;
+    }
+  }
+  return {
+    policy: "allow",
+    expiration: expirationMixed ? { kind: "mixed" } : firstExpiration,
+  };
 }
 
 export function setPermissionDraftPolicy({

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -328,6 +328,14 @@ function dialogForElement(element: HTMLElement): HTMLElement {
   return dialog;
 }
 
+function permissionGroupHeader(element: HTMLElement): HTMLElement {
+  const header = element.closest("button")?.parentElement;
+  if (!(header instanceof HTMLElement)) {
+    throw new Error("permission group header not found");
+  }
+  return header;
+}
+
 async function findLoadedPermissionsDialog(): Promise<HTMLElement> {
   const unknownEndpoints = await screen.findByText("Other endpoints");
   return dialogForElement(unknownEndpoints);
@@ -1397,6 +1405,91 @@ describe("team page navigation", () => {
     expect(buttonByText("Restore", permissionsDialog)).toBeDisabled();
   });
 
+  it("shows aggregate persisted durations on permission category headers", async () => {
+    mockNow();
+    mockTeamAPIs();
+    const metadata = await loadFirewallPermissionMetadata("slack");
+    if (!metadata?.categories) {
+      throw new Error("slack permission categories not found");
+    }
+    const categoryByPermission = metadata.categories.categories;
+    const permissionNamesInCategory = (category: string): string[] => {
+      return metadata.permissions
+        .filter((permission) => {
+          return categoryByPermission[permission.name] === category;
+        })
+        .map((permission) => {
+          return permission.name;
+        });
+    };
+    const expiresAt = isoFromNowMs(2 * 60 * 60 * 1000);
+    const createPersistedGrant = (
+      permission: string,
+      expiration: string | null,
+    ): UserPermissionGrantResponse => {
+      return {
+        agentId: researchAgentId,
+        connectorRef: "slack",
+        permission,
+        action: "allow",
+        expiresAt: expiration,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      };
+    };
+    const grants = [
+      ...permissionNamesInCategory("Read").map((permission) => {
+        return createPersistedGrant(permission, expiresAt);
+      }),
+      ...permissionNamesInCategory("Misc").map((permission, index) => {
+        return createPersistedGrant(permission, index === 0 ? null : expiresAt);
+      }),
+    ];
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, grants);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("@ops")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Manage Slack permissions"));
+
+    const readGroupLabel = await connectorCategoryLabel("slack", "Read");
+    const readHeader = permissionGroupHeader(
+      await screen.findByText(readGroupLabel),
+    );
+    expect(within(readHeader).getByText("2 hours")).toBeInTheDocument();
+    expect(buttonByText("Allow", readHeader)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      within(readHeader).getByLabelText("Read allow options"),
+    ).toBeInTheDocument();
+
+    const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
+    const miscHeader = permissionGroupHeader(
+      await screen.findByText(miscGroupLabel),
+    );
+    expect(within(miscHeader).getByText("Mixed")).toBeInTheDocument();
+    expect(buttonByText("Allow", miscHeader)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      within(miscHeader).queryByLabelText("Misc allow options"),
+    ).not.toBeInTheDocument();
+  });
+
   it("saves permission duration changes from an agent page", async () => {
     mockNow();
     mockTeamAPIs();
@@ -1558,10 +1651,65 @@ describe("team page navigation", () => {
       within(loadedGroupedDialog).getByText("Slack permissions"),
     ).toBeInTheDocument();
     expect(readGroupElement).toBeInTheDocument();
+    const readGroupHeader = permissionGroupHeader(readGroupElement);
     const writeGroupElement = await screen.findByText(writeGroupLabel);
     expect(writeGroupElement).toBeInTheDocument();
     const miscGroupElement = await screen.findByText(miscGroupLabel);
     expect(miscGroupElement).toBeInTheDocument();
+
+    expect(within(readGroupHeader).getByText("Mixed")).toBeInTheDocument();
+    expect(buttonByText("Allow", readGroupHeader)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(
+      within(readGroupHeader).queryByLabelText("Read allow options"),
+    ).not.toBeInTheDocument();
+
+    click(buttonByText("Allow", readGroupHeader));
+    await waitFor(() => {
+      expect(
+        within(readGroupHeader).getByLabelText("Read allow options"),
+      ).toHaveTextContent("Always");
+    });
+    click(within(readGroupHeader).getByLabelText("Read allow options"));
+    click(menuItemByText("Allow for 7d"));
+    await waitFor(() => {
+      expect(
+        within(readGroupHeader).getByLabelText("Read allow options"),
+      ).toHaveTextContent("7d");
+    });
+
+    click(readGroupElement);
+    const bookmarksReadRow = await permissionRowByName(
+      loadedGroupedDialog,
+      "bookmarks:read",
+    );
+    click(
+      within(bookmarksReadRow).getByLabelText("bookmarks:read allow options"),
+    );
+    click(menuItemByText("Allow for 1h"));
+    await waitFor(() => {
+      expect(within(readGroupHeader).getByText("Mixed")).toBeInTheDocument();
+      expect(buttonByText("Allow", readGroupHeader)).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(
+        within(readGroupHeader).queryByLabelText("Read allow options"),
+      ).not.toBeInTheDocument();
+    });
+
+    click(
+      within(bookmarksReadRow).getByLabelText("bookmarks:read allow options"),
+    );
+    click(menuItemByText("Allow for 7d"));
+    await waitFor(() => {
+      expect(
+        within(readGroupHeader).getByLabelText("Read allow options"),
+      ).toHaveTextContent("7d");
+      expect(within(readGroupHeader).queryByText("Mixed")).toBeNull();
+    });
 
     click(screen.getByText(miscGroupLabel));
     const channelsJoinRow = await permissionRowByName(

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -1679,6 +1679,20 @@ describe("team page navigation", () => {
         within(readGroupHeader).getByLabelText("Read allow options"),
       ).toHaveTextContent("7d");
     });
+    click(within(readGroupHeader).getByLabelText("Read allow options"));
+    click(menuItemByText("Allow always"));
+    await waitFor(() => {
+      expect(
+        within(readGroupHeader).getByLabelText("Read allow options"),
+      ).toHaveTextContent("Always");
+    });
+    click(within(readGroupHeader).getByLabelText("Read allow options"));
+    click(menuItemByText("Allow for 7d"));
+    await waitFor(() => {
+      expect(
+        within(readGroupHeader).getByLabelText("Read allow options"),
+      ).toHaveTextContent("7d");
+    });
 
     click(readGroupElement);
     const bookmarksReadRow = await permissionRowByName(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -49,7 +49,7 @@ import {
   permissionDraftInitialPolicyKey,
   permissionDraftMetadataKey,
   resolvePermissionDraftExpiration,
-  resolvePermissionDraftGroupExpiration,
+  resolvePermissionDraftGroupConfiguration,
   resolvePermissionDraftListPolicy,
   resolvePermissionDraftPolicy,
   resolvePermissionDraftUnknownPolicy,
@@ -596,6 +596,7 @@ function PermissionGrantPolicyControl({
   grant,
   selected,
   allowAlwaysActive,
+  allowDurationMixed = false,
   expirationStatusExpiresAt,
   readOnly,
   saving,
@@ -610,6 +611,7 @@ function PermissionGrantPolicyControl({
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
   allowAlwaysActive: boolean;
+  allowDurationMixed?: boolean;
   expirationStatusExpiresAt?: string | null;
   readOnly?: boolean;
   saving: boolean;
@@ -625,10 +627,12 @@ function PermissionGrantPolicyControl({
   const expirationStatusValue =
     expirationStatusExpiresAt ?? allowGrant?.expiresAt ?? null;
   const showSplitPolicy = !readOnly;
-  const durationLabel = permissionDurationLabel({
-    expiresAt: expirationStatusValue,
-    selected,
-  });
+  const durationLabel = allowDurationMixed
+    ? "Mixed"
+    : permissionDurationLabel({
+        expiresAt: expirationStatusValue,
+        selected,
+      });
 
   return (
     <div className="flex shrink-0 items-center gap-2">
@@ -647,18 +651,21 @@ function PermissionGrantPolicyControl({
         </>
       ) : (
         <>
-          {policy === "allow" && (
-            <PermissionAllowDurationDropdown
-              permission={permission}
-              label={durationLabel}
-              selected={selected}
-              allowAlwaysActive={allowAlwaysActive}
-              saving={saving}
-              onSelect={(expiresIn) => {
-                onAllowDurationChange(expiresIn);
-              }}
-            />
-          )}
+          {policy === "allow" &&
+            (allowDurationMixed ? (
+              <PermissionAllowDurationStatic label={durationLabel} />
+            ) : (
+              <PermissionAllowDurationDropdown
+                permission={permission}
+                label={durationLabel}
+                selected={selected}
+                allowAlwaysActive={allowAlwaysActive}
+                saving={saving}
+                onSelect={(expiresIn) => {
+                  onAllowDurationChange(expiresIn);
+                }}
+              />
+            ))}
           {policy === "mixed" && <PermissionPolicyMixedBadge />}
           <PermissionPolicyToggle
             policy={policy}
@@ -709,6 +716,7 @@ function PermissionGroupHeader({
   draft,
   category,
   permissions,
+  explicitGrants,
   expanded,
   readOnly,
   saving,
@@ -721,6 +729,7 @@ function PermissionGroupHeader({
   draft: PermissionDraftIntent;
   category: string;
   permissions: ConnectorPermission[];
+  explicitGrants: ReadonlyMap<string, UserPermissionGrantResponse>;
   expanded: boolean;
   readOnly?: boolean;
   saving: boolean;
@@ -729,17 +738,16 @@ function PermissionGroupHeader({
   onGroupDeny: () => void;
   onGroupAllowDuration: (expiresIn: UserPermissionGrantExpiresIn) => void;
 }) {
-  const policy = resolvePermissionDraftListPolicy({
+  const configuration = resolvePermissionDraftGroupConfiguration({
     context,
     draft,
     permissions,
+    explicitGrants,
   });
-  const selected = resolvePermissionDraftGroupExpiration({
-    context,
-    draft,
-    category,
-    permissions,
-  });
+  const expiration =
+    configuration.policy === "allow" ? configuration.expiration : undefined;
+  const selected =
+    expiration?.kind === "selected" ? expiration.expiresIn : undefined;
   return (
     <div className="flex items-center gap-2 px-3 py-2">
       <button
@@ -758,10 +766,16 @@ function PermissionGroupHeader({
         <div className="ml-auto">
           <PermissionGrantPolicyControl
             permission={category}
-            policy={policy}
+            policy={configuration.policy}
             grant={undefined}
             selected={selected}
-            allowAlwaysActive={selected === undefined}
+            allowAlwaysActive={expiration?.kind === "always"}
+            allowDurationMixed={expiration?.kind === "mixed"}
+            expirationStatusExpiresAt={
+              expiration?.kind === "persisted"
+                ? expiration.expiresAt
+                : undefined
+            }
             showCurrentExpirationStatus={false}
             saving={saving}
             onAllowClick={onGroupAllow}
@@ -845,6 +859,7 @@ function PermissionRows({
             draft={draft}
             category={group.category}
             permissions={group.permissions}
+            explicitGrants={explicitGrants}
             expanded={expanded}
             readOnly={readOnly}
             saving={saving}


### PR DESCRIPTION
## Summary

- aggregate each permission category from its effective child policies and Allow expiration states
- include both unsaved semantic durations and persisted absolute `expiresAt` values in category state
- keep Allow selected for duration-only mixtures and render a non-interactive `Mixed` duration status
- preserve the existing editable duration menu for uniform Allow categories

## Scope

- does not add a group duration menu or bulk normalization action while duration is mixed
- does not change individual permission rows, the ungrouped `Select all` control, grant APIs, or persisted data

## Testing

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/permission-draft-intent.test.ts src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm knip --workspace @vm0/app`
- repository pre-commit hooks, including full Turbo type checking

Closes #21375
