### PR TITLE
test(mitm-addon): enforce x non-object fallback audit contract

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -117,9 +117,13 @@ def test_invalid_json_with_no_hints_skips_billing(x_usage, tmp_path, real_flow):
 
 
 def test_non_dict_json_with_no_hints_skips_billing(x_usage, tmp_path, real_flow):
-    """A valid non-object JSON response preserves the old unparseable fallback."""
+    """A valid top-level non-object JSON response remains unparsed; without reliable
+    request hints, billing is skipped and a lost-visibility audit error is recorded."""
     flow = x_usage.make_flow(real_flow, tmp_path, body=b"[1,2,3]")
+    proxy_log = tmp_path / "proxy.jsonl"
+
     assert x_usage.call_and_get_billing(flow) == []
+    assert_lost_visibility_error(proxy_log)
 
 
 def test_array_element_fields_do_not_drive_x_billing(x_usage, tmp_path, real_flow):


### PR DESCRIPTION
## Summary

- replace the stale X non-object JSON fallback description with the current loud-but-zero behavior
- require the existing integration test to observe exactly one lost-visibility audit error in addition to no billing payload
- leave production parsing and billing behavior unchanged

## Validation

- `./.venv/bin/ruff format --check .`
- `./.venv/bin/ruff check .`
- `./.venv/bin/basedpyright -p .`
- `./.venv/bin/python -m pytest -q tests/x_connector_usage/test_unparseable.py::test_non_dict_json_with_no_hints_skips_billing`
- `./.venv/bin/python -m pytest tests/` (`3917 passed`)
- `git diff --check`

Closes #21357
