### PR TITLE
docs(runner): clarify job budget and parking lifecycle

### DIFF
--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -88,9 +88,16 @@ impl ActiveBudgetLease {
 }
 
 /// Budget ownership after sandbox finalization but before completion is reported.
+///
+/// This distinguishes a lease that completion must release from one already
+/// transferred to an accepted idle-pool entry.
 #[must_use]
 pub(super) enum BudgetOwnership {
+    /// The active job retains the lease through provider completion and active-status
+    /// removal, after which completion releases it.
     Active(ActiveBudgetLease),
+    /// The idle pool accepted the sandbox and its lease, so completion performs no
+    /// release. Reuse transfers the lease; idle destruction drops it.
     IdleOwned,
 }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -481,10 +481,11 @@ impl DeferredUploadPhase {
 /// agent session id is available. Park failure, cancellation before idle-pool
 /// transfer, or pool rejection falls back to destruction.
 ///
-/// Finalization returns [`BudgetOwnership`](super::job_lifecycle::BudgetOwnership)
-/// for completion. Non-accepted paths keep the active lease through provider
-/// completion and active-status removal, then release it. An accepted idle entry
-/// owns and retains the lease until reuse or destruction.
+/// The completion state returned by finalization carries
+/// [`BudgetOwnership`](super::job_lifecycle::BudgetOwnership). Non-accepted paths
+/// keep the active lease through provider completion and active-status removal,
+/// then release it. An accepted idle entry owns and retains the lease until reuse
+/// or destruction.
 pub(super) fn spawn_job(
     request: SpawnJobRequest,
     ctx: &SpawnContext,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -469,14 +469,22 @@ impl DeferredUploadPhase {
 /// Spawn a job executor task.
 ///
 /// The provider has already claimed the job and the caller has reserved
-/// resources in the budget: this function spawns the executor, reports
-/// completion via the provider, and releases the budget when done.
+/// resources in the budget. The spawned task runs the executor, reports
+/// completion through the provider, and delegates the post-executor
+/// park-or-destroy decision to [`finalize_sandbox_for_completion`].
 ///
 /// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
 /// Otherwise it creates a new one via the factory.
 ///
-/// After a successful execution with a CLI agent session id available, the sandbox
-/// is parked in the idle pool instead of being destroyed.
+/// A sandbox is considered for idle parking only after a successful, uncancelled
+/// execution while parking is open and a validated supplied or discovered CLI
+/// agent session id is available. Park failure, cancellation before idle-pool
+/// transfer, or pool rejection falls back to destruction.
+///
+/// Finalization returns [`BudgetOwnership`](super::job_lifecycle::BudgetOwnership)
+/// for completion. Non-accepted paths keep the active lease through provider
+/// completion and active-status removal, then release it. An accepted idle entry
+/// owns and retains the lease until reuse or destruction.
 pub(super) fn spawn_job(
     request: SpawnJobRequest,
     ctx: &SpawnContext,


### PR DESCRIPTION
## Summary

- correct `spawn_job` rustdoc to describe the real parking eligibility gates and destroy fallbacks
- distinguish active budget release from lease ownership transferred to an accepted idle-pool entry
- document the release responsibility of both `BudgetOwnership` variants at the enforcing type

## Scope

- documentation only; runner lifecycle and resource-accounting behavior are unchanged
- no schema, persisted-data, API, protocol, migration, feature-switch, or rollout changes
- no new tests: existing runner tests already cover active release, accepted idle ownership, park failure, and park rejection

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo doc -p runner --all-features --no-deps --document-private-items`
- `cd crates && cargo test -p runner`

Closes #21359
