### PR TITLE
docs(mitm-addon): document registry lookup failure semantics

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -472,7 +472,13 @@ def load_registry_state(registry_path: str) -> RegistryState:
 
 
 def load_registry(registry_path: str) -> dict:
-    """Load the proxy registry, reusing cached data when possible."""
+    """Load a lossy compatibility view containing only usable VM entries.
+
+    Invalid entries are omitted. An empty mapping can mean either that a
+    successfully loaded registry has no usable entries or that the registry is
+    unavailable after an open, stat, read, or parse failure. Use
+    `load_registry_state()` when those states must be distinguished.
+    """
     state = load_registry_state(registry_path)
     if isinstance(state, RegistryUnavailable):
         return {}
@@ -480,7 +486,12 @@ def load_registry(registry_path: str) -> dict:
 
 
 def get_vm_info(client_ip: str, registry_path: str) -> dict | None:
-    """Look up VM info by client IP address."""
+    """Look up VM info in the lossy compatibility view for a client IP.
+
+    `None` can mean that the IP is absent, its registry entry is invalid, or the
+    registry is unavailable. Use `load_registry_state()` when those states must
+    be distinguished.
+    """
     return load_registry(registry_path).get(client_ip)
 
 
@@ -488,7 +499,12 @@ def get_vm_context(
     client_ip: str,
     registry_path: str,
 ) -> VmContext | None:
-    """Look up raw VM info with compiled firewall and policy matcher sidecars."""
+    """Look up raw VM info with compiled matcher sidecars in a compatibility view.
+
+    `None` can mean that the IP is absent, its registry entry is invalid, or the
+    registry is unavailable. Use `load_registry_state()` when those states must
+    be distinguished.
+    """
     snapshot = load_registry_state(registry_path)
     if isinstance(snapshot, RegistryUnavailable):
         return None


### PR DESCRIPTION
## Summary

- document that the registry convenience helpers are intentionally lossy compatibility views
- list the absent, invalid, empty, and unavailable states collapsed into `{}` or `None`
- direct enforcement and diagnostic callers that need those distinctions to `load_registry_state()`

## Scope

- docstrings only in `crates/runner/mitm-addon/src/registry.py`
- no function signature, runtime behavior, cache, error, schema, protocol, or configuration changes
- no exact-docstring tests; existing behavior tests already cover the documented state transitions

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python -m pytest tests/test_registry_loading.py tests/test_registry_context.py tests/test_registry_context_state.py` (55 passed)
- `python -m pytest tests/` (3917 passed)

Closes #21358
