### PR TITLE
fix: improve teams okou bot validation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -56,9 +56,11 @@ const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
 const APP_ORIGIN = "https://app.vm0.test";
 const KEY_ID = "teams-test-key";
 const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
-  "Please connect your account to use Zero in this Teams workspace.";
+  "Please connect your account to use Okou in this Teams workspace.";
 const TEAMS_LOGIN_PROMPT_CARD_TEXT =
-  "Please connect your account to use Zero in this Teams workspace.";
+  "Please connect your account to use Okou in this Teams workspace.";
+const TEAMS_WELCOME_TEXT =
+  "Hi, I'm Okou. Use `help` to see commands, or `connect` to link this Teams workspace to Okou.";
 const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
 const BOT_FRAMEWORK_KEYS_URL =
@@ -941,6 +943,132 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
   });
 
+  it("sends a welcome message when Teams adds the bot in team scope", async () => {
+    botFrameworkHandlers();
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+
+    const response = await postTeamsActivity({
+      activity: teamsBotInstalledActivity(),
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    await response.json();
+    await flushWaitUntilForTest();
+    expect(outboundRequests).toHaveLength(1);
+    expect(outboundRequests[0]).toMatchObject({
+      conversationId: "19:thread@thread.tacv2",
+      activityId: null,
+      body: {
+        type: "message",
+        text: TEAMS_WELCOME_TEXT,
+        textFormat: "markdown",
+        channelData: {
+          tenant: { id: "tenant-1" },
+        },
+      },
+    });
+    expect(outboundRequests[0]?.body).not.toHaveProperty("replyToId");
+  });
+
+  it("ignores Teams help, slash help, and greeting messages without a mention", async () => {
+    botFrameworkHandlers();
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+
+    const helpResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-validation-help",
+        text: "help",
+        entities: [],
+      }),
+      token: teamsToken(),
+    });
+    const helpBody = await readTeamsBotResponseAndFlush(helpResponse);
+    expect(helpBody).not.toHaveProperty("dispatch");
+
+    const slashHelpResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-validation-slash-help",
+        text: "/help",
+        entities: [],
+      }),
+      token: teamsToken(),
+    });
+    const slashHelpBody = await readTeamsBotResponseAndFlush(slashHelpResponse);
+    expect(slashHelpBody).not.toHaveProperty("dispatch");
+
+    const greetingResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-validation-hi",
+        text: "Hi",
+        entities: [],
+      }),
+      token: teamsToken(),
+    });
+    const greetingBody = await readTeamsBotResponseAndFlush(greetingResponse);
+    expect(greetingBody).not.toHaveProperty("dispatch");
+    expect(outboundRequests).toHaveLength(0);
+  });
+
+  it("responds to Teams greeting messages with a mention", async () => {
+    botFrameworkHandlers();
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+
+    const response = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-mentioned-hi",
+        text: "<at>Zero</at> Hi",
+      }),
+      token: teamsToken(),
+    });
+
+    const body = await readTeamsBotResponseAndFlush(response);
+    expect(body).toMatchObject({
+      activity: {
+        kind: "message",
+        text: "Hi",
+        mentionsRecipient: true,
+      },
+    });
+    expect(outboundRequests).toHaveLength(1);
+    expect(outboundRequests[0]).toMatchObject({
+      conversationId: "19:thread@thread.tacv2",
+      activityId: "activity-mentioned-hi",
+      body: {
+        type: "message",
+        text: TEAMS_WELCOME_TEXT,
+        replyToId: "activity-mentioned-hi",
+      },
+    });
+  });
+
+  it("does not run other Teams commands without a mention in channel scope", async () => {
+    botFrameworkHandlers();
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+
+    const response = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-unmentioned-disconnect",
+        text: "disconnect",
+        entities: [],
+      }),
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      activity: {
+        kind: "message",
+        text: "disconnect",
+        mentionsRecipient: false,
+      },
+    });
+    expect(body).not.toHaveProperty("dispatch");
+    await flushWaitUntilForTest();
+    expect(outboundRequests).toHaveLength(0);
+  });
+
   it("handles Teams personal messages without requiring a bot mention", async () => {
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
@@ -1185,7 +1313,7 @@ describe("POST /api/zero/teams/bot", () => {
       activity: teamsPersonalMessageActivity({
         fixture,
         id: "activity-command-help",
-        text: "help",
+        text: "/help",
       }),
       token: teamsToken(),
     });
@@ -1193,11 +1321,23 @@ describe("POST /api/zero/teams/bot", () => {
     const helpBody = await readTeamsBotResponseAndFlush(helpResponse);
     expect(helpBody).not.toHaveProperty("dispatch");
 
+    const connectResponse = await postTeamsActivity({
+      activity: teamsPersonalMessageActivity({
+        fixture,
+        id: "activity-command-connect",
+        text: "/connect",
+      }),
+      token: teamsToken(),
+    });
+    expect(connectResponse.status).toBe(200);
+    const connectBody = await readTeamsBotResponseAndFlush(connectResponse);
+    expect(connectBody).not.toHaveProperty("dispatch");
+
     const switchResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
         id: "activity-command-switch",
-        text: "/zero switch",
+        text: "/switch",
       }),
       token: teamsToken(),
     });
@@ -1209,7 +1349,7 @@ describe("POST /api/zero/teams/bot", () => {
       activity: teamsPersonalMessageActivity({
         fixture,
         id: "activity-command-model",
-        text: "zero model",
+        text: "/model",
       }),
       token: teamsToken(),
     });
@@ -1271,13 +1411,14 @@ describe("POST /api/zero/teams/bot", () => {
       selectedModel: "claude-sonnet-4-6",
     });
 
-    expect(outboundRequests).toHaveLength(5);
+    expect(outboundRequests).toHaveLength(6);
     expect(
       outboundRequests.map((request) => {
         return request.activityId;
       }),
     ).toStrictEqual([
       "activity-command-help",
+      "activity-command-connect",
       "activity-command-switch",
       "activity-command-model",
       "activity-command-switch-submit",
@@ -1285,9 +1426,13 @@ describe("POST /api/zero/teams/bot", () => {
     ]);
     expect(outboundRequests[0]?.body).toMatchObject({
       type: "message",
-      text: expect.stringContaining("Zero Teams Bot Help"),
+      text: expect.stringContaining("Okou Teams Bot Help"),
     });
     expect(outboundRequests[1]?.body).toMatchObject({
+      type: "message",
+      text: expect.stringContaining("You're already connected"),
+    });
+    expect(outboundRequests[2]?.body).toMatchObject({
       type: "message",
       summary: expect.stringContaining("Choose which agent should respond"),
       attachments: [
@@ -1323,7 +1468,7 @@ describe("POST /api/zero/teams/bot", () => {
         },
       ],
     });
-    expect(outboundRequests[2]?.body).toMatchObject({
+    expect(outboundRequests[3]?.body).toMatchObject({
       type: "message",
       summary: expect.stringContaining("Choose the model"),
       attachments: [
@@ -1355,11 +1500,11 @@ describe("POST /api/zero/teams/bot", () => {
         },
       ],
     });
-    expect(outboundRequests[3]?.body).toMatchObject({
+    expect(outboundRequests[4]?.body).toMatchObject({
       type: "message",
       text: expect.stringContaining("Teams support agent"),
     });
-    expect(outboundRequests[4]?.body).toMatchObject({
+    expect(outboundRequests[5]?.body).toMatchObject({
       type: "message",
       text: expect.stringContaining("Claude Sonnet 4.6"),
     });
@@ -1397,7 +1542,7 @@ describe("POST /api/zero/teams/bot", () => {
       activity: teamsPersonalMessageActivity({
         fixture,
         id: "activity-command-disconnect",
-        text: "disconnect",
+        text: "/disconnect",
       }),
       token: teamsToken(),
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -525,7 +525,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
               body: [
                 {
                   type: "TextBlock",
-                  text: "You're connected! 🎉\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
+                  text: "You're connected! 🎉\nMention `@Okou` in any channel or send a DM to start chatting with your agent.",
                   wrap: true,
                 },
               ],

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -17,6 +17,7 @@ import { authorization$, request$ } from "../context/hono";
 import { waitUntil } from "../context/wait-until";
 import {
   deleteTeamsReaction,
+  sendTeamsMessage,
   sendTeamsMessageReply,
   type TeamsAdaptiveCard,
 } from "../external/teams-bot-client";
@@ -27,13 +28,16 @@ import {
   publishTeamsChanged$,
   recordTeamsInstallationActivity$,
 } from "../services/zero-teams-connect.service";
-import { dispatchTeamsMessageToAgent$ } from "../services/zero-teams-dispatch.service";
+import {
+  dispatchTeamsMessageToAgent$,
+  TEAMS_WELCOME_TEXT,
+} from "../services/zero-teams-dispatch.service";
 import { ApiDispatchTimingCollector } from "../services/api-dispatch-timing.service";
 import { safeJsonParse, settle, tapError } from "../utils";
 
 const L = logger("TeamsBot");
 const TEAMS_LOGIN_PROMPT_CARD_TEXT =
-  "Please connect your account to use Zero in this Teams workspace.";
+  "Please connect your account to use Okou in this Teams workspace.";
 const TEAMS_THINKING_REACTION_TYPE = "1f4ad_thoughtballoon";
 
 function errorResponse(
@@ -130,6 +134,10 @@ type TeamsDispatchReplySource =
   | { readonly kind: "ignored" | "accepted" };
 
 type TeamsMessageActivity = Extract<TeamsInboundActivity, { kind: "message" }>;
+type TeamsInstallWelcomeActivity = Extract<
+  TeamsInboundActivity,
+  { kind: "conversation_update" | "installation_update" }
+>;
 type TeamsInstallation = typeof teamsOrgInstallations.$inferSelect;
 
 function dispatchReplyContent(dispatch: TeamsDispatchReplySource): {
@@ -162,6 +170,55 @@ function dispatchReplyContent(dispatch: TeamsDispatchReplySource): {
   }
   return { replyText: null };
 }
+
+function teamsInstallWelcomeActivity(
+  activity: TeamsInboundActivity,
+): TeamsInstallWelcomeActivity | null {
+  if (activity.kind === "installation_update") {
+    return activity.action === "add" ? activity : null;
+  }
+  if (activity.kind !== "conversation_update") {
+    return null;
+  }
+  if (activity.action !== "members_added") {
+    return null;
+  }
+  const botAdded = activity.membersAdded.some((member) => {
+    return member.id === activity.recipient.id;
+  });
+  return botAdded ? activity : null;
+}
+
+const sendTeamsInstallWelcome$ = command(
+  async (
+    _,
+    activity: TeamsInboundActivity,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const welcomeActivity = teamsInstallWelcomeActivity(activity);
+    if (!welcomeActivity) {
+      return;
+    }
+
+    const reply = await sendTeamsMessage({
+      serviceUrl: welcomeActivity.serviceUrl,
+      conversationId: welcomeActivity.conversationId,
+      tenantId: welcomeActivity.tenantId,
+      text: TEAMS_WELCOME_TEXT,
+      signal,
+    });
+    signal.throwIfAborted();
+
+    if (reply.kind === "teams-error") {
+      L.warn("Teams install welcome failed", {
+        tenantId: welcomeActivity.tenantId,
+        conversationId: welcomeActivity.conversationId,
+        status: reply.status,
+        error: reply.error,
+      });
+    }
+  },
+);
 
 async function clearTeamsThinkingReactionForActivity(args: {
   readonly activity: TeamsMessageActivity;
@@ -349,6 +406,17 @@ const handleZeroTeamsBot$ = command(
           ),
           (error) => {
             L.error("Error handling Teams message activity", { error });
+          },
+        ),
+      );
+    }
+
+    if (teamsInstallWelcomeActivity(normalized.activity)) {
+      waitUntil(
+        tapError(
+          set(sendTeamsInstallWelcome$, normalized.activity, signal),
+          (error) => {
+            L.error("Error sending Teams install welcome", { error });
           },
         ),
       );

--- a/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
@@ -776,7 +776,7 @@ function buildTeamsWelcomeCard(): TeamsAdaptiveCard {
     body: [
       {
         type: "TextBlock",
-        text: "You're connected! 🎉\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
+        text: "You're connected! 🎉\nMention `@Okou` in any channel or send a DM to start chatting with your agent.",
         wrap: true,
       },
     ],

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -69,7 +69,9 @@ import { createZeroRun$ } from "./zero-runs-create.service";
 
 const L = logger("TeamsDispatch");
 const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
-  "Please connect your account to use Zero in this Teams workspace.";
+  "Please connect your account to use Okou in this Teams workspace.";
+export const TEAMS_WELCOME_TEXT =
+  "Hi, I'm Okou. Use `help` to see commands, or `connect` to link this Teams workspace to Okou.";
 const TEAMS_AGENT_PICKER_MAX_OPTIONS = 100;
 const TEAMS_MODEL_PICKER_MAX_OPTIONS = 100;
 const TEAMS_CARD_ACTION_KEY = "zeroTeamsAction";
@@ -231,13 +233,23 @@ function modelLabel(option: TeamsModelPickerOption): string {
 
 function parseTeamsBotCommand(prompt: string): TeamsBotCommand | null {
   const parts = prompt.trim().split(/\s+/u);
-  const first = parts[0]?.toLowerCase() ?? "";
-  const prefixed = first === "/zero" || first === "zero";
-  const command = prefixed ? (parts[1]?.toLowerCase() ?? "") : first;
+  const first = parts[0]?.toLowerCase().replace(/^\//u, "") ?? "";
+  const prefixed = first === "zero";
+  const command = prefixed
+    ? (parts[1]?.toLowerCase().replace(/^\//u, "") ?? "")
+    : first;
   if (!isTeamsBotCommand(command)) {
     return null;
   }
   return prefixed || parts.length === 1 ? command : null;
+}
+
+function isTeamsBotGreeting(prompt: string): boolean {
+  const normalized = prompt
+    .trim()
+    .toLowerCase()
+    .replace(/[.!?]+$/u, "");
+  return normalized === "hi" || normalized === "hello" || normalized === "hey";
 }
 
 function commandHelpNotice(args: {
@@ -251,16 +263,23 @@ function commandHelpNotice(args: {
   return {
     kind: "notice",
     replyText: [
-      "**Zero Teams Bot Help**",
+      "**Okou Teams Bot Help**",
       "",
       "**Commands**",
-      `- \`connect\` - Connect to Zero${switchLine}${modelLine}`,
-      "- `disconnect` - Disconnect from Zero",
+      `- \`connect\` - Connect to Okou${switchLine}${modelLine}`,
+      "- `disconnect` - Disconnect from Okou",
       "",
       "**Usage**",
-      "- `@Zero <message>` - Send a message to your agent",
-      "- Send a DM to Zero to chat without mentioning the bot",
+      "- `@Okou <message>` - Send a message to your agent",
+      "- Send a DM to Okou to chat without mentioning the bot",
     ].join("\n"),
+  };
+}
+
+function greetingNotice(): TeamsMessageDispatchResult {
+  return {
+    kind: "notice",
+    replyText: TEAMS_WELCOME_TEXT,
   };
 }
 
@@ -268,7 +287,7 @@ function connectedNotice(): TeamsMessageDispatchResult {
   return {
     kind: "notice",
     replyText:
-      "You're already connected. Mention @Zero in any channel or send a DM to start chatting with your agent.",
+      "You're already connected. Mention @Okou in any channel or send a DM to start chatting with your agent.",
   };
 }
 
@@ -276,7 +295,7 @@ function notInstalledNotice(): TeamsMessageDispatchResult {
   return {
     kind: "notice",
     replyText:
-      "The Zero Teams app hasn't been set up for this workspace yet. An org admin can complete the setup from VM0.",
+      "The Okou Teams app hasn't been set up for this workspace yet. An org admin can complete the setup in Okou.",
   };
 }
 
@@ -1735,6 +1754,7 @@ function composeResolutionNotice(
 
 function unboundInstallationNotice(args: {
   readonly command: TeamsBotCommand | null;
+  readonly isGreeting: boolean;
   readonly activity: TeamsMessageActivity;
   readonly installation: TeamsInstallation | null;
 }): TeamsMessageDispatchResult {
@@ -1744,16 +1764,23 @@ function unboundInstallationNotice(args: {
   if (args.command === "connect" && !args.installation) {
     return notInstalledNotice();
   }
+  if (args.isGreeting) {
+    return greetingNotice();
+  }
   return connectNotice(args.activity, args.installation);
 }
 
 function missingConnectionNotice(args: {
   readonly command: TeamsBotCommand | null;
+  readonly isGreeting: boolean;
   readonly activity: TeamsMessageActivity;
   readonly installation: TeamsInstallation;
 }): TeamsMessageDispatchResult {
   if (args.command === "help") {
     return commandHelpNotice({ canSwitch: true, canModel: false });
+  }
+  if (args.isGreeting) {
+    return greetingNotice();
   }
   return connectNotice(args.activity, args.installation);
 }
@@ -2111,19 +2138,20 @@ export const dispatchTeamsMessageToAgent$ = command(
     }
 
     const cardAction = teamsCardAction(activity.value);
-    if (!shouldDispatchTeamsMessage(activity) && !cardAction) {
+    if (!cardAction && !shouldDispatchTeamsMessage(activity)) {
       return { kind: "ignored" };
     }
 
     const prompt = activity.text.trim();
+    const command = cardAction ? null : parseTeamsBotCommand(prompt);
+    const isGreeting = !cardAction && isTeamsBotGreeting(prompt);
     const promptFiles = cardAction ? [] : teamsPromptFiles(activity);
     if (!prompt && promptFiles.length === 0 && !cardAction) {
       return {
         kind: "notice",
-        replyText: "Please include a message for Zero.",
+        replyText: "Please include a message for Okou.",
       };
     }
-    const command = cardAction ? null : parseTeamsBotCommand(prompt);
 
     const db = set(writeDb$);
     const installation =
@@ -2133,7 +2161,12 @@ export const dispatchTeamsMessageToAgent$ = command(
     signal.throwIfAborted();
 
     if (!installation?.orgId) {
-      return unboundInstallationNotice({ command, activity, installation });
+      return unboundInstallationNotice({
+        command,
+        isGreeting,
+        activity,
+        installation,
+      });
     }
     const boundInstallation: BoundTeamsInstallation = {
       ...installation,
@@ -2149,7 +2182,12 @@ export const dispatchTeamsMessageToAgent$ = command(
     signal.throwIfAborted();
 
     if (!connection) {
-      return missingConnectionNotice({ command, activity, installation });
+      return missingConnectionNotice({
+        command,
+        isGreeting,
+        activity,
+        installation,
+      });
     }
 
     if (cardAction) {
@@ -2168,7 +2206,12 @@ export const dispatchTeamsMessageToAgent$ = command(
 
     const commandResult = await set(
       connectedCommandBeforeCompose$,
-      { db, command, installation: boundInstallation, connection },
+      {
+        db,
+        command,
+        installation: boundInstallation,
+        connection,
+      },
       signal,
     );
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary
- send an Okou welcome message when Teams adds the bot in team scope
- update Teams user-facing bot copy from Zero/VM0 to Okou
- handle slash commands and greeting/help responses only in DM or mention contexts
- add regression coverage for Teams install welcome, unmentioned channel ignores, mention greetings, and slash commands

## Tests
- pnpm -C turbo -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts src/signals/routes/__tests__/zero-teams-connect.test.ts
- pnpm -C turbo -F api lint
- pnpm -C turbo -F api check-types
- git diff --check
- pre-commit: prettier, knip, full check-types