### PR TITLE
perf(runner): measure session history append lineage

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -325,6 +325,7 @@ fn build_session_history_restore_plan(
         return SessionHistoryRestorePlan::Default;
     }
 
+    let mut prefix_attribution = None;
     let fallback = match reuse.result {
         SandboxReuseResult::Reused => {
             let requested_identity = RestoredSessionIdentity::from_context(context);
@@ -348,8 +349,11 @@ fn build_session_history_restore_plan(
                         }
                     }
                     Some(restored_identity) => {
+                        let (mismatch_reason, attribution) = restored_identity
+                            .mismatch_reason_and_prefix_attribution(&requested_identity);
+                        prefix_attribution = attribution;
                         Some(SessionHistoryRestoreFallback::IdentityMismatch(
-                            restored_identity.mismatch_reason_for_request(&requested_identity),
+                            mismatch_reason,
                         ))
                     }
                     None => Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
@@ -372,14 +376,27 @@ fn build_session_history_restore_plan(
     }
 
     let started_at = Instant::now();
-    let materializer = SessionHistoryMaterializer::start_cancellable(
-        http,
-        cpu,
-        Some(resume_session),
-        effective_cli_framework(&context.cli_agent_type),
-        cancel.token(),
-        probe,
-    );
+    let materializer = match prefix_attribution {
+        Some(prefix_attribution) => {
+            SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
+                http,
+                cpu,
+                Some(resume_session),
+                effective_cli_framework(&context.cli_agent_type),
+                cancel.token(),
+                probe,
+                prefix_attribution,
+            )
+        }
+        None => SessionHistoryMaterializer::start_cancellable(
+            http,
+            cpu,
+            Some(resume_session),
+            effective_cli_framework(&context.cli_agent_type),
+            cancel.token(),
+            probe,
+        ),
+    };
     pre_spawn_timing.record_phase_elapsed(
         RunnerPreSpawnPhase::SessionHistoryMaterializerStart,
         started_at,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -37,7 +37,7 @@ use super::env::{
     write_user_env_file,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
-use super::session_history_cpu::SessionHistoryCpuJob;
+use super::session_history_cpu::{SessionHistoryCpuJob, SessionHistoryPrefixOutcome};
 use super::session_history_download::{
     SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
     SessionHistoryMaterialization, SessionHistoryMaterializer,
@@ -60,7 +60,9 @@ use crate::restored_session_identity::{
     RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
 };
 use crate::storage_plan::build_storage_plan;
-use crate::telemetry::{JobTelemetry, SessionHistoryTelemetryMetadata};
+use crate::telemetry::{
+    JobTelemetry, SessionHistoryTelemetryMetadata, session_history_prefix_extension_action_type,
+};
 use crate::types::ExecutionContext;
 use crate::workspace_image_cache::{
     WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarRepresentation,
@@ -219,6 +221,34 @@ fn record_session_history_identity_mismatch_reason(
     }
 }
 
+fn record_session_history_prefix_outcome(
+    telemetry: &mut JobTelemetry,
+    outcome: SessionHistoryPrefixOutcome,
+) {
+    match outcome {
+        SessionHistoryPrefixOutcome::Verified { raw_extension_size } => {
+            telemetry.record(
+                "session_history_requested_larger_prefix_verified",
+                Duration::ZERO,
+                true,
+                None,
+            );
+            telemetry.record(
+                session_history_prefix_extension_action_type(raw_extension_size),
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
+        SessionHistoryPrefixOutcome::Divergent => telemetry.record(
+            "session_history_requested_larger_prefix_divergent",
+            Duration::ZERO,
+            true,
+            None,
+        ),
+    }
+}
+
 fn record_session_history_download_timings(
     telemetry: &mut JobTelemetry,
     timings: &SessionHistoryDownloadTimings,
@@ -369,6 +399,7 @@ async fn materialize_session_history_sidecar(
         .materialize(job, cancel)
         .await?
         .result
+        .map(|materialization| materialization.session)
 }
 
 async fn materialize_inline_resume_session(
@@ -395,7 +426,9 @@ async fn materialize_inline_resume_session(
                 cancel,
             )
             .await?;
-        return outcome.result.map(Some);
+        return outcome
+            .result
+            .map(|materialization| Some(materialization.session));
     }
     Ok(Some(MaterializedResumeSession::new_shared(
         resume_session.cli_agent_session_id.clone(),
@@ -1221,6 +1254,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             SessionHistoryMaterialization::NoDownloadNeeded => None,
             SessionHistoryMaterialization::Downloaded {
                 session,
+                prefix_outcome,
                 elapsed,
                 timings,
             } => {
@@ -1249,6 +1283,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     timings.metadata(),
                 );
                 record_session_history_download_timings(telemetry, &timings);
+                if let Some(prefix_outcome) = prefix_outcome {
+                    record_session_history_prefix_outcome(telemetry, prefix_outcome);
+                }
                 Some(session)
             }
             SessionHistoryMaterialization::Failed {

--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -1,5 +1,6 @@
 //! Bounded CPU execution for resume-session history materialization.
 
+use std::fmt;
 use std::io::{self, BufRead, BufReader, Read};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -16,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use super::cli_framework::EffectiveCliFramework;
 use super::session_restore::MaterializedResumeSession;
 use super::{RunnerError, RunnerResult};
+use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
 
 const CPU_CHUNK_BYTES: usize = 64 * 1024;
 const DECODER_BUFFER_BYTES: usize = 8 * 1024;
@@ -41,7 +43,12 @@ struct SessionHistoryCpuTaskGuard {
     armed: bool,
 }
 
-pub(super) enum SessionHistoryCpuJob {
+pub(super) struct SessionHistoryCpuJob {
+    kind: SessionHistoryCpuJobKind,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
+}
+
+enum SessionHistoryCpuJobKind {
     Raw {
         cli_agent_session_id: String,
         bytes: Vec<u8>,
@@ -76,12 +83,53 @@ struct CompressedSessionHistoryJob {
     expected_hash: String,
     framework: EffectiveCliFramework,
     encoding: CompressedEncoding,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
 }
 
-#[derive(Debug)]
+struct RawSessionHistoryJob {
+    cli_agent_session_id: String,
+    bytes: Vec<u8>,
+    expected_raw_size: u64,
+    expected_hash: String,
+    framework: EffectiveCliFramework,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
+}
+
 pub(super) struct SessionHistoryCpuOutcome {
     pub(super) timings: SessionHistoryCpuTimings,
-    pub(super) result: RunnerResult<MaterializedResumeSession>,
+    pub(super) result: RunnerResult<SessionHistoryCpuMaterialization>,
+}
+
+pub(super) struct SessionHistoryCpuMaterialization {
+    pub(super) session: MaterializedResumeSession,
+    pub(super) prefix_outcome: Option<SessionHistoryPrefixOutcome>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum SessionHistoryPrefixOutcome {
+    Verified { raw_extension_size: u64 },
+    Divergent,
+}
+
+impl fmt::Debug for SessionHistoryCpuOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionHistoryCpuOutcome")
+            .field("timings", &self.timings)
+            .field(
+                "result",
+                &self.result.as_ref().map(|_| "[redacted-materialization]"),
+            )
+            .finish()
+    }
+}
+
+impl fmt::Debug for SessionHistoryCpuMaterialization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionHistoryCpuMaterialization")
+            .field("session", &"[redacted]")
+            .field("prefix_outcome", &self.prefix_outcome.map(|_| "[redacted]"))
+            .finish()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -234,12 +282,15 @@ impl SessionHistoryCpuJob {
         expected_hash: String,
         framework: EffectiveCliFramework,
     ) -> Self {
-        Self::Raw {
-            cli_agent_session_id,
-            bytes,
-            expected_raw_size,
-            expected_hash,
-            framework,
+        Self {
+            kind: SessionHistoryCpuJobKind::Raw {
+                cli_agent_session_id,
+                bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+            },
+            prefix_attribution: None,
         }
     }
 
@@ -250,12 +301,15 @@ impl SessionHistoryCpuJob {
         expected_hash: String,
         framework: EffectiveCliFramework,
     ) -> Self {
-        Self::Gzip {
-            cli_agent_session_id,
-            encoded_bytes,
-            expected_raw_size,
-            expected_hash,
-            framework,
+        Self {
+            kind: SessionHistoryCpuJobKind::Gzip {
+                cli_agent_session_id,
+                encoded_bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+            },
+            prefix_attribution: None,
         }
     }
 
@@ -266,20 +320,34 @@ impl SessionHistoryCpuJob {
         expected_hash: String,
         framework: EffectiveCliFramework,
     ) -> Self {
-        Self::Zstd {
-            cli_agent_session_id,
-            encoded_bytes,
-            expected_raw_size,
-            expected_hash,
-            framework,
+        Self {
+            kind: SessionHistoryCpuJobKind::Zstd {
+                cli_agent_session_id,
+                encoded_bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+            },
+            prefix_attribution: None,
         }
     }
 
     pub(super) fn inline_codex(cli_agent_session_id: String, history: Arc<String>) -> Self {
-        Self::InlineCodex {
-            cli_agent_session_id,
-            history,
+        Self {
+            kind: SessionHistoryCpuJobKind::InlineCodex {
+                cli_agent_session_id,
+                history,
+            },
+            prefix_attribution: None,
         }
+    }
+
+    pub(super) fn with_prefix_attribution(
+        mut self,
+        prefix_attribution: RestoredSessionHistoryPrefixAttribution,
+    ) -> Self {
+        self.prefix_attribution = Some(prefix_attribution);
+        self
     }
 }
 
@@ -330,23 +398,30 @@ fn materialize_blocking(
             result: Err(error),
         };
     }
-    match job {
-        SessionHistoryCpuJob::Raw {
+    let SessionHistoryCpuJob {
+        kind,
+        prefix_attribution,
+    } = job;
+    match kind {
+        SessionHistoryCpuJobKind::Raw {
             cli_agent_session_id,
             bytes,
             expected_raw_size,
             expected_hash,
             framework,
         } => materialize_raw(
-            cli_agent_session_id,
-            bytes,
-            expected_raw_size,
-            &expected_hash,
-            framework,
+            RawSessionHistoryJob {
+                cli_agent_session_id,
+                bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+                prefix_attribution,
+            },
             cancel,
             hooks,
         ),
-        SessionHistoryCpuJob::Gzip {
+        SessionHistoryCpuJobKind::Gzip {
             cli_agent_session_id,
             encoded_bytes,
             expected_raw_size,
@@ -360,11 +435,12 @@ fn materialize_blocking(
                 expected_hash,
                 framework,
                 encoding: CompressedEncoding::Gzip,
+                prefix_attribution,
             },
             cancel,
             hooks,
         ),
-        SessionHistoryCpuJob::Zstd {
+        SessionHistoryCpuJobKind::Zstd {
             cli_agent_session_id,
             encoded_bytes,
             expected_raw_size,
@@ -375,10 +451,11 @@ fn materialize_blocking(
             encoded_bytes,
             expected_raw_size,
             &expected_hash,
+            prefix_attribution,
             cancel,
             hooks,
         ),
-        SessionHistoryCpuJob::Zstd {
+        SessionHistoryCpuJobKind::Zstd {
             cli_agent_session_id,
             encoded_bytes,
             expected_raw_size,
@@ -392,16 +469,24 @@ fn materialize_blocking(
                 expected_hash,
                 framework,
                 encoding: CompressedEncoding::Zstd,
+                prefix_attribution,
             },
             cancel,
             hooks,
         ),
-        SessionHistoryCpuJob::InlineCodex {
+        SessionHistoryCpuJobKind::InlineCodex {
             cli_agent_session_id,
             history,
         } => {
             let result = scan_valid_utf8_history(&history, cancel, hooks).map(|timestamp| {
-                MaterializedResumeSession::new_shared(cli_agent_session_id, history, timestamp)
+                SessionHistoryCpuMaterialization {
+                    session: MaterializedResumeSession::new_shared(
+                        cli_agent_session_id,
+                        history,
+                        timestamp,
+                    ),
+                    prefix_outcome: None,
+                }
             });
             SessionHistoryCpuOutcome {
                 timings: SessionHistoryCpuTimings::default(),
@@ -412,28 +497,37 @@ fn materialize_blocking(
 }
 
 fn materialize_raw(
-    cli_agent_session_id: String,
-    bytes: Vec<u8>,
-    expected_raw_size: u64,
-    expected_hash: &str,
-    framework: EffectiveCliFramework,
+    job: RawSessionHistoryJob,
     cancel: &CancellationToken,
     hooks: &SessionHistoryCpuHooks,
 ) -> SessionHistoryCpuOutcome {
+    let RawSessionHistoryJob {
+        cli_agent_session_id,
+        bytes,
+        expected_raw_size,
+        expected_hash,
+        framework,
+        prefix_attribution,
+    } = job;
     let mut timings = SessionHistoryCpuTimings::default();
     let result = (|| {
         validate_raw_size(&bytes, expected_raw_size, &mut timings)?;
-        verify_hash(&bytes, expected_hash, &mut timings, cancel)?;
+        let prefix_outcome = verify_hash(
+            &bytes,
+            &expected_hash,
+            prefix_attribution,
+            &mut timings,
+            cancel,
+        )?;
         let timestamp = if framework == EffectiveCliFramework::Codex {
             scan_raw_codex_history(&bytes, cancel, hooks)?
         } else {
             None
         };
-        Ok(MaterializedResumeSession::new(
-            cli_agent_session_id,
-            bytes,
-            timestamp,
-        ))
+        Ok(SessionHistoryCpuMaterialization {
+            session: MaterializedResumeSession::new(cli_agent_session_id, bytes, timestamp),
+            prefix_outcome,
+        })
     })();
     SessionHistoryCpuOutcome { timings, result }
 }
@@ -465,6 +559,7 @@ fn materialize_compressed(
         expected_hash,
         framework,
         encoding,
+        prefix_attribution,
     } = job;
     let mut timings = SessionHistoryCpuTimings::default();
     let result = (|| {
@@ -474,17 +569,22 @@ fn materialize_compressed(
         timings.record_decompression(decompression_started.elapsed(), result.is_ok());
         let bytes = result?;
         validate_decompressed_size(&bytes, expected_raw_size, &mut timings)?;
-        verify_hash(&bytes, &expected_hash, &mut timings, cancel)?;
+        let prefix_outcome = verify_hash(
+            &bytes,
+            &expected_hash,
+            prefix_attribution,
+            &mut timings,
+            cancel,
+        )?;
         let timestamp = if framework == EffectiveCliFramework::Codex {
             scan_raw_codex_history(&bytes, cancel, hooks)?
         } else {
             None
         };
-        Ok(MaterializedResumeSession::new(
-            cli_agent_session_id,
-            bytes,
-            timestamp,
-        ))
+        Ok(SessionHistoryCpuMaterialization {
+            session: MaterializedResumeSession::new(cli_agent_session_id, bytes, timestamp),
+            prefix_outcome,
+        })
     })();
     SessionHistoryCpuOutcome { timings, result }
 }
@@ -494,25 +594,30 @@ fn materialize_codex_zstd(
     encoded_bytes: Vec<u8>,
     expected_raw_size: u64,
     expected_hash: &str,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     cancel: &CancellationToken,
     hooks: &SessionHistoryCpuHooks,
 ) -> SessionHistoryCpuOutcome {
     let mut timings = SessionHistoryCpuTimings::default();
     let result = (|| {
         validate_compressed_raw_size(expected_raw_size, "zstd", &mut timings)?;
-        let timestamp = verify_codex_zstd(
+        let (timestamp, prefix_outcome) = verify_codex_zstd(
             &encoded_bytes,
             expected_raw_size,
             expected_hash,
+            prefix_attribution,
             &mut timings,
             cancel,
             hooks,
         )?;
-        Ok(MaterializedResumeSession::new_codex_zstd(
-            cli_agent_session_id,
-            encoded_bytes,
-            timestamp,
-        ))
+        Ok(SessionHistoryCpuMaterialization {
+            session: MaterializedResumeSession::new_codex_zstd(
+                cli_agent_session_id,
+                encoded_bytes,
+                timestamp,
+            ),
+            prefix_outcome,
+        })
     })();
     SessionHistoryCpuOutcome { timings, result }
 }
@@ -588,31 +693,99 @@ fn validate_compressed_raw_size(
 fn verify_hash(
     bytes: &[u8],
     expected_hash: &str,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     timings: &mut SessionHistoryCpuTimings,
     cancel: &CancellationToken,
-) -> RunnerResult<()> {
+) -> RunnerResult<Option<SessionHistoryPrefixOutcome>> {
     let started = Instant::now();
     let result = (|| {
-        let mut hasher = Sha256::new();
-        update_hash(&mut hasher, bytes, cancel)?;
-        let actual_hash = hex::encode(hasher.finalize());
-        if actual_hash != expected_hash {
-            return Err(RunnerError::Internal(
-                "session history hash mismatch".into(),
-            ));
-        }
-        Ok(())
+        let mut observer = SessionHistoryHashObserver::new(prefix_attribution);
+        observer.update(bytes, cancel)?;
+        observer.finish(expected_hash)
     })();
     timings.record_hash_verification(started.elapsed(), result.is_ok());
     result
 }
 
-fn update_hash(hasher: &mut Sha256, bytes: &[u8], cancel: &CancellationToken) -> RunnerResult<()> {
-    for chunk in bytes.chunks(CPU_CHUNK_BYTES) {
-        check_cancelled(cancel)?;
-        hasher.update(chunk);
+struct SessionHistoryHashObserver {
+    full_hasher: Sha256,
+    observed_bytes: u64,
+    prefix_hasher: Option<SessionHistoryPrefixHasher>,
+}
+
+struct SessionHistoryPrefixHasher {
+    hasher: Sha256,
+    remaining_bytes: u64,
+    expected_hash: String,
+    history_size_bytes: u64,
+}
+
+impl SessionHistoryHashObserver {
+    fn new(prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>) -> Self {
+        Self {
+            full_hasher: Sha256::new(),
+            observed_bytes: 0,
+            prefix_hasher: prefix_attribution.map(SessionHistoryPrefixHasher::new),
+        }
     }
-    check_cancelled(cancel)
+
+    fn update(&mut self, bytes: &[u8], cancel: &CancellationToken) -> RunnerResult<()> {
+        for chunk in bytes.chunks(CPU_CHUNK_BYTES) {
+            check_cancelled(cancel)?;
+            self.full_hasher.update(chunk);
+            self.observed_bytes += chunk.len() as u64;
+            if let Some(prefix_hasher) = &mut self.prefix_hasher {
+                prefix_hasher.update(chunk);
+            }
+        }
+        check_cancelled(cancel)
+    }
+
+    fn finish(self, expected_hash: &str) -> RunnerResult<Option<SessionHistoryPrefixOutcome>> {
+        let actual_hash = hex::encode(self.full_hasher.finalize());
+        if actual_hash != expected_hash {
+            return Err(RunnerError::Internal(
+                "session history hash mismatch".into(),
+            ));
+        }
+        Ok(self
+            .prefix_hasher
+            .map(|prefix_hasher| prefix_hasher.finish(self.observed_bytes)))
+    }
+}
+
+impl SessionHistoryPrefixHasher {
+    fn new(attribution: RestoredSessionHistoryPrefixAttribution) -> Self {
+        let (expected_hash, history_size_bytes) = attribution.into_parts();
+        Self {
+            hasher: Sha256::new(),
+            remaining_bytes: history_size_bytes,
+            expected_hash,
+            history_size_bytes,
+        }
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        if self.remaining_bytes == 0 {
+            return;
+        }
+        let prefix_bytes = self.remaining_bytes.min(bytes.len() as u64) as usize;
+        let prefix = bytes.get(..prefix_bytes).unwrap_or(bytes);
+        self.hasher.update(prefix);
+        self.remaining_bytes -= prefix_bytes as u64;
+    }
+
+    fn finish(self, observed_bytes: u64) -> SessionHistoryPrefixOutcome {
+        debug_assert_eq!(self.remaining_bytes, 0);
+        if hex::encode(self.hasher.finalize()) == self.expected_hash {
+            debug_assert!(observed_bytes > self.history_size_bytes);
+            SessionHistoryPrefixOutcome::Verified {
+                raw_extension_size: observed_bytes - self.history_size_bytes,
+            }
+        } else {
+            SessionHistoryPrefixOutcome::Divergent
+        }
+    }
 }
 
 fn decompress_history(
@@ -677,10 +850,14 @@ fn verify_codex_zstd(
     encoded_bytes: &[u8],
     expected_raw_size: u64,
     expected_hash: &str,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     timings: &mut SessionHistoryCpuTimings,
     cancel: &CancellationToken,
     hooks: &SessionHistoryCpuHooks,
-) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+) -> RunnerResult<(
+    Option<chrono::DateTime<chrono::Utc>>,
+    Option<SessionHistoryPrefixOutcome>,
+)> {
     let decompression_started = Instant::now();
     let input = CancellationReader::new(encoded_bytes, cancel.clone(), hooks.clone());
     let decoder = match zstd::stream::read::Decoder::new(input) {
@@ -695,7 +872,7 @@ fn verify_codex_zstd(
     let decoded = decoder.take(expected_raw_size.saturating_add(1));
     let output = CancellationReader::new(decoded, cancel.clone(), hooks.clone());
     let mut reader = BufReader::with_capacity(DECODER_BUFFER_BYTES, output);
-    let mut hasher = Sha256::new();
+    let mut observer = SessionHistoryHashObserver::new(prefix_attribution);
     let mut decoded_bytes = 0u64;
     let mut timestamp = None;
     let mut line = Vec::new();
@@ -726,7 +903,7 @@ fn verify_codex_zstd(
                 "session history is too large after decompression: {decoded_bytes} bytes exceeds {expected_raw_size} bytes"
             )));
         }
-        update_hash(&mut hasher, &line, cancel)?;
+        observer.update(&line, cancel)?;
         if timestamp.is_none() {
             timestamp = parse_codex_timestamp_line(strip_jsonl_line_ending(&line), cancel, hooks)?;
         }
@@ -746,17 +923,10 @@ fn verify_codex_zstd(
 
     let hash_started = Instant::now();
     check_cancelled(cancel)?;
-    let actual_hash = hex::encode(hasher.finalize());
-    let hash_result = if actual_hash == expected_hash {
-        Ok(())
-    } else {
-        Err(RunnerError::Internal(
-            "session history hash mismatch".into(),
-        ))
-    };
+    let hash_result = observer.finish(expected_hash);
     timings.record_hash_verification(hash_started.elapsed(), hash_result.is_ok());
-    hash_result?;
-    Ok(timestamp)
+    let prefix_outcome = hash_result?;
+    Ok((timestamp, prefix_outcome))
 }
 
 fn scan_raw_codex_history(
@@ -1303,9 +1473,10 @@ mod tests {
             )
             .await
             .unwrap();
-        let session = outcome.result.unwrap();
+        let materialization = outcome.result.unwrap();
         assert_eq!(
-            session
+            materialization
+                .session
                 .codex_timestamp()
                 .map(|timestamp| timestamp.to_rfc3339())
                 .as_deref(),
@@ -1326,7 +1497,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(outcome.result.unwrap().codex_timestamp().is_none());
+        assert!(outcome.result.unwrap().session.codex_timestamp().is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -28,11 +28,13 @@ use tokio_util::sync::CancellationToken;
 
 use super::cli_framework::EffectiveCliFramework;
 use super::session_history_cpu::{
-    SessionHistoryCpuJob, SessionHistoryCpuPool, SessionHistoryCpuTimings,
+    SessionHistoryCpuJob, SessionHistoryCpuMaterialization, SessionHistoryCpuPool,
+    SessionHistoryCpuTimings, SessionHistoryPrefixOutcome,
 };
 use super::session_restore::MaterializedResumeSession;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
+use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
 use crate::telemetry::{
     SessionHistoryCacheProbeMetadata, SessionHistoryContentEncodingState,
     SessionHistoryContentLengthState, SessionHistoryResponseTelemetryMetadata,
@@ -112,6 +114,7 @@ pub(super) enum SessionHistoryMaterialization {
     NoDownloadNeeded,
     Downloaded {
         session: MaterializedResumeSession,
+        prefix_outcome: Option<SessionHistoryPrefixOutcome>,
         elapsed: Duration,
         timings: SessionHistoryDownloadTimings,
     },
@@ -125,7 +128,7 @@ pub(super) enum SessionHistoryMaterialization {
 struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
     timings: SessionHistoryDownloadTimings,
-    result: RunnerResult<MaterializedResumeSession>,
+    result: RunnerResult<SessionHistoryCpuMaterialization>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -441,6 +444,38 @@ impl SessionHistoryMaterializer {
         cancel: CancellationToken,
         probe: Option<&SessionHistoryProbe>,
     ) -> Self {
+        Self::start_cancellable_inner(http, cpu, session, framework, cancel, probe, None)
+    }
+
+    pub(crate) fn start_cancellable_with_prefix_attribution(
+        http: &HttpClient,
+        cpu: &SessionHistoryCpuPool,
+        session: Option<&ResumeSession>,
+        framework: EffectiveCliFramework,
+        cancel: CancellationToken,
+        probe: Option<&SessionHistoryProbe>,
+        prefix_attribution: RestoredSessionHistoryPrefixAttribution,
+    ) -> Self {
+        Self::start_cancellable_inner(
+            http,
+            cpu,
+            session,
+            framework,
+            cancel,
+            probe,
+            Some(prefix_attribution),
+        )
+    }
+
+    fn start_cancellable_inner(
+        http: &HttpClient,
+        cpu: &SessionHistoryCpuPool,
+        session: Option<&ResumeSession>,
+        framework: EffectiveCliFramework,
+        cancel: CancellationToken,
+        probe: Option<&SessionHistoryProbe>,
+        prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
+    ) -> Self {
         let Some(session) = session else {
             return Self {
                 state: SessionHistoryMaterializerState::Missing,
@@ -479,6 +514,7 @@ impl SessionHistoryMaterializer {
                         session,
                         framework,
                         metadata,
+                        prefix_attribution,
                         task_cancel_for_task,
                     )
                     .await;
@@ -586,8 +622,9 @@ impl SessionHistoryMaterializer {
 impl SessionHistoryDownloadTaskResult {
     fn into_materialization(self) -> SessionHistoryMaterialization {
         match self.result {
-            Ok(session) => SessionHistoryMaterialization::Downloaded {
-                session,
+            Ok(materialization) => SessionHistoryMaterialization::Downloaded {
+                session: materialization.session,
+                prefix_outcome: materialization.prefix_outcome,
                 elapsed: self.elapsed,
                 timings: self.timings,
             },
@@ -640,6 +677,7 @@ async fn download_resume_session_history_timed(
     session: ResumeSession,
     framework: EffectiveCliFramework,
     metadata: SessionHistoryTelemetryMetadata,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     cancel: CancellationToken,
 ) -> SessionHistoryDownloadTaskResult {
     let started_at = Instant::now();
@@ -647,9 +685,16 @@ async fn download_resume_session_history_timed(
     if cancel.is_cancelled() {
         return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata);
     }
-    let result =
-        download_resume_session_history(http, &cpu, session, framework, &cancel, &mut timings)
-            .await;
+    let result = download_resume_session_history(
+        http,
+        &cpu,
+        session,
+        framework,
+        prefix_attribution,
+        &cancel,
+        &mut timings,
+    )
+    .await;
     if cancel.is_cancelled() {
         return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata);
     }
@@ -665,9 +710,10 @@ async fn download_resume_session_history(
     cpu: &SessionHistoryCpuPool,
     session: ResumeSession,
     framework: EffectiveCliFramework,
+    prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     cancel: &CancellationToken,
     timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<MaterializedResumeSession> {
+) -> RunnerResult<SessionHistoryCpuMaterialization> {
     // The history ref is treated as untrusted input. The request timeout and
     // 128 MiB cap bound resource use; declared size, HTTP content-length, final
     // byte count, and SHA-256 must all agree before the bytes become sandbox
@@ -740,6 +786,10 @@ async fn download_resume_session_history(
                 framework,
             )
         }
+    };
+    let job = match prefix_attribution {
+        Some(prefix_attribution) => job.with_prefix_attribution(prefix_attribution),
+        None => job,
     };
     let outcome = cpu.materialize(job, cancel).await?;
     timings.merge_cpu(outcome.timings);
@@ -1192,6 +1242,7 @@ mod tests {
 
     use super::*;
     use crate::http::{HttpClient, HttpClientConfig};
+    use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
     use crate::test_fixtures::OneShotSessionHistoryServer;
     use crate::types::{
         ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
@@ -1303,6 +1354,29 @@ mod tests {
 
     fn start_materializer(session: &ResumeSession) -> SessionHistoryMaterializer {
         start_materializer_with_framework(session, EffectiveCliFramework::ClaudeCode)
+    }
+
+    fn prefix_attribution(local_history: &[u8]) -> RestoredSessionHistoryPrefixAttribution {
+        RestoredSessionHistoryPrefixAttribution::for_test(
+            hex::encode(Sha256::digest(local_history)),
+            local_history.len() as u64,
+        )
+    }
+
+    fn start_materializer_with_prefix_attribution(
+        session: &ResumeSession,
+        framework: EffectiveCliFramework,
+        prefix_attribution: RestoredSessionHistoryPrefixAttribution,
+    ) -> SessionHistoryMaterializer {
+        SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
+            &http_client(),
+            &SessionHistoryCpuPool::with_capacity(1),
+            Some(session),
+            framework,
+            CancellationToken::new(),
+            None,
+            prefix_attribution,
+        )
     }
 
     fn identity_metadata() -> SessionHistoryTelemetryMetadata {
@@ -1625,6 +1699,60 @@ mod tests {
             _ => panic!("expected downloaded session"),
         }
         server.assert_served().await;
+    }
+
+    #[tokio::test]
+    async fn materializer_attributes_verified_and_divergent_raw_prefixes() {
+        let requested_history = b"prefix\nextension\n";
+        let cases: [(&[u8], bool); 2] = [(b"prefix\n", true), (b"differ\n", false)];
+
+        for (local_history, expected_verified) in cases {
+            let hash = hex::encode(Sha256::digest(requested_history));
+            let server = serve_once(
+                "200 OK",
+                requested_history,
+                Some(requested_history.len() as u64),
+            )
+            .await;
+            let session = ref_session(
+                server.url(),
+                hash,
+                requested_history.len() as u64,
+                requested_history.len() as u64,
+            );
+
+            let result = start_materializer_with_prefix_attribution(
+                &session,
+                EffectiveCliFramework::ClaudeCode,
+                prefix_attribution(local_history),
+            )
+            .finish(&CancellationToken::new())
+            .await;
+
+            match result {
+                SessionHistoryMaterialization::Downloaded {
+                    session,
+                    prefix_outcome,
+                    ..
+                } => {
+                    assert_eq!(session.history_bytes(), requested_history);
+                    match prefix_outcome {
+                        Some(SessionHistoryPrefixOutcome::Verified { raw_extension_size })
+                            if expected_verified =>
+                        {
+                            assert_eq!(
+                                raw_extension_size,
+                                (requested_history.len() - local_history.len()) as u64
+                            );
+                        }
+                        Some(SessionHistoryPrefixOutcome::Divergent) if !expected_verified => {}
+                        _ => panic!("unexpected prefix attribution outcome"),
+                    }
+                }
+                _ => panic!("expected downloaded session"),
+            }
+            server.assert_served().await;
+        }
     }
 
     #[tokio::test]
@@ -2029,6 +2157,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn compressed_materializers_preserve_complete_validation_with_prefix_attribution() {
+        let body = b"prefix\nextension\n";
+        let local_history = b"prefix\n";
+        let representations = [
+            (ResumeSessionHistoryEncoding::Gzip, gzip_bytes(body)),
+            (ResumeSessionHistoryEncoding::Zstd, zstd_bytes(body)),
+        ];
+
+        for (encoding, compressed) in representations {
+            let encoded_size = compressed.len() as u64;
+            let server = serve_once("200 OK", compressed, None).await;
+            let session = compressed_ref_session(
+                server.url(),
+                hex::encode(Sha256::digest(body)),
+                body.len() as u64,
+                encoded_size,
+                encoding,
+            );
+
+            let result = start_materializer_with_prefix_attribution(
+                &session,
+                EffectiveCliFramework::ClaudeCode,
+                prefix_attribution(local_history),
+            )
+            .finish(&CancellationToken::new())
+            .await;
+
+            match result {
+                SessionHistoryMaterialization::Downloaded {
+                    session,
+                    prefix_outcome:
+                        Some(SessionHistoryPrefixOutcome::Verified { raw_extension_size }),
+                    ..
+                } => {
+                    assert_eq!(session.history_bytes(), body);
+                    assert_eq!(
+                        raw_extension_size,
+                        (body.len() - local_history.len()) as u64
+                    );
+                }
+                _ => panic!("expected verified attributed compressed session"),
+            }
+            server.assert_served().await;
+        }
+    }
+
+    #[tokio::test]
     async fn codex_materializer_preserves_verified_zstd_history() {
         let body =
             b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
@@ -2070,6 +2245,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_zstd_attributes_prefix_inside_a_buffered_jsonl_line() {
+        const PREFIX_BOUNDARY: usize = 8 * 1024 + 37;
+
+        let padding = "x".repeat(PREFIX_BOUNDARY + 256);
+        let body = format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"timestamp\":\"2026-07-02T10:00:00Z\",\"padding\":\"{padding}\"}}}}\n{{\"type\":\"response\"}}\n"
+        );
+        let body = body.as_bytes();
+        let local_size = PREFIX_BOUNDARY;
+        let local_history = &body[..local_size];
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let server = serve_once("200 OK", compressed.clone(), None).await;
+        let session = zstd_ref_session(
+            server.url(),
+            hex::encode(Sha256::digest(body)),
+            body.len() as u64,
+            encoded_size,
+        );
+
+        let result = start_materializer_with_prefix_attribution(
+            &session,
+            EffectiveCliFramework::Codex,
+            prefix_attribution(local_history),
+        )
+        .finish(&CancellationToken::new())
+        .await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded {
+                session,
+                prefix_outcome: Some(SessionHistoryPrefixOutcome::Verified { raw_extension_size }),
+                ..
+            } => {
+                assert_eq!(session.history_bytes(), compressed);
+                session
+                    .codex_zstd_history()
+                    .expect("Codex zstd history should retain its compressed representation");
+                assert_eq!(
+                    session
+                        .codex_timestamp()
+                        .map(|timestamp| timestamp.to_rfc3339())
+                        .as_deref(),
+                    Some("2026-07-02T10:00:00+00:00")
+                );
+                assert_eq!(raw_extension_size, (body.len() - local_size) as u64);
+            }
+            _ => panic!("expected verified attributed Codex zstd session"),
+        }
+        server.assert_served().await;
+    }
+
+    #[tokio::test]
     async fn codex_materializer_rejects_zstd_hash_mismatch() {
         let body =
             b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
@@ -2083,8 +2311,11 @@ mod tests {
             encoded_size,
         );
 
-        let materializer =
-            start_materializer_with_framework(&session, EffectiveCliFramework::Codex);
+        let materializer = start_materializer_with_prefix_attribution(
+            &session,
+            EffectiveCliFramework::Codex,
+            prefix_attribution(&body[..16]),
+        );
         let result = materializer.finish(&CancellationToken::new()).await;
 
         match result {
@@ -2524,7 +2755,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn materializer_reports_cancelled_download() {
+    async fn attributed_materializer_reports_cancelled_download_without_an_outcome() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let shutdown = CancellationToken::new();
@@ -2538,16 +2769,23 @@ mod tests {
                 _ = shutdown_for_server.cancelled() => {}
             }
         });
+        let requested_history = b"xy";
         let session = ref_session(
             format!("http://{address}/history.blob?token=secret"),
-            hex::encode(Sha256::digest(b"")),
-            1,
-            1,
+            hex::encode(Sha256::digest(requested_history)),
+            requested_history.len() as u64,
+            requested_history.len() as u64,
         );
         let cancel = CancellationToken::new();
         cancel.cancel();
 
-        let result = start_materializer(&session).finish(&cancel).await;
+        let result = start_materializer_with_prefix_attribution(
+            &session,
+            EffectiveCliFramework::ClaudeCode,
+            prefix_attribution(&requested_history[..1]),
+        )
+        .finish(&cancel)
+        .await;
 
         match result {
             SessionHistoryMaterialization::Failed { error, timings, .. } => {
@@ -2725,11 +2963,14 @@ mod tests {
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
                 timings: SessionHistoryDownloadTimings::default(),
-                result: Ok(MaterializedResumeSession::new(
-                    "sess-123".to_string(),
-                    br#"{"type":"init"}"#.to_vec(),
-                    None,
-                )),
+                result: Ok(SessionHistoryCpuMaterialization {
+                    session: MaterializedResumeSession::new(
+                        "sess-123".to_string(),
+                        br#"{"type":"init"}"#.to_vec(),
+                        None,
+                    ),
+                    prefix_outcome: None,
+                }),
             }
         });
         while !task.is_finished() {
@@ -2765,11 +3006,14 @@ mod tests {
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
                 timings: SessionHistoryDownloadTimings::default(),
-                result: Ok(MaterializedResumeSession::new(
-                    "sess-123".to_string(),
-                    br#"{"type":"init"}"#.to_vec(),
-                    None,
-                )),
+                result: Ok(SessionHistoryCpuMaterialization {
+                    session: MaterializedResumeSession::new(
+                        "sess-123".to_string(),
+                        br#"{"type":"init"}"#.to_vec(),
+                        None,
+                    ),
+                    prefix_outcome: None,
+                }),
             }
         });
         let materializer = SessionHistoryMaterializer {

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -2714,7 +2714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn materializer_records_body_read_failure_timing() {
+    async fn attributed_materializer_preserves_body_read_failure() {
         let server = MultiShotSessionHistoryServer::respond_many(vec![
             MultiShotSessionHistoryResponse::ok(b"short", Some(999));
             SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS
@@ -2727,9 +2727,13 @@ mod tests {
             999,
         );
 
-        let result = start_materializer(&session)
-            .finish(&CancellationToken::new())
-            .await;
+        let result = start_materializer_with_prefix_attribution(
+            &session,
+            EffectiveCliFramework::ClaudeCode,
+            prefix_attribution(b"x"),
+        )
+        .finish(&CancellationToken::new())
+        .await;
 
         match result {
             SessionHistoryMaterialization::Failed { timings, .. } => {

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -53,7 +53,8 @@ use super::support::{
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::restored_session_identity::{
-    RestoredSessionHistoryHashSizeRelationship, RestoredSessionIdentityMismatchReason,
+    RestoredSessionHistoryHashSizeRelationship, RestoredSessionHistoryPrefixAttribution,
+    RestoredSessionIdentityMismatchReason,
 };
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::telemetry::SessionHistoryTelemetrySnapshot;
@@ -77,6 +78,13 @@ fn gzip_bytes(raw: &[u8]) -> Vec<u8> {
 
 fn zstd_bytes(raw: &[u8]) -> Vec<u8> {
     zstd::encode_all(raw, 0).unwrap()
+}
+
+fn history_prefix_attribution(history: &[u8]) -> RestoredSessionHistoryPrefixAttribution {
+    RestoredSessionHistoryPrefixAttribution::for_test(
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+    )
 }
 
 async fn serve_history_once(body: &[u8]) -> OneShotSessionHistoryServer {
@@ -1779,13 +1787,14 @@ async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
         },
     });
 
-    let materializer = SessionHistoryMaterializer::start_cancellable(
+    let materializer = SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
         &config.http,
         &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
         None,
+        history_prefix_attribution(&history[..4]),
     );
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
         while !materializer.is_download_finished() {
@@ -1835,6 +1844,11 @@ async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
         &ops,
         "session_history_download_hash_verification",
         "session history download phase failed",
+    );
+    assert!(
+        ops.iter()
+            .all(|op| !op.0.starts_with("session_history_requested_larger_prefix_")),
+        "failed materialization must not emit prefix attribution telemetry: {ops:?}"
     );
 }
 
@@ -2578,6 +2592,133 @@ async fn run_in_sandbox_records_mismatch_fallback_and_restores_prestarted_histor
             "expected restore telemetry, got: {ops:?}"
         );
         assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
+        assert!(
+            ops.iter()
+                .all(|op| { !op.0.starts_with("session_history_requested_larger_prefix_") }),
+            "ineligible materializers must not emit prefix attribution telemetry: {ops:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_requested_larger_prefix_outcomes_without_changing_restore() {
+    let requested_history = b"prefix\nextension\n";
+    let cases: [(&[u8], bool); 2] = [(b"prefix\n", true), (b"differ\n", false)];
+
+    for (local_history, expected_verified) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let sandbox = sandbox_mock::MockSandbox::new("test");
+        let server = MockServer::start_async().await;
+        let history_mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/history.blob");
+                then.status(200).body(requested_history);
+            })
+            .await;
+        let requested_hash = hex::encode(Sha256::digest(requested_history));
+        let local_hash = hex::encode(Sha256::digest(local_history));
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            cli_agent_session_id: "sess-prefix-attribution-123".into(),
+            history: ResumeSessionHistory::Ref {
+                history_ref: ResumeSessionHistoryRef {
+                    kind: ResumeSessionHistoryRefKind::Blob,
+                    hash: requested_hash.clone(),
+                    url: server.url("/history.blob?token=secret"),
+                    encoding: None,
+                    raw_size: requested_history.len() as u64,
+                    encoded_size: requested_history.len() as u64,
+                    download_source: None,
+                },
+            },
+        });
+        sandbox.push_read_file_result(Ok(None));
+        let materializer = SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
+            &config.http,
+            &config.session_history_cpu,
+            ctx.resume_session.as_ref(),
+            effective_cli_framework(&ctx.cli_agent_type),
+            tokio_util::sync::CancellationToken::new(),
+            None,
+            history_prefix_attribution(local_history),
+        );
+        let mut telemetry = test_telemetry(&config, &ctx);
+
+        let result = run_in_sandbox(
+            &sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::Reused,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+                .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                    materializer,
+                    fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        RestoredSessionIdentityMismatchReason::HistoryHash(
+                            RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
+                        ),
+                    ))),
+                }),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.failure.is_none());
+        assert!(result.reusable_session_identity.is_none());
+        history_mock.assert_calls_async(1).await;
+        let writes = sandbox.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].content, requested_history);
+
+        let ops = telemetry.pending_ops_snapshot();
+        assert_successful_action_once(&ops, "session_history_restore_fallback_identity_mismatch");
+        assert_successful_action_once(&ops, "session_history_identity_mismatch_history_hash");
+        assert_successful_action_once(
+            &ops,
+            "session_history_identity_mismatch_history_hash_requested_larger",
+        );
+        assert_successful_action_once(&ops, "session_history_download");
+        assert_successful_action_once(&ops, "session_restore");
+
+        let extension_actions = ops
+            .iter()
+            .filter(|op| {
+                op.0.starts_with("session_history_requested_larger_prefix_extension_")
+            })
+            .count();
+        if expected_verified {
+            assert_successful_action_once(&ops, "session_history_requested_larger_prefix_verified");
+            assert_no_action(&ops, "session_history_requested_larger_prefix_divergent");
+            assert_successful_action_once(
+                &ops,
+                "session_history_requested_larger_prefix_extension_lt_64_kib",
+            );
+            assert_eq!(
+                extension_actions, 1,
+                "unexpected extension actions: {ops:?}"
+            );
+        } else {
+            assert_no_action(&ops, "session_history_requested_larger_prefix_verified");
+            assert_successful_action_once(
+                &ops,
+                "session_history_requested_larger_prefix_divergent",
+            );
+            assert_eq!(
+                extension_actions, 0,
+                "unexpected extension actions: {ops:?}"
+            );
+        }
+
+        let diagnostics = format!("{ops:?}");
+        assert!(!diagnostics.contains(&requested_hash));
+        assert!(!diagnostics.contains(&local_hash));
+        assert!(!diagnostics.contains("token=secret"));
+        assert!(!diagnostics.contains("prefix\nextension"));
     }
 }
 

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -126,6 +126,12 @@ pub(crate) struct RestoredSessionIdentityFields<'a> {
     pub(crate) history_size_bytes: u64,
 }
 
+#[derive(Clone)]
+pub(crate) struct RestoredSessionHistoryPrefixAttribution {
+    history_hash: String,
+    history_size_bytes: u64,
+}
+
 impl RestoredSessionIdentity {
     pub(crate) fn new(
         framework: RestoredSessionFramework,
@@ -242,6 +248,28 @@ impl RestoredSessionIdentity {
         self.final_metadata_verification().is_some()
     }
 
+    pub(crate) fn mismatch_reason_and_prefix_attribution(
+        &self,
+        requested: &Self,
+    ) -> (
+        Option<RestoredSessionIdentityMismatchReason>,
+        Option<RestoredSessionHistoryPrefixAttribution>,
+    ) {
+        let reason = self.mismatch_reason_for_request(requested);
+        let prefix_attribution = match reason {
+            Some(RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
+            )) => self.final_metadata_verification().map(|verification| {
+                RestoredSessionHistoryPrefixAttribution {
+                    history_hash: verification.history_hash.to_owned(),
+                    history_size_bytes: verification.history_size_bytes,
+                }
+            }),
+            _ => None,
+        };
+        (reason, prefix_attribution)
+    }
+
     pub(crate) fn is_verified_match_for_request(&self, requested: &Self) -> bool {
         self == requested
             && self.has_final_metadata_verification()
@@ -301,6 +329,30 @@ impl RestoredSessionIdentity {
             Ordering::Equal => RestoredSessionHistoryHashSizeRelationship::RequestedEqual,
             Ordering::Greater => RestoredSessionHistoryHashSizeRelationship::RequestedLarger,
         }
+    }
+}
+
+impl RestoredSessionHistoryPrefixAttribution {
+    #[cfg(test)]
+    pub(crate) fn for_test(history_hash: String, history_size_bytes: u64) -> Self {
+        Self {
+            history_hash,
+            history_size_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn history_hash(&self) -> &str {
+        &self.history_hash
+    }
+
+    #[cfg(test)]
+    pub(crate) fn history_size_bytes(&self) -> u64 {
+        self.history_size_bytes
+    }
+
+    pub(crate) fn into_parts(self) -> (String, u64) {
+        (self.history_hash, self.history_size_bytes)
     }
 }
 
@@ -367,5 +419,99 @@ fn resume_history_ref_kind_from_final(
 fn final_session_history_ref_kind(kind: ResumeSessionHistoryRefKind) -> FinalSessionHistoryRefKind {
     match kind {
         ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requested_identity(
+        identity_session_id: &str,
+        history_hash: &str,
+        history_size_bytes: u64,
+    ) -> RestoredSessionIdentity {
+        RestoredSessionIdentity::new(
+            RestoredSessionFramework::ClaudeCode,
+            identity_session_id,
+            ResumeSessionHistoryRefKind::Blob,
+            history_hash,
+            Some(history_size_bytes),
+        )
+    }
+
+    fn verified_restored_identity(
+        history_hash: &str,
+        history_size_bytes: u64,
+    ) -> RestoredSessionIdentity {
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"session-id")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            history_size_bytes,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap();
+        RestoredSessionIdentity::from_final_metadata(
+            metadata,
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
+            "/home/user/.vm0/guest-agent/runs/previous",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn prefix_attribution_requires_verified_requested_larger_history_hash_mismatch() {
+        let local_history_hash = "a".repeat(64);
+        let requested_history_hash = "b".repeat(64);
+        let restored = verified_restored_identity(&local_history_hash, 12);
+        let requested_larger = requested_identity("session-id", &requested_history_hash, 13);
+
+        let (reason, attribution) =
+            restored.mismatch_reason_and_prefix_attribution(&requested_larger);
+        assert_eq!(
+            reason,
+            Some(RestoredSessionIdentityMismatchReason::HistoryHash(
+                RestoredSessionHistoryHashSizeRelationship::RequestedLarger
+            ))
+        );
+        let attribution =
+            attribution.expect("verified requested-larger mismatch should carry attribution");
+        assert_eq!(attribution.history_hash(), local_history_hash);
+        assert_eq!(attribution.history_size_bytes(), 12);
+
+        let requested_equal = requested_identity("session-id", &requested_history_hash, 12);
+        assert!(
+            restored
+                .mismatch_reason_and_prefix_attribution(&requested_equal)
+                .1
+                .is_none()
+        );
+
+        let requested_smaller = requested_identity("session-id", &requested_history_hash, 11);
+        assert!(
+            restored
+                .mismatch_reason_and_prefix_attribution(&requested_smaller)
+                .1
+                .is_none()
+        );
+
+        let different_session =
+            requested_identity("different-session", &requested_history_hash, 13);
+        assert!(
+            restored
+                .mismatch_reason_and_prefix_attribution(&different_session)
+                .1
+                .is_none()
+        );
+
+        let unverified = requested_identity("session-id", &local_history_hash, 12);
+        assert!(
+            unverified
+                .mismatch_reason_and_prefix_attribution(&requested_larger)
+                .1
+                .is_none()
+        );
     }
 }

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -341,16 +341,6 @@ impl RestoredSessionHistoryPrefixAttribution {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn history_hash(&self) -> &str {
-        &self.history_hash
-    }
-
-    #[cfg(test)]
-    pub(crate) fn history_size_bytes(&self) -> u64 {
-        self.history_size_bytes
-    }
-
     pub(crate) fn into_parts(self) -> (String, u64) {
         (self.history_hash, self.history_size_bytes)
     }
@@ -419,99 +409,5 @@ fn resume_history_ref_kind_from_final(
 fn final_session_history_ref_kind(kind: ResumeSessionHistoryRefKind) -> FinalSessionHistoryRefKind {
     match kind {
         ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn requested_identity(
-        identity_session_id: &str,
-        history_hash: &str,
-        history_size_bytes: u64,
-    ) -> RestoredSessionIdentity {
-        RestoredSessionIdentity::new(
-            RestoredSessionFramework::ClaudeCode,
-            identity_session_id,
-            ResumeSessionHistoryRefKind::Blob,
-            history_hash,
-            Some(history_size_bytes),
-        )
-    }
-
-    fn verified_restored_identity(
-        history_hash: &str,
-        history_size_bytes: u64,
-    ) -> RestoredSessionIdentity {
-        let metadata = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
-            hex::encode(Sha256::digest(b"session-id")),
-            FinalSessionHistoryRefKind::Blob,
-            history_hash,
-            history_size_bytes,
-            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-        )
-        .unwrap();
-        RestoredSessionIdentity::from_final_metadata(
-            metadata,
-            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
-            "/home/user/.vm0/guest-agent/runs/previous",
-        )
-        .unwrap()
-    }
-
-    #[test]
-    fn prefix_attribution_requires_verified_requested_larger_history_hash_mismatch() {
-        let local_history_hash = "a".repeat(64);
-        let requested_history_hash = "b".repeat(64);
-        let restored = verified_restored_identity(&local_history_hash, 12);
-        let requested_larger = requested_identity("session-id", &requested_history_hash, 13);
-
-        let (reason, attribution) =
-            restored.mismatch_reason_and_prefix_attribution(&requested_larger);
-        assert_eq!(
-            reason,
-            Some(RestoredSessionIdentityMismatchReason::HistoryHash(
-                RestoredSessionHistoryHashSizeRelationship::RequestedLarger
-            ))
-        );
-        let attribution =
-            attribution.expect("verified requested-larger mismatch should carry attribution");
-        assert_eq!(attribution.history_hash(), local_history_hash);
-        assert_eq!(attribution.history_size_bytes(), 12);
-
-        let requested_equal = requested_identity("session-id", &requested_history_hash, 12);
-        assert!(
-            restored
-                .mismatch_reason_and_prefix_attribution(&requested_equal)
-                .1
-                .is_none()
-        );
-
-        let requested_smaller = requested_identity("session-id", &requested_history_hash, 11);
-        assert!(
-            restored
-                .mismatch_reason_and_prefix_attribution(&requested_smaller)
-                .1
-                .is_none()
-        );
-
-        let different_session =
-            requested_identity("different-session", &requested_history_hash, 13);
-        assert!(
-            restored
-                .mismatch_reason_and_prefix_attribution(&different_session)
-                .1
-                .is_none()
-        );
-
-        let unverified = requested_identity("session-id", &local_history_hash, 12);
-        assert!(
-            unverified
-                .mismatch_reason_and_prefix_attribution(&requested_larger)
-                .1
-                .is_none()
-        );
     }
 }

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -603,22 +603,72 @@ const fn session_history_download_source_value(
     }
 }
 
-const fn size_bucket(size: u64) -> &'static str {
-    if size < SIZE_64_KIB {
-        "lt_64_kib"
-    } else if size < SIZE_256_KIB {
-        "64_256_kib"
-    } else if size < SIZE_1_MIB {
-        "256_kib_1_mib"
-    } else if size < SIZE_4_MIB {
-        "1_4_mib"
-    } else if size < SIZE_16_MIB {
-        "4_16_mib"
-    } else if size < SIZE_64_MIB {
-        "16_64_mib"
-    } else {
-        "64_128_mib"
+#[derive(Clone, Copy)]
+enum SessionHistorySizeBucket {
+    LessThan64Kib,
+    From64To256Kib,
+    From256KibTo1Mib,
+    From1To4Mib,
+    From4To16Mib,
+    From16To64Mib,
+    From64To128Mib,
+}
+
+impl SessionHistorySizeBucket {
+    const fn from_size(size: u64) -> Self {
+        if size < SIZE_64_KIB {
+            Self::LessThan64Kib
+        } else if size < SIZE_256_KIB {
+            Self::From64To256Kib
+        } else if size < SIZE_1_MIB {
+            Self::From256KibTo1Mib
+        } else if size < SIZE_4_MIB {
+            Self::From1To4Mib
+        } else if size < SIZE_16_MIB {
+            Self::From4To16Mib
+        } else if size < SIZE_64_MIB {
+            Self::From16To64Mib
+        } else {
+            Self::From64To128Mib
+        }
     }
+
+    const fn value(self) -> &'static str {
+        match self {
+            Self::LessThan64Kib => "lt_64_kib",
+            Self::From64To256Kib => "64_256_kib",
+            Self::From256KibTo1Mib => "256_kib_1_mib",
+            Self::From1To4Mib => "1_4_mib",
+            Self::From4To16Mib => "4_16_mib",
+            Self::From16To64Mib => "16_64_mib",
+            Self::From64To128Mib => "64_128_mib",
+        }
+    }
+
+    const fn requested_larger_prefix_extension_action_type(self) -> &'static str {
+        match self {
+            Self::LessThan64Kib => "session_history_requested_larger_prefix_extension_lt_64_kib",
+            Self::From64To256Kib => "session_history_requested_larger_prefix_extension_64_256_kib",
+            Self::From256KibTo1Mib => {
+                "session_history_requested_larger_prefix_extension_256_kib_1_mib"
+            }
+            Self::From1To4Mib => "session_history_requested_larger_prefix_extension_1_4_mib",
+            Self::From4To16Mib => "session_history_requested_larger_prefix_extension_4_16_mib",
+            Self::From16To64Mib => "session_history_requested_larger_prefix_extension_16_64_mib",
+            Self::From64To128Mib => "session_history_requested_larger_prefix_extension_64_128_mib",
+        }
+    }
+}
+
+const fn size_bucket(size: u64) -> &'static str {
+    SessionHistorySizeBucket::from_size(size).value()
+}
+
+pub(crate) const fn session_history_prefix_extension_action_type(
+    raw_extension_size: u64,
+) -> &'static str {
+    SessionHistorySizeBucket::from_size(raw_extension_size)
+        .requested_larger_prefix_extension_action_type()
 }
 
 fn compression_ratio_bucket(
@@ -777,6 +827,85 @@ mod tests {
         assert_eq!(json["duration_ms"], 1500);
         assert_eq!(json["success"], true);
         assert!(json.get("error").is_none()); // omitted when None
+    }
+
+    #[test]
+    fn session_history_size_bucket_boundaries_keep_stable_labels_and_actions() {
+        let cases = [
+            (
+                0,
+                "lt_64_kib",
+                "session_history_requested_larger_prefix_extension_lt_64_kib",
+            ),
+            (
+                SIZE_64_KIB - 1,
+                "lt_64_kib",
+                "session_history_requested_larger_prefix_extension_lt_64_kib",
+            ),
+            (
+                SIZE_64_KIB,
+                "64_256_kib",
+                "session_history_requested_larger_prefix_extension_64_256_kib",
+            ),
+            (
+                SIZE_256_KIB - 1,
+                "64_256_kib",
+                "session_history_requested_larger_prefix_extension_64_256_kib",
+            ),
+            (
+                SIZE_256_KIB,
+                "256_kib_1_mib",
+                "session_history_requested_larger_prefix_extension_256_kib_1_mib",
+            ),
+            (
+                SIZE_1_MIB - 1,
+                "256_kib_1_mib",
+                "session_history_requested_larger_prefix_extension_256_kib_1_mib",
+            ),
+            (
+                SIZE_1_MIB,
+                "1_4_mib",
+                "session_history_requested_larger_prefix_extension_1_4_mib",
+            ),
+            (
+                SIZE_4_MIB - 1,
+                "1_4_mib",
+                "session_history_requested_larger_prefix_extension_1_4_mib",
+            ),
+            (
+                SIZE_4_MIB,
+                "4_16_mib",
+                "session_history_requested_larger_prefix_extension_4_16_mib",
+            ),
+            (
+                SIZE_16_MIB - 1,
+                "4_16_mib",
+                "session_history_requested_larger_prefix_extension_4_16_mib",
+            ),
+            (
+                SIZE_16_MIB,
+                "16_64_mib",
+                "session_history_requested_larger_prefix_extension_16_64_mib",
+            ),
+            (
+                SIZE_64_MIB - 1,
+                "16_64_mib",
+                "session_history_requested_larger_prefix_extension_16_64_mib",
+            ),
+            (
+                SIZE_64_MIB,
+                "64_128_mib",
+                "session_history_requested_larger_prefix_extension_64_128_mib",
+            ),
+        ];
+
+        for (size, expected_label, expected_action) in cases {
+            assert_eq!(size_bucket(size), expected_label);
+            assert_eq!(
+                session_history_prefix_extension_action_type(size),
+                expected_action
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify final-metadata-backed `requested_larger` session-history mismatches as verified append lineage or divergent history
- compute the local-length prefix digest during the existing complete-history SHA-256 traversal for identity, gzip, zstd, and streaming Codex zstd histories
- emit fixed low-cardinality outcome actions and one extension-size bucket for verified prefixes
- preserve the existing full download, complete size/hash validation, restore representation, fallback behavior, and cancellation semantics

## Scope

This is shadow attribution only. It does not skip downloads, append only the extension, alter restore selection, or change guest-visible history. It introduces no database, persisted-state, blob-format, API, queue, guest-protocol, or deployment-order change. Sidecar, inline, failed, cancelled, and ineligible restore paths remain unattributed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner`
- focused prefix, bucket-boundary, full-hash-failure, and cancellation tests

Closes #21403

Parent context: #18746
