### PR TITLE
refactor(platform): rename workflow trigger copy to automation

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2539,11 +2539,13 @@ describe("workflow detail page", () => {
     click(webhookCard);
 
     const upgradeTitle = await screen.findByText(
-      "Upgrade for webhook triggers",
+      "Upgrade for webhook automations",
     );
     expect(upgradeTitle).toBeInTheDocument();
     expect(
-      screen.getByText("Webhook triggers require a Team or Custom workspace."),
+      screen.getByText(
+        "Webhook automations require a Team or Custom workspace.",
+      ),
     ).toBeInTheDocument();
     expect(buttonByText("Upgrade to Team")).toBeInTheDocument();
   });
@@ -2608,7 +2610,7 @@ describe("workflow detail page", () => {
 
     click(await screen.findByRole("switch", { name: "Enable Webhook" }));
     const upgradeTitle = await screen.findByText(
-      "Upgrade for webhook triggers",
+      "Upgrade for webhook automations",
     );
     expect(upgradeTitle).toBeInTheDocument();
     expect(

--- a/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
@@ -47,9 +47,9 @@ export function WorkflowWebhookUpgradeDialog() {
           <div className="mb-1 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-amber-700">
             <IconLock size={19} stroke={1.6} />
           </div>
-          <DialogTitle>Upgrade for webhook triggers</DialogTitle>
+          <DialogTitle>Upgrade for webhook automations</DialogTitle>
           <DialogDescription>
-            Webhook triggers require a Team or Custom workspace.
+            Webhook automations require a Team or Custom workspace.
           </DialogDescription>
         </DialogHeader>
         <div className="rounded-xl border border-border/60 bg-muted/30 px-4 py-3">

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -468,7 +468,7 @@ function emptyDescriptionForFilter(filter: WorkflowFilter): string {
       return "Every workflow here runs on a schedule or event.";
     }
     case "automated": {
-      return "Add a schedule or trigger to a workflow and it shows up here.";
+      return "Add an automation to a workflow and it shows up here.";
     }
     case "private": {
       return "No private workflows yet.";

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -268,7 +268,7 @@ export function triggerTypeLabel(trigger: ZeroWorkflowTriggerSummary): string {
   if (trigger.eventType === "webhook-received") {
     return "Webhook";
   }
-  return "Trigger";
+  return "Automation";
 }
 
 function agentInitials(label: string): string {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2368,7 +2368,7 @@ function HeaderWorkflowQueueSection({ threadId }: { threadId: string }) {
           <span className="mt-1 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary" />
           <div className="min-w-0 flex-1">
             <div className="truncate text-foreground">
-              {queue.running.triggerBrief ?? "Running trigger event"}
+              {queue.running.triggerBrief ?? "Running automation"}
             </div>
             <div className="text-muted-foreground">
               {queue.running.status === "running" ? "Running" : "Starting"}


### PR DESCRIPTION
## Summary

- replace the remaining user-visible workflow-trigger entity copy with Automation terminology
- update the automated-workflow empty state, webhook upgrade dialog, and fallback automation type label
- preserve internal identifiers, API contracts, feature-switch keys, and run-provenance terminology for their dedicated migration phases
- update platform integration-test expectations for the new copy

Part of #21408.

## Verification

- `pnpm exec prettier --check apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx apps/platform/src/views/workflows-page/workflows-page.tsx apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx --silent=passed-only`

Browser verification was intentionally not run: this copy-only PR did not start a local development server, per the repository PR verification guidance.