### PR TITLE
fix(platform): unify focus states with theme colors

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -218,6 +218,35 @@ describe("previewPresentationHtml", () => {
     expect(injectedCss).toContain("border-radius: 0 !important");
   });
 
+  it("uses the semantic focus ring for editable presentation content", () => {
+    const previewHtml = previewPresentationHtml({
+      activeSlideId: "slide-1",
+      html: `
+        <!doctype html>
+        <html>
+          <body>
+            <section data-vm0-slide data-slide-id="slide-1">
+              <h1 data-vm0-editable="text">Slide</h1>
+            </section>
+          </body>
+        </html>
+      `,
+    });
+    const doc = new DOMParser().parseFromString(previewHtml, "text/html");
+    const injectedCss = Array.from(doc.querySelectorAll("style"))
+      .map((style) => {
+        return style.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(injectedCss).toMatch(
+      /\[data-vm0-editor-edit-id\]:hover\s*{\s*outline-color:\s*#0f82ff\s*!important;/,
+    );
+    expect(injectedCss).toMatch(
+      /\[data-vm0-editor-edit-id\]:focus\s*{\s*outline-color:\s*hsl\(var\(--ring, 15 80% 66%\)\)\s*!important;/,
+    );
+  });
+
   it("appends additional head styles to the preview document", () => {
     const previewHtml = previewPresentationHtml({
       activeSlideId: "slide-1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2324,9 +2324,14 @@ describe("zero attachment chips", () => {
     ).toBeInTheDocument();
     const listDeleteButtons =
       within(commentsList).getAllByLabelText("Delete comment");
+    const heroListButton = heroListItem.closest('[role="button"]');
+    expect(heroListButton).not.toBeNull();
+    expect(heroListButton).toHaveClass("focus:border-primary");
+    expect(heroListButton).toHaveClass("focus:ring-ring/30");
     expect(listDeleteButtons).toHaveLength(2);
     expect(listDeleteButtons[0]).toHaveClass("opacity-0");
     expect(listDeleteButtons[0]).toHaveClass("group-hover/comment:opacity-100");
+    expect(listDeleteButtons[0]).toHaveClass("focus:ring-ring");
 
     fireEvent.click(heroListItem);
     await waitFor(() => {
@@ -2678,6 +2683,9 @@ describe("zero attachment chips", () => {
       expect(
         screen.getByTestId("html-dom-color-control-color"),
       ).toHaveTextContent("#ff0000");
+      expect(screen.getByTestId("html-dom-color-control-color")).toHaveClass(
+        "focus:ring-ring/25",
+      );
       expect(
         screen.getByTestId("html-dom-color-control-backgroundColor"),
       ).toHaveTextContent("#000000");

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -272,7 +272,7 @@ function HtmlDomCommentsList({
                 key={comment.id}
                 role="button"
                 tabIndex={0}
-                className="group/comment relative cursor-pointer rounded-lg border border-transparent bg-muted/35 px-3 py-2.5 pr-10 text-left transition-colors hover:border-blue-200 hover:bg-blue-50/70 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+                className="group/comment relative cursor-pointer rounded-lg border border-transparent bg-muted/35 px-3 py-2.5 pr-10 text-left transition-colors hover:border-blue-200 hover:bg-blue-50/70 focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring/30"
                 onClick={focusCurrentComment}
                 onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
                   if (event.key !== "Enter" && event.key !== " ") {
@@ -288,7 +288,7 @@ function HtmlDomCommentsList({
                 <button
                   type="button"
                   aria-label="Delete comment"
-                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-blue-200 bg-background text-blue-600 opacity-0 shadow-sm transition-opacity hover:bg-blue-600 hover:text-white focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 group-hover/comment:opacity-100"
+                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-blue-200 bg-background text-blue-600 opacity-0 shadow-sm transition-opacity hover:bg-blue-600 hover:text-white focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 group-hover/comment:opacity-100"
                   data-testid="html-dom-comments-list-delete"
                   onKeyDown={(event) => {
                     event.stopPropagation();
@@ -579,7 +579,7 @@ function HtmlDomColorControl({
       type="button"
       aria-expanded={active}
       aria-label={`Open ${property === "color" ? "text" : "background"} color panel`}
-      className={`inline-flex h-9 w-full min-w-0 items-center justify-between gap-2 overflow-hidden rounded-full border px-3 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-500/25 ${
+      className={`inline-flex h-9 w-full min-w-0 items-center justify-between gap-2 overflow-hidden rounded-full border px-3 text-left transition focus:outline-none focus:ring-2 focus:ring-ring/25 ${
         active
           ? "border-blue-500/45 bg-blue-500/10 text-foreground ring-2 ring-blue-500/15"
           : "border-border/70 bg-background text-foreground hover:bg-muted/45"
@@ -630,7 +630,7 @@ function HtmlDomColorField({
     <button
       type="button"
       aria-label={`Pick ${activeProperty === "backgroundColor" ? "background" : "text"} color saturation and brightness`}
-      className="relative block h-28 w-full cursor-crosshair border-0 p-0 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      className="relative block h-28 w-full cursor-crosshair border-0 p-0 focus:outline-none focus:ring-2 focus:ring-ring"
       data-testid="html-dom-color-field"
       style={{ backgroundColor: hueHex }}
       onPointerDown={(event) => {
@@ -680,7 +680,7 @@ function HtmlDomHueSlider({
     <button
       type="button"
       aria-label="Hue"
-      className="relative h-7 min-w-0 flex-1 cursor-pointer border-0 bg-transparent p-0 focus:outline-none focus:ring-2 focus:ring-blue-500/25"
+      className="relative h-7 min-w-0 flex-1 cursor-pointer border-0 bg-transparent p-0 focus:outline-none focus:ring-2 focus:ring-ring/25"
       data-testid="html-dom-color-hue-slider"
       onPointerDown={(event) => {
         event.preventDefault();
@@ -731,7 +731,7 @@ function HtmlDomRgbInputs({
         return (
           <label
             key={channel}
-            className="flex h-8 min-w-0 items-center rounded-lg border border-border/70 bg-muted/45 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+            className="flex h-8 min-w-0 items-center rounded-lg border border-border/70 bg-muted/45 px-2 focus-within:border-primary focus-within:bg-background focus-within:ring-2 focus-within:ring-ring/15"
           >
             <span className="w-4 text-[11px] font-semibold text-muted-foreground">
               {label}
@@ -781,7 +781,7 @@ function HtmlDomEyeDropperButton({
       type="button"
       aria-label="Pick color from screen"
       title="Pick color from screen"
-      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/45 text-muted-foreground transition hover:bg-muted/80 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/25"
+      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/45 text-muted-foreground transition hover:bg-muted/80 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/25"
       data-testid="html-dom-color-eyedropper"
       onClick={() => {
         detach(pickColor(), Reason.DomCallback, "pickHtmlDomColor");
@@ -1173,7 +1173,7 @@ function HtmlDomImageLinkForm({
 }) {
   return (
     <form
-      className="flex h-9 items-center gap-1 rounded-full border border-border/70 bg-muted/25 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+      className="flex h-9 items-center gap-1 rounded-full border border-border/70 bg-muted/25 px-2 focus-within:border-primary focus-within:bg-background focus-within:ring-2 focus-within:ring-ring/15"
       onSubmit={onSubmit}
       data-testid="html-dom-image-link-form"
     >

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -790,9 +790,11 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       -webkit-user-modify: read-write-plaintext-only !important;
       caret-color: auto !important;
     }
-    [data-vm0-editor-edit-id]:hover,
-    [data-vm0-editor-edit-id]:focus {
+    [data-vm0-editor-edit-id]:hover {
       outline-color: #0f82ff !important;
+    }
+    [data-vm0-editor-edit-id]:focus {
+      outline-color: hsl(var(--ring, 15 80% 66%)) !important;
     }
   `;
   previewDoc.head.append(style);

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -1,0 +1,39 @@
+/// <reference types="node" />
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function readGlobalCss(): string {
+  const candidates = [
+    join(process.cwd(), "src/styles/globals.css"),
+    join(process.cwd(), "packages/ui/src/styles/globals.css"),
+  ];
+  const path = candidates.find((candidate) => {
+    return existsSync(candidate);
+  });
+  if (path === undefined) {
+    throw new Error("Unable to locate UI global CSS");
+  }
+  return readFileSync(path, "utf8");
+}
+
+const globalCss = readGlobalCss();
+
+describe("global focus colors", () => {
+  it("sets native outlines to the semantic focus color before focus", () => {
+    expect(globalCss).toMatch(
+      /\*\s*{[\s\S]*?outline-color:\s*hsl\(var\(--ring\)\);[\s\S]*?}/,
+    );
+  });
+
+  it("resolves the focus color from each theme's primary scale", () => {
+    expect(globalCss).toMatch(
+      /:root\s*{[\s\S]*?--primary-600:\s*15 80% 66%;[\s\S]*?--ring:\s*var\(--primary-600\);/,
+    );
+    expect(globalCss).toMatch(
+      /\[data-theme="dark"\]\s*{[\s\S]*?--primary-600:\s*16 62% 41%;[\s\S]*?--ring:\s*var\(--primary-600\);/,
+    );
+  });
+});

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -344,6 +344,8 @@
 @layer base {
   * {
     @apply border-border;
+    /* Keep native focus outlines stable when transition-colors is applied. */
+    outline-color: hsl(var(--ring));
   }
 
   body {


### PR DESCRIPTION
## Summary

- make the default browser focus outline inherit Zero's semantic focus-ring color in both themes
- replace hardcoded blue focus borders and rings in the HTML artifact editor with `primary` and `ring` tokens
- use the theme focus color for editable presentation content while preserving its existing hover treatment

## User impact

Focused controls now use the Zero theme color consistently instead of mixing browser blue, editor blue, and theme-colored indicators.

## Verification

- `pnpm exec prettier --check apps/platform/src/views/zero-page/html-dom-comment-editor.tsx apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts packages/ui/src/styles/globals.css`
- `pnpm -F @vm0/ui lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/ui check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts --maxWorkers=4 --silent=passed-only` (49 tests)
- `pnpm -F @vm0/app build`
- verified computed focus colors against the light and dark theme tokens in the loaded Vite app
