### PR TITLE
fix(platform): keep codex fast mode for gpt-5.6 threads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -579,9 +579,6 @@ function createModelSelection(
       return false;
     }
     const selectedModel = await get(selectedModel$);
-    if (selectedModel !== "gpt-5.5") {
-      return false;
-    }
     const policies = await get(orgModelPolicies$);
     if (
       !isCodexFastModeAvailableForSelection({
@@ -668,8 +665,7 @@ function createModelSelectionForSend({
         toast.error("The selected model is not available");
         return { available: false };
       }
-      const codexFastModeActive =
-        selectedModel === "gpt-5.5" && (await get(codexFastModeActive$));
+      const codexFastModeActive = await get(codexFastModeActive$);
       signal.throwIfAborted();
       return {
         available: true,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1800,8 +1800,8 @@ describe("chat composer models", () => {
     context.mocks.data.orgModelPolicies([
       buildModelPolicy({
         id: "00000000-0000-4000-a000-000000000914",
-        model: "gpt-5.5",
-        modelLabel: "GPT 5.5",
+        model: "gpt-5.6-sol",
+        modelLabel: "GPT 5.6 Sol",
         isDefault: true,
         defaultProviderType: "codex-oauth-token",
         credentialScope: "member",
@@ -1810,7 +1810,7 @@ describe("chat composer models", () => {
     context.mocks.data.personalModelProviders([codexProvider]);
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
-      selectedModel: "gpt-5.5",
+      selectedModel: "gpt-5.6-sol",
       codexServiceTier: "fast",
       onRunCreate: (body) => {
         sentBody = body;
@@ -1825,9 +1825,17 @@ describe("chat composer models", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /GPT 5\.5/ }),
+        screen.getByRole("combobox", { name: /GPT 5\.6 Sol/ }),
       ).toBeInTheDocument();
     });
+
+    await user.click(screen.getByRole("combobox", { name: /GPT 5\.6 Sol/ }));
+    const runSpeed = await screen.findByRole("group", { name: "Run speed" });
+    expect(buttonContainingText("Fast", runSpeed)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await user.keyboard("{Escape}");
 
     await sendMessageInUI(
       user,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3985,9 +3985,7 @@ function useChatComposerModel(
     ? { selectedModel: selectedModelResolved }
     : null;
   const modelSelection =
-    baseModelSelection &&
-    baseModelSelection.selectedModel === "gpt-5.5" &&
-    codexFastModeActive
+    baseModelSelection && codexFastModeActive
       ? {
           ...baseModelSelection,
           codexServiceTier: "fast" as const,


### PR DESCRIPTION
## Summary

- Remove the stale GPT-5.5-only guards from hydrated thread Fast mode state, composer selection, and run-option creation.
- Reuse the existing model-policy and ChatGPT Codex OAuth admission checks for GPT-5.6 models.
- Extend the hydrated-thread regression coverage to GPT-5.6 Sol, including the selected Fast state and outgoing run option.

## Verification

- `pnpm --filter @vm0/app check-types`
- Targeted Oxlint and ESLint on the three changed files
- Targeted Vitest coverage for the GPT-5.6 new-thread and hydrated-thread Fast mode cases

The repository pre-commit hook completed formatting and knip; its global 16-package type-check exceeded the local 120-second hook timeout, while the affected platform type-check passed separately.
