### PR TITLE
perf(runner): copy guest logs concurrently

### DIFF
--- a/crates/runner/src/executor/diagnostics/guest_logs.rs
+++ b/crates/runner/src/executor/diagnostics/guest_logs.rs
@@ -1,3 +1,4 @@
+use futures_util::future::join_all;
 use sandbox::{CopyFileOptions, Sandbox};
 use tracing::{info, warn};
 
@@ -49,18 +50,24 @@ pub(in crate::executor) async fn copy_guest_logs(
         }
     };
 
-    for (guest_path, host_path) in &files {
-        if let Err(e) = crate::log_file::validate_copy_destination(host_path) {
-            warn!(
-                run_id = %run_id,
-                error = %e,
-                guest_path = %guest_path,
-                host_path = %host_path.display(),
-                "skipping unsafe guest log destination"
-            );
-            continue;
-        }
+    let files = files
+        .into_iter()
+        .filter(|(guest_path, host_path)| {
+            if let Err(e) = crate::log_file::validate_copy_destination(host_path) {
+                warn!(
+                    run_id = %run_id,
+                    error = %e,
+                    guest_path = %guest_path,
+                    host_path = %host_path.display(),
+                    "skipping unsafe guest log destination"
+                );
+                return false;
+            }
+            true
+        })
+        .collect::<Vec<_>>();
 
+    join_all(files.iter().map(|(guest_path, host_path)| async move {
         if let Err(e) = sandbox
             .copy_file(
                 guest_path,
@@ -82,5 +89,6 @@ pub(in crate::executor) async fn copy_guest_logs(
                 }
             }
         }
-    }
+    }))
+    .await;
 }

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_logs.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_logs.rs
@@ -1,6 +1,8 @@
 use std::os::unix::fs::symlink;
+use std::sync::Arc;
+use std::time::Duration;
 
-use sandbox_mock::MockSandbox;
+use sandbox_mock::{MockLifecycleGate, MockSandbox};
 
 use super::super::super::diagnostics::{
     AgentStdoutStreamDiagnostics, GuestLogCopyFailureKind, copy_guest_logs,
@@ -180,6 +182,57 @@ async fn copy_guest_logs_continues_after_copy_failure() {
     assert_eq!(calls[0].host_path, log_paths.system_log(ctx.run_id));
     assert_eq!(calls[1].host_path, log_paths.metrics_log(ctx.run_id));
     assert_eq!(calls[2].host_path, log_paths.sandbox_ops_log(ctx.run_id));
+}
+
+#[tokio::test]
+async fn copy_guest_logs_starts_independent_copies_concurrently() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_paths = LogPaths::new(dir.path().to_path_buf());
+    let sandbox = Arc::new(MockSandbox::new("test"));
+    let gate = MockLifecycleGate::new();
+    sandbox.set_copy_file_lifecycle_gate(gate.clone());
+    sandbox.push_copy_file_result(Ok(b"guest log\n".to_vec()));
+    sandbox.push_copy_file_result(Ok(b"guest log\n".to_vec()));
+    sandbox.push_copy_file_result(Ok(b"guest log\n".to_vec()));
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let destinations = [
+        log_paths.system_log(run_id),
+        log_paths.metrics_log(run_id),
+        log_paths.sandbox_ops_log(run_id),
+    ];
+
+    let task = {
+        let sandbox = Arc::clone(&sandbox);
+        let task_log_paths = log_paths.clone();
+        tokio::spawn(async move {
+            copy_guest_logs(sandbox.as_ref(), &ctx, &task_log_paths, false).await;
+        })
+    };
+
+    gate.wait_entered(3, Duration::from_secs(5)).await.unwrap();
+    assert_eq!(sandbox.copy_file_calls().len(), 3);
+    assert!(destinations.iter().all(|path| !path.exists()));
+
+    gate.release_many(2);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if destinations.iter().filter(|path| path.exists()).count() == 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("two independent copies must finish while one remains delayed");
+    assert!(!task.is_finished(), "the final copy must remain gated");
+
+    gate.release_one();
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("all guest log copies must finish after release")
+        .unwrap();
+    assert!(destinations.iter().all(|path| path.exists()));
 }
 
 #[tokio::test]

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -35,6 +35,7 @@ pub struct MockSandbox {
     read_file_calls: Mutex<Vec<ReadFileCall>>,
     copy_file_results: Mutex<VecDeque<Result<Vec<u8>>>>,
     copy_file_calls: Mutex<Vec<CopyFileCall>>,
+    copy_file_gate: Mutex<Option<MockLifecycleGate>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
     write_files_calls: Mutex<Vec<WriteFilesCall>>,
@@ -74,6 +75,7 @@ impl MockSandbox {
             read_file_calls: Mutex::new(Vec::new()),
             copy_file_results: Mutex::new(VecDeque::new()),
             copy_file_calls: Mutex::new(Vec::new()),
+            copy_file_gate: Mutex::new(None),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
             write_files_calls: Mutex::new(Vec::new()),
@@ -142,6 +144,14 @@ impl MockSandbox {
     /// [`MockSandboxOverrides::copy_file_calls`].
     pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
         self.copy_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Block every copy operation with a durable lifecycle gate.
+    ///
+    /// Calls are recorded and queued results are assigned before entering the
+    /// gate, while host publication waits for release.
+    pub fn set_copy_file_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.copy_file_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Queue a write-operation result.
@@ -449,6 +459,10 @@ impl Sandbox for MockSandbox {
         }
 
         let queued = self.copy_file_results.lock_ignoring_poison().pop_front();
+        let gate = self.copy_file_gate.lock_ignoring_poison().clone();
+        if let Some(gate) = gate {
+            gate.enter_and_wait().await;
+        }
         let bytes = match queued {
             Some(result) => result?,
             None if options.missing_ok => {

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -215,6 +215,39 @@ async fn sandbox_copy_file_allows_relative_host_path_without_parent() {
 }
 
 #[tokio::test]
+async fn sandbox_copy_file_lifecycle_gate_blocks_until_released() {
+    let sandbox = Arc::new(MockSandbox::new("test-1"));
+    let gate = MockLifecycleGate::new();
+    sandbox.set_copy_file_lifecycle_gate(gate.clone());
+    sandbox.push_copy_file_result(Ok(b"guest log\n".to_vec()));
+    let (_host_dir, path) = temp_host_path("gated.log");
+
+    let task = {
+        let sandbox = Arc::clone(&sandbox);
+        let task_path = path.clone();
+        tokio::spawn(async move {
+            sandbox
+                .copy_file("/tmp/system.log", &task_path, copy_file_options(false))
+                .await
+        })
+    };
+
+    gate.wait_entered(1, test_timeout()).await.unwrap();
+    assert_eq!(sandbox.copy_file_calls().len(), 1);
+    assert!(!path.exists());
+    assert!(!task.is_finished(), "copy_file must wait for gate release");
+
+    gate.release_one();
+    let result = tokio::time::timeout(test_timeout(), task)
+        .await
+        .expect("copy_file must finish after gate release")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.bytes_copied, 10);
+    assert_eq!(std::fs::read(path).unwrap(), b"guest log\n");
+}
+
+#[tokio::test]
 async fn sandbox_read_file_applies_mock_max_bytes() {
     let sandbox = MockSandbox::new("test-1");
     sandbox.push_read_file_result(Ok(Some(b"too long".to_vec())));


### PR DESCRIPTION
## Summary

- copy validated guest diagnostic logs concurrently so one slow stream does not serialize the others
- preserve independent best-effort failure handling, destination validation, byte limits, and per-copy timeouts
- add a durable mock copy lifecycle gate and integration coverage for concurrent progress

## Scope

- no API, schema, protocol, configuration, or deployment changes
- no new outer timeout or detached background work

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p sandbox-mock sandbox_copy_file_lifecycle_gate_blocks_until_released`
- `cargo test -p runner diagnostics_tests::guest_logs`
- `cargo test -p sandbox-mock -p runner -- --quiet`
- `cargo clippy -p sandbox-mock -p runner --all-targets --all-features`
- `cargo doc -p sandbox-mock -p runner --all-features --no-deps`

Closes #21364
