### PR TITLE
fix: show full artifact names on hover

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   artifactsContract,
   type ArtifactItem,
@@ -578,6 +579,26 @@ describe("artifacts page", () => {
       height: "800px",
       width: "1280px",
     });
+  });
+
+  it("shows the full artifact name when hovering its truncated title", async () => {
+    const user = userEvent.setup();
+    setupTeam();
+    const scope = testAuthScope("filename-tooltip");
+    const filename =
+      "zero-template-picker-ui-7-final-production-hosted-site.html";
+    mockArtifacts([createArtifact({ filename })]);
+
+    setupArtifactsPage({ scope });
+
+    const title = await screen.findByRole("heading", { name: filename });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.hover(title);
+
+    await expect(screen.findByRole("tooltip")).resolves.toHaveTextContent(
+      filename,
+    );
   });
 
   it("provides visible focus feedback for the agent filter", async () => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -40,6 +40,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   cn,
 } from "@vm0/ui";
 
@@ -782,9 +786,16 @@ function ArtifactCard({
         className="flex h-16 min-w-0 shrink-0 items-center gap-2 border-t border-border p-3"
       >
         <div className="min-w-0 flex-1">
-          <h2 className="truncate text-sm font-semibold text-foreground">
-            {item.filename}
-          </h2>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <h2 className="truncate text-sm font-semibold text-foreground">
+                  {item.filename}
+                </h2>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{item.filename}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <p className="mt-1 truncate text-[11px] text-muted-foreground/80">
             {contextLabel}
           </p>

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -789,7 +789,7 @@ function ArtifactCard({
           <TooltipProvider delayDuration={300}>
             <Tooltip>
               <TooltipTrigger asChild>
-                <h2 className="truncate text-sm font-semibold text-foreground">
+                <h2 className="min-w-0 cursor-default truncate text-sm font-semibold leading-5 text-foreground">
                   {item.filename}
                 </h2>
               </TooltipTrigger>


### PR DESCRIPTION
## Summary

- show the full artifact filename when hovering its truncated title
- match the presentation picker by reusing the same 300 ms tooltip interaction and bottom placement
- keep the existing card layout, truncation, and actions unchanged

## Verification

- `pnpm exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx` (26 tests passed)
- Prettier check on the changed files
- Oxlint and ESLint on the changed files

## Test coverage

- added an interaction test that hovers a long artifact title and verifies the full filename appears in the tooltip
