### PR TITLE
refactor(api): accept workflow automation callback kinds before cutover

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
@@ -14,6 +14,18 @@ interface SeedAgentRunCallbackOptions {
   readonly status?: "pending" | "delivered" | "failed";
 }
 
+interface AgentRunCallbackSnapshot {
+  readonly id: string;
+  readonly internalKind: string | null;
+  readonly status: "pending" | "delivered" | "failed";
+}
+
+interface ReadAgentRunCallbacksOptions {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly prompt: string;
+}
+
 function requestTelegramState(
   signal: AbortSignal,
   path: string,
@@ -35,6 +47,31 @@ function expectOk(response: Response, operation: string): void {
     return;
   }
   throw new Error(`${operation} failed with ${response.status}`);
+}
+
+function agentRunCallbackSnapshot(
+  value: unknown,
+): AgentRunCallbackSnapshot | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const id = "id" in value && typeof value.id === "string" ? value.id : null;
+  const internalKind =
+    "internalKind" in value &&
+    (typeof value.internalKind === "string" || value.internalKind === null)
+      ? value.internalKind
+      : null;
+  const status =
+    "status" in value &&
+    (value.status === "pending" ||
+      value.status === "delivered" ||
+      value.status === "failed")
+      ? value.status
+      : null;
+  if (!id || !status) {
+    return null;
+  }
+  return { id, internalKind, status };
 }
 
 export const seedAgentRunCallback$ = command(
@@ -71,5 +108,40 @@ export const seedAgentRunCallback$ = command(
       throw new Error("seedAgentRunCallback$: response missing callback_id");
     }
     return { callbackId };
+  },
+);
+
+export const readAgentRunCallbacks$ = command(
+  async (
+    _,
+    options: ReadAgentRunCallbacksOptions,
+    signal: AbortSignal,
+  ): Promise<readonly AgentRunCallbackSnapshot[]> => {
+    const response = await requestTelegramState(
+      signal,
+      TELEGRAM_STATE_ACTION_ROUTE,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "get-post-run-state",
+          org_id: options.orgId,
+          user_id: options.userId,
+          prompt: options.prompt,
+        }),
+      },
+    );
+    signal.throwIfAborted();
+    expectOk(response, "readAgentRunCallbacks$");
+    signal.throwIfAborted();
+    const body = await readJson<Record<string, unknown>>(response);
+    signal.throwIfAborted();
+    if (!Array.isArray(body.callbacks)) {
+      return [];
+    }
+    return body.callbacks.flatMap((value) => {
+      const callback = agentRunCallbackSnapshot(value);
+      return callback ? [callback] : [];
+    });
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
@@ -17,6 +17,10 @@ import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import {
+  readAgentRunCallbacks$,
+  seedAgentRunCallback$,
+} from "./helpers/agent-run-callback";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -533,6 +537,74 @@ describe("zero workflow trigger scheduler", () => {
       throw new Error("Expected the loop trigger to be rescheduled");
     }
     expect(Date.parse(read.nextRunAt)).toBeGreaterThanOrEqual(before + 290_000);
+    await disableTrigger(trigger.triggerId);
+  });
+
+  it("emits automation callback kinds and advances an in-flight legacy callback", async () => {
+    const scenario = await setup();
+    const trigger = await createDueLoopTrigger(scenario, 300);
+
+    await executeDueWorkflowTriggers();
+    await onlyWorkflowRunMessage(trigger.threadId);
+
+    const emittedCallbacks = await store.set(
+      readAgentRunCallbacks$,
+      {
+        orgId: scenario.orgId,
+        userId: scenario.userId,
+        prompt: `/${WORKFLOW_NAME}`,
+      },
+      context.signal,
+    );
+    expect(emittedCallbacks).toContainEqual(
+      expect.objectContaining({
+        internalKind: "workflow-automation:loop",
+        status: "pending",
+      }),
+    );
+    expect(emittedCallbacks).not.toContainEqual(
+      expect.objectContaining({ internalKind: "workflow-trigger:loop" }),
+    );
+    expect((await wf.readTrigger(trigger.triggerId)).nextRunAt).toBeNull();
+
+    const legacyPrompt = "complete a persisted legacy workflow callback";
+    const legacyRun = await runsApi.createRun(scenario.actor, {
+      agentId: scenario.agentId,
+      prompt: legacyPrompt,
+      modelProvider: "anthropic-api-key",
+    });
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: legacyRun.runId,
+        internalKind: "workflow-trigger:loop",
+        payload: { triggerId: trigger.triggerId },
+      },
+      context.signal,
+    );
+
+    await completeRunThroughSandbox(scenario, legacyRun.runId, 0);
+
+    await expect
+      .poll(async () => {
+        return (await wf.readTrigger(trigger.triggerId)).nextRunAt;
+      })
+      .not.toBeNull();
+    const legacyCallbacks = await store.set(
+      readAgentRunCallbacks$,
+      {
+        orgId: scenario.orgId,
+        userId: scenario.userId,
+        prompt: legacyPrompt,
+      },
+      context.signal,
+    );
+    expect(legacyCallbacks).toContainEqual(
+      expect.objectContaining({
+        internalKind: "workflow-trigger:loop",
+        status: "delivered",
+      }),
+    );
     await disableTrigger(trigger.triggerId);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
@@ -540,7 +540,7 @@ describe("zero workflow trigger scheduler", () => {
     await disableTrigger(trigger.triggerId);
   });
 
-  it("emits automation callback kinds and advances an in-flight legacy callback", async () => {
+  it("keeps legacy writes while accepting an in-flight automation callback", async () => {
     const scenario = await setup();
     const trigger = await createDueLoopTrigger(scenario, 300);
 
@@ -558,50 +558,50 @@ describe("zero workflow trigger scheduler", () => {
     );
     expect(emittedCallbacks).toContainEqual(
       expect.objectContaining({
-        internalKind: "workflow-automation:loop",
+        internalKind: "workflow-trigger:loop",
         status: "pending",
       }),
     );
     expect(emittedCallbacks).not.toContainEqual(
-      expect.objectContaining({ internalKind: "workflow-trigger:loop" }),
+      expect.objectContaining({ internalKind: "workflow-automation:loop" }),
     );
     expect((await wf.readTrigger(trigger.triggerId)).nextRunAt).toBeNull();
 
-    const legacyPrompt = "complete a persisted legacy workflow callback";
-    const legacyRun = await runsApi.createRun(scenario.actor, {
+    const futurePrompt = "complete a future workflow automation callback";
+    const futureRun = await runsApi.createRun(scenario.actor, {
       agentId: scenario.agentId,
-      prompt: legacyPrompt,
+      prompt: futurePrompt,
       modelProvider: "anthropic-api-key",
     });
     await store.set(
       seedAgentRunCallback$,
       {
-        runId: legacyRun.runId,
-        internalKind: "workflow-trigger:loop",
+        runId: futureRun.runId,
+        internalKind: "workflow-automation:loop",
         payload: { triggerId: trigger.triggerId },
       },
       context.signal,
     );
 
-    await completeRunThroughSandbox(scenario, legacyRun.runId, 0);
+    await completeRunThroughSandbox(scenario, futureRun.runId, 0);
 
     await expect
       .poll(async () => {
         return (await wf.readTrigger(trigger.triggerId)).nextRunAt;
       })
       .not.toBeNull();
-    const legacyCallbacks = await store.set(
+    const futureCallbacks = await store.set(
       readAgentRunCallbacks$,
       {
         orgId: scenario.orgId,
         userId: scenario.userId,
-        prompt: legacyPrompt,
+        prompt: futurePrompt,
       },
       context.signal,
     );
-    expect(legacyCallbacks).toContainEqual(
+    expect(futureCallbacks).toContainEqual(
       expect.objectContaining({
-        internalKind: "workflow-trigger:loop",
+        internalKind: "workflow-automation:loop",
         status: "delivered",
       }),
     );

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -41,7 +41,7 @@ import {
   internalRunCallbackKindForRecord,
   type InternalRunCallbackDispatchResult,
   type InternalRunCallbackEnvelope,
-  type InternalRunCallbackKind,
+  type NormalizedInternalRunCallbackKind,
 } from "./internal-run-callback";
 import {
   handleWorkflowTriggerInternalCallback,
@@ -92,11 +92,11 @@ interface DispatchInternalRunCallbackInput {
   readonly status: TerminalCallbackStatus;
   readonly result?: Record<string, unknown>;
   readonly error?: string;
-  readonly kind: InternalRunCallbackKind;
+  readonly kind: NormalizedInternalRunCallbackKind;
 }
 
 interface DispatchInternalCallbackInput {
-  readonly kind: InternalRunCallbackKind;
+  readonly kind: NormalizedInternalRunCallbackKind;
   readonly envelope: InternalRunCallbackEnvelope;
 }
 
@@ -149,8 +149,8 @@ const dispatchInternalCallback$ = command(
           signal,
         );
       }
-      case "workflow-automation:cron":
-      case "workflow-automation:loop": {
+      case "workflow-trigger:cron":
+      case "workflow-trigger:loop": {
         return await set(
           handleWorkflowTriggerInternalCallback$,
           { kind: input.kind, callback: input.envelope },
@@ -451,7 +451,7 @@ async function dispatchInternalCallback(
 
 async function dispatchInternalCallbackWithoutCcstate(
   input: DispatchSingleCallbackInput,
-  kind: InternalRunCallbackKind,
+  kind: NormalizedInternalRunCallbackKind,
 ): Promise<InternalRunCallbackDispatchResult> {
   switch (kind) {
     case "agent": {
@@ -493,8 +493,8 @@ async function dispatchInternalCallbackWithoutCcstate(
         callbackEnvelope(input),
       );
     }
-    case "workflow-automation:cron":
-    case "workflow-automation:loop": {
+    case "workflow-trigger:cron":
+    case "workflow-trigger:loop": {
       return await handleWorkflowTriggerInternalCallback(input.db, {
         kind,
         callback: callbackEnvelope(input),

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -149,8 +149,8 @@ const dispatchInternalCallback$ = command(
           signal,
         );
       }
-      case "workflow-trigger:cron":
-      case "workflow-trigger:loop": {
+      case "workflow-automation:cron":
+      case "workflow-automation:loop": {
         return await set(
           handleWorkflowTriggerInternalCallback$,
           { kind: input.kind, callback: input.envelope },
@@ -493,8 +493,8 @@ async function dispatchInternalCallbackWithoutCcstate(
         callbackEnvelope(input),
       );
     }
-    case "workflow-trigger:cron":
-    case "workflow-trigger:loop": {
+    case "workflow-automation:cron":
+    case "workflow-automation:loop": {
       return await handleWorkflowTriggerInternalCallback(input.db, {
         kind,
         callback: callbackEnvelope(input),

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -6,8 +6,8 @@ export const internalRunCallbackKinds = [
   "slack:org",
   "teams:org",
   "telegram",
-  "workflow-trigger:cron",
-  "workflow-trigger:loop",
+  "workflow-automation:cron",
+  "workflow-automation:loop",
 ] as const;
 
 export type InternalRunCallbackKind = (typeof internalRunCallbackKinds)[number];
@@ -42,8 +42,8 @@ function isInternalRunCallbackKind(
     case "slack:org":
     case "teams:org":
     case "telegram":
-    case "workflow-trigger:cron":
-    case "workflow-trigger:loop": {
+    case "workflow-automation:cron":
+    case "workflow-automation:loop": {
       return true;
     }
     default: {
@@ -58,5 +58,18 @@ export function internalRunCallbackKindForRecord(
   if (isInternalRunCallbackKind(callback.internalKind)) {
     return callback.internalKind;
   }
-  return null;
+
+  // Compatibility for callback rows written before the workflow automation
+  // rename. Remove these aliases after the one-release-cycle drain in #21408.
+  switch (callback.internalKind) {
+    case "workflow-trigger:cron": {
+      return "workflow-automation:cron";
+    }
+    case "workflow-trigger:loop": {
+      return "workflow-automation:loop";
+    }
+    default: {
+      return null;
+    }
+  }
 }

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -1,3 +1,8 @@
+/**
+ * Persisted callback kinds accepted during the expand phase. Producers must
+ * keep emitting `workflow-trigger:*` until this acceptance release is fully
+ * deployed; the follow-up release can then switch writes safely.
+ */
 export const internalRunCallbackKinds = [
   "agent",
   "agentphone",
@@ -6,11 +11,18 @@ export const internalRunCallbackKinds = [
   "slack:org",
   "teams:org",
   "telegram",
+  "workflow-trigger:cron",
+  "workflow-trigger:loop",
   "workflow-automation:cron",
   "workflow-automation:loop",
 ] as const;
 
 export type InternalRunCallbackKind = (typeof internalRunCallbackKinds)[number];
+
+export type NormalizedInternalRunCallbackKind = Exclude<
+  InternalRunCallbackKind,
+  "workflow-automation:cron" | "workflow-automation:loop"
+>;
 
 export type InternalRunCallbackStatus = "completed" | "failed" | "progress";
 
@@ -31,9 +43,9 @@ interface InternalRunCallbackRecord {
   readonly internalKind: string | null;
 }
 
-function isInternalRunCallbackKind(
+function isNormalizedInternalRunCallbackKind(
   value: string | null,
-): value is InternalRunCallbackKind {
+): value is NormalizedInternalRunCallbackKind {
   switch (value) {
     case "agent":
     case "agentphone":
@@ -42,8 +54,8 @@ function isInternalRunCallbackKind(
     case "slack:org":
     case "teams:org":
     case "telegram":
-    case "workflow-automation:cron":
-    case "workflow-automation:loop": {
+    case "workflow-trigger:cron":
+    case "workflow-trigger:loop": {
       return true;
     }
     default: {
@@ -54,19 +66,19 @@ function isInternalRunCallbackKind(
 
 export function internalRunCallbackKindForRecord(
   callback: InternalRunCallbackRecord,
-): InternalRunCallbackKind | null {
-  if (isInternalRunCallbackKind(callback.internalKind)) {
+): NormalizedInternalRunCallbackKind | null {
+  if (isNormalizedInternalRunCallbackKind(callback.internalKind)) {
     return callback.internalKind;
   }
 
-  // Compatibility for callback rows written before the workflow automation
-  // rename. Remove these aliases after the one-release-cycle drain in #21408.
+  // Expand-phase compatibility for rows written by the follow-up emission
+  // release. Keep this normalization through the rolling-deploy drain.
   switch (callback.internalKind) {
-    case "workflow-trigger:cron": {
-      return "workflow-automation:cron";
+    case "workflow-automation:cron": {
+      return "workflow-trigger:cron";
     }
-    case "workflow-trigger:loop": {
-      return "workflow-automation:loop";
+    case "workflow-automation:loop": {
+      return "workflow-trigger:loop";
     }
     default: {
       return null;

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
@@ -21,7 +21,7 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 
 type WorkflowTriggerInternalRunCallbackKind = Extract<
   InternalRunCallbackKind,
-  "workflow-trigger:cron" | "workflow-trigger:loop"
+  "workflow-automation:cron" | "workflow-automation:loop"
 >;
 
 type WorkflowTriggerPayload =
@@ -38,11 +38,11 @@ function parseWorkflowTriggerPayload(
   payload: unknown,
 ): WorkflowTriggerPayload | null {
   switch (kind) {
-    case "workflow-trigger:cron": {
+    case "workflow-automation:cron": {
       const result = triggerCronCallbackPayloadSchema.safeParse(payload);
       return result.success ? { kind: "cron", data: result.data } : null;
     }
-    case "workflow-trigger:loop": {
+    case "workflow-automation:loop": {
       const result = triggerLoopCallbackPayloadSchema.safeParse(payload);
       return result.success ? { kind: "loop", data: result.data } : null;
     }

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
@@ -8,7 +8,7 @@ import { advanceTimeTriggerAfterCompletion } from "./time-trigger";
 import type {
   InternalRunCallbackDispatchResult,
   InternalRunCallbackEnvelope,
-  InternalRunCallbackKind,
+  NormalizedInternalRunCallbackKind,
 } from "./internal-run-callback";
 import {
   triggerCronCallbackPayloadSchema,
@@ -20,8 +20,8 @@ import {
 const MAX_CONSECUTIVE_FAILURES = 3;
 
 type WorkflowTriggerInternalRunCallbackKind = Extract<
-  InternalRunCallbackKind,
-  "workflow-automation:cron" | "workflow-automation:loop"
+  NormalizedInternalRunCallbackKind,
+  "workflow-trigger:cron" | "workflow-trigger:loop"
 >;
 
 type WorkflowTriggerPayload =
@@ -38,11 +38,11 @@ function parseWorkflowTriggerPayload(
   payload: unknown,
 ): WorkflowTriggerPayload | null {
   switch (kind) {
-    case "workflow-automation:cron": {
+    case "workflow-trigger:cron": {
       const result = triggerCronCallbackPayloadSchema.safeParse(payload);
       return result.success ? { kind: "cron", data: result.data } : null;
     }
-    case "workflow-automation:loop": {
+    case "workflow-trigger:loop": {
       const result = triggerLoopCallbackPayloadSchema.safeParse(payload);
       return result.success ? { kind: "loop", data: result.data } : null;
     }

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -145,13 +145,13 @@ function buildWorkflowTriggerCallbacks(
   const callbacks: InternalRunCallbackInput[] = [];
   if (trigger.scheduleType === "loop") {
     callbacks.push({
-      internalKind: "workflow-automation:loop",
+      internalKind: "workflow-trigger:loop",
       secret: generateCallbackSecret(),
       payload: { triggerId: trigger.id },
     });
   } else {
     callbacks.push({
-      internalKind: "workflow-automation:cron",
+      internalKind: "workflow-trigger:cron",
       secret: generateCallbackSecret(),
       payload: {
         triggerId: trigger.id,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -145,13 +145,13 @@ function buildWorkflowTriggerCallbacks(
   const callbacks: InternalRunCallbackInput[] = [];
   if (trigger.scheduleType === "loop") {
     callbacks.push({
-      internalKind: "workflow-trigger:loop",
+      internalKind: "workflow-automation:loop",
       secret: generateCallbackSecret(),
       payload: { triggerId: trigger.id },
     });
   } else {
     callbacks.push({
-      internalKind: "workflow-trigger:cron",
+      internalKind: "workflow-automation:cron",
       secret: generateCallbackSecret(),
       payload: {
         triggerId: trigger.id,


### PR DESCRIPTION
## Summary

- Expand persisted callback-kind acceptance to include both `workflow-trigger:*` and `workflow-automation:*`.
- Normalize future automation kinds to the current trigger kinds at the callback-record boundary so both ccstate and non-ccstate dispatch paths handle either persisted value.
- Keep every producer writing `workflow-trigger:*` in this release.
- Add an API integration regression proving scheduled callbacks remain legacy while a manually seeded future automation callback is delivered and advances `nextRunAt`.

## Rollout sequence

This PR is the expand/read-compatibility release. It must be fully deployed before callback writers switch to the new values.

1. Merge and deploy this PR: accept both kinds, continue writing `workflow-trigger:*`.
2. After this release is fully deployed and rollback-safe, merge a follow-up PR that writes `workflow-automation:*` while still accepting both.
3. After the persisted-state drain window, remove recognition of `workflow-trigger:*`.

Separating acceptance from emission prevents older API instances, including an instant rollback target, from encountering a newly persisted kind they cannot recognize.

## Scope and safety

- Both callback dispatch implementations normalize at the persisted-record boundary before routing.
- The queue schema also accepts both values because it derives from the shared callback-kind list.
- No public routes, CLI behavior, database names, provenance fields, or broad workflow identifiers change in this PR.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts` (12 passed)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm knip --workspace api`
- Prettier plus changed-file Oxlint and ESLint checks

The package-wide `pnpm -F api lint` type-aware subprocess was killed by the 3.8 GiB local environment after its initial pass; changed-file lint is clean and CI will run the complete package check.

Part of #21408.
