### PR TITLE
feat(api): add workflow automation routes with legacy parity

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -143,7 +143,8 @@ import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-provide
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroScrapeRoutes } from "./routes/zero-scrape";
 import { zeroWorkflowsRoutes } from "./routes/zero-workflows";
-import { zeroWorkflowTriggersRoutes } from "./routes/zero-workflow-triggers";
+import { zeroWorkflowAutomationsRoutes } from "./routes/zero-workflow-automations";
+import { legacyWorkflowTriggerAliasRoutes } from "./routes/legacy-workflow-trigger-aliases";
 import { zeroWorkflowQueueRoutes } from "./routes/zero-workflow-queue";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
@@ -349,7 +350,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUserModelPreferenceRoutes,
   ...zeroSecretsRoutes,
   ...zeroWorkflowsRoutes,
-  ...zeroWorkflowTriggersRoutes,
+  ...zeroWorkflowAutomationsRoutes,
+  ...legacyWorkflowTriggerAliasRoutes,
   ...zeroWorkflowQueueRoutes,
   ...integrationsGithubRoutes,
   ...zeroSlackBrowserConnectRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  zeroWorkflowAutomationsContract,
   zeroWorkflowsDetailContract,
   zeroWorkflowTriggersContract,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -43,6 +44,10 @@ function authHeaders() {
 
 function triggersClient() {
   return setupApp({ context })(zeroWorkflowTriggersContract);
+}
+
+function automationsClient() {
+  return setupApp({ context })(zeroWorkflowAutomationsContract);
 }
 
 function detailClient() {
@@ -584,6 +589,138 @@ describe("zero workflow triggers", () => {
     );
     return connector.id;
   }
+
+  it("keeps automation routes in parity with legacy trigger aliases", async () => {
+    const { workflowId } = await setupFixture();
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { schedule: { type: "loop", intervalSeconds: 60 } },
+      }),
+      [201],
+    );
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to bind a chat thread");
+    }
+
+    const [automationGet, legacyGet] = await Promise.all([
+      accept(
+        automationsClient().get({
+          headers: authHeaders(),
+          params: { id: created.body.id },
+        }),
+        [200],
+      ),
+      accept(
+        triggersClient().get({
+          headers: authHeaders(),
+          params: { id: created.body.id },
+        }),
+        [200],
+      ),
+    ]);
+    expect(automationGet.body).toStrictEqual(legacyGet.body);
+
+    const [automationList, legacyList] = await Promise.all([
+      accept(
+        automationsClient().list({
+          headers: authHeaders(),
+          params: { workflowId },
+        }),
+        [200],
+      ),
+      accept(
+        triggersClient().list({
+          headers: authHeaders(),
+          params: { workflowId },
+        }),
+        [200],
+      ),
+    ]);
+    expect(automationList.body).toStrictEqual(legacyList.body);
+
+    const [automationThreadList, legacyThreadList] = await Promise.all([
+      accept(
+        automationsClient().listForChatThread({
+          headers: authHeaders(),
+          params: { threadId: created.body.chatThreadId },
+        }),
+        [200],
+      ),
+      accept(
+        triggersClient().listForChatThread({
+          headers: authHeaders(),
+          params: { threadId: created.body.chatThreadId },
+        }),
+        [200],
+      ),
+    ]);
+    expect(automationThreadList.body).toStrictEqual(legacyThreadList.body);
+
+    const [automationWorkspaceList, legacyWorkspaceList] = await Promise.all([
+      accept(
+        automationsClient().listWorkspace({ headers: authHeaders() }),
+        [200],
+      ),
+      accept(triggersClient().listWorkspace({ headers: authHeaders() }), [200]),
+    ]);
+    expect(automationWorkspaceList.body).toStrictEqual(
+      legacyWorkspaceList.body.map(({ workflow, trigger }) => {
+        return { workflow, automation: trigger };
+      }),
+    );
+    expect(automationWorkspaceList.body[0]).not.toHaveProperty("trigger");
+    expect(legacyWorkspaceList.body[0]).not.toHaveProperty("automation");
+
+    const updated = await accept(
+      triggersClient().update({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+        body: { schedule: { type: "loop", intervalSeconds: 120 } },
+      }),
+      [200],
+    );
+    const readUpdated = await accept(
+      automationsClient().get({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(readUpdated.body).toStrictEqual(updated.body);
+
+    const disabled = await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    const readDisabled = await accept(
+      triggersClient().get({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(readDisabled.body).toStrictEqual(disabled.body);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
+    await accept(
+      triggersClient().get({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [404],
+    );
+  });
 
   it("creates a cron trigger and eagerly binds a chat thread", async () => {
     const { workflowId } = await setupFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -593,7 +593,6 @@ describe("zero workflow triggers", () => {
   it("keeps automation routes in parity with legacy trigger aliases", async () => {
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const scenario = await setupFixture("team");
-    await enableWebhookWorkflowTriggers(scenario.fixture);
     const { actor, workflowId } = scenario;
     const created = await accept(
       automationsClient().create({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -591,7 +591,10 @@ describe("zero workflow triggers", () => {
   }
 
   it("keeps automation routes in parity with legacy trigger aliases", async () => {
-    const { workflowId } = await setupFixture();
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    const scenario = await setupFixture("team");
+    await enableWebhookWorkflowTriggers(scenario.fixture);
+    const { actor, workflowId } = scenario;
     const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
@@ -674,7 +677,7 @@ describe("zero workflow triggers", () => {
     expect(legacyWorkspaceList.body[0]).not.toHaveProperty("automation");
 
     const updated = await accept(
-      triggersClient().update({
+      automationsClient().update({
         headers: authHeaders(),
         params: { id: created.body.id },
         body: { schedule: { type: "loop", intervalSeconds: 120 } },
@@ -706,6 +709,95 @@ describe("zero workflow triggers", () => {
     );
     expect(readDisabled.body).toStrictEqual(disabled.body);
 
+    const enabled = await accept(
+      automationsClient().enable({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    const readEnabled = await accept(
+      triggersClient().get({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+    expect(readEnabled.body).toStrictEqual(enabled.body);
+
+    const automationRun = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [201],
+    );
+    await cancelWorkflowTriggerRun(actor, automationRun.body.runId);
+    const legacyRun = await accept(
+      triggersClient().run({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [201],
+    );
+    expect({ ...automationRun.body, runId: "<dynamic>" }).toStrictEqual({
+      ...legacyRun.body,
+      runId: "<dynamic>",
+    });
+    await cancelWorkflowTriggerRun(actor, legacyRun.body.runId);
+
+    const webhook = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { kind: "event", eventType: "webhook-received" },
+      }),
+      [201],
+    );
+    const [automationSecret, legacySecret] = await Promise.all([
+      accept(
+        automationsClient().revealWebhookSecret({
+          headers: authHeaders(),
+          params: { id: webhook.body.id },
+          body: undefined,
+        }),
+        [200],
+      ),
+      accept(
+        triggersClient().revealWebhookSecret({
+          headers: authHeaders(),
+          params: { id: webhook.body.id },
+          body: undefined,
+        }),
+        [200],
+      ),
+    ]);
+    expect(automationSecret.body).toStrictEqual(legacySecret.body);
+
+    const hidden = await createAgentWithWorkflow(scenario, {
+      userId: `user_${randomUUID()}`,
+      agentDisplayName: "Hidden Automation Agent",
+      workflowName: "hidden-automation-workflow",
+      visibility: "private",
+    });
+    const [automationHidden, legacyHidden] = await Promise.all([
+      accept(
+        automationsClient().list({
+          headers: authHeaders(),
+          params: { workflowId: hidden.workflowId },
+        }),
+        [404],
+      ),
+      accept(
+        triggersClient().list({
+          headers: authHeaders(),
+          params: { workflowId: hidden.workflowId },
+        }),
+        [404],
+      ),
+    ]);
+    expect(automationHidden.body).toStrictEqual(legacyHidden.body);
+
     await accept(
       automationsClient().delete({
         headers: authHeaders(),
@@ -719,6 +811,13 @@ describe("zero workflow triggers", () => {
         params: { id: created.body.id },
       }),
       [404],
+    );
+    await accept(
+      triggersClient().delete({
+        headers: authHeaders(),
+        params: { id: webhook.body.id },
+      }),
+      [204],
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/legacy-workflow-trigger-aliases.ts
+++ b/turbo/apps/api/src/signals/routes/legacy-workflow-trigger-aliases.ts
@@ -1,0 +1,72 @@
+import { computed } from "ccstate";
+import { zeroWorkflowTriggersContract } from "@vm0/api-contracts/contracts/zero-workflows";
+
+import {
+  workflowAutomationReadAuth,
+  workflowAutomationRouteHandlers,
+  workspaceWorkflowAutomationEntries$,
+} from "./zero-workflow-automations";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route-entry";
+
+const listWorkspaceLegacyWorkflowTriggersInner$ = computed(async (get) => {
+  const entries = await get(workspaceWorkflowAutomationEntries$);
+  return { status: 200 as const, body: [...entries] };
+});
+
+const listWorkspaceLegacyWorkflowTriggersHandler = authRoute(
+  workflowAutomationReadAuth,
+  listWorkspaceLegacyWorkflowTriggersInner$,
+);
+
+/**
+ * Temporary compatibility routes for clients using the legacy workflow-trigger
+ * API. Remove this file after legacy-path traffic reaches zero for the sunset
+ * window tracked in #21408.
+ */
+export const legacyWorkflowTriggerAliasRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroWorkflowTriggersContract.listWorkspace,
+    handler: listWorkspaceLegacyWorkflowTriggersHandler,
+  },
+  {
+    route: zeroWorkflowTriggersContract.listForChatThread,
+    handler: workflowAutomationRouteHandlers.listForChatThread,
+  },
+  {
+    route: zeroWorkflowTriggersContract.list,
+    handler: workflowAutomationRouteHandlers.list,
+  },
+  {
+    route: zeroWorkflowTriggersContract.create,
+    handler: workflowAutomationRouteHandlers.create,
+  },
+  {
+    route: zeroWorkflowTriggersContract.get,
+    handler: workflowAutomationRouteHandlers.get,
+  },
+  {
+    route: zeroWorkflowTriggersContract.update,
+    handler: workflowAutomationRouteHandlers.update,
+  },
+  {
+    route: zeroWorkflowTriggersContract.delete,
+    handler: workflowAutomationRouteHandlers.delete,
+  },
+  {
+    route: zeroWorkflowTriggersContract.enable,
+    handler: workflowAutomationRouteHandlers.enable,
+  },
+  {
+    route: zeroWorkflowTriggersContract.disable,
+    handler: workflowAutomationRouteHandlers.disable,
+  },
+  {
+    route: zeroWorkflowTriggersContract.run,
+    handler: workflowAutomationRouteHandlers.run,
+  },
+  {
+    route: zeroWorkflowTriggersContract.revealWebhookSecret,
+    handler: workflowAutomationRouteHandlers.revealWebhookSecret,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { zeroWorkflowTriggersContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -31,7 +31,7 @@ import {
 } from "../services/zero-workflow-trigger.service";
 import type { RouteEntry } from "../route-entry";
 
-const workflowReadAuth = {
+export const workflowAutomationReadAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "agent:read",
@@ -83,23 +83,32 @@ function triggerErrorResponse(
   }
 }
 
-const createTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.create);
-const updateTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.update);
+const createTriggerBody$ = bodyResultOf(zeroWorkflowAutomationsContract.create);
+const updateTriggerBody$ = bodyResultOf(zeroWorkflowAutomationsContract.update);
 
-const listWorkspaceTriggersInner$ = computed(async (get) => {
+export const workspaceWorkflowAutomationEntries$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const db = get(db$);
-  const triggers = await listWorkspaceWorkflowTriggers(db, {
+  return await listWorkspaceWorkflowTriggers(db, {
     orgId: auth.orgId,
     member: memberFromAuth(auth),
   });
-  return { status: 200 as const, body: [...triggers] };
+});
+
+const listWorkspaceAutomationsInner$ = computed(async (get) => {
+  const entries = await get(workspaceWorkflowAutomationEntries$);
+  return {
+    status: 200 as const,
+    body: entries.map(({ workflow, trigger }) => {
+      return { workflow, automation: trigger };
+    }),
+  };
 });
 
 const listChatThreadTriggersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(
-    pathParamsOf(zeroWorkflowTriggersContract.listForChatThread),
+    pathParamsOf(zeroWorkflowAutomationsContract.listForChatThread),
   );
   const db = get(db$);
   const triggers = await listThreadBoundWorkflowTriggers(db, {
@@ -112,7 +121,7 @@ const listChatThreadTriggersInner$ = computed(async (get) => {
 
 const listTriggersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  const params = get(pathParamsOf(zeroWorkflowTriggersContract.list));
+  const params = get(pathParamsOf(zeroWorkflowAutomationsContract.list));
   const db = get(db$);
   const visible = await loadVisibleWorkflowById(db, {
     orgId: auth.orgId,
@@ -133,7 +142,7 @@ const listTriggersInner$ = computed(async (get) => {
 const createTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(pathParamsOf(zeroWorkflowTriggersContract.create));
+    const params = get(pathParamsOf(zeroWorkflowAutomationsContract.create));
     const bodyResult = await get(createTriggerBody$);
     signal.throwIfAborted();
     if (!bodyResult.ok) {
@@ -233,7 +242,7 @@ const createTriggerInner$ = command(
 
 const getTriggerInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  const params = get(pathParamsOf(zeroWorkflowTriggersContract.get));
+  const params = get(pathParamsOf(zeroWorkflowAutomationsContract.get));
   const db = get(db$);
   const trigger = await getWorkflowTrigger(db, {
     orgId: auth.orgId,
@@ -249,7 +258,7 @@ const getTriggerInner$ = computed(async (get) => {
 const revealWebhookSecretInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(
-    pathParamsOf(zeroWorkflowTriggersContract.revealWebhookSecret),
+    pathParamsOf(zeroWorkflowAutomationsContract.revealWebhookSecret),
   );
   const db = get(db$);
   const secret = await revealWorkflowWebhookSecret(db, {
@@ -266,7 +275,7 @@ const revealWebhookSecretInner$ = computed(async (get) => {
 const updateTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(pathParamsOf(zeroWorkflowTriggersContract.update));
+    const params = get(pathParamsOf(zeroWorkflowAutomationsContract.update));
     const bodyResult = await get(updateTriggerBody$);
     signal.throwIfAborted();
     if (!bodyResult.ok) {
@@ -301,7 +310,7 @@ const updateTriggerInner$ = command(
 const deleteTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(pathParamsOf(zeroWorkflowTriggersContract.delete));
+    const params = get(pathParamsOf(zeroWorkflowAutomationsContract.delete));
     const result = await set(
       deleteWorkflowTrigger$,
       {
@@ -322,7 +331,7 @@ const deleteTriggerInner$ = command(
 const enableTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(pathParamsOf(zeroWorkflowTriggersContract.enable));
+    const params = get(pathParamsOf(zeroWorkflowAutomationsContract.enable));
     const result = await set(
       enableWorkflowTrigger$,
       {
@@ -343,7 +352,7 @@ const enableTriggerInner$ = command(
 const disableTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(pathParamsOf(zeroWorkflowTriggersContract.disable));
+    const params = get(pathParamsOf(zeroWorkflowAutomationsContract.disable));
     const result = await set(
       disableWorkflowTrigger$,
       {
@@ -363,7 +372,7 @@ const disableTriggerInner$ = command(
 
 const runTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const params = get(pathParamsOf(zeroWorkflowTriggersContract.run));
+  const params = get(pathParamsOf(zeroWorkflowAutomationsContract.run));
   const result = await set(
     runOwnedWorkflowTriggerNow$,
     {
@@ -389,49 +398,69 @@ const runTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return triggerErrorResponse(result);
 });
 
-export const zeroWorkflowTriggersRoutes: readonly RouteEntry[] = [
+export const workflowAutomationRouteHandlers = {
+  listWorkspace: authRoute(
+    workflowAutomationReadAuth,
+    listWorkspaceAutomationsInner$,
+  ),
+  listForChatThread: authRoute(
+    workflowAutomationReadAuth,
+    listChatThreadTriggersInner$,
+  ),
+  list: authRoute(workflowAutomationReadAuth, listTriggersInner$),
+  create: authRoute(workflowWriteAuth, createTriggerInner$),
+  get: authRoute(workflowAutomationReadAuth, getTriggerInner$),
+  update: authRoute(workflowWriteAuth, updateTriggerInner$),
+  delete: authRoute(workflowWriteAuth, deleteTriggerInner$),
+  enable: authRoute(workflowWriteAuth, enableTriggerInner$),
+  disable: authRoute(workflowWriteAuth, disableTriggerInner$),
+  run: authRoute(workflowWriteAuth, runTriggerInner$),
+  revealWebhookSecret: authRoute(workflowWriteAuth, revealWebhookSecretInner$),
+} as const;
+
+export const zeroWorkflowAutomationsRoutes: readonly RouteEntry[] = [
   {
-    route: zeroWorkflowTriggersContract.listWorkspace,
-    handler: authRoute(workflowReadAuth, listWorkspaceTriggersInner$),
+    route: zeroWorkflowAutomationsContract.listWorkspace,
+    handler: workflowAutomationRouteHandlers.listWorkspace,
   },
   {
-    route: zeroWorkflowTriggersContract.listForChatThread,
-    handler: authRoute(workflowReadAuth, listChatThreadTriggersInner$),
+    route: zeroWorkflowAutomationsContract.listForChatThread,
+    handler: workflowAutomationRouteHandlers.listForChatThread,
   },
   {
-    route: zeroWorkflowTriggersContract.list,
-    handler: authRoute(workflowReadAuth, listTriggersInner$),
+    route: zeroWorkflowAutomationsContract.list,
+    handler: workflowAutomationRouteHandlers.list,
   },
   {
-    route: zeroWorkflowTriggersContract.create,
-    handler: authRoute(workflowWriteAuth, createTriggerInner$),
+    route: zeroWorkflowAutomationsContract.create,
+    handler: workflowAutomationRouteHandlers.create,
   },
   {
-    route: zeroWorkflowTriggersContract.get,
-    handler: authRoute(workflowReadAuth, getTriggerInner$),
+    route: zeroWorkflowAutomationsContract.get,
+    handler: workflowAutomationRouteHandlers.get,
   },
   {
-    route: zeroWorkflowTriggersContract.update,
-    handler: authRoute(workflowWriteAuth, updateTriggerInner$),
+    route: zeroWorkflowAutomationsContract.update,
+    handler: workflowAutomationRouteHandlers.update,
   },
   {
-    route: zeroWorkflowTriggersContract.delete,
-    handler: authRoute(workflowWriteAuth, deleteTriggerInner$),
+    route: zeroWorkflowAutomationsContract.delete,
+    handler: workflowAutomationRouteHandlers.delete,
   },
   {
-    route: zeroWorkflowTriggersContract.enable,
-    handler: authRoute(workflowWriteAuth, enableTriggerInner$),
+    route: zeroWorkflowAutomationsContract.enable,
+    handler: workflowAutomationRouteHandlers.enable,
   },
   {
-    route: zeroWorkflowTriggersContract.disable,
-    handler: authRoute(workflowWriteAuth, disableTriggerInner$),
+    route: zeroWorkflowAutomationsContract.disable,
+    handler: workflowAutomationRouteHandlers.disable,
   },
   {
-    route: zeroWorkflowTriggersContract.run,
-    handler: authRoute(workflowWriteAuth, runTriggerInner$),
+    route: zeroWorkflowAutomationsContract.run,
+    handler: workflowAutomationRouteHandlers.run,
   },
   {
-    route: zeroWorkflowTriggersContract.revealWebhookSecret,
-    handler: authRoute(workflowWriteAuth, revealWebhookSecretInner$),
+    route: zeroWorkflowAutomationsContract.revealWebhookSecret,
+    handler: workflowAutomationRouteHandlers.revealWebhookSecret,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
@@ -29,7 +29,7 @@ import {
   updateWorkflowTrigger$,
   type TriggerResult,
 } from "../services/zero-workflow-trigger.service";
-import type { RouteEntry } from "../route-entry";
+import type { RouteEntry, SignalRouteHandler } from "../route-entry";
 
 export const workflowAutomationReadAuth = {
   requireOrganization: true,
@@ -398,7 +398,12 @@ const runTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return triggerErrorResponse(result);
 });
 
-export const workflowAutomationRouteHandlers = {
+export const workflowAutomationRouteHandlers: Readonly<
+  Record<
+    keyof typeof zeroWorkflowAutomationsContract,
+    SignalRouteHandler<unknown>
+  >
+> = {
   listWorkspace: authRoute(
     workflowAutomationReadAuth,
     listWorkspaceAutomationsInner$,
@@ -416,7 +421,7 @@ export const workflowAutomationRouteHandlers = {
   disable: authRoute(workflowWriteAuth, disableTriggerInner$),
   run: authRoute(workflowWriteAuth, runTriggerInner$),
   revealWebhookSecret: authRoute(workflowWriteAuth, revealWebhookSecretInner$),
-} as const;
+};
 
 export const zeroWorkflowAutomationsRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1007,6 +1007,8 @@ export {
   chatThreadWorkflowTriggerSchema,
   zeroWorkflowTriggerCreateRequestSchema,
   zeroWorkflowTriggerUpdateRequestSchema,
+  zeroWorkflowAutomationsListEntrySchema,
+  zeroWorkflowAutomationsListResponseSchema,
   zeroWorkflowSummarySchema,
   zeroWorkflowDetailResponseSchema,
   zeroWorkflowListResponseSchema,
@@ -1017,6 +1019,7 @@ export {
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
   zeroWorkflowVisibilityContract,
+  zeroWorkflowAutomationsContract,
   zeroWorkflowTriggersContract,
   type ZeroWorkflowVisibility,
   type WorkflowFileEntry,
@@ -1034,6 +1037,7 @@ export {
   type ChatThreadWorkflowTrigger,
   type ZeroWorkflowTriggerCreateRequest,
   type ZeroWorkflowTriggerUpdateRequest,
+  type ZeroWorkflowAutomationsListEntry,
   type ZeroWorkflowSummary,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowCreateRequest,
@@ -1043,6 +1047,7 @@ export {
   type ZeroWorkflowsCollectionContract,
   type ZeroWorkflowsDetailContract,
   type ZeroWorkflowVisibilityContract,
+  type ZeroWorkflowAutomationsContract,
   type ZeroWorkflowTriggersContract,
 } from "./zero-workflows";
 export {

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -931,6 +931,14 @@ export const zeroWorkflowAutomationListResponseSchema = z.array(
   zeroWorkflowAutomationEntrySchema,
 );
 
+export const zeroWorkflowAutomationsListEntrySchema = z.object({
+  workflow: zeroWorkflowSummarySchema,
+  automation: zeroWorkflowTriggerSummarySchema,
+});
+export const zeroWorkflowAutomationsListResponseSchema = z.array(
+  zeroWorkflowAutomationsListEntrySchema,
+);
+
 export const zeroWorkflowCreateRequestSchema = z.object({
   agentId: z.string().uuid(),
   chatThreadId: z.string().uuid().optional(),
@@ -1362,6 +1370,69 @@ export const zeroWorkflowTriggersContract = c.router({
   },
 });
 
+export const zeroWorkflowAutomationsContract = c.router({
+  listWorkspace: {
+    ...zeroWorkflowTriggersContract.listWorkspace,
+    path: "/api/zero/workflow-automations",
+    responses: {
+      ...zeroWorkflowTriggersContract.listWorkspace.responses,
+      200: zeroWorkflowAutomationsListResponseSchema,
+    },
+    summary: "List the caller's automations across visible workflows",
+  },
+  listForChatThread: {
+    ...zeroWorkflowTriggersContract.listForChatThread,
+    path: "/api/zero/chat-threads/:threadId/workflow-automations",
+    summary: "List workflow automations bound to a chat thread",
+  },
+  list: {
+    ...zeroWorkflowTriggersContract.list,
+    path: "/api/zero/workflows/:workflowId/automations",
+    summary: "List the caller's own automations for a workflow",
+  },
+  create: {
+    ...zeroWorkflowTriggersContract.create,
+    path: "/api/zero/workflows/:workflowId/automations",
+    summary: "Create an automation on a workflow",
+  },
+  get: {
+    ...zeroWorkflowTriggersContract.get,
+    path: "/api/zero/workflow-automations/:id",
+    summary: "Get a workflow automation",
+  },
+  update: {
+    ...zeroWorkflowTriggersContract.update,
+    path: "/api/zero/workflow-automations/:id",
+    summary: "Update a workflow automation",
+  },
+  delete: {
+    ...zeroWorkflowTriggersContract.delete,
+    path: "/api/zero/workflow-automations/:id",
+    summary: "Delete a workflow automation",
+  },
+  enable: {
+    ...zeroWorkflowTriggersContract.enable,
+    path: "/api/zero/workflow-automations/:id/enable",
+    summary: "Enable a workflow automation",
+  },
+  disable: {
+    ...zeroWorkflowTriggersContract.disable,
+    path: "/api/zero/workflow-automations/:id/disable",
+    summary: "Disable a workflow automation",
+  },
+  run: {
+    ...zeroWorkflowTriggersContract.run,
+    path: "/api/zero/workflow-automations/:id/run",
+    summary: "Run a workflow automation immediately in its bound chat thread",
+  },
+  revealWebhookSecret: {
+    ...zeroWorkflowTriggersContract.revealWebhookSecret,
+    path: "/api/zero/workflow-automations/:id/webhook-secret",
+    summary:
+      "Reveal the webhook URL and signing secret for a workflow automation",
+  },
+});
+
 export type WorkflowFileEntry = z.infer<typeof workflowFileEntrySchema>;
 export type WorkflowFileMetadata = z.infer<typeof workflowFileMetadataSchema>;
 export type ZeroWorkflowSummary = z.infer<typeof zeroWorkflowSummarySchema>;
@@ -1386,9 +1457,14 @@ export type ZeroWorkflowRunResponse = z.infer<
 export type ZeroWorkflowAutomationEntry = z.infer<
   typeof zeroWorkflowAutomationEntrySchema
 >;
+export type ZeroWorkflowAutomationsListEntry = z.infer<
+  typeof zeroWorkflowAutomationsListEntrySchema
+>;
 export type ZeroWorkflowsCollectionContract =
   typeof zeroWorkflowsCollectionContract;
 export type ZeroWorkflowsDetailContract = typeof zeroWorkflowsDetailContract;
 export type ZeroWorkflowVisibilityContract =
   typeof zeroWorkflowVisibilityContract;
 export type ZeroWorkflowTriggersContract = typeof zeroWorkflowTriggersContract;
+export type ZeroWorkflowAutomationsContract =
+  typeof zeroWorkflowAutomationsContract;


### PR DESCRIPTION
## Summary

- add automation-named API contracts and routes for workspace, workflow, chat-thread, resource, enable/disable, run, and webhook-secret operations
- return `automation` from the new workspace listing while preserving `trigger` on legacy responses
- route both surfaces through the same authorization and business handlers, with legacy route registration quarantined in `legacy-workflow-trigger-aliases.ts` for the measured sunset in #21408
- keep database schema, inbound webhook URLs, CLI commands, callback kinds, and broad internal identifiers unchanged

## Rolling-deploy compatibility

Existing `/workflow-triggers` and `/workflows/:id/triggers` callers keep their current paths and payloads. New automation routes coexist with them and reuse the same auth/security boundaries and mutations, so independently deployed clients can migrate without a cutover gap.

## Verification

- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- focused API Oxlint, type-aware Oxlint, and ESLint on changed files
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-triggers.test.ts --silent=passed-only` (49 tests passed)
- parity coverage successfully invokes all 11 new routes, compares legacy/new responses, and verifies an invisible-workflow 404 across both auth surfaces
- `pnpm knip --workspace api --workspace @vm0/api-contracts`

The full API type-check and full API lint exceed the local container memory limit; focused type-aware checks pass and the PR pipeline runs the complete workspace checks.

Part of #21408.