### PR TITLE
fix: move claimed chat messages out of the composer queue

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -133,6 +133,21 @@ export async function publishChatThreadMessageCreatedSafely(
 }
 
 /**
+ * Notify a chat thread's UI that an existing message row changed in place.
+ * The payload lets clients refetch that exact row instead of relying on the
+ * append-only message cursor, which cannot observe updates to an older row.
+ */
+export async function publishChatThreadMessageUpdated(
+  userId: string,
+  threadId: string,
+  messageId: string,
+): Promise<void> {
+  await publishUserSignal([userId], `chatThreadMessageUpdated:${threadId}`, {
+    messageId,
+  });
+}
+
+/**
  * Notify a chat thread's UI that its linked automation set changed (created,
  * deleted, enabled, or disabled). The chat-thread header automation menu
  * subscribes to this topic and refetches its thread-scoped list.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3454,6 +3454,17 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
         return message.revokesMessageId === messageId;
       }),
     ).toBeFalsy();
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some((call) => {
+          return (
+            call[0] === `chatThreadMessageUpdated:${sent.body.threadId}` &&
+            (call[1] as { messageId?: string } | undefined)?.messageId ===
+              messageId
+          );
+        });
+      })
+      .toBe(true);
 
     await cancelChatRun(actor, runId);
   }, 90_000);
@@ -3561,6 +3572,17 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
         return message.revokesMessageId === queuedId;
       }),
     ).toBeFalsy();
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some((call) => {
+          return (
+            call[0] === `chatThreadMessageUpdated:${anchor.threadId}` &&
+            (call[1] as { messageId?: string } | undefined)?.messageId ===
+              queuedId
+          );
+        });
+      })
+      .toBe(true);
 
     const followUp = await api.readRun(actor, promoted.runId);
     expect(followUp.prompt).toContain("queue-first waits for the anchor");

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -42,6 +42,7 @@ import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
 import {
+  publishChatThreadMessageUpdated,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -2410,6 +2411,7 @@ async function queueUnassociatedNormalMessage(params: {
   readonly userId: string;
   readonly touchThreadSort: boolean;
   readonly queueFirstOrgId: string | undefined;
+  readonly publishCreated: boolean;
 }): Promise<{
   readonly response:
     | CreatedChatMessageResponse
@@ -2430,10 +2432,12 @@ async function queueUnassociatedNormalMessage(params: {
     queueFirstOrgId: params.queueFirstOrgId,
   });
   if (message.kind === "queued" && message.inserted) {
-    await publishChatMessageCreated(
-      params.userId,
-      params.prepared.thread.threadId,
-    );
+    if (params.publishCreated) {
+      await publishChatMessageCreated(
+        params.userId,
+        params.prepared.thread.threadId,
+      );
+    }
     await publishThreadListChanged(params.userId);
   }
   const response = clientMessageIdResolutionResponse(
@@ -2615,10 +2619,14 @@ function scheduleQueueFirstMessageClaim(params: {
             });
           });
         }
-        await publishUserSignal(
-          [params.userId],
-          `chatThreadMessageCreated:${params.threadId}`,
+        await publishChatThreadMessageUpdated(
+          params.userId,
+          params.threadId,
+          params.messageId,
         );
+        if (params.appendQueueMarker) {
+          await publishChatMessageCreated(params.userId, params.threadId);
+        }
       }
       await publishUserSignal(
         [params.userId],
@@ -3174,6 +3182,7 @@ export const sendNormalMessage$ = command(
           prepared.thread.isNewThread,
         ),
         queueFirstOrgId: undefined,
+        publishCreated: true,
       });
       signal.throwIfAborted();
       return response;
@@ -3215,6 +3224,11 @@ const sendQueueFirstNormalMessage$ = command(
             prepared.thread.isNewThread,
           ),
           queueFirstOrgId: args.orgId,
+          // Queue-first inserts are an internal transition. Publish only if
+          // the dispatch decision below leaves the message genuinely queued;
+          // an idle-thread send stays in the transcript optimistically until
+          // its in-place claim is broadcast as a message update.
+          publishCreated: false,
         });
       },
     );
@@ -3242,12 +3256,16 @@ const sendQueueFirstNormalMessage$ = command(
     );
     signal.throwIfAborted();
     if (dispatch === "wait") {
+      await publishChatMessageCreated(args.userId, threadId);
+      signal.throwIfAborted();
       return response;
     }
     if (dispatch === "drain") {
       // The thread is idle but an older unclaimed message holds the queue
       // head (e.g. left behind by a cancelled run). Dispatch the head so the
       // thread keeps draining; this message stays queued behind it (#21392).
+      await publishChatMessageCreated(args.userId, threadId);
+      signal.throwIfAborted();
       await set(
         drainQueuedUserMessagesForThread$,
         { chatThreadId: threadId },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -38,6 +38,7 @@ import { getDatasetName, queryAxiomDirect } from "../external/axiom";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadMessageCreatedSafely,
+  publishChatThreadMessageUpdated,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -346,6 +347,15 @@ type CreatedQueuedRun = {
   readonly runId: string;
   readonly status: "queued" | "pending" | "running";
 };
+
+type QueuedUserMessageClaim =
+  | { readonly kind: "created"; readonly messageId: string }
+  | { readonly kind: "updated"; readonly messageId: string };
+
+interface CreatedAutoSentQueuedRun {
+  readonly run: CreatedQueuedRun;
+  readonly claim: QueuedUserMessageClaim;
+}
 
 type CreateQueuedRun = (
   input: CreateQueuedChatRunInput,
@@ -1737,7 +1747,7 @@ async function claimQueuedUserMessageForDispatch(args: {
   readonly queuedMessage: QueuedUserMessage;
   readonly runId: string;
   readonly threadId: string;
-}): Promise<boolean> {
+}): Promise<QueuedUserMessageClaim | null> {
   const claimed = await args.db.transaction(async (tx) => {
     // Serialize auto-send dispatch decisions per thread. Otherwise two terminal
     // callbacks can insert candidate runs, each see the other as active, and
@@ -1808,7 +1818,9 @@ async function claimQueuedUserMessageForDispatch(args: {
       if (updated) {
         await deleteUserMessageQueueItem(tx, args.queuedMessage.id);
       }
-      return updated ? [updated] : [];
+      return updated
+        ? { kind: "updated" as const, messageId: updated.id }
+        : null;
     }
 
     const [message] = await tx
@@ -1829,10 +1841,10 @@ async function claimQueuedUserMessageForDispatch(args: {
       })
       .onConflictDoNothing({ target: chatMessages.revokesMessageId })
       .returning({ id: chatMessages.id });
-    return message ? [message] : [];
+    return message ? { kind: "created" as const, messageId: message.id } : null;
   });
 
-  return claimed.length > 0;
+  return claimed;
 }
 
 async function appendAutoSentQueuedRunMarker(args: {
@@ -1890,8 +1902,9 @@ async function createAutoSentQueuedRun(args: {
   readonly queuedMessage: QueuedUserMessage;
   readonly threadId: string;
   readonly timing: ChatCallbackPreCreateTimingCollector;
-}): Promise<CreatedQueuedRun | null> {
-  return await measureChatCallbackPreCreateTiming(
+}): Promise<CreatedAutoSentQueuedRun | null> {
+  let claim: QueuedUserMessageClaim | null = null;
+  const run = await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run",
     "top_level",
@@ -1899,7 +1912,7 @@ async function createAutoSentQueuedRun(args: {
       return args.createRun({
         ...args.runInput,
         beforeDispatch: async ({ runId }) => {
-          const claimed = await measureChatCallbackPreCreateTiming(
+          claim = await measureChatCallbackPreCreateTiming(
             args.timing,
             "api_dispatch_pre_create_zero_chat_callback_auto_send_claim_message",
             "nested",
@@ -1912,7 +1925,7 @@ async function createAutoSentQueuedRun(args: {
               });
             },
           );
-          if (!claimed) {
+          if (!claim) {
             log.warn(
               "Auto-send could not claim queued message before dispatch",
               {
@@ -1922,11 +1935,12 @@ async function createAutoSentQueuedRun(args: {
               },
             );
           }
-          return claimed;
+          return claim !== null;
         },
       });
     },
   );
+  return run && claim ? { run, claim } : null;
 }
 
 async function appendAutoSentQueuedRunMarkerIfQueued(args: {
@@ -1957,6 +1971,8 @@ async function appendAutoSentQueuedRunMarkerIfQueued(args: {
 async function publishAutoSentQueuedRunSignals(args: {
   readonly threadId: string;
   readonly userId: string;
+  readonly claim: QueuedUserMessageClaim;
+  readonly runStatus: CreatedQueuedRun["status"];
   readonly timing: ChatCallbackPreCreateTimingCollector;
 }): Promise<void> {
   await measureChatCallbackPreCreateTiming(
@@ -1964,10 +1980,19 @@ async function publishAutoSentQueuedRunSignals(args: {
     "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals",
     "nested",
     async () => {
-      await publishUserSignal(
-        [args.userId],
-        `chatThreadMessageCreated:${args.threadId}`,
-      );
+      if (args.claim.kind === "updated") {
+        await publishChatThreadMessageUpdated(
+          args.userId,
+          args.threadId,
+          args.claim.messageId,
+        );
+      }
+      if (args.claim.kind === "created" || args.runStatus === "queued") {
+        await publishUserSignal(
+          [args.userId],
+          `chatThreadMessageCreated:${args.threadId}`,
+        );
+      }
       await publishUserSignal(
         [args.userId],
         `chatThreadRunCreated:${args.threadId}`,
@@ -2087,7 +2112,7 @@ async function autoSendQueuedMessageForThread(args: {
   let createdRunId: string | null = null;
   const run = await onRejection(
     (async () => {
-      const createdRun = await createAutoSentQueuedRun({
+      const created = await createAutoSentQueuedRun({
         createRun: args.createRun,
         db: args.db,
         runInput,
@@ -2095,9 +2120,10 @@ async function autoSendQueuedMessageForThread(args: {
         threadId,
         timing: args.timing,
       });
-      if (!createdRun) {
+      if (!created) {
         return null;
       }
+      const { run: createdRun, claim } = created;
       createdRunId = createdRun.runId;
       await appendAutoSentQueuedRunMarkerIfQueued({
         db: args.db,
@@ -2109,6 +2135,8 @@ async function autoSendQueuedMessageForThread(args: {
       await publishAutoSentQueuedRunSignals({
         threadId,
         userId,
+        claim,
+        runStatus: createdRun.status,
         timing: args.timing,
       });
       return createdRun;

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1759,7 +1759,7 @@ async function claimQueuedUserMessageForDispatch(args: {
       FOR UPDATE
     `);
     if (!threadRows.rows[0]) {
-      return [];
+      return null;
     }
 
     const rows = await tx.execute<{
@@ -1780,7 +1780,7 @@ async function claimQueuedUserMessageForDispatch(args: {
       run.chatThreadId !== args.threadId ||
       (run.status !== "queued" && run.status !== "pending")
     ) {
-      return [];
+      return null;
     }
 
     const [competingRun] = await tx
@@ -1796,7 +1796,7 @@ async function claimQueuedUserMessageForDispatch(args: {
       )
       .limit(1);
     if (competingRun) {
-      return [];
+      return null;
     }
 
     // Queue-first messages (identified by their chat_message_queue item) are

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5848,6 +5848,57 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
+  it("moves an in-place claimed message out of the composer queue after an update event", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000731";
+    const messageId = "00000000-0000-4000-8000-000000004031";
+    const runId = "run-queue-first-claimed";
+    const prompt = "Run this message immediately";
+    const queuedMessage: {
+      id: string;
+      role: "user";
+      content: string;
+      runId: string | undefined;
+      createdAt: string;
+    } = {
+      id: messageId,
+      role: "user",
+      content: prompt,
+      runId: undefined,
+      createdAt: "2026-06-09T10:00:00Z",
+    };
+    const fetchedMessageIds: string[] = [];
+
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [queuedMessage],
+      activeRunIds: [runId],
+      onMessageGet: (fetchedMessageId) => {
+        fetchedMessageIds.push(fetchedMessageId);
+      },
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getByText("1 message waiting to send")).toBeInTheDocument();
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(prompt);
+    });
+
+    queuedMessage.runId = runId;
+    context.mocks.ably.trigger(`chatThreadMessageUpdated:${threadId}`, {
+      messageId,
+    });
+
+    await waitFor(() => {
+      expect(fetchedMessageIds).toContain(messageId);
+      expect(
+        screen.queryByText("1 message waiting to send"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+      expect(screen.getByText(prompt)).toBeInTheDocument();
+    });
+  });
+
   it("catches recommended follow-ups written before realtime subscription is ready", async () => {
     const assistantReply = "I can turn this into a launch package.";
     const followupPrompt = "Create a presentation outline";


### PR DESCRIPTION
## Summary

- keep idle queue-first sends in the conversation transcript instead of exposing their temporary unclaimed database state in the composer queue
- publish `chatThreadMessageUpdated` with the exact message ID whenever an existing queued row is claimed in place, so the client immediately moves it from the queue into the transcript
- preserve `chatThreadMessageCreated` for genuinely waiting messages, legacy shadow rows, and queued-run markers
- add API coverage for direct and auto-send claims plus a UI regression test for removing a claimed message from the composer queue

## User-visible impact

Messages sent while a thread is idle now appear and run directly in the conversation. Messages sent while a run is active still appear in the composer queue, then move into the conversation as soon as they are claimed.

## Verification

- `pnpm format` — passed
- `pnpm turbo run lint --log-order grouped` — passed
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types` — passed
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx` — passed (130 tests)
- API BDD test is included for CI; the local PostgreSQL installation lacks the required `pgvector` extension
