### PR TITLE
test(vsock-host): assert file trackers close after disconnect

### DIFF
--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::net::UnixStream;
 use tokio::task::JoinHandle;
@@ -452,7 +453,7 @@ async fn copy_file_connection_close_after_request_removes_temp_and_marks_not_par
 }
 
 #[tokio::test]
-async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_not_not_parkable() {
+async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let temp_dir = HostTempDir::new("vsock-host-copy-terminal-close");
@@ -485,13 +486,16 @@ async fn copy_file_terminal_result_before_connection_close_keeps_tracker_closed_
     )
     .await;
     drop(guest);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
 
     let result = copy_task.await.unwrap().unwrap();
     assert_eq!(result.bytes_copied, 9);
     assert_eq!(std::fs::read(&host_path).unwrap(), b"complete\n");
-    assert_ne!(
+    assert_eq!(
         normal_operation_readiness(&host),
-        NormalOperationReadiness::NotParkable
+        NormalOperationReadiness::Closed
     );
 }
 

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -980,8 +980,7 @@ async fn write_file_chunked_tracks_one_operation_until_rename_result() {
 }
 
 #[tokio::test]
-async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_closed_not_not_parkable()
- {
+async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_closed() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
@@ -1002,11 +1001,14 @@ async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_
     .await;
     let host = Arc::clone(&fixture.host);
     drop(fixture.guest);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
 
     write_task.await.unwrap().unwrap();
-    assert_ne!(
+    assert_eq!(
         normal_operation_readiness(&host),
-        NormalOperationReadiness::NotParkable
+        NormalOperationReadiness::Closed
     );
 }
 


### PR DESCRIPTION
## Summary

- wait for reader-side EOF closure in the copy and chunked-write terminal-result regression scenarios
- assert `NormalOperationReadiness::Closed` exactly after operation completion
- rename both tests to describe the exact closed-state contract without a double negative

## Scope

This changes only `vsock-host` test modules. It does not change production behavior, APIs, the wire protocol, schemas, or persisted data.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vsock-host before_connection_close_keeps_tracker_closed` (2 passed)
- `cargo test -p vsock-host --all-targets --all-features` (307 passed)
- `cargo clippy -p vsock-host --all-targets --all-features`
- `cargo doc -p vsock-host --all-features --no-deps`
- pre-commit workspace Cargo format, Clippy, documentation, file-size, generated-artifact, and commitlint checks

Closes #21379
