### PR TITLE
refactor(guest-agent): share event sender worker

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -12,7 +12,6 @@ use tokio::sync::oneshot;
 
 use crate::env::Framework;
 use crate::error::AgentError;
-use crate::events;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
@@ -21,7 +20,7 @@ use super::codex_app_server::{
     CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, ServerNotification,
 };
 use super::codex_app_server_events::{IGNORED_NOTIFICATION_METHODS, notification_to_codex_event};
-use super::event_delivery::{AckedEventPrefix, PreparedEvent};
+use super::event_delivery::{PreparedEvent, run_event_sender};
 use super::{
     CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
     LOG_TAG, ParsedEventAction, command,
@@ -73,35 +72,13 @@ pub(super) async fn execute_codex_app_server_for_runtime(
 ) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let should_send_events = http.has_api();
-    let event_http = http.clone();
-    let event_error_flag = runtime.event_error_flag.to_string();
-    let event_sender = tokio::spawn(async move {
-        let mut acked_prefix = AckedEventPrefix::default();
-        while let Some(event) = event_rx.recv().await {
-            match event {
-                PreparedEvent::Webhook { sequence, payload } => {
-                    match events::post_event_with_error_flag(
-                        &event_http,
-                        &payload,
-                        &event_error_flag,
-                    )
-                    .await
-                    {
-                        Ok(()) => {
-                            acked_prefix.record_success(sequence);
-                        }
-                        Err(e) => {
-                            acked_prefix.record_failure(sequence);
-                            log_warn!(LOG_TAG, "Event send failed: {e}");
-                        }
-                    }
-                }
-            }
-        }
-        acked_prefix.last_contiguous()
-    });
+    let event_sender = tokio::spawn(run_event_sender(
+        event_rx,
+        http.clone(),
+        runtime.event_error_flag.to_string(),
+    ));
 
     let run_result = run_codex_app_server(
         masker,

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -1,24 +1,28 @@
-//! CLI stdout event delivery state.
+//! Shared CLI event delivery worker and acknowledgement state.
 //!
-//! Event schema transformation and HTTP posting stay in `events`; this module
-//! only owns execution-delivery state consumed by `execute_cli`.
+//! Event schema transformation and HTTP retry details stay in `events` and
+//! `http`; this module owns ordered background delivery shared by CLI backends.
 
-pub(super) enum PreparedEvent {
-    Webhook {
-        sequence: u32,
-        payload: serde_json::Value,
-    },
+use crate::events;
+use crate::http::HttpClient;
+use guest_common::log_warn;
+
+use super::LOG_TAG;
+
+pub(super) struct PreparedEvent {
+    pub(super) sequence: u32,
+    pub(super) payload: serde_json::Value,
 }
 
 #[derive(Default)]
-pub(super) struct AckedEventPrefix {
+struct AckedEventPrefix {
     next_expected: u32,
     last_contiguous: Option<u32>,
     prefix_broken: bool,
 }
 
 impl AckedEventPrefix {
-    pub(super) fn record_success(&mut self, sequence: u32) {
+    fn record_success(&mut self, sequence: u32) {
         if self.prefix_broken {
             return;
         }
@@ -31,15 +35,35 @@ impl AckedEventPrefix {
         }
     }
 
-    pub(super) fn record_failure(&mut self, sequence: u32) {
+    fn record_failure(&mut self, sequence: u32) {
         if sequence >= self.next_expected {
             self.prefix_broken = true;
         }
     }
 
-    pub(super) fn last_contiguous(&self) -> Option<u32> {
+    fn last_contiguous(&self) -> Option<u32> {
         self.last_contiguous
     }
+}
+
+pub(super) async fn run_event_sender(
+    mut event_rx: tokio::sync::mpsc::UnboundedReceiver<PreparedEvent>,
+    http: HttpClient,
+    event_error_flag: String,
+) -> Option<u32> {
+    let mut acked_prefix = AckedEventPrefix::default();
+    while let Some(PreparedEvent { sequence, payload }) = event_rx.recv().await {
+        match events::post_event_with_error_flag(&http, &payload, &event_error_flag).await {
+            Ok(()) => {
+                acked_prefix.record_success(sequence);
+            }
+            Err(e) => {
+                acked_prefix.record_failure(sequence);
+                log_warn!(LOG_TAG, "Event send failed: {e}");
+            }
+        }
+    }
+    acked_prefix.last_contiguous()
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -44,7 +44,7 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
-use event_delivery::{AckedEventPrefix, PreparedEvent};
+use event_delivery::{PreparedEvent, run_event_sender};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
@@ -491,7 +491,7 @@ impl CliEventIngestor {
             let payload =
                 events::prepare_event_payload_for_run_id(event, self.seq, masker, &self.run_id);
             if event_tx
-                .send(PreparedEvent::Webhook {
+                .send(PreparedEvent {
                     sequence: self.seq,
                     payload,
                 })
@@ -733,35 +733,13 @@ async fn execute_cli_inner(
     // Background event sender: HTTP POSTs happen here, never in the
     // stdout reading loop.  Unbounded channel because events are small
     // and CLI lifetime is bounded by JOB_TIMEOUT.
-    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let should_send_events = http.has_api();
-    let event_http = http.clone();
-    let event_error_flag = runtime.event_error_flag.to_string();
-    let event_sender = tokio::spawn(async move {
-        let mut acked_prefix = AckedEventPrefix::default();
-        while let Some(event) = event_rx.recv().await {
-            match event {
-                PreparedEvent::Webhook { sequence, payload } => {
-                    match events::post_event_with_error_flag(
-                        &event_http,
-                        &payload,
-                        &event_error_flag,
-                    )
-                    .await
-                    {
-                        Ok(()) => {
-                            acked_prefix.record_success(sequence);
-                        }
-                        Err(e) => {
-                            acked_prefix.record_failure(sequence);
-                            log_warn!(LOG_TAG, "Event send failed: {e}");
-                        }
-                    }
-                }
-            }
-        }
-        acked_prefix.last_contiguous()
-    });
+    let event_sender = tokio::spawn(run_event_sender(
+        event_rx,
+        http.clone(),
+        runtime.event_error_flag.to_string(),
+    ));
 
     let mut heartbeat_done = false;
     let mut cli_exit_at: Option<Instant> = None;

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -1,0 +1,90 @@
+//! Event-delivery integration coverage for the experimental Codex app-server backend.
+//!
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use std::time::Duration;
+
+const RUN_ID: &str = "codex-app-server-event-delivery-test";
+
+#[tokio::test]
+async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: RUN_ID,
+                prompt: "drive app-server event delivery",
+                scenario: Some("runtime-turn-complete-without-thread-started"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        RUN_ID,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let sequence_0 = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""sequenceNumber":0"#);
+        then.status(200);
+    });
+    let sequence_1 = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""sequenceNumber":1"#);
+        then.status(500);
+    });
+    let sequence_2 = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""sequenceNumber":2"#);
+        then.status(200);
+    });
+    let sequence_3 = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""sequenceNumber":3"#);
+        then.status(200);
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(cli_result.last_event_sequence, Some(0));
+    assert_eq!(
+        std::fs::read_to_string(runtime.paths.event_error_flag())?,
+        "1"
+    );
+    sequence_0.assert_calls_async(1).await;
+    sequence_1.assert_calls_async(3).await;
+    sequence_2.assert_calls_async(1).await;
+    sequence_3.assert_calls_async(1).await;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- move the ordered guest event sender worker into the shared CLI event-delivery module
- reuse the same delivery, retry-error logging, and contiguous-watermark behavior in both stdout and Codex app-server backends
- replace the single-variant prepared-event enum with its concrete payload structure
- add app-server integration coverage proving that a terminal event failure does not stop later delivery and does stop the acknowledged watermark

## Scope

This is a behavior-preserving refactor. Event payload preparation, HTTP retry policy, sender task ownership, shutdown draining, and abort behavior remain unchanged. It does not change the event API contract or enable the experimental app-server backend for additional callers.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test execute_cli_api_mode`
- `cargo test -p guest-agent --test codex_app_server_event_delivery`
- `cargo test -p guest-agent --all-targets --all-features`

Closes #21380
