### PR TITLE
fix(ui): center running-indicator glow and sync pulse across sidebar rows

### DIFF
--- a/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
@@ -1,0 +1,98 @@
+/// <reference types="node" />
+
+import { render, screen } from "@testing-library/react";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RunningIndicator } from "../running-indicator";
+
+const packageStylesPath = resolve(process.cwd(), "src/styles/globals.css");
+const globalsCss = readFileSync(
+  existsSync(packageStylesPath)
+    ? packageStylesPath
+    : resolve(process.cwd(), "packages/ui/src/styles/globals.css"),
+  "utf8",
+);
+
+function getCssBlock(selector: string) {
+  const selectorIndex = globalsCss.indexOf(selector);
+  if (selectorIndex === -1) {
+    throw new Error(`Missing CSS selector ${selector}`);
+  }
+  const openingBraceIndex = globalsCss.indexOf("{", selectorIndex);
+  let depth = 0;
+
+  for (let index = openingBraceIndex; index < globalsCss.length; index += 1) {
+    if (globalsCss[index] === "{") {
+      depth += 1;
+    } else if (globalsCss[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return globalsCss.slice(openingBraceIndex + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Missing CSS block for ${selector}`);
+}
+
+describe("RunningIndicator", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the center and ripple layers concentric", () => {
+    render(<RunningIndicator />);
+
+    const indicator = screen.getByLabelText("Running");
+    const center = indicator.querySelector(".running-indicator-center");
+    const ripple = indicator.querySelector(".running-indicator-ripple");
+
+    expect(center).toBeInTheDocument();
+    expect(ripple).toBeInTheDocument();
+
+    const centerRule = getCssBlock(".running-indicator-center");
+    const rippleRule = getCssBlock(".running-indicator-ripple");
+    const centerKeyframes = getCssBlock("@keyframes running-indicator-center");
+    const rippleKeyframes = getCssBlock("@keyframes running-indicator-ripple");
+
+    expect(centerRule).toContain("top: 50%");
+    expect(centerRule).toContain("left: 50%");
+    expect(rippleRule).toContain("top: 50%");
+    expect(rippleRule).toContain("left: 50%");
+    expect(centerRule).toContain("transform: translate(-50%, -50%)");
+    expect(rippleRule).toContain("transform: translate(-50%, -50%)");
+    expect(centerKeyframes).not.toMatch(/transform:(?![^;]*translate\()/);
+    expect(rippleKeyframes).not.toMatch(/transform:(?![^;]*translate\()/);
+  });
+
+  it("keeps indicators mounted at different times on one pulse phase", () => {
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(125);
+    const first = render(<RunningIndicator label="First running" />);
+
+    now.mockReturnValue(725);
+    const second = render(<RunningIndicator label="Second running" />);
+
+    const firstDelay = Number.parseInt(
+      first
+        .getByLabelText("First running")
+        .style.getPropertyValue("--running-indicator-delay"),
+      10,
+    );
+    const secondDelay = Number.parseInt(
+      second
+        .getByLabelText("Second running")
+        .style.getPropertyValue("--running-indicator-delay"),
+      10,
+    );
+
+    const observationTime = 800;
+    const firstPhase = observationTime - 125 - firstDelay;
+    const secondPhase = observationTime - 725 - secondDelay;
+
+    expect(firstPhase).toBe(observationTime);
+    expect(secondPhase).toBe(observationTime);
+  });
+});

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -1,17 +1,35 @@
-import { type HTMLAttributes } from "react";
+import { type HTMLAttributes, useEffect, useRef } from "react";
 import { cn } from "../../lib/utils";
 
 interface RunningIndicatorProps extends HTMLAttributes<HTMLSpanElement> {
   label?: string;
 }
 
+// Keep this in sync with the animation durations in globals.css.
+const RUNNING_INDICATOR_CYCLE_MS = 2400;
+
 function RunningIndicator({
   className,
   label = "Running",
   ...rest
 }: RunningIndicatorProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  // Anchor every indicator to the same wall-clock cycle grid via a negative
+  // animation-delay so the pulses stay in phase regardless of when each row
+  // mounts (e.g. virtualized sidebar rows that mount at different times).
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    node.style.setProperty(
+      "--running-indicator-delay",
+      `-${Date.now() % RUNNING_INDICATOR_CYCLE_MS}ms`,
+    );
+  }, []);
   return (
     <span
+      ref={ref}
       aria-label={label}
       className={cn("running-indicator", className)}
       {...rest}

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -442,20 +442,30 @@
   }
   .running-indicator-center {
     position: absolute;
-    inset: 2.5px;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 5px);
+    height: calc(100% - 5px);
     border-radius: inherit;
     background: currentColor;
+    transform: translate(-50%, -50%);
     transform-origin: center;
     animation: running-indicator-center 2400ms cubic-bezier(0.33, 0, 0.66, 1)
       infinite;
+    animation-delay: var(--running-indicator-delay, 0ms);
   }
   .running-indicator-ripple {
     position: absolute;
-    inset: 1.5px;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 3px);
+    height: calc(100% - 3px);
     border-radius: inherit;
     border: 1px solid currentColor;
+    transform: translate(-50%, -50%);
     transform-origin: center;
     animation: running-indicator-ripple 2400ms ease-out infinite;
+    animation-delay: var(--running-indicator-delay, 0ms);
   }
 }
 
@@ -498,11 +508,11 @@
 @keyframes running-indicator-center {
   0%,
   100% {
-    transform: scale(0.64);
+    transform: translate(-50%, -50%) scale(0.64);
     opacity: 0.34;
   }
   52% {
-    transform: scale(0.88);
+    transform: translate(-50%, -50%) scale(0.88);
     opacity: 0.52;
   }
 }
@@ -510,15 +520,15 @@
 @keyframes running-indicator-ripple {
   0%,
   45% {
-    transform: scale(0.8);
+    transform: translate(-50%, -50%) scale(0.8);
     opacity: 0;
   }
   52% {
-    transform: scale(0.8);
+    transform: translate(-50%, -50%) scale(0.8);
     opacity: 0.34;
   }
   100% {
-    transform: scale(1.56);
+    transform: translate(-50%, -50%) scale(1.56);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Problem

The sidebar "running" status indicator (`RunningIndicator`, `@vm0/ui`, rendered for the `running` state of each sidebar row via `SessionStateIndicator` in `sidebar-threads.tsx`) had two visible defects reported from the platform sidebar:

1. **Glow ring not concentric with the dot.** The inner dot and the outer glow ring were absolutely positioned with mismatched fractional insets (`inset: 2.5px` vs `inset: 1.5px`) on a ~14px element. On tiny elements those different fractional edges round to device pixels differently, shifting each layer's center by up to ~1px, so the halo looked off-center from the dot.
2. **Pulse speed looked inconsistent between rows.** Every indicator started its CSS animation the moment its row mounted. The sidebar list mounts rows at different times (virtualized / re-rendered rows), so indicators pulsed out of phase, which reads as different blink speeds even though all use the same 2400ms duration.

## Fix

- **Concentricity:** Both the center dot and the ripple ring are now centered with `top/left: 50%` + `transform: translate(-50%, -50%)` instead of symmetric insets. The center point resolves to the exact same parent-50% pixel for both layers, independent of each layer's size or sub-pixel rounding, so the glow stays perfectly concentric with the dot. The keyframes carry the same `translate(-50%, -50%)` alongside the existing `scale()` so the animation preserves the current look.
- **Pulse sync:** A negative `animation-delay` anchored to the shared 2400ms wall-clock grid (`-(Date.now() % 2400)ms`, applied once on mount via a `--running-indicator-delay` CSS variable) makes every indicator converge to the same phase regardless of when its row mounts. Computed in an effect (not during render) to satisfy the React purity lint; SPA-only (`createRoot`), so no SSR/hydration concern.

## User-visible impact

The running-status dots in the platform sidebar now show a halo that is centered on the dot, and all visible indicators breathe in sync at the same rhythm.

## Verification

- `pnpm format` — clean
- `pnpm turbo run lint --filter=@vm0/ui` — 0 errors
- `pnpm turbo run check-types --filter=@vm0/ui --filter=@vm0/app` — passes

`aria-label="Running"` is preserved, so existing `getByLabelText("Running")` sidebar tests are unaffected. Relying on the PR pipeline for the full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)