### PR TITLE
docs(mitm-addon): document connected endpoint contract

### DIFF
--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -18,6 +18,13 @@ def connection_sockname(connection: object) -> tuple[str, int] | None:
 
 
 def address_pair(address: object) -> tuple[str, int] | None:
+    """Return the first host-port pair from a mitmproxy address tuple.
+
+    ``address`` must be a tuple with at least two elements whose first two values are a
+    ``str`` host and an ``int`` port. Additional elements, such as IPv6 flowinfo and scope ID
+    fields, are ignored. This validates shape only: it neither parses the host nor validates the
+    port value. Unusable shapes return ``None``.
+    """
     if not isinstance(address, tuple) or len(address) < _ADDRESS_PAIR_LENGTH:
         return None
     host, port = address[:_ADDRESS_PAIR_LENGTH]
@@ -27,6 +34,13 @@ def address_pair(address: object) -> tuple[str, int] | None:
 
 
 def authoritative_connected_endpoint(endpoint: object) -> tuple[str, int] | None:
+    """Return an endpoint that supplies acceptable connected IP evidence.
+
+    The endpoint must have an ``address_pair`` shape and its host must parse as an IPv4 or IPv6
+    literal. DNS names, malformed endpoints, loopback addresses, and unspecified addresses return
+    ``None``. Other parsed IP address categories are not filtered: ``authoritative`` describes
+    connected endpoint evidence, not public routability. Accepted endpoints are returned unchanged.
+    """
     endpoint_pair = address_pair(endpoint)
     if endpoint_pair is None:
         return None
@@ -46,6 +60,17 @@ def connected_ip_destination_endpoint(
     port: int,
     extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
 ) -> tuple[str, int] | None:
+    """Resolve connected IP evidence for ``port`` using fail-closed precedence.
+
+    Check ``server.peername`` and then ``server.address``. The first authoritative primary
+    endpoint is final: return it when its port matches, or return ``None`` without consulting
+    lower-priority evidence when it does not.
+
+    Only when neither primary endpoint is authoritative are ``extra_endpoints`` checked in order.
+    Non-authoritative and wrong-port extras are skipped, and the first authoritative matching-port
+    extra is returned. ``None`` means no acceptable evidence established the requested destination,
+    including when an authoritative primary endpoint contradicted the requested port.
+    """
     peername = authoritative_connected_endpoint(server_peername(server))
     if peername is not None:
         return peername if peername[1] == port else None


### PR DESCRIPTION
## Summary

- document the accepted tuple shape and trailing-field handling for connected endpoints
- clarify that authoritative endpoints are IP-literal connection evidence, not necessarily public
  addresses
- record peername/address/extras precedence and fail-closed primary port mismatches

## Exclusions

- no runtime behavior, API, schema, persisted data, protocol, or caller changes
- no new tests because existing integration coverage already exercises the unchanged policy

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `pytest tests/` (3928 passed)

Closes #21384
