### PR TITLE
perf(mitm-addon): bulk-skip discarded json strings

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -15,6 +15,7 @@ for keys such as ``includes.users`` and ``includes.tweets``.
 
 import json
 import json.decoder
+import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from typing import Literal, cast
@@ -29,6 +30,9 @@ _UNKNOWN_KEY = "\0__vm0_json_unknown_key__"
 _ARRAY_ELEMENT = "\0__vm0_json_array_element__"
 _INTERNAL_PATH_MARKERS = frozenset((_UNKNOWN_KEY, _ARRAY_ELEMENT))
 _JSON_CONTROL_CHAR_MAX = 0x20
+# These are the only bytes that can change discarded string state. Non-ASCII
+# bytes stay on the bytewise path so UTF-8 validation remains unchanged.
+_DISCARDED_STRING_STATE_BYTE_RE = re.compile(rb'[\x00-\x1f"\\\x80-\xff]')
 _UTF8_ONE_BYTE_MAX = 0x80
 _UTF8_CONT_MIN = 0x80
 _UTF8_CONT_MAX = 0xBF
@@ -539,6 +543,16 @@ class JsonSelectiveExtractor:
         if state is None:
             self._error = "missing string parser state"
             return i
+        if (
+            state.raw is None
+            and not state.escape
+            and not state.unicode_remaining
+            and not state.utf8_remaining
+        ):
+            match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i)
+            if match is None:
+                return len(chunk)
+            i = match.start()
         while i < len(chunk):
             b = chunk[i]
             i += 1

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -549,6 +549,10 @@ class JsonSelectiveExtractor:
             and not state.unicode_remaining
             and not state.utf8_remaining
         ):
+            if chunk[i] == ord('"'):
+                self._finish_string(state)
+                self._string = None
+                return i + 1
             match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i)
             if match is None:
                 return len(chunk)

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -557,6 +557,10 @@ class JsonSelectiveExtractor:
             if match is None:
                 return len(chunk)
             i = match.start()
+            if chunk[i] == ord('"'):
+                self._finish_string(state)
+                self._string = None
+                return i + 1
         while i < len(chunk):
             b = chunk[i]
             i += 1

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -405,15 +405,74 @@ def test_lone_surrogate_key_does_not_abort_later_selected_fields():
     assert result.values == {("usage", "input_tokens"): 7}
 
 
-def test_skips_large_unselected_string_without_storing_value():
+def test_bulk_skips_large_unselected_string_without_storing_value(monkeypatch):
+    bytewise_accept_calls = 0
+    original_accept_string_byte = JsonSelectiveExtractor._accept_string_byte
+
+    # The public result cannot reveal whether discarded bytes were scanned one
+    # at a time, so count the narrow bytewise operation as a performance contract.
+    def counting_accept_string_byte(self, state, byte):
+        nonlocal bytewise_accept_calls
+        bytewise_accept_calls += 1
+        original_accept_string_byte(self, state, byte)
+
+    monkeypatch.setattr(
+        JsonSelectiveExtractor,
+        "_accept_string_byte",
+        counting_accept_string_byte,
+    )
     extractor = JsonSelectiveExtractor(
         scalar_fields={("usage", "input_tokens"): ScalarField("int")}
     )
-    large_text = b"x" * (512 * 1024)
+    large_text = b"x" * (2 * 1024 * 1024)
+    payload = b'{"content":[{"text":"' + large_text + b'"}],"usage":{"input_tokens":7}}'
 
-    extractor.feed(b'{"content":[{"text":"')
-    extractor.feed(large_text)
-    extractor.feed(b'"}],"usage":{"input_tokens":7}}')
+    chunk_size = 64 * 1024
+    for offset in range(0, len(payload), chunk_size):
+        extractor.feed(payload[offset : offset + chunk_size])
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+    assert bytewise_accept_calls < 64
+
+
+@pytest.mark.parametrize(
+    ("invalid_suffix", "error"),
+    [
+        (b"\x01", "control character in string"),
+        (b"\\x", "invalid string escape"),
+        (b"\\u12xz", "invalid unicode escape"),
+        (b"\xff", "invalid string"),
+        (b"\xe2\x98", "invalid string"),
+    ],
+)
+def test_bulk_skip_stops_before_invalid_string_byte(invalid_suffix, error):
+    extractor = JsonSelectiveExtractor()
+
+    extractor.feed(b'{"content":"' + b"x" * (64 * 1024))
+    extractor.feed(invalid_suffix + b'"}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == error
+    assert result.values == {}
+
+
+@pytest.mark.parametrize(
+    ("first_suffix", "second_suffix"),
+    [
+        (b"\\", b"n"),
+        (b"\\u12", b"34"),
+    ],
+)
+def test_bulk_skip_preserves_pending_escape_state_across_chunks(first_suffix, second_suffix):
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":"' + b"x" * (64 * 1024) + first_suffix)
+    extractor.feed(second_suffix + b'","usage":{"input_tokens":7}}')
     result = _finish(extractor)
 
     assert result.complete is True

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -1,6 +1,8 @@
 """Tests for bounded selective JSON extraction."""
 
 import json
+import sys
+from types import FrameType
 
 import pytest
 
@@ -405,22 +407,17 @@ def test_lone_surrogate_key_does_not_abort_later_selected_fields():
     assert result.values == {("usage", "input_tokens"): 7}
 
 
-def test_bulk_skips_large_unselected_string_without_storing_value(monkeypatch):
+def test_bulk_skips_large_unselected_string_without_storing_value():
     bytewise_accept_calls = 0
-    original_accept_string_byte = JsonSelectiveExtractor._accept_string_byte
+    accept_string_byte_code = JsonSelectiveExtractor._accept_string_byte.__code__
 
-    # The public result cannot reveal whether discarded bytes were scanned one
-    # at a time, so count the narrow bytewise operation as a performance contract.
-    def counting_accept_string_byte(self, state, byte):
+    # Profile the public parser operation so the real implementation stays in
+    # place while bytewise calls provide a deterministic performance contract.
+    def count_bytewise_accept_calls(frame: FrameType, event: str, _arg: object) -> None:
         nonlocal bytewise_accept_calls
-        bytewise_accept_calls += 1
-        original_accept_string_byte(self, state, byte)
+        if event == "call" and frame.f_code is accept_string_byte_code:
+            bytewise_accept_calls += 1
 
-    monkeypatch.setattr(
-        JsonSelectiveExtractor,
-        "_accept_string_byte",
-        counting_accept_string_byte,
-    )
     extractor = JsonSelectiveExtractor(
         scalar_fields={("usage", "input_tokens"): ScalarField("int")}
     )
@@ -428,8 +425,13 @@ def test_bulk_skips_large_unselected_string_without_storing_value(monkeypatch):
     payload = b'{"content":[{"text":"' + large_text + b'"}],"usage":{"input_tokens":7}}'
 
     chunk_size = 64 * 1024
-    for offset in range(0, len(payload), chunk_size):
-        extractor.feed(payload[offset : offset + chunk_size])
+    previous_profile = sys.getprofile()
+    sys.setprofile(count_bytewise_accept_calls)
+    try:
+        for offset in range(0, len(payload), chunk_size):
+            extractor.feed(payload[offset : offset + chunk_size])
+    finally:
+        sys.setprofile(previous_profile)
     result = _finish(extractor)
 
     assert result.complete is True

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -439,6 +439,18 @@ def test_bulk_skips_large_unselected_string_without_storing_value():
     assert bytewise_accept_calls < 64
 
 
+def test_bulk_skip_accepts_empty_unselected_key_and_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":{"":""},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+
+
 @pytest.mark.parametrize(
     ("invalid_suffix", "error"),
     [


### PR DESCRIPTION
## Summary

- bulk-advance over ordinary ASCII bytes in discarded JSON strings with a precompiled bytes regex
- preserve the existing bytewise path for quotes, escapes, controls, and non-ASCII bytes so validation and parser state remain unchanged
- keep empty and short discarded strings on an equal-or-faster path while adding deterministic performance and boundary regression coverage

## Scope

- Selected strings, object keys, parser results, and error messages are unchanged.
- Non-ASCII discarded strings continue through the existing UTF-8 validator.
- No schema, protocol, configuration, dependency, or deployment-contract changes.

## Performance

Measured on Python 3.12.3 with 64 KiB input chunks. Each case had one warm-up followed by five samples; the table reports both the best and median samples from the same process while loading the baseline directly from `origin/main`.

| Workload | `origin/main` best | Current best | Speedup | `origin/main` median | Current median |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 MiB ASCII discarded string | 129.104 ms | 1.938 ms | 66.62x | 129.781 ms | 1.969 ms |
| 5 MiB ASCII discarded string | 643.177 ms | 9.607 ms | 66.95x | 644.865 ms | 9.618 ms |
| ~1 MiB UTF-8 discarded string | 251.850 ms | 252.021 ms | 1.00x | 252.436 ms | 252.858 ms |
| 100k empty discarded strings | 84.298 ms | 82.854 ms | 1.02x | 84.758 ms | 83.525 ms |
| 100k one-byte discarded strings | 98.222 ms | 95.607 ms | 1.03x | 98.803 ms | 95.884 ms |
| 100k eight-byte discarded strings | 187.904 ms | 97.040 ms | 1.94x | 189.208 ms | 97.404 ms |

<details>
<summary>Benchmark command</summary>

```bash
cd crates/runner/mitm-addon
python3 - <<'PY'
from pathlib import Path
import statistics
import subprocess
import sys
import time
import types

source_path = Path("src/usage/json_selective.py")
chunk_size = 64 * 1024
rounds = 5


def load_module(name, source):
    module = types.ModuleType(name)
    module.__file__ = str(source_path)
    sys.modules[name] = module
    exec(compile(source, module.__file__, "exec"), module.__dict__)
    return module


def parse(module, payload):
    extractor = module.JsonSelectiveExtractor(
        scalar_fields={("usage", "input_tokens"): module.ScalarField("int")}
    )
    for offset in range(0, len(payload), chunk_size):
        extractor.feed(payload[offset : offset + chunk_size])
    result = extractor.finish()
    assert result.complete
    assert result.values == {("usage", "input_tokens"): 7}


def measure(module, payload):
    parse(module, payload)
    samples = []
    for _ in range(rounds):
        start = time.perf_counter()
        parse(module, payload)
        samples.append((time.perf_counter() - start) * 1000)
    return min(samples), statistics.median(samples)


base = load_module(
    "json_selective_base",
    subprocess.check_output(
        [
            "git",
            "show",
            "origin/main:crates/runner/mitm-addon/src/usage/json_selective.py",
        ]
    ),
)
current = load_module("json_selective_current", source_path.read_bytes())

cases = [
    (
        "ascii-1MiB",
        b'{"content":[{"text":"'
        + b"x" * (1024 * 1024)
        + b'"}],"usage":{"input_tokens":7}}',
    ),
    (
        "ascii-5MiB",
        b'{"content":[{"text":"'
        + b"x" * (5 * 1024 * 1024)
        + b'"}],"usage":{"input_tokens":7}}',
    ),
    (
        "utf8-1MiB",
        b'{"content":[{"text":"'
        + "☃".encode() * ((1024 * 1024) // 3)
        + b'"}],"usage":{"input_tokens":7}}',
    ),
]
for label, value in (
    ("empty-100k", b""),
    ("one-byte-100k", b"x"),
    ("eight-byte-100k", b"abcdefgh"),
):
    payload = b'{"content":[' + b",".join([b'"' + value + b'"'] * 100_000)
    payload += b'],"usage":{"input_tokens":7}}'
    cases.append((label, payload))

print(f"chunk={chunk_size} rounds={rounds} values=milliseconds")
print("case base_best current_best speedup base_median current_median")
for label, payload in cases:
    base_best, base_median = measure(base, payload)
    current_best, current_median = measure(current, payload)
    print(
        f"{label} {base_best:.3f} {current_best:.3f} "
        f"{base_best / current_best:.2f}x {base_median:.3f} {current_median:.3f}"
    )
PY
```

</details>

## Validation

- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/test_json_selective.py -q` — 135 passed
- `python3 -m pytest tests/ -q` — 3936 passed
- deterministic differential harness against `origin/main` — 20,000 randomized valid/invalid byte and chunk-boundary cases matched (seed 21383)

Closes #21383
