### PR TITLE
feat(api): register refreshed playful launch runbook archive

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -218,6 +218,8 @@ const PRESENTATION_RUNBOOK_ARCHIVE_VERSION_IDS_BY_SHA256 = {
       "958d5fe6f53598ff3cb920fe6dd91433b16a4eb5cbfb10fb179ae98b15765cce",
   },
   "template:html-ppt-playful-launch-runbook": {
+    "78292a9a5c454e36a5255f22d147ac56f53c69538a4ac0897160239c2ca941e3":
+      "6a81763e63f55e2fe446957fccd8bf770d02efe6d613b1fc988fc206b697d511",
     "9c7524540e98a3605b71a35c918d1a186d9599f34f9e67aa8c86c457dc6b4582":
       "6bbcb6decd53b667eb4aae4f79b05b10eb487fd83496265105d5b4c47542c9aa",
   },


### PR DESCRIPTION
## User impact
Registers the refreshed Playful Launch presentation runbook archive in private R2 without changing the default resource version. Existing CLI users continue to receive the current archive.

## Implementation
- Maps the verified archive SHA-256 `78292a9…41e3` to R2 storage version `6a81763e…d511`.
- Retains the prior SHA/version mapping for compatibility.
- Leaves the core registry digest unchanged; the follow-up CLI PR will opt new clients into this archive.

## Verification
- Uploaded the 35-file package from the supplied Google Drive folder.
- Downloaded the committed R2 archive and verified its SHA-256 and file tree against the source.
- `git diff --check` passed.