### PR TITLE
fix(mitm-addon): preserve original error for invalid utf-8 bodies

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -311,7 +311,7 @@ def _fetch_firewall_headers_sync(
         with e:
             try:
                 error_body = json.loads(_read_firewall_auth_response_body(e))
-            except (json.JSONDecodeError, OSError):
+            except (UnicodeDecodeError, json.JSONDecodeError, OSError):
                 raise e from None
             if not isinstance(error_body, dict):
                 raise e from None

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -2482,6 +2482,7 @@ class TestFetchFirewallHeaders:
     @pytest.mark.parametrize(
         "error_body",
         [
+            pytest.param(b"\xff", id="invalid-utf8"),
             b"not-json",
             b'"plain string"',
             b"[1, 2, 3]",
@@ -2673,6 +2674,28 @@ class TestFetchFirewallHeadersResourceBoundary:
             auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
 
         assert exc_info.value is http_error
+        http_error.close.assert_called_once()
+
+    def test_closes_http_error_response_when_body_has_invalid_utf8(self, mitm_ctx):
+        http_error = _http_error(
+            "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+            400,
+            "Bad Request",
+            b"\xff",
+        )
+        http_error.close = MagicMock()
+
+        with (
+            mitm_ctx(),
+            patch("platform_api.urllib.request.Request"),
+            patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+            pytest.raises(urllib.error.HTTPError) as exc_info,
+        ):
+            auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
+
+        assert exc_info.value is http_error
+        assert exc_info.value.code == 400
         http_error.close.assert_called_once()
 
     def test_closes_http_error_response_when_body_is_too_large(self, mitm_ctx):


### PR DESCRIPTION
## Summary

- treat invalid UTF-8 firewall-auth HTTP error bodies as malformed error envelopes
- preserve the original `HTTPError`, status code, and response-close behavior
- cover the async client behavior and the urllib resource-ownership boundary

## Behavior

`json.loads(bytes)` can raise `UnicodeDecodeError` before JSON parsing. The firewall-auth client now handles that decoding failure alongside its existing malformed-body cases and re-raises the caught `HTTPError`.

Recognized structured error envelopes, oversized-body handling, and the final flow-level 502 `auth_failed` behavior are unchanged.

## Explicit exclusions

- no success-response parsing change
- no flow-level HTTP status or firewall action change
- no database schema or persisted-data change
- no API schema, queue payload, or runner protocol change
- no migration, backfill, feature switch, or special rollout

## Verification

- `.venv/bin/pytest -q tests/test_firewall_auth.py -k 'malformed_http_error_envelope_reraises_http_error or body_has_invalid_utf8'` — 10 passed
- `.venv/bin/pytest -q tests/test_firewall_auth.py` — 149 passed
- `.venv/bin/ruff format --check .` — passed
- `.venv/bin/ruff check .` — passed
- `.venv/bin/basedpyright -p .` — 0 errors, 0 warnings
- `.venv/bin/pytest -q tests/` — 3930 passed
- `lefthook run pre-commit` — passed

Closes #21386
