### PR TITLE
refactor(workflows): rename notion automation switch with rollout compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -4,7 +4,10 @@ import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroReportErrorContract } from "@vm0/api-contracts/contracts/zero-report-error";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import apiPackage from "../../../../package.json";
@@ -189,6 +192,96 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       readAfterDelete.body.switches[FeatureSwitchKey.Dummy],
     ).toBeUndefined();
+  });
+
+  it("canonicalizes the Notion automation switch while serving old clients", async () => {
+    const admin = api.user();
+    if (!admin.orgId) {
+      throw new Error("Feature switch tests require an organization");
+    }
+
+    const legacyUpdate = await accept(
+      featureSwitchesClient().update({
+        headers: headersFor(admin),
+        body: {
+          switches: {
+            [LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY]: true,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(
+      legacyUpdate.body.switches[FeatureSwitchKey.NotionWorkflowAutomations],
+    ).toBeTruthy();
+    expect(
+      legacyUpdate.body.switches[
+        LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY
+      ],
+    ).toBeTruthy();
+
+    const readAfterLegacyUpdate = await accept(
+      featureSwitchesClient().get({ headers: headersFor(admin) }),
+      [200],
+    );
+    expect(
+      readAfterLegacyUpdate.body.switches[
+        FeatureSwitchKey.NotionWorkflowAutomations
+      ],
+    ).toBeTruthy();
+    expect(
+      readAfterLegacyUpdate.body.switches[
+        LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY
+      ],
+    ).toBeTruthy();
+
+    const conflictingUpdate = await accept(
+      featureSwitchesClient().update({
+        headers: headersFor(admin),
+        body: {
+          switches: {
+            [LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY]: true,
+            [FeatureSwitchKey.NotionWorkflowAutomations]: false,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(
+      conflictingUpdate.body.switches[
+        FeatureSwitchKey.NotionWorkflowAutomations
+      ],
+    ).toBeFalsy();
+    expect(
+      conflictingUpdate.body.switches[
+        LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY
+      ],
+    ).toBeFalsy();
+    expect(
+      conflictingUpdate.body.effectiveSwitches[
+        FeatureSwitchKey.NotionWorkflowAutomations
+      ],
+    ).toBeFalsy();
+    expect(
+      conflictingUpdate.body.effectiveSwitches[
+        LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY
+      ],
+    ).toBeFalsy();
+
+    const readAfterConflictingUpdate = await accept(
+      featureSwitchesClient().get({ headers: headersFor(admin) }),
+      [200],
+    );
+    expect(
+      readAfterConflictingUpdate.body.switches[
+        FeatureSwitchKey.NotionWorkflowAutomations
+      ],
+    ).toBeFalsy();
+    expect(
+      readAfterConflictingUpdate.body.switches[
+        LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY
+      ],
+    ).toBeFalsy();
   });
 
   it("stores org-scoped feature switch overrides separately from personal overrides", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -88,11 +88,11 @@ function memoryClient() {
   return setupApp({ context })(zeroMemoryContract);
 }
 
-async function enableNotionWorkflowTriggers(
+async function enableNotionWorkflowAutomations(
   fixture: WorkflowsFixture,
 ): Promise<void> {
   await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.NotionWorkflowTriggers]: true,
+    [FeatureSwitchKey.NotionWorkflowAutomations]: true,
   });
 }
 
@@ -510,7 +510,7 @@ describe("POST /api/webhooks/notion", () => {
   it("verifies, signs, de-duplicates, and refreshes pending child page events", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionParentPageMock(entities);
 
@@ -608,7 +608,7 @@ describe("POST /api/webhooks/notion", () => {
   it("enqueues and refreshes pending database item events", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionDatabaseMock(entities);
 
@@ -689,7 +689,7 @@ describe("POST /api/webhooks/notion", () => {
   it("enqueues and debounces page content updated events for a page scope", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionChildPageMock(entities);
 
@@ -788,7 +788,7 @@ describe("POST /api/webhooks/notion", () => {
     mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionChildPageMock(entities);
 
@@ -914,7 +914,7 @@ describe("POST /api/webhooks/notion", () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
     await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.NotionWorkflowTriggers]: true,
+      [FeatureSwitchKey.NotionWorkflowAutomations]: true,
       [FeatureSwitchKey.RelationshipMemory]: true,
     });
     await connectNotion(scenario);
@@ -1023,7 +1023,7 @@ describe("POST /api/webhooks/notion", () => {
   it("enqueues page content updated events for a database scope", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionDatabaseMock(entities);
 
@@ -1077,7 +1077,7 @@ describe("POST /api/webhooks/notion", () => {
   it("suppresses content updated events while child page creation is pending", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionParentAndChildPageMock(entities);
 
@@ -1162,7 +1162,7 @@ describe("POST /api/webhooks/notion", () => {
   it("suppresses content updated events while database item creation is pending", async () => {
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
     await connectNotion(scenario);
     configureNotionDatabaseMock(entities);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -273,11 +273,11 @@ function futureIso(offsetMs: number): string {
   return new Date(now() + offsetMs).toISOString();
 }
 
-async function enableNotionWorkflowTriggers(
+async function enableNotionWorkflowAutomations(
   fixture: WorkflowsFixture,
 ): Promise<void> {
   await updateFeatureSwitchesForUser(context, fixture, {
-    [FeatureSwitchKey.NotionWorkflowTriggers]: true,
+    [FeatureSwitchKey.NotionWorkflowAutomations]: true,
   });
 }
 
@@ -1345,7 +1345,7 @@ describe("zero workflow triggers", () => {
     );
 
     expect(rejected.body.error.message).toBe(
-      "Notion workflow triggers are not enabled",
+      "Notion workflow automations are not enabled",
     );
   });
 
@@ -1369,7 +1369,7 @@ describe("zero workflow triggers", () => {
     );
 
     expect(rejected.body.error.message).toBe(
-      "Notion workflow triggers are not enabled",
+      "Notion workflow automations are not enabled",
     );
   });
 
@@ -1393,13 +1393,13 @@ describe("zero workflow triggers", () => {
     );
 
     expect(rejected.body.error.message).toBe(
-      "Notion workflow triggers are not enabled",
+      "Notion workflow automations are not enabled",
     );
   });
 
   it("requires a connected Notion account for Notion child page triggers", async () => {
     const { fixture, workflowId } = await setupFixture();
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
 
     const rejected = await accept(
       triggersClient().create({
@@ -1425,7 +1425,7 @@ describe("zero workflow triggers", () => {
 
   it("requires a connected Notion account for Notion database item triggers", async () => {
     const { fixture, workflowId } = await setupFixture();
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
 
     const rejected = await accept(
       triggersClient().create({
@@ -1451,7 +1451,7 @@ describe("zero workflow triggers", () => {
 
   it("requires a connected Notion account for Notion page content updated triggers", async () => {
     const { fixture, workflowId } = await setupFixture();
-    await enableNotionWorkflowTriggers(fixture);
+    await enableNotionWorkflowAutomations(fixture);
 
     const rejected = await accept(
       triggersClient().create({
@@ -1477,7 +1477,7 @@ describe("zero workflow triggers", () => {
 
   it("requires a standard notion.so page URL for Notion child page triggers", async () => {
     const scenario = await setupFixture();
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     await connectNotion(scenario);
 
     const rejected = await accept(
@@ -1504,7 +1504,7 @@ describe("zero workflow triggers", () => {
 
   it("requires a standard notion.so database URL for Notion database item triggers", async () => {
     const scenario = await setupFixture();
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     await connectNotion(scenario);
 
     const rejected = await accept(
@@ -1532,7 +1532,7 @@ describe("zero workflow triggers", () => {
   it("creates Notion child page triggers by validating and storing the parent page", async () => {
     const scenario = await setupFixture();
     const connectorId = await connectNotion(scenario);
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     configureNotionPageMock();
 
     const created = await accept(
@@ -1577,7 +1577,7 @@ describe("zero workflow triggers", () => {
   it("creates Notion database item triggers by validating and storing the data source", async () => {
     const scenario = await setupFixture();
     const connectorId = await connectNotion(scenario);
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     configureNotionDatabaseMock();
 
     const created = await accept(
@@ -1622,7 +1622,7 @@ describe("zero workflow triggers", () => {
   it("creates Notion page content updated triggers for a page scope", async () => {
     const scenario = await setupFixture();
     const connectorId = await connectNotion(scenario);
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     configureNotionPageMock();
 
     const created = await accept(
@@ -1670,7 +1670,7 @@ describe("zero workflow triggers", () => {
   it("creates Notion page content updated triggers for a database scope", async () => {
     const scenario = await setupFixture();
     const connectorId = await connectNotion(scenario);
-    await enableNotionWorkflowTriggers(scenario.fixture);
+    await enableNotionWorkflowAutomations(scenario.fixture);
     configureNotionDatabaseMock();
 
     const created = await accept(

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -1,5 +1,9 @@
 import { command, computed } from "ccstate";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/connectors/feature-switch-key";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -22,14 +26,27 @@ function featureSwitchResponseBody(params: {
   readonly userId: string;
   readonly switches: Record<string, boolean>;
 }) {
+  const effectiveSwitches = getAllFeatureStates({
+    orgId: params.orgId,
+    userId: params.userId,
+    overrides: params.switches,
+  });
+
   return {
-    switches: params.switches,
-    effectiveSwitches: getAllFeatureStates({
-      orgId: params.orgId,
-      userId: params.userId,
-      overrides: params.switches,
-    }),
+    switches: mirrorLegacyNotionWorkflowSwitch(params.switches),
+    effectiveSwitches: mirrorLegacyNotionWorkflowSwitch(effectiveSwitches),
   };
+}
+
+function mirrorLegacyNotionWorkflowSwitch(
+  switches: Readonly<Record<string, boolean>>,
+): Record<string, boolean> {
+  const result = { ...switches };
+  const value = switches[FeatureSwitchKey.NotionWorkflowAutomations];
+  if (value !== undefined) {
+    result[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY] = value;
+  }
+  return result;
 }
 
 const getFeatureSwitchesInner$ = computed(async (get): Promise<unknown> => {

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -3,7 +3,10 @@ import {
   filterUserOverridableFeatureSwitchOverrides,
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/core/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
@@ -23,12 +26,30 @@ function isOrgScopedFeatureSwitchKey(key: string): boolean {
   return ORG_SCOPED_FEATURE_SWITCH_KEYS.includes(key);
 }
 
+function canonicalizeFeatureSwitchAliases(
+  switches: Readonly<Record<string, boolean>>,
+): Record<string, boolean> {
+  const canonical = { ...switches };
+  const notionWorkflowAutomations =
+    switches[FeatureSwitchKey.NotionWorkflowAutomations] ??
+    switches[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY];
+
+  delete canonical[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY];
+  if (notionWorkflowAutomations !== undefined) {
+    canonical[FeatureSwitchKey.NotionWorkflowAutomations] =
+      notionWorkflowAutomations;
+  }
+
+  return canonical;
+}
+
 function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
   readonly userSwitches: Record<string, boolean>;
   readonly orgSwitches: Record<string, boolean>;
 } {
-  const userOverridableSwitches =
-    filterUserOverridableFeatureSwitchOverrides(switches);
+  const userOverridableSwitches = filterUserOverridableFeatureSwitchOverrides(
+    canonicalizeFeatureSwitchAliases(switches),
+  );
   const userSwitches: Record<string, boolean> = {};
   const orgSwitches: Record<string, boolean> = {};
 
@@ -84,7 +105,9 @@ async function loadFeatureSwitchOverrideRow(
     )
     .limit(1);
 
-  return filterUserOverridableFeatureSwitchOverrides(row?.switches ?? {});
+  return filterUserOverridableFeatureSwitchOverrides(
+    canonicalizeFeatureSwitchAliases(row?.switches ?? {}),
+  );
 }
 
 async function loadUserFeatureSwitchOverrides(
@@ -200,8 +223,12 @@ async function upsertFeatureSwitches(
   const existing =
     (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
   const merged: Record<string, boolean> = {
-    ...filterUserOverridableFeatureSwitchOverrides(existing),
-    ...filterUserOverridableFeatureSwitchOverrides(switches),
+    ...filterUserOverridableFeatureSwitchOverrides(
+      canonicalizeFeatureSwitchAliases(existing),
+    ),
+    ...filterUserOverridableFeatureSwitchOverrides(
+      canonicalizeFeatureSwitchAliases(switches),
+    ),
   };
   const now = nowDate();
 

--- a/turbo/apps/api/src/signals/services/notion-workflow-automation-feature-switch.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-automation-feature-switch.service.ts
@@ -5,13 +5,13 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
-export function notionWorkflowTriggerCreationEnabledForOwner(
+export function notionWorkflowAutomationCreationEnabledForOwner(
   orgId: string,
   userId: string,
 ) {
   return computed(async (get) => {
     const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
-    return isFeatureEnabled(FeatureSwitchKey.NotionWorkflowTriggers, {
+    return isFeatureEnabled(FeatureSwitchKey.NotionWorkflowAutomations, {
       orgId,
       userId,
       overrides,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -66,7 +66,7 @@ import {
   prepareNotionDatabaseItemEventConfigForPersist,
   prepareNotionPageContentUpdatedEventConfigForPersist,
 } from "./notion-workflow-event.service";
-import { notionWorkflowTriggerCreationEnabledForOwner } from "./notion-workflow-trigger-feature-switch.service";
+import { notionWorkflowAutomationCreationEnabledForOwner } from "./notion-workflow-automation-feature-switch.service";
 import { lockWorkflowWebhookTriggerTierEligibleForOrg } from "./workflow-webhook-trigger-entitlement.service";
 import {
   buildWorkflowWebhookSummaryFields,
@@ -139,13 +139,13 @@ function workflowWebhookTeamRequiredResult(): {
   };
 }
 
-function notionWorkflowTriggersDisabledResult(): {
+function notionWorkflowAutomationsDisabledResult(): {
   readonly kind: "bad-request";
   readonly message: string;
 } {
   return {
     kind: "bad-request",
-    message: "Notion workflow triggers are not enabled",
+    message: "Notion workflow automations are not enabled",
   };
 }
 
@@ -1601,14 +1601,14 @@ const createEventTriggerForWorkflow$ = command(
 
     if (triggerCreateInputIsNotion(input)) {
       const featureEnabled = await get(
-        notionWorkflowTriggerCreationEnabledForOwner(
+        notionWorkflowAutomationCreationEnabledForOwner(
           input.orgId,
           input.member.userId,
         ),
       );
       signal.throwIfAborted();
       if (!featureEnabled) {
-        return notionWorkflowTriggersDisabledResult();
+        return notionWorkflowAutomationsDisabledResult();
       }
 
       return await createNotionEventTriggerForWorkflow({

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -49,9 +49,9 @@ import {
 } from "@vm0/connectors/firewall-metadata";
 import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { FEATURE_SWITCH_CACHE_KEY } from "../../signals/external/feature-switch.ts";
 import { mockApi } from "../msw-contract.ts";
 
-const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
 const MOCK_CONNECTOR_TYPE_SET = new Set<string>(CONNECTOR_TYPE_KEYS);
 
 let mockConnectors: ConnectorResponse[] = [];

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,7 +1,10 @@
 import { command, computed } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/connectors/feature-switch-key";
 import { authenticatedIdentity$, clerk$ } from "../auth";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
@@ -9,7 +12,7 @@ import { createAuthedContractClient } from "../api-client-base.ts";
 import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
-export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
+export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v2";
 export const LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY = "artifactFavorites";
 
 type FeatureSwitchStates = Record<FeatureSwitchKey, boolean> &
@@ -44,6 +47,17 @@ function applySwitches(
         result[key] = Boolean(value);
       }
     }
+  }
+
+  const notionWorkflowAutomations =
+    overrides?.[FeatureSwitchKey.NotionWorkflowAutomations] ??
+    overrides?.[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY] ??
+    effectiveSwitches?.[FeatureSwitchKey.NotionWorkflowAutomations] ??
+    effectiveSwitches?.[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY];
+  if (notionWorkflowAutomations !== undefined) {
+    result[FeatureSwitchKey.NotionWorkflowAutomations] = Boolean(
+      notionWorkflowAutomations,
+    );
   }
 
   // Keep the retired key only for the cross-version window where a new
@@ -108,10 +122,17 @@ export const setFeatureSwitch$ = command(
     signal: AbortSignal,
   ) => {
     const client = get(apiFeatureSwitchClient$);
+    const compatibleOverrides: Record<string, boolean> = { ...overrides };
+    const notionWorkflowAutomations =
+      overrides[FeatureSwitchKey.NotionWorkflowAutomations];
+    if (notionWorkflowAutomations !== undefined) {
+      compatibleOverrides[LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY] =
+        notionWorkflowAutomations;
+    }
     signal.throwIfAborted();
     await accept(
       client.update({
-        body: { switches: overrides },
+        body: { switches: compatibleOverrides },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -1,5 +1,8 @@
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -104,6 +107,68 @@ describe("lab page", () => {
     });
   });
 
+  it("maps the legacy Notion switch response to the automation key", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: {
+          [LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY]: true,
+        },
+        effectiveSwitches: {
+          [LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY]: true,
+        },
+      });
+    });
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(
+        featureSwitchControl(FeatureSwitchKey.NotionWorkflowAutomations),
+      ).toHaveAttribute("aria-checked", "true");
+    });
+    expect(
+      screen.queryByText(LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dual-writes the Notion automation switch for old APIs", async () => {
+    let switches: Record<string, boolean> = {
+      [FeatureSwitchKey.Lab]: true,
+      [FeatureSwitchKey.NotionWorkflowAutomations]: false,
+    };
+    let updateBody: Record<string, boolean> | undefined;
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, { switches, effectiveSwitches: switches });
+    });
+    context.mocks.api(
+      zeroFeatureSwitchesContract.update,
+      ({ body, respond }) => {
+        updateBody = body.switches;
+        switches = { ...switches, ...body.switches };
+        return respond(200, {
+          switches,
+          effectiveSwitches: switches,
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(
+        featureSwitchControl(FeatureSwitchKey.NotionWorkflowAutomations),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+    click(featureSwitchControl(FeatureSwitchKey.NotionWorkflowAutomations));
+
+    await waitFor(() => {
+      expect(updateBody).toStrictEqual({
+        [FeatureSwitchKey.NotionWorkflowAutomations]: true,
+        [LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY]: true,
+      });
+    });
+  });
+
   it("shows feature switches in name order without sort controls", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, { switches: {}, effectiveSwitches: {} });
@@ -140,7 +205,7 @@ describe("lab page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(FeatureSwitchKey.NotionWorkflowTriggers),
+        screen.getByText(FeatureSwitchKey.NotionWorkflowAutomations),
       ).toBeInTheDocument();
       expect(
         screen.queryByText(FeatureSwitchKey.AhrefsConnector),

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2427,7 +2427,7 @@ describe("workflow detail page", () => {
     });
 
     detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
-      [FeatureSwitchKey.NotionWorkflowTriggers]: true,
+      [FeatureSwitchKey.NotionWorkflowAutomations]: true,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -590,8 +590,8 @@ function TriggerCreateAction() {
     billing === undefined ||
     billing.tier === "team" ||
     billing.tier === "custom";
-  const notionWorkflowTriggersEnabled =
-    features[FeatureSwitchKey.NotionWorkflowTriggers] ?? false;
+  const notionWorkflowAutomationsEnabled =
+    features[FeatureSwitchKey.NotionWorkflowAutomations] ?? false;
 
   return (
     <TriggerCreateMenu
@@ -605,7 +605,7 @@ function TriggerCreateAction() {
       githubLabelTriggersEnabled
       googleCalendarTriggersEnabled
       googleMeetTriggersEnabled
-      notionWorkflowTriggersEnabled={notionWorkflowTriggersEnabled}
+      notionWorkflowAutomationsEnabled={notionWorkflowAutomationsEnabled}
       webhookTierEligible={webhookTierEligible}
     />
   );
@@ -2834,9 +2834,9 @@ function buildIntegrationTriggerOptions({
 }
 
 function buildNotionTriggerOptions(
-  notionWorkflowTriggersEnabled: boolean,
+  notionWorkflowAutomationsEnabled: boolean,
 ): TriggerCreateOption[] {
-  if (!notionWorkflowTriggersEnabled) {
+  if (!notionWorkflowAutomationsEnabled) {
     return [];
   }
   return [
@@ -2876,13 +2876,13 @@ function buildTriggerCreateCategories({
   githubLabelTriggersEnabled,
   googleCalendarTriggersEnabled,
   googleMeetTriggersEnabled,
-  notionWorkflowTriggersEnabled,
+  notionWorkflowAutomationsEnabled,
   webhookTierEligible,
 }: {
   readonly githubLabelTriggersEnabled: boolean;
   readonly googleCalendarTriggersEnabled: boolean;
   readonly googleMeetTriggersEnabled: boolean;
-  readonly notionWorkflowTriggersEnabled: boolean;
+  readonly notionWorkflowAutomationsEnabled: boolean;
   readonly webhookTierEligible: boolean;
 }): readonly TriggerCreateCategory[] {
   const calendarOptions: TriggerCreateOption[] = [];
@@ -2922,7 +2922,7 @@ function buildTriggerCreateCategories({
     webhookTierEligible,
   });
   const notionOptions = buildNotionTriggerOptions(
-    notionWorkflowTriggersEnabled,
+    notionWorkflowAutomationsEnabled,
   );
 
   const categories: readonly TriggerCreateCategory[] = [
@@ -3069,14 +3069,14 @@ function TriggerCreateMenu({
   githubLabelTriggersEnabled,
   googleCalendarTriggersEnabled,
   googleMeetTriggersEnabled,
-  notionWorkflowTriggersEnabled,
+  notionWorkflowAutomationsEnabled,
   webhookTierEligible,
 }: {
   readonly onSelect: (kind: TriggerCreateDialogKind) => void;
   readonly githubLabelTriggersEnabled: boolean;
   readonly googleCalendarTriggersEnabled: boolean;
   readonly googleMeetTriggersEnabled: boolean;
-  readonly notionWorkflowTriggersEnabled: boolean;
+  readonly notionWorkflowAutomationsEnabled: boolean;
   readonly webhookTierEligible: boolean;
 }) {
   const open = useGet(workflowTriggerPickerOpen$);
@@ -3087,7 +3087,7 @@ function TriggerCreateMenu({
     githubLabelTriggersEnabled,
     googleCalendarTriggersEnabled,
     googleMeetTriggersEnabled,
-    notionWorkflowTriggersEnabled,
+    notionWorkflowAutomationsEnabled,
     webhookTierEligible,
   });
   const activeCategory =

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -44,7 +44,7 @@ export enum FeatureSwitchKey {
   ZeroScrape = "zeroScrape",
   Banking = "banking",
   Lab = "lab",
-  NotionWorkflowTriggers = "notionWorkflowTriggers",
+  NotionWorkflowAutomations = "notionWorkflowAutomations",
   AgentDetailWorkflowsTab = "agentDetailWorkflowsTab",
   TestOauthConnector = "testOauthConnector",
   FreshdeskConnector = "freshdeskConnector",
@@ -81,3 +81,10 @@ export enum FeatureSwitchKey {
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
 }
+
+/**
+ * Temporary wire alias used while old platform and API versions drain.
+ * Remove after the Notion workflow automation feature-switch migration.
+ */
+export const LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY =
+  "notionWorkflowTriggers";

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -1,1 +1,4 @@
-export { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+export {
+  FeatureSwitchKey,
+  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY,
+} from "@vm0/connectors/feature-switch-key";

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -250,10 +250,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.NotionWorkflowTriggers]: {
+  [FeatureSwitchKey.NotionWorkflowAutomations]: {
     maintainer: "lancy@vm0.ai",
     description:
-      "Enable Notion event workflow triggers, starting with child pages created under a configured parent page.",
+      "Enable Notion event workflow automations, starting with child pages created under a configured parent page.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

- Rename the active Notion workflow feature switch to `NotionWorkflowAutomations` / `notionWorkflowAutomations` across the registry, API gate, Platform consumer, and Lab.
- Keep mixed-version deployments safe: the API accepts old and new keys with the new key winning, stores only the canonical new key, and temporarily mirrors the legacy key in responses.
- Make the new Platform understand legacy API responses and dual-write both keys for old APIs, while showing only the automation key in Lab and moving the local cache to v2.
- Keep connector catalog mocks on the exported cache key so gated connectors follow runtime feature-switch refreshes.
- Add API and Platform coverage for old/new client-server combinations.

## Rollout phases

This is the **expand phase** only. It intentionally adds **no database migration**.

Follow-ups under #21408 will:
1. **Migrate** any persisted legacy JSONB keys after the compatibility version has rolled out.
2. **Contract** by removing the legacy constant, API normalization/response mirror, Platform fallback/dual-write, and the temporary cache compatibility.

## Verification

- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx -t 'refreshes connector catalog status when connector feature switches change|connects AWS with an authorization code and authorizes an agent'`
- Targeted oxlint and ESLint for all changed files

Part of #21408.