### PR TITLE
perf(runner): bound session history buffer residency

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -24,9 +24,9 @@ use super::idle_lifecycle::{
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryCpuPool, SessionHistoryMaterializer,
-    SessionHistoryProbe, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
-    effective_cli_framework, validate_resume_session_id,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializationResources,
+    SessionHistoryMaterializer, SessionHistoryProbe, SessionHistoryRestoreFallback,
+    SessionHistoryRestorePlan, effective_cli_framework, validate_resume_session_id,
 };
 use crate::http::HttpClient;
 use crate::idle_pool::{
@@ -244,7 +244,7 @@ pub(super) async fn handle_discovered_job(
     let session_history_restore_plan = if resume_session_valid {
         build_session_history_restore_plan(
             &ctx.spawn_ctx.exec_config.http,
-            &ctx.spawn_ctx.exec_config.session_history_cpu,
+            &ctx.spawn_ctx.exec_config.session_history_materialization,
             claimed.context(),
             &job_cancel,
             SessionHistoryRestoreReuse {
@@ -311,7 +311,7 @@ struct SessionHistoryRestoreReuse<'a> {
 
 fn build_session_history_restore_plan(
     http: &HttpClient,
-    cpu: &SessionHistoryCpuPool,
+    resources: &SessionHistoryMaterializationResources,
     context: &ExecutionContext,
     cancel: &RunCancellationHandle,
     reuse: SessionHistoryRestoreReuse<'_>,
@@ -380,7 +380,7 @@ fn build_session_history_restore_plan(
         Some(prefix_attribution) => {
             SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
                 http,
-                cpu,
+                resources,
                 Some(resume_session),
                 effective_cli_framework(&context.cli_agent_type),
                 cancel.token(),
@@ -390,7 +390,7 @@ fn build_session_history_restore_plan(
         }
         None => SessionHistoryMaterializer::start_cancellable(
             http,
-            cpu,
+            resources,
             Some(resume_session),
             effective_cli_framework(&context.cli_agent_type),
             cancel.token(),
@@ -1314,7 +1314,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1379,7 +1379,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1427,7 +1427,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1457,7 +1457,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1505,7 +1505,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1539,7 +1539,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1571,7 +1571,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1627,7 +1627,7 @@ mod tests {
 
             let plan = build_session_history_restore_plan(
                 &http,
-                &SessionHistoryCpuPool::with_capacity(1),
+                &SessionHistoryMaterializationResources::for_host_cpus(2),
                 &context,
                 &cancel,
                 SessionHistoryRestoreReuse {
@@ -1665,7 +1665,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1700,7 +1700,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1737,7 +1737,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {
@@ -1779,7 +1779,7 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             &context,
             &cancel,
             SessionHistoryRestoreReuse {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -47,7 +47,9 @@ use crate::config::{self, ProfileConfig};
 use crate::deps;
 use crate::dns;
 use crate::error::{RunnerError, RunnerResult};
-use crate::executor::{ExecutorConfig, SessionHistoryCpuPool, SessionHistoryProbe};
+use crate::executor::{
+    ExecutorConfig, SessionHistoryMaterializationResources, SessionHistoryProbe,
+};
 use crate::host;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
@@ -673,7 +675,9 @@ async fn run_start_with_home(
         network_log_drain,
         mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
         network_policy_refresh,
-        session_history_cpu: SessionHistoryCpuPool::for_host_cpus(host_cpus),
+        session_history_materialization: SessionHistoryMaterializationResources::for_host_cpus(
+            host_cpus,
+        ),
         session_history_probe: SessionHistoryProbe::default(),
         home: home.clone(),
         workspace_cache: Some(SessionWorkspaceCache::shared(

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -254,7 +254,8 @@ fn build_mock_run_config_with_runtime(
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             mitm_jsonl_flush: None,
             network_policy_refresh: None,
-            session_history_cpu: executor::SessionHistoryCpuPool::with_capacity(1),
+            session_history_materialization:
+                executor::SessionHistoryMaterializationResources::for_host_cpus(2),
             session_history_probe: executor::SessionHistoryProbe::default(),
             home,
             workspace_cache: None,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -37,6 +37,7 @@ use super::env::{
     write_user_env_file,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
+use super::session_history_buffer::SessionHistoryBufferClaim;
 use super::session_history_cpu::{SessionHistoryCpuJob, SessionHistoryPrefixOutcome};
 use super::session_history_download::{
     SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
@@ -256,6 +257,12 @@ fn record_session_history_download_timings(
     let metadata = timings.metadata();
     record_session_history_download_phase(
         telemetry,
+        "session_history_buffer_admission",
+        timings.buffer_admission(),
+        metadata,
+    );
+    record_session_history_download_phase(
+        telemetry,
         "session_history_download_request_status",
         timings.request_status(),
         metadata,
@@ -362,6 +369,7 @@ async fn materialize_session_history_sidecar(
     sidecar: &WorkspaceSessionHistorySidecar,
     config: &ExecutorConfig,
     cancel: &CancellationToken,
+    telemetry: &mut JobTelemetry,
 ) -> RunnerResult<MaterializedResumeSession> {
     let resume_session = context.resume_session.as_ref().ok_or_else(|| {
         RunnerError::Internal("resume session missing for sidecar restore".into())
@@ -369,6 +377,32 @@ async fn materialize_session_history_sidecar(
     let history_ref = resume_session.history_ref().ok_or_else(|| {
         RunnerError::Internal("resume session history ref missing for sidecar restore".into())
     })?;
+    let claim = match sidecar.representation {
+        WorkspaceSessionHistorySidecarRepresentation::Raw => {
+            SessionHistoryBufferClaim::sidecar_raw(history_ref.raw_size)?
+        }
+        WorkspaceSessionHistorySidecarRepresentation::CodexZstd => {
+            SessionHistoryBufferClaim::sidecar_preserved(
+                sidecar.encoded_size,
+                history_ref.raw_size,
+            )?
+        }
+    };
+    let admission = config
+        .session_history_materialization
+        .acquire_buffer(claim, cancel)
+        .await;
+    telemetry.record(
+        "session_history_buffer_admission",
+        admission.elapsed,
+        admission.result.is_ok(),
+        admission
+            .result
+            .as_ref()
+            .err()
+            .map(|_| SESSION_HISTORY_DOWNLOAD_PHASE_TELEMETRY_ERROR),
+    );
+    let buffer_reservation = admission.result?;
     let bytes = tokio::select! {
         biased;
         _ = cancel.cancelled() => {
@@ -393,9 +427,10 @@ async fn materialize_session_history_sidecar(
             history_ref.hash.clone(),
             super::cli_framework::EffectiveCliFramework::Codex,
         ),
-    };
+    }
+    .with_buffer_reservation(buffer_reservation);
     config
-        .session_history_cpu
+        .session_history_materialization
         .materialize(job, cancel)
         .await?
         .result
@@ -417,7 +452,7 @@ async fn materialize_inline_resume_session(
         == super::cli_framework::EffectiveCliFramework::Codex
     {
         let outcome = config
-            .session_history_cpu
+            .session_history_materialization
             .materialize(
                 SessionHistoryCpuJob::inline_codex(
                     resume_session.cli_agent_session_id.clone(),
@@ -440,12 +475,21 @@ async fn materialize_inline_resume_session(
 async fn read_session_history_sidecar_bytes(
     sidecar: &WorkspaceSessionHistorySidecar,
 ) -> RunnerResult<Vec<u8>> {
-    let file = tokio::fs::File::open(&sidecar.path).await?;
-    let mut bytes = Vec::with_capacity(sidecar.encoded_size.min(1024 * 1024) as usize);
-    file.take(sidecar.encoded_size.saturating_add(1))
-        .read_to_end(&mut bytes)
-        .await?;
-    if bytes.len() as u64 != sidecar.encoded_size {
+    let mut file = tokio::fs::File::open(&sidecar.path).await?;
+    let capacity = usize::try_from(sidecar.encoded_size).map_err(|_| {
+        RunnerError::Internal("workspace session history sidecar exceeds platform capacity".into())
+    })?;
+    let mut bytes = vec![0; capacity];
+    if let Err(error) = file.read_exact(&mut bytes).await {
+        if error.kind() != std::io::ErrorKind::UnexpectedEof {
+            return Err(error.into());
+        }
+        return Err(RunnerError::Internal(
+            "workspace session history sidecar size mismatch".into(),
+        ));
+    }
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra).await? != 0 {
         return Err(RunnerError::Internal(
             "workspace session history sidecar size mismatch".into(),
         ));
@@ -1121,7 +1165,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     record_session_history_identity_reason(telemetry, reason);
                     Some(SessionHistoryMaterializer::start_cancellable(
                         &config.http,
-                        &config.session_history_cpu,
+                        &config.session_history_materialization,
                         context.resume_session.as_ref(),
                         effective_cli_framework(&context.cli_agent_type),
                         cancel.clone(),
@@ -1134,7 +1178,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             record_session_history_restore_fallback(telemetry, fallback);
             Some(SessionHistoryMaterializer::start_cancellable(
                 &config.http,
-                &config.session_history_cpu,
+                &config.session_history_materialization,
                 context.resume_session.as_ref(),
                 effective_cli_framework(&context.cli_agent_type),
                 cancel.clone(),
@@ -1143,7 +1187,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
         SessionHistoryRestorePlan::Default => Some(SessionHistoryMaterializer::start_cancellable(
             &config.http,
-            &config.session_history_cpu,
+            &config.session_history_materialization,
             context.resume_session.as_ref(),
             effective_cli_framework(&context.cli_agent_type),
             cancel.clone(),
@@ -1164,7 +1208,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
     if let Some(sidecar) = local_session_history_sidecar {
         let restore_started = Instant::now();
-        match materialize_session_history_sidecar(context, &sidecar, config, &cancel).await {
+        match materialize_session_history_sidecar(context, &sidecar, config, &cancel, telemetry)
+            .await
+        {
             Ok(session) => match restore_session(sandbox, context, &session).await {
                 Ok(diagnostics) => {
                     telemetry.record(
@@ -1200,7 +1246,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     session_history_materializer =
                         Some(SessionHistoryMaterializer::start_cancellable(
                             &config.http,
-                            &config.session_history_cpu,
+                            &config.session_history_materialization,
                             context.resume_session.as_ref(),
                             effective_cli_framework(&context.cli_agent_type),
                             cancel.clone(),
@@ -1231,7 +1277,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 );
                 session_history_materializer = Some(SessionHistoryMaterializer::start_cancellable(
                     &config.http,
-                    &config.session_history_cpu,
+                    &config.session_history_materialization,
                     context.resume_session.as_ref(),
                     effective_cli_framework(&context.cli_agent_type),
                     cancel.clone(),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -30,8 +30,10 @@ mod diagnostics;
 mod env;
 mod guest_state;
 mod sandbox_run;
+mod session_history_buffer;
 mod session_history_cpu;
 mod session_history_download;
+mod session_history_materialization;
 mod session_id;
 mod session_restore;
 mod storage;
@@ -41,8 +43,8 @@ pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use agent_run::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
 pub(crate) use cli_framework::effective_cli_framework;
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
-pub(crate) use session_history_cpu::SessionHistoryCpuPool;
 pub(crate) use session_history_download::{SessionHistoryMaterializer, SessionHistoryProbe};
+pub(crate) use session_history_materialization::SessionHistoryMaterializationResources;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};
@@ -159,7 +161,7 @@ pub struct ExecutorConfig {
     pub network_log_drain: NetworkLogDrainCoordinator,
     pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
     pub(crate) network_policy_refresh: Option<crate::provider::NetworkPolicyRefreshHandle>,
-    pub(crate) session_history_cpu: SessionHistoryCpuPool,
+    pub(crate) session_history_materialization: SessionHistoryMaterializationResources,
     pub(crate) session_history_probe: SessionHistoryProbe,
     pub home: HomePaths,
     pub workspace_cache: Option<SessionWorkspaceCache>,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -618,7 +618,7 @@ fn start_fresh_session_history_materializer(
     let started = Instant::now();
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
-        &config.session_history_cpu,
+        &config.session_history_materialization,
         context.resume_session.as_ref(),
         effective_cli_framework(&context.cli_agent_type),
         cancel,

--- a/crates/runner/src/executor/session_history_buffer.rs
+++ b/crates/runner/src/executor/session_history_buffer.rs
@@ -1,0 +1,226 @@
+//! Bounded payload residency for resume-session history materialization.
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
+#[cfg(test)]
+use tokio::sync::Notify;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+use super::{RunnerError, RunnerResult};
+
+const BUFFER_ADMISSION_CANCELLED: &str = "session history buffer admission cancelled";
+
+#[derive(Clone)]
+pub(super) struct SessionHistoryBufferPool {
+    permits: Arc<Semaphore>,
+    capacity_bytes: u32,
+    #[cfg(test)]
+    probe: Option<SessionHistoryBufferTestProbe>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct SessionHistoryBufferTestProbe {
+    submissions: Arc<AtomicUsize>,
+    changed: Arc<Notify>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct SessionHistoryBufferClaim {
+    peak_bytes: u32,
+    retained_bytes: u32,
+}
+
+pub(super) struct SessionHistoryBufferAdmission {
+    pub(super) elapsed: Duration,
+    pub(super) result: RunnerResult<SessionHistoryBufferReservation>,
+}
+
+pub(super) struct SessionHistoryBufferReservation {
+    permit: OwnedSemaphorePermit,
+    retained_bytes: u32,
+}
+
+pub(super) struct SessionHistoryBufferLease {
+    permit: OwnedSemaphorePermit,
+}
+
+impl SessionHistoryBufferPool {
+    pub(super) fn for_cpu_capacity(cpu_capacity: usize) -> Self {
+        let capacity_bytes = RESUME_SESSION_HISTORY_MAX_BYTES
+            .saturating_mul(cpu_capacity.max(1).saturating_add(1) as u64);
+        Self::with_capacity_bytes(capacity_bytes)
+    }
+
+    fn with_capacity_bytes(capacity_bytes: u64) -> Self {
+        let capacity_bytes = capacity_bytes.clamp(1, u32::MAX as u64) as u32;
+        Self {
+            permits: Arc::new(Semaphore::new(capacity_bytes as usize)),
+            capacity_bytes,
+            #[cfg(test)]
+            probe: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_test_capacity(capacity_bytes: u32) -> Self {
+        let mut pool = Self::with_capacity_bytes(capacity_bytes as u64);
+        pool.probe = Some(SessionHistoryBufferTestProbe::default());
+        pool
+    }
+
+    #[cfg(test)]
+    pub(super) async fn wait_for_submissions(&self, expected: usize) {
+        let probe = self
+            .probe
+            .as_ref()
+            .expect("session history buffer test probe should be configured");
+        loop {
+            if probe.submissions.load(Ordering::Acquire) >= expected {
+                return;
+            }
+            let changed = probe.changed.notified();
+            if probe.submissions.load(Ordering::Acquire) >= expected {
+                return;
+            }
+            changed.await;
+        }
+    }
+
+    pub(super) async fn acquire(
+        &self,
+        claim: SessionHistoryBufferClaim,
+        cancel: &CancellationToken,
+    ) -> SessionHistoryBufferAdmission {
+        let started_at = Instant::now();
+        #[cfg(test)]
+        if let Some(probe) = &self.probe {
+            probe.submissions.fetch_add(1, Ordering::Release);
+            probe.changed.notify_waiters();
+        }
+        if claim.peak_bytes > self.capacity_bytes {
+            return SessionHistoryBufferAdmission {
+                elapsed: started_at.elapsed(),
+                result: Err(RunnerError::Internal(format!(
+                    "session history buffer claim is too large: {} bytes exceeds {} bytes",
+                    claim.peak_bytes, self.capacity_bytes
+                ))),
+            };
+        }
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(buffer_admission_cancelled_error()),
+            permit = Arc::clone(&self.permits).acquire_many_owned(claim.peak_bytes) => {
+                permit
+                    .map(|permit| SessionHistoryBufferReservation {
+                        permit,
+                        retained_bytes: claim.retained_bytes,
+                    })
+                    .map_err(|error| RunnerError::Internal(format!(
+                        "acquire session history buffer capacity: {error}"
+                    )))
+            }
+        };
+        SessionHistoryBufferAdmission {
+            elapsed: started_at.elapsed(),
+            result,
+        }
+    }
+}
+
+impl SessionHistoryBufferClaim {
+    /// Account for a reqwest chunk copied into the destination and the later
+    /// representation-specific CPU peak. The incoming chunk can be as large
+    /// as the valid encoded body, so the larger of encoded and raw is charged
+    /// in addition to the encoded destination.
+    pub(super) fn remote_decoded(encoded_bytes: u64, raw_bytes: u64) -> RunnerResult<Self> {
+        Self::remote(encoded_bytes, raw_bytes, raw_bytes)
+    }
+
+    pub(super) fn remote_preserved(encoded_bytes: u64, raw_bytes: u64) -> RunnerResult<Self> {
+        Self::remote(encoded_bytes, raw_bytes, encoded_bytes)
+    }
+
+    pub(super) fn sidecar_raw(raw_bytes: u64) -> RunnerResult<Self> {
+        Self::new(raw_bytes, raw_bytes)
+    }
+
+    pub(super) fn sidecar_preserved(encoded_bytes: u64, raw_bytes: u64) -> RunnerResult<Self> {
+        let peak_bytes = encoded_bytes.checked_add(raw_bytes).ok_or_else(|| {
+            RunnerError::Internal("session history sidecar buffer claim overflow".into())
+        })?;
+        Self::new(peak_bytes, encoded_bytes)
+    }
+
+    fn remote(encoded_bytes: u64, raw_bytes: u64, retained_bytes: u64) -> RunnerResult<Self> {
+        let peak_bytes = encoded_bytes
+            .checked_add(encoded_bytes.max(raw_bytes))
+            .ok_or_else(|| {
+                RunnerError::Internal("session history remote buffer claim overflow".into())
+            })?;
+        Self::new(peak_bytes, retained_bytes)
+    }
+
+    fn new(peak_bytes: u64, retained_bytes: u64) -> RunnerResult<Self> {
+        if peak_bytes == 0 || retained_bytes == 0 {
+            return Err(RunnerError::Internal(
+                "session history buffer claim must be positive".into(),
+            ));
+        }
+        let peak_bytes = u32::try_from(peak_bytes).map_err(|_| {
+            RunnerError::Internal("session history buffer peak exceeds semaphore range".into())
+        })?;
+        let retained_bytes = u32::try_from(retained_bytes).map_err(|_| {
+            RunnerError::Internal("session history retained buffer exceeds semaphore range".into())
+        })?;
+        if retained_bytes > peak_bytes {
+            return Err(RunnerError::Internal(
+                "session history retained buffer exceeds peak claim".into(),
+            ));
+        }
+        Ok(Self {
+            peak_bytes,
+            retained_bytes,
+        })
+    }
+}
+
+impl SessionHistoryBufferReservation {
+    pub(super) fn into_retained_lease(mut self) -> RunnerResult<SessionHistoryBufferLease> {
+        let reserved_bytes = self.permit.num_permits();
+        let retained_bytes = self.retained_bytes as usize;
+        let release_bytes = reserved_bytes.checked_sub(retained_bytes).ok_or_else(|| {
+            RunnerError::Internal(
+                "session history retained buffer exceeds acquired capacity".into(),
+            )
+        })?;
+        if release_bytes > 0 {
+            let released = self.permit.split(release_bytes).ok_or_else(|| {
+                RunnerError::Internal("split session history buffer reservation".into())
+            })?;
+            drop(released);
+        }
+        Ok(SessionHistoryBufferLease {
+            permit: self.permit,
+        })
+    }
+}
+
+impl fmt::Debug for SessionHistoryBufferLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionHistoryBufferLease")
+            .field("bytes", &self.permit.num_permits())
+            .finish()
+    }
+}
+
+fn buffer_admission_cancelled_error() -> RunnerError {
+    RunnerError::Internal(BUFFER_ADMISSION_CANCELLED.into())
+}

--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -15,6 +15,7 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use super::cli_framework::EffectiveCliFramework;
+use super::session_history_buffer::SessionHistoryBufferReservation;
 use super::session_restore::MaterializedResumeSession;
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
@@ -46,6 +47,7 @@ struct SessionHistoryCpuTaskGuard {
 pub(super) struct SessionHistoryCpuJob {
     kind: SessionHistoryCpuJobKind,
     prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
+    buffer_reservation: Option<SessionHistoryBufferReservation>,
 }
 
 enum SessionHistoryCpuJobKind {
@@ -146,11 +148,6 @@ pub(super) struct SessionHistoryCpuPhaseTiming {
 }
 
 impl SessionHistoryCpuPool {
-    pub(crate) fn for_host_cpus(host_cpus: usize) -> Self {
-        let capacity = (host_cpus / 2).clamp(1, 4);
-        Self::with_capacity(capacity)
-    }
-
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             permits: Arc::new(Semaphore::new(capacity.max(1))),
@@ -291,6 +288,7 @@ impl SessionHistoryCpuJob {
                 framework,
             },
             prefix_attribution: None,
+            buffer_reservation: None,
         }
     }
 
@@ -310,6 +308,7 @@ impl SessionHistoryCpuJob {
                 framework,
             },
             prefix_attribution: None,
+            buffer_reservation: None,
         }
     }
 
@@ -329,6 +328,7 @@ impl SessionHistoryCpuJob {
                 framework,
             },
             prefix_attribution: None,
+            buffer_reservation: None,
         }
     }
 
@@ -339,6 +339,7 @@ impl SessionHistoryCpuJob {
                 history,
             },
             prefix_attribution: None,
+            buffer_reservation: None,
         }
     }
 
@@ -347,6 +348,14 @@ impl SessionHistoryCpuJob {
         prefix_attribution: RestoredSessionHistoryPrefixAttribution,
     ) -> Self {
         self.prefix_attribution = Some(prefix_attribution);
+        self
+    }
+
+    pub(super) fn with_buffer_reservation(
+        mut self,
+        buffer_reservation: SessionHistoryBufferReservation,
+    ) -> Self {
+        self.buffer_reservation = Some(buffer_reservation);
         self
     }
 }
@@ -401,8 +410,9 @@ fn materialize_blocking(
     let SessionHistoryCpuJob {
         kind,
         prefix_attribution,
+        buffer_reservation,
     } = job;
-    match kind {
+    let mut outcome = match kind {
         SessionHistoryCpuJobKind::Raw {
             cli_agent_session_id,
             bytes,
@@ -493,7 +503,15 @@ fn materialize_blocking(
                 result,
             }
         }
+    };
+    if let Some(buffer_reservation) = buffer_reservation {
+        outcome.result = outcome.result.and_then(|mut materialization| {
+            let lease = buffer_reservation.into_retained_lease()?;
+            materialization.session.attach_buffer_lease(lease);
+            Ok(materialization)
+        });
     }
+    outcome
 }
 
 fn materialize_raw(
@@ -816,7 +834,10 @@ fn read_compressed_history(
     encoding: &str,
     cancel: &CancellationToken,
 ) -> RunnerResult<Vec<u8>> {
-    let mut bytes = Vec::new();
+    let capacity = usize::try_from(max_raw_bytes).map_err(|_| {
+        RunnerError::Internal("session history raw size exceeds platform capacity".into())
+    })?;
+    let mut bytes = Vec::with_capacity(capacity);
     let mut buffer = [0u8; DECODER_BUFFER_BYTES];
     let mut decoded = 0u64;
     loop {

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -14,7 +14,9 @@
 //!
 //! Download diagnostics must not expose presigned URL query strings, and the
 //! downloaded bytes must satisfy the declared size, byte cap, and hash contract
-//! before they are restored into the sandbox.
+//! before they are restored into the sandbox. A runner-shared weighted budget
+//! reserves the complete body/CPU peak before each request and remains owned by
+//! successful output until guest restore no longer needs it.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -27,10 +29,12 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use super::cli_framework::EffectiveCliFramework;
+use super::session_history_buffer::{SessionHistoryBufferClaim, SessionHistoryBufferReservation};
 use super::session_history_cpu::{
-    SessionHistoryCpuJob, SessionHistoryCpuMaterialization, SessionHistoryCpuPool,
-    SessionHistoryCpuTimings, SessionHistoryPrefixOutcome,
+    SessionHistoryCpuJob, SessionHistoryCpuMaterialization, SessionHistoryCpuTimings,
+    SessionHistoryPrefixOutcome,
 };
+use super::session_history_materialization::SessionHistoryMaterializationResources;
 use super::session_restore::MaterializedResumeSession;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
@@ -131,9 +135,15 @@ struct SessionHistoryDownloadTaskResult {
     result: RunnerResult<SessionHistoryCpuMaterialization>,
 }
 
+struct DownloadedSessionHistoryBody {
+    bytes: Vec<u8>,
+    buffer_reservation: SessionHistoryBufferReservation,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(super) struct SessionHistoryDownloadTimings {
     metadata: Option<SessionHistoryTelemetryMetadata>,
+    buffer_admission: Option<SessionHistoryDownloadPhaseTiming>,
     request_status: Option<SessionHistoryDownloadPhaseTiming>,
     body_read: Option<SessionHistoryDownloadPhaseTiming>,
     validation: Option<SessionHistoryDownloadPhaseTiming>,
@@ -161,6 +171,10 @@ impl SessionHistoryDownloadTimings {
         self.request_status
     }
 
+    pub(super) fn buffer_admission(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
+        self.buffer_admission
+    }
+
     pub(super) fn body_read(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
         self.body_read
     }
@@ -179,6 +193,10 @@ impl SessionHistoryDownloadTimings {
 
     fn record_request_status(&mut self, elapsed: Duration, success: bool) {
         self.request_status = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+    }
+
+    fn record_buffer_admission(&mut self, elapsed: Duration, success: bool) {
+        merge_phase_timing(&mut self.buffer_admission, elapsed, success);
     }
 
     #[cfg(test)]
@@ -438,18 +456,18 @@ impl Drop for SessionHistoryProbeGuardInner {
 impl SessionHistoryMaterializer {
     pub(crate) fn start_cancellable(
         http: &HttpClient,
-        cpu: &SessionHistoryCpuPool,
+        resources: &SessionHistoryMaterializationResources,
         session: Option<&ResumeSession>,
         framework: EffectiveCliFramework,
         cancel: CancellationToken,
         probe: Option<&SessionHistoryProbe>,
     ) -> Self {
-        Self::start_cancellable_inner(http, cpu, session, framework, cancel, probe, None)
+        Self::start_cancellable_inner(http, resources, session, framework, cancel, probe, None)
     }
 
     pub(crate) fn start_cancellable_with_prefix_attribution(
         http: &HttpClient,
-        cpu: &SessionHistoryCpuPool,
+        resources: &SessionHistoryMaterializationResources,
         session: Option<&ResumeSession>,
         framework: EffectiveCliFramework,
         cancel: CancellationToken,
@@ -458,7 +476,7 @@ impl SessionHistoryMaterializer {
     ) -> Self {
         Self::start_cancellable_inner(
             http,
-            cpu,
+            resources,
             session,
             framework,
             cancel,
@@ -469,7 +487,7 @@ impl SessionHistoryMaterializer {
 
     fn start_cancellable_inner(
         http: &HttpClient,
-        cpu: &SessionHistoryCpuPool,
+        resources: &SessionHistoryMaterializationResources,
         session: Option<&ResumeSession>,
         framework: EffectiveCliFramework,
         cancel: CancellationToken,
@@ -493,7 +511,7 @@ impl SessionHistoryMaterializer {
         }
 
         let http = http.clone();
-        let cpu = cpu.clone();
+        let resources = resources.clone();
         let session = session.clone();
         let started_at = Instant::now();
         let task_cancel = cancel.child_token();
@@ -510,7 +528,7 @@ impl SessionHistoryMaterializer {
                 task: Some(tokio::spawn(async move {
                     let result = download_resume_session_history_timed(
                         http,
-                        cpu,
+                        resources,
                         session,
                         framework,
                         metadata,
@@ -566,12 +584,15 @@ impl SessionHistoryMaterializer {
                 let metadata = *metadata;
                 if cancel.is_cancelled() || task_cancel.is_cancelled() {
                     task_cancel.cancel();
-                    if let Some(task) = task.take() {
-                        let _ = task.await;
-                    }
+                    let result = match task.take() {
+                        Some(task) => task.await.map_or_else(
+                            |_| SessionHistoryDownloadTaskResult::cancelled(started_at, metadata),
+                            |result| result.into_cancelled(started_at),
+                        ),
+                        None => SessionHistoryDownloadTaskResult::cancelled(started_at, metadata),
+                    };
                     finish_session_history_probe(probe_registration);
-                    return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
-                        .into_materialization();
+                    return result.into_materialization();
                 }
                 let Some(mut task) = task.take() else {
                     finish_session_history_probe(probe_registration);
@@ -587,12 +608,16 @@ impl SessionHistoryMaterializer {
                     biased;
                     _ = cancel.cancelled() => {
                         task_cancel.cancel();
-                        let _ = task.await;
-                        SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
+                        task.await.map_or_else(
+                            |_| SessionHistoryDownloadTaskResult::cancelled(started_at, metadata),
+                            |result| result.into_cancelled(started_at),
+                        )
                     }
                     _ = task_cancel.cancelled() => {
-                        let _ = task.await;
-                        SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
+                        task.await.map_or_else(
+                            |_| SessionHistoryDownloadTaskResult::cancelled(started_at, metadata),
+                            |result| result.into_cancelled(started_at),
+                        )
                     }
                     joined = &mut task => {
                         joined.unwrap_or_else(|error| {
@@ -610,8 +635,7 @@ impl SessionHistoryMaterializer {
                 // Re-check after joining because the task itself can observe
                 // cancellation while still producing a successful result.
                 if cancel.is_cancelled() || task_cancel.is_cancelled() {
-                    return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
-                        .into_materialization();
+                    return result.into_cancelled(started_at).into_materialization();
                 }
                 result.into_materialization()
             }
@@ -645,6 +669,14 @@ impl SessionHistoryDownloadTaskResult {
             )),
         }
     }
+
+    fn into_cancelled(mut self, started_at: Instant) -> Self {
+        self.elapsed = started_at.elapsed();
+        self.result = Err(RunnerError::Internal(
+            "session history download cancelled".into(),
+        ));
+        self
+    }
 }
 
 impl Drop for SessionHistoryMaterializer {
@@ -673,7 +705,7 @@ fn finish_session_history_probe(registration: &Option<SessionHistoryProbeRegistr
 
 async fn download_resume_session_history_timed(
     http: HttpClient,
-    cpu: SessionHistoryCpuPool,
+    resources: SessionHistoryMaterializationResources,
     session: ResumeSession,
     framework: EffectiveCliFramework,
     metadata: SessionHistoryTelemetryMetadata,
@@ -687,7 +719,7 @@ async fn download_resume_session_history_timed(
     }
     let result = download_resume_session_history(
         http,
-        &cpu,
+        &resources,
         session,
         framework,
         prefix_attribution,
@@ -695,30 +727,31 @@ async fn download_resume_session_history_timed(
         &mut timings,
     )
     .await;
-    if cancel.is_cancelled() {
-        return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata);
-    }
-    SessionHistoryDownloadTaskResult {
+    let result = SessionHistoryDownloadTaskResult {
         elapsed: started_at.elapsed(),
         timings,
         result,
+    };
+    if cancel.is_cancelled() {
+        return result.into_cancelled(started_at);
     }
+    result
 }
 
 async fn download_resume_session_history(
     http: HttpClient,
-    cpu: &SessionHistoryCpuPool,
+    resources: &SessionHistoryMaterializationResources,
     session: ResumeSession,
     framework: EffectiveCliFramework,
     prefix_attribution: Option<RestoredSessionHistoryPrefixAttribution>,
     cancel: &CancellationToken,
     timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<SessionHistoryCpuMaterialization> {
-    // The history ref is treated as untrusted input. The request timeout and
-    // 128 MiB cap bound resource use; declared size, HTTP content-length, final
-    // byte count, and SHA-256 must all agree before the bytes become sandbox
-    // session history. URL diagnostics redact query strings because the ref URL
-    // can be presigned.
+    // The history ref is treated as untrusted input. The request timeout,
+    // per-object cap, and shared buffer admission bound resource use; declared
+    // size, HTTP content-length, final byte count, and SHA-256 must all agree
+    // before the bytes become sandbox session history. URL diagnostics redact
+    // query strings because the ref URL can be presigned.
     let history_ref = session
         .history_ref()
         .ok_or_else(|| RunnerError::Internal("resume session history ref is missing".into()))?
@@ -734,8 +767,14 @@ async fn download_resume_session_history(
     let job = match encoding {
         ResumeSessionHistoryEncoding::Identity => {
             validate_identity_ref(&history_ref, timings)?;
-            let bytes = download_body(
+            let claim = SessionHistoryBufferClaim::remote_decoded(
+                history_ref.encoded_size,
+                history_ref.raw_size,
+            )?;
+            let downloaded = download_body(
                 &http,
+                resources,
+                claim,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
                 cancel,
@@ -744,16 +783,21 @@ async fn download_resume_session_history(
             .await?;
             SessionHistoryCpuJob::raw(
                 session.cli_agent_session_id,
-                bytes,
+                downloaded.bytes,
                 history_ref.raw_size,
                 history_ref.hash,
                 framework,
             )
+            .with_buffer_reservation(downloaded.buffer_reservation)
         }
         ResumeSessionHistoryEncoding::Gzip => {
             let raw_size = validate_compressed_ref("gzip", &history_ref, timings)?;
-            let encoded_bytes = download_body(
+            let claim =
+                SessionHistoryBufferClaim::remote_decoded(history_ref.encoded_size, raw_size)?;
+            let downloaded = download_body(
                 &http,
+                resources,
+                claim,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
                 cancel,
@@ -762,16 +806,24 @@ async fn download_resume_session_history(
             .await?;
             SessionHistoryCpuJob::gzip(
                 session.cli_agent_session_id,
-                encoded_bytes,
+                downloaded.bytes,
                 raw_size,
                 history_ref.hash,
                 framework,
             )
+            .with_buffer_reservation(downloaded.buffer_reservation)
         }
         ResumeSessionHistoryEncoding::Zstd => {
             let raw_size = validate_compressed_ref("zstd", &history_ref, timings)?;
-            let encoded_bytes = download_body(
+            let claim = if framework == EffectiveCliFramework::Codex {
+                SessionHistoryBufferClaim::remote_preserved(history_ref.encoded_size, raw_size)?
+            } else {
+                SessionHistoryBufferClaim::remote_decoded(history_ref.encoded_size, raw_size)?
+            };
+            let downloaded = download_body(
                 &http,
+                resources,
+                claim,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
                 cancel,
@@ -780,18 +832,19 @@ async fn download_resume_session_history(
             .await?;
             SessionHistoryCpuJob::zstd(
                 session.cli_agent_session_id,
-                encoded_bytes,
+                downloaded.bytes,
                 raw_size,
                 history_ref.hash,
                 framework,
             )
+            .with_buffer_reservation(downloaded.buffer_reservation)
         }
     };
     let job = match prefix_attribution {
         Some(prefix_attribution) => job.with_prefix_attribution(prefix_attribution),
         None => job,
     };
-    let outcome = cpu.materialize(job, cancel).await?;
+    let outcome = resources.materialize(job, cancel).await?;
     timings.merge_cpu(outcome.timings);
     outcome.result
 }
@@ -874,18 +927,29 @@ fn validate_compressed_ref(
 
 async fn download_body(
     http: &HttpClient,
+    resources: &SessionHistoryMaterializationResources,
+    claim: SessionHistoryBufferClaim,
     url: &str,
     expected_size: Option<u64>,
     cancel: &CancellationToken,
     timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<Vec<u8>> {
+) -> RunnerResult<DownloadedSessionHistoryBody> {
     let mut attempt = 1usize;
     loop {
         timings.reset_download_attempt();
+        let admission = resources.acquire_buffer(claim, cancel).await;
+        timings.record_buffer_admission(admission.elapsed, admission.result.is_ok());
+        let buffer_reservation = admission.result?;
         let result = tokio::select! {
             biased;
             _ = cancel.cancelled() => return Err(session_history_download_cancelled_error()),
-            result = download_body_once(http, url, expected_size, timings) => result,
+            result = download_body_once(
+                http,
+                url,
+                expected_size,
+                buffer_reservation,
+                timings,
+            ) => result,
         };
         match result {
             Ok(body) => return Ok(body),
@@ -923,8 +987,9 @@ async fn download_body_once(
     http: &HttpClient,
     url: &str,
     expected_size: Option<u64>,
+    buffer_reservation: SessionHistoryBufferReservation,
     timings: &mut SessionHistoryDownloadTimings,
-) -> Result<Vec<u8>, SessionHistoryDownloadBodyError> {
+) -> Result<DownloadedSessionHistoryBody, SessionHistoryDownloadBodyError> {
     let request_started = Instant::now();
     let response = http
         .get(url)
@@ -1020,7 +1085,10 @@ async fn download_body_once(
     }
     timings.record_body_read(body_started.elapsed(), true);
 
-    Ok(body)
+    Ok(DownloadedSessionHistoryBody {
+        bytes: body,
+        buffer_reservation,
+    })
 }
 
 #[derive(Debug)]
@@ -1232,12 +1300,13 @@ fn redact_url_query(url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::io::{self, Write};
+    use std::sync::Arc;
 
     use flate2::{Compression, write::GzEncoder};
     use sha2::{Digest, Sha256};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
-    use tokio::sync::oneshot;
+    use tokio::sync::{Notify, oneshot};
     use tokio::task::JoinHandle;
 
     use super::*;
@@ -1344,7 +1413,7 @@ mod tests {
     ) -> SessionHistoryMaterializer {
         SessionHistoryMaterializer::start_cancellable(
             &http_client(),
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             Some(session),
             framework,
             CancellationToken::new(),
@@ -1370,7 +1439,7 @@ mod tests {
     ) -> SessionHistoryMaterializer {
         SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
             &http_client(),
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             Some(session),
             framework,
             CancellationToken::new(),
@@ -1702,6 +1771,233 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn materialized_session_holds_buffer_capacity_until_drop() {
+        let body = b"history\n";
+        let hash = hex::encode(Sha256::digest(body));
+        let buffer_capacity = u32::try_from(body.len() * 2).unwrap();
+        let resources =
+            SessionHistoryMaterializationResources::with_test_capacities(1, buffer_capacity);
+
+        let first_server = serve_once("200 OK", body, Some(body.len() as u64)).await;
+        let first_resume_session = ref_session(
+            first_server.url(),
+            hash.clone(),
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let first_materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&first_resume_session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        );
+        let first_session = match first_materializer.finish(&CancellationToken::new()).await {
+            SessionHistoryMaterialization::Downloaded {
+                session, timings, ..
+            } => {
+                assert_phase_success(timings.buffer_admission());
+                session
+            }
+            _ => panic!("expected first downloaded session"),
+        };
+        first_server.assert_served().await;
+
+        let small_body = b"tiny";
+        let small_server = serve_once("200 OK", small_body, Some(small_body.len() as u64)).await;
+        let small_resume_session = ref_session(
+            small_server.url(),
+            hex::encode(Sha256::digest(small_body)),
+            small_body.len() as u64,
+            small_body.len() as u64,
+        );
+        let small_materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&small_resume_session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        );
+        match small_materializer.finish(&CancellationToken::new()).await {
+            SessionHistoryMaterialization::Downloaded { session, .. } => {
+                assert_eq!(session.history_bytes(), small_body);
+            }
+            _ => panic!("expected small downloaded session"),
+        }
+        small_server.assert_served().await;
+
+        let (request_received_tx, mut request_received_rx) = oneshot::channel();
+        let release_response = Arc::new(Notify::new());
+        let second_server = OneShotSessionHistoryServer::respond_once_after_request(
+            body,
+            request_received_tx,
+            Arc::clone(&release_response),
+        )
+        .await;
+        let second_resume_session = ref_session(
+            second_server.url(),
+            hash,
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let second_materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&second_resume_session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        );
+
+        resources.wait_for_buffer_submissions(3).await;
+        assert!(matches!(
+            request_received_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        drop(first_session);
+        request_received_rx
+            .await
+            .expect("second request should start after the first session drops");
+        release_response.notify_one();
+
+        match second_materializer.finish(&CancellationToken::new()).await {
+            SessionHistoryMaterialization::Downloaded { session, .. } => {
+                assert_eq!(session.history_bytes(), body);
+            }
+            _ => panic!("expected second downloaded session"),
+        }
+        second_server.assert_served().await;
+    }
+
+    #[tokio::test]
+    async fn remote_body_waits_for_destination_and_chunk_capacity_before_request() {
+        let body = b"history\n";
+        let (request_received_tx, mut request_received_rx) = oneshot::channel();
+        let server = OneShotSessionHistoryServer::respond_once_after_request(
+            body,
+            request_received_tx,
+            Arc::new(Notify::new()),
+        )
+        .await;
+        let session = ref_session(
+            server.url(),
+            hex::encode(Sha256::digest(body)),
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let resources = SessionHistoryMaterializationResources::with_test_capacities(
+            1,
+            u32::try_from(body.len()).unwrap(),
+        );
+
+        let result = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        )
+        .finish(&CancellationToken::new())
+        .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(error.to_string().contains("buffer claim is too large"));
+                assert_phase_failure(timings.buffer_admission());
+                assert_no_phase(timings.request_status());
+                assert_no_phase(timings.body_read());
+            }
+            _ => panic!("expected buffer admission failure"),
+        }
+        assert!(matches!(
+            request_received_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelling_buffer_waiter_does_not_request_or_block_later_download() {
+        let body = b"history\n";
+        let buffer_capacity = u32::try_from(body.len() * 2).unwrap();
+        let resources =
+            SessionHistoryMaterializationResources::with_test_capacities(1, buffer_capacity);
+        let blocker = resources
+            .acquire_buffer(
+                SessionHistoryBufferClaim::sidecar_raw(buffer_capacity as u64).unwrap(),
+                &CancellationToken::new(),
+            )
+            .await
+            .result
+            .unwrap();
+
+        let (request_received_tx, mut request_received_rx) = oneshot::channel();
+        let blocked_server = OneShotSessionHistoryServer::respond_once_after_request(
+            body,
+            request_received_tx,
+            Arc::new(Notify::new()),
+        )
+        .await;
+        let blocked_session = ref_session(
+            blocked_server.url(),
+            hex::encode(Sha256::digest(body)),
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let cancel = CancellationToken::new();
+        let blocked_materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&blocked_session),
+            EffectiveCliFramework::ClaudeCode,
+            cancel.clone(),
+            None,
+        );
+        resources.wait_for_buffer_submissions(2).await;
+        assert!(matches!(
+            request_received_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        cancel.cancel();
+        let cancelled = blocked_materializer.finish(&CancellationToken::new()).await;
+        match cancelled {
+            SessionHistoryMaterialization::Failed { timings, .. } => {
+                assert_phase_failure(timings.buffer_admission());
+            }
+            _ => panic!("expected cancelled buffer admission"),
+        }
+        drop(blocked_server);
+        drop(blocker);
+
+        let next_server = serve_once("200 OK", body, Some(body.len() as u64)).await;
+        let next_session = ref_session(
+            next_server.url(),
+            hex::encode(Sha256::digest(body)),
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let next_result = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&next_session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        )
+        .finish(&CancellationToken::new())
+        .await;
+        assert!(matches!(
+            next_result,
+            SessionHistoryMaterialization::Downloaded { .. }
+        ));
+        next_server.assert_served().await;
+    }
+
+    #[tokio::test]
     async fn materializer_attributes_verified_and_divergent_raw_prefixes() {
         let requested_history = b"prefix\nextension\n";
         let cases: [(&[u8], bool); 2] = [(b"prefix\n", true), (b"differ\n", false)];
@@ -1796,16 +2092,29 @@ mod tests {
         ])
         .await;
         let session = zstd_ref_session(server.url(), hash, body.len() as u64, encoded_size);
+        let claim_bytes = encoded_size + encoded_size.max(body.len() as u64);
+        let resources = SessionHistoryMaterializationResources::with_test_capacities(
+            1,
+            u32::try_from(claim_bytes).unwrap(),
+        );
 
-        let result = start_materializer(&session)
-            .finish(&CancellationToken::new())
-            .await;
+        let result = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        )
+        .finish(&CancellationToken::new())
+        .await;
 
         match result {
             SessionHistoryMaterialization::Downloaded {
                 session, timings, ..
             } => {
                 assert_eq!(session.history_bytes(), body);
+                assert_phase_success(timings.buffer_admission());
                 assert_phase_success(timings.request_status());
                 assert_phase_success(timings.body_read());
                 assert_phase_success(timings.validation());
@@ -2828,10 +3137,11 @@ mod tests {
             1,
         );
         let probe = SessionHistoryProbe::with_limits_for_test(Duration::from_secs(60), 8);
+        let resources = SessionHistoryMaterializationResources::with_test_capacities(1, 2);
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
-            &SessionHistoryCpuPool::with_capacity(1),
+            &resources,
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             CancellationToken::new(),
@@ -2856,6 +3166,30 @@ mod tests {
             SessionHistoryCacheProbeMetadata::new(true, false)
         );
         repeated.finish();
+
+        let body = b"x";
+        let next_server = serve_once("200 OK", body, Some(body.len() as u64)).await;
+        let next_session = ref_session(
+            next_server.url(),
+            hex::encode(Sha256::digest(body)),
+            body.len() as u64,
+            body.len() as u64,
+        );
+        let next_result = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            &resources,
+            Some(&next_session),
+            EffectiveCliFramework::ClaudeCode,
+            CancellationToken::new(),
+            None,
+        )
+        .finish(&CancellationToken::new())
+        .await;
+        assert!(matches!(
+            next_result,
+            SessionHistoryMaterialization::Downloaded { .. }
+        ));
+        next_server.assert_served().await;
     }
 
     #[tokio::test]
@@ -2884,7 +3218,7 @@ mod tests {
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             cancel.clone(),
@@ -2938,7 +3272,7 @@ mod tests {
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
-            &SessionHistoryCpuPool::with_capacity(1),
+            &SessionHistoryMaterializationResources::for_host_cpus(2),
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             cancel.clone(),

--- a/crates/runner/src/executor/session_history_materialization.rs
+++ b/crates/runner/src/executor/session_history_materialization.rs
@@ -1,0 +1,56 @@
+//! Shared CPU and payload resources for session-history materialization.
+
+use tokio_util::sync::CancellationToken;
+
+use super::RunnerResult;
+use super::session_history_buffer::{
+    SessionHistoryBufferAdmission, SessionHistoryBufferClaim, SessionHistoryBufferPool,
+};
+use super::session_history_cpu::{
+    SessionHistoryCpuJob, SessionHistoryCpuOutcome, SessionHistoryCpuPool,
+};
+
+#[derive(Clone)]
+pub(crate) struct SessionHistoryMaterializationResources {
+    cpu: SessionHistoryCpuPool,
+    buffers: SessionHistoryBufferPool,
+}
+
+impl SessionHistoryMaterializationResources {
+    pub(crate) fn for_host_cpus(host_cpus: usize) -> Self {
+        let cpu_capacity = (host_cpus / 2).clamp(1, 4);
+        Self {
+            cpu: SessionHistoryCpuPool::with_capacity(cpu_capacity),
+            buffers: SessionHistoryBufferPool::for_cpu_capacity(cpu_capacity),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_capacities(cpu_capacity: usize, buffer_capacity_bytes: u32) -> Self {
+        Self {
+            cpu: SessionHistoryCpuPool::with_capacity(cpu_capacity),
+            buffers: SessionHistoryBufferPool::with_test_capacity(buffer_capacity_bytes),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_buffer_submissions(&self, expected: usize) {
+        self.buffers.wait_for_submissions(expected).await;
+    }
+
+    pub(super) async fn acquire_buffer(
+        &self,
+        claim: SessionHistoryBufferClaim,
+        cancel: &CancellationToken,
+    ) -> SessionHistoryBufferAdmission {
+        self.buffers.acquire(claim, cancel).await
+    }
+
+    pub(super) async fn materialize(
+        &self,
+        job: SessionHistoryCpuJob,
+        cancel: &CancellationToken,
+    ) -> RunnerResult<SessionHistoryCpuOutcome> {
+        self.cpu.materialize(job, cancel).await
+    }
+}

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -10,6 +10,7 @@ use tracing::{info, warn};
 
 use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
+use super::session_history_buffer::SessionHistoryBufferLease;
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
@@ -59,6 +60,7 @@ pub(super) struct MaterializedResumeSession {
     cli_agent_session_id: String,
     history: MaterializedResumeHistory,
     codex_timestamp: Option<DateTime<Utc>>,
+    _buffer_lease: Option<SessionHistoryBufferLease>,
 }
 
 #[derive(Debug)]
@@ -78,6 +80,7 @@ impl MaterializedResumeSession {
             cli_agent_session_id,
             history: MaterializedResumeHistory::Bytes(history_bytes),
             codex_timestamp,
+            _buffer_lease: None,
         }
     }
 
@@ -90,6 +93,7 @@ impl MaterializedResumeSession {
             cli_agent_session_id,
             history: MaterializedResumeHistory::SharedText(session_history),
             codex_timestamp,
+            _buffer_lease: None,
         }
     }
 
@@ -102,7 +106,13 @@ impl MaterializedResumeSession {
             cli_agent_session_id,
             history: MaterializedResumeHistory::CodexZstd(history_bytes),
             codex_timestamp,
+            _buffer_lease: None,
         }
+    }
+
+    pub(super) fn attach_buffer_lease(&mut self, buffer_lease: SessionHistoryBufferLease) {
+        debug_assert!(self._buffer_lease.is_none());
+        self._buffer_lease = Some(buffer_lease);
     }
 
     pub(super) fn cli_agent_session_id(&self) -> &str {

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -37,18 +37,19 @@ use super::super::agent_run::{
     ProcessCancelTimeouts, RunControls, RunStart, build_agent_start_command, run_in_sandbox,
 };
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
+use super::super::session_history_buffer::SessionHistoryBufferClaim;
 use super::super::storage::guest_download_stdin_command;
 use super::super::telemetry::RunnerSpawnTiming;
 use super::super::{
     EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
-    SessionHistoryMaterializer, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
-    effective_cli_framework,
+    SessionHistoryMaterializationResources, SessionHistoryMaterializer,
+    SessionHistoryRestoreFallback, SessionHistoryRestorePlan, effective_cli_framework,
 };
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, StartProcessGateSandbox, api_artifact,
     api_storage, create_overridden_sandbox, minimal_context, sandbox_exec_error,
-    sandbox_read_file_error, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
-    test_executor_config, test_telemetry,
+    sandbox_read_file_error, sandbox_write_file_error, spawn_run_in_sandbox_test,
+    spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -1135,6 +1136,14 @@ async fn run_in_sandbox_records_gzip_session_history_download_encoding() {
     );
     assert_successful_action_with_session_history_metadata(
         &ops,
+        "session_history_buffer_admission",
+        "gzip",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+    assert_successful_action_with_session_history_metadata(
+        &ops,
         "session_history_download_request_status",
         "gzip",
         "lt_64_kib",
@@ -1325,7 +1334,7 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
 
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
-        &config.session_history_cpu,
+        &config.session_history_materialization,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -1503,22 +1512,24 @@ async fn run_in_sandbox_restores_session_history_from_workspace_sidecar() {
     assert_eq!(writes[0].content, history);
     history_mock.assert_calls_async(0).await;
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action_once(&ops, "session_history_buffer_admission");
     assert_successful_action_once(&ops, "session_history_workspace_cache_restore");
     assert_successful_action_once(&ops, "session_restore");
     assert_no_action(&ops, "session_history_download");
 }
 
 #[tokio::test]
-async fn run_in_sandbox_falls_back_when_workspace_sidecar_hash_mismatches() {
+async fn run_in_sandbox_admits_sidecar_before_read_and_releases_before_fallback() {
     let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
+    let mut config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
     let history = br#"{"type":"init"}"#;
     let corrupt_history = vec![b'x'; history.len()];
     let sidecar_path = dir.path().join("session-history.blob");
-    tokio::fs::write(&sidecar_path, corrupt_history)
-        .await
-        .unwrap();
+    tokio::fs::write(&sidecar_path, history).await.unwrap();
+    let buffer_capacity = u32::try_from(history.len() * 2).unwrap();
+    config.session_history_materialization =
+        SessionHistoryMaterializationResources::with_test_capacities(1, buffer_capacity);
     let server = MockServer::start_async().await;
     let history_mock = server
         .mock_async(|when, then| {
@@ -1542,8 +1553,17 @@ async fn run_in_sandbox_falls_back_when_workspace_sidecar_hash_mismatches() {
         },
     });
 
+    let blocker_claim = SessionHistoryBufferClaim::sidecar_raw(buffer_capacity as u64).unwrap();
+    let blocker = config
+        .session_history_materialization
+        .acquire_buffer(blocker_claim, &tokio_util::sync::CancellationToken::new())
+        .await
+        .result
+        .unwrap();
+    let sidecar_path_for_mutation = sidecar_path.clone();
+
     let mut telemetry = test_telemetry(&config, &ctx);
-    let result = run_in_sandbox(
+    let run = run_in_sandbox(
         &sandbox,
         &ctx,
         &config,
@@ -1562,9 +1582,19 @@ async fn run_in_sandbox_falls_back_when_workspace_sidecar_hash_mismatches() {
                 },
                 fallback: None,
             }),
-    )
-    .await
-    .unwrap();
+    );
+    let release = async {
+        config
+            .session_history_materialization
+            .wait_for_buffer_submissions(2)
+            .await;
+        tokio::fs::write(&sidecar_path_for_mutation, corrupt_history)
+            .await
+            .unwrap();
+        drop(blocker);
+    };
+    let (result, ()) = tokio::join!(run, release);
+    let result = result.unwrap();
 
     assert!(result.failure.is_none());
     let writes = sandbox.write_file_calls();
@@ -1582,6 +1612,101 @@ async fn run_in_sandbox_falls_back_when_workspace_sidecar_hash_mismatches() {
         "materialize_error",
     );
     assert_successful_action_once(&ops, "session_history_download");
+    assert_eq!(
+        ops.iter()
+            .filter(|(action, success, _)| {
+                action == "session_history_buffer_admission" && *success
+            })
+            .count(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_releases_sidecar_buffer_after_restore_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    sandbox.push_write_file_result(Err(sandbox_write_file_error("sidecar restore failed")));
+    let history = br#"{"type":"init"}"#;
+    let sidecar_path = dir.path().join("session-history.blob");
+    tokio::fs::write(&sidecar_path, history).await.unwrap();
+    config.session_history_materialization =
+        SessionHistoryMaterializationResources::with_test_capacities(
+            1,
+            u32::try_from(history.len() * 2).unwrap(),
+        );
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-sidecar-restore-fallback-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                encoding: None,
+                raw_size: history.len() as u64,
+                encoded_size: history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = tokio::time::timeout(
+        RUN_IN_SANDBOX_TEST_TIMEOUT,
+        run_in_sandbox(
+            &sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+                .with_session_history_restore_plan(SessionHistoryRestorePlan::LocalSidecar {
+                    sidecar: WorkspaceSessionHistorySidecar {
+                        path: sidecar_path,
+                        representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+                        encoded_size: history.len() as u64,
+                    },
+                    fallback: None,
+                }),
+        ),
+    )
+    .await
+    .expect("remote fallback should not remain blocked by the sidecar buffer")
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 2);
+    assert_eq!(writes[1].content, history);
+    history_mock.assert_calls_async(1).await;
+    let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_workspace_cache_restore",
+        "restore_error",
+    );
+    assert_successful_action_once(&ops, "session_history_download");
+    assert_eq!(
+        ops.iter()
+            .filter(|(action, success, _)| {
+                action == "session_history_buffer_admission" && *success
+            })
+            .count(),
+        2
+    );
 }
 
 #[tokio::test]
@@ -1789,7 +1914,7 @@ async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
 
     let materializer = SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
         &config.http,
-        &config.session_history_cpu,
+        &config.session_history_materialization,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -2525,7 +2650,7 @@ async fn run_in_sandbox_records_mismatch_fallback_and_restores_prestarted_histor
         sandbox.push_read_file_result(Ok(None));
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &config.http,
-            &config.session_history_cpu,
+            &config.session_history_materialization,
             ctx.resume_session.as_ref(),
             effective_cli_framework(&ctx.cli_agent_type),
             tokio_util::sync::CancellationToken::new(),
@@ -2636,7 +2761,7 @@ async fn run_in_sandbox_records_requested_larger_prefix_outcomes_without_changin
         sandbox.push_read_file_result(Ok(None));
         let materializer = SessionHistoryMaterializer::start_cancellable_with_prefix_attribution(
             &config.http,
-            &config.session_history_cpu,
+            &config.session_history_materialization,
             ctx.resume_session.as_ref(),
             effective_cli_framework(&ctx.cli_agent_type),
             tokio_util::sync::CancellationToken::new(),
@@ -2753,7 +2878,7 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
     sandbox.push_read_file_result(Ok(None));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
-        &config.session_history_cpu,
+        &config.session_history_materialization,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -2846,7 +2971,7 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
     ))));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
-        &config.session_history_cpu,
+        &config.session_history_materialization,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -37,7 +37,8 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         network_log_drain: NetworkLogDrainCoordinator::noop(),
         mitm_jsonl_flush: None,
         network_policy_refresh: None,
-        session_history_cpu: super::super::super::SessionHistoryCpuPool::with_capacity(1),
+        session_history_materialization:
+            super::super::super::SessionHistoryMaterializationResources::for_host_cpus(2),
         session_history_probe: super::super::super::SessionHistoryProbe::default(),
         home: HomePaths::with_root(dir.to_path_buf()),
         workspace_cache: None,


### PR DESCRIPTION
## Summary

- add a runner-shared weighted byte budget for remote and workspace-sidecar session-history payloads
- reserve each representation's conservative peak before HTTP or file I/O, then carry RAII ownership through CPU admission, completed materializers, and guest restore
- expose buffer-admission telemetry and add deterministic coverage for contention, retry, cancellation, fallback, and restore-error release

The production budget is derived from the existing session-history CPU and object-size limits, so it requires no operator configuration. Legacy inline history remains outside this budget because its allocation already exists in the claimed job payload before materialization starts.

## Compatibility

- no API, queue payload, persisted-state, sidecar-format, guest-protocol, or database changes
- mixed runner versions continue to consume the same jobs and artifacts

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps --document-private-items`
- `cargo test -p runner --all-features` (2670 passed, 9 ignored; guest inventory passed)
- `git diff --check`

Closes #21365
