### PR TITLE
docs(rust): document guest-write-file private and batch modes

### DIFF
--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -1,12 +1,25 @@
 //! Direct guest file writer used by vsock-guest.
 //!
-//! Usage: `guest-write-file [--append | --create-parents] [--] <path>`.
+//! Accepted syntax:
+//!
+//! ```text
+//! guest-write-file [--private] [--append | --create-parents] [--] <path>
+//! guest-write-file --batch
+//! ```
 //!
 //! Content is read from stdin. Create mode truncates or creates the target.
 //! Append mode creates the target file when its parent already exists, matching
 //! shell `>>`, but does not create missing parents.
 //! Create-parents mode creates missing parent directories before writing.
+//! Private mode writes through the guest runtime private file helpers, ensuring
+//! parent directories are private, creating missing parent directories even
+//! with append mode, and rejecting symlinked parent components.
+//! Batch mode reads a `vsock-proto` `write_files` payload from stdin and writes
+//! every ordinary file entry with create-parent and truncate semantics.
 //! Use `--` before a path that begins with `-`.
+//!
+//! The detailed canonical CLI contract is documented on
+//! [`guest_write_file::run_cli`](fn.run_cli.html).
 
 use std::io;
 


### PR DESCRIPTION
## Summary

- document the `guest-write-file` single-file syntax with `--private`
- document the separate `--batch` invocation and both modes' implemented semantics
- point binary rustdoc readers to the detailed canonical `run_cli` contract

## Scope

This is a documentation-only change. Argument parsing, runtime usage output, file behavior, protocols, callers, dependencies, and deployment behavior are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-write-file --all-targets --all-features`
- `cargo doc -p guest-write-file --all-features --no-deps`
- `cargo doc -p guest-write-file --bin guest-write-file --all-features --no-deps --target-dir target/guest-write-file-bin-doc-check`
- inspected generated binary rustdoc syntax, semantics, and the resolved `run_cli` target
- `cargo test -p guest-write-file`
- pre-commit workspace Rust documentation and Clippy checks

Closes #21440
