### PR TITLE
perf(api): bound storage manifest preload to requested keys

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1852,6 +1852,75 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, initialized.runId, [200]);
   });
 
+  it("preserves missing-volume and artifact resolution with exact candidates", async () => {
+    const api = createRunsApi(context);
+    const storages = createStoragesBddApi(context);
+    const { actor, runnerGroup } = await entitledRunActor();
+    const storageName = `bdd-exact-candidate-${randomUUID().slice(0, 8)}`;
+    const missingComposeName = `bdd-missing-compose-${randomUUID().slice(0, 8)}`;
+    const missingAdditionalName = `bdd-missing-additional-${randomUUID().slice(0, 8)}`;
+    const storageFile = storageTextFile(
+      "candidate.txt",
+      `exact candidate ${storageName}`,
+    );
+    const prepared = await storages.prepareStorage(actor, {
+      storageName,
+      storageType: "volume",
+      files: [storageFile],
+    });
+    await storages.commitStorage(actor, {
+      storageName,
+      storageType: "volume",
+      versionId: prepared.versionId,
+      files: [storageFile],
+    });
+
+    const composeName = `bdd-exact-candidate-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      volumes: {
+        primary: { name: storageName, version: prepared.versionId },
+        optional: {
+          name: missingComposeName,
+          version: "latest",
+          optional: true,
+        },
+      },
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          volumes: ["primary:/primary", "optional:/optional"],
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const created = await api.createDirectRun(actor, {
+      agentComposeVersionId: compose.versionId,
+      prompt: "resolve only exact storage candidates",
+      additionalVolumes: [
+        { name: missingAdditionalName, mountPath: "/additional" },
+      ],
+    });
+    expect(created.status).toBe("pending");
+
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.storageManifest?.storages).toStrictEqual([
+      expect.objectContaining({
+        mountPath: "/primary",
+        vasStorageName: storageName,
+        vasVersionId: prepared.versionId,
+      }),
+    ]);
+    expect(
+      claim.storageManifest?.artifacts.some((artifact) => {
+        return artifact.vasStorageName === "memory";
+      }),
+    ).toBeTruthy();
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("keeps a committed artifact head after initial empty artifact creation", async () => {
     const api = createRunsApi(context);
     const storages = createStoragesBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
@@ -21,6 +21,8 @@ import { mockEnv } from "../../../lib/env";
 import { mockNow, nowDate } from "../../../lib/time";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { storageTextFile } from "./helpers/api-bdd-storage-files";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
 import { cronRefreshStoragePresignedUrlsRoutes } from "../cron-refresh-storage-presigned-urls";
 
@@ -381,6 +383,96 @@ describe("system storage presigned URL cache", () => {
         );
       },
     );
+  });
+
+  it("prefers system storage and falls back to the primary organization", async () => {
+    const api = createRunsApi(context);
+    const storages = createStoragesBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const skill = isolatedSystemSkillStorage();
+    const primaryFile = storageTextFile(
+      "primary.txt",
+      `primary fallback ${randomUUID()}`,
+    );
+    const primary = await storages.prepareStorage(actor, {
+      storageName: skill.storageName,
+      storageType: "volume",
+      files: [primaryFile],
+    });
+    await storages.commitStorage(actor, {
+      storageName: skill.storageName,
+      storageType: "volume",
+      versionId: primary.versionId,
+      files: [primaryFile],
+    });
+
+    await withCacheCleanup({ objectKeyPrefix: skill.s3Prefix }, async () => {
+      await withStorageStateRestore(
+        {
+          orgId: SYSTEM_ORG_ID,
+          userId: VOLUME_ORG_USER_ID,
+          storageName: skill.storageName,
+          cleanupVersionId: skill.versionId,
+        },
+        async () => {
+          await seedStorageVersion({
+            orgId: SYSTEM_ORG_ID,
+            userId: VOLUME_ORG_USER_ID,
+            storageName: skill.storageName,
+            versionId: skill.versionId,
+            s3Prefix: skill.s3Prefix,
+            s3Key: skill.s3Key,
+          });
+
+          const systemRun = await api.createRun(actor, {
+            agentId,
+            prompt: "prefer the system storage candidate",
+            modelProvider: "anthropic-api-key",
+          });
+          await api.heartbeatRunner(runnerGroup);
+          const systemClaim = await api.claimRunnerJob(systemRun.runId);
+          expect(
+            systemClaim.storageManifest?.storages.find((storage) => {
+              return storage.vasStorageName === skill.storageName;
+            }),
+          ).toMatchObject({ vasVersionId: skill.versionId });
+
+          // A system row without a HEAD is intentionally treated as missing,
+          // so the same injected volume must resolve from the primary org.
+          await restoreStorageState({
+            orgId: SYSTEM_ORG_ID,
+            userId: VOLUME_ORG_USER_ID,
+            storageName: skill.storageName,
+            previous: {
+              s3_prefix: skill.s3Prefix,
+              size: 1,
+              file_count: 1,
+              head_version_id: null,
+            },
+          });
+
+          const fallbackRun = await api.createRun(actor, {
+            agentId,
+            prompt: "fall back to the primary storage candidate",
+            modelProvider: "anthropic-api-key",
+          });
+          const fallbackClaim = await api.claimRunnerJob(fallbackRun.runId);
+          expect(
+            fallbackClaim.storageManifest?.storages.find((storage) => {
+              return storage.vasStorageName === skill.storageName;
+            }),
+          ).toMatchObject({ vasVersionId: primary.versionId });
+          expect(
+            fallbackClaim.storageManifest?.artifacts.some((artifact) => {
+              return artifact.vasStorageName === "memory";
+            }),
+          ).toBeTruthy();
+
+          await api.requestCancelRun(actor, systemRun.runId, [200]);
+          await api.requestCancelRun(actor, fallbackRun.runId, [200]);
+        },
+      );
+    });
   });
 
   it("refreshes only a bounded due cache batch from cron", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -12,7 +12,7 @@ import {
 import { MIN_VERSION_PREFIX_LENGTH } from "@vm0/core/version-id";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { computed, type Computed } from "ccstate";
-import { and, eq, inArray, isNull, like } from "drizzle-orm";
+import { and, eq, isNull, like, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { generatePresignedGetUrl } from "../external/s3";
@@ -228,8 +228,8 @@ interface StorageManifestPhaseTimingWindow {
 /**
  * Pre-fetched (orgId, userId, name, type) -> storage row map. A single run
  * resolves dozens to hundreds of volumes/artifacts; looking each up with its
- * own `SELECT storages` round-trip saturates the connection pool, so all rows
- * for the relevant orgs are loaded once and resolved from memory instead.
+ * own `SELECT storages` round-trip saturates the connection pool, so the exact
+ * requested rows are loaded once and resolved from memory instead.
  */
 type StorageIndex = ReadonlyMap<string, StorageIndexEntry>;
 
@@ -1036,11 +1036,44 @@ function storageIndexKey(
   return JSON.stringify([orgId, userId, name, type]);
 }
 
+function artifactStorageLookup(
+  orgId: string,
+  userId: string,
+  name: string,
+): StorageLookup {
+  return { orgId, userId, name, type: "artifact" };
+}
+
 async function loadStorageIndex(
   db: Db,
-  orgIds: readonly string[],
+  lookups: readonly StorageLookup[],
 ): Promise<StorageIndex> {
-  const uniqueOrgIds = [...new Set(orgIds)];
+  const lookupsByKey = new Map<string, StorageLookup>();
+  for (const lookup of lookups) {
+    lookupsByKey.set(
+      storageIndexKey(lookup.orgId, lookup.userId, lookup.name, lookup.type),
+      lookup,
+    );
+  }
+  const uniqueLookups = [...lookupsByKey.values()];
+  if (uniqueLookups.length === 0) {
+    return new Map<string, StorageIndexEntry>();
+  }
+
+  const orgIds = uniqueLookups.map((lookup) => {
+    return lookup.orgId;
+  });
+  const userIds = uniqueLookups.map((lookup) => {
+    return lookup.userId;
+  });
+  const names = uniqueLookups.map((lookup) => {
+    return lookup.name;
+  });
+  const types = uniqueLookups.map((lookup) => {
+    return lookup.type;
+  });
+  // Raw array interpolation expands to a SQL tuple in Drizzle. Keep each
+  // zipped array in one driver parameter so the statement shape stays fixed.
   const rows = await db
     .select({
       orgId: storages.orgId,
@@ -1054,8 +1087,19 @@ async function loadStorageIndex(
       fileCount: storageVersions.fileCount,
     })
     .from(storages)
-    .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
-    .where(inArray(storages.orgId, uniqueOrgIds));
+    .innerJoin(
+      sql`unnest(
+        ${sql.param(orgIds)}::text[],
+        ${sql.param(userIds)}::text[],
+        ${sql.param(names)}::varchar(256)[],
+        ${sql.param(types)}::varchar(16)[]
+      ) AS requested(org_id, user_id, name, type)`,
+      sql`${storages.orgId} = requested.org_id
+        AND ${storages.userId} = requested.user_id
+        AND ${storages.name} = requested.name
+        AND ${storages.type} = requested.type`,
+    )
+    .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id));
 
   const index = new Map<string, StorageIndexEntry>();
   for (const row of rows) {
@@ -1216,12 +1260,7 @@ function ensureArtifactStorage(
   args: EnsureArtifactStorageArgs,
 ): Computed<Promise<void>> {
   return computed(async (): Promise<void> => {
-    const lookup = {
-      orgId: args.orgId,
-      userId: args.userId,
-      name: args.name,
-      type: "artifact" as const,
-    };
+    const lookup = artifactStorageLookup(args.orgId, args.userId, args.name);
     const storage = await findOrCreateArtifactStorage(args, lookup);
     if (!storage) {
       throw new Error(`Failed to create artifact storage "${args.name}"`);
@@ -1382,6 +1421,18 @@ function volumeVersion(
   return "vasVersion" in volume ? volume.vasVersion : volume.version;
 }
 
+function volumeStorageLookup(
+  orgId: string,
+  volume: ResolvedVolume | AdditionalVolume,
+): StorageLookup {
+  return {
+    orgId,
+    userId: VOLUME_ORG_USER_ID,
+    name: volumeStorageName(volume),
+    type: "volume",
+  };
+}
+
 async function resolveVolumeStorage(args: {
   readonly db: Db;
   readonly index: StorageIndex;
@@ -1394,12 +1445,7 @@ async function resolveVolumeStorage(args: {
       resolveStorageVersion(
         args.db,
         args.index,
-        {
-          orgId: SYSTEM_ORG_ID,
-          userId: VOLUME_ORG_USER_ID,
-          name: volumeStorageName(args.volume),
-          type: "volume",
-        },
+        volumeStorageLookup(SYSTEM_ORG_ID, args.volume),
         volumeVersion(args.volume),
       ),
     );
@@ -1414,12 +1460,7 @@ async function resolveVolumeStorage(args: {
   return await resolveStorageVersion(
     args.db,
     args.index,
-    {
-      orgId: args.primaryOrgId,
-      userId: VOLUME_ORG_USER_ID,
-      name: volumeStorageName(args.volume),
-      type: "volume",
-    },
+    volumeStorageLookup(args.primaryOrgId, args.volume),
     volumeVersion(args.volume),
   );
 }
@@ -1500,12 +1541,7 @@ async function resolveArtifactStorageInput(args: {
   const resolved = await resolveStorageVersion(
     args.db,
     args.index,
-    {
-      orgId: args.runtimeOrgId,
-      userId: args.userId,
-      name: args.artifact.name,
-      type: "artifact",
-    },
+    artifactStorageLookup(args.runtimeOrgId, args.userId, args.artifact.name),
     args.artifact.version,
   );
   return { artifact: args.artifact, resolved, source: args.source };
@@ -1902,8 +1938,7 @@ async function ensureStorageManifestArtifacts(
 
 async function loadTimedStorageIndex(args: {
   readonly db: Db;
-  readonly agentOrgId: string;
-  readonly runtimeOrgId: string;
+  readonly lookups: readonly StorageLookup[];
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<StorageIndex> {
   // Resolve every volume/artifact from one pre-fetched snapshot instead of a
@@ -1914,13 +1949,40 @@ async function loadTimedStorageIndex(args: {
     "api_dispatch_prepare_storage_manifest_load_storage_index",
     "nested",
     async () => {
-      return await loadStorageIndex(args.db, [
-        args.agentOrgId,
-        args.runtimeOrgId,
-        SYSTEM_ORG_ID,
-      ]);
+      return await loadStorageIndex(args.db, args.lookups);
     },
   );
+}
+
+function storageManifestLookups(args: {
+  readonly agentOrgId: string;
+  readonly runtimeOrgId: string;
+  readonly userId: string;
+  readonly composeVolumes: readonly ResolvedVolume[];
+  readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly artifacts: readonly ContextArtifact[];
+}): readonly StorageLookup[] {
+  const lookups: StorageLookup[] = [];
+
+  for (const volume of args.composeVolumes) {
+    if (volume.system) {
+      lookups.push(volumeStorageLookup(SYSTEM_ORG_ID, volume));
+    }
+    lookups.push(volumeStorageLookup(args.agentOrgId, volume));
+  }
+  for (const volume of args.additionalVolumes ?? []) {
+    if (volume.system) {
+      lookups.push(volumeStorageLookup(SYSTEM_ORG_ID, volume));
+    }
+    lookups.push(volumeStorageLookup(args.runtimeOrgId, volume));
+  }
+  for (const artifact of args.artifacts) {
+    lookups.push(
+      artifactStorageLookup(args.runtimeOrgId, args.userId, artifact.name),
+    );
+  }
+
+  return lookups;
 }
 
 function createStorageManifestEntryPhaseTimings(args: {
@@ -2205,8 +2267,14 @@ export function prepareAgentRunStorageManifest(
 
     const storageIndex = await loadTimedStorageIndex({
       db: args.db,
-      agentOrgId: args.agentOrgId,
-      runtimeOrgId: args.runtimeOrgId,
+      lookups: storageManifestLookups({
+        agentOrgId: args.agentOrgId,
+        runtimeOrgId: args.runtimeOrgId,
+        userId: args.userId,
+        composeVolumes,
+        additionalVolumes: args.additionalVolumes,
+        artifacts,
+      }),
       timing: args.timing,
     });
 


### PR DESCRIPTION
## Summary

- derive and deduplicate the exact volume and artifact storage keys a run can resolve
- replace the organization-wide preload with one stable four-array `unnest` join using the existing composite unique index
- preserve system-first fallback, optional/missing volume handling, artifact initialization, pinned versions, manifest ordering, and existing timing boundaries
- add real-route PostgreSQL coverage for system precedence, primary fallback, optional compose volumes, missing additional volumes, and artifacts

## Query plan evidence

A representative `EXPLAIN (ANALYZE, BUFFERS)` used the real migrated tables and indexes with 17 requested keys, 5,000 unrelated same-org rows, and 45,000 other-org rows:

```text
Function Scan on requested                          actual rows=17
Index Scan using idx_storages_org_user_name_type   actual rows=1 loops=17
Index Scan using storage_versions_pkey             actual rows=1 loops=17
Planning Time: 0.280 ms
Execution Time: 0.104 ms
```

The query returned exactly 17 rows. Fixture writes ran in a transaction, were rolled back, and left no benchmark rows.

## Compatibility and exclusions

- no schema, migration, backfill, or persisted-data change
- no process-local or persisted cache
- no public API, queue payload, runner protocol, or feature-switch change
- rollback is code-only and old/new API instances remain compatible

## Validation

- [x] `pnpm exec prettier --check <affected files>`
- [x] `pnpm -F api lint`
- [x] `pnpm knip --workspace api`
- [x] `pnpm -F api check-types`
- [x] `DATABASE_URL=<isolated-local-db> pnpm -F api exec vitest run src/signals/routes/__tests__/storage-presigned-url-cache.test.ts --silent=passed-only` (8 passed)
- [x] `DATABASE_URL=<isolated-local-db> pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (103 passed)
- [x] pinned-prefix checkpoint resume integration test (1 passed)
- [x] `DATABASE_URL=<isolated-local-db> pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (161 files, 2,178 tests passed)
- [x] pre-commit full Knip and 13-workspace typecheck

Closes #21422

Parent context: #18746
