### PR TITLE
fix(mitm-addon): stop linting after terminal exhaustive matches

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -436,9 +436,19 @@ def _statement_flow(statement: ast.stmt) -> _FlowSummary:
             raises=body_flow.raises or orelse_flow.raises,
         )
     if isinstance(statement, ast.Match):
+        case_falls_through = False
+        has_unmatched_path = True
+        raises = False
+        for case in statement.cases:
+            case_flow = _body_flow(case.body)
+            case_falls_through = case_falls_through or case_flow.falls_through
+            raises = raises or case_flow.raises
+            if case.guard is None and _pattern_is_exhaustive(case.pattern):
+                has_unmatched_path = False
+                break
         return _FlowSummary(
-            falls_through=True,
-            raises=any(_body_flow(case.body).raises for case in statement.cases),
+            falls_through=has_unmatched_path or case_falls_through,
+            raises=raises,
         )
     if isinstance(statement, ast.ClassDef):
         return _body_flow(statement.body)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_reachability.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_reachability.base.py.txt
@@ -1,0 +1,45 @@
+def terminal_returns(flow, value):
+    match value:
+        case 1:
+            return
+        case _:
+            return
+    flow.metadata["vm_run_id"] = "dead-return"
+
+def terminal_raise(flow, value):
+    match value:
+        case 1:
+            return
+        case _:
+            raise RuntimeError
+    flow.metadata["vm_run_id"] = "dead-raise"
+
+def unmatched_path(flow, value):
+    match value:
+        case 1:
+            return
+    flow.metadata["vm_run_id"] = "unmatched"
+
+def guarded_wildcard(flow, value, condition):
+    match value:
+        case _ if condition:
+            return
+    flow.metadata["vm_run_id"] = "guarded"
+
+def case_fallthrough(flow, value):
+    match value:
+        case 1:
+            return
+        case _:
+            pass
+    flow.metadata["vm_run_id"] = "case-fallthrough"
+
+def suppressible_raise(flow, value):
+    meta = flow.metadata
+    with context():
+        match value:
+            case 1:
+                return
+            case _:
+                raise RuntimeError
+    meta["vm_run_id"] = "suppressed"

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_reachability.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/match_reachability.expected.txt
@@ -1,0 +1,4 @@
+match_reachability.py:21: use metadata_keys.VM_RUN_ID for flow.metadata access
+match_reachability.py:27: use metadata_keys.VM_RUN_ID for flow.metadata access
+match_reachability.py:35: use metadata_keys.VM_RUN_ID for flow.metadata access
+match_reachability.py:45: use metadata_keys.VM_RUN_ID for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -159,6 +159,17 @@ def test_registered_flow_metadata_guard_tracks_context_manager_exception_paths(t
     )
 
 
+def test_registered_flow_metadata_guard_tracks_match_reachability(tmp_path):
+    source_path = tmp_path / "match_reachability.py"
+    _write_python_source(source_path, "match_reachability.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "match_reachability.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_tracks_with_item_binding_order(tmp_path):
     source_path = tmp_path / "with_item_bindings.py"
     _write_python_source(source_path, "with_item_bindings.base.py.txt")


### PR DESCRIPTION
## Summary

- model `match` fallthrough from both reachable case-body exits and the unmatched-subject path
- keep explicit raises independent so surrounding context managers and exception handling retain their existing behavior
- add a public-entry regression matrix for terminal, non-exhaustive, guarded, fallthrough, and suppressible-raise paths

## Scope

- repository-only flow-metadata lint tooling and tests
- no runtime addon, API, schema, persisted-data, dependency, migration, generated-output, or deployment-protocol changes

## Validation

- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .` (0 errors, 0 warnings, 0 notes)
- `python3 -m pytest tests/test_flow_metadata_key_contract.py -q` (12 passed)
- `python3 scripts/check-flow-metadata-keys.py`
- `python3 -m pytest tests/ -q` (3939 passed)

Closes #21445
