### PR TITLE
refactor: route chat queues through one per-thread scheduler

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -67,7 +67,7 @@ import {
   type BeforeRunDispatch,
 } from "../services/agent-run-create.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { drainQueuedUserMessagesForThread$ } from "../services/internal-chat-run-callback.service";
+import { drainChatThreadQueueForThread$ } from "../services/chat-thread-queue-drain.service";
 import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
@@ -3395,8 +3395,11 @@ const sendQueueFirstNormalMessage$ = command(
       await publishChatMessageCreated(args.userId, threadId);
       signal.throwIfAborted();
       await set(
-        drainQueuedUserMessagesForThread$,
-        { chatThreadId: threadId },
+        drainChatThreadQueueForThread$,
+        {
+          chatThreadId: threadId,
+          dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        },
         signal,
       );
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
@@ -20,7 +20,8 @@ import {
   setWorkflowQueuePause,
   type WorkflowQueueThreadRow,
 } from "../services/chat-message-queue.service";
-import { drainWorkflowQueueForThread$ } from "../services/zero-workflow-queue-drain.service";
+import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
+import { drainChatThreadQueueForThread$ } from "../services/chat-thread-queue-drain.service";
 import type { RouteEntry } from "../route-entry";
 
 const workflowReadAuth = {
@@ -213,8 +214,11 @@ const setPauseInner = (paused: boolean) => {
       // Resuming re-drains immediately instead of waiting for the next
       // terminal run or the safety-net cron.
       await set(
-        drainWorkflowQueueForThread$,
-        { chatThreadId: params.threadId },
+        drainChatThreadQueueForThread$,
+        {
+          chatThreadId: params.threadId,
+          dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        },
         signal,
       );
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -10,6 +10,7 @@ import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { settle, tapError } from "../utils";
+import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { handleAgentInternalCallback$ } from "./internal-agent-run-callback.service";
@@ -85,6 +86,23 @@ interface DispatchSingleCallbackInput {
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
+export async function chatCallbackIdForRun(
+  db: Db,
+  runId: string,
+): Promise<string | undefined> {
+  const [callback] = await db
+    .select({ id: agentRunCallbacks.id })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.internalKind, "chat"),
+      ),
+    )
+    .limit(1);
+  return callback?.id;
+}
+
 interface DispatchInternalRunCallbackInput {
   readonly db: Db;
   readonly callback: CallbackRecord;
@@ -119,7 +137,24 @@ const dispatchInternalCallback$ = command(
         );
       }
       case "chat": {
-        return await set(handleChatInternalCallback$, input.envelope, signal);
+        return await set(
+          handleChatInternalCallback$,
+          {
+            callback: input.envelope,
+            drainThreadQueue: (chatThreadId, inputSignal, timing) => {
+              return set(
+                drainChatThreadQueueForThread$,
+                {
+                  chatThreadId,
+                  dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+                  timing,
+                },
+                inputSignal,
+              );
+            },
+          },
+          signal,
+        );
       }
       case "github:issues": {
         return await set(

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -14,11 +14,15 @@ import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { publishRunChangedForUserSafely } from "../external/realtime";
 import { tapError } from "../utils";
-import { dispatchRunCallbacks$ } from "./agent-run-callback.service";
+import {
+  chatCallbackIdForRun,
+  dispatchFailedRunCallbacks,
+  dispatchRunCallbacks$,
+} from "./agent-run-callback.service";
+import { drainChatThreadQueueForRun$ } from "./chat-thread-queue-drain.service";
 import { maybeEmitRunUsageMessage$ } from "./zero-chat-usage-message.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import { drainOrgQueue$ } from "./zero-run-queue.service";
-import { drainWorkflowQueueForRun$ } from "./zero-workflow-queue-drain.service";
 
 type WebhookCompleteBody = z.infer<
   typeof webhookCompleteContract.complete.body
@@ -374,7 +378,9 @@ export const dispatchCompleteSideEffects$ = command(
     const db = set(writeDb$);
     const callbackStatus =
       input.status === "completed" ? "completed" : "failed";
-    await tapError(
+    const chatCallbackId = await chatCallbackIdForRun(db, input.runId);
+    signal.throwIfAborted();
+    const callbackResults = await tapError(
       set(
         dispatchRunCallbacks$,
         {
@@ -394,23 +400,35 @@ export const dispatchCompleteSideEffects$ = command(
     );
     signal.throwIfAborted();
 
+    const chatCallbackDrained = callbackResults?.some((result) => {
+      return result.callbackId === chatCallbackId && result.success;
+    });
+    if (!chatCallbackDrained) {
+      await tapError(
+        set(
+          drainChatThreadQueueForRun$,
+          {
+            runId: input.runId,
+            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("Failed to drain chat thread queue", {
+            runId: input.runId,
+            error,
+          });
+        },
+      );
+      signal.throwIfAborted();
+    }
+
     await tapError(
       set(drainOrgQueue$, { orgId: input.orgId }, signal),
       (error) => {
         L.error("Failed to drain org queue", {
           runId: input.runId,
           orgId: input.orgId,
-          error,
-        });
-      },
-    );
-    signal.throwIfAborted();
-
-    await tapError(
-      set(drainWorkflowQueueForRun$, { runId: input.runId }, signal),
-      (error) => {
-        L.error("Failed to drain workflow queue", {
-          runId: input.runId,
           error,
         });
       },

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -1,0 +1,110 @@
+import { command } from "ccstate";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { eq } from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
+import { pendingWorkflowQueueThreadIds } from "./chat-message-queue.service";
+import {
+  drainQueuedUserMessagesForThread$,
+  type ChatCallbackPreCreateTimingCollector,
+} from "./internal-chat-run-callback.service";
+import { drainWorkflowQueueForThread$ } from "./zero-workflow-queue-drain.service";
+
+const DRAIN_SWEEP_LIMIT = 20;
+
+interface DrainChatThreadQueueInput {
+  readonly chatThreadId: string;
+  readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+  readonly timing?: ChatCallbackPreCreateTimingCollector;
+}
+
+/**
+ * The single per-thread scheduler entry. User messages are attempted first;
+ * the workflow drain then observes the newly-created active run and stops, or
+ * consumes the oldest workflow event when no user message dispatched.
+ *
+ * Compatibility-specific reads remain inside the two drain halves until the
+ * follow-up cleanup removes the old queue representations.
+ */
+export const drainChatThreadQueueForThread$ = command(
+  async (
+    { set },
+    input: DrainChatThreadQueueInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      drainQueuedUserMessagesForThread$,
+      { chatThreadId: input.chatThreadId, timing: input.timing },
+      signal,
+    );
+    signal.throwIfAborted();
+    await set(
+      drainWorkflowQueueForThread$,
+      {
+        chatThreadId: input.chatThreadId,
+        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+      },
+      signal,
+    );
+  },
+);
+
+/** Resolve a terminal run's thread before entering the shared scheduler. */
+export const drainChatThreadQueueForRun$ = command(
+  async (
+    { set },
+    input: {
+      readonly runId: string;
+      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({ chatThreadId: zeroRuns.chatThreadId })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.id, input.runId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (!run?.chatThreadId) {
+      return;
+    }
+    await set(
+      drainChatThreadQueueForThread$,
+      {
+        chatThreadId: run.chatThreadId,
+        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+      },
+      signal,
+    );
+  },
+);
+
+/** Re-enter the shared scheduler for workflow queues missed by callbacks. */
+export const drainStaleChatThreadQueues$ = command(
+  async (
+    { set },
+    input: { readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks },
+    signal: AbortSignal,
+  ): Promise<number> => {
+    const db = set(writeDb$);
+    const threadIds = await pendingWorkflowQueueThreadIds(
+      db,
+      DRAIN_SWEEP_LIMIT,
+    );
+    signal.throwIfAborted();
+    for (const chatThreadId of threadIds) {
+      await set(
+        drainChatThreadQueueForThread$,
+        {
+          chatThreadId,
+          dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+    return threadIds.length;
+  },
+);

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -26,7 +26,8 @@ import {
   drainStaleQueues$,
   type QueuedRunMaintenanceTimeout,
 } from "./zero-run-queue.service";
-import { drainStaleWorkflowQueues$ } from "./zero-workflow-queue-drain.service";
+import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { drainStaleChatThreadQueues$ } from "./chat-thread-queue-drain.service";
 import type { QueueMarkerRevokeNotification } from "./zero-chat-queue-marker.service";
 
 const L = logger("CronCleanupSandboxes");
@@ -527,9 +528,16 @@ export const cleanupSandboxes$ = command(
     signal.throwIfAborted();
     const drainedCount = await set(drainStaleQueues$, signal);
     signal.throwIfAborted();
-    await tapError(set(drainStaleWorkflowQueues$, signal), (error) => {
-      L.error("Failed to drain stale workflow queues", { error });
-    });
+    await tapError(
+      set(
+        drainStaleChatThreadQueues$,
+        { dispatchFailedCallbacks: dispatchFailedRunCallbacks },
+        signal,
+      ),
+      (error) => {
+        L.error("Failed to drain stale chat thread queues", { error });
+      },
+    );
     signal.throwIfAborted();
     const queuedTerminalRuns = [
       ...expiredQueueResult.timedOutRuns,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -133,7 +133,7 @@ interface ChatCallbackPreCreateTimingRecord {
   readonly timestamp: string;
 }
 
-class ChatCallbackPreCreateTimingCollector {
+export class ChatCallbackPreCreateTimingCollector {
   private readonly records: ChatCallbackPreCreateTimingRecord[] = [];
   private flushed = false;
 
@@ -394,6 +394,11 @@ interface ChatCallbackDependencies {
   ) => Promise<string>;
   readonly getResolvedAttachFiles: ResolveAttachFiles;
   readonly createQueuedRun?: CreateQueuedRun;
+  readonly drainThreadQueue?: (
+    chatThreadId: string,
+    signal: AbortSignal,
+    timing?: ChatCallbackPreCreateTimingCollector,
+  ) => Promise<void>;
 }
 
 interface ChatThreadForRunRow {
@@ -440,11 +445,11 @@ type FailedChatCallbackResult =
   | { readonly inserted: false };
 
 interface TerminalChatCallbackWork {
-  readonly shouldAutoSendQueuedMessage: boolean;
+  readonly shouldDrainThreadQueue: boolean;
   readonly deferredSideEffects?: () => Promise<void>;
 }
 
-type AutoSendOutcome =
+type DrainOutcome =
   | { readonly ok: true }
   | { readonly ok: false; readonly error: unknown };
 
@@ -2114,43 +2119,11 @@ async function publishAutoSentQueuedRunSignals(args: {
   );
 }
 
-async function autoSendQueuedMessageOnRunComplete(args: {
-  readonly getResolvedAttachFiles: ResolveAttachFiles;
-  readonly createRun: (
-    input: CreateQueuedChatRunInput,
-  ) => Promise<CreatedQueuedRun | null>;
-  readonly db: Db;
-  readonly runId: string;
-  readonly agentId: string;
-  readonly timing: ChatCallbackPreCreateTimingCollector;
-}): Promise<void> {
-  const chatThread = await measureChatCallbackPreCreateTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
-    "nested",
-    () => {
-      return chatThreadForRunFromDb(args.db, args.runId);
-    },
-  );
-  if (!chatThread) {
-    return;
-  }
-  await autoSendQueuedMessageForThread({
-    getResolvedAttachFiles: args.getResolvedAttachFiles,
-    createRun: args.createRun,
-    db: args.db,
-    chatThreadId: chatThread.chatThreadId,
-    userId: chatThread.userId,
-    agentId: args.agentId,
-    timing: args.timing,
-  });
-}
-
 /**
- * Core user-message drain: when the thread has no in-flight run, dispatch the
- * oldest unclaimed queued message — whoever sent it. Shared by the terminal
- * chat callback, cancel side effects, and the send route (#21392): together
- * these cover every path into the "idle + non-empty queue" state.
+ * User-message half of the per-thread scheduler: when the thread has no
+ * in-flight run, dispatch the oldest queued user message — whoever sent it.
+ * The shared thread scheduler calls this before attempting the workflow-event
+ * half, preserving user-message priority.
  */
 async function autoSendQueuedMessageForThread(args: {
   readonly getResolvedAttachFiles: ResolveAttachFiles;
@@ -2341,39 +2314,6 @@ async function loadTerminalChatCallback(args: {
   return { run, chatThread };
 }
 
-async function autoSendQueuedMessageForTerminalCallback(args: {
-  readonly db: Db;
-  readonly runId: string;
-  readonly agentId: string;
-  readonly apiStartTime: number;
-  readonly dependencies: ChatCallbackDependencies;
-  readonly timing: ChatCallbackPreCreateTimingCollector;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  const createQueuedRun = args.dependencies.createQueuedRun;
-  if (!createQueuedRun) {
-    return;
-  }
-
-  await autoSendQueuedMessageOnRunComplete({
-    db: args.db,
-    runId: args.runId,
-    agentId: args.agentId,
-    timing: args.timing,
-    getResolvedAttachFiles: args.dependencies.getResolvedAttachFiles,
-    createRun: (input) => {
-      return createQueuedChatRun({
-        db: args.db,
-        input,
-        signal: args.signal,
-        createRun: (runInput) => {
-          return createQueuedRun(runInput, args.apiStartTime, args.signal);
-        },
-      });
-    },
-  });
-}
-
 async function prepareCompletedTerminalChatCallbackWork(args: {
   readonly db: Db;
   readonly runId: string;
@@ -2411,11 +2351,11 @@ async function prepareCompletedTerminalChatCallbackWork(args: {
     },
   );
   if (!completed.inserted) {
-    return { shouldAutoSendQueuedMessage: false };
+    return { shouldDrainThreadQueue: false };
   }
 
   return {
-    shouldAutoSendQueuedMessage: true,
+    shouldDrainThreadQueue: true,
     deferredSideEffects: () => {
       return runCompletedChatCallbackSideEffects({
         db: args.db,
@@ -2473,11 +2413,11 @@ async function prepareFailedTerminalChatCallbackWork(args: {
     },
   );
   if (!failed.inserted) {
-    return { shouldAutoSendQueuedMessage: false };
+    return { shouldDrainThreadQueue: false };
   }
 
   return {
-    shouldAutoSendQueuedMessage: true,
+    shouldDrainThreadQueue: true,
     deferredSideEffects: () => {
       return runFailedChatCallbackSideEffects({
         db: args.db,
@@ -2489,37 +2429,29 @@ async function prepareFailedTerminalChatCallbackWork(args: {
   };
 }
 
-async function maybeAutoSendQueuedMessageForTerminalCallback(args: {
+async function maybeDrainThreadQueueForTerminalCallback(args: {
   readonly enabled: boolean;
-  readonly db: Db;
-  readonly runId: string;
-  readonly agentId: string;
-  readonly apiStartTime: number;
+  readonly chatThreadId: string;
   readonly dependencies: ChatCallbackDependencies;
   readonly timing: ChatCallbackPreCreateTimingCollector;
   readonly signal: AbortSignal;
-}): Promise<AutoSendOutcome> {
-  if (!args.enabled) {
+}): Promise<DrainOutcome> {
+  if (!args.enabled || !args.dependencies.drainThreadQueue) {
     return { ok: true };
   }
 
   const result = await settle(
-    autoSendQueuedMessageForTerminalCallback({
-      db: args.db,
-      runId: args.runId,
-      agentId: args.agentId,
-      apiStartTime: args.apiStartTime,
-      dependencies: args.dependencies,
-      timing: args.timing,
-      signal: args.signal,
-    }),
+    args.dependencies.drainThreadQueue(
+      args.chatThreadId,
+      args.signal,
+      args.timing,
+    ),
     args.signal,
   );
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
 async function processTerminalChatCallback(args: {
-  readonly apiStartTime: number;
   readonly db: Db;
   readonly callback: InternalRunCallbackEnvelope;
   readonly payload: ChatCallbackPayload;
@@ -2553,9 +2485,9 @@ async function processTerminalChatCallback(args: {
   const { run, chatThread } = loaded;
   const isGoalRun = args.payload.isGoalRun ?? false;
 
-  const work =
+  const prepared = await settle(
     callbackStatus === "completed"
-      ? await prepareCompletedTerminalChatCallbackWork({
+      ? prepareCompletedTerminalChatCallbackWork({
           db: args.db,
           runId,
           run,
@@ -2565,7 +2497,7 @@ async function processTerminalChatCallback(args: {
           timing,
           signal: args.signal,
         })
-      : await prepareFailedTerminalChatCallbackWork({
+      : prepareFailedTerminalChatCallbackWork({
           db: args.db,
           runId,
           run,
@@ -2577,14 +2509,31 @@ async function processTerminalChatCallback(args: {
           dependencies: args.dependencies,
           timing,
           signal: args.signal,
-        });
+        }),
+    args.signal,
+  );
 
-  const autoSendResult = await maybeAutoSendQueuedMessageForTerminalCallback({
-    enabled: work.shouldAutoSendQueuedMessage,
-    db: args.db,
-    runId,
-    agentId: args.payload.agentId,
-    apiStartTime: args.apiStartTime,
+  if (!prepared.ok) {
+    const fallbackDrain = await maybeDrainThreadQueueForTerminalCallback({
+      enabled: true,
+      chatThreadId: chatThread.chatThreadId,
+      dependencies: args.dependencies,
+      timing,
+      signal: args.signal,
+    });
+    if (!fallbackDrain.ok) {
+      log.error("Failed to drain thread queue after terminal callback error", {
+        runId,
+        error: fallbackDrain.error,
+      });
+    }
+    throw prepared.error;
+  }
+  const work = prepared.value;
+
+  const drainResult = await maybeDrainThreadQueueForTerminalCallback({
+    enabled: work.shouldDrainThreadQueue,
+    chatThreadId: chatThread.chatThreadId,
     dependencies: args.dependencies,
     timing,
     signal: args.signal,
@@ -2598,8 +2547,8 @@ async function processTerminalChatCallback(args: {
     });
   }
 
-  if (!autoSendResult.ok) {
-    throw autoSendResult.error;
+  if (!drainResult.ok) {
+    throw drainResult.error;
   }
 }
 
@@ -2611,6 +2560,7 @@ function withoutQueuedRunDependency(
     saveRunSummary: dependencies.saveRunSummary,
     formatRunError: dependencies.formatRunError,
     getResolvedAttachFiles: dependencies.getResolvedAttachFiles,
+    drainThreadQueue: dependencies.drainThreadQueue,
   };
 }
 
@@ -2633,7 +2583,6 @@ async function claimedUserMessageExistsForRun(
 }
 
 function buildQueuedChatDispatchFailedCallbacks(args: {
-  readonly apiStartTime: number;
   readonly dependencies: ChatCallbackDependencies;
   readonly runInput: CreateQueuedChatRunInput;
   readonly signal: AbortSignal;
@@ -2647,7 +2596,6 @@ function buildQueuedChatDispatchFailedCallbacks(args: {
       agentId: args.runInput.agentId,
     };
     await processTerminalChatCallback({
-      apiStartTime: args.apiStartTime,
       db,
       callback: {
         runId,
@@ -2670,7 +2618,6 @@ function handleChatInternalCallback(args: {
 }):
   | { readonly success: true }
   | { readonly success: false; readonly error: string } {
-  const apiStartTime = now();
   const payload = chatCallbackPayloadSchema.safeParse(args.callback.payload);
   if (!payload.success) {
     return {
@@ -2695,7 +2642,6 @@ function handleChatInternalCallback(args: {
   waitUntil(
     tapError(
       processTerminalChatCallback({
-        apiStartTime,
         db: args.db,
         callback: args.callback,
         payload: payload.data,
@@ -2754,7 +2700,14 @@ export async function handleChatInternalCallbackWithoutCcstate(
 }
 
 const buildChatCallbackDependencies$ = command(
-  ({ get, set }, { db }: { readonly db: Db }): ChatCallbackDependencies => {
+  (
+    { get, set },
+    input: {
+      readonly db: Db;
+      readonly drainThreadQueue?: ChatCallbackDependencies["drainThreadQueue"];
+    },
+  ): ChatCallbackDependencies => {
+    const { db } = input;
     const baseDependencies: ChatCallbackDependencies = {
       insertAssistantItems: async (args, inputSignal) => {
         await set(insertAssistantEventMessages$, args, inputSignal);
@@ -2777,6 +2730,7 @@ const buildChatCallbackDependencies$ = command(
       getResolvedAttachFiles: (userId, fileIds) => {
         return get(resolveAttachFileUrls(userId, fileIds));
       },
+      drainThreadQueue: input.drainThreadQueue,
     };
     const dependencies: ChatCallbackDependencies = {
       ...baseDependencies,
@@ -2785,7 +2739,6 @@ const buildChatCallbackDependencies$ = command(
           runInput,
           apiStartTime,
           buildQueuedChatDispatchFailedCallbacks({
-            apiStartTime,
             dependencies: baseDependencies,
             runInput,
             signal: inputSignal,
@@ -2836,26 +2789,34 @@ const buildChatCallbackDependencies$ = command(
 );
 
 /**
- * Ensure a thread's user-message queue is draining: when the thread is idle,
- * dispatch the queue head — whoever sent it (#21392). Trigger surface for the
- * "idle + non-empty queue" state alongside the terminal chat callback: the
- * send route (head is another message) and cancel side effects.
+ * User-message drain used by the shared per-thread scheduler. Compatibility
+ * reads remain here until the follow-up cleanup removes the old queue paths.
  */
 export const drainQueuedUserMessagesForThread$ = command(
   async (
     { set },
-    args: { readonly chatThreadId: string },
+    args: {
+      readonly chatThreadId: string;
+      readonly timing?: ChatCallbackPreCreateTimingCollector;
+    },
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
-    const [thread] = await db
-      .select({
-        userId: chatThreads.userId,
-        agentId: chatThreads.agentComposeId,
-      })
-      .from(chatThreads)
-      .where(eq(chatThreads.id, args.chatThreadId))
-      .limit(1);
+    const [thread] = await measureChatCallbackPreCreateTiming(
+      args.timing,
+      "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
+      "nested",
+      () => {
+        return db
+          .select({
+            userId: chatThreads.userId,
+            agentId: chatThreads.agentComposeId,
+          })
+          .from(chatThreads)
+          .where(eq(chatThreads.id, args.chatThreadId))
+          .limit(1);
+      },
+    );
     signal.throwIfAborted();
     if (!thread) {
       return;
@@ -2871,7 +2832,7 @@ export const drainQueuedUserMessagesForThread$ = command(
       chatThreadId: args.chatThreadId,
       userId: thread.userId,
       agentId: thread.agentId,
-      timing: new ChatCallbackPreCreateTimingCollector(),
+      timing: args.timing ?? new ChatCallbackPreCreateTimingCollector(),
       getResolvedAttachFiles: dependencies.getResolvedAttachFiles,
       createRun: (input) => {
         return createQueuedChatRun({
@@ -2884,51 +2845,30 @@ export const drainQueuedUserMessagesForThread$ = command(
         });
       },
     });
-  },
-);
-
-/**
- * Cancel-side-effect hook: resolve the cancelled run's chat thread and drain
- * its queued user messages, mirroring `drainWorkflowQueueForRun$`.
- */
-export const drainQueuedUserMessagesForRun$ = command(
-  async (
-    { set },
-    args: { readonly runId: string },
-    signal: AbortSignal,
-  ): Promise<void> => {
-    const db = set(writeDb$);
-    const [run] = await db
-      .select({ chatThreadId: zeroRuns.chatThreadId })
-      .from(zeroRuns)
-      .where(eq(zeroRuns.id, args.runId))
-      .limit(1);
     signal.throwIfAborted();
-    if (!run?.chatThreadId) {
-      return;
-    }
-    await set(
-      drainQueuedUserMessagesForThread$,
-      { chatThreadId: run.chatThreadId },
-      signal,
-    );
   },
 );
 
 export const handleChatInternalCallback$ = command(
   async (
     { set },
-    callback: InternalRunCallbackEnvelope,
+    input: {
+      readonly callback: InternalRunCallbackEnvelope;
+      readonly drainThreadQueue?: ChatCallbackDependencies["drainThreadQueue"];
+    },
     signal: AbortSignal,
   ): Promise<
     | { readonly success: true }
     | { readonly success: false; readonly error: string }
   > => {
     const db = set(writeDb$);
-    const dependencies = set(buildChatCallbackDependencies$, { db });
+    const dependencies = set(buildChatCallbackDependencies$, {
+      db,
+      drainThreadQueue: input.drainThreadQueue,
+    });
     return await handleChatInternalCallback({
       db,
-      callback,
+      callback: input.callback,
       signal,
       dependencies,
     });

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -14,11 +14,14 @@ import {
 import { logger } from "../../lib/log";
 import { notFound, runNotCancellable } from "../../lib/error";
 import { tapError } from "../utils";
-import { dispatchRunCallbacks$ } from "./agent-run-callback.service";
-import { drainQueuedUserMessagesForRun$ } from "./internal-chat-run-callback.service";
+import {
+  chatCallbackIdForRun,
+  dispatchFailedRunCallbacks,
+  dispatchRunCallbacks$,
+} from "./agent-run-callback.service";
+import { drainChatThreadQueueForRun$ } from "./chat-thread-queue-drain.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 import { drainOrgQueue$ } from "./zero-run-queue.service";
-import { drainWorkflowQueueForRun$ } from "./zero-workflow-queue-drain.service";
 
 const L = logger("ZeroRunCancel");
 
@@ -210,7 +213,9 @@ export const dispatchCancelSideEffects$ = command(
     );
     signal.throwIfAborted();
 
-    await tapError(
+    const chatCallbackId = await chatCallbackIdForRun(db, result.runId);
+    signal.throwIfAborted();
+    const callbackResults = await tapError(
       set(
         dispatchRunCallbacks$,
         {
@@ -230,35 +235,35 @@ export const dispatchCancelSideEffects$ = command(
     );
     signal.throwIfAborted();
 
-    // Queued user messages fire as soon as the thread frees up — cancel
-    // included, symmetric with the workflow drain below. User messages keep
-    // priority by draining first (#21392).
-    await tapError(
-      set(drainQueuedUserMessagesForRun$, { runId: result.runId }, signal),
-      (error) => {
-        L.error("Failed to drain queued user messages after cancel", {
-          runId: result.runId,
-          error,
-        });
-      },
-    );
-    signal.throwIfAborted();
+    const chatCallbackDrained = callbackResults?.some((callbackResult) => {
+      return (
+        callbackResult.callbackId === chatCallbackId && callbackResult.success
+      );
+    });
+    if (!chatCallbackDrained) {
+      await tapError(
+        set(
+          drainChatThreadQueueForRun$,
+          {
+            runId: result.runId,
+            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("Failed to drain chat thread queue after cancel", {
+            runId: result.runId,
+            error,
+          });
+        },
+      );
+      signal.throwIfAborted();
+    }
 
     // Promote one queued run to pending; the runner picks it up on its
     // next poll cycle. Queue dispatch (compose loading + sandbox
     // provisioning) lands in Stage 4.
     await set(drainOrgQueue$, { orgId: result.orgId }, signal);
-    signal.throwIfAborted();
-
-    await tapError(
-      set(drainWorkflowQueueForRun$, { runId: result.runId }, signal),
-      (error) => {
-        L.error("Failed to drain workflow queue after cancel", {
-          runId: result.runId,
-          error,
-        });
-      },
-    );
     signal.throwIfAborted();
 
     // Reconcile credits when the cancelled run had been doing

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -1,5 +1,4 @@
 import { triggerSourceSchema } from "@vm0/api-contracts/contracts/logs";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   zeroWorkflows,
   zeroWorkflowAutomations,
@@ -8,14 +7,13 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   claimNextWorkflowQueueEvent,
   decryptWorkflowQueueEventParams,
-  pendingWorkflowQueueThreadIds,
   restoreWorkflowQueueEventAndPause,
   type ClaimedWorkflowQueueEvent,
 } from "./chat-message-queue.service";
@@ -26,8 +24,6 @@ const log = logger("ZeroWorkflowQueueDrain");
 // Consecutive stale events (deleted/disabled automations) skipped per drain call
 // before giving up; a successful run creation always stops the loop.
 const MAX_DRAIN_ATTEMPTS = 5;
-
-const DRAIN_SWEEP_LIMIT = 20;
 
 interface DequeueTarget {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
@@ -70,7 +66,10 @@ async function loadDequeueTarget(
 export const drainWorkflowQueueForThread$ = command(
   async (
     { set },
-    args: { readonly chatThreadId: string },
+    args: {
+      readonly chatThreadId: string;
+      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+    },
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
@@ -130,7 +129,7 @@ export const drainWorkflowQueueForThread$ = command(
           recordLastRunId: params.recordLastRunId,
           recordLastRunAt: params.recordLastRunAt,
           bypassWorkflowQueue: true,
-          dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+          dispatchFailedCallbacks: args.dispatchFailedCallbacks,
         },
         signal,
       );
@@ -171,55 +170,5 @@ export const drainWorkflowQueueForThread$ = command(
       signal.throwIfAborted();
       return;
     }
-  },
-);
-
-/**
- * Terminal-run hook: resolve the run's chat thread and advance that thread's
- * workflow queue. No-op for runs without a chat thread or threads without a
- * workflow queue.
- */
-export const drainWorkflowQueueForRun$ = command(
-  async (
-    { set },
-    args: { readonly runId: string },
-    signal: AbortSignal,
-  ): Promise<void> => {
-    const db = set(writeDb$);
-    const [run] = await db
-      .select({ chatThreadId: zeroRuns.chatThreadId })
-      .from(zeroRuns)
-      .where(eq(zeroRuns.id, args.runId))
-      .limit(1);
-    signal.throwIfAborted();
-    if (!run?.chatThreadId) {
-      return;
-    }
-    await set(
-      drainWorkflowQueueForThread$,
-      { chatThreadId: run.chatThreadId },
-      signal,
-    );
-  },
-);
-
-/**
- * Safety-net sweep for the cleanup cron: re-drain workflow queues that have
- * pending events but no in-flight run, covering terminal-run drains that were
- * lost (process crash, dropped callback).
- */
-export const drainStaleWorkflowQueues$ = command(
-  async ({ set }, signal: AbortSignal): Promise<number> => {
-    const db = set(writeDb$);
-    const threadIds = await pendingWorkflowQueueThreadIds(
-      db,
-      DRAIN_SWEEP_LIMIT,
-    );
-    signal.throwIfAborted();
-    for (const chatThreadId of threadIds) {
-      await set(drainWorkflowQueueForThread$, { chatThreadId }, signal);
-      signal.throwIfAborted();
-    }
-    return threadIds.length;
   },
 );


### PR DESCRIPTION
## Summary

- add one per-thread drain entry that always attempts queued user messages before workflow events
- route queue-first send recovery, terminal callbacks, cancellation, workflow resume, and the stale sweep through that shared entry
- preserve terminal transcript ordering by draining from the chat callback, with a shared fallback for runs that have no successful chat callback
- keep the `ChatMessageQueue` switch, legacy send/read compatibility, `zero_workflow_queue_events`, and legacy pause columns for a later cleanup PR

## User-visible impact

Queue behavior is unchanged, but every transition that can leave a thread idle now enters the same scheduler. Queued user messages retain priority over workflow events and FIFO behavior within each queue.

## Deployment compatibility

This is the first, non-destructive part of #21336. It changes only backend orchestration and preserves all persisted formats and rollout fallbacks, so old backend instances and existing queue rows remain compatible during deployment. Removing the feature switch and legacy runtime/schema paths is intentionally deferred until this scheduler is deployed and observed.

## Verification

- `pnpm --filter api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- repository pre-commit hooks: Prettier, knip, and all 13 type-check tasks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` (26 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts src/signals/routes/__tests__/zero-workflow-queue-api.test.ts` (9 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "idle-thread sends|terminal drain|auto-fires queued messages when the active run is cancelled"` (3 passed)

Part of #21336.
