### PR TITLE
fix(cli): map api service hosts to app links

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -157,13 +157,11 @@ export function stubConnectorCatalog(
 
 export function stubConnectorCatalogStatus(
   connectors: readonly PublicConnectorCatalogStatusItem[],
+  origin = "http://localhost:3000",
 ) {
-  return http.get(
-    "http://localhost:3000/api/zero/connector-catalog/status",
-    () => {
-      return HttpResponse.json({ connectors });
-    },
-  );
+  return http.get(`${origin}/api/zero/connector-catalog/status`, () => {
+    return HttpResponse.json({ connectors });
+  });
 }
 
 export function stubConnectorCatalogPermissions(

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -55,25 +55,24 @@ function stubConnector(
   body: Record<string, unknown>,
   status = 200,
   type = "github",
-  origin = "http://localhost:3000",
 ) {
   if (status === 200) {
-    return stubConnectorCatalogStatus([statusItemFromConnector(body)], origin);
+    return stubConnectorCatalogStatus([statusItemFromConnector(body)]);
   }
   if (status === 404) {
-    return stubConnectorCatalogStatus(
-      [
-        catalogStatusItem({
-          connectorRef: type,
-          authMethods: [authCodeMethod("oauth")],
-        }),
-      ],
-      origin,
-    );
+    return stubConnectorCatalogStatus([
+      catalogStatusItem({
+        connectorRef: type,
+        authMethods: [authCodeMethod("oauth")],
+      }),
+    ]);
   }
-  return http.get(`${origin}/api/zero/connector-catalog/status`, () => {
-    return HttpResponse.json(body, { status });
-  });
+  return http.get(
+    "http://localhost:3000/api/zero/connector-catalog/status",
+    () => {
+      return HttpResponse.json(body, { status });
+    },
+  );
 }
 
 function stubAgent(
@@ -260,7 +259,10 @@ describe("zero connector status command", () => {
       const apiOrigin = "https://api.vm0.ai";
       vi.stubEnv("VM0_API_BACKEND_URL", apiOrigin);
       server.use(
-        stubConnector(connectedGithub, 200, "github", apiOrigin),
+        stubConnectorCatalogStatus(
+          [statusItemFromConnector(connectedGithub)],
+          apiOrigin,
+        ),
         stubAgent(AGENT_UUID, "maya", apiOrigin),
         stubUserConnectors(AGENT_UUID, [], apiOrigin),
       );

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -55,28 +55,33 @@ function stubConnector(
   body: Record<string, unknown>,
   status = 200,
   type = "github",
+  origin = "http://localhost:3000",
 ) {
   if (status === 200) {
-    return stubConnectorCatalogStatus([statusItemFromConnector(body)]);
+    return stubConnectorCatalogStatus([statusItemFromConnector(body)], origin);
   }
   if (status === 404) {
-    return stubConnectorCatalogStatus([
-      catalogStatusItem({
-        connectorRef: type,
-        authMethods: [authCodeMethod("oauth")],
-      }),
-    ]);
+    return stubConnectorCatalogStatus(
+      [
+        catalogStatusItem({
+          connectorRef: type,
+          authMethods: [authCodeMethod("oauth")],
+        }),
+      ],
+      origin,
+    );
   }
-  return http.get(
-    "http://localhost:3000/api/zero/connector-catalog/status",
-    () => {
-      return HttpResponse.json(body, { status });
-    },
-  );
+  return http.get(`${origin}/api/zero/connector-catalog/status`, () => {
+    return HttpResponse.json(body, { status });
+  });
 }
 
-function stubAgent(id: string, displayName: string | null) {
-  return http.get(`http://localhost:3000/api/zero/agents/${id}`, () => {
+function stubAgent(
+  id: string,
+  displayName: string | null,
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/agents/${id}`, () => {
     return HttpResponse.json({
       agentId: id,
       ownerId: "owner-1",
@@ -88,13 +93,14 @@ function stubAgent(id: string, displayName: string | null) {
   });
 }
 
-function stubUserConnectors(id: string, enabledTypes: string[]) {
-  return http.get(
-    `http://localhost:3000/api/zero/agents/${id}/user-connectors`,
-    () => {
-      return HttpResponse.json({ enabledTypes });
-    },
-  );
+function stubUserConnectors(
+  id: string,
+  enabledTypes: string[],
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/agents/${id}/user-connectors`, () => {
+    return HttpResponse.json({ enabledTypes });
+  });
 }
 
 function stubAvailableConnectors(types: string[]) {
@@ -248,6 +254,29 @@ describe("zero connector status command", () => {
       expect(logCalls).not.toContain("is not connected");
       expect(logCalls).not.toContain("[Connect github]");
       expect(logCalls).not.toContain("zero doctor check-connector");
+    });
+
+    it("uses the production app origin in authorization links", async () => {
+      const apiOrigin = "https://api.vm0.ai";
+      vi.stubEnv("VM0_API_BACKEND_URL", apiOrigin);
+      server.use(
+        stubConnector(connectedGithub, 200, "github", apiOrigin),
+        stubAgent(AGENT_UUID, "maya", apiOrigin),
+        stubUserConnectors(AGENT_UUID, [], apiOrigin),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        `[Authorize github](https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_UUID})`,
+      );
     });
 
     it("shows connect link when connector is not connected", async () => {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -531,28 +531,80 @@ describe("zero doctor check-connector command", () => {
       },
     );
 
-    it("transforms a www API origin into app links", async () => {
-      const baseUrl = "https://www.vm0.ai";
-      vi.stubEnv("VM0_API_BACKEND_URL", baseUrl);
-      stubDiagnostic(resolvedEnvironment(), undefined, baseUrl);
-      stubResolvedDependencies("github", {
-        connector: null,
-        enabledTypes: [],
-        baseUrl,
-      });
+    it.each([
+      {
+        name: "production API",
+        baseUrl: "https://api.vm0.ai",
+        platformOrigin: "https://app.vm0.ai",
+      },
+      {
+        name: "legacy production web",
+        baseUrl: "https://www.vm0.ai",
+        platformOrigin: "https://app.vm0.ai",
+      },
+      {
+        name: "legacy production platform",
+        baseUrl: "https://platform.vm0.ai",
+        platformOrigin: "https://app.vm0.ai",
+      },
+      {
+        name: "canonical production app",
+        baseUrl: "https://app.vm0.ai",
+        platformOrigin: "https://app.vm0.ai",
+      },
+      {
+        name: "preview API",
+        baseUrl: "https://pr-123-api.vm6.ai",
+        platformOrigin: "https://pr-123-app.vm6.ai",
+      },
+      {
+        name: "legacy preview web",
+        baseUrl: "https://pr-123-www.vm6.ai",
+        platformOrigin: "https://pr-123-app.vm6.ai",
+      },
+      {
+        name: "canonical preview app",
+        baseUrl: "https://pr-123-app.vm6.ai",
+        platformOrigin: "https://pr-123-app.vm6.ai",
+      },
+      {
+        name: "tunnel API",
+        baseUrl: "https://tunnel-user-host-api.vm7.ai",
+        platformOrigin: "https://tunnel-user-host-app.vm7.ai",
+      },
+      {
+        name: "localhost with a port",
+        baseUrl: "http://localhost:4310",
+        platformOrigin: "http://localhost:4310",
+      },
+      {
+        name: "custom host",
+        baseUrl: "https://custom.example.com",
+        platformOrigin: "https://app.custom.example.com",
+      },
+    ])(
+      "maps $name links to the platform origin",
+      async ({ baseUrl, platformOrigin }) => {
+        vi.stubEnv("VM0_API_BACKEND_URL", baseUrl);
+        stubDiagnostic(resolvedEnvironment(), undefined, baseUrl);
+        stubResolvedDependencies("github", {
+          connector: null,
+          enabledTypes: [],
+          baseUrl,
+        });
 
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--env-name",
-        "GH_TOKEN",
-      ]);
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+        ]);
 
-      expect(getOutput()).toContain(
-        `[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID})`,
-      );
-      expect(getOutput()).not.toContain("https://www.vm0.ai/connectors");
-    });
+        expect(getOutput()).toContain(
+          `[Authorize GitHub](${platformOrigin}/connectors/github/authorize?agentId=${AGENT_ID})`,
+        );
+      },
+    );
 
     it.each([
       {

--- a/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
@@ -3,19 +3,34 @@ import { getApiUrl } from "../../../lib/api/config";
 /**
  * Transform the API host to the platform (app) host.
  *
+ *   api.vm0.ai                    → app.vm0.ai
  *   www.vm0.ai                    → app.vm0.ai
  *   platform.vm0.ai               → app.vm0.ai
+ *   pr-123-api.vm6.ai             → pr-123-app.vm6.ai
  *   tunnel-user-host-www.vm7.ai   → tunnel-user-host-app.vm7.ai
+ *   pr-123-app.vm6.ai             → pr-123-app.vm6.ai
+ *   localhost:3000                → localhost:3000
  *   custom.example.com            → app.custom.example.com
  */
 export function toPlatformUrl(apiUrl: string): URL {
   const parsed = new URL(apiUrl);
   const parts = parsed.hostname.split(".");
-  if (parts[0]!.endsWith("-www")) {
-    parts[0] = parts[0]!.slice(0, -"-www".length) + "-app";
-  } else if (parts[0] === "www" || parts[0] === "platform") {
+  const serviceLabel = parts[0]!;
+  if (serviceLabel.endsWith("-www")) {
+    parts[0] = serviceLabel.slice(0, -"-www".length) + "-app";
+  } else if (serviceLabel.endsWith("-api")) {
+    parts[0] = serviceLabel.slice(0, -"-api".length) + "-app";
+  } else if (
+    serviceLabel === "api" ||
+    serviceLabel === "www" ||
+    serviceLabel === "platform"
+  ) {
     parts[0] = "app";
-  } else if (parts[0] !== "app" && parts[0] !== "localhost") {
+  } else if (
+    serviceLabel !== "app" &&
+    !serviceLabel.endsWith("-app") &&
+    serviceLabel !== "localhost"
+  ) {
     parts.unshift("app");
   }
   parsed.hostname = parts.join(".");


### PR DESCRIPTION
## Summary

- map the production API host and managed `-api` / `-www` service labels to their App origins
- preserve canonical App hosts, localhost ports, and the existing custom-host fallback
- cover connector diagnostics and status output with command-level regression tests

## Scope

- CLI URL derivation only
- no API, runner, guest, deployment, or persisted-state contract changes
- no change to the Platform action-card origin validation boundary

## Validation

- `pnpm exec prettier --check` for the four changed files
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli build`
- `pnpm knip --workspace @vm0/cli`
- focused CLI connector tests: 81 passed
- full CLI test workspace: 1,494 passed, 1 pre-existing skipped
- Platform action-card regression test: 18 passed
- repository pre-commit and commit-message hooks

Closes #21455
