### PR TITLE
refactor(api): emit workflow automation callback kinds

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
@@ -507,6 +507,24 @@ describe("zero workflow trigger scheduler", () => {
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
     await executeDueWorkflowTriggers();
     const run = await onlyWorkflowRunMessage(threadId);
+    const emittedCallbacks = await store.set(
+      readAgentRunCallbacks$,
+      {
+        orgId: scenario.orgId,
+        userId: scenario.userId,
+        prompt: `/${WORKFLOW_NAME}`,
+      },
+      context.signal,
+    );
+    expect(emittedCallbacks).toContainEqual(
+      expect.objectContaining({
+        internalKind: "workflow-automation:cron",
+        status: "pending",
+      }),
+    );
+    expect(emittedCallbacks).not.toContainEqual(
+      expect.objectContaining({ internalKind: "workflow-trigger:cron" }),
+    );
     await completeRunThroughSandbox(scenario, run.runId, 0);
 
     await expect
@@ -540,7 +558,7 @@ describe("zero workflow trigger scheduler", () => {
     await disableTrigger(trigger.triggerId);
   });
 
-  it("keeps legacy writes while accepting an in-flight automation callback", async () => {
+  it("emits an automation callback while accepting an in-flight legacy callback", async () => {
     const scenario = await setup();
     const trigger = await createDueLoopTrigger(scenario, 300);
 
@@ -558,50 +576,50 @@ describe("zero workflow trigger scheduler", () => {
     );
     expect(emittedCallbacks).toContainEqual(
       expect.objectContaining({
-        internalKind: "workflow-trigger:loop",
+        internalKind: "workflow-automation:loop",
         status: "pending",
       }),
     );
     expect(emittedCallbacks).not.toContainEqual(
-      expect.objectContaining({ internalKind: "workflow-automation:loop" }),
+      expect.objectContaining({ internalKind: "workflow-trigger:loop" }),
     );
     expect((await wf.readTrigger(trigger.triggerId)).nextRunAt).toBeNull();
 
-    const futurePrompt = "complete a future workflow automation callback";
-    const futureRun = await runsApi.createRun(scenario.actor, {
+    const legacyPrompt = "complete an in-flight legacy workflow callback";
+    const legacyRun = await runsApi.createRun(scenario.actor, {
       agentId: scenario.agentId,
-      prompt: futurePrompt,
+      prompt: legacyPrompt,
       modelProvider: "anthropic-api-key",
     });
     await store.set(
       seedAgentRunCallback$,
       {
-        runId: futureRun.runId,
-        internalKind: "workflow-automation:loop",
+        runId: legacyRun.runId,
+        internalKind: "workflow-trigger:loop",
         payload: { triggerId: trigger.triggerId },
       },
       context.signal,
     );
 
-    await completeRunThroughSandbox(scenario, futureRun.runId, 0);
+    await completeRunThroughSandbox(scenario, legacyRun.runId, 0);
 
     await expect
       .poll(async () => {
         return (await wf.readTrigger(trigger.triggerId)).nextRunAt;
       })
       .not.toBeNull();
-    const futureCallbacks = await store.set(
+    const legacyCallbacks = await store.set(
       readAgentRunCallbacks$,
       {
         orgId: scenario.orgId,
         userId: scenario.userId,
-        prompt: futurePrompt,
+        prompt: legacyPrompt,
       },
       context.signal,
     );
-    expect(futureCallbacks).toContainEqual(
+    expect(legacyCallbacks).toContainEqual(
       expect.objectContaining({
-        internalKind: "workflow-automation:loop",
+        internalKind: "workflow-trigger:loop",
         status: "delivered",
       }),
     );

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -1,7 +1,7 @@
 /**
- * Persisted callback kinds accepted during the expand phase. Producers must
- * keep emitting `workflow-trigger:*` until this acceptance release is fully
- * deployed; the follow-up release can then switch writes safely.
+ * Persisted callback kinds accepted during the rolling-deploy drain. Producers
+ * emit `workflow-automation:*`; legacy `workflow-trigger:*` rows remain readable
+ * until every in-flight run from the previous release has completed.
  */
 export const internalRunCallbackKinds = [
   "agent",

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -145,13 +145,13 @@ function buildWorkflowTriggerCallbacks(
   const callbacks: InternalRunCallbackInput[] = [];
   if (trigger.scheduleType === "loop") {
     callbacks.push({
-      internalKind: "workflow-trigger:loop",
+      internalKind: "workflow-automation:loop",
       secret: generateCallbackSecret(),
       payload: { triggerId: trigger.id },
     });
   } else {
     callbacks.push({
-      internalKind: "workflow-trigger:cron",
+      internalKind: "workflow-automation:cron",
       secret: generateCallbackSecret(),
       payload: {
         triggerId: trigger.id,


### PR DESCRIPTION
## Summary

- switch newly persisted recurrence callback kinds from `workflow-trigger:cron|loop` to `workflow-automation:cron|loop`
- retain the expand-phase normalizer added in #21425 so callbacks persisted by the previous release still dispatch through the existing scheduling handlers
- verify both canonical cron/loop emission and an in-flight legacy loop callback that advances `next_run_at` on completion

## Rolling-deploy compatibility

This is the write-cutover phase after #21425. New API instances emit Automation kinds, while both new and old API instances from the compatibility release can read them. The legacy `workflow-trigger:*` values remain accepted until the release overlap and in-flight run drain are complete.

Merge gate: confirm the release containing #21425 is fully promoted to production before merging this write switch, preserving instant rollback compatibility.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- workspace type-check: 12 workspaces passed; the aggregate API process hit the default 2 GB Node heap limit
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts --silent=passed-only` (12 tests passed, rerun after rebasing onto current `main`)

Part of #21408.