### PR TITLE
refactor(mitm-addon): extract runner flush lifecycle owner

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -14,14 +14,9 @@ This addon runs on the runner HOST (not inside VMs) and:
 import asyncio
 import base64
 import binascii
-import json
-import os
 import signal
 import tempfile
-import threading
-import time
 from collections.abc import Awaitable
-from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, NoReturn
@@ -32,14 +27,15 @@ from mitmproxy.addonmanager import Loader
 # --- Sub-module imports ---
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/matching/registry/
-# response_encoding_negotiation/response_streaming/terminal_usage/upstream_admission/
-# usage are imported by module (not selective `from X import ...`) so that:
+# response_encoding_negotiation/response_streaming/runner_flush_lifecycle/terminal_usage/
+# upstream_admission/usage are imported by module (not selective `from X import ...`) so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
 #      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
 #      ``connector_intent.X(...)`` /
 #      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)`` /
-#      ``terminal_usage.X(...)`` / ``upstream_admission.X(...)`` / ``usage.X(...)``,
-#      making the module boundary visible at call sites.
+#      ``runner_flush_lifecycle.X(...)`` / ``terminal_usage.X(...)`` /
+#      ``upstream_admission.X(...)`` / ``usage.X(...)``, making the module boundary
+#      visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
@@ -59,6 +55,7 @@ import request_classification
 import request_streaming
 import response_encoding_negotiation
 import response_streaming
+import runner_flush_lifecycle
 import tcp_logging
 import terminal_usage
 import upstream_admission
@@ -87,7 +84,6 @@ from logging_utils import (
     NETWORK_LOG_MAX_SAFE_SIZE_DIGITS,
     add_firewall_metadata,
     elapsed_ms,
-    flush_log_path,
     log_network_entry,
     log_proxy_entry,
     shutdown_log_writer,
@@ -112,7 +108,6 @@ _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
-_UsageFlushPhase = Literal["running", "draining", "closed"]
 
 
 @dataclass(frozen=True)
@@ -122,31 +117,6 @@ class _AuthBaseBodyCheck:
     reason: str = ""
 
 
-# Runner-triggered flush protocols:
-# - Rust writes `usage-flush-request` with the active usageStateId and a fresh
-#   flushRequestId, then sends SIGUSR1 to this addon process.
-# - This addon flushes buffered usage and writes `usage-pending` with the
-#   matching flushRequestId so the runner can observe a fresh snapshot.
-# - Rust performs a bounded wait for the acknowledged snapshot to have zero
-#   flows, buffered events, and reports before stopping the proxy.
-# - Rust may also write `jsonl-flush-request` for a concrete network log path.
-#   This addon drains accepted JSONL writes for that path and acknowledges with
-#   `jsonl-flush-state` before the runner uploads the file.
-#
-# Keep this in sync with usage/counters.py and the Rust wait path in
-# crates/runner/src/proxy.rs plus crates/runner/src/cmd/start/mod.rs.
-_RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
-_usage_flush_requested = threading.Event()
-_usage_flush_signal_lock = threading.Lock()
-# Running workers own requests under the lock. During shutdown, done() changes
-# the phase before waiting for that lock and becomes the sole draining owner.
-_usage_flush_phase: _UsageFlushPhase = "running"
-_jsonl_flush_state_write_lock = threading.Lock()
-_last_jsonl_flush_request_id: str | None = None
-_JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
-_JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
-RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
-
 # ============================================================================
 # Addon Configuration
 # ============================================================================
@@ -154,7 +124,10 @@ RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
 
 def load(loader: Loader) -> None:
     """Register custom options for the addon."""
-    signal.signal(_RUNNER_USAGE_FLUSH_SIGNAL, _handle_runner_usage_flush_signal)
+    signal.signal(
+        runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
+        runner_flush_lifecycle.handle_runner_usage_flush_signal,
+    )
     loader.add_option(
         name="vm0_api_url",
         typespec=str,
@@ -220,194 +193,6 @@ def configure(updated: set[str]) -> None:
             str(Path(__file__).resolve().parent / "usage-pending"),
             usage_state_id=ctx.options.vm0_usage_state_id or None,
         )
-
-
-def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
-    """Schedule runner-requested flush work from the SIGUSR1 handler.
-
-    Keep this handler minimal: it may interrupt mitmproxy's event loop, so it
-    only records that work is needed and lets the background worker perform
-    file I/O, usage flushing, and JSONL flushing.
-    """
-    del signum
-    if _usage_flush_phase == "closed":
-        return
-    _usage_flush_requested.set()
-    _start_usage_flush_worker()
-
-
-def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -> None:
-    deadline = time.monotonic() + timeout
-    while True:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise AssertionError("runner usage flush worker did not stop")
-
-        acquired = _usage_flush_signal_lock.acquire(timeout=remaining)
-        if not acquired:
-            raise AssertionError("runner usage flush worker did not stop")
-        try:
-            if not _usage_flush_requested.is_set():
-                return
-        finally:
-            _usage_flush_signal_lock.release()
-        _start_usage_flush_worker()
-
-
-def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
-    global _last_jsonl_flush_request_id, _usage_flush_phase
-
-    acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
-    if not acquired:
-        raise AssertionError("runner usage flush worker did not stop")
-    try:
-        _usage_flush_phase = "running"
-        _usage_flush_requested.clear()
-        _last_jsonl_flush_request_id = None
-    finally:
-        _usage_flush_signal_lock.release()
-
-
-def _start_usage_flush_worker() -> None:
-    """Start one flush worker, coalescing repeated signals while active."""
-    if _usage_flush_phase != "running":
-        return
-    if not _usage_flush_signal_lock.acquire(blocking=False):
-        return
-    if _usage_flush_phase != "running":
-        _usage_flush_signal_lock.release()
-        return
-
-    thread = threading.Thread(
-        target=_run_usage_flush_worker,
-        name="runner-flush-request",
-        daemon=True,
-    )
-    started = False
-    try:
-        thread.start()
-        started = True
-    finally:
-        if not started:
-            _usage_flush_signal_lock.release()
-
-
-def _run_usage_flush_worker() -> None:
-    """Drain coalesced runner flush requests under the worker lock.
-
-    The event can be set again while a flush is running. Loop until no request
-    is pending. After releasing the lock, restart for a running-phase signal;
-    draining-phase requests belong to ``done()``.
-    """
-    try:
-        _drain_runner_usage_flush_requests()
-    finally:
-        _usage_flush_signal_lock.release()
-        if _usage_flush_requested.is_set():
-            _start_usage_flush_worker()
-
-
-def _drain_runner_usage_flush_requests() -> None:
-    """Drain coalesced runner requests while the caller owns the signal lock."""
-    while _usage_flush_requested.is_set():
-        _usage_flush_requested.clear()
-        _flush_usage_for_runner_request()
-        _flush_jsonl_for_runner_request()
-
-
-def _flush_usage_for_runner_request() -> None:
-    """Flush buffered usage and acknowledge the runner's current request.
-
-    The pending snapshot is written in ``finally`` so the runner can observe
-    fresh counters and the current flushRequestId even if usage flushing fails.
-    """
-    flush_request_id = usage.read_usage_flush_request_id()
-    try:
-        usage.flush_usage_events(trigger="runner")
-    except Exception as exc:
-        ctx.log.warn(f"Failed to flush usage events after runner request ({type(exc).__name__})")
-    finally:
-        usage.write_pending_snapshot(flush_request_id=flush_request_id)
-
-
-def _flush_jsonl_for_runner_request() -> None:
-    global _last_jsonl_flush_request_id
-
-    request = _read_jsonl_flush_request()
-    if request is None:
-        return
-
-    log_path, flush_request_id = request
-    pending = 0
-    timed_out = False
-    try:
-        if not flush_log_path(log_path, timeout=RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS):
-            pending = 1
-            timed_out = True
-            ctx.log.warn("JSONL flush did not complete before timeout")
-    except Exception as exc:
-        pending = 1
-        ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
-    finally:
-        state_written = _write_jsonl_flush_state(log_path, flush_request_id, pending=pending)
-        if state_written and (pending == 0 or timed_out):
-            _last_jsonl_flush_request_id = flush_request_id
-
-
-def _read_jsonl_flush_request() -> tuple[str, str] | None:
-    marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
-    try:
-        marker = json.loads(marker_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    if not isinstance(marker, dict):
-        return None
-    if marker.get("usageStateId") != usage.current_usage_state_id():
-        return None
-    flush_request_id = marker.get("flushRequestId")
-    if (
-        not isinstance(flush_request_id, str)
-        or not flush_request_id
-        or not _is_safe_jsonl_flush_request_id(flush_request_id)
-        or flush_request_id == _last_jsonl_flush_request_id
-    ):
-        return None
-    log_path = marker.get("path")
-    if not isinstance(log_path, str) or not log_path:
-        return None
-    return log_path, flush_request_id
-
-
-def _is_safe_jsonl_flush_request_id(flush_request_id: str) -> bool:
-    return all(
-        ("a" <= char <= "z") or ("A" <= char <= "Z") or ("0" <= char <= "9") or char in "-_"
-        for char in flush_request_id
-    )
-
-
-def _write_jsonl_flush_state(log_path: str, flush_request_id: str, *, pending: int = 0) -> bool:
-    state_path = Path(__file__).resolve().parent / _JSONL_FLUSH_STATE_FILE
-    state = {
-        "pid": os.getpid(),
-        "usageStateId": usage.current_usage_state_id(),
-        "updatedAtMs": int(time.time() * 1000),
-        "flushRequestId": flush_request_id,
-        "path": log_path,
-        "pending": pending,
-    }
-    tmp_path = state_path.with_name(f"{state_path.name}.{flush_request_id}.tmp")
-    with _jsonl_flush_state_write_lock:
-        try:
-            with tmp_path.open("w") as f:
-                json.dump(state, f, separators=(",", ":"))
-            tmp_path.replace(state_path)
-            return True
-        except OSError as exc:
-            with suppress(OSError):
-                tmp_path.unlink()
-            ctx.log.warn(f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}")
-            return False
 
 
 def get_api_url() -> str:
@@ -1589,31 +1374,15 @@ def _handle_error(flow: http.HTTPFlow) -> None:
 def done():
     """Flush pending usage reports and forwarding workers before mitmproxy exits.
 
-    Runner-triggered flush workers and shutdown flush share
-    ``_usage_flush_signal_lock``. Waiting here keeps shutdown from closing the
-    executor while a SIGUSR1 worker is still converting buffered usage into
-    webhook reports. Shutdown then owns signals received before the request
-    cutoff and acknowledges them before ``shutdown(wait=True)`` drains submitted
-    webhook futures. Auth.base forwarding does not need to finish running work
-    during shutdown, so its worker shutdown stops new forwards and best-effort
-    closes active upstream sockets without waiting for slow upstream responses.
+    The runner flush lifecycle waits for any active SIGUSR1 worker, drains
+    accepted requests, and closes admission before this hook shuts down the
+    usage executor and JSONL writer. Auth.base forwarding does not need to
+    finish running work during shutdown, so its worker shutdown stops new
+    forwards and best-effort closes active upstream sockets without waiting for
+    slow upstream responses.
     """
-    global _usage_flush_phase
-
-    _usage_flush_phase = "draining"
     try:
-        # Wait for any in-flight runner-triggered flush before closing the
-        # executor used by webhook report delivery. Once the lock is ours,
-        # shutdown also owns requests recorded while the final drain runs.
-        with _usage_flush_signal_lock:
-            try:
-                usage.flush_usage_events(trigger="shutdown")
-                _drain_runner_usage_flush_requests()
-            finally:
-                # Close request admission while still owning the lock, then
-                # consume any event recorded immediately before this cutoff.
-                _usage_flush_phase = "closed"
-                _drain_runner_usage_flush_requests()
+        runner_flush_lifecycle.drain_and_close()
     finally:
         try:
             usage.webhook.usage_executor.shutdown(wait=True)

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -1,0 +1,254 @@
+"""Runner-triggered usage and JSONL flush lifecycle owner."""
+
+import json
+import os
+import signal
+import threading
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Literal
+
+from mitmproxy import ctx
+
+import logging_utils
+import usage
+
+_UsageFlushPhase = Literal["running", "draining", "closed"]
+
+# Runner-triggered flush protocols:
+# - Rust writes `usage-flush-request` with the active usageStateId and a fresh
+#   flushRequestId, then sends SIGUSR1 to this addon process.
+# - This addon flushes buffered usage and writes `usage-pending` with the
+#   matching flushRequestId so the runner can observe a fresh snapshot.
+# - Rust performs a bounded wait for the acknowledged snapshot to have zero
+#   flows, buffered events, and reports before stopping the proxy.
+# - Rust may also write `jsonl-flush-request` for a concrete network log path.
+#   This addon drains accepted JSONL writes for that path and acknowledges with
+#   `jsonl-flush-state` before the runner uploads the file.
+#
+# Keep this in sync with usage/counters.py and the Rust wait path in
+# crates/runner/src/proxy/flush.rs plus crates/runner/src/cmd/start/mod.rs.
+RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
+_usage_flush_requested = threading.Event()
+_usage_flush_signal_lock = threading.Lock()
+# Running workers own requests under the lock. During shutdown, drain_and_close()
+# changes the phase before waiting for that lock and becomes the sole draining owner.
+_usage_flush_phase: _UsageFlushPhase = "running"
+_jsonl_flush_state_write_lock = threading.Lock()
+_last_jsonl_flush_request_id: str | None = None
+_JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
+_JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
+RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
+
+
+def handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
+    """Schedule runner-requested flush work from the SIGUSR1 handler.
+
+    Keep this handler minimal: it may interrupt mitmproxy's event loop, so it
+    only records that work is needed and lets the background worker perform
+    file I/O, usage flushing, and JSONL flushing.
+    """
+    del signum
+    if _usage_flush_phase == "closed":
+        return
+    _usage_flush_requested.set()
+    _start_usage_flush_worker()
+
+
+def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError("runner usage flush worker did not stop")
+
+        acquired = _usage_flush_signal_lock.acquire(timeout=remaining)
+        if not acquired:
+            raise AssertionError("runner usage flush worker did not stop")
+        try:
+            if not _usage_flush_requested.is_set():
+                return
+        finally:
+            _usage_flush_signal_lock.release()
+        _start_usage_flush_worker()
+
+
+def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
+    global _last_jsonl_flush_request_id, _usage_flush_phase
+
+    acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
+    if not acquired:
+        raise AssertionError("runner usage flush worker did not stop")
+    try:
+        _usage_flush_phase = "running"
+        _usage_flush_requested.clear()
+        _last_jsonl_flush_request_id = None
+    finally:
+        _usage_flush_signal_lock.release()
+
+
+def _start_usage_flush_worker() -> None:
+    """Start one flush worker, coalescing repeated signals while active."""
+    if _usage_flush_phase != "running":
+        return
+    if not _usage_flush_signal_lock.acquire(blocking=False):
+        return
+    if _usage_flush_phase != "running":
+        _usage_flush_signal_lock.release()
+        return
+
+    thread = threading.Thread(
+        target=_run_usage_flush_worker,
+        name="runner-flush-request",
+        daemon=True,
+    )
+    started = False
+    try:
+        thread.start()
+        started = True
+    finally:
+        if not started:
+            _usage_flush_signal_lock.release()
+
+
+def _run_usage_flush_worker() -> None:
+    """Drain coalesced runner flush requests under the worker lock.
+
+    The event can be set again while a flush is running. Loop until no request
+    is pending. After releasing the lock, restart for a running-phase signal;
+    draining-phase requests belong to ``drain_and_close()``.
+    """
+    try:
+        _drain_runner_usage_flush_requests()
+    finally:
+        _usage_flush_signal_lock.release()
+        if _usage_flush_requested.is_set():
+            _start_usage_flush_worker()
+
+
+def _drain_runner_usage_flush_requests() -> None:
+    """Drain coalesced runner requests while the caller owns the signal lock."""
+    while _usage_flush_requested.is_set():
+        _usage_flush_requested.clear()
+        _flush_usage_for_runner_request()
+        _flush_jsonl_for_runner_request()
+
+
+def _flush_usage_for_runner_request() -> None:
+    """Flush buffered usage and acknowledge the runner's current request.
+
+    The pending snapshot is written in ``finally`` so the runner can observe
+    fresh counters and the current flushRequestId even if usage flushing fails.
+    """
+    flush_request_id = usage.read_usage_flush_request_id()
+    try:
+        usage.flush_usage_events(trigger="runner")
+    except Exception as exc:
+        ctx.log.warn(f"Failed to flush usage events after runner request ({type(exc).__name__})")
+    finally:
+        usage.write_pending_snapshot(flush_request_id=flush_request_id)
+
+
+def _flush_jsonl_for_runner_request() -> None:
+    global _last_jsonl_flush_request_id
+
+    request = _read_jsonl_flush_request()
+    if request is None:
+        return
+
+    log_path, flush_request_id = request
+    pending = 0
+    timed_out = False
+    try:
+        if not logging_utils.flush_log_path(
+            log_path,
+            timeout=RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+        ):
+            pending = 1
+            timed_out = True
+            ctx.log.warn("JSONL flush did not complete before timeout")
+    except Exception as exc:
+        pending = 1
+        ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
+    finally:
+        state_written = _write_jsonl_flush_state(log_path, flush_request_id, pending=pending)
+        if state_written and (pending == 0 or timed_out):
+            _last_jsonl_flush_request_id = flush_request_id
+
+
+def _read_jsonl_flush_request() -> tuple[str, str] | None:
+    marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(marker, dict):
+        return None
+    if marker.get("usageStateId") != usage.current_usage_state_id():
+        return None
+    flush_request_id = marker.get("flushRequestId")
+    if (
+        not isinstance(flush_request_id, str)
+        or not flush_request_id
+        or not _is_safe_jsonl_flush_request_id(flush_request_id)
+        or flush_request_id == _last_jsonl_flush_request_id
+    ):
+        return None
+    log_path = marker.get("path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    return log_path, flush_request_id
+
+
+def _is_safe_jsonl_flush_request_id(flush_request_id: str) -> bool:
+    return all(
+        ("a" <= char <= "z") or ("A" <= char <= "Z") or ("0" <= char <= "9") or char in "-_"
+        for char in flush_request_id
+    )
+
+
+def _write_jsonl_flush_state(
+    log_path: str,
+    flush_request_id: str,
+    *,
+    pending: int = 0,
+) -> bool:
+    state_path = Path(__file__).resolve().parent / _JSONL_FLUSH_STATE_FILE
+    state = {
+        "pid": os.getpid(),
+        "usageStateId": usage.current_usage_state_id(),
+        "updatedAtMs": int(time.time() * 1000),
+        "flushRequestId": flush_request_id,
+        "path": log_path,
+        "pending": pending,
+    }
+    tmp_path = state_path.with_name(f"{state_path.name}.{flush_request_id}.tmp")
+    with _jsonl_flush_state_write_lock:
+        try:
+            with tmp_path.open("w") as f:
+                json.dump(state, f, separators=(",", ":"))
+            tmp_path.replace(state_path)
+            return True
+        except OSError as exc:
+            with suppress(OSError):
+                tmp_path.unlink()
+            ctx.log.warn(f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}")
+            return False
+
+
+def drain_and_close() -> None:
+    """Drain accepted runner flush requests and close further admission."""
+    global _usage_flush_phase
+
+    _usage_flush_phase = "draining"
+    with _usage_flush_signal_lock:
+        try:
+            usage.flush_usage_events(trigger="shutdown")
+            _drain_runner_usage_flush_requests()
+        finally:
+            # Close request admission while still owning the lock, then consume
+            # any event recorded immediately before this cutoff.
+            _usage_flush_phase = "closed"
+            _drain_runner_usage_flush_requests()

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -32,6 +32,7 @@ import logging_utils
 import mitm_addon
 import platform_api
 import registry
+import runner_flush_lifecycle
 import upstream_admission
 import upstream_destination_binding
 import usage
@@ -57,7 +58,7 @@ def _reset_module_state() -> Iterator[None]:
     registry.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
     upstream_admission.reset_upstream_destination_resolution_cache_for_tests()
-    mitm_addon.reset_runner_usage_flush_state_for_tests()
+    runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     upstream_admission.reset_tls_admission_state_for_tests()
     platform_api.configure_client_headers(client_session_id="", client_version="")
     clear_auth_state()
@@ -67,7 +68,7 @@ def _reset_module_state() -> Iterator[None]:
     usage.reset_usage_buffer_for_tests()
     logging_utils.reset_log_writer_for_tests()
     yield
-    mitm_addon.reset_runner_usage_flush_state_for_tests()
+    runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     usage.reset_usage_buffer_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -12,6 +12,7 @@ from mitmproxy.addonmanager import Loader
 
 import mitm_addon
 import platform_api
+import runner_flush_lifecycle
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
@@ -115,8 +116,8 @@ class TestAddonConfiguration:
         assert "vm0_usage_flush_interval_seconds" in option_names
         assert not pending_path.exists()
         signal_handler.assert_called_once_with(
-            mitm_addon._RUNNER_USAGE_FLUSH_SIGNAL,
-            mitm_addon._handle_runner_usage_flush_signal,
+            runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
+            runner_flush_lifecycle.handle_runner_usage_flush_signal,
         )
 
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import mitm_addon
+import runner_flush_lifecycle
 import usage
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
 
@@ -78,7 +79,7 @@ class TestDoneHook:
         mock_executor.shutdown.side_effect = shutdown
 
         with (
-            patch.object(mitm_addon, "_usage_flush_signal_lock", lock),
+            patch.object(runner_flush_lifecycle, "_usage_flush_signal_lock", lock),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
@@ -88,7 +89,7 @@ class TestDoneHook:
             ),
             patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert runner_flush_started.wait(timeout=1)
 
             done_thread = ThreadUnderTest(target=mitm_addon.done)
@@ -124,7 +125,7 @@ class TestDoneHook:
         def flush_usage_events(*, trigger: str) -> int:
             assert trigger == "shutdown"
             calls.append("flush:shutdown")
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             return 0
 
         def flush_usage_for_runner_request() -> None:
@@ -132,7 +133,7 @@ class TestDoneHook:
             runner_flush_count += 1
             calls.append("flush:runner")
             if runner_flush_count == 1:
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
 
         mock_executor = MagicMock()
         mock_executor.shutdown.side_effect = lambda *, wait: calls.append(f"shutdown:{wait}")
@@ -140,12 +141,12 @@ class TestDoneHook:
         with (
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(
-                mitm_addon,
+                runner_flush_lifecycle,
                 "_flush_usage_for_runner_request",
                 side_effect=flush_usage_for_runner_request,
             ),
             patch.object(
-                mitm_addon,
+                runner_flush_lifecycle,
                 "_flush_jsonl_for_runner_request",
                 side_effect=lambda: calls.append("flush:jsonl"),
             ),
@@ -169,7 +170,7 @@ class TestDoneHook:
             "auth-base:shutdown:False",
             "jsonl:shutdown",
         ]
-        assert not mitm_addon._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
     def test_signal_after_done_does_not_start_worker(self):
         mock_executor = MagicMock()
@@ -182,18 +183,18 @@ class TestDoneHook:
         ):
             mitm_addon.done()
 
-        with patch.object(mitm_addon, "_start_usage_flush_worker") as start_worker:
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+        with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker") as start_worker:
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
 
         start_worker.assert_not_called()
-        assert not mitm_addon._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
 
         def fail_shutdown_flush(*, trigger: str) -> int:
             assert trigger == "shutdown"
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             raise RuntimeError("flush failed")
 
         with (
@@ -202,8 +203,14 @@ class TestDoneHook:
                 "flush_usage_events",
                 side_effect=fail_shutdown_flush,
             ) as flush_usage_events,
-            patch.object(mitm_addon, "_flush_usage_for_runner_request") as flush_runner_usage,
-            patch.object(mitm_addon, "_flush_jsonl_for_runner_request") as flush_runner_jsonl,
+            patch.object(
+                runner_flush_lifecycle,
+                "_flush_usage_for_runner_request",
+            ) as flush_runner_usage,
+            patch.object(
+                runner_flush_lifecycle,
+                "_flush_jsonl_for_runner_request",
+            ) as flush_runner_jsonl,
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
@@ -220,8 +227,8 @@ class TestDoneHook:
         mock_executor.shutdown.assert_called_once_with(wait=True)
         shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
-        assert not mitm_addon._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
-        with patch.object(mitm_addon, "_start_usage_flush_worker") as start_worker:
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+        with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker") as start_worker:
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
         start_worker.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -12,6 +12,7 @@ import pytest
 import jsonl_writer
 import logging_utils
 import mitm_addon
+import runner_flush_lifecycle
 import usage
 from tests.pending_helpers import assert_pending
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
@@ -25,12 +26,12 @@ _REQUESTED_AT_MS = 1_770_000_000_000
 
 
 def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
-    mitm_addon.wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout=timeout)
+    runner_flush_lifecycle.wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout=timeout)
 
 
 def record_stranded_runner_usage_flush_signal() -> None:
-    with patch.object(mitm_addon, "_start_usage_flush_worker"):
-        mitm_addon._handle_runner_usage_flush_signal(0, None)
+    with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker"):
+        runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
 
 
 @dataclass(frozen=True)
@@ -93,7 +94,7 @@ def runner_usage_flush_files(tmp_path: Path) -> Iterator[RunnerUsageFlushFiles]:
     try:
         yield files
     finally:
-        mitm_addon.reset_runner_usage_flush_state_for_tests()
+        runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
         usage.set_pending_path("")
 
 
@@ -142,7 +143,7 @@ class TestRunnerUsageFlushSignal:
                 side_effect=write_pending_snapshot,
             ),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert flushed.wait(timeout=1)
             assert snapshotted.wait(timeout=1)
             wait_for_usage_flush_worker_to_stop()
@@ -184,14 +185,16 @@ class TestRunnerUsageFlushSignal:
             assert state["flushRequestId"] == "jsonl-request-1"
             assert state["path"] == str(log_path)
             assert state["pending"] == 0
-            assert not mitm_addon._usage_flush_requested.is_set()
+            assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
         mock_executor = MagicMock()
         mock_executor.shutdown.side_effect = shutdown_usage_executor
         done_thread = ThreadUnderTest(target=mitm_addon.done)
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
@@ -210,7 +213,7 @@ class TestRunnerUsageFlushSignal:
                     message="done did not start the shutdown usage flush",
                 )
 
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 state_before_release = json.loads(runner_usage_flush_files.pending_path.read_text())
                 assert "flushRequestId" not in state_before_release
                 assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
@@ -229,7 +232,7 @@ class TestRunnerUsageFlushSignal:
             "auth-base:shutdown:False",
             "jsonl:shutdown",
         ]
-        assert not mitm_addon._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
     def test_signal_handler_writes_snapshot_when_flush_fails(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
@@ -255,9 +258,9 @@ class TestRunnerUsageFlushSignal:
                 "write_pending_snapshot",
                 side_effect=write_pending_snapshot,
             ),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert snapshotted.wait(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
@@ -275,11 +278,13 @@ class TestRunnerUsageFlushSignal:
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
             patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
         ):
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
         entry = json.loads(log_path.read_text().strip())
@@ -300,10 +305,12 @@ class TestRunnerUsageFlushSignal:
         runner_usage_flush_files.write_jsonl_flush_request(flush_request_id="../jsonl-request-1")
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
-            patch.object(mitm_addon, "flush_log_path") as flush_log_path,
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
+            patch.object(logging_utils, "flush_log_path") as flush_log_path,
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
         flush_log_path.assert_not_called()
@@ -315,10 +322,12 @@ class TestRunnerUsageFlushSignal:
         runner_usage_flush_files.jsonl_flush_request_path.write_bytes(b"\xff")
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
-            patch.object(mitm_addon, "flush_log_path") as flush_log_path,
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
+            patch.object(logging_utils, "flush_log_path") as flush_log_path,
         ):
-            mitm_addon._flush_jsonl_for_runner_request()
+            runner_flush_lifecycle._flush_jsonl_for_runner_request()
 
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
@@ -330,11 +339,13 @@ class TestRunnerUsageFlushSignal:
         log = MagicMock()
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
-            patch.object(mitm_addon, "flush_log_path", side_effect=RuntimeError("secret")),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
+            patch.object(logging_utils, "flush_log_path", side_effect=RuntimeError("secret")),
+            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
         state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
@@ -366,21 +377,22 @@ class TestRunnerUsageFlushSignal:
             original_append_lines(path, content)
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
             patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
             patch.object(
-                mitm_addon,
+                runner_flush_lifecycle,
                 "RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS",
                 0.01,
-                create=True,
             ),
-            patch.object(mitm_addon.ctx, "log", log, create=True),
+            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
         ):
             try:
                 logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
                 assert append_started.wait(timeout=1)
 
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
                 state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
@@ -393,8 +405,8 @@ class TestRunnerUsageFlushSignal:
                     "pending": 1,
                 }
 
-                with patch.object(mitm_addon, "flush_log_path") as retry_flush:
-                    mitm_addon._handle_runner_usage_flush_signal(0, None)
+                with patch.object(logging_utils, "flush_log_path") as retry_flush:
+                    runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                     wait_for_usage_flush_worker_to_stop()
 
                 retry_flush.assert_not_called()
@@ -410,18 +422,20 @@ class TestRunnerUsageFlushSignal:
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
-            patch.object(mitm_addon, "flush_log_path") as flush_log_path,
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
+            patch.object(logging_utils, "flush_log_path") as flush_log_path,
+            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
         flush_log_path.assert_called_once_with(
             str(log_path),
-            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
         )
 
     def test_jsonl_flush_failure_is_retryable(
@@ -430,28 +444,30 @@ class TestRunnerUsageFlushSignal:
         log_path = runner_usage_flush_files.write_jsonl_flush_request()
 
         with (
-            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
-            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            patch.object(
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+            ),
+            patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
         ):
             with patch.object(
-                mitm_addon,
+                logging_utils,
                 "flush_log_path",
                 side_effect=RuntimeError("flush failed"),
             ) as failed_flush:
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
-            with patch.object(mitm_addon, "flush_log_path") as retry_flush:
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+            with patch.object(logging_utils, "flush_log_path") as retry_flush:
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
         failed_flush.assert_called_once_with(
             str(log_path),
-            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
         )
         retry_flush.assert_called_once_with(
             str(log_path),
-            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+            timeout=runner_flush_lifecycle.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
         )
         state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
         assert state["pending"] == 0
@@ -460,14 +476,14 @@ class TestRunnerUsageFlushSignal:
         log = MagicMock()
 
         with (
-            patch.object(mitm_addon.ctx, "log", log, create=True),
+            patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
             patch.object(
                 usage,
                 "flush_usage_events",
                 side_effect=RuntimeError("secret-token"),
             ),
         ):
-            mitm_addon._flush_usage_for_runner_request()
+            runner_flush_lifecycle._flush_usage_for_runner_request()
 
         log.warn.assert_called_once()
         message = log.warn.call_args.args[0]
@@ -510,8 +526,8 @@ class TestRunnerUsageFlushSignal:
             str(runner_usage_flush_files.proxy_log_path),
         )
 
-        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
-            mitm_addon._flush_usage_for_runner_request()
+        with patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True):
+            runner_flush_lifecycle._flush_usage_for_runner_request()
 
         assert enqueue_calls == 1
         assert_pending(
@@ -564,7 +580,7 @@ class TestRunnerUsageFlushSignal:
                 message="timer enqueue did not start",
             )
 
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_event(
                 flush_owner_lock.blocking_acquire_started,
                 timeout=1,
@@ -654,7 +670,7 @@ class TestRunnerUsageFlushSignal:
                 message="first timer enqueue did not start",
             )
 
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_event(
                 flush_owner_lock.blocking_acquire_started,
                 timeout=1,
@@ -705,10 +721,10 @@ class TestRunnerUsageFlushSignal:
             return 0
 
         with patch.object(usage, "flush_usage_events", side_effect=flush_usage_events):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert first_flush_started.wait(timeout=1)
 
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             release_first_flush.set()
 
             assert second_flush_completed.wait(timeout=1)
@@ -727,11 +743,11 @@ class TestRunnerUsageFlushSignal:
         record_stranded_runner_usage_flush_signal()
         with (
             patch.object(
-                mitm_addon,
+                runner_flush_lifecycle,
                 "_flush_usage_for_runner_request",
                 side_effect=flush_usage_for_runner_request,
             ),
-            patch.object(mitm_addon, "_flush_jsonl_for_runner_request"),
+            patch.object(runner_flush_lifecycle, "_flush_jsonl_for_runner_request"),
         ):
             wait_for_usage_flush_worker_to_stop()
             assert flush_count == 1
@@ -739,9 +755,9 @@ class TestRunnerUsageFlushSignal:
     def test_reset_runner_usage_flush_state_clears_stranded_pending_signal(self):
         record_stranded_runner_usage_flush_signal()
 
-        mitm_addon.reset_runner_usage_flush_state_for_tests()
+        runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
 
-        assert not mitm_addon._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
 
     def test_failed_signal_flush_releases_worker_for_later_signal(self, mitm_ctx):
         second_flush_completed = threading.Event()
@@ -758,10 +774,10 @@ class TestRunnerUsageFlushSignal:
             mitm_ctx() as log,
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
         ):
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
             assert second_flush_completed.wait(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
@@ -790,7 +806,7 @@ class TestRunnerUsageFlushSignal:
             usage_webhook_server.queue_response(500)
             usage_webhook_server.queue_response(500)
             with mitm_ctx(), patch.object(usage.webhook.time, "sleep"):
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
             assert usage_webhook_server.request_count == 2
@@ -805,7 +821,7 @@ class TestRunnerUsageFlushSignal:
 
             usage_webhook_server.queue_response(204)
             with mitm_ctx():
-                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
             assert usage_webhook_server.request_count == 3

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -43,7 +43,7 @@ class RunnerUsageFlushFiles:
     jsonl_flush_state_path: Path
     network_log_path: Path
     proxy_log_path: Path
-    addon_file: Path
+    lifecycle_file: Path
 
     def write_usage_flush_request(
         self, *, flush_request_id: str = _DEFAULT_USAGE_FLUSH_REQUEST_ID
@@ -88,7 +88,7 @@ def runner_usage_flush_files(tmp_path: Path) -> Iterator[RunnerUsageFlushFiles]:
         jsonl_flush_state_path=tmp_path / "jsonl-flush-state",
         network_log_path=tmp_path / "network.jsonl",
         proxy_log_path=tmp_path / "proxy.jsonl",
-        addon_file=tmp_path / "mitm_addon.py",
+        lifecycle_file=tmp_path / "runner_flush_lifecycle.py",
     )
     usage.set_pending_path(str(files.pending_path), usage_state_id=_RUNNER_USAGE_STATE_ID)
     try:
@@ -193,7 +193,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
             patch.object(usage.webhook, "usage_executor", mock_executor),
@@ -279,7 +279,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
         ):
@@ -306,7 +306,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
         ):
@@ -323,7 +323,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
         ):
@@ -340,7 +340,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(logging_utils, "flush_log_path", side_effect=RuntimeError("secret")),
             patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
@@ -378,7 +378,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
             patch.object(
@@ -423,7 +423,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(logging_utils, "flush_log_path") as flush_log_path,
             patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
@@ -445,7 +445,7 @@ class TestRunnerUsageFlushSignal:
 
         with (
             patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.addon_file)
+                runner_flush_lifecycle, "__file__", str(runner_usage_flush_files.lifecycle_file)
             ),
             patch.object(runner_flush_lifecycle.ctx, "log", MagicMock(), create=True),
         ):

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -36,7 +36,9 @@
 //! for `usage-pending`, then calls `stop`.
 //!
 //! Addon-side details live in `crates/runner/mitm-addon/src/mitm_addon.py`
-//! (SIGUSR1 worker and request handling),
+//! (mitmproxy hook orchestration),
+//! `crates/runner/mitm-addon/src/runner_flush_lifecycle.py` (SIGUSR1 worker and
+//! request handling),
 //! `crates/runner/mitm-addon/src/usage/counters.py` (`usage-pending`),
 //! `crates/runner/mitm-addon/src/registry.py` (registry loading), and
 //! `crates/runner/mitm-addon/src/jsonl_writer.py` (accepted-write flush

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -902,6 +902,7 @@ PY
             "matching.py",
             "registry.py",
             "response_streaming.py",
+            "runner_flush_lifecycle.py",
             "terminal_usage.py",
             "upstream_admission.py",
             "url_utils.py",


### PR DESCRIPTION
## Summary

- move the runner-triggered usage and JSONL flush state machine from `mitm_addon.py` into its owning `runner_flush_lifecycle.py` module
- keep signal registration and shutdown sequencing explicit at the mitmproxy addon entry points
- update integration tests and the Rust embedded-addon inventory to follow the new ownership boundary

## Compatibility

- no schema, CLI, file-protocol, signal, timeout, or runtime behavior changes
- usage and JSONL request/acknowledgement payloads and shutdown ordering remain unchanged

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m compileall src scripts tests`
- `pytest tests/test_addon_configuration.py tests/test_runner_usage_flush_signal.py tests/test_done_hook.py`
- `pytest tests/`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`

Closes #21447
