### PR TITLE
refactor(api): read webhook deliveries by automation id

### DIFF
--- a/turbo/apps/api/src/signals/services/workflow-webhook-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-trigger.service.ts
@@ -425,7 +425,7 @@ async function rateLimitExceeded(args: {
     .from(zeroWorkflowWebhookDeliveries)
     .where(
       and(
-        eq(zeroWorkflowWebhookDeliveries.triggerId, args.triggerId),
+        eq(zeroWorkflowWebhookDeliveries.automationId, args.triggerId),
         gte(
           zeroWorkflowWebhookDeliveries.receivedAt,
           new Date(args.currentTime.getTime() - 60_000),


### PR DESCRIPTION
## Summary

- switch webhook delivery rate-limit/deduplication reads from legacy `trigger_id` to canonical `automation_id`
- keep the current explicit dual-write and migration-level synchronization from #21478 so previous and rollback releases remain compatible
- confirm the GitHub processed-event path has no ID-column reads to switch; its uniqueness enforcement already exists on canonical `automation_id`

## Rollout safety

This read cutover follows the merged migration 0594 in #21478. That migration backfills every canonical value and synchronizes both columns before this application code can deploy, so the query is valid for old rows and writes from either release. The branch was patch-equivalently rebased onto `main`; `git range-diff` reports the application commit unchanged.

## Verification

- targeted Prettier
- `pnpm -F api lint` (passes with one pre-existing `no-unused-vars` warning in `internal-chat-run-callback.service.ts`)
- `pnpm --filter api run check-types`
- `git diff --check`
- targeted `webhooks-workflow-triggers.test.ts` was attempted, but the local PostgreSQL service is unavailable (`ECONNREFUSED` during fixture onboarding); PR CI provides the real PostgreSQL integration gate

Part of #21408.
