### PR TITLE
test(runner): remove storage cache lock race

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -5088,15 +5088,6 @@ mod tests {
             .expect("both background fills should finish before later warm staging")
             .unwrap();
 
-        let cold_lock = tokio::time::timeout(
-            Duration::from_secs(5),
-            lock::acquire(home.storage_lock(cold_name, version)),
-        )
-        .await
-        .expect("cold worker should release the host cache lock before guest staging unblocks")
-        .unwrap();
-        drop(cold_lock);
-
         gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
         gate.release_one();
         let manifest = task.await.unwrap().unwrap();


### PR DESCRIPTION
## Summary

- remove the exclusive lock probe from `multi_group_background_fill_precedes_later_warm_staging`
- use the awaited background-fill helper and guest staging gate as the deterministic completion boundary
- prevent the test from turning the later warm read into an expected busy passthrough

## Root cause

The test acquired the cold cache lock after the background response was sent. That acquisition raced with the second `populate_cache` pass, which intentionally uses a non-blocking shared lock. When the test won, the cold target remained on its remote URL and the staged batch correctly contained only one file, causing a false failure.

## Testing

- repeated the targeted test 1,000 times after the fix
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `lefthook run pre-commit --file crates/runner/src/storage_cache.rs --no-tty`
