### PR TITLE
refactor(api): read notion pending events by automation id

### DIFF
--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -1494,7 +1494,7 @@ async function enqueueOrRefreshNotionPageContentUpdatedEvents(args: {
       })
       .where(
         and(
-          eq(notionWorkflowPendingEvents.triggerId, trigger.id),
+          eq(notionWorkflowPendingEvents.automationId, trigger.id),
           eq(notionWorkflowPendingEvents.pageId, args.pageId),
           eq(notionWorkflowPendingEvents.eventFamily, "page_content_updated"),
           eq(notionWorkflowPendingEvents.status, "pending"),


### PR DESCRIPTION
## Summary

- switch Notion page-content debounce refresh lookups from the legacy `trigger_id` column to canonical `automation_id`
- preserve the existing `trigger_id`/`automation_id` dual write and database synchronization window for older and rollback API releases
- complete the only application read that remained across the four event-bookkeeping tables expanded by migration 0596

## Impact

Notion page-content automations continue coalescing repeated webhook events into one pending run, now through the canonical Automation identifier. This is a behavior-preserving database read cutover; the legacy column remains available during the compatibility window.

Part of #21408.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types`
- `git diff --check`
- attempted `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-notion.test.ts`; the local PostgreSQL service was unavailable, so all 10 cases stopped in fixture setup with `ECONNREFUSED :5432`. PR CI is the authoritative real-database gate.

## Rollout safety

Production release workflow 29339294963 successfully applied migration 0596 before this cutover. The compatibility columns and database synchronization trigger remain unchanged.
