### PR TITLE
fix(runner): observe cancellation before process spawn

### DIFF
--- a/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/create_destroy.rs
@@ -66,19 +66,14 @@ async fn failed_job_with_session_not_parked() {
     shutdown(&env, run_handle).await;
 }
 
-/// Test 21: Cancelled job is not parked.
-///
-/// `wait_process_gate` blocks the agent execution. The test cancels the job
-/// via the cancel token, causing `select!` in the executor to take the
-/// cancellation branch. `job_cancel.is_cancelled()` is true, so
-/// `parkable_session` is `None` → sandbox destroyed.
+/// Test 21: A cancelled job is destroyed instead of parked.
 #[tokio::test(start_paused = true)]
 async fn cancelled_job_not_parked() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        gate,
-    ));
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
@@ -92,9 +87,11 @@ async fn cancelled_job_not_parked() {
         Some(context_with_session(run_id, "sess-cancel")),
     );
 
-    // Wait for the job to be claimed (cancel token inserted).
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter before cancellation");
     let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
-    // Cancel the job — executor's select! takes the cancelled branch.
     cancel_handle.cancel().await;
 
     let c = env
@@ -112,6 +109,9 @@ async fn cancelled_job_not_parked() {
         0,
         "cancelled job must not park"
     );
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.park_call_count(), 0);
+    assert_eq!(overrides.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::time::{Duration, Instant};
 
 use guest_contracts::diagnostics::FailureDiagnostic;
@@ -13,8 +14,8 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
 };
 use sandbox::{
-    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
-    Sandbox, StartProcessRequest,
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessHandle, ProcessControlMode,
+    ProcessOutputMode, Sandbox, StartProcessRequest,
 };
 use shell_quote::quote_shell_arg;
 use tokio::io::AsyncReadExt;
@@ -22,11 +23,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use super::diagnostics::{
-    AgentBootstrapAbnormalExitLogContext, AgentStdoutStreamDiagnostics, StdoutDrainReport,
-    build_agent_env_diagnostics, build_agent_env_key_diagnostics, check_host_oom,
-    collect_agent_abnormal_exit_diagnostics, dmesg_indicates_oom, drain_stdout_to_file,
-    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
-    log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
+    AgentBootstrapAbnormalExitLogContext, AgentEnvDiagnostics, AgentStdoutStreamDiagnostics,
+    StdoutDrainReport, build_agent_env_diagnostics, build_agent_env_key_diagnostics,
+    check_host_oom, collect_agent_abnormal_exit_diagnostics, dmesg_indicates_oom,
+    drain_stdout_to_file, log_agent_abnormal_exit_env_diagnostics,
+    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
+    read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
     should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
@@ -42,7 +44,9 @@ use super::session_history_download::{
     SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
     SessionHistoryMaterialization, SessionHistoryMaterializer,
 };
-use super::session_restore::{MaterializedResumeSession, restore_session};
+use super::session_restore::{
+    MaterializedResumeSession, SessionRestoreDiagnostics, restore_session,
+};
 use super::storage::download_storages;
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
@@ -770,6 +774,14 @@ impl AgentExecutionResult {
         Self::failure(1, error, None)
     }
 
+    pub(super) fn cancelled() -> Self {
+        Self {
+            failure: Some(ExecutionFailure::cancelled()),
+            stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
+            reusable_session_identity: None,
+        }
+    }
+
     pub(super) fn exit_code(&self) -> i32 {
         self.failure.as_ref().map_or(0, |failure| failure.exit_code)
     }
@@ -934,6 +946,31 @@ impl RunControls {
     }
 }
 
+struct PreparedAgentProcess {
+    handle: GuestProcessHandle,
+    agent_started_at: Instant,
+    deferred_background_fill: Option<crate::storage_cache::DeferredBackgroundFill>,
+    session_restore_diagnostics: Option<SessionRestoreDiagnostics>,
+    pre_run_restored_session_identity: Option<RestoredSessionIdentity>,
+    env_diagnostics: AgentEnvDiagnostics,
+    env_pairs: Vec<(String, String)>,
+}
+
+async fn run_pre_spawn_phase<T>(
+    cancel: &CancellationToken,
+    phase: impl Future<Output = T>,
+) -> Option<T> {
+    if cancel.is_cancelled() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        result = phase => Some(result),
+        () = cancel.cancelled() => None,
+    }
+}
+
 pub(super) async fn run_in_sandbox(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
@@ -970,7 +1007,15 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         session_history_restore_plan,
     } = controls;
     let has_active_input_source = active_input_source.is_some();
-    let mut deferred_background_fill = None;
+    let pre_spawn_started = Instant::now();
+    let pre_spawn_cancel = cancel.clone();
+    let pre_spawn_start = &start;
+    let pre_spawn_telemetry = &mut *telemetry;
+    let prepared_agent = run_pre_spawn_phase(&cancel, async move {
+        let cancel = pre_spawn_cancel;
+        let start = pre_spawn_start;
+        let telemetry = pre_spawn_telemetry;
+        let mut deferred_background_fill = None;
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -1475,7 +1520,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         })
         .await;
 
-    let mut handle = match handle {
+    let handle = match handle {
         Ok(h) => {
             let spawned_at = Instant::now();
             telemetry.record(
@@ -1498,6 +1543,46 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             );
             telemetry.record("agent_execute", t.elapsed(), false, Some(&e.to_string()));
             return Err(e.into());
+        }
+    };
+
+        RunnerResult::Ok(PreparedAgentProcess {
+            handle,
+            agent_started_at: t,
+            deferred_background_fill,
+            session_restore_diagnostics,
+            pre_run_restored_session_identity,
+            env_diagnostics,
+            env_pairs,
+        })
+    })
+    .await;
+    let PreparedAgentProcess {
+        mut handle,
+        agent_started_at: t,
+        deferred_background_fill,
+        session_restore_diagnostics,
+        mut pre_run_restored_session_identity,
+        env_diagnostics,
+        env_pairs,
+    } = match prepared_agent {
+        Some(result) => result?,
+        None => {
+            info!(
+                run_id = %context.run_id,
+                "cancel received before guest process started"
+            );
+            let result = AgentExecutionResult::cancelled();
+            telemetry.record(
+                "agent_execute",
+                pre_spawn_started.elapsed(),
+                false,
+                result
+                    .failure
+                    .as_ref()
+                    .map(|failure| failure.error.as_str()),
+            );
+            return Ok(result);
         }
     };
 

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -32,7 +32,9 @@ mod oom;
 mod resource;
 mod stdout_stream;
 
-pub(super) use environment::{build_agent_env_diagnostics, build_agent_env_key_diagnostics};
+pub(super) use environment::{
+    AgentEnvDiagnostics, build_agent_env_diagnostics, build_agent_env_key_diagnostics,
+};
 pub(super) use exit::{
     AgentBootstrapAbnormalExitLogContext, log_agent_abnormal_exit_env_diagnostics,
     log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -27,7 +27,7 @@ use sandbox::{
     ExecResult, ExecTermination, ProcessExit, ProcessOutputChunk, ProcessOutputMode, SandboxConfig,
     SandboxFactory, SandboxId,
 };
-use sandbox_mock::MockSandboxFactory;
+use sandbox_mock::{MockLifecycleGate, MockSandboxFactory};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -45,10 +45,11 @@ use super::super::{
     effective_cli_framework,
 };
 use super::support::{
-    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, StartProcessGateSandbox, api_artifact,
-    api_storage, create_overridden_sandbox, minimal_context, sandbox_exec_error,
-    sandbox_read_file_error, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
-    test_executor_config, test_telemetry,
+    CancelAtProcessBoundarySandbox, OperationGateSandbox, ProcessCancellationPoint,
+    RUN_IN_SANDBOX_TEST_TIMEOUT, SandboxGatePoint, api_artifact, api_storage,
+    create_overridden_sandbox, minimal_context, sandbox_exec_error, sandbox_read_file_error,
+    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts, test_executor_config,
+    test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -510,7 +511,7 @@ async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
     ))));
     let cancel = tokio_util::sync::CancellationToken::new();
     let factory = MockSandboxFactory::with_overrides(overrides);
-    let sandbox = CancelAfterWaitSandbox {
+    let sandbox = CancelAtProcessBoundarySandbox {
         inner: factory
             .create(SandboxConfig {
                 id: SandboxId::new_v4(),
@@ -524,6 +525,7 @@ async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
             .await
             .unwrap(),
         cancel: cancel.clone(),
+        point: ProcessCancellationPoint::WaitResult,
     };
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -631,8 +633,9 @@ async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let start_process_entered = Arc::new(Notify::new());
     let start_process_release = Arc::new(Notify::new());
-    let sandbox = StartProcessGateSandbox {
+    let sandbox = OperationGateSandbox {
         inner: create_overridden_sandbox(Arc::clone(&overrides)).await,
+        point: SandboxGatePoint::StartProcess,
         entered: Arc::clone(&start_process_entered),
         release: Arc::clone(&start_process_release),
     };
@@ -1979,14 +1982,12 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
 async fn run_in_sandbox_drops_checkpointed_identity_when_agent_is_cancelled() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&wait_gate),
-    ));
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let start_process_entered = Arc::new(Notify::new());
     let start_process_release = Arc::new(Notify::new());
-    let sandbox = StartProcessGateSandbox {
+    let sandbox = OperationGateSandbox {
         inner: create_overridden_sandbox(Arc::clone(&overrides)).await,
+        point: SandboxGatePoint::StartProcess,
         entered: Arc::clone(&start_process_entered),
         release: Arc::clone(&start_process_release),
     };
@@ -2026,25 +2027,11 @@ async fn run_in_sandbox_drops_checkpointed_identity_when_agent_is_cancelled() {
     assert_eq!(overrides.exec_calls().len(), 1);
 
     cancel.cancel();
-    let release_wait = tokio::spawn({
-        let overrides = Arc::clone(&overrides);
-        let wait_gate = Arc::clone(&wait_gate);
-        async move {
-            assert!(
-                overrides
-                    .wait_for_process_cancel_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
-                    .await
-            );
-            wait_gate.notify_one();
-        }
-    });
-    start_process_release.notify_one();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut run)
         .await
         .expect("cancelled run should finish")
         .unwrap();
-    release_wait.await.unwrap();
 
     assert_eq!(
         result.failure.as_ref().map(|failure| failure.exit_code),
@@ -2052,6 +2039,9 @@ async fn run_in_sandbox_drops_checkpointed_identity_when_agent_is_cancelled() {
     );
     assert!(result.reusable_session_identity.is_none());
     assert_eq!(overrides.exec_calls().len(), 1);
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+    assert!(overrides.process_cancel_calls().is_empty());
 }
 
 #[tokio::test]
@@ -3495,13 +3485,121 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_starts_no_guest_work_when_already_cancelled() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let cancel = tokio_util::sync::CancellationToken::new();
+    cancel.cancel();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        sandbox.as_ref(),
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(cancel, None),
+    )
+    .await
+    .unwrap();
+
+    let failure = result.failure.expect("cancelled run should fail");
+    assert_eq!(failure.exit_code, EXIT_SIGKILL);
+    assert_eq!(failure.error, "cancelled by user");
+    assert!(overrides.exec_calls().is_empty());
+    assert!(overrides.write_file_calls().is_empty());
+    assert!(overrides.private_write_file_calls().is_empty());
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_observes_cancellation_while_guest_helper_is_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let helper_entered = Arc::new(Notify::new());
+    let helper_release = Arc::new(Notify::new());
+    let sandbox = OperationGateSandbox {
+        inner: create_overridden_sandbox(Arc::clone(&overrides)).await,
+        point: SandboxGatePoint::WritePrivateFile,
+        entered: Arc::clone(&helper_entered),
+        release: helper_release,
+    };
+    let ctx = minimal_context();
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let run_task = spawn_run_in_sandbox_test(Box::new(sandbox), ctx, config, cancel.clone());
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, helper_entered.notified())
+        .await
+        .expect("run should enter the guest helper");
+    cancel.cancel();
+
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .expect("cancelled helper should not hold the run open")
+        .unwrap()
+        .unwrap();
+
+    let failure = result.failure.expect("cancelled run should fail");
+    assert_eq!(failure.exit_code, EXIT_SIGKILL);
+    assert_eq!(failure.error, "cancelled by user");
+    assert!(overrides.exec_calls().is_empty());
+    assert!(overrides.private_write_file_calls().is_empty());
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_preserves_ready_start_result_when_cancellation_arrives() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let sandbox = CancelAtProcessBoundarySandbox {
+        inner: create_overridden_sandbox(Arc::clone(&overrides)).await,
+        cancel: cancel.clone(),
+        point: ProcessCancellationPoint::StartResult,
+    };
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(cancel.clone(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(cancel.is_cancelled());
+    assert!(result.failure.is_none());
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.wait_process_calls().len(), 1);
+    assert!(overrides.process_cancel_calls().is_empty());
+}
+
+#[tokio::test]
 async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&wait_gate),
-    ));
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.push_start_process_stdout_chunks(vec![ProcessOutputChunk {
         bytes: b"partial stdout".to_vec(),
         truncated: true,
@@ -3513,6 +3611,10 @@ async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
     let ctx = minimal_context();
     let cancel = tokio_util::sync::CancellationToken::new();
     let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
     cancel.cancel();
 
     assert!(
@@ -3551,15 +3653,18 @@ async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
 async fn run_in_sandbox_returns_cancelled_when_cancel_handle_is_missing() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        wait_gate,
-    ));
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.set_process_cancel_supported(false);
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let cancel = tokio_util::sync::CancellationToken::new();
     let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
     cancel.cancel();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
@@ -3579,15 +3684,18 @@ async fn run_in_sandbox_returns_cancelled_when_cancel_handle_is_missing() {
 async fn run_in_sandbox_returns_cancelled_when_process_cancel_send_fails() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        wait_gate,
-    ));
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.push_process_cancel_error("cancel write failed");
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let cancel = tokio_util::sync::CancellationToken::new();
     let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
     cancel.cancel();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
@@ -3612,14 +3720,19 @@ async fn run_in_sandbox_returns_cancelled_when_process_cancel_send_fails() {
 async fn run_in_sandbox_returns_cancelled_when_wait_fails_after_process_cancel() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let mut overrides = sandbox_mock::MockSandboxOverrides::with_wait_process_gate(wait_gate);
+    let wait_gate = MockLifecycleGate::new();
+    let mut overrides = sandbox_mock::MockSandboxOverrides::new();
     overrides.set_wait_process_error("wait failed after cancel");
     let overrides = Arc::new(overrides);
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let cancel = tokio_util::sync::CancellationToken::new();
     let run_task = spawn_run_in_sandbox_test(sandbox, ctx, config, cancel.clone());
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
     cancel.cancel();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
@@ -3644,10 +3757,9 @@ async fn run_in_sandbox_returns_cancelled_when_wait_fails_after_process_cancel()
 async fn run_in_sandbox_returns_cancelled_when_terminal_grace_times_out() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        wait_gate,
-    ));
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     overrides.set_process_cancel_releases_wait_gate(false);
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
@@ -3662,6 +3774,10 @@ async fn run_in_sandbox_returns_cancelled_when_terminal_grace_times_out() {
             terminal_grace: Duration::ZERO,
         },
     );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("run should enter process wait before cancellation");
     cancel.cancel();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -22,9 +22,10 @@ pub(super) use self::execution::{
 };
 pub(super) use self::manifest::{api_artifact, api_storage};
 pub(super) use self::sandbox::{
-    CancelAfterWaitSandbox, DestroyPanicFactory, QueuedCopyFileSandbox, StartProcessGateSandbox,
-    create_overridden_sandbox, sandbox_copy_file_error, sandbox_create_error, sandbox_exec_error,
-    sandbox_read_file_error, sandbox_write_file_error,
+    CancelAtProcessBoundarySandbox, DestroyPanicFactory, OperationGateSandbox,
+    ProcessCancellationPoint, QueuedCopyFileSandbox, SandboxGatePoint, create_overridden_sandbox,
+    sandbox_copy_file_error, sandbox_create_error, sandbox_exec_error, sandbox_read_file_error,
+    sandbox_write_file_error,
 };
 pub(super) use self::tracing::{CapturedEvent, CapturedEvents};
 pub(super) use self::workspace_cache::seed_workspace_image_cache;

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -153,19 +153,43 @@ pub(in crate::executor::tests) fn sandbox_create_error(message: impl Into<String
     }
 }
 
-pub(in crate::executor::tests) struct CancelAfterWaitSandbox {
-    pub(in crate::executor::tests) inner: Box<dyn Sandbox>,
-    pub(in crate::executor::tests) cancel: tokio_util::sync::CancellationToken,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::executor::tests) enum ProcessCancellationPoint {
+    StartResult,
+    WaitResult,
 }
 
-pub(in crate::executor::tests) struct StartProcessGateSandbox {
+pub(in crate::executor::tests) struct CancelAtProcessBoundarySandbox {
     pub(in crate::executor::tests) inner: Box<dyn Sandbox>,
+    pub(in crate::executor::tests) cancel: tokio_util::sync::CancellationToken,
+    pub(in crate::executor::tests) point: ProcessCancellationPoint,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::executor::tests) enum SandboxGatePoint {
+    Exec,
+    StartProcess,
+    WritePrivateFile,
+}
+
+pub(in crate::executor::tests) struct OperationGateSandbox {
+    pub(in crate::executor::tests) inner: Box<dyn Sandbox>,
+    pub(in crate::executor::tests) point: SandboxGatePoint,
     pub(in crate::executor::tests) entered: Arc<tokio::sync::Notify>,
     pub(in crate::executor::tests) release: Arc<tokio::sync::Notify>,
 }
 
+impl OperationGateSandbox {
+    async fn wait_at(&self, point: SandboxGatePoint) {
+        if self.point == point {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+    }
+}
+
 #[async_trait]
-impl Sandbox for StartProcessGateSandbox {
+impl Sandbox for OperationGateSandbox {
     fn id(&self) -> &str {
         self.inner.id()
     }
@@ -199,6 +223,7 @@ impl Sandbox for StartProcessGateSandbox {
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        self.wait_at(SandboxGatePoint::Exec).await;
         self.inner.exec(request).await
     }
 
@@ -207,6 +232,7 @@ impl Sandbox for StartProcessGateSandbox {
         request: &ExecRequest<'_>,
         label: &'static str,
     ) -> sandbox::Result<ExecResult> {
+        self.wait_at(SandboxGatePoint::Exec).await;
         self.inner.exec_with_diagnostic_label(request, label).await
     }
 
@@ -228,6 +254,7 @@ impl Sandbox for StartProcessGateSandbox {
     }
 
     async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.wait_at(SandboxGatePoint::WritePrivateFile).await;
         self.inner.write_private_file(path, content).await
     }
 
@@ -235,8 +262,7 @@ impl Sandbox for StartProcessGateSandbox {
         &self,
         request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<sandbox::GuestProcessHandle> {
-        self.entered.notify_one();
-        self.release.notified().await;
+        self.wait_at(SandboxGatePoint::StartProcess).await;
         self.inner.start_process(request).await
     }
 
@@ -250,7 +276,7 @@ impl Sandbox for StartProcessGateSandbox {
 }
 
 #[async_trait]
-impl Sandbox for CancelAfterWaitSandbox {
+impl Sandbox for CancelAtProcessBoundarySandbox {
     fn id(&self) -> &str {
         self.inner.id()
     }
@@ -320,7 +346,11 @@ impl Sandbox for CancelAfterWaitSandbox {
         &self,
         request: &StartProcessRequest<'_>,
     ) -> sandbox::Result<sandbox::GuestProcessHandle> {
-        self.inner.start_process(request).await
+        let result = self.inner.start_process(request).await;
+        if self.point == ProcessCancellationPoint::StartResult {
+            self.cancel.cancel();
+        }
+        result
     }
 
     async fn wait_process(
@@ -329,7 +359,9 @@ impl Sandbox for CancelAfterWaitSandbox {
         timeout: Duration,
     ) -> sandbox::Result<ProcessExit> {
         let result = self.inner.wait_process(handle, timeout).await;
-        self.cancel.cancel();
+        if self.point == ProcessCancellationPoint::WaitResult {
+            self.cancel.cancel();
+        }
         result
     }
 }

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -167,7 +167,6 @@ pub(in crate::executor::tests) struct CancelAtProcessBoundarySandbox {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::executor::tests) enum SandboxGatePoint {
-    Exec,
     StartProcess,
     WritePrivateFile,
 }
@@ -223,7 +222,6 @@ impl Sandbox for OperationGateSandbox {
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
-        self.wait_at(SandboxGatePoint::Exec).await;
         self.inner.exec(request).await
     }
 
@@ -232,7 +230,6 @@ impl Sandbox for OperationGateSandbox {
         request: &ExecRequest<'_>,
         label: &'static str,
     ) -> sandbox::Result<ExecResult> {
-        self.wait_at(SandboxGatePoint::Exec).await;
         self.inner.exec_with_diagnostic_label(request, label).await
     }
 


### PR DESCRIPTION
## Summary

- race cancellation against the complete pre-spawn preparation phase, including guest helpers, downloads, session restore, payload writes, and `start_process`
- return the existing synthetic cancellation result before a process handle exists while preserving ready `start_process` results so post-spawn cancellation can retire the guest process safely
- make cancellation tests deterministic at helper, spawn, and process-wait boundaries, and verify cancelled sandboxes are destroyed instead of parked

## Exclusions

- no sandbox or vsock protocol changes
- no change to cancellation behavior after a guest process handle has been acquired

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_` (49 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2670 passed, 9 existing ignored; guest inventory passed)
- pre-commit Rust workspace format, documentation, and Clippy hooks

Closes #21450
