### PR TITLE
perf(api): batch usage allowance settlement

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -146,11 +146,11 @@ async function createVm0Run(
   });
 }
 
-async function recordPendingUsage(args: {
+async function recordPendingUsageEvents(args: {
   readonly actor: ApiTestUser;
   readonly runId: string;
   readonly provider: string;
-  readonly quantity: number;
+  readonly quantities: readonly number[];
 }): Promise<void> {
   const api = createRunsApi(context);
   const webhooks = createWebhookCallbackApi(context);
@@ -166,21 +166,35 @@ async function recordPendingUsage(args: {
   await webhooks.requestAgentUsageEvent(
     {
       runId: args.runId,
-      events: [
-        {
+      events: args.quantities.map((quantity) => {
+        return {
           idempotencyKey: randomUUID(),
           kind: "connector",
           provider: args.provider,
           category: "credits",
-          quantity: args.quantity,
-        },
-      ],
+          quantity,
+        };
+      }),
     },
     {
       authorization: `Bearer ${api.sandboxTokenForRun(args.actor, args.runId)}`,
     },
     [200],
   );
+}
+
+async function recordPendingUsage(args: {
+  readonly actor: ApiTestUser;
+  readonly runId: string;
+  readonly provider: string;
+  readonly quantity: number;
+}): Promise<void> {
+  await recordPendingUsageEvents({
+    actor: args.actor,
+    runId: args.runId,
+    provider: args.provider,
+    quantities: [args.quantity],
+  });
 }
 
 async function processUsageEvents(): Promise<void> {
@@ -232,6 +246,49 @@ describe("Usage Allowance", () => {
 
     await expect(readOrgCredits(actor)).resolves.toBe(10);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
+  });
+
+  it("settles multiple events and runs against shared allowance windows", async () => {
+    const { actor, agentId } = await vm0AllowanceActor({
+      credits: 100,
+      allowance: { shortWindowUnits: 100, weeklyWindowUnits: 90 },
+    });
+    const firstRun = await createVm0Run(actor, agentId, "batched first run");
+    const secondRun = await createVm0Run(actor, agentId, "batched second run");
+    const provider = usageProvider();
+    await recordPendingUsageEvents({
+      actor,
+      runId: firstRun.runId,
+      provider,
+      quantities: [30, 40],
+    });
+    await recordPendingUsage({
+      actor,
+      runId: secondRun.runId,
+      provider,
+      quantity: 50,
+    });
+
+    await processUsageEvents();
+
+    await expect(readOrgCredits(actor)).resolves.toBe(70);
+    await expect(readRunCreditsCharged(actor, firstRun.runId)).resolves.toBe(
+      70,
+    );
+    await expect(readRunCreditsCharged(actor, secondRun.runId)).resolves.toBe(
+      50,
+    );
+    const status = await createRunsApi(context).readBillingStatus(actor);
+    if (!status.usageAllowance) {
+      throw new Error("Expected usage allowance windows");
+    }
+    expect(
+      Object.fromEntries(
+        status.usageAllowance.windows.map((window) => {
+          return [window.kind, window.consumedUnits];
+        }),
+      ),
+    ).toStrictEqual({ short: 90, weekly: 90 });
   });
 
   it("falls back to org credits after the binding window cap is exhausted", async () => {

--- a/turbo/apps/api/src/signals/services/usage-allowance.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-allowance.service.ts
@@ -91,7 +91,6 @@ interface UsageAllowanceCandidate {
 
 interface UsageAllowanceWindowState {
   readonly id: string;
-  readonly kind: string;
   readonly unitLimit: number;
   consumedUnits: number;
   readonly initialConsumedUnits: number;
@@ -140,7 +139,9 @@ function addSeconds(date: Date, seconds: number): Date {
   return new Date(date.getTime() + seconds * 1000);
 }
 
-function remainingUnits(window: UsageAllowanceWindow): number {
+function remainingUnits(
+  window: Pick<UsageAllowanceWindow, "unitLimit" | "consumedUnits">,
+): number {
   return Math.max(window.unitLimit - window.consumedUnits, 0);
 }
 
@@ -708,7 +709,6 @@ async function lockIssuedWindowsForRuns(
   const windows = await tx
     .select({
       id: orgUsageAllowanceWindows.id,
-      kind: orgUsageAllowanceWindows.kind,
       unitLimit: orgUsageAllowanceWindows.unitLimit,
       consumedUnits: orgUsageAllowanceWindows.consumedUnits,
       startsAt: orgUsageAllowanceWindows.startsAt,
@@ -886,6 +886,7 @@ export async function applyUsageAllowanceToUsageEventsInLockedTransaction(
   });
   const eligibleRunIds = [...runCreatedAtById.keys()];
 
+  // Preserve the existing short-before-weekly row-lock order.
   const shortWindows = await lockIssuedWindowsForRuns(tx, {
     orgId: args.orgId,
     kind: "short",

--- a/turbo/apps/api/src/signals/services/usage-allowance.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-allowance.service.ts
@@ -7,6 +7,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   and,
+  asc,
   desc,
   eq,
   gte,
@@ -74,6 +75,41 @@ interface UsageAllowanceWindow {
 interface UsageAllowanceWindows {
   readonly shortWindow: UsageAllowanceWindow;
   readonly weeklyWindow: UsageAllowanceWindow;
+}
+
+interface UsageAllowanceEventInput {
+  readonly usageEventId: string;
+  readonly runId: string | null;
+  readonly grossUnits: number;
+}
+
+interface UsageAllowanceCandidate {
+  readonly usageEventId: string;
+  readonly runId: string;
+  readonly grossUnits: number;
+}
+
+interface UsageAllowanceWindowState {
+  readonly id: string;
+  readonly kind: string;
+  readonly unitLimit: number;
+  consumedUnits: number;
+  readonly initialConsumedUnits: number;
+  readonly startsAt: Date;
+  readonly expiresAt: Date;
+}
+
+interface MutableUsageAllowanceWindows {
+  readonly shortWindow: UsageAllowanceWindowState;
+  readonly weeklyWindow: UsageAllowanceWindowState;
+}
+
+interface NewUsageAllowanceAllocation {
+  readonly usageEventId: string;
+  readonly runId: string;
+  readonly shortWindowId: string;
+  readonly weeklyWindowId: string;
+  readonly unitsApplied: number;
 }
 
 interface UsageAllowanceAvailability {
@@ -604,68 +640,306 @@ export async function resolveUsageAllowanceAvailabilityForRun(
   });
 }
 
-export async function applyUsageAllowanceToUsageEvent(
+async function loadExistingUsageAllowanceAllocations(
+  tx: UsageAllowanceStore,
+  usageEventIds: readonly string[],
+): Promise<Map<string, number>> {
+  if (usageEventIds.length === 0) {
+    return new Map();
+  }
+
+  const rows = await tx
+    .select({
+      usageEventId: usageAllowanceAllocations.usageEventId,
+      unitsApplied: usageAllowanceAllocations.unitsApplied,
+    })
+    .from(usageAllowanceAllocations)
+    .where(
+      sql`${usageAllowanceAllocations.usageEventId} = ANY(${sql.param([...usageEventIds])}::uuid[])`,
+    );
+  return new Map(
+    rows.map((row) => {
+      return [row.usageEventId, row.unitsApplied];
+    }),
+  );
+}
+
+async function loadVm0RunCreatedAts(
   tx: UsageAllowanceStore,
   args: {
-    readonly usageEventId: string;
     readonly orgId: string;
-    readonly runId: string | null;
-    readonly grossUnits: number;
+    readonly runIds: readonly string[];
   },
-): Promise<number> {
-  if (args.grossUnits <= 0 || !args.runId) {
-    return 0;
+): Promise<Map<string, Date>> {
+  if (args.runIds.length === 0) {
+    return new Map();
   }
 
-  await lockUsageAllowanceOrg(tx, args.orgId);
-
-  const [existing] = await tx
-    .select({ unitsApplied: usageAllowanceAllocations.unitsApplied })
-    .from(usageAllowanceAllocations)
-    .where(eq(usageAllowanceAllocations.usageEventId, args.usageEventId))
-    .limit(1);
-  if (existing) {
-    return existing.unitsApplied;
-  }
-
-  const windows = await loadExistingWindowsForRun(tx, {
-    orgId: args.orgId,
-    runId: args.runId,
-  });
-  if (!windows) {
-    return 0;
-  }
-
-  const unitsApplied = Math.min(
-    args.grossUnits,
-    remainingUnits(windows.shortWindow),
-    remainingUnits(windows.weeklyWindow),
-  );
-  if (unitsApplied <= 0) {
-    return 0;
-  }
-
-  await tx
-    .update(orgUsageAllowanceWindows)
-    .set({
-      consumedUnits: sql`${orgUsageAllowanceWindows.consumedUnits} + ${unitsApplied}`,
-      updatedAt: nowDate(),
-    })
+  const rows = await tx
+    .select({ id: agentRuns.id, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .where(
-      inArray(orgUsageAllowanceWindows.id, [
-        windows.shortWindow.id,
-        windows.weeklyWindow.id,
-      ]),
+      and(
+        eq(agentRuns.orgId, args.orgId),
+        eq(zeroRuns.modelProvider, "vm0"),
+        sql`${agentRuns.id} = ANY(${sql.param([...args.runIds])}::uuid[])`,
+      ),
     );
+  return new Map(
+    rows.map((row) => {
+      return [row.id, row.createdAt];
+    }),
+  );
+}
 
-  await tx.insert(usageAllowanceAllocations).values({
-    usageEventId: args.usageEventId,
-    orgId: args.orgId,
-    runId: args.runId,
-    shortWindowId: windows.shortWindow.id,
-    weeklyWindowId: windows.weeklyWindow.id,
-    unitsApplied,
+async function lockIssuedWindowsForRuns(
+  tx: UsageAllowanceStore,
+  args: {
+    readonly orgId: string;
+    readonly kind: UsageAllowanceWindowKind;
+    readonly runIds: readonly string[];
+  },
+): Promise<UsageAllowanceWindowState[]> {
+  if (args.runIds.length === 0) {
+    return [];
+  }
+
+  const windows = await tx
+    .select({
+      id: orgUsageAllowanceWindows.id,
+      kind: orgUsageAllowanceWindows.kind,
+      unitLimit: orgUsageAllowanceWindows.unitLimit,
+      consumedUnits: orgUsageAllowanceWindows.consumedUnits,
+      startsAt: orgUsageAllowanceWindows.startsAt,
+      expiresAt: orgUsageAllowanceWindows.expiresAt,
+    })
+    .from(orgUsageAllowanceWindows)
+    .where(
+      and(
+        eq(orgUsageAllowanceWindows.orgId, args.orgId),
+        eq(orgUsageAllowanceWindows.kind, args.kind),
+        sql`EXISTS (
+          SELECT 1
+          FROM ${agentRuns}
+          INNER JOIN ${zeroRuns} ON ${zeroRuns.id} = ${agentRuns.id}
+          WHERE ${agentRuns.orgId} = ${args.orgId}
+            AND ${zeroRuns.modelProvider} = 'vm0'
+            AND ${agentRuns.id} = ANY(${sql.param([...args.runIds])}::uuid[])
+            AND ${orgUsageAllowanceWindows.startsAt} <= ${agentRuns.createdAt}
+            AND ${orgUsageAllowanceWindows.expiresAt} > ${agentRuns.createdAt}
+        )`,
+      ),
+    )
+    .orderBy(asc(orgUsageAllowanceWindows.id))
+    .for("update");
+
+  return windows.map((window) => {
+    return {
+      ...window,
+      initialConsumedUnits: window.consumedUnits,
+    };
+  });
+}
+
+function latestIssuedWindowAt(
+  windows: readonly UsageAllowanceWindowState[],
+  at: Date,
+): UsageAllowanceWindowState | null {
+  let latest: UsageAllowanceWindowState | null = null;
+  const atMs = at.getTime();
+  for (const window of windows) {
+    if (
+      window.startsAt.getTime() <= atMs &&
+      window.expiresAt.getTime() > atMs &&
+      (!latest || window.startsAt.getTime() > latest.startsAt.getTime())
+    ) {
+      latest = window;
+    }
+  }
+  return latest;
+}
+
+async function persistUsageAllowanceWindowConsumption(
+  tx: UsageAllowanceStore,
+  windows: readonly UsageAllowanceWindowState[],
+): Promise<void> {
+  const changedWindows = windows.filter((window) => {
+    return window.consumedUnits > window.initialConsumedUnits;
+  });
+  if (changedWindows.length === 0) {
+    return;
+  }
+
+  const windowIds = changedWindows.map((window) => {
+    return window.id;
+  });
+  const unitDeltas = changedWindows.map((window) => {
+    return window.consumedUnits - window.initialConsumedUnits;
+  });
+  await tx.execute(sql`
+    UPDATE ${orgUsageAllowanceWindows}
+    SET
+      "consumed_units" = ${orgUsageAllowanceWindows.consumedUnits} + consumption.units_applied,
+      "updated_at" = ${nowDate()}
+    FROM unnest(
+      ${sql.param(windowIds)}::uuid[],
+      ${sql.param(unitDeltas)}::bigint[]
+    ) AS consumption(window_id, units_applied)
+    WHERE ${orgUsageAllowanceWindows.id} = consumption.window_id
+  `);
+}
+
+async function insertUsageAllowanceAllocations(
+  tx: UsageAllowanceStore,
+  orgId: string,
+  allocations: readonly NewUsageAllowanceAllocation[],
+): Promise<void> {
+  if (allocations.length === 0) {
+    return;
+  }
+
+  const usageEventIds = allocations.map((allocation) => {
+    return allocation.usageEventId;
+  });
+  const runIds = allocations.map((allocation) => {
+    return allocation.runId;
+  });
+  const shortWindowIds = allocations.map((allocation) => {
+    return allocation.shortWindowId;
+  });
+  const weeklyWindowIds = allocations.map((allocation) => {
+    return allocation.weeklyWindowId;
+  });
+  const unitsApplied = allocations.map((allocation) => {
+    return allocation.unitsApplied;
   });
 
-  return unitsApplied;
+  await tx.execute(sql`
+    INSERT INTO ${usageAllowanceAllocations} (
+      "usage_event_id",
+      "org_id",
+      "run_id",
+      "short_window_id",
+      "weekly_window_id",
+      "units_applied"
+    )
+    SELECT
+      allocation.usage_event_id,
+      ${orgId},
+      allocation.run_id,
+      allocation.short_window_id,
+      allocation.weekly_window_id,
+      allocation.units_applied
+    FROM unnest(
+      ${sql.param(usageEventIds)}::uuid[],
+      ${sql.param(runIds)}::uuid[],
+      ${sql.param(shortWindowIds)}::uuid[],
+      ${sql.param(weeklyWindowIds)}::uuid[],
+      ${sql.param(unitsApplied)}::bigint[]
+    ) AS allocation(
+      usage_event_id,
+      run_id,
+      short_window_id,
+      weekly_window_id,
+      units_applied
+    )
+  `);
+}
+
+export async function applyUsageAllowanceToUsageEventsInLockedTransaction(
+  tx: UsageAllowanceStore,
+  args: {
+    readonly orgId: string;
+    readonly events: readonly UsageAllowanceEventInput[];
+  },
+): Promise<ReadonlyMap<string, number>> {
+  const candidates: UsageAllowanceCandidate[] = [];
+  for (const event of args.events) {
+    if (event.grossUnits > 0 && event.runId) {
+      candidates.push({
+        usageEventId: event.usageEventId,
+        runId: event.runId,
+        grossUnits: event.grossUnits,
+      });
+    }
+  }
+
+  const allowanceByUsageEvent = await loadExistingUsageAllowanceAllocations(
+    tx,
+    candidates.map((candidate) => {
+      return candidate.usageEventId;
+    }),
+  );
+  const unresolvedRunIds = [
+    ...new Set(
+      candidates.flatMap((candidate) => {
+        return allowanceByUsageEvent.has(candidate.usageEventId)
+          ? []
+          : [candidate.runId];
+      }),
+    ),
+  ];
+  const runCreatedAtById = await loadVm0RunCreatedAts(tx, {
+    orgId: args.orgId,
+    runIds: unresolvedRunIds,
+  });
+  const eligibleRunIds = [...runCreatedAtById.keys()];
+
+  const shortWindows = await lockIssuedWindowsForRuns(tx, {
+    orgId: args.orgId,
+    kind: "short",
+    runIds: eligibleRunIds,
+  });
+  const weeklyWindows = await lockIssuedWindowsForRuns(tx, {
+    orgId: args.orgId,
+    kind: "weekly",
+    runIds: eligibleRunIds,
+  });
+  const windowsByRunId = new Map<string, MutableUsageAllowanceWindows>();
+  for (const [runId, runCreatedAt] of runCreatedAtById) {
+    const shortWindow = latestIssuedWindowAt(shortWindows, runCreatedAt);
+    const weeklyWindow = latestIssuedWindowAt(weeklyWindows, runCreatedAt);
+    if (shortWindow && weeklyWindow) {
+      windowsByRunId.set(runId, { shortWindow, weeklyWindow });
+    }
+  }
+
+  const newAllocations: NewUsageAllowanceAllocation[] = [];
+  for (const candidate of candidates) {
+    if (allowanceByUsageEvent.has(candidate.usageEventId)) {
+      continue;
+    }
+    const windows = windowsByRunId.get(candidate.runId);
+    if (!windows) {
+      continue;
+    }
+    const unitsApplied = Math.min(
+      candidate.grossUnits,
+      remainingUnits(windows.shortWindow),
+      remainingUnits(windows.weeklyWindow),
+    );
+    if (unitsApplied <= 0) {
+      continue;
+    }
+
+    windows.shortWindow.consumedUnits += unitsApplied;
+    windows.weeklyWindow.consumedUnits += unitsApplied;
+    allowanceByUsageEvent.set(candidate.usageEventId, unitsApplied);
+    newAllocations.push({
+      usageEventId: candidate.usageEventId,
+      runId: candidate.runId,
+      shortWindowId: windows.shortWindow.id,
+      weeklyWindowId: windows.weeklyWindow.id,
+      unitsApplied,
+    });
+  }
+
+  await persistUsageAllowanceWindowConsumption(tx, [
+    ...shortWindows,
+    ...weeklyWindows,
+  ]);
+  await insertUsageAllowanceAllocations(tx, args.orgId, newAllocations);
+
+  return allowanceByUsageEvent;
 }

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -17,7 +17,7 @@ import {
   type CreditLowBalanceAlertArgs,
 } from "./zero-credit-low-balance-alert.service";
 import { triggerAutoRecharge$ } from "./zero-credit-recharge.service";
-import { applyUsageAllowanceToUsageEvent } from "./usage-allowance.service";
+import { applyUsageAllowanceToUsageEventsInLockedTransaction } from "./usage-allowance.service";
 import { publishBillingChangedForOrg } from "./zero-billing-realtime.service";
 
 const L = logger("CreditUsage");
@@ -136,6 +136,123 @@ interface ProcessOrgUsageEventsResult {
   readonly lowBalanceAlert: CreditLowBalanceAlertArgs | null;
 }
 
+type UsageEventRecord = typeof usageEvent.$inferSelect;
+type UsagePricingRecord = typeof usagePricing.$inferSelect;
+type UsageEventBillingError = "missing_pricing" | "fallback_pricing" | null;
+
+interface PricedUsageEvent {
+  readonly record: UsageEventRecord;
+  readonly grossCredits: number;
+  readonly billingError: UsageEventBillingError;
+}
+
+function priceUsageEvents(
+  records: readonly UsageEventRecord[],
+  pricingRecords: readonly UsagePricingRecord[],
+  orgId: string,
+): PricedUsageEvent[] {
+  const pricingByKey = new Map(
+    pricingRecords.map((pricing) => {
+      return [
+        `${pricing.kind}|${pricing.provider}|${pricing.category}`,
+        pricing,
+      ];
+    }),
+  );
+  const pricedEvents: PricedUsageEvent[] = [];
+  for (const record of records) {
+    const exactPricing = pricingByKey.get(
+      `${record.kind}|${record.provider}|${record.category}`,
+    );
+    const pricing =
+      exactPricing ??
+      pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
+
+    if (!pricing) {
+      L.error("Missing usage_pricing — charged zero", {
+        ...usageUnderbillingFields("missing_pricing", "confirmed"),
+        orgId,
+        runId: record.runId,
+        idempotencyKey: record.idempotencyKey,
+        userId: record.userId,
+        kind: record.kind,
+        provider: record.provider,
+        category: record.category,
+        quantity: record.quantity,
+      });
+      pricedEvents.push({
+        record,
+        grossCredits: 0,
+        billingError: "missing_pricing",
+      });
+      continue;
+    }
+
+    if (!exactPricing) {
+      L.error("Missing usage_pricing — billed at fallback rate", {
+        ...usageUnderbillingFields("fallback_pricing", "confirmed"),
+        orgId,
+        runId: record.runId,
+        idempotencyKey: record.idempotencyKey,
+        userId: record.userId,
+        kind: record.kind,
+        provider: record.provider,
+        category: record.category,
+        quantity: record.quantity,
+        fallbackUnitPrice: pricing.unitPrice,
+      });
+    }
+
+    pricedEvents.push({
+      record,
+      grossCredits: Math.ceil(
+        (record.quantity * pricing.unitPrice) / pricing.unitSize,
+      ),
+      billingError: exactPricing ? null : "fallback_pricing",
+    });
+  }
+  return pricedEvents;
+}
+
+interface UsageEventSettlementOutcome {
+  readonly usageEventId: string;
+  readonly creditsCharged: number;
+  readonly billingError: UsageEventBillingError;
+}
+
+async function markUsageEventsProcessed(
+  tx: WriteTx,
+  outcomes: readonly UsageEventSettlementOutcome[],
+): Promise<void> {
+  if (outcomes.length === 0) {
+    return;
+  }
+
+  const usageEventIds = outcomes.map((outcome) => {
+    return outcome.usageEventId;
+  });
+  const creditsCharged = outcomes.map((outcome) => {
+    return outcome.creditsCharged;
+  });
+  const billingErrors = outcomes.map((outcome) => {
+    return outcome.billingError;
+  });
+  await tx.execute(sql`
+    UPDATE ${usageEvent}
+    SET
+      "credits_charged" = settlement.credits_charged,
+      "status" = 'processed',
+      "processed_at" = ${nowDate()},
+      "billing_error" = settlement.billing_error
+    FROM unnest(
+      ${sql.param(usageEventIds)}::uuid[],
+      ${sql.param(creditsCharged)}::bigint[],
+      ${sql.param(billingErrors)}::varchar(50)[]
+    ) AS settlement(usage_event_id, credits_charged, billing_error)
+    WHERE ${usageEvent.id} = settlement.usage_event_id
+  `);
+}
+
 async function processOrgUsageEventsInTransaction(
   tx: WriteTx,
   orgId: string,
@@ -168,83 +285,33 @@ async function processOrgUsageEventsInTransaction(
   ];
 
   const pricingRecords = await tx.select().from(usagePricing);
-  const pricingByKey = new Map(
-    pricingRecords.map((p) => {
-      return [`${p.kind}|${p.provider}|${p.category}`, p];
-    }),
-  );
+  const pricedEvents = priceUsageEvents(pendingRecords, pricingRecords, orgId);
 
+  const allowanceByUsageEvent =
+    await applyUsageAllowanceToUsageEventsInLockedTransaction(tx, {
+      orgId,
+      events: pricedEvents.map((event) => {
+        return {
+          usageEventId: event.record.id,
+          runId: event.record.runId,
+          grossUnits: event.grossCredits,
+        };
+      }),
+    });
   let billableCredits = 0;
   let allowanceCreditsApplied = 0;
-  for (const record of pendingRecords) {
-    const exactPricing = pricingByKey.get(
-      `${record.kind}|${record.provider}|${record.category}`,
-    );
-    const pricing =
-      exactPricing ??
-      pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
-
-    if (!pricing) {
-      await tx
-        .update(usageEvent)
-        .set({
-          creditsCharged: 0,
-          status: "processed",
-          processedAt: nowDate(),
-          billingError: "missing_pricing",
-        })
-        .where(eq(usageEvent.id, record.id));
-      L.error("Missing usage_pricing — charged zero", {
-        ...usageUnderbillingFields("missing_pricing", "confirmed"),
-        orgId,
-        runId: record.runId,
-        idempotencyKey: record.idempotencyKey,
-        userId: record.userId,
-        kind: record.kind,
-        provider: record.provider,
-        category: record.category,
-        quantity: record.quantity,
-      });
-      continue;
-    }
-
-    if (!exactPricing) {
-      L.error("Missing usage_pricing — billed at fallback rate", {
-        ...usageUnderbillingFields("fallback_pricing", "confirmed"),
-        orgId,
-        runId: record.runId,
-        idempotencyKey: record.idempotencyKey,
-        userId: record.userId,
-        kind: record.kind,
-        provider: record.provider,
-        category: record.category,
-        quantity: record.quantity,
-        fallbackUnitPrice: pricing.unitPrice,
-      });
-    }
-
-    const grossCredits = Math.ceil(
-      (record.quantity * pricing.unitPrice) / pricing.unitSize,
-    );
-    const allowanceUnits = await applyUsageAllowanceToUsageEvent(tx, {
-      usageEventId: record.id,
-      orgId,
-      runId: record.runId,
-      grossUnits: grossCredits,
-    });
-    const creditsCharged = grossCredits - allowanceUnits;
+  const settlementOutcomes = pricedEvents.map((event) => {
+    const allowanceUnits = allowanceByUsageEvent.get(event.record.id) ?? 0;
+    const creditsCharged = event.grossCredits - allowanceUnits;
     allowanceCreditsApplied += allowanceUnits;
-    await tx
-      .update(usageEvent)
-      .set({
-        creditsCharged,
-        status: "processed",
-        processedAt: nowDate(),
-        billingError: exactPricing ? null : "fallback_pricing",
-      })
-      .where(eq(usageEvent.id, record.id));
     billableCredits += creditsCharged;
-  }
+    return {
+      usageEventId: event.record.id,
+      creditsCharged,
+      billingError: event.billingError,
+    };
+  });
+  await markUsageEventsProcessed(tx, settlementOutcomes);
   signal.throwIfAborted();
 
   let lowBalanceAlert: CreditLowBalanceAlertArgs | null = null;


### PR DESCRIPTION
## Summary

- batch existing allocation and VM0 run lookups, lock distinct issued short then weekly windows once, and replay pending usage order in memory
- persist window deltas, audit allocations, and usage-event outcomes with fixed-shape array/`unnest` statements
- add real-database API integration coverage for multiple events and runs, shared caps, and partial spillover to organization credits

## Correctness and compatibility

- retains the same `credit_<org>` advisory lock and transaction boundary
- retains row locks and historical `createdAt` window eligibility
- preserves allocation idempotency, missing and fallback pricing behavior, credit settlement, and downstream side-effect ordering
- changes no schema, persisted data shape, public API, frontend, queue, runner protocol, or cache

## Tests

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/usage-allowance.test.ts` (15 passed)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (2,179 passed)
- `pnpm knip --workspace api`
- pre-commit full Knip and Turbo type checks

Closes #21491

Parent: #18746
