### PR TITLE
refactor(db): canonicalize workflow automation schema identifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -17,9 +17,9 @@ import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
-  zeroWorkflowWebhookTriggers as zeroWorkflowWebhookAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
+  zeroWorkflowWebhookAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 import { and, eq, ne } from "drizzle-orm";
@@ -757,7 +757,7 @@ async function copyWorkflowWebhookAutomationConfig(
     })
     .from(zeroWorkflowWebhookAutomations)
     .where(
-      eq(zeroWorkflowWebhookAutomations.triggerId, args.sourceAutomationId),
+      eq(zeroWorkflowWebhookAutomations.automationId, args.sourceAutomationId),
     )
     .limit(1);
   const token = mintWorkflowWebhookToken();
@@ -776,7 +776,7 @@ async function copyWorkflowWebhookAutomationConfig(
   }
 
   await tx.insert(zeroWorkflowWebhookAutomations).values({
-    triggerId: args.targetAutomationId,
+    automationId: args.targetAutomationId,
     tokenHash: hashWorkflowWebhookToken(token),
     encryptedToken: await encryptWorkflowWebhookToken(token, {
       orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -6,8 +6,8 @@ import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
 } from "@vm0/db/schema/zero-workflow";
 import { zeroWorkflowQueueEvents } from "@vm0/db/schema/zero-workflow-queue";
 import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";

--- a/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
@@ -8,9 +8,9 @@ import {
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
+  workflowUserAutomationThreads,
   zeroWorkflowGithubProcessedEvents,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -20,8 +20,8 @@ import {
 } from "@vm0/db/schema/gmail-event";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -18,8 +18,8 @@ import {
 } from "@vm0/db/schema/google-calendar-event";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -14,8 +14,8 @@ import {
 } from "@vm0/db/schema/google-workspace-event";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -26,8 +26,8 @@ import {
 } from "@vm0/db/schema/notion-event";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 import { command } from "ccstate";

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation-entitlement.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation-entitlement.service.ts
@@ -1,8 +1,8 @@
 import { and, eq, inArray } from "drizzle-orm";
 
 import {
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
-  zeroWorkflowWebhookTriggers as zeroWorkflowWebhookAutomations,
+  zeroWorkflowAutomations,
+  zeroWorkflowWebhookAutomations,
 } from "@vm0/db/schema/zero-workflow";
 
 import type { Db } from "../external/db";
@@ -36,7 +36,7 @@ export async function disableIneligibleWorkflowWebhookAutomationsForOrg(
     }
 
     const webhookAutomationIds = tx
-      .select({ triggerId: zeroWorkflowWebhookAutomations.triggerId })
+      .select({ automationId: zeroWorkflowWebhookAutomations.automationId })
       .from(zeroWorkflowWebhookAutomations);
     const currentTime = nowDate();
     const disabled = await tx
@@ -63,7 +63,7 @@ export async function disableIneligibleWorkflowWebhookAutomationsForOrg(
       })
       .where(
         inArray(
-          zeroWorkflowWebhookAutomations.triggerId,
+          zeroWorkflowWebhookAutomations.automationId,
           disabled.map((automation) => {
             return automation.id;
           }),

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
@@ -6,10 +6,10 @@ import { and, eq, gte } from "drizzle-orm";
 
 import type { WebhookReceivedEventConfig } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflowWebhookDeliveries,
-  zeroWorkflowWebhookTriggers as zeroWorkflowWebhookAutomations,
+  zeroWorkflowWebhookAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 
@@ -132,7 +132,7 @@ export async function buildWorkflowWebhookSummaryFields(
   const [webhook] = await db
     .select()
     .from(zeroWorkflowWebhookAutomations)
-    .where(eq(zeroWorkflowWebhookAutomations.triggerId, args.automation.id))
+    .where(eq(zeroWorkflowWebhookAutomations.automationId, args.automation.id))
     .limit(1);
   if (!webhook) {
     throw new Error(
@@ -162,7 +162,7 @@ export async function revealWorkflowWebhookSecretFields(
   const [webhook] = await db
     .select()
     .from(zeroWorkflowWebhookAutomations)
-    .where(eq(zeroWorkflowWebhookAutomations.triggerId, args.automation.id))
+    .where(eq(zeroWorkflowWebhookAutomations.automationId, args.automation.id))
     .limit(1);
   if (!webhook) {
     throw new Error(
@@ -342,7 +342,10 @@ async function loadWebhookAutomationForToken(args: {
     .from(zeroWorkflowWebhookAutomations)
     .innerJoin(
       zeroWorkflowAutomations,
-      eq(zeroWorkflowWebhookAutomations.triggerId, zeroWorkflowAutomations.id),
+      eq(
+        zeroWorkflowWebhookAutomations.automationId,
+        zeroWorkflowAutomations.id,
+      ),
     )
     .innerJoin(
       zeroWorkflows,
@@ -518,7 +521,7 @@ async function recordWebhookDeliveryDispatched(
   await db
     .update(zeroWorkflowWebhookAutomations)
     .set({ lastReceivedAt: args.currentTime, updatedAt: args.currentTime })
-    .where(eq(zeroWorkflowWebhookAutomations.triggerId, args.automationId));
+    .where(eq(zeroWorkflowWebhookAutomations.automationId, args.automationId));
 }
 
 function workflowWebhookRunError(): DispatchWorkflowWebhookResult {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -40,7 +40,7 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { userArtifactFavorites } from "@vm0/db/schema/user-artifact-favorite";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { zeroWorkflowTriggers as zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import {
   and,
   asc,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-access.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-access.service.ts
@@ -1,5 +1,5 @@
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { zeroWorkflowTriggers as zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { and, eq } from "drizzle-orm";
 
 import type { ReadonlyDb } from "../external/db";

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-memory-embedding.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-memory-embedding.service.ts
@@ -1,4 +1,4 @@
-import { zeroWorkflowTriggerMemoryEmbeddings as zeroWorkflowAutomationMemoryEmbeddings } from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflowAutomationMemoryEmbeddings } from "@vm0/db/schema/zero-workflow";
 import { eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -57,7 +57,7 @@ export async function loadWorkflowAutomationMemoryEmbedding(
       .from(zeroWorkflowAutomationMemoryEmbeddings)
       .where(
         eq(
-          zeroWorkflowAutomationMemoryEmbeddings.workflowTriggerId,
+          zeroWorkflowAutomationMemoryEmbeddings.workflowAutomationId,
           args.workflowAutomationId,
         ),
       )
@@ -101,13 +101,13 @@ export async function loadWorkflowAutomationMemoryEmbedding(
     db
       .insert(zeroWorkflowAutomationMemoryEmbeddings)
       .values({
-        workflowTriggerId: args.workflowAutomationId,
+        workflowAutomationId: args.workflowAutomationId,
         embeddingModel: embedded.model,
         queryHash: embeddedQueryHash,
         embedding: [...embedded.embedding],
       })
       .onConflictDoUpdate({
-        target: zeroWorkflowAutomationMemoryEmbeddings.workflowTriggerId,
+        target: zeroWorkflowAutomationMemoryEmbeddings.workflowAutomationId,
         set: {
           embeddingModel: embedded.model,
           queryHash: embeddedQueryHash,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -2,8 +2,8 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 import { command, type Computed } from "ccstate";

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run-callback.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroWorkflowTriggers as zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { and, eq } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { zeroWorkflowTriggers as zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { command, type Computed } from "ccstate";
 import { eq } from "drizzle-orm";
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -34,10 +34,10 @@ import { parseScheduledAtTime } from "@vm0/core/timezone";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
-  workflowUserTriggerThreads as workflowUserAutomationThreads,
-  zeroWorkflowTriggerMemoryEmbeddings as zeroWorkflowAutomationMemoryEmbeddings,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
-  zeroWorkflowWebhookTriggers as zeroWorkflowWebhookAutomations,
+  workflowUserAutomationThreads,
+  zeroWorkflowAutomationMemoryEmbeddings,
+  zeroWorkflowAutomations,
+  zeroWorkflowWebhookAutomations,
   zeroWorkflows,
   type ZeroWorkflowScheduleType,
 } from "@vm0/db/schema/zero-workflow";
@@ -1209,7 +1209,7 @@ async function insertWebhookEventAutomation(
     const token = mintWorkflowWebhookToken();
     const secret = mintWorkflowWebhookSecret();
     await tx.insert(zeroWorkflowWebhookAutomations).values({
-      triggerId: row.id,
+      automationId: row.id,
       tokenHash: hashWorkflowWebhookToken(token),
       encryptedToken: await encryptWorkflowWebhookToken(token, {
         orgId: args.input.orgId,
@@ -2023,7 +2023,7 @@ export const updateWorkflowAutomation$ = command(
           .delete(zeroWorkflowAutomationMemoryEmbeddings)
           .where(
             eq(
-              zeroWorkflowAutomationMemoryEmbeddings.workflowTriggerId,
+              zeroWorkflowAutomationMemoryEmbeddings.workflowAutomationId,
               automation.id,
             ),
           );
@@ -2321,7 +2321,7 @@ async function persistEnabledWorkflowAutomation(
         .update(zeroWorkflowWebhookAutomations)
         .set({ disabledReason: null, updatedAt: args.now })
         .where(
-          eq(zeroWorkflowWebhookAutomations.triggerId, args.automation.id),
+          eq(zeroWorkflowWebhookAutomations.automationId, args.automation.id),
         );
     }
     return { status: "ok", row: enabledRow };

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -13,7 +13,7 @@ import {
 } from "@vm0/connectors/connectors";
 import type { getAllFeatureStates } from "@vm0/core/feature-switch";
 import {
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  zeroWorkflowAutomations,
   type ZeroWorkflowEventType,
 } from "@vm0/db/schema/zero-workflow";
 import { command } from "ccstate";

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -2,7 +2,7 @@ import { triggerSourceSchema } from "@vm0/api-contracts/contracts/logs";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   zeroWorkflows,
-  zeroWorkflowTriggers as zeroWorkflowAutomations,
+  zeroWorkflowAutomations,
 } from "@vm0/db/schema/zero-workflow";
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";

--- a/turbo/apps/api/src/signals/services/zero-workflow-user-automation-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-user-automation-thread.service.ts
@@ -1,5 +1,5 @@
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { workflowUserTriggerThreads as workflowUserAutomationThreads } from "@vm0/db/schema/zero-workflow";
+import { workflowUserAutomationThreads } from "@vm0/db/schema/zero-workflow";
 import { and, eq } from "drizzle-orm";
 
 import type { Db, ReadonlyDb } from "../external/db";

--- a/turbo/packages/db/src/schema/chat-message-queue.ts
+++ b/turbo/packages/db/src/schema/chat-message-queue.ts
@@ -10,7 +10,7 @@ import { sql } from "drizzle-orm";
 
 import { chatMessages } from "./chat-message";
 import { chatThreads } from "./chat-thread";
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 
 export const chatMessageQueueItemType = pgEnum("chat_message_queue_item_type", [
   "user_message",
@@ -63,7 +63,7 @@ export const chatMessageQueue = pgTable(
     // covers workflow deletion (triggers cascade from workflows).
     triggerId: uuid("trigger_id").references(
       () => {
-        return zeroWorkflowTriggers.id;
+        return zeroWorkflowAutomations.id;
       },
       { onDelete: "cascade" },
     ),

--- a/turbo/packages/db/src/schema/gmail-event.ts
+++ b/turbo/packages/db/src/schema/gmail-event.ts
@@ -9,7 +9,7 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { connectors } from "./connector";
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 
 export const gmailWatchStates = pgTable(
   "gmail_watch_states",
@@ -65,7 +65,7 @@ export const gmailProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -73,7 +73,7 @@ export const gmailProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),

--- a/turbo/packages/db/src/schema/google-calendar-event.ts
+++ b/turbo/packages/db/src/schema/google-calendar-event.ts
@@ -10,7 +10,7 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { connectors } from "./connector";
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 import type { GoogleCalendarEventSnapshot } from "@vm0/db/jsonb-contracts/google-calendar-event";
 
 export const googleCalendarWatchStates = pgTable(
@@ -110,7 +110,7 @@ export const googleCalendarProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -118,7 +118,7 @@ export const googleCalendarProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),

--- a/turbo/packages/db/src/schema/google-workspace-event.ts
+++ b/turbo/packages/db/src/schema/google-workspace-event.ts
@@ -10,7 +10,7 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { connectors } from "./connector";
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 import type { GoogleWorkspaceEventTypes } from "@vm0/db/jsonb-contracts/google-workspace-event";
 
 export type GoogleWorkspaceEventProvider = "google-meet";
@@ -86,7 +86,7 @@ export const googleWorkspaceProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -94,7 +94,7 @@ export const googleWorkspaceProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),

--- a/turbo/packages/db/src/schema/notion-event.ts
+++ b/turbo/packages/db/src/schema/notion-event.ts
@@ -14,7 +14,7 @@ import { sql } from "drizzle-orm";
 
 import type { NotionWorkflowPendingEventContextJson } from "@vm0/db/jsonb-contracts/notion-event";
 
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 
 export type { NotionWorkflowPendingEventContext } from "@vm0/db/jsonb-contracts/notion-event";
 
@@ -75,7 +75,7 @@ export const notionWorkflowPendingEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -83,7 +83,7 @@ export const notionWorkflowPendingEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),

--- a/turbo/packages/db/src/schema/zero-run.ts
+++ b/turbo/packages/db/src/schema/zero-run.ts
@@ -10,7 +10,7 @@ import { sql } from "drizzle-orm";
 import { agentRuns } from "./agent-run";
 import { agentComposes } from "./agent-compose";
 import { chatThreads } from "./chat-thread";
-import { zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations } from "./zero-workflow";
 import { threadGoals } from "./thread-goal";
 
 /**
@@ -33,18 +33,18 @@ export const zeroRuns = pgTable(
     // Legacy column retained during the Automation ID expand window.
     workflowTriggerId: uuid("workflow_trigger_id").references(
       (): AnyPgColumn => {
-        return zeroWorkflowTriggers.id;
+        return zeroWorkflowAutomations.id;
       },
       { onDelete: "set null" },
     ),
     // Canonical run provenance for the Automation that started this run.
     workflowAutomationId: uuid("workflow_automation_id").references(
       (): AnyPgColumn => {
-        return zeroWorkflowTriggers.id;
+        return zeroWorkflowAutomations.id;
       },
       { onDelete: "set null" },
     ),
-    // Stable grouping key copied from workflow triggers/goals for chat
+    // Stable grouping key copied from workflow automations/goals for chat
     // rendering of repeated automated runs.
     runGroupId: uuid("run_group_id"),
     // Run provenance for autonomous thread-goal continuation.

--- a/turbo/packages/db/src/schema/zero-workflow-queue.ts
+++ b/turbo/packages/db/src/schema/zero-workflow-queue.ts
@@ -1,7 +1,7 @@
 import { pgTable, uuid, text, timestamp, index } from "drizzle-orm/pg-core";
 
 import { chatThreads } from "./chat-thread";
-import { zeroWorkflows, zeroWorkflowTriggers } from "./zero-workflow";
+import { zeroWorkflowAutomations, zeroWorkflows } from "./zero-workflow";
 
 /**
  * Pending workflow trigger events.
@@ -30,7 +30,7 @@ export const zeroWorkflowQueueEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),

--- a/turbo/packages/db/src/schema/zero-workflow.ts
+++ b/turbo/packages/db/src/schema/zero-workflow.ts
@@ -91,13 +91,13 @@ export const zeroWorkflows = pgTable(
 );
 
 /**
- * Shared trigger chat thread for one workflow execution owner.
+ * Shared automation chat thread for one workflow execution owner.
  *
- * Trigger-fired runs use the trigger owner's identity. Keep the linked chat
- * thread at the workflow-user level so every trigger owned by the same user
- * for a workflow writes to one conversation.
+ * Automation-fired runs use the automation owner's identity. Keep the linked
+ * chat thread at the workflow-user level so every automation owned by the same
+ * user for a workflow writes to one conversation.
  */
-export const workflowUserTriggerThreads = pgTable(
+export const workflowUserAutomationThreads = pgTable(
   "workflow_user_automation_threads",
   {
     id: uuid("id").defaultRandom().primaryKey(),
@@ -170,16 +170,16 @@ export type ZeroWorkflowEventType =
 export type ZeroWorkflowWebhookDisabledReason = "paid_plan_required";
 
 /**
- * Workflow triggers.
+ * Workflow automations.
  *
- * A trigger answers "when" (schedule) and "where" (agent) a workflow runs; the
- * workflow's SKILL.md is the "what". Trigger chat is shared at the
- * workflow-user level by `workflow_user_trigger_threads`.
+ * An automation answers "when" a workflow runs; the workflow's SKILL.md is the
+ * "what". Automation chat is shared at the workflow-user level by
+ * `workflow_user_automation_threads`.
  *
- * Schedule triggers are polled by `next_run_at`. Event triggers keep
+ * Schedule automations are polled by `next_run_at`. Event automations keep
  * `next_run_at = NULL` and fire from their event-specific junction.
  */
-export const zeroWorkflowTriggers = pgTable(
+export const zeroWorkflowAutomations = pgTable(
   "zero_workflow_automations",
   {
     id: uuid("id").defaultRandom().primaryKey(),
@@ -222,11 +222,11 @@ export const zeroWorkflowTriggers = pgTable(
     return [
       index("idx_zero_workflow_automations_workflow").on(table.workflowId),
       index("idx_zero_workflow_automations_org").on(table.orgId),
-      // Partial index for the time poller: enabled triggers with a due next run.
+      // Partial index for the time poller: enabled automations with a due run.
       index("idx_zero_workflow_automations_next_run")
         .on(table.nextRunAt)
         .where(sql`enabled = true`),
-      // Each trigger kind carries exactly its own config.
+      // Each automation kind carries exactly its own config.
       check(
         "zero_workflow_automations_schedule_config_check",
         sql`(
@@ -253,14 +253,14 @@ export const zeroWorkflowTriggers = pgTable(
   },
 );
 
-export const zeroWorkflowTriggerMemoryEmbeddings = pgTable(
+export const zeroWorkflowAutomationMemoryEmbeddings = pgTable(
   "zero_workflow_automation_memory_embeddings",
   {
-    workflowTriggerId: uuid("workflow_trigger_id")
+    workflowAutomationId: uuid("workflow_trigger_id")
       .primaryKey()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -278,14 +278,14 @@ export const zeroWorkflowTriggerMemoryEmbeddings = pgTable(
   },
 );
 
-export const zeroWorkflowWebhookTriggers = pgTable(
+export const zeroWorkflowWebhookAutomations = pgTable(
   "zero_workflow_webhook_automations",
   {
-    triggerId: uuid("automation_id")
+    automationId: uuid("automation_id")
       .primaryKey()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -317,7 +317,7 @@ export const zeroWorkflowWebhookDeliveries = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -325,7 +325,7 @@ export const zeroWorkflowWebhookDeliveries = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -367,7 +367,7 @@ export const zeroWorkflowGithubProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),
@@ -375,7 +375,7 @@ export const zeroWorkflowGithubProcessedEvents = pgTable(
       .notNull()
       .references(
         () => {
-          return zeroWorkflowTriggers.id;
+          return zeroWorkflowAutomations.id;
         },
         { onDelete: "cascade" },
       ),


### PR DESCRIPTION
## Summary

- promote canonical Workflow Automation exports from the database schema and remove API-local aliases of the retired trigger entity names
- canonicalize the TypeScript primary-key properties for webhook automation config and automation memory embeddings while preserving their deployed physical columns
- keep `zero_runs.workflow_trigger_id`, processed-event dual-write columns, and the legacy workflow/chat queue boundaries unchanged for rollback compatibility and #21267 ownership

This is a behavior-frozen internal naming cutover. It adds no migration, changes no wire contract, and retains the generic `triggerSource`, `triggerAgentId`, and `triggerBrief` run-provenance fields. Exact non-migration legacy terminology falls from 157 to 106 hits; the DB package falls from 35 to 7.

Part of #21408.

## Verification

- `pnpm -F @vm0/db check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F api lint`
- `pnpm knip`
- Prettier and `git diff --check`
- Targeted Automation/webhook integration files were attempted locally, but their shared fixture could not complete because the clean runtime lacks the repository production PostgreSQL 18 + pgvector test environment; PR CI is the authoritative real-database gate.