### PR TITLE
refactor(api): retire drained workflow callback kinds

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -17,10 +17,7 @@ import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
-import {
-  readAgentRunCallbacks$,
-  seedAgentRunCallback$,
-} from "./helpers/agent-run-callback";
+import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -538,9 +535,6 @@ describe("zero workflow automation scheduler", () => {
         status: "pending",
       }),
     );
-    expect(emittedCallbacks).not.toContainEqual(
-      expect.objectContaining({ internalKind: "workflow-trigger:cron" }),
-    );
     await completeRunThroughSandbox(scenario, run.runId, 0);
 
     await expect
@@ -559,28 +553,6 @@ describe("zero workflow automation scheduler", () => {
     await executeDueWorkflowAutomations();
     const before = now();
     const run = await onlyWorkflowRunMessage(automation.threadId);
-    await completeRunThroughSandbox(scenario, run.runId, 0);
-
-    await expect
-      .poll(async () => {
-        return (await wf.readAutomation(automation.automationId)).nextRunAt;
-      })
-      .not.toBeNull();
-    const read = await wf.readAutomation(automation.automationId);
-    if (!read.nextRunAt) {
-      throw new Error("Expected the loop automation to be rescheduled");
-    }
-    expect(Date.parse(read.nextRunAt)).toBeGreaterThanOrEqual(before + 290_000);
-    await disableAutomation(automation.automationId);
-  });
-
-  it("emits an automation callback while accepting an in-flight legacy callback", async () => {
-    const scenario = await setup();
-    const automation = await createDueLoopAutomation(scenario, 300);
-
-    await executeDueWorkflowAutomations();
-    await onlyWorkflowRunMessage(automation.threadId);
-
     const emittedCallbacks = await store.set(
       readAgentRunCallbacks$,
       {
@@ -596,51 +568,18 @@ describe("zero workflow automation scheduler", () => {
         status: "pending",
       }),
     );
-    expect(emittedCallbacks).not.toContainEqual(
-      expect.objectContaining({ internalKind: "workflow-trigger:loop" }),
-    );
-    expect(
-      (await wf.readAutomation(automation.automationId)).nextRunAt,
-    ).toBeNull();
-
-    const legacyPrompt = "complete an in-flight legacy workflow callback";
-    const legacyRun = await runsApi.createRun(scenario.actor, {
-      agentId: scenario.agentId,
-      prompt: legacyPrompt,
-      modelProvider: "anthropic-api-key",
-    });
-    await store.set(
-      seedAgentRunCallback$,
-      {
-        runId: legacyRun.runId,
-        internalKind: "workflow-trigger:loop",
-        payload: { triggerId: automation.automationId },
-      },
-      context.signal,
-    );
-
-    await completeRunThroughSandbox(scenario, legacyRun.runId, 0);
+    await completeRunThroughSandbox(scenario, run.runId, 0);
 
     await expect
       .poll(async () => {
         return (await wf.readAutomation(automation.automationId)).nextRunAt;
       })
       .not.toBeNull();
-    const legacyCallbacks = await store.set(
-      readAgentRunCallbacks$,
-      {
-        orgId: scenario.orgId,
-        userId: scenario.userId,
-        prompt: legacyPrompt,
-      },
-      context.signal,
-    );
-    expect(legacyCallbacks).toContainEqual(
-      expect.objectContaining({
-        internalKind: "workflow-trigger:loop",
-        status: "delivered",
-      }),
-    );
+    const read = await wf.readAutomation(automation.automationId);
+    if (!read.nextRunAt) {
+      throw new Error("Expected the loop automation to be rescheduled");
+    }
+    expect(Date.parse(read.nextRunAt)).toBeGreaterThanOrEqual(before + 290_000);
     await disableAutomation(automation.automationId);
   });
 

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -41,7 +41,7 @@ import {
   internalRunCallbackKindForRecord,
   type InternalRunCallbackDispatchResult,
   type InternalRunCallbackEnvelope,
-  type NormalizedInternalRunCallbackKind,
+  type InternalRunCallbackKind,
 } from "./internal-run-callback";
 import {
   handleWorkflowAutomationInternalCallback,
@@ -92,11 +92,11 @@ interface DispatchInternalRunCallbackInput {
   readonly status: TerminalCallbackStatus;
   readonly result?: Record<string, unknown>;
   readonly error?: string;
-  readonly kind: NormalizedInternalRunCallbackKind;
+  readonly kind: InternalRunCallbackKind;
 }
 
 interface DispatchInternalCallbackInput {
-  readonly kind: NormalizedInternalRunCallbackKind;
+  readonly kind: InternalRunCallbackKind;
   readonly envelope: InternalRunCallbackEnvelope;
 }
 
@@ -451,7 +451,7 @@ async function dispatchInternalCallback(
 
 async function dispatchInternalCallbackWithoutCcstate(
   input: DispatchSingleCallbackInput,
-  kind: NormalizedInternalRunCallbackKind,
+  kind: InternalRunCallbackKind,
 ): Promise<InternalRunCallbackDispatchResult> {
   switch (kind) {
     case "agent": {

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -1,8 +1,3 @@
-/**
- * Persisted callback kinds accepted during the rolling-deploy drain. Producers
- * emit `workflow-automation:*`; legacy `workflow-trigger:*` rows remain readable
- * until every in-flight run from the previous release has completed.
- */
 export const internalRunCallbackKinds = [
   "agent",
   "agentphone",
@@ -11,18 +6,11 @@ export const internalRunCallbackKinds = [
   "slack:org",
   "teams:org",
   "telegram",
-  "workflow-trigger:cron",
-  "workflow-trigger:loop",
   "workflow-automation:cron",
   "workflow-automation:loop",
 ] as const;
 
 export type InternalRunCallbackKind = (typeof internalRunCallbackKinds)[number];
-
-export type NormalizedInternalRunCallbackKind = Exclude<
-  InternalRunCallbackKind,
-  "workflow-trigger:cron" | "workflow-trigger:loop"
->;
 
 export type InternalRunCallbackStatus = "completed" | "failed" | "progress";
 
@@ -43,9 +31,9 @@ interface InternalRunCallbackRecord {
   readonly internalKind: string | null;
 }
 
-function isNormalizedInternalRunCallbackKind(
+function isInternalRunCallbackKind(
   value: string | null,
-): value is NormalizedInternalRunCallbackKind {
+): value is InternalRunCallbackKind {
   switch (value) {
     case "agent":
     case "agentphone":
@@ -66,22 +54,8 @@ function isNormalizedInternalRunCallbackKind(
 
 export function internalRunCallbackKindForRecord(
   callback: InternalRunCallbackRecord,
-): NormalizedInternalRunCallbackKind | null {
-  if (isNormalizedInternalRunCallbackKind(callback.internalKind)) {
-    return callback.internalKind;
-  }
-
-  // Contract-phase compatibility for rows written before canonical emission.
-  // Keep this normalization through the rolling-deploy drain.
-  switch (callback.internalKind) {
-    case "workflow-trigger:cron": {
-      return "workflow-automation:cron";
-    }
-    case "workflow-trigger:loop": {
-      return "workflow-automation:loop";
-    }
-    default: {
-      return null;
-    }
-  }
+): InternalRunCallbackKind | null {
+  return isInternalRunCallbackKind(callback.internalKind)
+    ? callback.internalKind
+    : null;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run-callback.service.ts
@@ -8,7 +8,7 @@ import { advanceTimeAutomationAfterCompletion } from "./time-automation";
 import type {
   InternalRunCallbackDispatchResult,
   InternalRunCallbackEnvelope,
-  NormalizedInternalRunCallbackKind,
+  InternalRunCallbackKind,
 } from "./internal-run-callback";
 import {
   automationCronCallbackPayloadSchema,
@@ -20,7 +20,7 @@ import {
 const MAX_CONSECUTIVE_FAILURES = 3;
 
 type WorkflowAutomationInternalRunCallbackKind = Extract<
-  NormalizedInternalRunCallbackKind,
+  InternalRunCallbackKind,
   "workflow-automation:cron" | "workflow-automation:loop"
 >;
 


### PR DESCRIPTION
## Summary

- stop recognizing persisted `workflow-trigger:cron|loop` callback kinds after the production drain completed
- keep only canonical `workflow-automation:cron|loop` values in the shared callback kind type and dispatcher
- preserve canonical cron and loop callback behavior through the existing real-PostgreSQL scheduler integration coverage

## Production compatibility gate

- #21425 deployed dual recognition before #21471 switched new writes to canonical kinds
- MaskDB live production audit on 2026-07-15 returned **0 undelivered legacy-kind callbacks**
- the last legacy callback was created at `2026-07-14T13:00:20.214Z` and delivered at `13:01:40.399Z`
- canonical callbacks are active and delivered; seven were observed through `17:33:36.080Z`
- public API/webhook compatibility routes are untouched and remain gated by their separate 2–4 week Axiom window

Evidence: https://github.com/vm0-ai/vm0/issues/21408#issuecomment-4972586118

On top of #21500, the exact non-migration acceptance search falls from 38 to 28 hits.

## Verification

- `pnpm exec prettier --write` on all four changed files
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- targeted scheduler Vitest attempted locally; all 12 cases stopped during shared setup because local PostgreSQL was unavailable (`ECONNREFUSED`), so the PR real-PostgreSQL CI shard is authoritative

Part of #21408.
