### PR TITLE
refactor(platform): stop using the legacy notion switch key

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,10 +1,7 @@
 import { command, computed } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import {
-  FeatureSwitchKey,
-  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY as LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY,
-} from "@vm0/connectors/feature-switch-key";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { authenticatedIdentity$, clerk$ } from "../auth";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
@@ -51,9 +48,7 @@ function applySwitches(
 
   const notionWorkflowAutomations =
     overrides?.[FeatureSwitchKey.NotionWorkflowAutomations] ??
-    overrides?.[LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY] ??
-    effectiveSwitches?.[FeatureSwitchKey.NotionWorkflowAutomations] ??
-    effectiveSwitches?.[LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY];
+    effectiveSwitches?.[FeatureSwitchKey.NotionWorkflowAutomations];
   if (notionWorkflowAutomations !== undefined) {
     result[FeatureSwitchKey.NotionWorkflowAutomations] = Boolean(
       notionWorkflowAutomations,
@@ -122,18 +117,10 @@ export const setFeatureSwitch$ = command(
     signal: AbortSignal,
   ) => {
     const client = get(apiFeatureSwitchClient$);
-    const compatibleOverrides: Record<string, boolean> = { ...overrides };
-    const notionWorkflowAutomations =
-      overrides[FeatureSwitchKey.NotionWorkflowAutomations];
-    if (notionWorkflowAutomations !== undefined) {
-      compatibleOverrides[
-        LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY
-      ] = notionWorkflowAutomations;
-    }
     signal.throwIfAborted();
     await accept(
       client.update({
-        body: { switches: compatibleOverrides },
+        body: { switches: overrides },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -1,8 +1,5 @@
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import {
-  FeatureSwitchKey,
-  LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY as LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY,
-} from "@vm0/connectors/feature-switch-key";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -107,31 +104,7 @@ describe("lab page", () => {
     });
   });
 
-  it("maps the legacy Notion switch response to the automation key", async () => {
-    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
-      return respond(200, {
-        switches: {
-          [LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY]: true,
-        },
-        effectiveSwitches: {
-          [LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY]: true,
-        },
-      });
-    });
-
-    detachedSetupPage({ context, path: "/_/lab" });
-
-    await waitFor(() => {
-      expect(
-        featureSwitchControl(FeatureSwitchKey.NotionWorkflowAutomations),
-      ).toHaveAttribute("aria-checked", "true");
-    });
-    expect(
-      screen.queryByText(LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY),
-    ).not.toBeInTheDocument();
-  });
-
-  it("dual-writes the Notion automation switch for old APIs", async () => {
+  it("writes only the canonical Notion automation switch", async () => {
     let switches: Record<string, boolean> = {
       [FeatureSwitchKey.Lab]: true,
       [FeatureSwitchKey.NotionWorkflowAutomations]: false,
@@ -164,7 +137,6 @@ describe("lab page", () => {
     await waitFor(() => {
       expect(updateBody).toStrictEqual({
         [FeatureSwitchKey.NotionWorkflowAutomations]: true,
-        [LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY]: true,
       });
     });
   });


### PR DESCRIPTION
## Summary

- Stop the current Platform bundle from reading `notionWorkflowTriggers` responses or dual-writing that retired key when Lab updates `notionWorkflowAutomations`.
- Keep canonical Notion automation behavior covered by asserting that Lab sends only the canonical key.
- Leave API legacy-key request normalization and response mirroring intact so browser tabs running the previous frontend remain compatible with the new backend.

## Rollout safety

This is the frontend half of the contract phase from #21446. The expand release is active in production, so the previous backend already understands the canonical key. Production MaskDB was checked at 2026-07-14T18:37:19Z: all 17 `user_feature_switches` rows were inspected and neither the legacy nor canonical Notion key was persisted. There is no stored override migration to perform.

The backend half is deliberately deferred until old browser bundles have drained; that compatibility code remains covered by API tests.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/external/feature-switch.ts apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx` (4/4 passed)

Part of #21408.