### PR TITLE
refactor: retire the workflow-trigger cron endpoint

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -31,8 +31,6 @@ const webhooksApi = createWebhookCallbackApi(context);
 const WORKFLOW_NAME = "scheduler-workflow";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
   "/api/cron/execute-workflow-automations";
-const LEGACY_CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
-  "/api/cron/execute-workflow-triggers";
 const CRON_SECRET = "test-cron-secret";
 
 interface Scenario {
@@ -274,18 +272,6 @@ describe("zero workflow automation scheduler", () => {
     const claim = await runsApi.claimRunnerJob(run.runId);
     const environment = claim.environment ?? {};
     expect(environment.ZERO_WORKFLOW_ID).toBeUndefined();
-    await disableAutomation(automation.automationId);
-  });
-
-  it("keeps the legacy cron path working during the rollout window", async () => {
-    const scenario = await setup();
-    const automation = await createDueLoopAutomation(scenario, 60);
-
-    await executeDueWorkflowAutomations(
-      LEGACY_CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE,
-    );
-
-    await onlyWorkflowRunMessage(automation.threadId);
     await disableAutomation(automation.automationId);
   });
 

--- a/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
@@ -8,7 +8,7 @@ import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 // The cron tick polls the zero_workflow_automations table; runs carry generic
 // trigger provenance and inject the workflow skill via the agent's attachment.
-export const executeWorkflowAutomationsRoute$: RouteEntry["handler"] = command(
+const executeWorkflowAutomationsRoute$: RouteEntry["handler"] = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();

--- a/turbo/apps/api/src/signals/routes/legacy-workflow-automation-aliases.ts
+++ b/turbo/apps/api/src/signals/routes/legacy-workflow-automation-aliases.ts
@@ -1,5 +1,4 @@
 import { computed } from "ccstate";
-import { legacyCronWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/cron";
 import { legacyWebhookWorkflowAutomationContract } from "@vm0/api-contracts/contracts/webhooks";
 import { legacyZeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
@@ -8,7 +7,6 @@ import {
   workflowAutomationRouteHandlers,
   workspaceWorkflowAutomationEntries$,
 } from "./zero-workflow-automations";
-import { executeWorkflowAutomationsRoute$ } from "./cron-execute-workflow-automations";
 import { postWorkflowAutomationWebhook$ } from "./webhooks-workflow-automations";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route-entry";
@@ -30,10 +28,6 @@ const listWorkspaceLegacyWorkflowAutomationsHandler = authRoute(
  * not a permanent shim.
  */
 export const legacyWorkflowAutomationAliasRoutes: readonly RouteEntry[] = [
-  {
-    route: legacyCronWorkflowAutomationsContract.execute,
-    handler: executeWorkflowAutomationsRoute$,
-  },
   {
     route: legacyWebhookWorkflowAutomationContract.post,
     handler: postWorkflowAutomationWebhook$,

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -357,14 +357,6 @@ export const cronExecuteWorkflowAutomationsContract = c.router({
   },
 });
 
-export const legacyCronWorkflowAutomationsContract = c.router({
-  execute: {
-    ...cronExecuteWorkflowAutomationsContract.execute,
-    path: "/api/cron/execute-workflow-triggers",
-    summary: "Execute due workflow automations through the legacy path",
-  },
-});
-
 export const cronAggregateInsightsContract = c.router({
   aggregate: {
     method: "GET",

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -459,7 +459,6 @@ export {
   cronDrainEmailOutboxContract,
   cronDrainEmailOutboxResponseSchema,
   cronExecuteWorkflowAutomationsContract,
-  legacyCronWorkflowAutomationsContract,
   cronRenewGmailWatchesContract,
   cronRenewGmailWatchesResponseSchema,
   cronRenewGoogleCalendarWatchesContract,


### PR DESCRIPTION
## Summary

- remove the legacy `/api/cron/execute-workflow-triggers` API contract and route registration
- remove its barrel export and rollout-only scheduler coverage
- keep the canonical `/api/cron/execute-workflow-automations` scheduler path unchanged
- leave the public Zero API and webhook compatibility aliases in place for their separate 2–4 week traffic window

## User-visible impact

The production scheduler now has a single workflow-automation endpoint. This removes the remaining workflow-trigger naming from the cron API without affecting scheduled automation execution.

## Rollout evidence

After API production promotion, Axiom observed three consecutive scheduler calls on the canonical endpoint and zero calls on the legacy endpoint between `2026-07-14T20:08:22Z` and `20:12:00Z`. Evidence is recorded in #21408: https://github.com/vm0-ai/vm0/issues/21408#issuecomment-4973545681

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped` (12/12 tasks passed)
- `pnpm check-types` passed all preceding tasks; the API task reached the runtime's default Node heap ceiling
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- repository scan confirms no active `execute-workflow-triggers` or `legacyCronWorkflowAutomationsContract` references remain outside migration history
- targeted scheduler Vitest was attempted, but the local runtime cannot initialize the test schema because its PostgreSQL installation lacks pgvector; the PR pipeline provides the standard PostgreSQL+pgvector test environment

Part of #21408.
