### PR TITLE
refactor: replace 56 optional settle branches with tap-error

### DIFF
--- a/turbo/apps/api/src/signals/external/telegram-domain.ts
+++ b/turbo/apps/api/src/signals/external/telegram-domain.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../lib/log";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 
 const TELEGRAM_OAUTH_BASE_URL = "https://oauth.telegram.org/auth";
 const log = logger("telegram:check-domain");
@@ -12,17 +12,19 @@ export async function checkTelegramDomain(
     bot_id: telegramBotId,
     origin: appUrl,
   });
-  const result = await settle(
+  const response = await tapError(
     fetch(`${TELEGRAM_OAUTH_BASE_URL}?${query}`, {
       method: "HEAD",
       signal: AbortSignal.timeout(3000),
     }),
+    (error) => {
+      log.warn("Domain probe failed", { telegramBotId, error });
+    },
   );
-  if (!result.ok) {
-    log.warn("Domain probe failed", { telegramBotId, error: result.error });
+  if (!response) {
     return false;
   }
 
-  const contentLength = result.value.headers.get("content-length");
+  const contentLength = response.headers.get("content-length");
   return contentLength !== null && Number(contentLength) > 1000;
 }

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -38,7 +38,7 @@ import {
   linkGithubVm0User,
   loadActiveGithubInstallationForOrg,
 } from "../services/github-oauth.service";
-import { safeJsonParse, settle } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import {
   getConnectorOAuthCanonicalRedirectUrl,
@@ -790,7 +790,7 @@ const handleOpenIdConnectorCallback$ = command(
       return resolvedState.response;
     }
 
-    const callbackResult = await settle(
+    const callbackResponse = await tapError(
       set(
         completeOpenIdCallback$,
         {
@@ -808,8 +808,8 @@ const handleOpenIdConnectorCallback$ = command(
     );
     signal.throwIfAborted();
 
-    if (callbackResult.ok) {
-      return callbackResult.value;
+    if (callbackResponse) {
+      return callbackResponse;
     }
 
     return redirectWithError(
@@ -920,7 +920,7 @@ const handleAuthCodeConnectorCallback$ = command(
       return resolvedState.response;
     }
 
-    const callbackResult = await settle(
+    const callbackResponse = await tapError(
       set(
         completeOAuthCallback$,
         {
@@ -944,8 +944,8 @@ const handleAuthCodeConnectorCallback$ = command(
     );
     signal.throwIfAborted();
 
-    if (callbackResult.ok) {
-      return callbackResult.value;
+    if (callbackResponse) {
+      return callbackResponse;
     }
 
     return redirectWithError(

--- a/turbo/apps/api/src/signals/routes/presentation-images.ts
+++ b/turbo/apps/api/src/signals/routes/presentation-images.ts
@@ -10,7 +10,7 @@ import { env } from "../../lib/env";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 
 const UNSPLASH_SEARCH_URL = "https://api.unsplash.com/search/photos";
 const UNSPLASH_HOME_URL = "https://unsplash.com/";
@@ -212,7 +212,7 @@ async function trackUnsplashDownload(
     return false;
   }
 
-  const responseResult = await settle(
+  const response = await tapError(
     fetch(downloadLocation, {
       headers: {
         Authorization: `Client-ID ${accessKey}`,
@@ -221,13 +221,13 @@ async function trackUnsplashDownload(
       },
       signal,
     }),
-    signal,
   );
-  if (!responseResult.ok) {
+  signal.throwIfAborted();
+  if (!response) {
     return false;
   }
 
-  return responseResult.value.ok;
+  return response.ok;
 }
 
 async function searchUnsplash(
@@ -244,7 +244,7 @@ async function searchUnsplash(
     url.searchParams.set("orientation", item.orientation);
   }
 
-  const responseResult = await settle(
+  const response = await tapError(
     fetch(url, {
       headers: {
         Authorization: `Client-ID ${accessKey}`,
@@ -253,13 +253,11 @@ async function searchUnsplash(
       },
       signal,
     }),
-    signal,
   );
-  if (!responseResult.ok) {
+  signal.throwIfAborted();
+  if (!response) {
     return providerError(`Unsplash search failed for "${item.query}"`);
   }
-
-  const response = responseResult.value;
   if (!response.ok) {
     return providerError(
       `Unsplash search failed with ${response.status} ${response.statusText}`,
@@ -355,7 +353,7 @@ async function searchPexels(
     url.searchParams.set("orientation", orientation);
   }
 
-  const responseResult = await settle(
+  const response = await tapError(
     fetch(url, {
       headers: {
         Authorization: apiKey,
@@ -363,13 +361,11 @@ async function searchPexels(
       },
       signal,
     }),
-    signal,
   );
-  if (!responseResult.ok) {
+  signal.throwIfAborted();
+  if (!response) {
     return providerError(`Pexels search failed for "${item.query}"`);
   }
-
-  const response = responseResult.value;
   if (!response.ok) {
     return providerError(
       `Pexels search failed with ${response.status} ${response.statusText}`,

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -7,7 +7,7 @@ import { logger } from "../../lib/log";
 import { request$ } from "../context/hono";
 import { waitUntil } from "../context/wait-until";
 import type { RouteEntry } from "../route-entry";
-import { settle, tapError } from "../utils";
+import { tapError } from "../utils";
 import { ensureOrgLimitedFreeBootstrap$ } from "../services/org-limited-free-bootstrap.service";
 import {
   cleanupClerkBannedUser$,
@@ -110,15 +110,13 @@ const postClerkWebhook$ = command(
     const request = get(request$).raw;
     const signingSecret = optionalEnv("CLERK_WEBHOOK_SIGNING_SECRET");
 
-    const eventResult = await settle(
+    const event = await tapError(
       verifyWebhook(request.clone(), { signingSecret }),
     );
     signal.throwIfAborted();
-    if (!eventResult.ok) {
+    if (!event) {
       return jsonError("Invalid webhook signature", 401);
     }
-
-    const event = eventResult.value;
     L.debug("clerk webhook received", { type: event.type });
 
     if ((event.type as string) === "organization.created") {

--- a/turbo/apps/api/src/signals/routes/zero-billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-redeem-code.ts
@@ -8,7 +8,7 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { clerk$ } from "../external/clerk";
 import type { RouteEntry } from "../route-entry";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 
 const adminRequired = Object.freeze({
   status: 403 as const,
@@ -185,41 +185,35 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const clerk = get(clerk$);
-  const emailResult = await settle(
-    primaryEmailForUser(clerk, auth.userId, signal),
-    signal,
-  );
+  const email = await tapError(primaryEmailForUser(clerk, auth.userId, signal));
   signal.throwIfAborted();
-  if (!emailResult.ok || !emailResult.value) {
+  if (!email) {
     return providerUnavailable("Redeem service user unavailable");
   }
-  const email = emailResult.value;
 
   const machineSecretKey = optionalEnv("VM0_MACHINE_SECRET_KEY");
   if (!machineSecretKey) {
     return providerUnavailable("Redeem service not configured");
   }
 
-  const m2mTokenResult = await settle(
+  const m2mToken = await tapError(
     clerk.m2m.createToken({
       machineSecretKey,
       secondsUntilExpiration: ATOM_M2M_TOKEN_TTL_SECONDS,
       minRemainingTtlSeconds: ATOM_M2M_TOKEN_MIN_REMAINING_TTL_SECONDS,
     }),
-    signal,
   );
   signal.throwIfAborted();
-  if (!m2mTokenResult.ok) {
+  if (!m2mToken) {
     return providerUnavailable("Redeem service authentication unavailable");
   }
-  const m2mToken = m2mTokenResult.value;
   if (!m2mToken.token) {
     return providerUnavailable("Redeem service authentication unavailable");
   }
 
   const url = new URL("/api/redeem-codes/consume", atomUrl);
 
-  const responseResult = await settle(
+  const response = await tapError(
     fetch(url, {
       method: "POST",
       headers: {
@@ -233,13 +227,11 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
       }),
       signal,
     }),
-    signal,
   );
   signal.throwIfAborted();
-  if (!responseResult.ok) {
+  if (!response) {
     return providerUnavailable("Redeem service unavailable");
   }
-  const response = responseResult.value;
   if (!response.ok) {
     if (response.status >= 400 && response.status < 500) {
       return badRequestMessage(await atomRedeemErrorMessage(response, signal));

--- a/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
+++ b/turbo/apps/api/src/signals/routes/zero-email-inbound.ts
@@ -43,7 +43,7 @@ import {
   verifyResendWebhook,
   verifySenderAuthenticity,
 } from "../services/zero-email-common.service";
-import { safeSync, settle, tapError } from "../utils";
+import { safeSync, tapError } from "../utils";
 
 const log = logger("zero:email:inbound");
 
@@ -646,7 +646,7 @@ const processReceivedEmail$ = command(
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const result = await settle(
+    await tapError(
       (async () => {
         const handlerResult = await set(
           args.hasReplyAddress
@@ -668,27 +668,29 @@ const processReceivedEmail$ = command(
           );
         }
       })(),
+      async (error) => {
+        log.error("Failed to handle inbound email", { error });
+        await tapError(
+          set(
+            sendInboundErrorReply$,
+            {
+              to: args.event.data.from,
+              subject: args.event.data.subject,
+              errorMessage:
+                "An internal error occurred while processing your email. Please try again later.",
+            },
+            signal,
+          ),
+          (sendError) => {
+            log.error("Failed to send inbound email error reply", {
+              sendError,
+            });
+          },
+        );
+        signal.throwIfAborted();
+      },
     );
     signal.throwIfAborted();
-    if (!result.ok) {
-      log.error("Failed to handle inbound email", { error: result.error });
-      await tapError(
-        set(
-          sendInboundErrorReply$,
-          {
-            to: args.event.data.from,
-            subject: args.event.data.subject,
-            errorMessage:
-              "An internal error occurred while processing your email. Please try again later.",
-          },
-          signal,
-        ),
-        (sendError) => {
-          log.error("Failed to send inbound email error reply", { sendError });
-        },
-      );
-      signal.throwIfAborted();
-    }
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/zero-integrations-github-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-github-download-file.ts
@@ -8,7 +8,7 @@ import { inferMimetype } from "../../lib/mimetype";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 
 const c = initContract();
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
@@ -151,17 +151,16 @@ const download$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const headers = new Headers({ Accept: "application/octet-stream" });
-  const downloadResult = await settle(
+  const downloadResponse = await tapError(
     fetch(fileUrl, {
       headers,
       signal,
     }),
   );
   signal.throwIfAborted();
-  if (!downloadResult.ok) {
+  if (!downloadResponse) {
     return jsonResponse(502, "Failed to download GitHub file", "BAD_GATEWAY");
   }
-  const downloadResponse = downloadResult.value;
   if (!downloadResponse.ok) {
     const status = downloadResponse.status === 404 ? 404 : 502;
     return jsonResponse(

--- a/turbo/apps/api/src/signals/routes/zero-integrations-phone-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-phone-download-file.ts
@@ -12,7 +12,7 @@ import { queryOf } from "../context/request";
 import { db$ } from "../external/db";
 import { agentPhoneFilenameFromMediaUrl } from "../services/zero-agentphone.service";
 import type { RouteEntry } from "../route-entry";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 
 const log = logger("api:zero:integrations:phone:download-file");
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
@@ -62,20 +62,23 @@ const download$ = command(async ({ get }, signal: AbortSignal) => {
   const fileName = agentPhoneFilenameFromMediaUrl(mediaUrl, query.file_id);
   const fallbackMimetype = inferMimetype(fileName);
 
-  const downloadResult = await settle(fetch(mediaUrl, { signal }));
+  const downloadResponse = await tapError(
+    fetch(mediaUrl, { signal }),
+    (error) => {
+      log.warn("AgentPhone file download failed", {
+        fileId: query.file_id,
+        error,
+      });
+    },
+  );
   signal.throwIfAborted();
-  if (!downloadResult.ok) {
-    log.warn("AgentPhone file download failed", {
-      fileId: query.file_id,
-      error: downloadResult.error,
-    });
+  if (!downloadResponse) {
     return jsonResponse(
       502,
       "Failed to download file from AgentPhone",
       "BAD_GATEWAY",
     );
   }
-  const downloadResponse = downloadResult.value;
   signal.throwIfAborted();
   if (!downloadResponse.ok) {
     log.warn("AgentPhone media download failed", {

--- a/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-telegram.ts
@@ -44,7 +44,7 @@ import {
 } from "../services/zero-telegram-post.service";
 import { handleTelegramInternalCallback$ } from "../services/internal-telegram-run-callback.service";
 import { inferMimetype } from "../../lib/mimetype";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 
 const c = initContract();
@@ -249,18 +249,18 @@ const getTelegramDownloadFileInner$ = command(
       return errorResponse(404, "Telegram bot not found", "NOT_FOUND");
     }
 
-    const settled = await settle(
+    const response = await tapError(
       downloadTelegramFile({ botToken, fileId: query.file_id, signal }),
     );
     signal.throwIfAborted();
-    if (!settled.ok) {
+    if (!response) {
       return errorResponse(
         502,
         "Failed to download file from Telegram",
         "BAD_GATEWAY",
       );
     }
-    return settled.value;
+    return response;
   },
 );
 
@@ -404,18 +404,18 @@ const getIntegrationTelegramAvatar$ = command(
       return errorResponse(404, "Telegram bot not found", "NOT_FOUND");
     }
 
-    const settled = await settle(
+    const response = await tapError(
       loadTelegramAvatar({ botToken, profileUserId, signal }),
     );
     signal.throwIfAborted();
-    if (!settled.ok) {
+    if (!response) {
       return errorResponse(
         502,
         "Failed to load Telegram bot avatar",
         "BAD_GATEWAY",
       );
     }
-    return settled.value;
+    return response;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/zero-report-error.ts
+++ b/turbo/apps/api/src/signals/routes/zero-report-error.ts
@@ -6,7 +6,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { submitZeroReportError$ } from "../services/zero-report-error.service";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 
 const log = logger("route:zero-report-error");
@@ -59,7 +59,7 @@ const submitInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
 
-  const submitted = await settle(
+  const result = await tapError(
     set(
       submitZeroReportError$,
       {
@@ -69,16 +69,16 @@ const submitInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
       signal,
     ),
+    (error) => {
+      log.warn("Failed to submit zero error report", {
+        error: String(error),
+      });
+    },
   );
   signal.throwIfAborted();
-  if (!submitted.ok) {
-    log.warn("Failed to submit zero error report", {
-      error: String(submitted.error),
-    });
+  if (!result) {
     return internalError;
   }
-
-  const result = submitted.value;
 
   if (result.kind === "run_not_found") {
     return runNotFound;

--- a/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
@@ -15,7 +15,7 @@ import {
 } from "../external/slack-oauth-client";
 import { logger } from "../../lib/log";
 import { env, optionalEnv } from "../../lib/env";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
@@ -368,24 +368,25 @@ const handleInstallCallback$ = command(
     },
     signal: AbortSignal,
   ): Promise<Response> => {
-    const exchange = await settle(
+    const oauthResult = await tapError(
       exchangeSlackOAuthCode(
         args.credentials.clientId,
         args.credentials.clientSecret,
         args.code,
         callbackRedirectUri(args.callbackOrigin),
       ),
+      (error) => {
+        L.error("Slack OAuth exchange failed", { error });
+      },
     );
     signal.throwIfAborted();
 
-    if (!exchange.ok) {
-      L.error("Slack OAuth exchange failed", { error: exchange.error });
+    if (!oauthResult) {
       return failedRedirect(
         "Failed to complete Slack installation. Please try again.",
       );
     }
 
-    const oauthResult = exchange.value;
     const writeDb = set(writeDb$);
     const featureSwitchContext =
       args.state.orgId && args.state.vm0UserId
@@ -504,20 +505,20 @@ const handleConnectCallback$ = command(
       return settingsErrorRedirect("Invalid connect state.");
     }
 
-    const exchange = await settle(
+    const oauthResult = await tapError(
       exchangeSlackOAuthCodeForUser(
         args.credentials.clientId,
         args.credentials.clientSecret,
         args.code,
         callbackRedirectUri(args.callbackOrigin),
       ),
+      (error) => {
+        L.error("Slack OAuth exchange failed (connect flow)", { error });
+      },
     );
     signal.throwIfAborted();
 
-    if (!exchange.ok) {
-      L.error("Slack OAuth exchange failed (connect flow)", {
-        error: exchange.error,
-      });
+    if (!oauthResult) {
       return settingsErrorRedirect(
         "Failed to connect Slack account. Please try again.",
       );
@@ -537,7 +538,7 @@ const handleConnectCallback$ = command(
       );
     }
 
-    if (exchange.value.teamId !== installation.slackWorkspaceId) {
+    if (oauthResult.teamId !== installation.slackWorkspaceId) {
       return settingsErrorRedirect(
         "You authenticated with a different Slack workspace. Please use the workspace connected to your organization.",
       );
@@ -562,7 +563,7 @@ const handleConnectCallback$ = command(
         orgId: args.state.orgId,
         orgRole: member.role,
         workspaceId: installation.slackWorkspaceId,
-        slackUserId: exchange.value.authedUserId,
+        slackUserId: oauthResult.authedUserId,
       },
       signal,
     );
@@ -583,7 +584,7 @@ const handleConnectCallback$ = command(
       notifyAfterConnect$,
       {
         installation,
-        slackUserId: exchange.value.authedUserId,
+        slackUserId: oauthResult.authedUserId,
         orgId: args.state.orgId,
         userId: args.state.vm0UserId,
         pendingPrompt: args.state.prompt,

--- a/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
@@ -14,7 +14,7 @@ import {
   prepareTeamsInstallation$,
   publishTeamsChanged$,
 } from "../services/zero-teams-connect.service";
-import { safeJsonParse, settle } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import { getOAuthApiOrigin } from "./oauth-web-origin";
 
@@ -348,7 +348,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     return settingsErrorRedirect("Invalid connect state.");
   }
 
-  const exchange = await settle(
+  const exchange = await tapError(
     exchangeMicrosoftTeamsOAuthCode({
       clientId: credentials.clientId,
       clientSecret: credentials.clientSecret,
@@ -356,11 +356,13 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
       redirectUri: callbackRedirectUri(origin),
       signal,
     }),
+    (error) => {
+      L.error("Microsoft Teams OAuth exchange failed", { error });
+    },
   );
   signal.throwIfAborted();
 
-  if (!exchange.ok) {
-    L.error("Microsoft Teams OAuth exchange failed", { error: exchange.error });
+  if (!exchange) {
     return settingsErrorRedirect(
       "Failed to connect Microsoft Teams account. Please try again.",
     );
@@ -370,13 +372,11 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     userId: auth.userId,
     orgId: auth.orgId,
     orgRole: auth.orgRole,
-    tenantId: exchange.value.tenantId,
-    teamsAadObjectId: exchange.value.user.id,
-    teamsUserDisplayName: exchange.value.user.displayName ?? undefined,
+    tenantId: exchange.tenantId,
+    teamsAadObjectId: exchange.user.id,
+    teamsUserDisplayName: exchange.user.displayName ?? undefined,
     teamsUserPrincipalName:
-      exchange.value.user.userPrincipalName ??
-      exchange.value.user.mail ??
-      undefined,
+      exchange.user.userPrincipalName ?? exchange.user.mail ?? undefined,
   };
 
   const result = await set(connectTeamsInstallation$, connectArgs, signal);
@@ -397,7 +397,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
     signal.throwIfAborted();
 
-    return teamsInstallRedirect(exchange.value.tenantId);
+    return teamsInstallRedirect(exchange.tenantId);
   }
 
   if (result.kind === "forbidden") {

--- a/turbo/apps/api/src/signals/routes/zero-uploads-import-image.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-import-image.ts
@@ -26,7 +26,7 @@ import { putS3Object } from "../external/s3";
 import { recordWebUploadedFile$ } from "../services/run-uploaded-files.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
 import type { RouteEntry } from "../route-entry";
-import { createDeferredPromise, settle } from "../utils";
+import { createDeferredPromise, tapError } from "../utils";
 
 const MAX_IMAGE_IMPORT_SIZE_BYTES = 25 * 1024 * 1024;
 const MAX_IMAGE_IMPORT_SIZE_LABEL = "25 MB";
@@ -59,23 +59,23 @@ function badGateway(message: string, code: string) {
 async function importHostAddresses(
   hostname: string,
 ): Promise<readonly ResolvedFetchAddress[] | ImportImageError> {
-  const resolved = await settle(resolveFetchHostAddresses(hostname));
-  if (!resolved.ok) {
+  const resolved = await tapError(resolveFetchHostAddresses(hostname));
+  if (!resolved) {
     return badGateway(
       "Couldn't resolve image URL host",
       "IMAGE_IMPORT_FETCH_FAILED",
     );
   }
-  if (fetchHostHasBlockedAddress(resolved.value)) {
+  if (fetchHostHasBlockedAddress(resolved)) {
     return badRequestMessage("Image URL host is not allowed");
   }
-  if (resolved.value.length === 0) {
+  if (resolved.length === 0) {
     return badGateway(
       "Couldn't resolve image URL host",
       "IMAGE_IMPORT_FETCH_FAILED",
     );
   }
-  return resolved.value;
+  return resolved;
 }
 
 async function parsedImportUrl(

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -35,7 +35,10 @@ export const ingestAxiomEvents$ = command(
     }
 
     const flushed = await tapError(
-      flushAxiom({ throwOnError: true, client: "sessions" }).then(() => true),
+      (async () => {
+        await flushAxiom({ throwOnError: true, client: "sessions" });
+        return true;
+      })(),
     );
     signal.throwIfAborted();
     if (!flushed) {

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 
 import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 
@@ -34,11 +34,11 @@ export const ingestAxiomEvents$ = command(
       };
     }
 
-    const flushed = await settle(
-      flushAxiom({ throwOnError: true, client: "sessions" }),
+    const flushed = await tapError(
+      flushAxiom({ throwOnError: true, client: "sessions" }).then(() => true),
     );
     signal.throwIfAborted();
-    if (!flushed.ok) {
+    if (!flushed) {
       return {
         status: 503 as const,
         body: { error: "Axiom agent-run-events flush failed" },

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -3349,14 +3349,14 @@ async function decryptFirewallAuthSecrets(
     orgId,
     auth.userId,
   );
-  const decryptedResult = await settle(
+  const secrets = await tapError(
     decryptPersistentSecretsMap(encryptedSecrets, featureSwitchContext),
   );
   return {
     ok: true,
     orgId,
     featureSwitchContext,
-    secrets: decryptedResult.ok ? decryptedResult.value : null,
+    secrets: secrets ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
@@ -16,6 +16,7 @@ import {
   safeJsonParse,
   safeSync,
   settle,
+  tapError,
 } from "../utils";
 import {
   decryptPersistentSecretValue,
@@ -175,18 +176,18 @@ async function decodeProviderState(
   if (!encryptedProviderState) {
     return null;
   }
-  const decrypted = await settle(
+  const decrypted = await tapError(
     decryptPersistentSecretValue(encryptedProviderState, {
       orgId: session.orgId,
       userId: session.userId,
     }),
   );
-  if (!decrypted.ok) {
+  if (!decrypted) {
     return null;
   }
   const decoded = safeSync(() => {
     const parsed = claudeCodeDeviceAuthProviderStateSchema.safeParse(
-      safeJsonParse(decrypted.value),
+      safeJsonParse(decrypted),
     );
     return parsed.success ? parsed.data : null;
   });
@@ -707,14 +708,13 @@ const importClaudeCodeOAuthToken$ = command(
     readonly provider: ModelProviderResponse;
     readonly created: boolean;
   }> => {
-    const metadataResult = await settle(
+    const metadata = await tapError(
       fetchClaudeCodeSubscriptionMetadata({
         accessToken: args.accessToken,
         signal,
       }),
-      signal,
     );
-    const metadata = metadataResult.ok ? metadataResult.value : undefined;
+    signal.throwIfAborted();
 
     const result =
       args.scope === "org"

--- a/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
@@ -14,6 +14,7 @@ import {
   safeJsonParse,
   safeSync,
   settle,
+  tapError,
 } from "../utils";
 import {
   decryptPersistentSecretValue,
@@ -220,18 +221,18 @@ async function decodeProviderState(
   if (!encryptedProviderState) {
     return null;
   }
-  const decrypted = await settle(
+  const decrypted = await tapError(
     decryptPersistentSecretValue(encryptedProviderState, {
       orgId: session.orgId,
       userId: session.userId,
     }),
   );
-  if (!decrypted.ok) {
+  if (!decrypted) {
     return null;
   }
   const decoded = safeSync(() => {
     const parsed = codexDeviceAuthProviderStateSchema.safeParse(
-      safeJsonParse(decrypted.value),
+      safeJsonParse(decrypted),
     );
     return parsed.success ? parsed.data : null;
   });

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -935,7 +935,7 @@ function primaryEmail(user: ClerkEmailProfile): string | null {
 
 function resolveUserEmail(userId: string): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
-    const result = await settle(
+    const email = await tapError(
       (async (): Promise<string> => {
         const client = get(clerk$);
         const users = await client.users.getUserList({ userId: [userId] });
@@ -945,16 +945,13 @@ function resolveUserEmail(userId: string): Computed<Promise<string>> {
         return user ? (primaryEmail(user) ?? userId) : userId;
       })(),
     );
-    if (!result.ok) {
-      return userId;
-    }
-    return result.value;
+    return email ?? userId;
   });
 }
 
 function resolveOrgName(orgId: string): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
-    const result = await settle(
+    const name = await tapError(
       (async (): Promise<string> => {
         const client = get(clerk$);
         const org = await client.organizations.getOrganization({
@@ -963,9 +960,6 @@ function resolveOrgName(orgId: string): Computed<Promise<string>> {
         return org.name;
       })(),
     );
-    if (!result.ok) {
-      return orgId;
-    }
-    return result.value;
+    return name ?? orgId;
   });
 }

--- a/turbo/apps/api/src/signals/services/github-memory-backfill.service.ts
+++ b/turbo/apps/api/src/signals/services/github-memory-backfill.service.ts
@@ -23,7 +23,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import { getGithubInstallationAccessToken } from "./github-app.service";
 import {
   fetchGithubInstallationRepositories,
@@ -1067,32 +1067,29 @@ export const advanceGithubMemorySourceBackfillJobs$ = command(
         continue;
       }
 
-      const result = await settle(
+      const result = await tapError(
         processGithubBackfillJob(db, lockedJob, signal),
-        signal,
+        async (error) => {
+          failed += 1;
+          log.warn("GitHub memory source backfill failed", {
+            jobId: lockedJob.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await markGithubBackfillFailed({
+            db,
+            job: lockedJob,
+            error,
+          });
+        },
       );
       signal.throwIfAborted();
-      if (result.ok) {
-        processed += 1;
-        scanned += result.value.scanned;
-        enqueued += result.value.recorded;
+      if (!result) {
         continue;
       }
 
-      failed += 1;
-      log.warn("GitHub memory source backfill failed", {
-        jobId: lockedJob.id,
-        error:
-          result.error instanceof Error
-            ? result.error.message
-            : String(result.error),
-      });
-      await markGithubBackfillFailed({
-        db,
-        job: lockedJob,
-        error: result.error,
-      });
-      signal.throwIfAborted();
+      processed += 1;
+      scanned += result.scanned;
+      enqueued += result.recorded;
     }
 
     return { processed, failed, scanned, enqueued };

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -1035,14 +1035,13 @@ async function verifyPubSubOidc(args: {
   const token = args.authorization.slice("Bearer ".length);
   const verifier =
     pubSubOidcVerifierOverride.get() ?? defaultPubSubOidcVerifier;
-  const claimsResult = await settle(verifier(token, audience, args.signal));
+  const claims = await tapError(verifier(token, audience, args.signal));
   args.signal.throwIfAborted();
-  if (!claimsResult.ok) {
+  if (!claims) {
     return { kind: "unauthorized" };
   }
 
-  return claimsResult.value.email === expectedEmail &&
-    claimsResult.value.emailVerified
+  return claims.email === expectedEmail && claims.emailVerified
     ? { kind: "ok" }
     : { kind: "unauthorized" };
 }

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -34,7 +34,12 @@ import {
   listS3Objects,
   s3ObjectExists,
 } from "../external/s3";
-import { createDeferredPromise, onRejection, safeSync, settle } from "../utils";
+import {
+  createDeferredPromise,
+  onRejection,
+  safeSync,
+  tapError,
+} from "../utils";
 import { decryptStoredSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -381,20 +386,20 @@ export function googleDriveArtifactStatusLookup(args: {
     // rather than failing the whole artifacts response. AbortError from the
     // 2s timeout intentionally propagates under the project-wide ban on
     // swallowing aborts.
-    const settled = await settle(
+    const files = await tapError(
       listArtifactFilesWithRefresh({
         tokens,
         threadId: args.threadId,
         signal: AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
       }),
     );
-    if (!settled.ok) {
+    if (files === undefined) {
       return { type: "unknown" };
     }
-    if (settled.value === "unauthorized") {
+    if (files === "unauthorized") {
       return { type: "unknown" };
     }
-    return { type: "ready", syncedByKey: buildStatusMap(settled.value) };
+    return { type: "ready", syncedByKey: buildStatusMap(files) };
   });
 }
 

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -23,7 +23,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { safeJsonParse, settle } from "../utils";
+import { safeJsonParse, settle, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   decryptStoredSecretValue,
@@ -1025,17 +1025,15 @@ async function verifyGoogleWorkspacePubSubOidc(args: {
   }
 
   const token = args.authorization.slice("Bearer ".length);
-  const claimsResult = await settle(
+  const claims = await tapError(
     defaultPubSubOidcVerifier(token, audience, args.signal),
-    args.signal,
   );
   args.signal.throwIfAborted();
-  if (!claimsResult.ok) {
+  if (!claims) {
     return { kind: "unauthorized" };
   }
 
-  return claimsResult.value.email === expectedEmail &&
-    claimsResult.value.emailVerified
+  return claims.email === expectedEmail && claims.emailVerified
     ? { kind: "ok" }
     : { kind: "unauthorized" };
 }

--- a/turbo/apps/api/src/signals/services/notion-memory-backfill.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-memory-backfill.service.ts
@@ -14,7 +14,7 @@ import { and, asc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import { recordNotionBackfillPageMemorySource } from "./notion-memory-source.service";
 import {
   NOTION_API_BASE,
@@ -584,32 +584,29 @@ export const advanceNotionMemorySourceBackfillJobs$ = command(
         continue;
       }
 
-      const result = await settle(
+      const result = await tapError(
         processNotionBackfillJob(db, lockedJob, signal),
-        signal,
+        async (error) => {
+          failed += 1;
+          log.warn("Notion memory source backfill failed", {
+            jobId: lockedJob.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await markNotionBackfillFailed({
+            db,
+            job: lockedJob,
+            error,
+          });
+        },
       );
       signal.throwIfAborted();
-      if (result.ok) {
-        processed += 1;
-        scanned += result.value.scanned;
-        enqueued += result.value.recorded;
+      if (!result) {
         continue;
       }
 
-      failed += 1;
-      log.warn("Notion memory source backfill failed", {
-        jobId: lockedJob.id,
-        error:
-          result.error instanceof Error
-            ? result.error.message
-            : String(result.error),
-      });
-      await markNotionBackfillFailed({
-        db,
-        job: lockedJob,
-        error: result.error,
-      });
-      signal.throwIfAborted();
+      processed += 1;
+      scanned += result.scanned;
+      enqueued += result.recorded;
     }
 
     return { processed, failed, scanned, enqueued };

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -735,7 +735,7 @@ async function notionFetchJson<T>(
   url: string,
   signal: AbortSignal,
 ): Promise<NotionFetchResult<T>> {
-  const responseResult = await settle(
+  const response = await tapError(
     fetch(url, {
       method: "GET",
       signal,
@@ -744,9 +744,9 @@ async function notionFetchJson<T>(
         "Notion-Version": NOTION_VERSION,
       },
     }),
-    signal,
   );
-  if (!responseResult.ok) {
+  signal.throwIfAborted();
+  if (!response) {
     return {
       kind: "transient_error",
       status: null,
@@ -754,7 +754,6 @@ async function notionFetchJson<T>(
     };
   }
 
-  const response = responseResult.value;
   if (response.status === 401) {
     return { kind: "unauthorized" };
   }

--- a/turbo/apps/api/src/signals/services/relationship-memory-gmail-backfill.service.ts
+++ b/turbo/apps/api/src/signals/services/relationship-memory-gmail-backfill.service.ts
@@ -25,7 +25,7 @@ import {
 import { logger } from "../../lib/log";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import {
   ensureGmailWatchForUser,
   fetchGmailMessageContextById,
@@ -780,28 +780,25 @@ export const advanceGmailRelationshipBackfillJobs$ = command(
         continue;
       }
 
-      const result = await settle(
+      const result = await tapError(
         processBackfillJob(db, lockedJob, signal),
-        signal,
+        async (error) => {
+          failed += 1;
+          log.warn("Gmail relationship backfill failed", {
+            jobId: lockedJob.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await markBackfillFailed({ db, job: lockedJob, error });
+        },
       );
       signal.throwIfAborted();
-      if (result.ok) {
-        processed += 1;
-        scanned += result.value.scanned;
-        enqueued += result.value.enqueued;
+      if (!result) {
         continue;
       }
 
-      failed += 1;
-      log.warn("Gmail relationship backfill failed", {
-        jobId: lockedJob.id,
-        error:
-          result.error instanceof Error
-            ? result.error.message
-            : String(result.error),
-      });
-      await markBackfillFailed({ db, job: lockedJob, error: result.error });
-      signal.throwIfAborted();
+      processed += 1;
+      scanned += result.scanned;
+      enqueued += result.enqueued;
     }
 
     return { processed, failed, scanned, enqueued };

--- a/turbo/apps/api/src/signals/services/relationship-memory-gmail.service.ts
+++ b/turbo/apps/api/src/signals/services/relationship-memory-gmail.service.ts
@@ -20,7 +20,7 @@ import { generateText, isLlmConfigured } from "../external/openrouter";
 import { createSlackClient } from "../external/slack-message-client";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import {
   fetchGmailMessageContextById,
   messageIsInbound,
@@ -1401,7 +1401,7 @@ export const drainRelationshipSyncJobs$ = command(
         .where(eq(relationshipSyncJobs.id, job.id));
       signal.throwIfAborted();
 
-      const result = await settle(
+      const updated = await tapError(
         job.kind === "gmail_relationship_refresh" ||
           (job.kind === "memory_source_relationship_extract" &&
             job.provider === "gmail")
@@ -1416,40 +1416,39 @@ export const drainRelationshipSyncJobs$ = command(
                   job.provider === "notion"
                 ? processNotionSourceRelationshipExtractionJob(db, job, signal)
                 : Promise.resolve(0),
+        async (error) => {
+          failed += 1;
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const retry = job.attempts + 1 < 3;
+          await db
+            .update(relationshipSyncJobs)
+            .set({
+              status: retry ? "pending" : "failed",
+              lockedAt: null,
+              runAfterAt: retry
+                ? new Date(nowDate().getTime() + RETRY_DELAY_MS)
+                : nowDate(),
+              lastError: message,
+              updatedAt: nowDate(),
+            })
+            .where(eq(relationshipSyncJobs.id, job.id));
+        },
       );
       signal.throwIfAborted();
 
-      if (result.ok) {
-        processed += 1;
-        relationshipsUpdated += result.value;
-        await db
-          .update(relationshipSyncJobs)
-          .set({
-            status: "done",
-            lockedAt: null,
-            lastError: null,
-            updatedAt: nowDate(),
-          })
-          .where(eq(relationshipSyncJobs.id, job.id));
-        signal.throwIfAborted();
+      if (updated === undefined) {
         continue;
       }
 
-      failed += 1;
-      const message =
-        result.error instanceof Error
-          ? result.error.message
-          : String(result.error);
-      const retry = job.attempts + 1 < 3;
+      processed += 1;
+      relationshipsUpdated += updated;
       await db
         .update(relationshipSyncJobs)
         .set({
-          status: retry ? "pending" : "failed",
+          status: "done",
           lockedAt: null,
-          runAfterAt: retry
-            ? new Date(nowDate().getTime() + RETRY_DELAY_MS)
-            : nowDate(),
-          lastError: message,
+          lastError: null,
           updatedAt: nowDate(),
         })
         .where(eq(relationshipSyncJobs.id, job.id));

--- a/turbo/apps/api/src/signals/services/slack-memory-backfill.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-memory-backfill.service.ts
@@ -17,7 +17,7 @@ import type { SlackFile } from "../../lib/slack-webhook-context";
 import { createSlackClient } from "../external/slack-message-client";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import {
@@ -734,32 +734,29 @@ export const advanceSlackMemorySourceBackfillJobs$ = command(
         continue;
       }
 
-      const result = await settle(
+      const result = await tapError(
         processSlackBackfillJob(db, lockedJob, signal),
-        signal,
+        async (error) => {
+          failed += 1;
+          log.warn("Slack memory source backfill failed", {
+            jobId: lockedJob.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await markSlackBackfillFailed({
+            db,
+            job: lockedJob,
+            error,
+          });
+        },
       );
       signal.throwIfAborted();
-      if (result.ok) {
-        processed += 1;
-        scanned += result.value.scanned;
-        enqueued += result.value.recorded;
+      if (!result) {
         continue;
       }
 
-      failed += 1;
-      log.warn("Slack memory source backfill failed", {
-        jobId: lockedJob.id,
-        error:
-          result.error instanceof Error
-            ? result.error.message
-            : String(result.error),
-      });
-      await markSlackBackfillFailed({
-        db,
-        job: lockedJob,
-        error: result.error,
-      });
-      signal.throwIfAborted();
+      processed += 1;
+      scanned += result.scanned;
+      enqueued += result.recorded;
     }
 
     return { processed, failed, scanned, enqueued };

--- a/turbo/apps/api/src/signals/services/steam-player.service.ts
+++ b/turbo/apps/api/src/signals/services/steam-player.service.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { db$ } from "../external/db";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 
 class SteamUpstreamError extends Error {
   constructor(message: string) {
@@ -165,11 +165,11 @@ async function fetchSteamJson<T>(
     url.searchParams.set(name, value);
   }
 
-  const responseResult = await settle(fetch(url, { signal }), signal);
-  if (!responseResult.ok) {
+  const response = await tapError(fetch(url, { signal }));
+  signal.throwIfAborted();
+  if (!response) {
     throw new SteamUpstreamError("Steam API request failed");
   }
-  const response = responseResult.value;
   if (!response.ok) {
     throw new SteamUpstreamError(
       `Steam API request failed with HTTP ${response.status}`,

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -39,7 +39,12 @@ import {
   putS3Object,
 } from "../external/s3";
 import { nowDate } from "../external/time";
-import { createDeferredPromise, onRejection, safeSync, settle } from "../utils";
+import {
+  createDeferredPromise,
+  onRejection,
+  safeSync,
+  tapError,
+} from "../utils";
 import {
   normalizeSessionHistoryBlobEncoding,
   resumeSessionHistoryBlobKey,
@@ -1141,30 +1146,25 @@ export const executeUserExportJob$ = command(
       bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
     };
 
-    const result = await settle(runExportJob(runtime, args));
-    signal.throwIfAborted();
+    await tapError(runExportJob(runtime, args), async (error) => {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      log.error("export job failed", { jobId: args.jobId, error });
 
-    if (result.ok) {
-      return;
-    }
-
-    const errorMessage =
-      result.error instanceof Error ? result.error.message : "Unknown error";
-    log.error("export job failed", { jobId: args.jobId, error: result.error });
-
-    await db
-      .update(exportJobs)
-      .set({
-        status: "failed",
-        error: errorMessage,
-        completedAt: nowDate(),
-      })
-      .where(
-        and(
-          eq(exportJobs.id, args.jobId),
-          inArray(exportJobs.status, ["pending", "running"]),
-        ),
-      );
+      await db
+        .update(exportJobs)
+        .set({
+          status: "failed",
+          error: errorMessage,
+          completedAt: nowDate(),
+        })
+        .where(
+          and(
+            eq(exportJobs.id, args.jobId),
+            inArray(exportJobs.status, ["pending", "running"]),
+          ),
+        );
+    });
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -24,7 +24,7 @@ import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { generatePresignedGetUrl, putS3Object } from "../external/s3";
 import { writeDb$, type Db } from "../external/db";
-import { bestEffort, settle } from "../utils";
+import { bestEffort, settle, tapError } from "../utils";
 
 type ClerkClient = ReturnType<typeof createClerkClient>;
 type Transaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -936,7 +936,7 @@ function downloadAndUploadEmailAttachment(
       return null;
     }
 
-    const bufferResult = await settle(
+    const buffer = await tapError(
       (async (): Promise<Buffer | null> => {
         const response = await fetch(attachment.downloadUrl);
         if (!response.ok) {
@@ -945,15 +945,13 @@ function downloadAndUploadEmailAttachment(
         return Buffer.from(await response.arrayBuffer());
       })(),
     );
-    if (!bufferResult.ok || !bufferResult.value) {
+    if (!buffer) {
       return null;
     }
 
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const key = `${R2_PATH_PREFIX}/${emailId}/${attachment.id}-${attachment.filename}`;
-    await get(
-      putS3Object(bucket, key, bufferResult.value, attachment.contentType),
-    );
+    await get(putS3Object(bucket, key, buffer, attachment.contentType));
     return await get(
       generatePresignedGetUrl(
         bucket,

--- a/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
@@ -405,15 +405,11 @@ async function fetchShareImage(args: {
     return xShareError("BAD_REQUEST", "Choose an image with a public URL");
   }
 
-  const responseResult = await settle(
-    fetch(parsed, { signal: args.signal }),
-    args.signal,
-  );
-  if (!responseResult.ok) {
+  const response = await tapError(fetch(parsed, { signal: args.signal }));
+  args.signal.throwIfAborted();
+  if (!response) {
     return xShareError("BAD_REQUEST", "Couldn't load the image");
   }
-  const response = responseResult.value;
-  args.signal.throwIfAborted();
 
   if (!response.ok) {
     return xShareError("BAD_REQUEST", "Couldn't load the image");
@@ -593,7 +589,7 @@ export const shareImageToX$ = command(
       return image;
     }
 
-    const postResult = await settle(
+    const postResult = await tapError(
       (async () => {
         const mediaId = await uploadXImageMedia({
           accessToken: accessTokenResult.accessToken,
@@ -612,9 +608,9 @@ export const shareImageToX$ = command(
           tweetUrl: `https://x.com/i/web/status/${tweetId}`,
         };
       })(),
-      signal,
     );
-    if (!postResult.ok) {
+    signal.throwIfAborted();
+    if (!postResult) {
       return xShareError(
         "PROVIDER_UNAVAILABLE",
         "X couldn't publish the post, try again",
@@ -630,6 +626,6 @@ export const shareImageToX$ = command(
     await set(processOrgUsageEvents$, args.orgId, signal);
     signal.throwIfAborted();
 
-    return postResult.value;
+    return postResult;
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -11,7 +11,7 @@ import { and, desc, eq, gte, sql } from "drizzle-orm";
 import { nowDate } from "../../lib/time";
 import { clerk$ } from "../external/clerk";
 import { db$ } from "../external/db";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 
 type DayInsightData = Partial<Omit<DayInsight, "date">>;
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
@@ -75,25 +75,25 @@ async function queryCurrentOrgMemberUserIds(
 ): Promise<Set<string> | null> {
   const userIds = new Set<string>();
   for (let offset = 0; ; offset += ORG_MEMBERSHIP_PAGE_SIZE) {
-    const result = await settle(
+    const page = await tapError(
       organizations.getOrganizationMembershipList({
         organizationId: orgId,
         limit: ORG_MEMBERSHIP_PAGE_SIZE,
         offset,
       }),
     );
-    if (!result.ok) {
+    if (!page) {
       return null;
     }
 
-    for (const membership of result.value.data) {
+    for (const membership of page.data) {
       const userId = membership.publicUserData?.userId;
       if (userId) {
         userIds.add(userId);
       }
     }
 
-    if (result.value.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
+    if (page.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
       return userIds;
     }
   }

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -438,11 +438,14 @@ async function configureTelegramBot(args: {
   readonly agentName: string;
 }): Promise<ReturnType<typeof badGateway> | undefined> {
   const webhookConfigured = await tapError(
-    setWebhook(
-      args.botToken,
-      buildTelegramWebhookUrl(args.telegramBotId),
-      args.webhookSecret,
-    ).then(() => true),
+    (async () => {
+      await setWebhook(
+        args.botToken,
+        buildTelegramWebhookUrl(args.telegramBotId),
+        args.webhookSecret,
+      );
+      return true;
+    })(),
     (error) => {
       log.error("Failed to set Telegram webhook", { error });
     },

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -437,17 +437,17 @@ async function configureTelegramBot(args: {
   readonly webhookSecret: string;
   readonly agentName: string;
 }): Promise<ReturnType<typeof badGateway> | undefined> {
-  const webhookResult = await settle(
+  const webhookConfigured = await tapError(
     setWebhook(
       args.botToken,
       buildTelegramWebhookUrl(args.telegramBotId),
       args.webhookSecret,
-    ),
+    ).then(() => true),
+    (error) => {
+      log.error("Failed to set Telegram webhook", { error });
+    },
   );
-  if (!webhookResult.ok) {
-    log.error("Failed to set Telegram webhook", {
-      error: webhookResult.error,
-    });
+  if (!webhookConfigured) {
     return badGateway("Failed to register webhook with Telegram");
   }
 

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -13,7 +13,7 @@ import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import { putS3Object } from "../external/s3";
-import { settle, tapError } from "../utils";
+import { tapError } from "../utils";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import {
   AUDIO_INPUT_BEHAVIOR_KEY,
@@ -557,17 +557,17 @@ async function parseCompressedAudioDurationSeconds(
   file: File,
 ): Promise<number | null> {
   const mimeType = file.type.split(";")[0] ?? file.type;
-  const parsed = await settle(
+  const parsed = await tapError(
     parseBuffer(
       new Uint8Array(await file.arrayBuffer()),
       { mimeType, size: file.size },
       { duration: true },
     ),
   );
-  if (!parsed.ok) {
+  if (!parsed) {
     return null;
   }
-  const { duration } = parsed.value.format;
+  const { duration } = parsed.format;
   return typeof duration === "number" ? Math.ceil(duration) : null;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -12,7 +12,7 @@ import { and, eq, lte } from "drizzle-orm";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { calculateNextRun } from "./time-automation";
 import {
@@ -403,7 +403,7 @@ export const executeDueWorkflowAutomations$ = command(
           claimed.scheduleType === "once" && !claimed.enabled,
       };
 
-      const runResult = await settle(
+      const result = await tapError(
         set(
           runWorkflowAutomationNow$,
           {
@@ -423,14 +423,15 @@ export const executeDueWorkflowAutomations$ = command(
           },
           signal,
         ),
+        async (error) => {
+          await recordPreRunFailure(db, claimed, error, signal);
+          skipped++;
+        },
       );
       signal.throwIfAborted();
-      if (!runResult.ok) {
-        await recordPreRunFailure(db, claimed, runResult.error, signal);
-        skipped++;
+      if (!result) {
         continue;
       }
-      const result = runResult.value;
       if (result.kind === "enqueued") {
         executed++;
         continue;

--- a/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
+++ b/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
@@ -3,7 +3,7 @@ import { bb0DeviceConfirmContract } from "@vm0/api-contracts/contracts/device-to
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { jsonParseOr, settle } from "../utils.ts";
+import { jsonParseOr, tapError } from "../utils.ts";
 
 const BB0_PROVISIONING_SERVICE_UUID = "bb000001-8f16-4b2a-9bb0-000000000001";
 
@@ -411,10 +411,11 @@ async function enableBb0InfoNotifications(
     { signal },
   );
 
-  const settled = await settle(
-    startNotifications.call(session.characteristics.info),
+  return Boolean(
+    await tapError(
+      startNotifications.call(session.characteristics.info).then(() => true),
+    ),
   );
-  return settled.ok;
 }
 
 function readNotificationText(event: Event): string {

--- a/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
+++ b/turbo/apps/platform/src/signals/device-bb0-page/bb0-device-onboarding.ts
@@ -413,7 +413,10 @@ async function enableBb0InfoNotifications(
 
   return Boolean(
     await tapError(
-      startNotifications.call(session.characteristics.info).then(() => true),
+      (async () => {
+        await startNotifications.call(session.characteristics.info);
+        return true;
+      })(),
     ),
   );
 }

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -7,7 +7,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { onRef, settle } from "../utils.ts";
+import { onRef, tapError } from "../utils.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
   "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
@@ -81,13 +81,12 @@ export async function isUnsupportedIntelMacForZeroDesktop(
     return false;
   }
 
-  const highEntropyValuesResult = await settle(
+  const highEntropyValues = await tapError(
     userAgentData.getHighEntropyValues(["architecture", "platform"]),
   );
-  if (!highEntropyValuesResult.ok) {
+  if (!highEntropyValues) {
     return false;
   }
-  const highEntropyValues = highEntropyValuesResult.value;
 
   const platform =
     highEntropyValues.platform ??

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -9,7 +9,13 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import { bestEffort, onRef, resetSignal, settle } from "../../utils.ts";
+import {
+  bestEffort,
+  onRef,
+  resetSignal,
+  settle,
+  tapError,
+} from "../../utils.ts";
 import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
@@ -184,16 +190,15 @@ function createClaudeCodeRunFlow$(ctx: ClaudeCodeDeviceAuthSignalContext) {
       const requestId = createRequestId(ctx.scope);
       set(ctx.internalFlowState$, { status: "starting", requestId });
 
-      const started = await settle(
+      const started = await tapError(
         set(startClaudeCodeDeviceAuth$, ctx.scope, signal),
-        signal,
       );
       signal.throwIfAborted();
 
       if (!isCurrentStarting(get(ctx.internalFlowState$), requestId)) {
         return false;
       }
-      if (!started.ok) {
+      if (!started) {
         set(ctx.internalFlowState$, {
           status: "error",
           message: "Claude Code connection failed. Start again to retry.",
@@ -204,9 +209,9 @@ function createClaudeCodeRunFlow$(ctx: ClaudeCodeDeviceAuthSignalContext) {
       set(ctx.internalFlowState$, {
         status: "pending",
         requestId,
-        sessionToken: started.value.sessionToken,
-        browserUrl: started.value.browserUrl,
-        expiresAtMs: now() + secondsToMilliseconds(started.value.expiresIn),
+        sessionToken: started.sessionToken,
+        browserUrl: started.browserUrl,
+        expiresAtMs: now() + secondsToMilliseconds(started.expiresIn),
         authorizationCode: "",
         approvalOpened: false,
         errorMessage: null,

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -16,6 +16,7 @@ import {
   resetSignal,
   settle,
   setLoop,
+  tapError,
 } from "../../utils.ts";
 import { writeToClipboard } from "../clipboard.ts";
 import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
@@ -307,16 +308,15 @@ function createCodexRunFlow$(
       const requestId = createRequestId(ctx.scope);
       set(ctx.internalFlowState$, { status: "starting", requestId });
 
-      const started = await settle(
+      const started = await tapError(
         set(startCodexDeviceAuth$, ctx.scope, signal),
-        signal,
       );
       signal.throwIfAborted();
 
       if (!isCurrentStarting(get(ctx.internalFlowState$), requestId)) {
         return false;
       }
-      if (!started.ok) {
+      if (!started) {
         set(ctx.internalFlowState$, {
           status: "error",
           message: "ChatGPT connection failed. Start again to retry.",
@@ -324,19 +324,18 @@ function createCodexRunFlow$(
         return false;
       }
 
-      const expiresAtMs =
-        now() + secondsToMilliseconds(started.value.expiresIn);
+      const expiresAtMs = now() + secondsToMilliseconds(started.expiresIn);
       const pollIntervalMs = Math.max(
-        secondsToMilliseconds(started.value.interval),
+        secondsToMilliseconds(started.interval),
         CODEX_DEVICE_AUTH_MIN_POLL_MS,
       );
 
       set(ctx.internalFlowState$, {
         status: "pending",
         requestId,
-        sessionToken: started.value.sessionToken,
-        browserUrl: started.value.browserUrl,
-        verificationCode: started.value.verificationCode,
+        sessionToken: started.sessionToken,
+        browserUrl: started.browserUrl,
+        verificationCode: started.verificationCode,
         expiresAtMs,
         pollIntervalMs,
         approvalOpened: false,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -55,6 +55,7 @@ import {
   resetSignal,
   settle,
   setLoop,
+  tapError,
   withCleanup,
 } from "../../utils.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
@@ -1599,7 +1600,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
           { apiBase: OAUTH_WEB_API_BASE },
         );
         const startOptionEntries = Object.entries(startOptions ?? {});
-        const startSettled = await settle(
+        const startResponse = await tapError(
           accept(
             client.create({
               params: { type },
@@ -1614,10 +1615,10 @@ const connectConnectorOAuthDeviceAuth$ = command(
             }),
             [200],
           ),
-          flowSignal,
         );
-        const startResult = startSettled.ok ? startSettled.value.body : null;
-        if (!startSettled.ok) {
+        flowSignal.throwIfAborted();
+        const startResult = startResponse?.body ?? null;
+        if (!startResponse) {
           if (flowSignal.aborted) {
             return false;
           }
@@ -1858,7 +1859,7 @@ export const connectConnectorExternalCode$ = command(
         const client = createClient(zeroConnectorExternalCodeSessionContract, {
           apiBase: OAUTH_WEB_API_BASE,
         });
-        const startSettled = await settle(
+        const startResponse = await tapError(
           accept(
             client.create({
               params: { type },
@@ -1867,10 +1868,10 @@ export const connectConnectorExternalCode$ = command(
             }),
             [200],
           ),
-          flowSignal,
         );
-        const startResult = startSettled.ok ? startSettled.value.body : null;
-        if (!startSettled.ok) {
+        flowSignal.throwIfAborted();
+        const startResult = startResponse?.body ?? null;
+        if (!startResponse) {
           if (flowSignal.aborted) {
             return false;
           }

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -7,7 +7,7 @@ import JSZip from "jszip";
 import {
   createDeferredPromise,
   jsonParseOr,
-  settle,
+  tapError,
   withCleanup,
 } from "../../signals/utils.ts";
 import { materializePresentationThemeSwitcherDefaults } from "./presentation-html-edit-protocol.ts";
@@ -169,22 +169,20 @@ async function fetchResourceAsDataUrl(
   url: string,
   signal: AbortSignal,
 ): Promise<string | null> {
-  const response = await settle(
+  const response = await tapError(
     fetch(readableAttachmentResourceUrl(url), {
       cache: "reload",
       mode: "cors",
       signal,
     }),
-    signal,
   );
-  if (!response.ok || !response.value.ok) {
+  signal.throwIfAborted();
+  if (!response?.ok) {
     return null;
   }
-  const dataUrl = await settle(
-    blobToDataUrl(await response.value.blob()),
-    signal,
-  );
-  return dataUrl.ok ? dataUrl.value : null;
+  const dataUrl = await tapError(blobToDataUrl(await response.blob()));
+  signal.throwIfAborted();
+  return dataUrl ?? null;
 }
 
 type ResourceDataUrlCache = Map<string, Promise<string | null>>;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -80,7 +80,6 @@ import {
   detach,
   onDomEventFn,
   Reason,
-  settle,
   tapError,
 } from "../../signals/utils.ts";
 import { sendMode$ } from "../../signals/send-mode.ts";
@@ -3121,12 +3120,12 @@ function TemplatePreview({
     });
     detach(
       (async () => {
-        const result = await settle(pendingLoad);
+        const result = await tapError(pendingLoad);
         if (cache.pendingLoads.get(item.embedUrl) === pendingLoad) {
           cache.pendingLoads.delete(item.embedUrl);
         }
 
-        if (!result.ok || result.value === null) {
+        if (result === undefined || result === null) {
           cache.failed.add(item.embedUrl);
           if (cache.activeTokens.get(item.embedUrl) === activeToken) {
             setHtmlPreview({
@@ -3142,11 +3141,11 @@ function TemplatePreview({
           return;
         }
 
-        cache.drafts.set(item.embedUrl, result.value);
+        cache.drafts.set(item.embedUrl, result);
         if (cache.activeTokens.get(item.embedUrl) === activeToken) {
           setHtmlPreview(
             createPresentationTemplateCardHtmlPreviewState({
-              draft: result.value,
+              draft: result,
               index: cache.activeIndexes.get(item.embedUrl) ?? 0,
               item,
               previousFrameUrl: previousActiveFrameUrlForImmediateRevocation,
@@ -3523,11 +3522,11 @@ function TemplatePreviewPage({
     }
     detach(
       (async () => {
-        const result = await settle(pendingLoad);
+        const result = await tapError(pendingLoad);
         if (cache.pendingLoads.get(item.embedUrl) === pendingLoad) {
           cache.pendingLoads.delete(item.embedUrl);
         }
-        if (!result.ok || result.value === null) {
+        if (result === undefined || result === null) {
           cache.failed.add(item.embedUrl);
           if (!isActive()) {
             return;
@@ -3544,10 +3543,10 @@ function TemplatePreviewPage({
           });
           return;
         }
-        cache.drafts.set(item.embedUrl, result.value);
+        cache.drafts.set(item.embedUrl, result);
         if (isActive()) {
           setLoadedDetailPreview({
-            draft: result.value,
+            draft: result,
             index: activeSlideIndex,
             previousFrameUrl: detailPreview?.frameUrl ?? null,
             theme: selectedTheme,
@@ -5467,16 +5466,16 @@ function SelectedPresentationTemplateChipPreview({
     }
     detach(
       (async () => {
-        const result = await settle(pendingLoad);
+        const result = await tapError(pendingLoad);
         if (cache.pendingLoads.get(item.embedUrl) === pendingLoad) {
           cache.pendingLoads.delete(item.embedUrl);
         }
-        if (!result.ok || result.value === null) {
+        if (result === undefined || result === null) {
           cache.failed.add(item.embedUrl);
           return;
         }
-        cache.drafts.set(item.embedUrl, result.value);
-        setChipPreview(result.value);
+        cache.drafts.set(item.embedUrl, result);
+        setChipPreview(result);
       })(),
       Reason.DomCallback,
     );


### PR DESCRIPTION
## Summary

- replace 56 audited production `settle` call sites with the existing `tapError` utility where callers only need an optional fallback
- preserve existing logging, fallback responses, persisted failure states, and abort propagation
- preserve fulfilled `void` operations with explicit completion sentinels instead of adding another utility or introducing `try/catch`

## User impact

Error handling across API provider boundaries, background jobs, and platform loading flows now uses the narrower existing utility without changing the intended success or failure behavior.

## Verification

- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- pre-commit Prettier, Knip, generated-firewall, and file-size checks
- production `settle` count across API and Platform: 167 on `origin/main`, 111 on this branch (56 removed)

Local Vitest was not run; the PR pipeline will provide test coverage for this cross-cutting behavior-preserving refactor.
