### PR TITLE
fix(app): clean up failed realtime subscriptions

### DIFF
--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -142,12 +142,15 @@ function invokeAuthCallback(cb: AuthCallback): Promise<AuthCallbackToken> {
 }
 
 const fakeChannel = {
-  // Mirror real Ably: subscribe is async (server roundtrip) and the server
-  // won't deliver events to this callback until the subscription has been
-  // confirmed. Register the callback only after the returned promise
-  // resolves so tests don't accidentally race with a callback that fires
-  // before the subscribe await in consumer code has returned.
+  // Mirror real Ably: subscribe registers the callback synchronously before
+  // waiting for the channel attach to complete.
   async subscribe(topic: string, callback: Callback): Promise<void> {
+    let cbs = subscriptions.get(topic);
+    if (!cbs) {
+      cbs = new Set();
+      subscriptions.set(topic, cbs);
+    }
+    cbs.add(callback);
     await Promise.resolve();
     if (connectionClosed) {
       throw new Error("Connection closed");
@@ -157,12 +160,6 @@ const fakeChannel = {
       nextSubscribeError = null;
       throw error;
     }
-    let cbs = subscriptions.get(topic);
-    if (!cbs) {
-      cbs = new Set();
-      subscriptions.set(topic, cbs);
-    }
-    cbs.add(callback);
   },
   unsubscribe(topic: string, callback: Callback): void {
     const cbs = subscriptions.get(topic);

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -296,6 +296,26 @@ describe("realtime signals", () => {
     expect(context.mocks.ably.hasSubscription(topic)).toBeFalsy();
   });
 
+  it("cleans up a payload subscription when channel attach fails", async () => {
+    mockSignedInUser();
+    const topic = "test:payload-subscribe-failure";
+
+    await context.store.set(setupRealtime$, context.signal);
+    context.mocks.ably.rejectNextSubscribe("Connection closed");
+
+    await expect(
+      context.store.set(
+        setAblyPayloadLoop$,
+        {
+          topic,
+          loopCommand$: keepAlivePayloadLoop$,
+        },
+        context.signal,
+      ),
+    ).resolves.toBeUndefined();
+    expect(context.mocks.ably.hasSubscription(topic)).toBeFalsy();
+  });
+
   it("reruns an active loop on reconnect", async () => {
     mockSignedInUser();
     const topic = "test:reconnect";

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -81,15 +81,6 @@ function isAblyConnectionClosedError(error: unknown): boolean {
   return errorMessage(error) === "Connection closed";
 }
 
-async function subscribeChannel(
-  channel: RealtimeChannel,
-  topic: string,
-  callback: (message: InboundMessage) => void,
-): Promise<boolean> {
-  await channel.subscribe(topic, callback);
-  return true;
-}
-
 async function waitForTransientRetry(
   signal: AbortSignal,
   retryCount: number,
@@ -140,7 +131,6 @@ const runWithChannel$ = command(
       L.debug("tab visible, poking loop", topic);
       pokeLoop();
     };
-    let subscribed = false;
     let registeredPoke = false;
 
     const cleanup = () => {
@@ -154,10 +144,7 @@ const runWithChannel$ = command(
       });
       registeredPoke = false;
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      if (subscribed) {
-        subscribed = false;
-        channel.unsubscribe(topic, callback);
-      }
+      channel.unsubscribe(topic, callback);
     };
 
     document.addEventListener("visibilitychange", onVisibilityChange, {
@@ -173,7 +160,7 @@ const runWithChannel$ = command(
 
     // eslint-disable-next-line no-restricted-syntax -- Ably can close during app teardown while a channel attach is in flight; suppress only that terminal close race.
     try {
-      subscribed = await subscribeChannel(channel, topic, callback);
+      await channel.subscribe(topic, callback);
       signal.throwIfAborted();
       options?.onSubscribed?.();
       if (options?.runOnSubscribe) {
@@ -263,7 +250,6 @@ const runWithChannelPayload$ = command(
       L.debug("tab visible, poking payload loop", topic);
       pokeLoop();
     };
-    let subscribed = false;
     let registeredPoke = false;
 
     const cleanup = () => {
@@ -277,10 +263,7 @@ const runWithChannelPayload$ = command(
       });
       registeredPoke = false;
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      if (subscribed) {
-        subscribed = false;
-        channel.unsubscribe(topic, callback);
-      }
+      channel.unsubscribe(topic, callback);
     };
 
     document.addEventListener("visibilitychange", onVisibilityChange, {
@@ -296,7 +279,7 @@ const runWithChannelPayload$ = command(
 
     // eslint-disable-next-line no-restricted-syntax -- Ably can close during app teardown while a channel attach is in flight; suppress only that terminal close race.
     try {
-      subscribed = await subscribeChannel(channel, topic, callback);
+      await channel.subscribe(topic, callback);
       signal.throwIfAborted();
       options?.onSubscribed?.();
       L.debug("subscribed to payload topic: " + topic);


### PR DESCRIPTION
## Summary

- always unsubscribe the exact Ably topic callback during abort and final cleanup, including when channel attach does not complete
- align the Ably test mock with the SDK ordering that registers callbacks before awaiting attach
- cover payload subscription cleanup after a failed channel attach

## Why

Ably registers a callback before its channel attach promise resolves. The previous cleanup gate only became true after that promise completed, so an attach rejection or an abort during attach could retain callbacks and their chat-thread state across navigation.

## Testing

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts` (16 tests)
- pre-commit full-repository Knip and type checks
- browser verification with more than 40 healthy thread switches, followed by repeated switches after forcing the Ably client closed; per-thread topics stayed at zero in the failed-attach path
