### PR TITLE
refactor: replace 18 settle branches with existing utils

### DIFF
--- a/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
@@ -8,7 +8,7 @@ import { request$ } from "../context/hono";
 import { now } from "../external/time";
 import type { RouteEntry } from "../route-entry";
 import { dispatchZeroSlackProbe$ } from "../services/zero-slack-webhooks.service";
-import { settle } from "../utils";
+import { settle, tapError } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -97,9 +97,8 @@ const postSlackDispatchProbe$ = command(
       return testEndpointNotFoundResponse();
     }
 
-    const settled = await settle(request.json());
+    const rawBody: unknown = (await tapError(request.json())) ?? null;
     signal.throwIfAborted();
-    const rawBody: unknown = settled.ok ? settled.value : null;
 
     const body = parseProbeBody(rawBody);
     if (!body) {

--- a/turbo/apps/api/src/signals/routes/test-slack-mock.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-mock.ts
@@ -10,7 +10,7 @@ import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import { now } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
-import { safeJsonParse, settle } from "../utils";
+import { bestEffort, safeJsonParse } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -78,7 +78,7 @@ async function logSlackMockCall(
   contentType: string,
 ): Promise<void> {
   const parsed = await readSlackMockBody(request, contentType);
-  await settle(
+  await bestEffort(
     db.insert(e2eSlackMockCallLog).values({
       method,
       teamId: parsed.teamId,

--- a/turbo/apps/api/src/signals/routes/test-teams-mock.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-mock.ts
@@ -7,7 +7,7 @@ import { request$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
-import { safeJsonParse, settle } from "../utils";
+import { bestEffort, safeJsonParse } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -60,7 +60,7 @@ async function logTeamsMockCall(args: {
   readonly conversationId?: string | null;
   readonly activityId?: string | null;
 }): Promise<void> {
-  await settle(
+  await bestEffort(
     args.db.insert(e2eTeamsMockCallLog).values({
       method: args.method,
       tenantId: args.tenantId ?? readTenantId(args.bodyJson),

--- a/turbo/apps/api/src/signals/routes/test-telegram-mock.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-mock.ts
@@ -8,7 +8,7 @@ import { request$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
-import { safeJsonParse, settle } from "../utils";
+import { bestEffort, safeJsonParse } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -82,7 +82,7 @@ async function logTelegramMockCall({
   readonly rawBody: string;
   readonly bodyJson: unknown;
 }): Promise<void> {
-  await settle(
+  await bestEffort(
     db.insert(e2eTelegramMockCallLog).values({
       method,
       botToken,

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -43,7 +43,7 @@ import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route-entry";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -1930,9 +1930,8 @@ const postTestTelegramState$ = command(
       return testEndpointNotFoundResponse();
     }
 
-    const settled = await settle(request.json());
+    const rawBody: unknown = (await tapError(request.json())) ?? null;
     signal.throwIfAborted();
-    const rawBody: unknown = settled.ok ? settled.value : null;
     const body = isSeedRecord(rawBody) ? rawBody : {};
     const botId = readString(body.bot_id);
     const telegramUserId = readString(body.telegram_user_id);

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -39,7 +39,7 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
-import { settle } from "../utils";
+import { onRejection, settle, throwIfAbort } from "../utils";
 import {
   decryptPersistentSecretValue,
   encryptPersistentSecretValue,
@@ -638,24 +638,24 @@ async function completeClaimedExternalCodeSession(
   // The provider code may already be consumed; finish DB commit even if the
   // client disconnects after provider success.
   const commitSignal = new AbortController().signal;
-  const persistedConnector = await settle(
+  const persistedConnector = await onRejection(
     persistClaimedConnector({
       ...args,
       token: providerResult.value,
       signal: commitSignal,
     }),
+    async (error) => {
+      throwIfAbort(error);
+      await markClaimError({
+        writeDb: args.writeDb,
+        session: args.session,
+        claimStartedAt: args.claimStartedAt,
+        errorMessage: errorMessage(error),
+        signal: commitSignal,
+      });
+    },
   );
-  if (!persistedConnector.ok) {
-    await markClaimError({
-      writeDb: args.writeDb,
-      session: args.session,
-      claimStartedAt: args.claimStartedAt,
-      errorMessage: errorMessage(persistedConnector.error),
-      signal: commitSignal,
-    });
-    throw persistedConnector.error;
-  }
-  return persistedConnector.value;
+  return persistedConnector;
 }
 
 function providerBadRequest(error: unknown) {

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -30,7 +30,7 @@ import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   decryptStoredSecretValue,
@@ -385,7 +385,7 @@ async function refreshGmailAccessToken(args: {
   const refreshToken = await decryptStoredSecretValue(
     args.refreshSecret.encryptedValue,
   );
-  const refreshResult = await settle(
+  const refreshed = await tapError(
     refreshGoogleToken(
       "gmail",
       clientId,
@@ -393,9 +393,9 @@ async function refreshGmailAccessToken(args: {
       refreshToken,
       args.signal,
     ),
-    args.signal,
   );
-  if (!refreshResult.ok) {
+  args.signal.throwIfAborted();
+  if (!refreshed) {
     await markGmailConnectorNeedsReconnect({
       db: args.db,
       connectorId: args.connector.id,
@@ -409,15 +409,13 @@ async function refreshGmailAccessToken(args: {
   }
 
   const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshResult.value.expiresIn,
+    refreshed.expiresIn,
     args.currentTime,
   );
   await args.db
     .update(secretsTable)
     .set({
-      encryptedValue: await encryptStoredSecretValue(
-        refreshResult.value.accessToken,
-      ),
+      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
       updatedAt: args.currentTime,
     })
     .where(
@@ -445,7 +443,7 @@ async function refreshGmailAccessToken(args: {
     access: {
       connectorId: args.connector.id,
       emailAddress: args.connector.externalEmail,
-      accessToken: refreshResult.value.accessToken,
+      accessToken: refreshed.accessToken,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -28,7 +28,7 @@ import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   decryptStoredSecretValue,
@@ -375,7 +375,7 @@ async function refreshGoogleCalendarAccessToken(args: {
   const refreshToken = await decryptStoredSecretValue(
     args.refreshSecret.encryptedValue,
   );
-  const refreshResult = await settle(
+  const refreshed = await tapError(
     refreshGoogleToken(
       "google-calendar",
       clientId,
@@ -383,9 +383,9 @@ async function refreshGoogleCalendarAccessToken(args: {
       refreshToken,
       args.signal,
     ),
-    args.signal,
   );
-  if (!refreshResult.ok) {
+  args.signal.throwIfAborted();
+  if (!refreshed) {
     await markGoogleCalendarConnectorNeedsReconnect({
       db: args.db,
       connectorId: args.connector.id,
@@ -400,15 +400,13 @@ async function refreshGoogleCalendarAccessToken(args: {
   }
 
   const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshResult.value.expiresIn,
+    refreshed.expiresIn,
     args.currentTime,
   );
   await args.db
     .update(secretsTable)
     .set({
-      encryptedValue: await encryptStoredSecretValue(
-        refreshResult.value.accessToken,
-      ),
+      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
       updatedAt: args.currentTime,
     })
     .where(
@@ -436,7 +434,7 @@ async function refreshGoogleCalendarAccessToken(args: {
     access: {
       connectorId: args.connector.id,
       emailAddress: args.connector.externalEmail,
-      accessToken: refreshResult.value.accessToken,
+      accessToken: refreshed.accessToken,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -23,7 +23,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { safeJsonParse, settle, tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   decryptStoredSecretValue,
@@ -353,7 +353,7 @@ async function refreshGoogleMeetAccessToken(args: {
   const refreshToken = await decryptStoredSecretValue(
     args.refreshSecret.encryptedValue,
   );
-  const refreshResult = await settle(
+  const refreshed = await tapError(
     refreshGoogleToken(
       "google-meet",
       clientId,
@@ -361,9 +361,9 @@ async function refreshGoogleMeetAccessToken(args: {
       refreshToken,
       args.signal,
     ),
-    args.signal,
   );
-  if (!refreshResult.ok) {
+  args.signal.throwIfAborted();
+  if (!refreshed) {
     await markGoogleMeetConnectorNeedsReconnect({
       db: args.db,
       connectorId: args.connector.id,
@@ -378,15 +378,13 @@ async function refreshGoogleMeetAccessToken(args: {
   }
 
   const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshResult.value.expiresIn,
+    refreshed.expiresIn,
     args.currentTime,
   );
   await args.db
     .update(secretsTable)
     .set({
-      encryptedValue: await encryptStoredSecretValue(
-        refreshResult.value.accessToken,
-      ),
+      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
       updatedAt: args.currentTime,
     })
     .where(
@@ -415,7 +413,7 @@ async function refreshGoogleMeetAccessToken(args: {
       connectorId: args.connector.id,
       externalId: args.connector.externalId,
       emailAddress: args.connector.externalEmail,
-      accessToken: refreshResult.value.accessToken,
+      accessToken: refreshed.accessToken,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -38,7 +38,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { safeJsonParse, safeUrlParse, settle, tapError } from "../utils";
+import { safeJsonParse, safeUrlParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import {
   decryptStoredSecretValue,
@@ -581,11 +581,11 @@ async function refreshNotionAccessToken(args: {
   const refreshToken = await decryptStoredSecretValue(
     args.refreshSecret.encryptedValue,
   );
-  const refreshResult = await settle(
+  const refreshed = await tapError(
     refreshNotionToken(clientId, clientSecret, refreshToken, args.signal),
-    args.signal,
   );
-  if (!refreshResult.ok) {
+  args.signal.throwIfAborted();
+  if (!refreshed) {
     await markNotionConnectorNeedsReconnect({
       db: args.db,
       connectorId: args.connector.id,
@@ -599,15 +599,13 @@ async function refreshNotionAccessToken(args: {
   }
 
   const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshResult.value.expiresIn,
+    refreshed.expiresIn,
     args.currentTime,
   );
   await args.db
     .update(secretsTable)
     .set({
-      encryptedValue: await encryptStoredSecretValue(
-        refreshResult.value.accessToken,
-      ),
+      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
       updatedAt: args.currentTime,
     })
     .where(
@@ -620,13 +618,11 @@ async function refreshNotionAccessToken(args: {
     );
   args.signal.throwIfAborted();
 
-  if (refreshResult.value.refreshToken) {
+  if (refreshed.refreshToken) {
     await args.db
       .update(secretsTable)
       .set({
-        encryptedValue: await encryptStoredSecretValue(
-          refreshResult.value.refreshToken,
-        ),
+        encryptedValue: await encryptStoredSecretValue(refreshed.refreshToken),
         updatedAt: args.currentTime,
       })
       .where(
@@ -654,7 +650,7 @@ async function refreshNotionAccessToken(args: {
     kind: "ok",
     access: {
       connectorId: args.connector.id,
-      accessToken: refreshResult.value.accessToken,
+      accessToken: refreshed.accessToken,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -24,7 +24,7 @@ import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { generatePresignedGetUrl, putS3Object } from "../external/s3";
 import { writeDb$, type Db } from "../external/db";
-import { bestEffort, settle, tapError } from "../utils";
+import { bestEffort, tapError } from "../utils";
 
 type ClerkClient = ReturnType<typeof createClerkClient>;
 type Transaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -1152,11 +1152,10 @@ export async function getOrgIdBySlug(
     return cached.orgId;
   }
 
-  const orgResult = await settle(clerk.organizations.getOrganization({ slug }));
-  if (!orgResult.ok) {
+  const org = await tapError(clerk.organizations.getOrganization({ slug }));
+  if (!org) {
     return null;
   }
-  const org = orgResult.value;
   if (!org.slug) {
     return null;
   }

--- a/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { now } from "../../lib/time";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { safeJsonParse, safeUrlParse, settle, tapError } from "../utils";
+import { safeJsonParse, safeUrlParse, tapError } from "../utils";
 import { lockConnectorState } from "./auth-state-lock.service";
 import {
   decryptStoredSecretValue,
@@ -220,14 +220,13 @@ async function refreshAndPersistXAccessToken(args: {
     return xShareError("PROVIDER_UNAVAILABLE", "X sharing is not configured");
   }
 
-  const refreshedResult = await settle(
+  const refreshed = await tapError(
     refreshXToken(clientId, clientSecret, args.refreshToken, args.signal),
-    args.signal,
   );
-  if (!refreshedResult.ok) {
+  args.signal.throwIfAborted();
+  if (!refreshed) {
     return xShareError("CONFLICT", "Reconnect X to post images");
   }
-  const refreshed = refreshedResult.value;
 
   const nextRefreshToken = refreshed.refreshToken ?? args.refreshToken;
   const tokenExpiresAt = new Date(

--- a/turbo/apps/api/src/signals/services/zero-scrape-target-policy.ts
+++ b/turbo/apps/api/src/signals/services/zero-scrape-target-policy.ts
@@ -4,7 +4,7 @@ import {
   fetchHostHasBlockedAddress,
   resolveFetchHostAddresses,
 } from "../../lib/blocked-fetch-host";
-import { safeUrlParse, settle } from "../utils";
+import { safeUrlParse, tapError } from "../utils";
 
 interface ScrapeTargetPolicyResult {
   readonly url: URL;
@@ -80,11 +80,11 @@ export async function validateScrapeTargetUrl(
     return "internal_hostname";
   }
 
-  const result = await settle(resolveFetchHostAddresses(url.hostname));
-  if (!result.ok) {
+  const addresses = await tapError(resolveFetchHostAddresses(url.hostname));
+  if (!addresses) {
     return "unresolvable_hostname";
   }
-  if (fetchHostHasBlockedAddress(result.value)) {
+  if (fetchHostHasBlockedAddress(addresses)) {
     return "blocked_address";
   }
 

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -53,7 +53,7 @@ import {
   isOfficialTelegramBotId,
 } from "../external/telegram-official";
 import { now, nowDate } from "../external/time";
-import { safeJsonParse, safeUrlParse, settle, tapError } from "../utils";
+import { safeJsonParse, safeUrlParse, tapError } from "../utils";
 import {
   decryptPersistentSecretValue,
   encryptPersistentSecretValue,
@@ -618,16 +618,16 @@ export const registerTelegramBot$ = command(
       return registerBodyError(bodyResult.response.body.error.message);
     }
 
-    const botInfoResult = await settle(getMe(bodyResult.data.botToken));
+    const botInfo = await tapError(getMe(bodyResult.data.botToken));
     signal.throwIfAborted();
-    if (!botInfoResult.ok) {
+    if (!botInfo) {
       return badRequest(
         "Invalid bot token. Please verify your token with @BotFather.",
       );
     }
 
     const db = set(writeDb$);
-    const telegramBotId = String(botInfoResult.value.id);
+    const telegramBotId = String(botInfo.id);
     if (
       bodyResult.data.reinstallBotId &&
       bodyResult.data.reinstallBotId !== telegramBotId
@@ -651,7 +651,7 @@ export const registerTelegramBot$ = command(
           db,
           existing,
           body: bodyResult.data,
-          botInfo: botInfoResult.value,
+          botInfo,
           auth,
         },
         signal,
@@ -682,7 +682,7 @@ export const registerTelegramBot$ = command(
       .insert(telegramInstallations)
       .values({
         telegramBotId,
-        botUsername: botInfoResult.value.username,
+        botUsername: botInfo.username,
         encryptedBotToken: await encryptPersistentSecretValue(
           bodyResult.data.botToken,
           featureSwitchContext,
@@ -769,20 +769,19 @@ export const setupTelegramStatus$ = command(
       return badRequest("botToken is required");
     }
 
-    const botInfoResult = await settle(getMe(bodyResult.data.botToken));
-    signal.throwIfAborted();
-    if (!botInfoResult.ok) {
-      if (!isInvalidTelegramTokenError(botInfoResult.error)) {
-        log.warn("Unable to verify Telegram setup status", {
-          error: botInfoResult.error,
-        });
+    const botInfo = await tapError(getMe(bodyResult.data.botToken), (error) => {
+      if (!isInvalidTelegramTokenError(error)) {
+        log.warn("Unable to verify Telegram setup status", { error });
       }
+    });
+    signal.throwIfAborted();
+    if (!botInfo) {
       return badRequest(
         "Invalid bot token. Please verify your token with @BotFather.",
       );
     }
 
-    const botId = String(botInfoResult.value.id);
+    const botId = String(botInfo.id);
     const db = set(writeDb$);
     const [existing] = await db
       .select({
@@ -814,10 +813,9 @@ export const setupTelegramStatus$ = command(
       status: 200 as const,
       body: {
         id: botId,
-        username: botInfoResult.value.username ?? null,
+        username: botInfo.username ?? null,
         domainConfigured,
-        privacyDisabled:
-          botInfoResult.value.can_read_all_group_messages === true,
+        privacyDisabled: botInfo.can_read_all_group_messages === true,
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-memory-embedding.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-memory-embedding.service.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
-import { settle } from "../utils";
+import { tapError } from "../utils";
 import {
   embedZeroMemoryText,
   isValidMemoryEmbedding,
@@ -47,7 +47,7 @@ export async function loadWorkflowAutomationMemoryEmbedding(
 ): Promise<LoadedMemoryEmbedding> {
   const model = zeroMemoryEmbeddingModel();
   const queryHash = memoryEmbeddingContentHash({ model, text: args.query });
-  const loaded = await settle(
+  const loaded = await tapError(
     db
       .select({
         embeddingModel: zeroWorkflowAutomationMemoryEmbeddings.embeddingModel,
@@ -62,14 +62,16 @@ export async function loadWorkflowAutomationMemoryEmbedding(
         ),
       )
       .limit(1),
+    () => {
+      log.warn("Failed to read workflow automation memory embedding cache");
+    },
   );
 
   let cacheResult: MemoryEmbeddingCacheResult;
-  if (!loaded.ok) {
-    log.warn("Failed to read workflow automation memory embedding cache");
+  if (!loaded) {
     cacheResult = "miss_read_failed";
   } else {
-    const row = loaded.value[0];
+    const row = loaded[0];
     if (
       row?.embeddingModel === model &&
       row.queryHash === queryHash &&
@@ -83,12 +85,9 @@ export async function loadWorkflowAutomationMemoryEmbedding(
     cacheResult = cacheMissResult({ row, model, queryHash });
   }
 
-  const embeddingResult = await settle(embedZeroMemoryText(args.query));
-  if (!embeddingResult.ok) {
+  const embedded = await tapError(embedZeroMemoryText(args.query), () => {
     log.warn("Failed to embed workflow automation memory query");
-    return { embedding: null, cacheResult };
-  }
-  const embedded = embeddingResult.value;
+  });
   if (!embedded) {
     return { embedding: null, cacheResult };
   }
@@ -96,7 +95,7 @@ export async function loadWorkflowAutomationMemoryEmbedding(
     model: embedded.model,
     text: args.query,
   });
-  const persisted = await settle(
+  await tapError(
     db
       .insert(zeroWorkflowAutomationMemoryEmbeddings)
       .values({
@@ -113,11 +112,11 @@ export async function loadWorkflowAutomationMemoryEmbedding(
           embedding: [...embedded.embedding],
         },
       }),
+    () => {
+      log.warn("Failed to persist workflow automation memory embedding cache");
+      cacheResult = "miss_write_failed";
+    },
   );
-  if (!persisted.ok) {
-    log.warn("Failed to persist workflow automation memory embedding cache");
-    cacheResult = "miss_write_failed";
-  }
 
   return { embedding: embedded, cacheResult };
 }


### PR DESCRIPTION
## Summary

- replace 14 optional `settle` branches with `tapError` while preserving existing fallback, logging, and abort checkpoints
- use `bestEffort` for 3 test-mock audit inserts whose failures are intentionally ignored
- use `onRejection` for the external-code connector commit so claim failure is still persisted before the original error propagates
- reduce the audited source count from 107 `settle` calls to 89 without adding a new utility or changing fallback outcomes

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped` (passes; reports one pre-existing unused-parameter warning in `internal-chat-run-callback.service.ts`)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- pre-commit hooks: Prettier, Knip, and all workspace type checks passed
- targeted API tests were attempted, but the local PostgreSQL migration cannot install the unavailable `vector` extension; PR CI will provide the database-backed test verification
