### PR TITLE
feat(connectors): make nintendo connectors generally available

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -577,9 +577,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();
     context.mocks.ably.publish.mockResolvedValue(undefined);
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.NintendoStoreConnector]: true,
-    });
 
     const session = await connectorsApi.startExternalCode(
       actor,
@@ -691,7 +688,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     expectNoVisibleSecret(secretList, "bdd-nintendo-access-token");
 
     await connectorsApi.deleteConnectorByType(actor, "nintendo-store");
-    await connectorsApi.deleteFeatureSwitches(actor);
   });
 
   it("replaces the remote Nintendo registration and keeps local deletion resilient", async () => {
@@ -699,9 +695,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();
     context.mocks.ably.publish.mockResolvedValue(undefined);
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: true,
-    });
 
     const session = await connectorsApi.startExternalCode(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -522,25 +522,12 @@ describe("GET /api/zero/connector-catalog", () => {
     });
   });
 
-  it("hides Nintendo Store until its connector switch is enabled", async () => {
+  it("exposes Nintendo Store without a connector switch", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
-    const hidden = await accept(
-      client.status({ headers: { authorization: "Bearer clerk-session" } }),
-      [200],
-    );
-    expect(
-      hidden.body.connectors.some((connector) => {
-        return connector.connectorRef === "nintendo-store";
-      }),
-    ).toBeFalsy();
-
-    await enableConnectorFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.NintendoStoreConnector]: true,
-    });
     const visible = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
       [200],
@@ -575,25 +562,12 @@ describe("GET /api/zero/connector-catalog", () => {
     ]);
   });
 
-  it("hides Nintendo Switch Parental Controls until its connector switch is enabled", async () => {
+  it("exposes Nintendo Switch Parental Controls without a connector switch", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
-    const hidden = await accept(
-      client.status({ headers: { authorization: "Bearer clerk-session" } }),
-      [200],
-    );
-    expect(
-      hidden.body.connectors.some((connector) => {
-        return connector.connectorRef === "nintendo-switch-parental-controls";
-      }),
-    ).toBeFalsy();
-
-    await enableConnectorFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: true,
-    });
     const visible = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
       [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -486,7 +486,7 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       connector: {
         connectorRef: "nintendo-switch-parental-controls",
         label: "Nintendo Switch Parental Controls",
-        visibility: "unavailable",
+        visibility: "available",
         credentialResolution: "network-boundary",
       },
       environmentNames: ["NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN"],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -98,11 +98,15 @@ describe("GET /api/zero/connectors", () => {
       client.list({ headers: authHeaders() }),
       [200],
     );
-    expect(nonStaff.body.configuredTypes).not.toContain("nintendo-store");
+    expect(nonStaff.body.configuredTypes).not.toContain("aws");
+    expect(nonStaff.body.configuredTypes).toContain("nintendo-store");
+    expect(nonStaff.body.configuredTypes).toContain(
+      "nintendo-switch-parental-controls",
+    );
 
     mocks.clerk.session(fixture.userId, STAFF_ORG_ID);
     const staff = await accept(client.list({ headers: authHeaders() }), [200]);
-    expect(staff.body.configuredTypes).toContain("nintendo-store");
+    expect(staff.body.configuredTypes).toContain("aws");
   });
 
   it("returns connectors created through the connector API", async () => {

--- a/turbo/packages/connectors/src/connectors/nintendo-store.ts
+++ b/turbo/packages/connectors/src/connectors/nintendo-store.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connector-config";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const nintendoStore = {
   "nintendo-store": {
@@ -10,7 +9,6 @@ export const nintendoStore = {
       "Connect your Nintendo Account to access Nintendo Store catalog, wishlist, points, and play activity data.",
     authMethods: {
       api: {
-        featureFlag: FeatureSwitchKey.NintendoStoreConnector,
         label: "Nintendo sign-in",
         helpText:
           "Sign in with Nintendo. After signing in, right-click the redirect button and copy its link address, then paste the full `npf...://auth` redirect URL or the `session_token_code` value.",

--- a/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
+++ b/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connector-config";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const NINTENDO_SWITCH_PARENTAL_CONTROLS_APP = {
   clientId: "54789befb391a838",
@@ -47,7 +46,6 @@ export const nintendoSwitchParentalControls = {
       "Connect Nintendo Switch Parental Controls to read household play activity and manage explicitly granted console settings.",
     authMethods: {
       api: {
-        featureFlag: FeatureSwitchKey.NintendoSwitchParentalControlsConnector,
         label: "Nintendo sign-in",
         helpText:
           "Sign in with the adult Nintendo Account used by the Nintendo Switch Parental Controls app. After signing in, right-click the redirect button and copy its link address, then paste the full `npf...://auth` redirect URL or the `session_token_code` value.",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -31,8 +31,6 @@ export enum FeatureSwitchKey {
   CloseConnector = "closeConnector",
   TikTokAdsConnector = "tiktokAdsConnector",
   AwsConnector = "awsConnector",
-  NintendoSwitchParentalControlsConnector = "nintendoSwitchParentalControlsConnector",
-  NintendoStoreConnector = "nintendoStoreConnector",
   PosthogConnector = "posthogConnector",
   PayPalConnector = "payPalConnector",
   RampConnector = "rampConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -118,10 +118,6 @@ describe("getAllFeatureStates", () => {
     const staffOrgStates = getAllFeatureStates({
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    expect(staffOrgStates[FeatureSwitchKey.NintendoStoreConnector]).toBe(true);
-    expect(
-      staffOrgStates[FeatureSwitchKey.NintendoSwitchParentalControlsConnector],
-    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(true);
@@ -150,10 +146,6 @@ describe("getAllFeatureStates", () => {
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
     });
-    expect(otherOrgStates[FeatureSwitchKey.NintendoStoreConnector]).toBe(false);
-    expect(
-      otherOrgStates[FeatureSwitchKey.NintendoSwitchParentalControlsConnector],
-    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -177,18 +177,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.NintendoStoreConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Nintendo Store connector",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Nintendo Switch Parental Controls connector",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the PostHog analytics connector",


### PR DESCRIPTION
## Summary

- make Nintendo Store and Nintendo Switch Parental Controls available to every organization
- remove their connector feature gates, switch keys, and rollout registry entries
- update API integration coverage for catalog, configured types, external-code flows, and diagnostics visibility

## Exclusions

- no Nintendo authentication, refresh, firewall, or permission behavior changes
- no database migration; existing unsupported override keys are ignored by the feature-switch filter

## Validation

- `pnpm -F @vm0/connectors exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/core exec vitest run --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/zero-connectors-list.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-check.test.ts --silent=passed-only`
- `pnpm turbo run lint --filter=@vm0/connectors --filter=@vm0/core --filter=api --concurrency=1`
- `pnpm turbo run check-types --filter=@vm0/connectors --filter=@vm0/core --filter=api --concurrency=1`
- `pnpm knip --workspace @vm0/connectors --workspace @vm0/core --workspace api`
- pre-commit hook: repository-wide Knip and TypeScript checks
