### PR TITLE
refactor(platform): accept workflow detail automation field

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   zeroWorkflowAutomationsContract,
+  zeroWorkflowDetailAutomations,
   zeroWorkflowsDetailContract,
   legacyZeroWorkflowAutomationsContract as legacyWorkflowAutomationsContract,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -2340,7 +2341,7 @@ describe("zero workflow automations", () => {
       }),
       [200],
     );
-    expect(detail.body.triggers).toHaveLength(1);
+    expect(zeroWorkflowDetailAutomations(detail.body)).toHaveLength(1);
   });
 
   it("updates the schedule of an existing automation", async () => {

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -4,7 +4,7 @@ import {
   zeroWorkflowAutomationsContract,
   zeroWorkflowVisibilityContract,
   type ChatThreadWorkflowAutomation,
-  type ZeroWorkflowDetailResponse,
+  type LegacyZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
   type ZeroWorkflowAutomationsListEntry,
   type ZeroWorkflowAutomationCreateRequest,
@@ -17,9 +17,9 @@ import {
   setMockWorkflowAutomations,
 } from "./workflow-automations-store.ts";
 
-const DEFAULT_WORKFLOWS: ZeroWorkflowDetailResponse[] = [];
+const DEFAULT_WORKFLOWS: LegacyZeroWorkflowDetailResponse[] = [];
 
-let mockWorkflows: ZeroWorkflowDetailResponse[] = [...DEFAULT_WORKFLOWS];
+let mockWorkflows: LegacyZeroWorkflowDetailResponse[] = [...DEFAULT_WORKFLOWS];
 
 function notFound(workflowId: string) {
   return {
@@ -27,7 +27,9 @@ function notFound(workflowId: string) {
   };
 }
 
-function summary(workflow: ZeroWorkflowDetailResponse): ZeroWorkflowSummary {
+function summary(
+  workflow: LegacyZeroWorkflowDetailResponse,
+): ZeroWorkflowSummary {
   return {
     id: workflow.id,
     agentId: workflow.agentId,
@@ -112,7 +114,7 @@ export const apiWorkflowsHandlers = [
 
   mockApi(zeroWorkflowsCollectionContract.create, ({ body, respond }) => {
     const now = new Date().toISOString();
-    const created: ZeroWorkflowDetailResponse = {
+    const created: LegacyZeroWorkflowDetailResponse = {
       id: crypto.randomUUID(),
       agentId: body.agentId,
       agentName: null,
@@ -163,7 +165,7 @@ export const apiWorkflowsHandlers = [
     const existing = mockWorkflows[index]!;
     const now = new Date().toISOString();
     const files = body.files ?? existing.fileContents ?? [];
-    const updated: ZeroWorkflowDetailResponse = {
+    const updated: LegacyZeroWorkflowDetailResponse = {
       ...existing,
       updatedByUserId: "test-user-123",
       updatedAt: now,
@@ -226,7 +228,7 @@ export const apiWorkflowsHandlers = [
       return respond(404, notFound(params.workflowId));
     }
     const now = new Date().toISOString();
-    const copied: ZeroWorkflowDetailResponse = {
+    const copied: LegacyZeroWorkflowDetailResponse = {
       ...source,
       id: crypto.randomUUID(),
       agentId: body.toAgentId,
@@ -283,7 +285,9 @@ export const apiWorkflowsHandlers = [
 function visibilityHandlers() {
   const transition = (
     workflowId: string,
-    apply: (workflow: ZeroWorkflowDetailResponse) => ZeroWorkflowDetailResponse,
+    apply: (
+      workflow: LegacyZeroWorkflowDetailResponse,
+    ) => LegacyZeroWorkflowDetailResponse,
   ): ZeroWorkflowSummary | null => {
     const index = mockWorkflows.findIndex((item) => {
       return item.id === workflowId;

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -11,7 +11,7 @@ import {
   type ZeroWorkflowAutomationCreateRequest,
   type ZeroWorkflowAutomationUpdateRequest,
   type ZeroWorkflowUpdateRequest,
-  type ZeroWorkflowDetailResponse,
+  type LegacyZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
   type ZeroWorkflowAutomationSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -470,15 +470,15 @@ function publicWorkflowAutomation(
 }
 
 function publicWorkflowDetail(
-  detail: ZeroWorkflowDetailResponse,
-): ZeroWorkflowDetailResponse {
+  detail: LegacyZeroWorkflowDetailResponse,
+): LegacyZeroWorkflowDetailResponse {
   return {
     ...detail,
     triggers: detail.triggers.map(publicWorkflowAutomation),
   };
 }
 
-function salesResearch(): ZeroWorkflowDetailResponse {
+function salesResearch(): LegacyZeroWorkflowDetailResponse {
   return {
     id: SALES_WORKFLOW_ID,
     agentId: AGENT_ID,
@@ -514,7 +514,7 @@ function salesResearch(): ZeroWorkflowDetailResponse {
   };
 }
 
-function opsPlaybook(): ZeroWorkflowDetailResponse {
+function opsPlaybook(): LegacyZeroWorkflowDetailResponse {
   return {
     id: OPS_WORKFLOW_ID,
     agentId: AGENT_ID,
@@ -538,7 +538,7 @@ function opsPlaybook(): ZeroWorkflowDetailResponse {
   };
 }
 
-function launchChecklistWorkflow(): ZeroWorkflowDetailResponse {
+function launchChecklistWorkflow(): LegacyZeroWorkflowDetailResponse {
   return {
     id: CHECKLIST_WORKFLOW_ID,
     agentId: AGENT_ID,
@@ -562,7 +562,7 @@ function launchChecklistWorkflow(): ZeroWorkflowDetailResponse {
   };
 }
 
-function otherAgentWorkflow(): ZeroWorkflowDetailResponse {
+function otherAgentWorkflow(): LegacyZeroWorkflowDetailResponse {
   return {
     id: OTHER_WORKFLOW_ID,
     agentId: OTHER_AGENT_ID,
@@ -600,7 +600,9 @@ function agent(id: string, displayName: string): TeamComposeItem {
   };
 }
 
-function summary(workflow: ZeroWorkflowDetailResponse): ZeroWorkflowSummary {
+function summary(
+  workflow: LegacyZeroWorkflowDetailResponse,
+): ZeroWorkflowSummary {
   return {
     id: workflow.id,
     agentId: workflow.agentId,
@@ -643,9 +645,9 @@ function mockAgentPageApis(): void {
 }
 
 function applyWorkflowUpdate(
-  workflow: ZeroWorkflowDetailResponse,
+  workflow: LegacyZeroWorkflowDetailResponse,
   body: ZeroWorkflowUpdateRequest,
-): ZeroWorkflowDetailResponse {
+): LegacyZeroWorkflowDetailResponse {
   return {
     ...workflow,
     ...(body.name !== undefined ? { name: body.name } : {}),
@@ -672,8 +674,9 @@ function applyWorkflowUpdate(
 }
 
 function mockWorkflowApis(
-  workflows: ZeroWorkflowDetailResponse[],
+  workflows: LegacyZeroWorkflowDetailResponse[],
   onUpdate?: (body: ZeroWorkflowUpdateRequest) => void,
+  detailField: "triggers" | "automations" | "both" = "triggers",
 ): void {
   const setAutomationEnabled = (
     automationId: string,
@@ -717,7 +720,18 @@ function mockWorkflowApis(
         error: { code: "NOT_FOUND", message: "missing" },
       });
     }
-    return respond(200, publicWorkflowDetail(detail));
+    const publicDetail = publicWorkflowDetail(detail);
+    if (detailField === "automations") {
+      const { triggers, ...workflow } = publicDetail;
+      return respond(200, { ...workflow, automations: triggers });
+    }
+    if (detailField === "both") {
+      return respond(200, {
+        ...publicDetail,
+        automations: publicDetail.triggers,
+      });
+    }
+    return respond(200, publicDetail);
   });
   context.mocks.api(
     zeroWorkflowAutomationsContract.listWorkspace,
@@ -806,7 +820,7 @@ function mockWorkflowApis(
 }
 
 function mockDeleteWorkflow(
-  workflows: ZeroWorkflowDetailResponse[],
+  workflows: LegacyZeroWorkflowDetailResponse[],
   onDelete: (workflowId: string) => void | Promise<void>,
 ): void {
   context.mocks.api(
@@ -1494,6 +1508,20 @@ describe("workflow detail page", () => {
     expect(search()).toBe("?file=config%2Fsettings.json");
   });
 
+  it("renders canonical automation fields during the rolling deploy", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    mockWorkflowApis([salesResearch()], undefined, "automations");
+    mockConnectedAutomationConnectors();
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"));
+
+    await screen.findByText("Every weekday at 9:00 AM");
+    expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Disable Every weekday at 9:00 AM" }),
+    ).toBeInTheDocument();
+  });
+
   it("checks connector readiness only on request and shows every status", async () => {
     const workflow = {
       ...salesResearch(),
@@ -1905,7 +1933,7 @@ describe("workflow detail page", () => {
 
   it("copies a workflow to another agent from the info tab", async () => {
     const workflows = [salesResearch()];
-    const copiedWorkflow: ZeroWorkflowDetailResponse = {
+    const copiedWorkflow: LegacyZeroWorkflowDetailResponse = {
       ...salesResearch(),
       id: COPIED_WORKFLOW_ID,
       agentId: OTHER_AGENT_ID,
@@ -2000,7 +2028,7 @@ describe("workflow detail page", () => {
 
   it("moves a workflow by removing the original after copying", async () => {
     const workflows = [salesResearch()];
-    const copiedWorkflow: ZeroWorkflowDetailResponse = {
+    const copiedWorkflow: LegacyZeroWorkflowDetailResponse = {
       ...salesResearch(),
       id: COPIED_WORKFLOW_ID,
       agentId: OTHER_AGENT_ID,

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4,20 +4,21 @@
 import type { FormEvent, ReactNode } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type {
-  GmailLabelAppliedEventConfig,
-  GmailNewMessageEventConfig,
-  GithubLabelAppliedEventConfig,
-  GithubLabelAppliedSubjectFilter,
-  NotionPageContentUpdatedEventCreateConfig,
-  WorkflowFileEntry,
-  WorkflowFileMetadata,
-  ZeroWorkflowConnectorReadinessEntry,
-  ZeroWorkflowDetailResponse,
-  ZeroWorkflowSchedule,
-  ZeroWorkflowScheduleType,
-  ZeroWorkflowAutomationSummary,
-  ZeroWorkflowUpdateRequest,
+import {
+  zeroWorkflowDetailAutomations,
+  type GmailLabelAppliedEventConfig,
+  type GmailNewMessageEventConfig,
+  type GithubLabelAppliedEventConfig,
+  type GithubLabelAppliedSubjectFilter,
+  type NotionPageContentUpdatedEventCreateConfig,
+  type WorkflowFileEntry,
+  type WorkflowFileMetadata,
+  type ZeroWorkflowConnectorReadinessEntry,
+  type ZeroWorkflowDetailResponse,
+  type ZeroWorkflowSchedule,
+  type ZeroWorkflowScheduleType,
+  type ZeroWorkflowAutomationSummary,
+  type ZeroWorkflowUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   IconAlertTriangle,
@@ -476,7 +477,9 @@ function DetailHeader({
         <>
           <div className="flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-3">
-              <WorkflowHeaderIcon automation={detail.triggers[0]} />
+              <WorkflowHeaderIcon
+                automation={zeroWorkflowDetailAutomations(detail)[0]}
+              />
               <div className="flex min-w-0 flex-col justify-center">
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>
@@ -1616,7 +1619,7 @@ function WorkflowCopyDialog({
     pauseLoadable.state === "loading" ||
     deleteLoadable.state === "loading";
   const sourceAgentName = agentLabel(detail);
-  const enabledSourceAutomationIds = detail.triggers
+  const enabledSourceAutomationIds = zeroWorkflowDetailAutomations(detail)
     .filter((automation) => {
       return automation.enabled;
     })
@@ -3291,7 +3294,7 @@ function AutomationsSection({
   const currentUserId =
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? "") : "";
   const displayTimezone = preferences?.timezone ?? browserTimezone();
-  const automations = detail.triggers;
+  const automations = zeroWorkflowDetailAutomations(detail);
 
   return (
     <section className="mx-auto flex max-w-[900px] flex-col gap-3">

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
@@ -8,9 +8,76 @@ import {
   gmailLabelAppliedEventConfigSchema,
   gmailNewMessageEventConfigSchema,
   zeroWorkflowConnectorReadinessResponseSchema,
+  zeroWorkflowDetailAutomations,
+  zeroWorkflowDetailResponseSchema,
   zeroWorkflowUpdateRequestSchema,
   zeroWorkflowAutomationCreateRequestSchema,
 } from "../zero-workflows";
+
+const workflowDetailBase = {
+  id: "d0000000-0000-4000-a000-000000000201",
+  agentId: "c0000000-0000-4000-a000-000000000101",
+  agentName: "research-agent",
+  agentDisplayName: "Research Agent",
+  name: "sales-research",
+  displayName: "Sales Research",
+  description: null,
+  visibility: "private",
+  ownerUserId: "user_123",
+  ownerUserDisplayName: null,
+  ownerUserImageUrl: null,
+  createdAt: "2026-07-15T00:00:00.000Z",
+  canManage: true,
+  canPublish: true,
+  createdByUserId: "user_123",
+  updatedByUserId: "user_123",
+  updatedAt: "2026-07-15T00:00:00.000Z",
+  instruction: null,
+  files: null,
+  fileContents: null,
+} as const;
+
+const canonicalAutomation = {
+  id: "canonical-automation",
+  ownerUserId: "user_123",
+  enabled: true,
+  chatThreadId: null,
+  nextRunAt: null,
+  lastRunAt: null,
+  kind: "schedule",
+  schedule: {
+    type: "cron",
+    cronExpression: "0 9 * * 1-5",
+    timezone: "UTC",
+  },
+  scheduleSummary: "Weekdays at 9:00 AM",
+} as const;
+
+describe("workflow detail automation compatibility", () => {
+  it("accepts legacy, canonical, and dual fields during the rolling deploy", () => {
+    const legacy = zeroWorkflowDetailResponseSchema.parse({
+      ...workflowDetailBase,
+      triggers: [],
+    });
+    const canonical = zeroWorkflowDetailResponseSchema.parse({
+      ...workflowDetailBase,
+      automations: [canonicalAutomation],
+    });
+    const dual = zeroWorkflowDetailResponseSchema.parse({
+      ...workflowDetailBase,
+      triggers: [],
+      automations: [canonicalAutomation],
+    });
+
+    expect(zeroWorkflowDetailAutomations(legacy)).toStrictEqual([]);
+    expect(zeroWorkflowDetailAutomations(canonical)).toStrictEqual([
+      canonicalAutomation,
+    ]);
+    expect(zeroWorkflowDetailAutomations(dual)).toStrictEqual([
+      canonicalAutomation,
+    ]);
+  });
+});
 
 describe("Gmail new message workflow automation contract", () => {
   it("accepts only explicit text match fields", () => {

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -909,16 +909,39 @@ export const zeroWorkflowSummarySchema = z.object({
     .optional(),
 });
 
-export const zeroWorkflowDetailResponseSchema =
-  zeroWorkflowSummarySchema.extend({
-    createdByUserId: z.string(),
-    updatedByUserId: z.string(),
-    updatedAt: z.string().datetime(),
-    instruction: z.string().nullable(),
-    files: z.array(workflowFileMetadataSchema).nullable(),
-    fileContents: z.array(workflowFileEntrySchema).nullable(),
+const zeroWorkflowDetailBaseResponseSchema = zeroWorkflowSummarySchema.extend({
+  createdByUserId: z.string(),
+  updatedByUserId: z.string(),
+  updatedAt: z.string().datetime(),
+  instruction: z.string().nullable(),
+  files: z.array(workflowFileMetadataSchema).nullable(),
+  fileContents: z.array(workflowFileEntrySchema).nullable(),
+});
+
+// Temporary rollout compatibility for #21408. The API will serve both fields
+// before `triggers` is removed so already-open browser bundles keep working.
+// Remove the legacy and dual variants after the production compatibility gate.
+const legacyZeroWorkflowDetailResponseSchema =
+  zeroWorkflowDetailBaseResponseSchema.extend({
     triggers: z.array(zeroWorkflowAutomationSummarySchema),
   });
+
+const canonicalZeroWorkflowDetailResponseSchema =
+  zeroWorkflowDetailBaseResponseSchema.extend({
+    automations: z.array(zeroWorkflowAutomationSummarySchema),
+  });
+
+const dualZeroWorkflowDetailResponseSchema =
+  zeroWorkflowDetailBaseResponseSchema.extend({
+    triggers: z.array(zeroWorkflowAutomationSummarySchema),
+    automations: z.array(zeroWorkflowAutomationSummarySchema),
+  });
+
+export const zeroWorkflowDetailResponseSchema = z.union([
+  dualZeroWorkflowDetailResponseSchema,
+  canonicalZeroWorkflowDetailResponseSchema,
+  legacyZeroWorkflowDetailResponseSchema,
+]);
 
 export const zeroWorkflowListResponseSchema = z.array(
   zeroWorkflowSummarySchema,
@@ -1437,9 +1460,18 @@ export const zeroWorkflowAutomationsContract = c.router({
 export type WorkflowFileEntry = z.infer<typeof workflowFileEntrySchema>;
 export type WorkflowFileMetadata = z.infer<typeof workflowFileMetadataSchema>;
 export type ZeroWorkflowSummary = z.infer<typeof zeroWorkflowSummarySchema>;
+export type LegacyZeroWorkflowDetailResponse = z.infer<
+  typeof legacyZeroWorkflowDetailResponseSchema
+>;
 export type ZeroWorkflowDetailResponse = z.infer<
   typeof zeroWorkflowDetailResponseSchema
 >;
+
+export function zeroWorkflowDetailAutomations(
+  detail: ZeroWorkflowDetailResponse,
+): readonly ZeroWorkflowAutomationSummary[] {
+  return "automations" in detail ? detail.automations : detail.triggers;
+}
 export type ZeroWorkflowCreateRequest = z.infer<
   typeof zeroWorkflowCreateRequestSchema
 >;


### PR DESCRIPTION
## Summary

- let the workflow-detail contract parse the current `triggers` field, canonical `automations` field, or an intentional dual-field response during a rolling deployment
- normalize every response through `zeroWorkflowDetailAutomations()` and move the Platform workflow page to that accessor
- keep the API producer on the current response field in this PR, so this release changes no production response payload
- keep Platform/API mocks explicitly typed to the currently emitted shape and cover the canonical shape in a Platform integration test

## Rollout role

This is the read-before-write prerequisite for the final workflow-detail response rename in #21408:

1. merge and promote this consumer-compatible release
2. have the API serve both `triggers` and `automations`, preserving already-open older browser bundles while new clients prefer `automations`
3. after the browser compatibility window and production gate, stop emitting `triggers`
4. remove the temporary legacy/dual contract variants and accessor in the terminal cleanup

The API producer stays unchanged in this PR. The explicit dual phase follows the repository deployment-compatibility contract for old frontend -> new backend traffic.

## Verification

- `pnpm format`
- `@vm0/api-contracts` lint and type-check
- `@vm0/app` lint and type-check
- API contracts: 17 files / 409 tests passed
- Platform workflow page: 44/44 tests passed, including canonical-field rendering
- `git diff --check`

Part of #21408.
