### PR TITLE
docs(rust): document tracing test capture api

### DIFF
--- a/crates/tracing-test-support/src/lib.rs
+++ b/crates/tracing-test-support/src/lib.rs
@@ -44,7 +44,7 @@ pub struct CapturedEvent {
     ///
     /// The event message, when present, uses the `message` key.
     pub fields: BTreeMap<String, String>,
-    /// The [`Visit`] recording method used for each entry in [`Self::fields`].
+    /// The `tracing::field::Visit` recording method used for each entry in [`Self::fields`].
     ///
     /// Each value is one of `str`, `i64`, `u64`, `i128`, `u128`, `bool`, or `debug`.
     pub field_kinds: BTreeMap<String, &'static str>,

--- a/crates/tracing-test-support/src/lib.rs
+++ b/crates/tracing-test-support/src/lib.rs
@@ -1,3 +1,32 @@
+#![deny(missing_docs)]
+
+//! Tracing event capture helpers for tests.
+//!
+//! [`CapturedEvents`] implements [`tracing_subscriber::layer::Layer`] and stores structured
+//! tracing events in a shared in-memory buffer for later assertions.
+//!
+//! # Example
+//!
+//! ```
+//! use tracing::Level;
+//! use tracing_subscriber::prelude::*;
+//! use tracing_test_support::CapturedEvents;
+//!
+//! let captured = CapturedEvents::default();
+//! let subscriber = tracing_subscriber::registry().with(captured.clone());
+//!
+//! tracing::subscriber::with_default(subscriber, || {
+//!     tracing::info!(request_id = 42_u64, "handled request");
+//! });
+//!
+//! let events = captured.entries();
+//! assert_eq!(events.len(), 1);
+//! assert!(events.iter().any(|event| {
+//!     event.level == Level::INFO
+//!         && event.fields.get("request_id").map(String::as_str) == Some("42")
+//! }));
+//! ```
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -6,23 +35,46 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
+/// A structured tracing event captured by [`CapturedEvents`].
 #[derive(Clone, Debug)]
 pub struct CapturedEvent {
+    /// The level from the event's tracing metadata.
     pub level: Level,
+    /// String representations of the event's fields, keyed by field name.
+    ///
+    /// The event message, when present, uses the `message` key.
     pub fields: BTreeMap<String, String>,
+    /// The [`Visit`] recording method used for each entry in [`Self::fields`].
+    ///
+    /// Each value is one of `str`, `i64`, `u64`, `i128`, `u128`, `bool`, or `debug`.
     pub field_kinds: BTreeMap<String, &'static str>,
 }
 
+/// A shared collector that captures tracing events as a [`Layer`].
+///
+/// The default value starts with an empty event buffer. Cloning a collector creates another
+/// handle to the same buffer, not an independent collector. Events recorded through a layer
+/// installed from any clone are therefore visible from every clone.
+///
+/// [`Layer`]: tracing_subscriber::layer::Layer
 #[derive(Clone, Default)]
 pub struct CapturedEvents {
     events: Arc<Mutex<Vec<CapturedEvent>>>,
 }
 
 impl CapturedEvents {
+    /// Returns a cloned, point-in-time snapshot of the captured events.
+    ///
+    /// The returned events are independent of the collector. Later captures or calls to
+    /// [`Self::clear`] do not change an existing snapshot.
     pub fn entries(&self) -> Vec<CapturedEvent> {
         self.lock_events().clone()
     }
 
+    /// Removes all events from the shared collector.
+    ///
+    /// Calling this method through any cloned handle clears the buffer observed by every handle.
+    /// Snapshots previously returned by [`Self::entries`] are unaffected.
     pub fn clear(&self) {
         self.lock_events().clear();
     }


### PR DESCRIPTION
## Summary

- document the `tracing-test-support` crate and every public type, field, and method
- add a runnable rustdoc example for installing the capture layer and reading events
- enforce future public documentation with crate-local `#![deny(missing_docs)]`

## Scope

- preserves all capture behavior, public APIs, dependencies, and consumer code
- documents clone sharing, snapshot independence, shared clearing, and exact field-kind values

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p tracing-test-support --all-targets --all-features`
- `cargo test -p tracing-test-support --all-features`
- `cargo test -p tracing-test-support --doc`
- `cargo doc -p tracing-test-support --all-features --no-deps`
- pre-commit workspace Cargo formatting, Clippy, and documentation hooks

Closes #21530
