### PR TITLE
fix(guest-agent): pass codex prompts through stdin

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -40,7 +40,6 @@ pub(super) fn build_cli_command_for_runtime(
                     fast_mode: runtime.codex_fast_mode,
                     resume_id: runtime.resume_session_id.as_ref(),
                     append_system_prompt: runtime.append_system_prompt.as_ref(),
-                    prompt: runtime.prompt.as_ref(),
                 },
             ))
         }
@@ -148,9 +147,11 @@ fn build_claude_command_with_config(
 
 /// Build the codex argument list (testable).
 ///
-/// Resume is a positional sub-subcommand (`codex exec resume <id> <prompt>`),
-/// not a `--resume <id>` flag. Use `--` before the prompt so user text that
-/// starts with `-` is not parsed as another codex option.
+/// Resume is a positional sub-subcommand (`codex exec resume <id> -`), not a
+/// `--resume <id>` flag. The `-` positional selects Codex's native stdin prompt
+/// path; `--` keeps that sentinel separate from Codex options.
+const CODEX_STDIN_PROMPT_SENTINEL: &str = "-";
+
 fn build_codex_developer_instructions_config(append_system_prompt: &str) -> String {
     let value = codex_runtime_config::quote_toml_basic_string(append_system_prompt);
     format!("developer_instructions={value}")
@@ -198,7 +199,6 @@ struct CodexArgsConfig<'a> {
     fast_mode: bool,
     resume_id: &'a str,
     append_system_prompt: &'a str,
-    prompt: &'a str,
 }
 
 fn build_codex_args(
@@ -208,7 +208,6 @@ fn build_codex_args(
     fast_mode: bool,
     resume_id: &str,
     append_system_prompt: &str,
-    prompt: &str,
 ) -> Vec<String> {
     let mut args = vec![
         "exec".to_string(),
@@ -255,11 +254,11 @@ fn build_codex_args(
         args.push("resume".to_string());
         args.push(resume_id.to_string());
         args.push("--".to_string());
-        args.push(prompt.to_string());
+        args.push(CODEX_STDIN_PROMPT_SENTINEL.to_string());
     } else {
         log_info!(LOG_TAG, "Starting new codex session");
         args.push("--".to_string());
-        args.push(prompt.to_string());
+        args.push(CODEX_STDIN_PROMPT_SENTINEL.to_string());
     }
 
     args
@@ -285,7 +284,6 @@ fn build_codex_command_with_config(
         config.fast_mode,
         config.resume_id,
         config.append_system_prompt,
-        config.prompt,
     ));
     cmd
 }
@@ -473,13 +471,17 @@ mod tests {
     fn build_codex_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", &[], false, resume_id, "", prompt)
+        let args = build_codex_args(model, "", &[], false, resume_id, "");
+        assert!(!args.iter().any(|arg| arg == prompt));
+        args
     }
 
     fn build_codex_fast_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", &[], true, resume_id, "", prompt)
+        let args = build_codex_args(model, "", &[], true, resume_id, "");
+        assert!(!args.iter().any(|arg| arg == prompt));
+        args
     }
 
     fn build_codex_args_with_base_url_for_test(
@@ -490,7 +492,9 @@ mod tests {
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, openai_base_url, &[], false, resume_id, "", prompt)
+        let args = build_codex_args(model, openai_base_url, &[], false, resume_id, "");
+        assert!(!args.iter().any(|arg| arg == prompt));
+        args
     }
 
     fn build_codex_args_with_startup_config_for_test(
@@ -500,7 +504,9 @@ mod tests {
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", startup_config_overrides, false, "", "", prompt)
+        let args = build_codex_args(model, "", startup_config_overrides, false, "", "");
+        assert!(!args.iter().any(|arg| arg == prompt));
+        args
     }
 
     fn build_codex_args_with_append_for_test(
@@ -511,15 +517,9 @@ mod tests {
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(
-            model,
-            "",
-            &[],
-            false,
-            resume_id,
-            append_system_prompt,
-            prompt,
-        )
+        let args = build_codex_args(model, "", &[], false, resume_id, append_system_prompt);
+        assert!(!args.iter().any(|arg| arg == prompt));
+        args
     }
 
     fn codex_args_have_config(args: &[String], config: &str) -> bool {
@@ -544,7 +544,6 @@ mod tests {
                 fast_mode: false,
                 resume_id: "",
                 append_system_prompt: "",
-                prompt: "",
             },
         )
     }
@@ -556,7 +555,7 @@ mod tests {
         let system_log_path = tmp.path().join("system.log");
         guest_common::log::set_system_log_file(system_log_path.to_string_lossy().as_ref());
 
-        let args = build_codex_args("", "", &[], false, "thread-secret-123", "", "prompt");
+        let args = build_codex_args("", "", &[], false, "thread-secret-123", "");
         guest_common::log::clear_system_log_file();
         let system_log = std::fs::read_to_string(system_log_path).unwrap();
 
@@ -578,7 +577,7 @@ mod tests {
         assert_eq!(args[c_idx + 1], paths::CANONICAL_WORKING_DIR);
         assert!(codex_args_have_config(&args, "features.memories=true"));
         assert_eq!(args[args.len() - 2], "--");
-        assert_eq!(args.last().unwrap(), "hello");
+        assert_eq!(args.last().unwrap(), CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
@@ -641,7 +640,6 @@ mod tests {
             false,
             "",
             "",
-            "p",
         );
 
         assert!(codex_args_have_config(&args, r#"model_provider="minimax""#));
@@ -715,52 +713,52 @@ mod tests {
         let r_idx = args.iter().position(|a| a == "resume").unwrap();
         assert_eq!(args[r_idx + 1], "thread-abc");
         assert_eq!(args[r_idx + 2], "--");
-        assert_eq!(args[r_idx + 3], "follow up");
+        assert_eq!(args[r_idx + 3], CODEX_STDIN_PROMPT_SENTINEL);
         // resume is a positional sub-subcommand, NOT a --resume flag
         assert!(!args.contains(&"--resume".to_string()));
     }
 
     #[test]
-    fn build_codex_args_resume_layout_is_resume_id_prompt() {
+    fn build_codex_args_resume_layout_is_resume_id_stdin_sentinel() {
         let args = build_codex_args_for_test("", "id1", "p1");
         let r_idx = args.iter().position(|a| a == "resume").unwrap();
         assert_eq!(args.len(), r_idx + 4);
         assert_eq!(args[r_idx + 1], "id1");
         assert_eq!(args[r_idx + 2], "--");
-        assert_eq!(args[r_idx + 3], "p1");
+        assert_eq!(args[r_idx + 3], CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
-    fn build_codex_args_separates_prompt_from_options() {
+    fn build_codex_args_separates_stdin_sentinel_from_options() {
         let args = build_codex_args_for_test("gpt-5", "id", "hello");
         let r_idx = args.iter().position(|a| a == "resume").unwrap();
         assert_eq!(args[r_idx + 2], "--");
-        assert_eq!(args[r_idx + 3], "hello");
+        assert_eq!(args[r_idx + 3], CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
-    fn build_codex_args_prompt_last_in_no_resume_path() {
+    fn build_codex_args_stdin_sentinel_last_in_no_resume_path() {
         let args = build_codex_args_for_test("gpt-5", "", "the prompt");
         assert_eq!(args[args.len() - 2], "--");
-        assert_eq!(args.last().unwrap(), "the prompt");
+        assert_eq!(args.last().unwrap(), CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
-    fn build_codex_args_keeps_dash_prefixed_prompt_as_prompt() {
+    fn build_codex_args_omits_dash_prefixed_prompt() {
         let prompt = "--input-format stream-json 是说从一个文件里读取 input 吗？";
         let args = build_codex_args_for_test("gpt-5", "", prompt);
         assert_eq!(args[args.len() - 2], "--");
-        assert_eq!(args.last().unwrap(), prompt);
+        assert_eq!(args.last().unwrap(), CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
-    fn build_codex_args_resume_keeps_dash_prefixed_prompt_as_prompt() {
+    fn build_codex_args_resume_omits_dash_prefixed_prompt() {
         let prompt = "--input-format stream-json 是说从一个文件里读取 input 吗？";
         let args = build_codex_args_for_test("gpt-5", "id1", prompt);
         let r_idx = args.iter().position(|a| a == "resume").unwrap();
         assert_eq!(args[r_idx + 1], "id1");
         assert_eq!(args[r_idx + 2], "--");
-        assert_eq!(args[r_idx + 3], prompt);
+        assert_eq!(args[r_idx + 3], CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
@@ -773,7 +771,7 @@ mod tests {
             r#"developer_instructions="Your name is Aria.""#
         ));
         assert_eq!(args[args.len() - 2], "--");
-        assert_eq!(args.last().unwrap(), "analyze this");
+        assert_eq!(args.last().unwrap(), CODEX_STDIN_PROMPT_SENTINEL);
     }
 
     #[test]
@@ -800,7 +798,7 @@ mod tests {
         assert_eq!(args[c_idx], r#"developer_instructions="Be concise.""#);
         assert_eq!(args[r_idx + 1], "thread-abc");
         assert_eq!(args[r_idx + 2], "--");
-        assert_eq!(args[r_idx + 3], "next");
+        assert_eq!(args[r_idx + 3], CODEX_STDIN_PROMPT_SENTINEL);
         assert_eq!(args.len(), r_idx + 4);
     }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -54,6 +54,7 @@ use guest_contracts::diagnostics::{
 use process_group::ChildProcessGroup;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::io::{Seek, Write};
 use std::path::Path;
 use std::pin::Pin;
 use std::process::{ExitStatus, Stdio};
@@ -99,6 +100,19 @@ fn claude_user_frame<'a>(uuid: &str, text: &'a str) -> ClaudeUserFrame<'a> {
 fn claude_initial_prompt_frame<'a>(run_id: &str, prompt: &'a str) -> ClaudeUserFrame<'a> {
     let uuid = crate::active_input::claude_initial_prompt_uuid(run_id);
     claude_user_frame(&uuid, prompt)
+}
+
+fn codex_prompt_stdin(prompt: &str) -> Result<Stdio, AgentError> {
+    let mut file = tempfile::tempfile().map_err(|error| {
+        AgentError::Execution(format!("create anonymous Codex prompt stdin: {error}"))
+    })?;
+    file.write_all(prompt.as_bytes()).map_err(|error| {
+        AgentError::Execution(format!("write anonymous Codex prompt stdin: {error}"))
+    })?;
+    file.rewind().map_err(|error| {
+        AgentError::Execution(format!("rewind anonymous Codex prompt stdin: {error}"))
+    })?;
+    Ok(Stdio::from(file))
 }
 
 async fn write_claude_user_frame_to_stdin(
@@ -562,11 +576,6 @@ async fn execute_cli_inner(
 
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args(args)
-        .stdin(if behavior.uses_stream_json_stdin() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .process_group(0)
@@ -632,6 +641,11 @@ async fn execute_cli_inner(
         &child_env_values,
     )
     .map_err(AgentError::Execution)?;
+    let stdin = match runtime.framework {
+        env::Framework::ClaudeCode => Stdio::piped(),
+        env::Framework::Codex => codex_prompt_stdin(runtime.prompt.as_ref())?,
+    };
+    cmd.stdin(stdin);
     child_env::apply_values_to_tokio_command(&mut cmd, &child_env_values);
     // Set the child cwd explicitly at spawn time so the CLI observes the
     // current canonical workspace mount instead of relying on inherited cwd.
@@ -1441,11 +1455,38 @@ mod tests {
     }
 
     #[test]
-    fn legacy_codex_large_prompt_is_rejected_by_process_argv_guard() {
+    fn ordinary_codex_large_prompt_is_not_rejected_by_process_argv_guard() {
         let user_env = HashMap::new();
         let prompt = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
         let runtime =
             runtime_for_exec_boundary_test(env::Framework::Codex, &prompt, "", false, &user_env);
+
+        let cmd = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+        let (bin, args) = cmd.split_first().unwrap();
+        let env_values = child_env::values_for_runtime(&runtime);
+        exec_boundary::validate_process_argv_env(
+            "test cli child",
+            bin,
+            args.iter().map(String::as_str),
+            &env_values,
+        )
+        .unwrap();
+
+        assert!(!args.iter().any(|arg| arg == &prompt));
+    }
+
+    #[test]
+    fn ordinary_codex_large_developer_instructions_still_fail_process_argv_guard() {
+        let user_env = HashMap::new();
+        let append_system_prompt =
+            "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        let runtime = runtime_for_exec_boundary_test(
+            env::Framework::Codex,
+            "user prompt",
+            &append_system_prompt,
+            false,
+            &user_env,
+        );
 
         let cmd = command::build_cli_command_for_runtime(&runtime, false).unwrap();
         let (bin, args) = cmd.split_first().unwrap();
@@ -1459,7 +1500,9 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("argv value too large"));
-        assert!(!error.contains(&prompt));
+        assert!(error.contains("length="));
+        assert!(error.contains("max=131071"));
+        assert!(!error.contains(&append_system_prompt));
     }
 
     #[test]

--- a/crates/guest-agent/tests/codex_prompt_stdin.rs
+++ b/crates/guest-agent/tests/codex_prompt_stdin.rs
@@ -1,0 +1,203 @@
+//! Ordinary Codex prompts must cross the child-process boundary through stdin.
+
+mod common;
+
+use guest_agent::active_input::ActiveInputRuntime;
+use guest_agent::masker::SecretMasker;
+use guest_agent::run_context::GuestRuntime;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const PRODUCTION_PROMPT_BYTES: usize = 140_421;
+const RESUME_THREAD_ID: &str = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::test]
+async fn fresh_and_resumed_codex_prompts_cross_size_boundaries_through_stdin() -> TestResult {
+    let mock = common::build_and_locate_mock_codex()?;
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let sizes = [
+        guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES - 1,
+        guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES,
+        guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1,
+        PRODUCTION_PROMPT_BYTES,
+    ];
+
+    for resume in [false, true] {
+        for size in sizes {
+            let prompt = sized_prompt(size);
+            let run_id = format!(
+                "codex-stdin-{}-{size}",
+                if resume { "resume" } else { "fresh" }
+            );
+            let runtime = build_runtime(root.path(), &mock, &run_id, &prompt, resume)?;
+
+            let events = execute_and_read_session(&runtime).await?;
+
+            assert_eq!(events[1]["item"]["text"], prompt);
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn fresh_and_resumed_codex_stdin_preserve_prompt_text_exactly() -> TestResult {
+    let mock = common::build_and_locate_mock_codex()?;
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let prompt = " \n--option-looking user text\n中文 and emoji 🚀\nliteral dash: -\n ";
+
+    for resume in [false, true] {
+        let run_id = format!(
+            "codex-stdin-text-{}",
+            if resume { "resume" } else { "fresh" }
+        );
+        let runtime = build_runtime(root.path(), &mock, &run_id, prompt, resume)?;
+
+        let events = execute_and_read_session(&runtime).await?;
+
+        assert_eq!(events[1]["item"]["text"], prompt);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn codex_exit_before_reading_stdin_preserves_exit_and_stderr() -> TestResult {
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let mock = executable_script(
+        root.path(),
+        "codex-early-exit",
+        "#!/bin/sh\necho 'codex auth failed before stdin' >&2\nexit 7\n",
+    )?;
+    let prompt = "x".repeat(PRODUCTION_PROMPT_BYTES);
+    let runtime = build_runtime(root.path(), &mock, "codex-stdin-early-exit", &prompt, false)?;
+
+    let result = execute_with_timeout(&runtime).await?;
+
+    assert_eq!(result.exit_code, 7);
+    assert_eq!(result.stderr_lines, vec!["codex auth failed before stdin"]);
+    assert!(result.control_error.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn codex_can_exit_successfully_without_reading_stdin() -> TestResult {
+    let root = tempfile::tempdir()?;
+    common::ensure_canonical_workspace_for_test()?;
+    let mock = executable_script(root.path(), "codex-ignore-stdin", "#!/bin/sh\nexit 0\n")?;
+    let prompt = "x".repeat(PRODUCTION_PROMPT_BYTES);
+    let runtime = build_runtime(root.path(), &mock, "codex-stdin-unread", &prompt, false)?;
+
+    let result = execute_with_timeout(&runtime).await?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.stderr_lines.is_empty());
+    assert!(result.control_error.is_none());
+    Ok(())
+}
+
+fn sized_prompt(size: usize) -> String {
+    let prefix = "stdin-boundary\n--option-looking-prefix\n";
+    let suffix = "\nend";
+    assert!(size >= prefix.len() + suffix.len());
+    let mut prompt = String::with_capacity(size);
+    prompt.push_str(prefix);
+    prompt.push_str(&"x".repeat(size - prefix.len() - suffix.len()));
+    prompt.push_str(suffix);
+    assert_eq!(prompt.len(), size);
+    prompt
+}
+
+fn build_runtime(
+    root: &Path,
+    mock_path: &Path,
+    run_id: &str,
+    prompt: &str,
+    resume: bool,
+) -> TestResult<GuestRuntime> {
+    let home = root.join(format!("home-{run_id}"));
+    let runtime_dir = home.join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: prompt.to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+    let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
+        run_id: run_id.to_string(),
+        api_url: "http://127.0.0.1:1".to_string(),
+        api_token: String::new(),
+        sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
+        sandbox_reuse_result: "reused".to_string(),
+        resume_session_id: if resume {
+            RESUME_THREAD_ID.to_string()
+        } else {
+            String::new()
+        },
+        use_mock_codex: "true".to_string(),
+        mock_codex_path: Some(mock_path.to_string_lossy().into_owned()),
+        cli_agent_type: "codex".to_string(),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+        home: Some(home.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir.clone()),
+        ..guest_agent::env::GuestConfigRaw::default()
+    })
+    .map_err(std::io::Error::other)?;
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
+    let http = guest_agent::http::HttpClient::for_config(&config)?;
+
+    Ok(GuestRuntime {
+        config,
+        paths,
+        http,
+    })
+}
+
+async fn execute_and_read_session(runtime: &GuestRuntime) -> TestResult<Vec<serde_json::Value>> {
+    let result = execute_with_timeout(runtime).await?;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    common::read_codex_session_history_events_for_paths(&runtime.paths)
+}
+
+async fn execute_with_timeout(
+    runtime: &GuestRuntime,
+) -> TestResult<guest_agent::cli::CliExecutionResult> {
+    let masker = SecretMasker::from_raw("");
+    let active_input = ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli_with_active_input_for_config(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            runtime.http.clone(),
+            active_input.into_writer(),
+            &runtime.config,
+            &runtime.paths,
+        ),
+    )
+    .await
+    .map_err(|_| std::io::Error::other("ordinary Codex execution timed out"))??;
+    Ok(result)
+}
+
+fn executable_script(root: &Path, name: &str, contents: &str) -> TestResult<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = root.join(name);
+    std::fs::write(&path, contents)?;
+    let mut permissions = std::fs::metadata(&path)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&path, permissions)?;
+    Ok(path)
+}

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -18,8 +18,8 @@
 //!   guest-mock-codex [-c <config>] exec [--json] [--sandbox <mode>] [--skip-git-repo-check]
 //!                          [-C <dir>] [-m <model>]
 //!                          [--append-system-prompt <s>] [--last]
-//!                          [-- <prompt>]
-//!   guest-mock-codex [-c <config>] exec resume <canonical-uuid-thread-id> [-- <prompt>]
+//!                          [-- <prompt|->]
+//!   guest-mock-codex [-c <config>] exec resume <canonical-uuid-thread-id> [-- <prompt|->]
 //!   guest-mock-codex [-c <config>] app-server --listen stdio://
 //!   guest-mock-codex [-c <config>] app-server --stdio
 //! ```
@@ -40,7 +40,8 @@ use clap::{Parser, Subcommand};
 use guest_mock_codex::{
     join_prompt_cow, lookup_fixture, run_app_server, run_fixture, run_new, run_resume,
 };
-use std::io;
+use std::borrow::Cow;
+use std::io::{self, Read};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -134,20 +135,37 @@ fn main() -> io::Result<()> {
             sub: Some(ExecSub::Resume { thread_id, prompt }),
             ..
         }) => {
+            let prompt = resolve_exec_prompt(&prompt)?;
             if maybe_run_fixture()? {
                 return Ok(());
             }
-            let joined_prompt = join_prompt_cow(&prompt);
-            run_resume(&thread_id, joined_prompt.as_ref())
+            run_resume(&thread_id, prompt.as_ref())
         }
         Cmd::Exec(ExecArgs { prompt, .. }) => {
+            let prompt = resolve_exec_prompt(&prompt)?;
             if maybe_run_fixture()? {
                 return Ok(());
             }
-            let joined_prompt = join_prompt_cow(&prompt);
-            run_new(joined_prompt.as_ref())
+            run_new(prompt.as_ref())
         }
     }
+}
+
+fn resolve_exec_prompt(parts: &[String]) -> io::Result<Cow<'_, str>> {
+    let prompt = join_prompt_cow(parts);
+    if prompt != "-" {
+        return Ok(prompt);
+    }
+
+    let mut stdin_prompt = String::new();
+    io::stdin().read_to_string(&mut stdin_prompt)?;
+    if stdin_prompt.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "No prompt provided via stdin.",
+        ));
+    }
+    Ok(Cow::Owned(stdin_prompt))
 }
 
 fn maybe_run_fixture() -> io::Result<bool> {

--- a/crates/guest-mock-codex/tests/integration/cli.rs
+++ b/crates/guest-mock-codex/tests/integration/cli.rs
@@ -1,7 +1,9 @@
 use guest_mock_codex::read_session_file;
 use tempfile::TempDir;
 
-use crate::support::{require_session_file, run, run_with_env};
+use crate::support::{
+    require_session_file, run, run_with_env, run_with_stdin, run_with_stdin_and_env,
+};
 
 #[test]
 fn happy_path_emits_three_events_and_persists_jsonl() -> std::io::Result<()> {
@@ -31,6 +33,41 @@ fn happy_path_emits_three_events_and_persists_jsonl() -> std::io::Result<()> {
 
     let events = read_session_file(&session_path)?;
     assert_eq!(events, out.events);
+    Ok(())
+}
+
+#[test]
+fn fresh_prompt_stdin_is_preserved_exactly() -> std::io::Result<()> {
+    let dir = TempDir::new()?;
+    let prompt = " \n--literal option-looking prompt\n中文 and emoji 🚀\n-\n ";
+    let out = run_with_stdin(dir.path(), &["exec", "--json", "--", "-"], prompt)?;
+
+    assert_eq!(out.status, 0);
+    assert_eq!(out.events[1]["item"]["text"], prompt);
+    let session_path = require_session_file(dir.path())?;
+    let persisted = read_session_file(&session_path)?;
+    assert_eq!(persisted[1]["item"]["text"], prompt);
+    Ok(())
+}
+
+#[test]
+fn fresh_prompt_stdin_preserves_literal_dash() -> std::io::Result<()> {
+    let dir = TempDir::new()?;
+    let out = run_with_stdin(dir.path(), &["exec", "--json", "--", "-"], "-")?;
+
+    assert_eq!(out.status, 0);
+    assert_eq!(out.events[1]["item"]["text"], "-");
+    Ok(())
+}
+
+#[test]
+fn fresh_prompt_stdin_rejects_whitespace_only_input() -> std::io::Result<()> {
+    let dir = TempDir::new()?;
+    let out = run_with_stdin(dir.path(), &["exec", "--json", "--", "-"], " \n\t")?;
+
+    assert_ne!(out.status, 0);
+    assert!(out.events.is_empty());
+    assert!(out.stderr.contains("No prompt provided via stdin."));
     Ok(())
 }
 
@@ -124,9 +161,10 @@ fn config_flags_before_resume_are_not_echoed() {
 #[test]
 fn fixture_event_mapping_rich_emits_full_event_set() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
-    let out = run_with_env(
+    let out = run_with_stdin_and_env(
         dir.path(),
-        &["exec", "--json", "--", "ignored"],
+        &["exec", "--json", "--", "-"],
+        "ignored through stdin",
         &[("MOCK_CODEX_FIXTURE", "event-mapping-rich")],
     )?;
 

--- a/crates/guest-mock-codex/tests/integration/session_resume.rs
+++ b/crates/guest-mock-codex/tests/integration/session_resume.rs
@@ -4,7 +4,7 @@ use guest_mock_codex::{build_events, read_session_file, session_files, write_ses
 use serde_json::Value;
 use tempfile::TempDir;
 
-use crate::support::{require_session_file, run};
+use crate::support::{require_session_file, run, run_with_stdin};
 
 #[test]
 fn resume_echoes_thread_id_and_appends_events() -> std::io::Result<()> {
@@ -22,6 +22,28 @@ fn resume_echoes_thread_id_and_appends_events() -> std::io::Result<()> {
     assert_eq!(events.len(), 6);
     assert_eq!(events[1]["item"]["text"], "turn-1");
     assert_eq!(events[4]["item"]["text"], "turn-2");
+    Ok(())
+}
+
+#[test]
+fn resume_prompt_stdin_is_preserved_exactly() -> std::io::Result<()> {
+    let dir = TempDir::new()?;
+    let first = run(dir.path(), &["exec", "--json", "--", "turn-1"])?;
+    let thread_id = first.events[0]["thread_id"].as_str().unwrap().to_string();
+    let prompt = " \n--resume input\n中文 and emoji 🚀\n ";
+
+    let second = run_with_stdin(
+        dir.path(),
+        &["exec", "resume", &thread_id, "--", "-"],
+        prompt,
+    )?;
+
+    assert_eq!(second.status, 0);
+    assert_eq!(second.events[0]["thread_id"], thread_id);
+    assert_eq!(second.events[1]["item"]["text"], prompt);
+    let session_path = require_session_file(dir.path())?;
+    let events = read_session_file(&session_path)?;
+    assert_eq!(events[4]["item"]["text"], prompt);
     Ok(())
 }
 

--- a/crates/guest-mock-codex/tests/integration/support.rs
+++ b/crates/guest-mock-codex/tests/integration/support.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
+use std::{io::Seek, io::Write};
 
 use guest_mock_codex::find_session_file;
 use serde_json::Value;
@@ -21,16 +22,53 @@ pub(crate) fn run(codex_home: &Path, args: &[&str]) -> std::io::Result<RunOutput
     run_with_env(codex_home, args, &[])
 }
 
+pub(crate) fn run_with_stdin(
+    codex_home: &Path,
+    args: &[&str],
+    stdin: &str,
+) -> std::io::Result<RunOutput> {
+    run_with_env_and_stdin(codex_home, args, &[], Some(stdin))
+}
+
+pub(crate) fn run_with_stdin_and_env(
+    codex_home: &Path,
+    args: &[&str],
+    stdin: &str,
+    env: &[(&str, &str)],
+) -> std::io::Result<RunOutput> {
+    run_with_env_and_stdin(codex_home, args, env, Some(stdin))
+}
+
 pub(crate) fn run_with_env(
     codex_home: &Path,
     args: &[&str],
     env: &[(&str, &str)],
+) -> std::io::Result<RunOutput> {
+    run_with_env_and_stdin(codex_home, args, env, None)
+}
+
+fn run_with_env_and_stdin(
+    codex_home: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+    stdin: Option<&str>,
 ) -> std::io::Result<RunOutput> {
     let mut cmd = Command::new(BIN);
     cmd.env("CODEX_HOME", codex_home).args(args);
     cmd.env_remove("MOCK_CODEX_FIXTURE");
     for (k, v) in env {
         cmd.env(k, v);
+    }
+    match stdin {
+        Some(stdin) => {
+            let mut file = tempfile::tempfile()?;
+            file.write_all(stdin.as_bytes())?;
+            file.rewind()?;
+            cmd.stdin(Stdio::from(file));
+        }
+        None => {
+            cmd.stdin(Stdio::null());
+        }
     }
     let output = output_with_timeout(cmd, args)?;
 
@@ -56,9 +94,7 @@ pub(crate) fn run_with_env(
 }
 
 fn output_with_timeout(mut cmd: Command, args: &[&str]) -> std::io::Result<Output> {
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let child = cmd.spawn()?;
     let pid = child.id();
     let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
## Summary

- Send ordinary Codex `exec` and `exec resume` user prompts through Codex's native stdin sentinel instead of process argv.
- Preload the prompt into an anonymous file-backed stdin so large prompts cannot hit per-argument exec limits and child startup cannot race a parent-side pipe writer.
- Extend guest-mock-codex and guest-agent integration coverage for exact prompt preservation, argv boundary sizes, resume, and children that exit without reading stdin.

## Scope

- Codex developer instructions and startup config remain argv/config values and retain existing exec-boundary validation.
- The Codex app-server path and active-input behavior are unchanged.
- This intentionally uses stdin for every ordinary Codex prompt instead of adding a size threshold or fallback path.
- Codex's native stdin parser rejects whitespace-only input; this PR preserves that upstream behavior.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features`
- `cd crates && cargo doc -p guest-agent -p guest-mock-codex --all-features --no-deps`
- `cd crates && cargo test -p guest-mock-codex`
- `cd crates && cargo test -p guest-agent --test codex_prompt_stdin`
- `cd crates && cargo test -p guest-agent`
- Repository pre-commit hooks, including workspace Rust format, Clippy, and documentation checks

Closes #21525
