### PR TITLE
perf(runner): attribute session history generation claims

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -251,6 +251,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
             restored_session_identity: None,
+            history_generation_run_id: None,
             workspace_image_size_bytes: b"workspace image".len() as u64,
             workspace_promotion: Some(fixture.promotion),
         });

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -35,7 +35,9 @@ use crate::idle_pool::{
 };
 use crate::ids::RunId;
 use crate::paths::short_digest;
-use crate::provider::{ClaimedJob, JobCandidate, PreLocalAdmissionOutcome};
+use crate::provider::{
+    ClaimedJob, JobCandidate, PreLocalAdmissionOutcome, SessionHistoryGenerationRelationship,
+};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
     RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
@@ -70,6 +72,29 @@ struct LocalAdmission {
 enum LocalAdmissionResource {
     Fresh(BudgetLease),
     Reusable(Box<ReservedIdleSandbox>),
+}
+
+impl LocalAdmissionResource {
+    fn session_history_generation_relationship(
+        &self,
+        target_generation_run_id: Option<RunId>,
+    ) -> SessionHistoryGenerationRelationship {
+        let Some(target_generation_run_id) = target_generation_run_id else {
+            return SessionHistoryGenerationRelationship::UnknownTarget;
+        };
+        match self {
+            Self::Fresh(_) => SessionHistoryGenerationRelationship::Fresh,
+            Self::Reusable(reservation) => match reservation.history_generation_run_id() {
+                Some(reserved_generation_run_id)
+                    if reserved_generation_run_id == target_generation_run_id =>
+                {
+                    SessionHistoryGenerationRelationship::Exact
+                }
+                Some(_) => SessionHistoryGenerationRelationship::Different,
+                None => SessionHistoryGenerationRelationship::UnknownReserved,
+            },
+        }
+    }
 }
 
 struct AdmittedClaim {
@@ -504,6 +529,10 @@ async fn claim_with_local_admission(
             return None;
         }
     }
+    let relationship = admission
+        .resource
+        .session_history_generation_relationship(candidate.history_generation_run_id());
+    candidate.set_session_history_generation_relationship(relationship);
     // claim() runs in the branch handler: non-interruptible, so a valid
     // successful claim is always paired with complete().
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -190,6 +190,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             source_ip,
             storage_fingerprints,
             restored_session_identity,
+            history_generation_run_id: Some(run_id),
             workspace_image_size_bytes,
             workspace_promotion,
         });
@@ -637,7 +638,7 @@ mod tests {
     };
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
-        test_support::ParkedIdleCandidateBuilder,
+        RestoreReservedIdleResult, test_support::ParkedIdleCandidateBuilder,
     };
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -843,7 +844,17 @@ mod tests {
         )
         .await;
 
-        assert_eq!(fixture.idle_pool.lock().await.len(), 1);
+        {
+            let mut idle_pool = fixture.idle_pool.lock().await;
+            let reservation = idle_pool
+                .reserve_reusable("sess-network-log-park", "vm0/default", &None)
+                .expect("finalized sandbox should be reusable");
+            assert_eq!(reservation.history_generation_run_id(), Some(run_id));
+            assert!(matches!(
+                idle_pool.restore_reserved(reservation),
+                RestoreReservedIdleResult::Restored
+            ));
+        }
         assert!(
             !fixture
                 .network_log_manager
@@ -1433,6 +1444,7 @@ mod tests {
             budget_lease: existing_lease,
             storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             restored_session_identity: None,
+            history_generation_run_id: None,
             workspace_image_size_bytes: b"image".len() as u64,
             workspace_promotion: Some(old_promotion),
         })

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,7 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
     assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool, seed_idle_pool_with_overrides,
+    mock_run_config_with_overrides, push_job, seed_idle_pool,
+    seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
     seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
     wait_cancel_token_removed, wait_discover_entered,
 };
@@ -140,12 +141,29 @@ async fn claim_failure_rolls_back_budget() {
 
     // First job: claim returns None (unavailable).
     let run_id_1 = RunId::new_v4();
-    push_job(&env, run_id_1, "vm0/default", None);
+    let target_generation_run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id_1, None);
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id_1, "vm0/default".into())
+                .with_history_generation_run_id(Some(target_generation_run_id)),
+        )
+        .unwrap();
 
     // Returning to discovery proves the failed claim was processed.
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id_1, Duration::from_secs(5)).await;
     assert_eq!(budget.allocated().2, 0);
+    let claim_candidates = env.handle.claim_candidates();
+    let unavailable_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == run_id_1)
+        .expect("unavailable candidate should reach claim");
+    assert_eq!(
+        unavailable_candidate.session_history_generation_relationship(),
+        Some(crate::provider::SessionHistoryGenerationRelationship::Fresh)
+    );
 
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
@@ -163,6 +181,15 @@ async fn claim_failure_rolls_back_budget() {
     assert!(
         completion.is_some(),
         "second job should complete (budget freed after unavailable claim)"
+    );
+    let claim_candidates = env.handle.claim_candidates();
+    let followup_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == run_id_2)
+        .expect("follow-up candidate should reach claim");
+    assert_eq!(
+        followup_candidate.session_history_generation_relationship(),
+        Some(crate::provider::SessionHistoryGenerationRelationship::UnknownTarget)
     );
 
     shutdown(&env, run_handle).await;
@@ -226,7 +253,17 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
     let session_id = "sess-conflict-restore";
-    seed_idle_pool(&idle_pool, &budget, session_id, "vm0/default", 2, 4096).await;
+    let reserved_generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_history_generation(
+        &idle_pool,
+        &budget,
+        session_id,
+        "vm0/default",
+        2,
+        4096,
+        reserved_generation_run_id,
+    )
+    .await;
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -235,7 +272,10 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(conflict_run_id, None);
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(conflict_run_id, session_id))
+        .send(
+            affinity_protected_candidate(conflict_run_id, session_id)
+                .with_history_generation_run_id(Some(reserved_generation_run_id)),
+        )
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -250,15 +290,28 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         (2, 4096, 1),
         "restored reservation should retain its original budget lease"
     );
+    let claim_candidates = env.handle.claim_candidates();
+    let conflict_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == conflict_run_id)
+        .expect("claim conflict candidate should reach claim");
+    assert_eq!(
+        conflict_candidate.session_history_generation_relationship(),
+        Some(crate::provider::SessionHistoryGenerationRelationship::Exact)
+    );
 
     let followup_run_id = RunId::new_v4();
+    let followup_target_generation_run_id = RunId::new_v4();
     env.provider.set_claim_result(
         followup_run_id,
         Some(context_with_session(followup_run_id, session_id)),
     );
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(followup_run_id, session_id))
+        .send(
+            affinity_protected_candidate(followup_run_id, session_id)
+                .with_history_generation_run_id(Some(followup_target_generation_run_id)),
+        )
         .unwrap();
     let completion = env
         .handle
@@ -266,6 +319,15 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         .await
         .expect("restored idle reservation should serve the next claim");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    let claim_candidates = env.handle.claim_candidates();
+    let followup_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == followup_run_id)
+        .expect("follow-up candidate should reach claim");
+    assert_eq!(
+        followup_candidate.session_history_generation_relationship(),
+        Some(crate::provider::SessionHistoryGenerationRelationship::Different)
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -481,7 +543,10 @@ async fn affinity_protected_candidate_with_local_session_claims() {
     );
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, "sess-held-local"))
+        .send(
+            affinity_protected_candidate(run_id, "sess-held-local")
+                .with_history_generation_run_id(Some(RunId::new_v4())),
+        )
         .unwrap();
 
     let completion = env
@@ -499,6 +564,10 @@ async fn affinity_protected_candidate_with_local_session_claims() {
     assert_eq!(
         claimed_candidate.pre_local_admission_outcome(),
         Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
+    );
+    assert_eq!(
+        claimed_candidate.session_history_generation_relationship(),
+        Some(crate::provider::SessionHistoryGenerationRelationship::UnknownReserved)
     );
     assert!(
         claimed_candidate

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -34,9 +34,56 @@ pub(in super::super) async fn seed_idle_pool(
     vcpu: u32,
     memory_mb: u32,
 ) -> SandboxId {
+    seed_idle_pool_with_generation(
+        pool,
+        budget,
+        session_id,
+        profile_name,
+        vcpu,
+        memory_mb,
+        None,
+    )
+    .await
+}
+
+pub(in super::super) async fn seed_idle_pool_with_history_generation(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    session_id: &str,
+    profile_name: &str,
+    vcpu: u32,
+    memory_mb: u32,
+    history_generation_run_id: RunId,
+) -> SandboxId {
+    seed_idle_pool_with_generation(
+        pool,
+        budget,
+        session_id,
+        profile_name,
+        vcpu,
+        memory_mb,
+        Some(history_generation_run_id),
+    )
+    .await
+}
+
+async fn seed_idle_pool_with_generation(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    session_id: &str,
+    profile_name: &str,
+    vcpu: u32,
+    memory_mb: u32,
+    history_generation_run_id: Option<RunId>,
+) -> SandboxId {
     let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-    let candidate = make_synthetic_parked_candidate(session_id, profile_name, budget_lease)
+    let builder = ParkedIdleCandidateBuilder::new(session_id, budget_lease)
+        .with_profile_name(profile_name)
         .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string());
+    let candidate = match history_generation_run_id {
+        Some(run_id) => builder.with_history_generation_run_id(run_id).build(),
+        None => builder.build(),
+    };
     let sandbox_id = candidate.sandbox_id();
     let mut guard = pool.lock().await;
     let result = guard.park(candidate);

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -10,8 +10,9 @@ pub(super) use self::env::{
 };
 pub(super) use self::idle_pool::{
     TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
-    seed_idle_pool_expired, seed_idle_pool_with_overrides, seed_idle_pool_with_timing,
-    seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state,
+    seed_idle_pool_expired, seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
+    seed_workspace_cache_state,
 };
 pub(super) use self::jobs::{
     TEST_SESSION_LAST_COMPLETED_AT, context_with_session, minimal_context, push_job, shutdown,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -784,6 +784,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
         restored_session_identity: None,
+        history_generation_run_id: None,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })
@@ -891,6 +892,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
         restored_session_identity: None,
+        history_generation_run_id: None,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -10,6 +10,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
+use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::status::IdleVm;
@@ -145,6 +146,7 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) source_ip: String,
     pub(crate) storage_fingerprints: StorageFingerprints,
     pub(crate) restored_session_identity: Option<RestoredSessionIdentity>,
+    pub(crate) history_generation_run_id: Option<RunId>,
     pub(crate) workspace_image_size_bytes: u64,
     pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -164,6 +166,7 @@ struct IdleSandboxMetadata {
     /// Verified hash-backed resume state restored into this sandbox before it
     /// was parked. Missing means reuse must fall back to materialize+restore.
     restored_session_identity: Option<RestoredSessionIdentity>,
+    history_generation_run_id: Option<RunId>,
     /// Local terminal timestamp for this parked session.
     ///
     /// `None` is reserved for synthetic test entries and means the VM is not
@@ -172,27 +175,6 @@ struct IdleSandboxMetadata {
 }
 
 impl IdleSandboxMetadata {
-    fn new(
-        cli_agent_session_id: String,
-        sandbox_id: SandboxId,
-        profile_name: String,
-        device_rate_limits: Option<DeviceRateLimits>,
-        source_ip: String,
-        storage_fingerprints: StorageFingerprints,
-        restored_session_identity: Option<RestoredSessionIdentity>,
-    ) -> Self {
-        Self {
-            cli_agent_session_id,
-            sandbox_id,
-            profile_name,
-            device_rate_limits,
-            source_ip,
-            storage_fingerprints,
-            restored_session_identity,
-            last_completed_at: None,
-        }
-    }
-
     fn cli_agent_session_id(&self) -> &str {
         &self.cli_agent_session_id
     }
@@ -284,11 +266,12 @@ impl IdleParkRequest {
             source_ip,
             storage_fingerprints,
             restored_session_identity,
+            history_generation_run_id,
             workspace_image_size_bytes,
             workspace_promotion,
         } = self.parts;
 
-        let metadata = IdleSandboxMetadata::new(
+        let metadata = IdleSandboxMetadata {
             cli_agent_session_id,
             sandbox_id,
             profile_name,
@@ -296,7 +279,9 @@ impl IdleParkRequest {
             source_ip,
             storage_fingerprints,
             restored_session_identity,
-        );
+            history_generation_run_id,
+            last_completed_at: None,
+        };
 
         if let Some(promotion) = workspace_promotion.as_ref()
             && let Err(mismatch) =
@@ -534,6 +519,7 @@ impl ReusableIdleSandbox {
             source_ip,
             storage_fingerprints,
             restored_session_identity,
+            history_generation_run_id: _,
             last_completed_at: _,
         } = metadata;
 
@@ -858,6 +844,10 @@ impl IdleEntry {
 impl ReservedIdleSandbox {
     pub fn cli_agent_session_id(&self) -> &str {
         self.entry.cli_agent_session_id()
+    }
+
+    pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
+        self.entry.metadata.history_generation_run_id
     }
 
     pub fn validate_workspace_promotion_identity(
@@ -1254,6 +1244,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
             restored_session_identity: None,
+            history_generation_run_id: None,
             workspace_image_size_bytes: 0,
             workspace_promotion: None,
         })
@@ -1285,6 +1276,7 @@ mod tests {
         let session_id = "session-metadata";
         let profile_name = "vm0/large";
         let source_ip = "10.99.0.42";
+        let history_generation_run_id = RunId::new_v4();
         let budget_lease = make_budget_lease(2, 2048);
         let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
             MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
@@ -1325,6 +1317,7 @@ mod tests {
             source_ip: source_ip.into(),
             storage_fingerprints,
             restored_session_identity: Some(restored_session_identity.clone()),
+            history_generation_run_id: Some(history_generation_run_id),
             workspace_image_size_bytes: 0,
             workspace_promotion: None,
         });
@@ -1338,16 +1331,25 @@ mod tests {
         assert_eq!(candidate.cli_agent_session_id(), session_id);
         assert_eq!(candidate.sandbox_id(), sandbox_id);
         assert_eq!(candidate.metadata.profile_name, profile_name);
+        assert_eq!(
+            candidate.metadata.history_generation_run_id,
+            Some(history_generation_run_id)
+        );
 
         let mut pool = IdlePool::new(pool_config(0));
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
-        let entry = pool.take(session_id).expect("idle entry should be parked");
-        assert_eq!(entry.profile_name(), profile_name);
+        let reservation = pool
+            .reserve_reusable(session_id, profile_name, &None)
+            .expect("idle entry should be reserved");
+        assert_eq!(
+            reservation.history_generation_run_id(),
+            Some(history_generation_run_id)
+        );
 
         let IdleUnparkResult::Reused {
             sandbox,
             budget_lease,
-        } = entry.try_unpark().await
+        } = reservation.try_unpark().await
         else {
             panic!("unpark should succeed");
         };

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
+use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
@@ -25,6 +26,7 @@ pub(crate) struct ParkedIdleCandidateBuilder {
     source_ip: String,
     storage_fingerprints: StorageFingerprints,
     restored_session_identity: Option<RestoredSessionIdentity>,
+    history_generation_run_id: Option<RunId>,
     last_completed_at: Option<String>,
     workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -45,6 +47,7 @@ impl ParkedIdleCandidateBuilder {
             source_ip: DEFAULT_SOURCE_IP.into(),
             storage_fingerprints: StorageFingerprints::default(),
             restored_session_identity: None,
+            history_generation_run_id: None,
             last_completed_at: None,
             workspace_promotion: None,
         }
@@ -93,6 +96,14 @@ impl ParkedIdleCandidateBuilder {
         self
     }
 
+    pub(crate) fn with_history_generation_run_id(
+        mut self,
+        history_generation_run_id: RunId,
+    ) -> Self {
+        self.history_generation_run_id = Some(history_generation_run_id);
+        self
+    }
+
     pub(crate) fn with_workspace_promotion(
         mut self,
         workspace_promotion: WorkspaceImagePromotionContext,
@@ -113,10 +124,11 @@ impl ParkedIdleCandidateBuilder {
             source_ip,
             storage_fingerprints,
             restored_session_identity,
+            history_generation_run_id,
             last_completed_at,
             workspace_promotion,
         } = self;
-        let mut metadata = IdleSandboxMetadata::new(
+        let metadata = IdleSandboxMetadata {
             cli_agent_session_id,
             sandbox_id,
             profile_name,
@@ -124,10 +136,9 @@ impl ParkedIdleCandidateBuilder {
             source_ip,
             storage_fingerprints,
             restored_session_identity,
-        );
-        if let Some(last_completed_at) = last_completed_at {
-            metadata = metadata.with_last_completed_at(last_completed_at);
-        }
+            history_generation_run_id,
+            last_completed_at,
+        };
         ParkedIdleCandidate {
             resources: IdleSandboxResources {
                 sandbox,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -25,7 +25,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    PreLocalAdmissionOutcome,
+    PreLocalAdmissionOutcome, SessionHistoryGenerationRelationship,
 };
 use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
@@ -62,6 +62,8 @@ struct ClaimRequestTelemetry {
     main_loop_to_local_admission_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pre_local_admission_outcome: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_history_generation_relationship: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -357,6 +359,7 @@ impl JobProvider for ApiProvider {
                     // (backwards compat with pre-profile API).
                     let run_id = job.run_id;
                     let cli_agent_session_id = job.cli_agent_session_id;
+                    let history_generation_run_id = job.history_generation_run_id;
                     let affinity_protected_until = job.affinity_protected_until;
                     let profile = job
                         .experimental_profile
@@ -364,6 +367,7 @@ impl JobProvider for ApiProvider {
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_affinity_metadata(cli_agent_session_id, affinity_protected_until)
+                        .with_history_generation_run_id(history_generation_run_id)
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -836,6 +840,9 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             provider_discovery_to_main_loop_ms,
             main_loop_to_local_admission_ms,
             pre_local_admission_outcome,
+            session_history_generation_relationship: candidate
+                .session_history_generation_relationship()
+                .map(SessionHistoryGenerationRelationship::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1623,15 +1630,21 @@ mod tests {
     #[test]
     fn claim_request_body_serializes_runner_timing() {
         let now = std::time::Instant::now();
-        let candidate = JobCandidate::new_with_timing_for_test(
+        let target_generation_run_id: RunId =
+            "00000000-0000-0000-0000-000000000099".parse().unwrap();
+        let mut candidate = JobCandidate::new_with_timing_for_test(
             RunId::nil(),
             crate::profile::DEFAULT_PROFILE.to_string(),
             now.checked_sub(Duration::from_millis(25)).unwrap(),
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
         )
         .with_discovery_source(JobDiscoverySource::Poll)
+        .with_history_generation_run_id(Some(target_generation_run_id))
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
+        candidate.set_session_history_generation_relationship(
+            SessionHistoryGenerationRelationship::Exact,
+        );
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
@@ -1649,6 +1662,15 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert_eq!(
+            body["telemetry"]["sessionHistoryGenerationRelationship"],
+            "exact"
+        );
+        assert!(
+            !body
+                .to_string()
+                .contains(&target_generation_run_id.to_string())
+        );
         assert!(body.get("capabilities").is_none());
     }
 
@@ -1870,6 +1892,8 @@ mod tests {
     async fn discover_returns_http_poll_job_after_wakeup() {
         let server = MockServer::start_async().await;
         let run_id: RunId = "00000000-0000-0000-0000-000000000003".parse().unwrap();
+        let history_generation_run_id: RunId =
+            "00000000-0000-0000-0000-000000000004".parse().unwrap();
         let mock = server
             .mock_async(|when, then| {
                 when.method(POST).path(routes::runners::poll::POLL.path);
@@ -1878,6 +1902,7 @@ mod tests {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
                         "cliAgentSessionId": "sess-poll",
+                        "historyGenerationRunId": history_generation_run_id,
                         "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
                     }
                 }));
@@ -1897,6 +1922,10 @@ mod tests {
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
         assert_eq!(discovered.cli_agent_session_id(), Some("sess-poll"));
+        assert_eq!(
+            discovered.history_generation_run_id(),
+            Some(history_generation_run_id)
+        );
         assert!(discovered.is_affinity_protected());
         assert_eq!(
             discovered.discovery_source(),

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -678,13 +678,16 @@ async fn handle_ably_message_with_network_policy_refresh(
                     profile = %profile,
                     "ably: job notification, queueing direct candidate"
                 );
-                JobNotificationAction::Direct(DirectJobCandidate::new_with_affinity_metadata(
-                    notif.run_id,
-                    profile.to_owned(),
-                    notification_received_at,
-                    notif.cli_agent_session_id.map(str::to_owned),
-                    notif.affinity_protected_until.map(str::to_owned),
-                ))
+                JobNotificationAction::Direct(
+                    DirectJobCandidate::new_with_affinity_metadata(
+                        notif.run_id,
+                        profile.to_owned(),
+                        notification_received_at,
+                        notif.cli_agent_session_id.map(str::to_owned),
+                        notif.affinity_protected_until.map(str::to_owned),
+                    )
+                    .with_history_generation_run_id(notif.history_generation_run_id),
+                )
             } else {
                 info!(
                     run_id = %notif.run_id,
@@ -723,6 +726,7 @@ struct JobNotification<'a> {
     run_id: RunId,
     profile: Option<&'a str>,
     cli_agent_session_id: Option<&'a str>,
+    history_generation_run_id: Option<RunId>,
     affinity_protected_until: Option<&'a str>,
 }
 
@@ -872,10 +876,16 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("affinityProtectedUntil")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
+    let history_generation_run_id = msg
+        .data
+        .get("historyGenerationRunId")
+        .and_then(|v| v.as_str())
+        .and_then(|value| value.parse().ok());
     Some(JobNotification {
         run_id,
         profile,
         cli_agent_session_id,
+        history_generation_run_id,
         affinity_protected_until,
     })
 }
@@ -2188,12 +2198,17 @@ mod tests {
                 "profile": "vm0/default",
                 "targetRunnerId": "00000000-0000-0000-0000-000000000099",
                 "cliAgentSessionId": "sess-target",
+                "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
             }),
         );
         let notif = parse_job_notification(&msg).unwrap();
         assert_eq!(notif.profile, Some("vm0/default"));
         assert_eq!(notif.cli_agent_session_id, Some("sess-target"));
+        assert_eq!(
+            notif.history_generation_run_id,
+            Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
+        );
         assert_eq!(
             notif.affinity_protected_until,
             Some("2999-01-01T00:00:00.000Z")

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -18,6 +18,7 @@ pub(super) struct DirectJobCandidate {
     discovered_at: StdInstant,
     enqueued_at: Option<StdInstant>,
     cli_agent_session_id: Option<String>,
+    history_generation_run_id: Option<RunId>,
     affinity_protected_until: Option<String>,
 }
 
@@ -62,6 +63,7 @@ impl DirectJobCandidate {
             discovered_at,
             enqueued_at: None,
             cli_agent_session_id,
+            history_generation_run_id: None,
             affinity_protected_until,
         }
     }
@@ -90,6 +92,14 @@ impl DirectJobCandidate {
         }
     }
 
+    pub(super) fn with_history_generation_run_id(
+        mut self,
+        history_generation_run_id: Option<RunId>,
+    ) -> Self {
+        self.history_generation_run_id = history_generation_run_id;
+        self
+    }
+
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -100,6 +110,7 @@ impl DirectJobCandidate {
             .map(|enqueued_at| dequeued_at.saturating_duration_since(enqueued_at));
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
+            .with_history_generation_run_id(self.history_generation_run_id)
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -119,6 +130,9 @@ impl DirectJobCandidate {
         }
         if candidate.affinity_protected_until.is_some() {
             self.affinity_protected_until = candidate.affinity_protected_until;
+        }
+        if candidate.history_generation_run_id.is_some() {
+            self.history_generation_run_id = candidate.history_generation_run_id;
         }
     }
 }
@@ -386,6 +400,7 @@ mod tests {
         let inbox = direct_candidate_inbox(4);
         let first_discovered_at = StdInstant::now() - Duration::from_secs(5);
         let second_discovered_at = StdInstant::now();
+        let history_generation_run_id = run_id(2);
         let run_id = run_id(1);
 
         let inserted = inbox
@@ -406,13 +421,16 @@ mod tests {
         );
 
         let updated = inbox
-            .push(DirectJobCandidate::new_with_affinity_metadata(
-                run_id,
-                "vm0/default".to_string(),
-                second_discovered_at,
-                None,
-                Some("2999-01-01T00:00:00.000Z".to_string()),
-            ))
+            .push(
+                DirectJobCandidate::new_with_affinity_metadata(
+                    run_id,
+                    "vm0/default".to_string(),
+                    second_discovered_at,
+                    None,
+                    Some("2999-01-01T00:00:00.000Z".to_string()),
+                )
+                .with_history_generation_run_id(Some(history_generation_run_id)),
+            )
             .await;
         assert!(matches!(
             updated,
@@ -430,6 +448,10 @@ mod tests {
         assert!(candidate.enqueued_at().is_some());
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-1"));
+        assert_eq!(
+            candidate.history_generation_run_id(),
+            Some(history_generation_run_id)
+        );
         assert!(candidate.is_affinity_protected());
         assert!(
             candidate

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -62,6 +62,27 @@ impl PreLocalAdmissionOutcome {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SessionHistoryGenerationRelationship {
+    Exact,
+    Different,
+    Fresh,
+    UnknownTarget,
+    UnknownReserved,
+}
+
+impl SessionHistoryGenerationRelationship {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Different => "different",
+            Self::Fresh => "fresh",
+            Self::UnknownTarget => "unknown_target",
+            Self::UnknownReserved => "unknown_reserved",
+        }
+    }
+}
+
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -82,6 +103,8 @@ pub struct JobCandidate {
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
     cli_agent_session_id: Option<String>,
+    history_generation_run_id: Option<RunId>,
+    session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
 
@@ -113,6 +136,8 @@ impl JobCandidate {
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
             cli_agent_session_id: None,
+            history_generation_run_id: None,
+            session_history_generation_relationship: None,
             affinity_protected_until: None,
         }
     }
@@ -207,6 +232,16 @@ impl JobCandidate {
         self.cli_agent_session_id.as_deref()
     }
 
+    pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
+        self.history_generation_run_id
+    }
+
+    pub(crate) fn session_history_generation_relationship(
+        &self,
+    ) -> Option<SessionHistoryGenerationRelationship> {
+        self.session_history_generation_relationship
+    }
+
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
         let protected_until = self.affinity_protected_until?;
         let now = Utc::now();
@@ -232,6 +267,21 @@ impl JobCandidate {
             .as_deref()
             .and_then(parse_affinity_protected_until);
         self
+    }
+
+    pub(crate) fn with_history_generation_run_id(
+        mut self,
+        history_generation_run_id: Option<RunId>,
+    ) -> Self {
+        self.history_generation_run_id = history_generation_run_id;
+        self
+    }
+
+    pub(crate) fn set_session_history_generation_relationship(
+        &mut self,
+        relationship: SessionHistoryGenerationRelationship,
+    ) {
+        self.session_history_generation_relationship = Some(relationship);
     }
 
     pub(crate) fn with_discovery_source(mut self, source: JobDiscoverySource) -> Self {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -35,6 +35,8 @@ pub struct Job {
     #[serde(default)]
     pub cli_agent_session_id: Option<String>,
     #[serde(default)]
+    pub history_generation_run_id: Option<RunId>,
+    #[serde(default)]
     pub affinity_protected_until: Option<String>,
 }
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -273,9 +273,10 @@ export async function publishRunnerJobNotification(
   group: string,
   runId: string,
   profile: string,
-  affinity?: {
+  metadata?: {
     readonly cliAgentSessionId: string | null;
     readonly affinityProtectedUntil: string | null;
+    readonly historyGenerationRunId: string | undefined;
   },
 ): Promise<boolean> {
   const published = await tapError(
@@ -284,11 +285,14 @@ export async function publishRunnerJobNotification(
       await channel.publish("job", {
         runId,
         profile,
-        ...(affinity?.cliAgentSessionId
-          ? { cliAgentSessionId: affinity.cliAgentSessionId }
+        ...(metadata?.cliAgentSessionId
+          ? { cliAgentSessionId: metadata.cliAgentSessionId }
           : {}),
-        ...(affinity?.affinityProtectedUntil
-          ? { affinityProtectedUntil: affinity.affinityProtectedUntil }
+        ...(metadata?.affinityProtectedUntil
+          ? { affinityProtectedUntil: metadata.affinityProtectedUntil }
+          : {}),
+        ...(metadata?.historyGenerationRunId
+          ? { historyGenerationRunId: metadata.historyGenerationRunId }
           : {}),
       });
       L.debug(`Published job ${runId} to runner-group:${group} (broadcast)`);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2414,8 +2414,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const claims = await Promise.all([
-      api.requestClaimRunnerJob(true, run.runId, [200, 404]),
-      api.requestClaimRunnerJob(true, run.runId, [200, 404]),
+      api.requestClaimRunnerJob(true, run.runId, [200, 404], {
+        telemetry: { sessionHistoryGenerationRelationship: "different" },
+      }),
+      api.requestClaimRunnerJob(true, run.runId, [200, 404], {
+        telemetry: { sessionHistoryGenerationRelationship: "different" },
+      }),
     ]);
     expect(
       claims
@@ -2426,6 +2430,26 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           return left - right;
         }),
     ).toStrictEqual([200, 404]);
+    const claimAttemptEvents = sandboxOperationEventsForRunByAction(
+      run.runId,
+      "runner_session_history_generation_claim_attempt",
+    );
+    expect(claimAttemptEvents).toHaveLength(2);
+    expect(
+      claimAttemptEvents
+        .map((event) => {
+          return event.claim_outcome;
+        })
+        .sort(),
+    ).toStrictEqual(["accepted", "unavailable"]);
+    for (const event of claimAttemptEvents) {
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          generation_relationship: "different",
+          auth_type: "official-runner",
+        }),
+      );
+    }
 
     const running = await api.readRun(actor, run.runId);
     expect(running.status).toBe("running");
@@ -7323,6 +7347,76 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
 
     await api.requestCancelRun(actor, attributed.runId, [200]);
     await api.requestCancelRun(actor, guarded.runId, [200]);
+  });
+
+  it("records generic preclaim response construction failures", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const source = await api.createRun(actor, {
+      agentId,
+      prompt: "create history for a failed claim response",
+      modelProvider: "anthropic-api-key",
+    });
+    const sourceClaim = await api.claimRunnerJob(source.runId);
+    const historyHash = createHash("sha256")
+      .update(`missing claim history ${source.runId}`)
+      .digest("hex");
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: source.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-failed-claim-${source.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${sourceClaim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: source.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${sourceClaim.sandboxToken}` },
+      [200],
+    );
+
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: source.sessionId,
+      prompt: "fail while constructing the claim response",
+      modelProvider: "anthropic-api-key",
+    });
+    context.mocks.s3.send.mockRejectedValueOnce(
+      new Error("session history metadata unavailable"),
+    );
+    const failedClaim = await api.requestClaimRunnerJob(
+      true,
+      resumed.runId,
+      [500],
+      {
+        telemetry: { sessionHistoryGenerationRelationship: "exact" },
+      },
+    );
+    expect(failedClaim.status).toBe(500);
+
+    const events = sandboxOperationEventsForRunByAction(
+      resumed.runId,
+      "runner_session_history_generation_claim_attempt",
+    );
+    expect(events).toStrictEqual([
+      expect.objectContaining({
+        success: false,
+        duration_ms: 0,
+        generation_relationship: "exact",
+        claim_outcome: "preclaim_error",
+        auth_type: "official-runner",
+        runner_group: runnerGroup,
+        profile: "vm0/default",
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain(source.runId);
+    expect(JSON.stringify(events)).not.toContain(historyHash);
+
+    await api.requestCancelRun(actor, resumed.runId, [200]);
   });
 
   it("dispatches, scopes, and claims runs through user API keys", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5497,6 +5497,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       true,
       missingRun.runId,
       [400],
+      {
+        telemetry: { sessionHistoryGenerationRelationship: "unknown_target" },
+      },
     );
     expectApiError(missingClaim.body);
     expect(missingClaim.body.error.message).toBe(
@@ -5510,6 +5513,20 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(failedMissingRun.error).toBe(
       "Runner job missing valid execution context",
     );
+    expect(
+      sandboxOperationEventsForRunByAction(
+        missingRun.runId,
+        "runner_session_history_generation_claim_attempt",
+      ),
+    ).toStrictEqual([
+      expect.objectContaining({
+        success: false,
+        duration_ms: 0,
+        generation_relationship: "unknown_target",
+        claim_outcome: "preclaim_error",
+        auth_type: "official-runner",
+      }),
+    ]);
 
     const invalidRun = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
@@ -6518,11 +6535,24 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(completed.status).toBe("completed");
 
     const resumedPrompt = "continue combined claim response timing";
+    context.mocks.ably.publish.mockClear();
     const resumed = await api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
       prompt: resumedPrompt,
       modelProvider: "anthropic-api-key",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: resumed.runId,
+        historyGenerationRunId: first.runId,
+      }),
+    );
+    const resumedPoll = await api.pollRunner(runnerGroup);
+    expect(resumedPoll.body.job).toMatchObject({
+      runId: resumed.runId,
+      historyGenerationRunId: first.runId,
     });
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
     expect(resumedClaim.resumeSession).toMatchObject({
@@ -6533,6 +6563,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         url: expect.any(String),
       },
     });
+    expect(resumedClaim.resumeSession).not.toHaveProperty(
+      "historyGenerationRunId",
+    );
     expect(resumedClaim.networkPolicies?.slack).toBeDefined();
     expectClaimRouteResponseTimingActions({
       runId: resumed.runId,
@@ -7174,6 +7207,124 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 });
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
+  it("records trusted terminal generation claim attempts without user-token pollution", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const actorRunnerKey = await api.createApiKey(actor);
+    const actorBearer = `Bearer ${actorRunnerKey.token}`;
+
+    const attributed = await api.createRun(actor, {
+      agentId,
+      prompt: "attribute terminal generation claims",
+      modelProvider: "anthropic-api-key",
+    });
+    const accepted = await api.requestClaimRunnerJob(
+      true,
+      attributed.runId,
+      [200],
+      {
+        telemetry: {
+          sessionHistoryGenerationRelationship: "different",
+        },
+      },
+    );
+    expect(accepted.status).toBe(200);
+
+    const lateUser = await api.requestClaimRunnerJobAs(
+      actorBearer,
+      attributed.runId,
+      [404],
+      {
+        telemetry: { sessionHistoryGenerationRelationship: "exact" },
+      },
+    );
+    expectApiError(lateUser.body);
+    expect(
+      sandboxOperationEventsForRunByAction(
+        attributed.runId,
+        "runner_session_history_generation_claim_attempt",
+      ),
+    ).toHaveLength(1);
+
+    const lateOfficial = await api.requestClaimRunnerJob(
+      true,
+      attributed.runId,
+      [404],
+      {
+        telemetry: { sessionHistoryGenerationRelationship: "exact" },
+      },
+    );
+    expectApiError(lateOfficial.body);
+    const attributedEvents = sandboxOperationEventsForRunByAction(
+      attributed.runId,
+      "runner_session_history_generation_claim_attempt",
+    );
+    expect(attributedEvents).toStrictEqual([
+      expect.objectContaining({
+        success: true,
+        duration_ms: 0,
+        generation_relationship: "different",
+        claim_outcome: "accepted",
+        auth_type: "official-runner",
+        runner_group: runnerGroup,
+        profile: "vm0/default",
+      }),
+      expect.objectContaining({
+        success: false,
+        duration_ms: 0,
+        generation_relationship: "exact",
+        claim_outcome: "unavailable",
+        auth_type: "official-runner",
+      }),
+    ]);
+    for (const event of attributedEvents) {
+      expect(event).not.toHaveProperty("history_generation_run_id");
+      expect(event).not.toHaveProperty("session_id");
+      expect(event).not.toHaveProperty("history_hash");
+      expect(JSON.stringify(event)).not.toContain(actorRunnerKey.token);
+    }
+
+    const guarded = await api.createRun(actor, {
+      agentId,
+      prompt: "reject untrusted generation attribution",
+      modelProvider: "anthropic-api-key",
+    });
+    const outsider = bdd.user();
+    const outsiderKey = await api.createApiKey(outsider);
+    const forbiddenClaim = await api.requestClaimRunnerJobAs(
+      `Bearer ${outsiderKey.token}`,
+      guarded.runId,
+      [403],
+      {
+        telemetry: { sessionHistoryGenerationRelationship: "exact" },
+      },
+    );
+    expectApiError(forbiddenClaim.body);
+    expect(
+      sandboxOperationEventsForRunByAction(
+        guarded.runId,
+        "runner_session_history_generation_claim_attempt",
+      ),
+    ).toHaveLength(0);
+
+    const oldRunnerClaim = await api.requestClaimRunnerJob(
+      true,
+      guarded.runId,
+      [200],
+    );
+    expect(oldRunnerClaim.status).toBe(200);
+    expect(
+      sandboxOperationEventsForRunByAction(
+        guarded.runId,
+        "runner_session_history_generation_claim_attempt",
+      ),
+    ).toHaveLength(0);
+
+    await api.requestCancelRun(actor, attributed.runId, [200]);
+    await api.requestCancelRun(actor, guarded.runId, [200]);
+  });
+
   it("dispatches, scopes, and claims runs through user API keys", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2025,6 +2025,7 @@ const claimAuthorizedJob$ = command(
       signal,
     );
     if (!responseBodyResult.ok) {
+      recordAttempt("preclaim_error");
       const response = await claimResponseBuildErrorResponse({
         db,
         run,
@@ -2035,7 +2036,6 @@ const claimAuthorizedJob$ = command(
           set(scheduleClaimFailedSideEffects$, failedArgs);
         },
       });
-      recordAttempt("preclaim_error");
       return response;
     }
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -11,6 +11,7 @@ import {
   type ExecutionContext,
   type HeldSessionState,
   type SessionHistoryDownloadSource,
+  type SessionHistoryGenerationRelationship,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import {
@@ -517,6 +518,9 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
       profile: runnerJobQueue.profile,
       cliAgentSessionId: runnerJobQueue.cliAgentSessionId,
+      historyGenerationRunId: sql<
+        string | null
+      >`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`,
       createdAt: runnerJobQueue.createdAt,
     })
     .from(runnerJobQueue)
@@ -582,6 +586,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         checkpointId: pendingJob.resumedFromCheckpointId ?? null,
         experimentalProfile: pendingJob.profile,
         cliAgentSessionId: pendingJob.cliAgentSessionId,
+        historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
       },
     },
@@ -624,6 +629,62 @@ interface ActiveRunNetworkPolicyScope {
 }
 
 type ClaimLookupResult = ClaimableJob | ReturnType<typeof notFound>;
+
+type SessionHistoryGenerationClaimOutcome =
+  | "accepted"
+  | "unavailable"
+  | "preclaim_error";
+
+function recordSessionHistoryGenerationClaimAttempt(args: {
+  readonly runId: string;
+  readonly relationship: SessionHistoryGenerationRelationship | undefined;
+  readonly outcome: SessionHistoryGenerationClaimOutcome;
+  readonly authType: RunnerAuthContext["type"];
+  readonly runnerGroup?: string;
+  readonly profile?: string;
+}): void {
+  if (!args.relationship) {
+    return;
+  }
+  const dimensions: Record<string, string> = {
+    generation_relationship: args.relationship,
+    claim_outcome: args.outcome,
+    auth_type: args.authType,
+  };
+  if (args.runnerGroup) {
+    dimensions.runner_group = args.runnerGroup;
+  }
+  if (args.profile) {
+    dimensions.profile = args.profile;
+  }
+  recordSandboxOperations([
+    {
+      sandboxType: "runner",
+      actionType: "runner_session_history_generation_claim_attempt",
+      durationMs: 0,
+      success: args.outcome === "accepted",
+      runId: args.runId,
+      dimensions,
+    },
+  ]);
+}
+
+function recordSessionHistoryGenerationClaimAttemptForJob(args: {
+  readonly runId: string;
+  readonly relationship: SessionHistoryGenerationRelationship | undefined;
+  readonly outcome: SessionHistoryGenerationClaimOutcome;
+  readonly authType: RunnerAuthContext["type"];
+  readonly job: ClaimableJob["job"];
+}): void {
+  recordSessionHistoryGenerationClaimAttempt({
+    runId: args.runId,
+    relationship: args.relationship,
+    outcome: args.outcome,
+    authType: args.authType,
+    runnerGroup: args.job.runnerGroup,
+    profile: args.job.profile,
+  });
+}
 
 function isClaimableJob(value: ClaimLookupResult): value is ClaimableJob {
   return "job" in value;
@@ -1515,27 +1576,27 @@ const buildClaimResponseBodyForClaim$ = command(
   },
 );
 
+interface ClaimTimingTelemetry {
+  readonly discoverySource?: string;
+  readonly jobDiscoveredToClaimRequestMs?: number;
+  readonly localAdmissionToClaimRequestMs?: number;
+  readonly directCandidateNotificationToEnqueueMs?: number;
+  readonly directCandidateInboxWaitMs?: number;
+  readonly providerDiscoveryToMainLoopMs?: number;
+  readonly mainLoopToLocalAdmissionMs?: number;
+  readonly preLocalAdmissionOutcome?: string;
+  readonly pollDueToJobDiscoveredMs?: number;
+  readonly pollHttpRequestMs?: number;
+  readonly pollReason?: string;
+}
+
 function scheduleSuccessfulClaimSideEffects(args: {
   readonly jobWithRun: ClaimableJob;
   readonly authType: RunnerAuthContext["type"];
   readonly storedContext: StoredExecutionContext;
   readonly claimRequestStartedAtMs: number;
   readonly claimResult: ClaimedTransitionResult;
-  readonly telemetry:
-    | {
-        readonly discoverySource?: string;
-        readonly jobDiscoveredToClaimRequestMs?: number;
-        readonly localAdmissionToClaimRequestMs?: number;
-        readonly directCandidateNotificationToEnqueueMs?: number;
-        readonly directCandidateInboxWaitMs?: number;
-        readonly providerDiscoveryToMainLoopMs?: number;
-        readonly mainLoopToLocalAdmissionMs?: number;
-        readonly preLocalAdmissionOutcome?: string;
-        readonly pollDueToJobDiscoveredMs?: number;
-        readonly pollHttpRequestMs?: number;
-        readonly pollReason?: string;
-      }
-    | undefined;
+  readonly telemetry: ClaimTimingTelemetry | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
   const { job, run } = args.jobWithRun;
@@ -1894,6 +1955,124 @@ async function claimResponseBuildErrorResponse(args: {
   });
 }
 
+const claimAuthorizedJob$ = command(
+  async (
+    { set },
+    args: {
+      readonly db: Db;
+      readonly runId: string;
+      readonly authType: RunnerAuthContext["type"];
+      readonly jobWithRun: ClaimableJob;
+      readonly generationRelationship:
+        | SessionHistoryGenerationRelationship
+        | undefined;
+      readonly telemetry: ClaimTimingTelemetry | undefined;
+      readonly claimRequestStartedAtMs: number;
+      readonly claimRouteTiming: ClaimRouteTimingCollector;
+      readonly signal: AbortSignal;
+    },
+  ) => {
+    const { db, runId, jobWithRun, claimRouteTiming, signal } = args;
+    const run = jobWithRun.run;
+    const recordAttempt = (outcome: SessionHistoryGenerationClaimOutcome) => {
+      recordSessionHistoryGenerationClaimAttemptForJob({
+        runId,
+        relationship: args.generationRelationship,
+        outcome,
+        authType: args.authType,
+        job: jobWithRun.job,
+      });
+    };
+
+    const contextParseStartedAt = now();
+    const storedContextResult = storedExecutionContextSchema.safeParse(
+      jobWithRun.job.executionContext,
+    );
+    claimRouteTiming.recordElapsed(
+      "claim_route_context_parse",
+      "top_level",
+      contextParseStartedAt,
+    );
+    signal.throwIfAborted();
+    if (!storedContextResult.success) {
+      warnInvalidStoredExecutionContext(
+        runId,
+        storedContextResult.error.issues,
+      );
+      const response = await failClaimForInvalidStoredExecutionContext({
+        db,
+        runId,
+        userId: run.userId,
+        orgId: run.orgId,
+        signal,
+        scheduleFailedSideEffects(failedArgs) {
+          set(scheduleClaimFailedSideEffects$, failedArgs);
+        },
+      });
+      recordAttempt("preclaim_error");
+      return response;
+    }
+    const storedContext = storedContextResult.data;
+
+    const responseBodyResult = await settle(
+      set(buildClaimResponseBodyForClaim$, {
+        db,
+        run,
+        storedContext,
+        timing: claimRouteTiming,
+        signal,
+      }),
+      signal,
+    );
+    if (!responseBodyResult.ok) {
+      const response = await claimResponseBuildErrorResponse({
+        db,
+        run,
+        runId,
+        error: responseBodyResult.error,
+        signal,
+        scheduleFailedSideEffects(failedArgs) {
+          set(scheduleClaimFailedSideEffects$, failedArgs);
+        },
+      });
+      recordAttempt("preclaim_error");
+      return response;
+    }
+    signal.throwIfAborted();
+
+    const claimResult = await claimRouteTiming.measure(
+      "claim_route_transition_running",
+      "top_level",
+      async () => {
+        return await transitionClaimedJobToRunning(
+          db,
+          runId,
+          signal,
+          claimRouteTiming,
+        );
+      },
+    );
+    signal.throwIfAborted();
+    if (claimResult.status !== "claimed") {
+      recordAttempt("unavailable");
+      return claimTransitionErrorResponse(claimResult);
+    }
+
+    recordAttempt("accepted");
+    scheduleSuccessfulClaimSideEffects({
+      jobWithRun,
+      authType: args.authType,
+      storedContext,
+      claimRequestStartedAtMs: args.claimRequestStartedAtMs,
+      claimResult,
+      telemetry: args.telemetry,
+      claimRouteTiming,
+    });
+
+    return { status: 200 as const, body: responseBodyResult.value };
+  },
+);
+
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const claimRequestStartedAtMs = now();
   const claimRouteTiming = new ClaimRouteTimingCollector();
@@ -1910,6 +2089,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const runId = get(pathParamsOf(runnersJobClaimContract.claim)).id;
+  const generationRelationship =
+    body.data.telemetry?.sessionHistoryGenerationRelationship;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -1920,6 +2101,14 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const lookupAuthorizationStartedAt = now();
   const jobWithRun = await getClaimableJob(db, runId, signal);
   if (!isClaimableJob(jobWithRun)) {
+    if (auth.type === "official-runner") {
+      recordSessionHistoryGenerationClaimAttempt({
+        runId,
+        relationship: generationRelationship,
+        outcome: "unavailable",
+        authType: auth.type,
+      });
+    }
     return jobWithRun;
   }
   const authError = claimAuthorizationError(auth, jobWithRun);
@@ -1932,86 +2121,17 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return authError;
   }
 
-  const run = jobWithRun.run;
-
-  const contextParseStartedAt = now();
-  const storedContextResult = storedExecutionContextSchema.safeParse(
-    jobWithRun.job.executionContext,
-  );
-  claimRouteTiming.recordElapsed(
-    "claim_route_context_parse",
-    "top_level",
-    contextParseStartedAt,
-  );
-  signal.throwIfAborted();
-  if (!storedContextResult.success) {
-    warnInvalidStoredExecutionContext(runId, storedContextResult.error.issues);
-    return await failClaimForInvalidStoredExecutionContext({
-      db,
-      runId,
-      userId: run.userId,
-      orgId: run.orgId,
-      signal,
-      scheduleFailedSideEffects(args) {
-        set(scheduleClaimFailedSideEffects$, args);
-      },
-    });
-  }
-  const storedContext = storedContextResult.data;
-
-  const responseBodyResult = await settle(
-    set(buildClaimResponseBodyForClaim$, {
-      db,
-      run,
-      storedContext,
-      timing: claimRouteTiming,
-      signal,
-    }),
-    signal,
-  );
-  if (!responseBodyResult.ok) {
-    return await claimResponseBuildErrorResponse({
-      db,
-      run,
-      runId,
-      error: responseBodyResult.error,
-      signal,
-      scheduleFailedSideEffects(args) {
-        set(scheduleClaimFailedSideEffects$, args);
-      },
-    });
-  }
-  const responseBody = responseBodyResult.value;
-  signal.throwIfAborted();
-
-  const claimResult = await claimRouteTiming.measure(
-    "claim_route_transition_running",
-    "top_level",
-    async () => {
-      return await transitionClaimedJobToRunning(
-        db,
-        runId,
-        signal,
-        claimRouteTiming,
-      );
-    },
-  );
-  signal.throwIfAborted();
-  if (claimResult.status !== "claimed") {
-    return claimTransitionErrorResponse(claimResult);
-  }
-
-  scheduleSuccessfulClaimSideEffects({
-    jobWithRun,
+  return await set(claimAuthorizedJob$, {
+    db,
+    runId,
     authType: auth.type,
-    storedContext,
-    claimRequestStartedAtMs,
-    claimResult,
+    jobWithRun,
+    generationRelationship,
     telemetry: body.data.telemetry,
+    claimRequestStartedAtMs,
     claimRouteTiming,
+    signal,
   });
-
-  return { status: 200 as const, body: responseBody };
 });
 
 const runnerRealtimeTokenBody$ = bodyResultOf(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4225,6 +4225,7 @@ function loadResumeSession(
     async (): Promise<StoredExecutionContext["resumeSession"] | undefined> => {
       const [conversation] = await db
         .select({
+          runId: conversations.runId,
           cliAgentSessionId: conversations.cliAgentSessionId,
           cliAgentSessionHistory: conversations.cliAgentSessionHistory,
           cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
@@ -4261,6 +4262,7 @@ function loadResumeSession(
           if (hash) {
             return Promise.resolve({
               sessionId: cliAgentSessionId,
+              historyGenerationRunId: conversation.runId,
               historyRef: {
                 kind: "blob",
                 hash,
@@ -5480,6 +5482,7 @@ function dispatchRun(
         runId: args.run.id,
         profile: payload.profile,
         cliAgentSessionId: payload.cliAgentSessionId,
+        historyGenerationRunId: payload.historyGenerationRunId,
         createdAt: persisted.runnerJobCreatedAt,
       });
       args.timing.flush({
@@ -7122,6 +7125,8 @@ async function committedAtomicLaunchResponse(args: {
     runId: args.committed.run.id,
     profile: args.committed.runnerJobPayload.profile,
     cliAgentSessionId: args.committed.runnerJobPayload.cliAgentSessionId,
+    historyGenerationRunId:
+      args.committed.runnerJobPayload.historyGenerationRunId,
     createdAt: args.committed.runnerJobCreatedAt,
   });
   args.timing.flush({

--- a/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
@@ -27,7 +27,17 @@ interface QueuedRunnerJobPayload {
   readonly runnerGroup: string;
   readonly profile: string;
   readonly cliAgentSessionId: string | null;
+  readonly historyGenerationRunId: string | undefined;
   readonly executionContext: StoredExecutionContext;
+}
+
+function historyGenerationRunId(
+  executionContext: StoredExecutionContext,
+): string | undefined {
+  const resumeSession = executionContext.resumeSession;
+  return resumeSession && "historyRef" in resumeSession
+    ? resumeSession.historyGenerationRunId
+    : undefined;
 }
 
 export async function encryptQueuedRunnerJobPayload(
@@ -73,6 +83,9 @@ export async function decryptQueuedRunnerJobPayload(
     runnerGroup: wirePayload.runnerGroup,
     profile: wirePayload.profile,
     cliAgentSessionId: wirePayload.sessionId,
+    historyGenerationRunId: historyGenerationRunId(
+      wirePayload.executionContext,
+    ),
     executionContext: wirePayload.executionContext,
   };
 }
@@ -88,6 +101,7 @@ export function queuedRunnerJobPayload(args: {
     runnerGroup: args.runnerGroup,
     profile: args.profile,
     cliAgentSessionId: args.cliAgentSessionId,
+    historyGenerationRunId: historyGenerationRunId(args.executionContext),
     executionContext: args.executionContext,
   };
 }

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -18,6 +18,7 @@ export async function notifyRunnerJob(
     readonly runId: string;
     readonly profile: string;
     readonly cliAgentSessionId: string | null;
+    readonly historyGenerationRunId: string | undefined;
     readonly createdAt: Date;
   },
 ): Promise<boolean> {
@@ -56,6 +57,7 @@ export async function notifyRunnerJob(
     {
       cliAgentSessionId: args.cliAgentSessionId,
       affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
+      historyGenerationRunId: args.historyGenerationRunId,
     },
   );
   const publishFinishedAt = now();

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -66,6 +66,7 @@ interface RunnerNotification {
   readonly runnerGroup: string;
   readonly profile: string;
   readonly cliAgentSessionId: string | null;
+  readonly historyGenerationRunId: string | undefined;
   readonly createdAt: Date;
 }
 
@@ -329,6 +330,7 @@ async function promoteQueuedCandidate(
         runnerGroup: args.payload.runnerGroup,
         profile: args.payload.profile,
         cliAgentSessionId: args.payload.cliAgentSessionId,
+        historyGenerationRunId: args.payload.historyGenerationRunId,
         createdAt: runnerJobCreatedAt,
       },
     };

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  jobSchema,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
   RESUME_SESSION_HISTORY_MAX_BYTES,
@@ -298,6 +299,7 @@ describe("runner storage manifest contract", () => {
 describe("runner resume session contract", () => {
   const historyHash =
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const historyGenerationRunId = "11111111-1111-4111-8111-111111111111";
 
   it("accepts inline stored and claim resume sessions", () => {
     const resumeSession = {
@@ -324,6 +326,39 @@ describe("runner resume session contract", () => {
       storedExecutionContextSchema.shape.resumeSession.safeParse(resumeSession)
         .success,
     ).toBe(true);
+  });
+
+  it("keeps generation metadata in stored and discovery shapes only", () => {
+    const storedResumeSession = {
+      sessionId: "sess-123",
+      historyGenerationRunId,
+      historyRef: { kind: "blob" as const, hash: historyHash },
+    };
+    expect(storedResumeSessionSchema.parse(storedResumeSession)).toEqual(
+      storedResumeSession,
+    );
+
+    const claimResumeSession = resumeSessionSchema.parse({
+      ...storedResumeSession,
+      historyRef: {
+        ...storedResumeSession.historyRef,
+        url: "https://r2.example.com/blobs/history.blob?sig=secret",
+        rawSize: 1024,
+        encodedSize: 1024,
+      },
+    });
+    expect(claimResumeSession).not.toHaveProperty("historyGenerationRunId");
+
+    const job = jobSchema.parse({
+      runId: "22222222-2222-4222-8222-222222222222",
+      prompt: "continue",
+      appendSystemPrompt: null,
+      agentComposeVersionId: null,
+      vars: null,
+      checkpointId: null,
+      historyGenerationRunId,
+    });
+    expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
   });
 
   it("requires a URL for hash-backed claim resume sessions", () => {
@@ -493,10 +528,15 @@ describe("runner claim capability contract", () => {
         providerDiscoveryToMainLoopMs: 3,
         mainLoopToLocalAdmissionMs: 4,
         preLocalAdmissionOutcome: "local_holder",
+        sessionHistoryGenerationRelationship: "exact",
       },
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it("accepts old claim bodies without generation telemetry", () => {
+    expect(runnersJobClaimContract.claim.body.safeParse({}).success).toBe(true);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -74,6 +74,13 @@ const runnerPreLocalAdmissionOutcomeSchema = z.enum([
   "local_holder",
   "missing_session_metadata",
 ]);
+export const sessionHistoryGenerationRelationshipSchema = z.enum([
+  "exact",
+  "different",
+  "fresh",
+  "unknown_target",
+  "unknown_reserved",
+]);
 
 const runnerClaimTelemetrySchema = z.object({
   discoverySource: runnerClaimDiscoverySourceSchema.optional(),
@@ -88,6 +95,8 @@ const runnerClaimTelemetrySchema = z.object({
   providerDiscoveryToMainLoopMs: z.number().int().nonnegative().optional(),
   mainLoopToLocalAdmissionMs: z.number().int().nonnegative().optional(),
   preLocalAdmissionOutcome: runnerPreLocalAdmissionOutcomeSchema.optional(),
+  sessionHistoryGenerationRelationship:
+    sessionHistoryGenerationRelationshipSchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),
@@ -163,6 +172,7 @@ export const jobSchema = z.object({
   checkpointId: z.uuid().nullable(),
   experimentalProfile: z.string().optional(),
   cliAgentSessionId: z.string().nullable().optional(),
+  historyGenerationRunId: z.uuid().optional(),
   affinityProtectedUntil: z
     .string()
     .datetime({ offset: true })
@@ -288,6 +298,7 @@ const resumeSessionHistoryEncodedSizeSchema = z
 
 const storedResumeSessionRefSchema = z.object({
   sessionId: z.string(),
+  historyGenerationRunId: z.uuid().optional(),
   historyRef: resumeSessionHistoryBlobRefSchema.extend({
     encoding: sessionHistoryEncodingSchema.optional(),
   }),
@@ -648,6 +659,9 @@ export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
 export type SessionHistoryDownloadSource = z.infer<
   typeof sessionHistoryDownloadSourceSchema
+>;
+export type SessionHistoryGenerationRelationship = z.infer<
+  typeof sessionHistoryGenerationRelationshipSchema
 >;
 
 export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;


### PR DESCRIPTION
## Summary

- carry the run that produced hash-backed session history through persisted queue payloads, poll responses, and realtime job notifications
- preserve each idle sandbox's last completed run and classify the actual local reservation as `exact`, `different`, `fresh`, `unknown_target`, or `unknown_reserved` immediately before claim
- send only that low-cardinality relationship in claim telemetry and record terminal API events for accepted, unavailable, and pre-claim-error outcomes

## Compatibility and scope

- all queue, discovery, and claim protocol fields are optional so old APIs and old runners continue to interoperate during independent deployments
- raw generation run IDs remain in discovery/local runner state and are not returned in claim responses or emitted in claim-attempt telemetry
- user-token authorization failures and late missing-row claims do not emit attribution events; official-runner late claims are retained so race losers remain measurable
- no database schema or migration, heartbeat payload, routing policy, reservation behavior, or cleanup mechanism is changed

## Production analysis

- wait until the mixed-version runner/API rollout has drained, then filter `runner_session_history_generation_claim_attempt` to `auth_type=official-runner`
- deduplicate by run, generation relationship, and claim outcome; report `unknown_target` and `unknown_reserved` coverage separately
- treat contention as proven only when one run has an `exact` attempt, a different known relationship with `claim_outcome=accepted`, and a later verified-prefix restore/materialization event
- do not infer a claim loss from event absence

## Validation

- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (105 tests)
- `pnpm knip`
- `pnpm format`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner`
- focused final-state idle metadata and sandbox finalization tests
- `cargo test -p api-contracts`
- repository pre-commit hooks, including full Turbo type checking

Closes #21522

Parent context: #18746
