### PR TITLE
refactor(api): dual-write workflow detail automation fields

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 
 import {
   zeroWorkflowAutomationsContract,
-  zeroWorkflowDetailAutomations,
   zeroWorkflowsDetailContract,
   legacyZeroWorkflowAutomationsContract as legacyWorkflowAutomationsContract,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -2301,7 +2300,7 @@ describe("zero workflow automations", () => {
     });
   });
 
-  it("returns created automations from list and workflow detail", async () => {
+  it("returns created automations from list and both workflow detail fields", async () => {
     const { workflowId } = await setupFixture();
 
     await accept(
@@ -2341,7 +2340,11 @@ describe("zero workflow automations", () => {
       }),
       [200],
     );
-    expect(zeroWorkflowDetailAutomations(detail.body)).toHaveLength(1);
+    if (!("triggers" in detail.body && "automations" in detail.body)) {
+      throw new Error("Expected dual workflow detail automation fields");
+    }
+    expect(detail.body.automations).toStrictEqual(detail.body.triggers);
+    expect(detail.body.automations).toHaveLength(1);
   });
 
   it("updates the schedule of an existing automation", async () => {

--- a/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
@@ -95,6 +95,7 @@ export function zeroWorkflowDetail(args: {
       files,
       fileContents,
       triggers: [...automations],
+      automations: [...automations],
     };
   });
 }


### PR DESCRIPTION
## Summary

- dual-emits `triggers` and `automations` from the workflow detail API after the compatible consumer shipped in App 0.599.8
- keeps both arrays identical so older open browser bundles and the canonical consumer continue to work during the traffic observation window
- adds route coverage that requires both fields and verifies their values remain in parity

## Rollout

- Stage A consumer compatibility is merged in #21528 and deployed through #21545
- the legacy `triggers` field remains until Axiom confirms a full two-week zero-traffic window
- terminal removal stays isolated in draft #21523

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint` (passes with one pre-existing unrelated unused-parameter warning)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- targeted API integration test reached database setup but local migrations are blocked because the local PostgreSQL installation does not provide the `vector` extension; PR CI is the authoritative integration run

Part of #21408
