### PR TITLE
perf(mitm-addon): avoid quadratic json literal probing

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_probe.py
+++ b/crates/runner/mitm-addon/src/usage/json_probe.py
@@ -392,14 +392,22 @@ def _skip_json_value(
         )
     if b == ord("-") or ord("0") <= b <= ord("9"):
         return _skip_json_number(body, i)
-    for literal in (b"true", b"false", b"null"):
-        if body.startswith(literal, i):
-            end = i + len(literal)
-            if end == len(body):
-                return _IndexResult("incomplete")
-            return _IndexResult("ok", end)
-        if literal.startswith(body[i:]):
+    if b == ord("t"):
+        literal = b"true"
+    elif b == ord("f"):
+        literal = b"false"
+    elif b == ord("n"):
+        literal = b"null"
+    else:
+        return _IndexResult("invalid")
+
+    remaining = len(body) - i
+    if remaining <= len(literal):
+        if body.startswith(literal[:remaining], i):
             return _IndexResult("incomplete")
+        return _IndexResult("invalid")
+    if body.startswith(literal, i):
+        return _IndexResult("ok", i + len(literal))
     return _IndexResult("invalid")
 
 

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -1,8 +1,31 @@
 """Tests for bounded JSON prefix probing helpers."""
 
+from typing import SupportsIndex, overload
+
 import pytest
 
 from usage.json_probe import probe_top_level_string_field
+
+
+class _SliceTrackingBytes(bytes):
+    slice_lengths: list[int]
+
+    def __new__(cls, value: bytes) -> "_SliceTrackingBytes":
+        instance = super().__new__(cls, value)
+        instance.slice_lengths = []
+        return instance
+
+    @overload
+    def __getitem__(self, key: SupportsIndex, /) -> int: ...
+
+    @overload
+    def __getitem__(self, key: slice, /) -> bytes: ...
+
+    def __getitem__(self, key: SupportsIndex | slice, /) -> int | bytes:
+        result = super().__getitem__(key)
+        if isinstance(result, bytes):
+            self.slice_lengths.append(len(result))
+        return result
 
 
 def test_probe_finds_top_level_string_field_without_scanning_rest():
@@ -76,6 +99,92 @@ def test_probe_reports_incomplete_fractional_and_exponent_prefixes_before_field(
     assert result.status == "incomplete"
     assert result.value is None
     assert not result.field_seen
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        pytest.param(b"true", id="true"),
+        pytest.param(b"false", id="false"),
+        pytest.param(b"null", id="null"),
+    ],
+)
+def test_probe_skips_complete_literal_before_field(literal: bytes):
+    result = probe_top_level_string_field(
+        b'{"padding":' + literal + b',"type":"response.completed"}'
+    )
+
+    assert result.status == "found"
+    assert result.value == "response.completed"
+    assert result.field_seen
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param(b"t", id="true-1"),
+        pytest.param(b"tr", id="true-2"),
+        pytest.param(b"tru", id="true-3"),
+        pytest.param(b"true", id="true-complete"),
+        pytest.param(b"f", id="false-1"),
+        pytest.param(b"fa", id="false-2"),
+        pytest.param(b"fal", id="false-3"),
+        pytest.param(b"fals", id="false-4"),
+        pytest.param(b"false", id="false-complete"),
+        pytest.param(b"n", id="null-1"),
+        pytest.param(b"nu", id="null-2"),
+        pytest.param(b"nul", id="null-3"),
+        pytest.param(b"null", id="null-complete"),
+    ],
+)
+def test_probe_reports_incomplete_literal_at_end_of_prefix(prefix: bytes):
+    result = probe_top_level_string_field(b'{"padding":' + prefix)
+
+    assert result.status == "incomplete"
+    assert result.value is None
+    assert not result.field_seen
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param(b"trux", id="true"),
+        pytest.param(b"falsx", id="false"),
+        pytest.param(b"nulx", id="null"),
+    ],
+)
+def test_probe_rejects_invalid_literal_prefix(prefix: bytes):
+    result = probe_top_level_string_field(b'{"padding":' + prefix)
+
+    assert result.status == "invalid"
+    assert result.value is None
+    assert not result.field_seen
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        pytest.param(b"false", id="false"),
+        pytest.param(b"null", id="null"),
+    ],
+)
+def test_probe_repeated_literals_do_not_copy_growing_body_suffixes(literal: bytes):
+    maximum_slice_lengths: list[int] = []
+    for repeat_count in (128, 256):
+        body = _SliceTrackingBytes(
+            b'{"padding":['
+            + b",".join([literal] * repeat_count)
+            + b'],"type":"response.completed"}'
+        )
+
+        result = probe_top_level_string_field(body)
+
+        assert result.status == "found"
+        assert result.value == "response.completed"
+        assert result.field_seen
+        maximum_slice_lengths.append(max(body.slice_lengths, default=0))
+
+    assert maximum_slice_lengths[1] <= maximum_slice_lengths[0]
 
 
 def test_probe_ignores_nested_fields_with_same_name():

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -1,6 +1,6 @@
 """Tests for bounded JSON prefix probing helpers."""
 
-from typing import SupportsIndex, overload
+from typing import SupportsIndex
 
 import pytest
 
@@ -14,12 +14,6 @@ class _SliceTrackingBytes(bytes):
         instance = super().__new__(cls, value)
         instance.slice_lengths = []
         return instance
-
-    @overload
-    def __getitem__(self, key: SupportsIndex, /) -> int: ...
-
-    @overload
-    def __getitem__(self, key: slice, /) -> bytes: ...
 
     def __getitem__(self, key: SupportsIndex | slice, /) -> int | bytes:
         result = super().__getitem__(key)


### PR DESCRIPTION
## Summary

- dispatch JSON `true`, `false`, and `null` parsing from their distinct first bytes
- compare incomplete literals against a bounded literal prefix without copying the remaining body
- cover complete, incomplete, and invalid literal prefixes plus repeated `false`/`null` payloads with a deterministic slice-growth regression

The updated probe matched `origin/main` across 54,241 generated prefix cases. Local 32k-to-64k scaling ratios were approximately 1.91x for `true`, 2.10x for `false`, and 2.03x for `null`; before the change, `false` and `null` were superlinear.

## Compatibility

- preserves all public probe statuses and literal prefix classifications
- preserves OpenAI Responses SSE and WebSocket caller policy
- does not change APIs, schemas, persisted data, queue payloads, runner protocols, or deployment sequencing

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright src tests`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_json_probe.py`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/` (`3962 passed`)
- `lefthook run pre-commit --no-tty --file crates/runner/mitm-addon/src/usage/json_probe.py --file crates/runner/mitm-addon/tests/test_json_probe.py`

Closes #21533
