### PR TITLE
fix(ably-subscriber): stop accepting api keys in argv

### DIFF
--- a/crates/ably-subscriber/examples/smoke_test.rs
+++ b/crates/ably-subscriber/examples/smoke_test.rs
@@ -1,15 +1,14 @@
 //! Smoke test: publish messages via the real Ably REST API and verify reception.
 //!
-//! Requires a real Ably API key — not run in CI.
+//! Requires a real Ably API key in the `ABLY_API_KEY` environment variable.
+//! Provision it with a secret manager or hidden shell prompt; do not put the
+//! value in the command itself.
 //!
 //! ```sh
-//! cargo run -p ably-subscriber --example smoke_test -- <API_KEY>
+//! cargo run -p ably-subscriber --example smoke_test
 //! ```
 //!
-//! Or via environment variable:
-//! ```sh
-//! ABLY_API_KEY=keyName:keySecret cargo run -p ably-subscriber --example smoke_test
-//! ```
+//! `ABLY_API_KEY` format: `keyName:keySecret` (from your Ably dashboard).
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -253,20 +252,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     // --- Parse API key ---
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let env_key = std::env::var("ABLY_API_KEY").ok();
-
-    let api_key = if let Some(ref key) = env_key {
-        key.as_str()
-    } else {
-        args.first()
-            .ok_or("usage: smoke_test <API_KEY>  (or set ABLY_API_KEY)")?
-            .as_str()
-    };
+    const USAGE: &str =
+        "usage: smoke_test (set ABLY_API_KEY; API keys are not accepted as arguments)";
+    if std::env::args_os().nth(1).is_some() {
+        return Err(USAGE.into());
+    }
+    let api_key = std::env::var("ABLY_API_KEY").map_err(
+        |_| "ABLY_API_KEY must be set to keyName:keySecret; API keys are not accepted as arguments",
+    )?;
 
     let (key_name, key_secret) = api_key
         .split_once(':')
-        .ok_or("API_KEY must be in format keyName:keySecret")?;
+        .ok_or("ABLY_API_KEY must be in format keyName:keySecret")?;
 
     let auth_header = BASE64.encode(api_key.as_bytes());
     let rest_host = "rest.ably.io";

--- a/crates/ably-subscriber/examples/subscribe.rs
+++ b/crates/ably-subscriber/examples/subscribe.rs
@@ -1,16 +1,13 @@
 //! Subscribe to an Ably channel using an API key.
 //!
+//! Set `ABLY_API_KEY` with a secret manager or hidden shell prompt; do not put
+//! the value in the command itself.
+//!
 //! ```sh
-//! cargo run -p ably-subscriber --example subscribe -- <API_KEY> <CHANNEL> [HOST]
+//! cargo run -p ably-subscriber --example subscribe -- <CHANNEL> [HOST]
 //! ```
 //!
-//! Or pass the API key via environment variable:
-//! ```sh
-//! ABLY_API_KEY=keyName:keySecret cargo run -p ably-subscriber --example subscribe \
-//!     -- <CHANNEL> [HOST]
-//! ```
-//!
-//! `API_KEY` format: `keyName:keySecret` (from your Ably dashboard).
+//! `ABLY_API_KEY` format: `keyName:keySecret` (from your Ably dashboard).
 //! Message data is printed to stdout (pipe to `jq` for formatting).
 
 use ably_subscriber::{Event, SubscribeConfig, subscribe};
@@ -21,25 +18,20 @@ mod common;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let env_key = std::env::var("ABLY_API_KEY").ok();
-
-    let (api_key, channel, host) = if let Some(ref key) = env_key {
-        let channel = args.first().ok_or("usage: subscribe <CHANNEL> [HOST]")?;
-        (key.as_str(), channel.as_str(), args.get(1).cloned())
-    } else {
-        let api_key = args
-            .first()
-            .ok_or("usage: subscribe <API_KEY> <CHANNEL> [HOST]")?;
-        let channel = args
-            .get(1)
-            .ok_or("usage: subscribe <API_KEY> <CHANNEL> [HOST]")?;
-        (api_key.as_str(), channel.as_str(), args.get(2).cloned())
-    };
+    const USAGE: &str = "usage: subscribe <CHANNEL> [HOST] (set ABLY_API_KEY; API keys are not accepted as arguments)";
+    let api_key = std::env::var("ABLY_API_KEY").map_err(
+        |_| "ABLY_API_KEY must be set to keyName:keySecret; API keys are not accepted as arguments",
+    )?;
+    let mut args = std::env::args().skip(1);
+    let channel = args.next().ok_or(USAGE)?;
+    let host = args.next();
+    if args.next().is_some() {
+        return Err(USAGE.into());
+    }
 
     let (key_name, key_secret) = api_key
         .split_once(':')
-        .ok_or("API_KEY must be in format keyName:keySecret")?;
+        .ok_or("ABLY_API_KEY must be in format keyName:keySecret")?;
 
     let key_name = key_name.to_string();
     let key_secret = key_secret.to_string();
@@ -52,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let ks = key_secret.clone();
             Box::pin(async move { common::create_token_request(&kn, &ks, common::ONE_HOUR_TTL_MS) })
         }),
-        channel.to_string(),
+        channel,
     );
     config.host = host;
     let mut sub = subscribe(config).await?;


### PR DESCRIPTION
## Summary

- require both Ably real-service examples to read API keys only from `ABLY_API_KEY`
- make `smoke_test` reject all positional arguments and `subscribe` reject missing or extra non-secret arguments
- remove positional-key and inline-secret commands from the example documentation

## Scope

This changes only the two manual example binaries. It does not change the `ably-subscriber` library API, authentication protocol, shared signing helper, Cargo dependencies, CI workflow, or production runtime behavior. The existing CI smoke test already injects `ABLY_API_KEY` without a positional key.

## Validation

- `cargo build -p ably-subscriber --examples`
- 8 direct example-binary cases covering legacy argv input, missing environment state, valid channel/host arity, missing channel, and extra arguments; all failed before network access with the expected contract error
- `cargo fmt --all -- --check`
- `cargo clippy -p ably-subscriber --all-targets --all-features`
- `cargo test -p ably-subscriber --all-features`
- `cargo test -p ably-subscriber --doc`
- `cargo doc -p ably-subscriber --all-features --no-deps`
- pre-commit workspace `cargo fmt --all`, `cargo clippy --all-targets --all-features`, and `cargo doc --workspace --all-features --no-deps`

Closes #21535
