### PR TITLE
fix: keep guest responsive during file writes

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -17,9 +17,9 @@ use crate::exec_operation::{
     ExecOperationRegistry, ExecOperationWorkerRequest, cancel_exec_operation, send_error_response,
     start_exec_operation,
 };
+use crate::file_write_worker::{FileWriteKind, FileWriteSubmitError, FileWriteWorker};
 use crate::handlers::{
     MessageOutcome, decode_write_file_message, decode_write_files_message, handle_basic_message,
-    handle_decoded_write_file_message, handle_decoded_write_files_message,
 };
 use crate::log::log;
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
@@ -57,10 +57,9 @@ enum DecodeDispatchError {
     Shutdown,
 }
 
-/// Signals all exec operation work spawned for this host connection when the
+/// Signals all operation work spawned for this host connection when the
 /// connection loop exits. `run()` may reconnect after a close, but in-flight
-/// exec operations belong to the old connection and should not survive into
-/// the next one.
+/// work belongs to the old connection and must not survive into the next one.
 struct ConnectionCancelGuard(Arc<AtomicBool>);
 
 impl Drop for ConnectionCancelGuard {
@@ -241,20 +240,24 @@ fn handle_resume_operations(
 struct ConnectionDispatcher {
     writer: GuestWriter,
     connection_cancel: Arc<AtomicBool>,
+    file_write_worker: FileWriteWorker,
     exec_operation_registry: ExecOperationRegistry,
     exec_control_registry: ExecControlRegistry,
     operation_state: OperationState,
 }
 
 impl ConnectionDispatcher {
-    fn new(writer: GuestWriter, connection_cancel: Arc<AtomicBool>) -> Self {
-        Self {
+    fn new(writer: GuestWriter, connection_cancel: Arc<AtomicBool>) -> io::Result<Self> {
+        let file_write_worker =
+            FileWriteWorker::start(writer.clone(), Arc::clone(&connection_cancel))?;
+        Ok(Self {
             writer,
             connection_cancel,
+            file_write_worker,
             exec_operation_registry: ExecOperationRegistry::default(),
             exec_control_registry: ExecControlRegistry::default(),
             operation_state: OperationState::default(),
-        }
+        })
     }
 
     fn dispatch(&self, msg: BorrowedRawMessage<'_>) -> io::Result<DispatchOutcome> {
@@ -373,22 +376,35 @@ impl ConnectionDispatcher {
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = match decode_write_file_message(msg.payload) {
-            Ok(decoded) => decoded,
-            Err(error) => {
-                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
-                return Ok(());
-            }
+        if let Err(error) = decode_write_file_message(msg.payload) {
+            send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+            return Ok(());
+        }
+        let Some(admission) = self.file_write_worker.try_admit() else {
+            send_error_response(msg.seq, "guest file write already active", &self.writer)?;
+            return Ok(());
         };
         let Some(operation_guard) =
             acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
         else {
             return Ok(());
         };
-        let response = handle_decoded_write_file_message(msg.seq, decoded)?;
-        self.writer.write_frame_after_lock(&response, || {
-            operation_guard.release();
-        })
+        match self.file_write_worker.submit(
+            FileWriteKind::File,
+            msg.seq,
+            msg.payload,
+            operation_guard,
+            admission,
+        ) {
+            Ok(()) => Ok(()),
+            Err(FileWriteSubmitError::Busy) => {
+                send_error_response(msg.seq, "guest file write already active", &self.writer)
+            }
+            Err(FileWriteSubmitError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "guest file-write worker stopped",
+            )),
+        }
     }
 
     fn handle_write_files(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
@@ -398,22 +414,35 @@ impl ConnectionDispatcher {
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = match decode_write_files_message(msg.payload) {
-            Ok(decoded) => decoded,
-            Err(error) => {
-                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
-                return Ok(());
-            }
+        if let Err(error) = decode_write_files_message(msg.payload) {
+            send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+            return Ok(());
+        }
+        let Some(admission) = self.file_write_worker.try_admit() else {
+            send_error_response(msg.seq, "guest file write already active", &self.writer)?;
+            return Ok(());
         };
         let Some(operation_guard) =
             acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
         else {
             return Ok(());
         };
-        let response = handle_decoded_write_files_message(msg.seq, decoded)?;
-        self.writer.write_frame_after_lock(&response, || {
-            operation_guard.release();
-        })
+        match self.file_write_worker.submit(
+            FileWriteKind::Files,
+            msg.seq,
+            msg.payload,
+            operation_guard,
+            admission,
+        ) {
+            Ok(()) => Ok(()),
+            Err(FileWriteSubmitError::Busy) => {
+                send_error_response(msg.seq, "guest file write already active", &self.writer)
+            }
+            Err(FileWriteSubmitError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "guest file-write worker stopped",
+            )),
+        }
     }
 
     fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
@@ -431,7 +460,9 @@ impl ConnectionDispatcher {
                 Ok(DispatchOutcome::Continue)
             }
             MessageOutcome::Shutdown(response) => {
-                if let Err(e) = self.writer.write_frame(&response) {
+                if let Err(e) = self.writer.write_frame_after_lock(&response, || {
+                    self.connection_cancel.store(true, Ordering::Release);
+                }) {
                     log("WARN", &format!("Failed to send shutdown_ack: {e}"));
                 }
                 log("INFO", "Shutdown complete, exiting");
@@ -525,7 +556,8 @@ fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, C
     log("INFO", "Sent ready signal");
 
     let mut session = ConnectionSession::new();
-    let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone());
+    let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone())
+        .map_err(|error| session.failure(error))?;
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
         // Read from stream (reader is separate, no lock needed)

--- a/crates/vsock-guest/src/file_write_worker.rs
+++ b/crates/vsock-guest/src/file_write_worker.rs
@@ -1,0 +1,189 @@
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::thread::{self, JoinHandle};
+
+use crate::handlers::{
+    decode_write_file_message, decode_write_files_message, handle_decoded_write_file_message,
+    handle_decoded_write_files_message,
+};
+use crate::log::log;
+use crate::quiesce::OperationGuard;
+use crate::writer::GuestWriter;
+
+const THREAD_FILE_WRITE: &str = "vsock-file-write";
+
+#[derive(Clone, Copy)]
+pub(crate) enum FileWriteKind {
+    File,
+    Files,
+}
+
+pub(crate) enum FileWriteSubmitError {
+    Busy,
+    Disconnected,
+}
+
+pub(crate) struct FileWriteAdmission {
+    active: Arc<AtomicBool>,
+}
+
+impl Drop for FileWriteAdmission {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::Release);
+    }
+}
+
+struct FileWriteRequest {
+    kind: FileWriteKind,
+    seq: u32,
+    payload: Vec<u8>,
+    operation_guard: OperationGuard,
+    admission: FileWriteAdmission,
+}
+
+pub(crate) struct FileWriteWorker {
+    sender: Option<SyncSender<FileWriteRequest>>,
+    handle: Option<JoinHandle<()>>,
+    active: Arc<AtomicBool>,
+    connection_cancel: Arc<AtomicBool>,
+}
+
+struct ShutdownConnectionOnDrop(GuestWriter);
+
+impl Drop for ShutdownConnectionOnDrop {
+    fn drop(&mut self) {
+        self.0.shutdown();
+    }
+}
+
+impl FileWriteWorker {
+    pub(crate) fn start(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+    ) -> io::Result<Self> {
+        // The atomic admission permit bounds active plus queued work to one.
+        // The channel still has capacity so the decoder can use try_send and
+        // can never wait for the worker to call recv.
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let worker_cancel = Arc::clone(&connection_cancel);
+        let handle = thread::Builder::new()
+            .name(THREAD_FILE_WRITE.to_string())
+            .spawn(move || {
+                // This worker exists for exactly one connection. Any exit,
+                // including an unwind, closes that connection so a pending
+                // host request cannot wait without a response producer.
+                let _shutdown_on_exit = ShutdownConnectionOnDrop(writer.clone());
+                while let Ok(request) = receiver.recv() {
+                    if let Err(error) = handle_request(request, &writer, &worker_cancel) {
+                        log("ERROR", &format!("file-write worker failed: {error}"));
+                        break;
+                    }
+                }
+            })?;
+
+        Ok(Self {
+            sender: Some(sender),
+            handle: Some(handle),
+            active: Arc::new(AtomicBool::new(false)),
+            connection_cancel,
+        })
+    }
+
+    pub(crate) fn try_admit(&self) -> Option<FileWriteAdmission> {
+        self.active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| FileWriteAdmission {
+                active: Arc::clone(&self.active),
+            })
+    }
+
+    pub(crate) fn submit(
+        &self,
+        kind: FileWriteKind,
+        seq: u32,
+        payload: &[u8],
+        operation_guard: OperationGuard,
+        admission: FileWriteAdmission,
+    ) -> Result<(), FileWriteSubmitError> {
+        let request = FileWriteRequest {
+            kind,
+            seq,
+            payload: payload.to_vec(),
+            operation_guard,
+            admission,
+        };
+        let Some(sender) = &self.sender else {
+            return Err(FileWriteSubmitError::Disconnected);
+        };
+        match sender.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(FileWriteSubmitError::Busy),
+            Err(TrySendError::Disconnected(_)) => Err(FileWriteSubmitError::Disconnected),
+        }
+    }
+}
+
+impl Drop for FileWriteWorker {
+    fn drop(&mut self) {
+        // Signal first so an active helper's cancellable wait kills and reaps
+        // its process group before this connection-owned worker is joined.
+        self.connection_cancel.store(true, Ordering::Release);
+        drop(self.sender.take());
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            log("ERROR", "file-write worker panicked");
+        }
+    }
+}
+
+fn handle_request(
+    request: FileWriteRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+) -> io::Result<()> {
+    let FileWriteRequest {
+        kind,
+        seq,
+        payload,
+        operation_guard,
+        admission,
+    } = request;
+
+    let response = match kind {
+        FileWriteKind::File => decode_write_file_message(&payload)
+            .map_err(protocol_error)
+            .and_then(|decoded| handle_decoded_write_file_message(seq, decoded, connection_cancel)),
+        FileWriteKind::Files => decode_write_files_message(&payload)
+            .map_err(protocol_error)
+            .and_then(|decoded| {
+                handle_decoded_write_files_message(seq, decoded, connection_cancel)
+            }),
+    };
+    // Admission may be released at the writer boundary, but do not retain the
+    // completed request's large payload while the result frame is being sent.
+    drop(payload);
+
+    match response {
+        Ok(response) => writer
+            .write_frame_after_lock_unless_cancelled(&response, connection_cancel, || {
+                operation_guard.release();
+                drop(admission);
+            })
+            .map(|_| ()),
+        Err(error) => {
+            writer.shutdown_after_lock(|| {
+                operation_guard.release();
+                drop(admission);
+            });
+            Err(error)
+        }
+    }
+}
+
+fn protocol_error(error: vsock_proto::ProtocolError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -18,7 +18,9 @@ use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_proces
 use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
-use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout_and_pre_reap_cleanup};
+use crate::wait::{
+    WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
+};
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
@@ -53,6 +55,7 @@ fn handle_write_file(
     use_sudo: bool,
     append: bool,
     private: bool,
+    connection_cancel: &AtomicBool,
 ) -> (bool, String) {
     log(
         "INFO",
@@ -71,10 +74,15 @@ fn handle_write_file(
         Err(e) => return (false, format!("Failed to spawn write command: {e}")),
     };
 
-    wait_write_file_child(child, content, SystemThreadSpawner)
+    wait_write_file_child(child, content, connection_cancel, SystemThreadSpawner)
 }
 
-fn handle_write_files(payload: &[u8], file_count: usize, content_bytes: usize) -> (bool, String) {
+fn handle_write_files(
+    payload: &[u8],
+    file_count: usize,
+    content_bytes: usize,
+    connection_cancel: &AtomicBool,
+) -> (bool, String) {
     log(
         "INFO",
         &format!("write_files: files={file_count} content_bytes={content_bytes}"),
@@ -85,20 +93,26 @@ fn handle_write_files(payload: &[u8], file_count: usize, content_bytes: usize) -
         Err(e) => return (false, format!("Failed to spawn batch write command: {e}")),
     };
 
-    wait_write_file_child(child, payload, SystemThreadSpawner)
+    wait_write_file_child(child, payload, connection_cancel, SystemThreadSpawner)
 }
 
-fn wait_write_file_child<S>(child: Child, content: &[u8], spawner: S) -> (bool, String)
+fn wait_write_file_child<S>(
+    child: Child,
+    content: &[u8],
+    connection_cancel: &AtomicBool,
+    spawner: S,
+) -> (bool, String)
 where
     S: ThreadSpawner,
 {
-    wait_write_file_child_with_timeout(child, content, WRITE_TIMEOUT_MS, spawner)
+    wait_write_file_child_with_timeout(child, content, WRITE_TIMEOUT_MS, connection_cancel, spawner)
 }
 
 fn wait_write_file_child_with_timeout<S>(
     mut child: Child,
     content: &[u8],
     timeout_ms: u32,
+    connection_cancel: &AtomicBool,
     spawner: S,
 ) -> (bool, String)
 where
@@ -167,12 +181,17 @@ where
             }
         };
 
-        let outcome = wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || {
-            matches!(
-                stdin_done_rx.try_recv(),
-                Err(std::sync::mpsc::TryRecvError::Empty)
-            )
-        });
+        let outcome = wait_with_kill_timeout_or_connection_cancelled(
+            child,
+            timeout_ms,
+            connection_cancel,
+            || {
+                matches!(
+                    stdin_done_rx.try_recv(),
+                    Err(std::sync::mpsc::TryRecvError::Empty)
+                )
+            },
+        );
         let stdin_result = match stdin_handle.join() {
             Ok(result) => result,
             Err(panic) => std::panic::resume_unwind(panic),
@@ -306,6 +325,7 @@ pub(crate) fn decode_write_files_message(
 pub(crate) fn handle_decoded_write_file_message(
     seq: u32,
     decoded: DecodedWriteFileMessage<'_>,
+    connection_cancel: &AtomicBool,
 ) -> io::Result<Vec<u8>> {
     let (success, error) = handle_write_file(
         decoded.path,
@@ -313,6 +333,7 @@ pub(crate) fn handle_decoded_write_file_message(
         decoded.use_sudo,
         decoded.append,
         decoded.private,
+        connection_cancel,
     );
     let payload = vsock_proto::encode_write_file_result(success, &error);
     vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
@@ -321,9 +342,14 @@ pub(crate) fn handle_decoded_write_file_message(
 pub(crate) fn handle_decoded_write_files_message(
     seq: u32,
     decoded: DecodedWriteFilesMessage<'_>,
+    connection_cancel: &AtomicBool,
 ) -> io::Result<Vec<u8>> {
-    let (success, error) =
-        handle_write_files(decoded.payload, decoded.file_count, decoded.content_bytes);
+    let (success, error) = handle_write_files(
+        decoded.payload,
+        decoded.file_count,
+        decoded.content_bytes,
+        connection_cancel,
+    );
     let payload = vsock_proto::encode_write_files_result(success, &error);
     vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)
 }
@@ -416,10 +442,12 @@ mod tests {
         let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
         let child = spawn_write_file_test_child("sleep 60");
         let pid = child.id();
+        let connection_cancel = AtomicBool::new(false);
 
         let (success, error) = wait_write_file_child(
             child,
             b"",
+            &connection_cancel,
             FailingThreadSpawner::fail_once(THREAD_WRITE_STDERR),
         );
 
@@ -455,9 +483,15 @@ mod tests {
         let child = spawn_write_file_test_child("sleep 60; cat >/dev/null");
         let pid = child.id();
         let content = vec![b'x'; 1024 * 1024];
+        let connection_cancel = AtomicBool::new(false);
 
-        let (success, error) =
-            wait_write_file_child_with_timeout(child, &content, 10, SystemThreadSpawner);
+        let (success, error) = wait_write_file_child_with_timeout(
+            child,
+            &content,
+            10,
+            &connection_cancel,
+            SystemThreadSpawner,
+        );
 
         assert!(!success);
         assert_eq!(error, "write timed out");
@@ -509,9 +543,15 @@ mod tests {
         writeln!(fifo, "exit").unwrap();
         drop(fifo);
         let content = vec![b'x'; 1024 * 1024];
+        let connection_cancel = AtomicBool::new(false);
 
-        let (success, error) =
-            wait_write_file_child_with_timeout(child, &content, 1_000, SystemThreadSpawner);
+        let (success, error) = wait_write_file_child_with_timeout(
+            child,
+            &content,
+            1_000,
+            &connection_cancel,
+            SystemThreadSpawner,
+        );
         let _ = std::fs::remove_file(&fifo_path);
 
         assert!(!success);

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -11,6 +11,7 @@ mod drain;
 mod error;
 mod exec_control;
 mod exec_operation;
+mod file_write_worker;
 mod handlers;
 mod log;
 mod process;

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -230,11 +230,12 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
+    use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     #[cfg(target_os = "linux")]
     use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
-    use crate::wait::{WaitOutcome, wait_with_kill_timeout_and_pre_reap_cleanup};
+    use crate::wait::{WaitOutcome, wait_with_kill_timeout_or_connection_cancelled};
 
     struct TempDirGuard(PathBuf);
 
@@ -536,8 +537,13 @@ mod tests {
             }
         };
 
-        let outcome =
-            wait_with_kill_timeout_and_pre_reap_cleanup(child.take().unwrap(), 100, || false);
+        let connection_cancel = AtomicBool::new(false);
+        let outcome = wait_with_kill_timeout_or_connection_cancelled(
+            child.take().unwrap(),
+            100,
+            &connection_cancel,
+            || false,
+        );
         if !matches!(outcome, WaitOutcome::TimedOut) {
             kill_pidfd_and_wait(&background_pidfd)
                 .unwrap_or_else(|e| panic!("failed to clean up background pidfd: {e}"));

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -64,15 +64,12 @@ pub(crate) fn await_drain_deadline(
     completed
 }
 
-/// Wait for `child` with an optional timeout, allowing the caller to request
-/// process-tree cleanup after natural exit is observed but before the direct
-/// child is reaped.
-///
-/// The callback returns `true` when a still-running descendant is holding a
-/// resource that must be released by killing the tracked process tree.
-pub(crate) fn wait_with_kill_timeout_and_pre_reap_cleanup(
+/// Wait for `child` while observing its owning connection cancellation flag
+/// and allowing pre-reap process-tree cleanup after natural exit.
+pub(crate) fn wait_with_kill_timeout_or_connection_cancelled(
     child: Child,
     timeout_ms: u32,
+    connection_cancel: &AtomicBool,
     pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
     let kill_target = process_tree_kill_target(child.id());
@@ -80,7 +77,7 @@ pub(crate) fn wait_with_kill_timeout_and_pre_reap_cleanup(
         child,
         kill_target,
         timeout_ms,
-        || false,
+        || connection_cancel.load(Ordering::Acquire),
         pre_reap_cleanup,
     )
 }
@@ -401,7 +398,13 @@ mod tests {
                     Err(e) => WaitOutcome::WaitFailed(e.to_string()),
                 }
             } else {
-                wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || false)
+                let connection_cancel = AtomicBool::new(false);
+                wait_with_kill_timeout_or_connection_cancelled(
+                    child,
+                    timeout_ms,
+                    &connection_cancel,
+                    || false,
+                )
             };
             let elapsed = start.elapsed();
             assert!(
@@ -544,16 +547,22 @@ mod tests {
         let child_id = child.id();
         let mut cleanup_called = false;
 
-        let outcome = wait_with_kill_timeout_and_pre_reap_cleanup(child, 30_000, || {
-            cleanup_called = true;
-            let stat = std::fs::read_to_string(format!("/proc/{child_id}/stat"))
-                .expect("unreaped direct child should remain visible in procfs");
-            let state = stat
-                .rsplit_once(") ")
-                .and_then(|(_, fields)| fields.chars().next());
-            assert_eq!(state, Some('Z'), "observed child should be waitable");
-            false
-        });
+        let connection_cancel = AtomicBool::new(false);
+        let outcome = wait_with_kill_timeout_or_connection_cancelled(
+            child,
+            30_000,
+            &connection_cancel,
+            || {
+                cleanup_called = true;
+                let stat = std::fs::read_to_string(format!("/proc/{child_id}/stat"))
+                    .expect("unreaped direct child should remain visible in procfs");
+                let state = stat
+                    .rsplit_once(") ")
+                    .and_then(|(_, fields)| fields.chars().next());
+                assert_eq!(state, Some('Z'), "observed child should be waitable");
+                false
+            },
+        );
 
         assert!(cleanup_called);
         assert!(matches!(outcome, WaitOutcome::Exited(status) if status.success()));

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::net::Shutdown;
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -28,6 +29,20 @@ impl GuestWriter {
         self.write_frame_with_deadline(frame, WRITE_DEADLINE)
     }
 
+    pub(crate) fn shutdown(&self) {
+        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = stream.shutdown(Shutdown::Both);
+    }
+
+    pub(crate) fn shutdown_after_lock<F>(&self, after_lock: F)
+    where
+        F: FnOnce(),
+    {
+        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        after_lock();
+        let _ = stream.shutdown(Shutdown::Both);
+    }
+
     fn write_frame_with_deadline(&self, frame: &[u8], deadline: Duration) -> io::Result<()> {
         self.write_frame_with_deadline_after_lock(frame, deadline, || {})
     }
@@ -43,6 +58,29 @@ impl GuestWriter {
         F: FnOnce(),
     {
         self.write_frame_with_deadline_after_lock(frame, WRITE_DEADLINE, after_lock)
+    }
+
+    /// Release operation ownership at the writer boundary, then send the
+    /// terminal frame only if the owning connection remains live.
+    pub(crate) fn write_frame_after_lock_unless_cancelled<F>(
+        &self,
+        frame: &[u8],
+        cancelled: &AtomicBool,
+        after_lock: F,
+    ) -> io::Result<bool>
+    where
+        F: FnOnce(),
+    {
+        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        after_lock();
+        if cancelled.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        let result = send_frame(stream.as_raw_fd(), frame, WRITE_DEADLINE);
+        if result.is_err() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        result.map(|()| true)
     }
 
     /// Build and send one frame while holding the writer mutex.

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -431,6 +431,7 @@ fn shared_with_logged_operation(
     let shared = Arc::new(Shared {
         writer: tokio::sync::Mutex::new(write_half),
         frame_builder: tokio::sync::Mutex::new(()),
+        file_write_gate: tokio::sync::Mutex::new(()),
         fd,
         seq: AtomicU32::new(2),
         state: std::sync::Mutex::new(ConnectionState::Connected {

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -622,6 +622,7 @@ impl VsockHost {
         }
         vsock_proto::validate_write_files(&proto_entries).map_err(protocol_invalid_input)?;
 
+        let _file_write_guard = self.shared.file_write_gate.lock().await;
         let timeout = Duration::from_secs(300);
         let resp = normal_request_on_shared_with_write_observer_frame_builder(
             &self.shared,
@@ -666,6 +667,7 @@ impl VsockHost {
     ) -> io::Result<()> {
         validate_write_file_chunk_request(request)?;
 
+        let _file_write_guard = self.shared.file_write_gate.lock().await;
         let timeout = Duration::from_secs(300);
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -217,6 +217,9 @@ struct Shared {
     /// Serialises memory-heavy encoded frame construction without blocking
     /// ordinary writer-lock users such as lifecycle and control frames.
     frame_builder: tokio::sync::Mutex<()>,
+    /// Serialises file-write request lifecycles through their terminal
+    /// responses while allowing control and lifecycle frames to bypass them.
+    file_write_gate: tokio::sync::Mutex<()>,
     /// Raw fd of the underlying socket, used to poison a corrupted stream.
     fd: RawFd,
     /// Monotonically increasing sequence number (starts at 2, skips 0).
@@ -949,6 +952,7 @@ impl VsockHost {
         let shared = Arc::new(Shared {
             writer: tokio::sync::Mutex::new(write_half),
             frame_builder: tokio::sync::Mutex::new(()),
+            file_write_gate: tokio::sync::Mutex::new(()),
             fd,
             seq: AtomicU32::new(2),
             state: std::sync::Mutex::new(ConnectionState::Connected {

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -867,6 +867,52 @@ async fn lifecycle_request_writes_while_file_frame_builder_waits() {
 }
 
 #[tokio::test]
+async fn file_write_gate_holds_through_result_and_lifecycle_bypasses_it() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let first_write = spawn_write_file(
+        Arc::clone(&host),
+        "/tmp/serialized-first.txt",
+        b"first".to_vec(),
+        false,
+    );
+
+    let first = expect_write_file(guest.stream_mut()).await;
+    assert_eq!(first.path, "/tmp/serialized-first.txt");
+    assert!(
+        host.shared.file_write_gate.try_lock().is_err(),
+        "file-write gate must remain held while the terminal result is pending"
+    );
+
+    let second_write = spawn_write_files(
+        Arc::clone(&host),
+        vec![("/tmp/serialized-second.txt", b"second".to_vec())],
+    );
+    let shutdown_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.shutdown(Duration::from_secs(5)).await })
+    };
+
+    let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+    guest
+        .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
+        .await;
+    assert!(shutdown_task.await.unwrap());
+    assert!(host.shared.file_write_gate.try_lock().is_err());
+
+    send_write_file_success(guest.stream_mut(), first.seq()).await;
+    first_write.await.unwrap().unwrap();
+
+    let second = expect_write_files(guest.stream_mut()).await;
+    assert_eq!(
+        second.files,
+        vec![("/tmp/serialized-second.txt".to_string(), b"second".to_vec())]
+    );
+    send_write_files_success(guest.stream_mut(), second.seq()).await;
+    second_write.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn write_file_cancelled_while_waiting_for_frame_builder_does_not_poison_or_send_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -781,112 +781,94 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
         false,
     );
     let mut temp_by_marker: BTreeMap<u8, String> = BTreeMap::new();
-    let mut first_chunks = BTreeMap::new();
-    while first_chunks.len() < 2 {
-        let msg = read_guest_message(&mut guest).await;
-        assert_eq!(msg.msg_type, MSG_WRITE_FILE);
-        let (path, content, sudo, append, private) =
-            vsock_proto::decode_write_file(&msg.payload).unwrap();
-        assert!(!sudo);
-        assert!(!private);
-        assert!(!append);
-        assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
-        assert_eq!(content.len(), chunk_limit);
-        let marker = *content.first().expect("chunk content");
-        assert!(matches!(marker, 0xAA | 0xBB));
-        assert!(content.iter().all(|byte| *byte == marker));
-        assert!(first_chunks.insert(marker, msg.seq).is_none());
-        assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
-    }
-
-    for seq in first_chunks.values() {
-        send_write_file_success(&mut guest, *seq).await;
-    }
-
-    let mut second_chunks = BTreeMap::new();
-    while second_chunks.len() < 2 {
-        let msg = read_guest_message(&mut guest).await;
-        assert_eq!(msg.msg_type, MSG_WRITE_FILE);
-        let (path, content, sudo, append, private) =
-            vsock_proto::decode_write_file(&msg.payload).unwrap();
-        assert!(!sudo);
-        assert!(!private);
-        assert!(append);
-        assert_eq!(content.len(), 1);
-        let marker = *content.first().expect("chunk content");
-        assert!(matches!(marker, 0xAA | 0xBB));
-        assert!(content.iter().all(|byte| *byte == marker));
-        assert_eq!(
-            path,
-            temp_by_marker
-                .get(&marker)
-                .expect("second chunk should use first chunk temp path")
-        );
-        assert!(second_chunks.insert(marker, msg.seq).is_none());
-    }
-
-    send_write_file_failure(
-        &mut guest,
-        *second_chunks
-            .get(&failure_marker)
-            .expect("failure second chunk"),
-        "disk full",
-    )
-    .await;
-    send_write_file_success(
-        &mut guest,
-        *second_chunks
-            .get(&success_marker)
-            .expect("success second chunk"),
-    )
-    .await;
-
+    let mut chunk_count_by_marker: BTreeMap<u8, usize> = BTreeMap::new();
     let mut successful_temp_renamed = false;
     let mut failed_temp_cleaned = false;
 
     while !(successful_temp_renamed && failed_temp_cleaned) {
         let msg = read_guest_message(&mut guest).await;
-        assert_eq!(msg.msg_type, MSG_EXEC_START);
-        let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
-        assert!(!decoded.sudo);
-        assert_eq!(decoded.stdout, helper_exec_capture_policy());
-        assert_eq!(decoded.stderr, helper_exec_capture_policy());
-        assert!(decoded.expected_exit_codes.is_empty());
-        let success_temp = temp_by_marker
-            .get(&success_marker)
-            .expect("successful temp path");
-        let failed_temp = temp_by_marker
-            .get(&failure_marker)
-            .expect("failed temp path");
-        assert_ne!(success_temp, failed_temp);
+        match msg.msg_type {
+            MSG_WRITE_FILE => {
+                let (path, content, sudo, append, private) =
+                    vsock_proto::decode_write_file(&msg.payload).unwrap();
+                assert!(!sudo);
+                assert!(!private);
+                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+                let marker = *content.first().expect("chunk content");
+                assert!(matches!(marker, 0xAA | 0xBB));
+                assert!(content.iter().all(|byte| *byte == marker));
 
-        match decoded.label {
-            "write-file-rename" => {
-                let expected_command = format!(
-                    "mv -fT -- {} {}",
-                    quote_shell_arg(success_temp),
-                    quote_shell_arg(target_path)
-                );
-                assert_eq!(decoded.command, expected_command);
-                successful_temp_renamed = true;
+                let chunk_count = chunk_count_by_marker.entry(marker).or_default();
+                if *chunk_count == 0 {
+                    assert!(!append);
+                    assert_eq!(content.len(), chunk_limit);
+                    assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
+                } else {
+                    assert_eq!(*chunk_count, 1);
+                    assert!(append);
+                    assert_eq!(content.len(), 1);
+                    assert_eq!(
+                        path,
+                        temp_by_marker
+                            .get(&marker)
+                            .expect("second chunk should use first chunk temp path")
+                    );
+                }
+                *chunk_count += 1;
+
+                if marker == failure_marker && append {
+                    send_write_file_failure(&mut guest, msg.seq, "disk full").await;
+                } else {
+                    send_write_file_success(&mut guest, msg.seq).await;
+                }
             }
-            "exec-cleanup" => {
-                let expected_command = format!("rm -f -- {}", quote_shell_arg(failed_temp));
-                assert_eq!(decoded.command, expected_command);
-                failed_temp_cleaned = true;
+            MSG_EXEC_START => {
+                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+                assert!(!decoded.sudo);
+                assert_eq!(decoded.stdout, helper_exec_capture_policy());
+                assert_eq!(decoded.stderr, helper_exec_capture_policy());
+                assert!(decoded.expected_exit_codes.is_empty());
+                let success_temp = temp_by_marker
+                    .get(&success_marker)
+                    .expect("successful temp path");
+                let failed_temp = temp_by_marker
+                    .get(&failure_marker)
+                    .expect("failed temp path");
+                assert_ne!(success_temp, failed_temp);
+
+                match decoded.label {
+                    "write-file-rename" => {
+                        let expected_command = format!(
+                            "mv -fT -- {} {}",
+                            quote_shell_arg(success_temp),
+                            quote_shell_arg(target_path)
+                        );
+                        assert_eq!(decoded.command, expected_command);
+                        successful_temp_renamed = true;
+                    }
+                    "exec-cleanup" => {
+                        let expected_command = format!("rm -f -- {}", quote_shell_arg(failed_temp));
+                        assert_eq!(decoded.command, expected_command);
+                        failed_temp_cleaned = true;
+                    }
+                    label => panic!("unexpected exec label {label}"),
+                }
+
+                send_exec_result(
+                    &mut guest,
+                    msg.seq,
+                    ExecTermination::Exited { exit_code: 0 },
+                    &[],
+                    &[],
+                )
+                .await;
             }
-            label => panic!("unexpected exec label {label}"),
+            _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
         }
-
-        send_exec_result(
-            &mut guest,
-            msg.seq,
-            ExecTermination::Exited { exit_code: 0 },
-            &[],
-            &[],
-        )
-        .await;
     }
+
+    assert_eq!(chunk_count_by_marker.get(&success_marker), Some(&2));
+    assert_eq!(chunk_count_by_marker.get(&failure_marker), Some(&2));
 
     successful_write.await.unwrap().unwrap();
     let err = failing_write.await.unwrap().unwrap_err();

--- a/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
+++ b/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
@@ -1,6 +1,6 @@
 use std::io;
+use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 const BLOCKING_PATH_SUFFIX: &str = ".vm0-vsock-test-block";
 
@@ -18,15 +18,13 @@ fn main() {
 }
 
 fn wait_for_release(path: &Path) -> io::Result<()> {
+    let listener = UnixListener::bind(path_with_suffix(path, ".release"))?;
     std::fs::write(
         path_with_suffix(path, ".pid"),
         std::process::id().to_string(),
     )?;
     std::fs::write(path_with_suffix(path, ".started"), b"")?;
-    let release = path_with_suffix(path, ".release");
-    while !release.exists() {
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    let _ = listener.accept()?;
     Ok(())
 }
 

--- a/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
+++ b/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
@@ -1,10 +1,44 @@
 use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const BLOCKING_PATH_SUFFIX: &str = ".vm0-vsock-test-block";
 
 fn main() {
-    let code = guest_write_file::run_cli(
-        std::env::args().skip(1),
-        io::stdin().lock(),
-        io::stderr().lock(),
-    );
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Some(path) = blocking_path(&args)
+        && let Err(error) = wait_for_release(path)
+    {
+        eprintln!("failed to prepare blocking write helper: {error}");
+        std::process::exit(1);
+    }
+
+    let code = guest_write_file::run_cli(args, io::stdin().lock(), io::stderr().lock());
     std::process::exit(code);
+}
+
+fn wait_for_release(path: &Path) -> io::Result<()> {
+    std::fs::write(
+        path_with_suffix(path, ".pid"),
+        std::process::id().to_string(),
+    )?;
+    std::fs::write(path_with_suffix(path, ".started"), b"")?;
+    let release = path_with_suffix(path, ".release");
+    while !release.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+fn blocking_path(args: &[String]) -> Option<&Path> {
+    let path = Path::new(args.last()?);
+    path.to_string_lossy()
+        .ends_with(BLOCKING_PATH_SUFFIX)
+        .then_some(path)
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
 }

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -29,12 +29,12 @@ pub(crate) type RawGuestHandle = JoinHandle<io::Result<()>>;
 pub(crate) fn start_raw_guest_connection() -> (RawGuestHandle, UnixStream) {
     install_write_file_helper();
     let (guest_stream, mut host_stream) = UnixStream::pair().expect("create raw guest stream pair");
-    let handle = thread::spawn(move || vsock_guest::handle_connection(guest_stream));
-    let ready = read_raw_message(&mut host_stream);
-    assert_eq!(ready.msg_type, vsock_proto::MSG_READY);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("set raw guest read timeout");
+    let handle = thread::spawn(move || vsock_guest::handle_connection(guest_stream));
+    let ready = read_raw_message(&mut host_stream);
+    assert_eq!(ready.msg_type, vsock_proto::MSG_READY);
     (handle, host_stream)
 }
 
@@ -80,6 +80,10 @@ pub(crate) fn blocking_write_started_path(path: &Path) -> std::path::PathBuf {
 
 pub(crate) fn blocking_write_release_path(path: &Path) -> std::path::PathBuf {
     path_with_suffix(path, ".release")
+}
+
+pub(crate) fn release_blocking_write(path: &Path) {
+    UnixStream::connect(blocking_write_release_path(path)).expect("release blocked write helper");
 }
 
 pub(crate) fn blocking_write_pid_path(path: &Path) -> std::path::PathBuf {

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -1,5 +1,6 @@
-use std::io;
+use std::io::{self, Read};
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Once;
@@ -15,11 +16,85 @@ use vsock_proto::ExecTermination;
 
 static WRITE_FILE_HELPER: Once = Once::new();
 const WRITE_FILE_HELPER_BIN: &str = env!("CARGO_BIN_EXE_guest-write-file-test-helper");
+const BLOCKING_WRITE_SUFFIX: &str = ".vm0-vsock-test-block";
 
 fn install_write_file_helper() {
     WRITE_FILE_HELPER.call_once(|| {
         vsock_guest::set_debug_guest_write_file_path_for_tests(WRITE_FILE_HELPER_BIN.into());
     });
+}
+
+pub(crate) type RawGuestHandle = JoinHandle<io::Result<()>>;
+
+pub(crate) fn start_raw_guest_connection() -> (RawGuestHandle, UnixStream) {
+    install_write_file_helper();
+    let (guest_stream, mut host_stream) = UnixStream::pair().expect("create raw guest stream pair");
+    let handle = thread::spawn(move || vsock_guest::handle_connection(guest_stream));
+    let ready = read_raw_message(&mut host_stream);
+    assert_eq!(ready.msg_type, vsock_proto::MSG_READY);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set raw guest read timeout");
+    (handle, host_stream)
+}
+
+pub(crate) fn join_raw_guest_connection(handle: RawGuestHandle) {
+    handle
+        .join()
+        .expect("raw guest connection thread panicked")
+        .expect("raw guest connection returned an error");
+}
+
+pub(crate) fn finish_raw_guest_connection(handle: RawGuestHandle, stream: UnixStream) {
+    drop(stream);
+    join_raw_guest_connection(handle);
+}
+
+pub(crate) fn read_raw_message(stream: &mut impl Read) -> vsock_proto::RawMessage {
+    let mut header = [0u8; 4];
+    stream
+        .read_exact(&mut header)
+        .expect("read raw guest message header");
+    let body_len = u32::from_be_bytes(header) as usize;
+    let mut body = vec![0u8; body_len];
+    stream
+        .read_exact(&mut body)
+        .expect("read raw guest message body");
+    let mut frame = Vec::with_capacity(header.len() + body.len());
+    frame.extend_from_slice(&header);
+    frame.extend_from_slice(&body);
+    let mut messages = vsock_proto::Decoder::new()
+        .decode(&frame)
+        .expect("decode raw guest message");
+    assert_eq!(messages.len(), 1);
+    messages.remove(0)
+}
+
+pub(crate) fn blocking_write_path(dir: &Path, name: &str) -> std::path::PathBuf {
+    dir.join(format!("{name}{BLOCKING_WRITE_SUFFIX}"))
+}
+
+pub(crate) fn blocking_write_started_path(path: &Path) -> std::path::PathBuf {
+    path_with_suffix(path, ".started")
+}
+
+pub(crate) fn blocking_write_release_path(path: &Path) -> std::path::PathBuf {
+    path_with_suffix(path, ".release")
+}
+
+pub(crate) fn blocking_write_pid_path(path: &Path) -> std::path::PathBuf {
+    path_with_suffix(path, ".pid")
+}
+
+pub(crate) fn pid_alive(pid: u32) -> bool {
+    // SAFETY: signal zero performs a process-existence check without sending a signal.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> std::path::PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    std::path::PathBuf::from(value)
 }
 
 /// Spawn a guest agent in a background OS thread that connects to the given socket path.

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -1,10 +1,249 @@
-use crate::support::{Harness, captured_output_bytes, exec_exit_code, run_exec, shell_quote};
+use crate::support::{
+    Harness, blocking_write_path, blocking_write_pid_path, blocking_write_release_path,
+    blocking_write_started_path, captured_output_bytes, exec_exit_code,
+    finish_raw_guest_connection, join_raw_guest_connection, pid_alive, read_raw_message, run_exec,
+    shell_quote, start_raw_guest_connection, wait_for_path,
+};
 use std::fs;
-use vsock_host::WriteFileEntry;
+use std::io::{Read, Write};
+use std::time::Duration;
+use vsock_host::{SupervisedExecControl, SupervisedExecRequest, WriteFileEntry};
+use vsock_proto::{
+    ExecOutputPolicy, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_PING, MSG_PONG,
+    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+};
 
 #[test]
 fn shell_quote_escapes_single_quotes() {
     assert_eq!(shell_quote("chunked'quote.bin"), "'chunked'\\''quote.bin'");
+}
+
+#[tokio::test]
+async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
+    let dir = tempfile::tempdir().expect("create blocked-write temp dir");
+    let blocked_path = blocking_write_path(dir.path(), "blocked");
+    let blocked_path_string = blocked_path.to_string_lossy();
+    let blocked_content = b"blocked content";
+    let overlap_path = dir.path().join("overlap.txt");
+    let overlap_path_string = overlap_path.to_string_lossy();
+    let (guest, mut stream) = start_raw_guest_connection();
+
+    let payload =
+        vsock_proto::encode_write_file(&blocked_path_string, blocked_content, false, false)
+            .expect("encode blocked write");
+    stream
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILE, 10, &payload).expect("frame blocked write"))
+        .expect("send blocked write");
+    wait_for_path(
+        &blocking_write_started_path(&blocked_path),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    stream
+        .write_all(&vsock_proto::encode(MSG_PING, 11, &[]).expect("encode ping"))
+        .expect("send ping");
+    let pong = read_raw_message(&mut stream);
+    assert_eq!(pong.msg_type, MSG_PONG);
+    assert_eq!(pong.seq, 11);
+
+    let overlap_payload =
+        vsock_proto::encode_write_file(&overlap_path_string, b"rejected", false, false)
+            .expect("encode overlapping write");
+    stream
+        .write_all(
+            &vsock_proto::encode(MSG_WRITE_FILE, 12, &overlap_payload)
+                .expect("frame overlapping write"),
+        )
+        .expect("send overlapping write");
+    let busy = read_raw_message(&mut stream);
+    assert_eq!(busy.msg_type, MSG_ERROR);
+    assert_eq!(busy.seq, 12);
+    assert_eq!(
+        vsock_proto::decode_error(&busy.payload).expect("decode busy error"),
+        "guest file write already active"
+    );
+    assert!(!overlap_path.exists());
+
+    fs::write(blocking_write_release_path(&blocked_path), b"")
+        .expect("release blocked write helper");
+    let first_result = read_raw_message(&mut stream);
+    assert_eq!(first_result.msg_type, MSG_WRITE_FILE_RESULT);
+    assert_eq!(first_result.seq, 10);
+    assert_eq!(
+        vsock_proto::decode_write_file_result(&first_result.payload)
+            .expect("decode first write result"),
+        (true, "")
+    );
+    assert_eq!(
+        fs::read(&blocked_path).expect("read blocked target"),
+        blocked_content
+    );
+
+    let later_payload =
+        vsock_proto::encode_write_file(&overlap_path_string, b"accepted", false, false)
+            .expect("encode later write");
+    stream
+        .write_all(
+            &vsock_proto::encode(MSG_WRITE_FILE, 13, &later_payload).expect("frame later write"),
+        )
+        .expect("send later write");
+    let later_result = read_raw_message(&mut stream);
+    assert_eq!(later_result.msg_type, MSG_WRITE_FILE_RESULT);
+    assert_eq!(later_result.seq, 13);
+    assert_eq!(
+        vsock_proto::decode_write_file_result(&later_result.payload)
+            .expect("decode later write result"),
+        (true, "")
+    );
+    assert_eq!(
+        fs::read(&overlap_path).expect("read later target"),
+        b"accepted"
+    );
+
+    finish_raw_guest_connection(guest, stream);
+}
+
+#[tokio::test]
+async fn blocked_write_allows_exec_cancel_and_quiesce() {
+    let h = Harness::new().await;
+    let handle = h
+        .host()
+        .start_supervised_exec(SupervisedExecRequest {
+            timeout: ExecTimeoutPolicy::None,
+            command: "exec sleep 60",
+            env: &[],
+            sudo: false,
+            label: "blocked-write-control",
+            stdout: ExecOutputPolicy::Discard,
+            stderr: ExecOutputPolicy::Discard,
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            control: SupervisedExecControl::Disabled,
+            stream_queue_capacity: None,
+            start_timeout: Duration::from_secs(5),
+        })
+        .await
+        .expect("start supervised exec");
+    let blocked_path = blocking_write_path(&h.dir, "control-blocked");
+    let blocked_path_string = blocked_path.to_string_lossy().to_string();
+
+    let write = h
+        .host()
+        .write_file(&blocked_path_string, b"control content", false);
+    let control = async {
+        wait_for_path(
+            &blocking_write_started_path(&blocked_path),
+            Duration::from_secs(5),
+        )
+        .await;
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            h.host().quiesce_operations(Duration::from_secs(1)),
+        )
+        .await
+        .expect("quiesce should respond while write helper is blocked")
+        .expect_err("quiesce should report the active write as pending");
+        let cancel_result = tokio::time::timeout(
+            Duration::from_secs(3),
+            handle.cancel_and_wait(Duration::from_secs(2)),
+        )
+        .await
+        .expect("exec cancel should not wait for blocked write")
+        .expect("cancel supervised exec");
+        fs::write(blocking_write_release_path(&blocked_path), b"")
+            .expect("release control blocked helper");
+        cancel_result
+    };
+
+    let (write_result, cancel_result) = tokio::join!(write, control);
+    write_result.expect("blocked write should finish after release");
+    assert_eq!(cancel_result.termination, ExecTermination::Cancelled);
+
+    h.host()
+        .quiesce_operations(Duration::from_secs(2))
+        .await
+        .expect("quiesce should succeed after write completion");
+    h.host()
+        .resume_operations(Duration::from_secs(2))
+        .await
+        .expect("resume operations");
+    h.finish();
+}
+
+#[tokio::test]
+async fn shutdown_cancels_blocked_write_helper_before_connection_exit() {
+    let dir = tempfile::tempdir().expect("create shutdown temp dir");
+    let blocked_path = blocking_write_path(dir.path(), "shutdown-blocked");
+    let blocked_path_string = blocked_path.to_string_lossy();
+    let (guest, mut stream) = start_raw_guest_connection();
+    let payload = vsock_proto::encode_write_file(&blocked_path_string, b"shutdown", false, false)
+        .expect("encode shutdown blocked write");
+    stream
+        .write_all(
+            &vsock_proto::encode(MSG_WRITE_FILE, 20, &payload)
+                .expect("frame shutdown blocked write"),
+        )
+        .expect("send shutdown blocked write");
+    let started_path = blocking_write_started_path(&blocked_path);
+    wait_for_path(&started_path, Duration::from_secs(5)).await;
+    let pid: u32 = fs::read_to_string(blocking_write_pid_path(&blocked_path))
+        .expect("read shutdown helper pid")
+        .parse()
+        .expect("parse shutdown helper pid");
+
+    stream
+        .write_all(&vsock_proto::encode(MSG_SHUTDOWN, 21, &[]).expect("encode shutdown"))
+        .expect("send shutdown");
+    let ack = read_raw_message(&mut stream);
+    assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
+    assert_eq!(ack.seq, 21);
+
+    join_raw_guest_connection(guest);
+    let mut trailing = [0u8; 1];
+    assert_eq!(
+        stream
+            .read(&mut trailing)
+            .expect("read shutdown stream EOF"),
+        0,
+        "no write result may follow shutdown acknowledgement"
+    );
+    assert!(
+        !pid_alive(pid),
+        "shutdown helper pid {pid} should be reaped"
+    );
+}
+
+#[tokio::test]
+async fn disconnect_cancels_blocked_write_helper_before_connection_exit() {
+    let dir = tempfile::tempdir().expect("create disconnect temp dir");
+    let blocked_path = blocking_write_path(dir.path(), "disconnect-blocked");
+    let blocked_path_string = blocked_path.to_string_lossy();
+    let (guest, mut stream) = start_raw_guest_connection();
+    let payload = vsock_proto::encode_write_file(&blocked_path_string, b"disconnect", false, false)
+        .expect("encode disconnect blocked write");
+    stream
+        .write_all(
+            &vsock_proto::encode(MSG_WRITE_FILE, 30, &payload)
+                .expect("frame disconnect blocked write"),
+        )
+        .expect("send disconnect blocked write");
+    wait_for_path(
+        &blocking_write_started_path(&blocked_path),
+        Duration::from_secs(5),
+    )
+    .await;
+    let pid: u32 = fs::read_to_string(blocking_write_pid_path(&blocked_path))
+        .expect("read disconnect helper pid")
+        .parse()
+        .expect("parse disconnect helper pid");
+
+    drop(stream);
+    join_raw_guest_connection(guest);
+    assert!(
+        !pid_alive(pid),
+        "disconnect helper pid {pid} should be reaped"
+    );
 }
 // ── write_file ───────────────────────────────────────────────────────
 

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -1,8 +1,8 @@
 use crate::support::{
-    Harness, blocking_write_path, blocking_write_pid_path, blocking_write_release_path,
-    blocking_write_started_path, captured_output_bytes, exec_exit_code,
-    finish_raw_guest_connection, join_raw_guest_connection, pid_alive, read_raw_message, run_exec,
-    shell_quote, start_raw_guest_connection, wait_for_path,
+    Harness, blocking_write_path, blocking_write_pid_path, blocking_write_started_path,
+    captured_output_bytes, exec_exit_code, finish_raw_guest_connection, join_raw_guest_connection,
+    pid_alive, read_raw_message, release_blocking_write, run_exec, shell_quote,
+    start_raw_guest_connection, wait_for_path,
 };
 use std::fs;
 use std::io::{Read, Write};
@@ -65,8 +65,7 @@ async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
     );
     assert!(!overlap_path.exists());
 
-    fs::write(blocking_write_release_path(&blocked_path), b"")
-        .expect("release blocked write helper");
+    release_blocking_write(&blocked_path);
     let first_result = read_raw_message(&mut stream);
     assert_eq!(first_result.msg_type, MSG_WRITE_FILE_RESULT);
     assert_eq!(first_result.seq, 10);
@@ -151,8 +150,7 @@ async fn blocked_write_allows_exec_cancel_and_quiesce() {
         .await
         .expect("exec cancel should not wait for blocked write")
         .expect("cancel supervised exec");
-        fs::write(blocking_write_release_path(&blocked_path), b"")
-            .expect("release control blocked helper");
+        release_blocking_write(&blocked_path);
         cancel_result
     };
 


### PR DESCRIPTION
## Summary

- move guest file helpers to a bounded connection-owned serial worker
- serialize host file-write request lifecycles while control traffic bypasses
- cancel and reap write helpers on disconnect or shutdown, with boundary regression coverage

## Compatibility

- no wire protocol or persisted-state changes
- runner and guest ship together; a new host remains compatible with an old guest
- overlapping raw writes receive a sequence-correlated busy error

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-host -p vsock-test`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-host -p vsock-test --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-host -p vsock-test --all-features --no-deps`

Closes #21532
