### PR TITLE
perf(api): reuse zero feature switch context during run preparation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1079,6 +1079,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       timingEvents,
       API_DISPATCH_ZERO_WEB_CHAT_PRE_CREATE_ACTION_TYPES,
     );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_feature_switches",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        feature_switch_context_source: "preloaded",
+      }),
+    );
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
@@ -1540,6 +1550,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectNoApiDispatchActions(
       timingEvents,
       API_DISPATCH_ZERO_WEB_CHAT_PRE_CREATE_ACTION_TYPES,
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_feature_switches",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        feature_switch_context_source: "database",
+      }),
     );
     expectApiDispatchSpanKind(
       timingEvents,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
@@ -362,6 +362,12 @@ describe("POST /api/test/telegram-dispatch-probe", () => {
           span_kind: "nested",
           trigger_source: "telegram",
         }),
+        expect.objectContaining({
+          op_type: "api_dispatch_prepare_context_feature_switches",
+          span_kind: "nested",
+          trigger_source: "telegram",
+          feature_switch_context_source: "preloaded",
+        }),
       ]),
     );
     const timingActionTypes = timingEvents.map((event) => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6343,6 +6343,7 @@ async function prepareRunBodyContext(args: {
   readonly get: PrepareRunContextGet;
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
+  readonly preloadedFeatureSwitchContext: FeatureSwitchContext | undefined;
   readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
   readonly initialBody: CreateRunBody;
@@ -6351,9 +6352,19 @@ async function prepareRunBodyContext(args: {
     "api_dispatch_prepare_context_feature_switches",
     "nested",
     async () => {
+      if (args.preloadedFeatureSwitchContext !== undefined) {
+        args.signal.throwIfAborted();
+        return args.preloadedFeatureSwitchContext;
+      }
       return await args.get(
         loadRunFeatureSwitchContext(args.createArgs, args.signal),
       );
+    },
+    {
+      feature_switch_context_source:
+        args.preloadedFeatureSwitchContext === undefined
+          ? "database"
+          : "preloaded",
     },
   );
   const resolved = await args.timing.measure(
@@ -6648,6 +6659,7 @@ function prepareRunContext(
   args: CreateAgentRunArgs,
   timing: ApiDispatchTimingCollector,
   signal: AbortSignal,
+  preloadedFeatureSwitchContext: FeatureSwitchContext | undefined,
 ): Computed<Promise<PreparedRunContext | CreateRunErrorResult>> {
   return computed(
     async (get): Promise<PreparedRunContext | CreateRunErrorResult> => {
@@ -6666,6 +6678,7 @@ function prepareRunContext(
         get,
         db,
         createArgs: args,
+        preloadedFeatureSwitchContext,
         timing,
         signal,
         initialBody,
@@ -7282,6 +7295,7 @@ interface PreparedAgentRun {
 interface PrepareAgentRunArgs {
   readonly args: CreateAgentRunArgs;
   readonly timing: ApiDispatchTimingCollector;
+  readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
 }
 
 interface CompleteAgentRunArgs {
@@ -7330,7 +7344,15 @@ export const prepareAgentRun$ = command(
       "api_dispatch_prepare_run_context",
       "top_level",
       async () => {
-        return await get(prepareRunContext(db, args, timing, signal));
+        return await get(
+          prepareRunContext(
+            db,
+            args,
+            timing,
+            signal,
+            input.preloadedFeatureSwitchContext,
+          ),
+        );
       },
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -7,7 +7,10 @@ import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import { resolveFirewallServerMetadataPolicies } from "@vm0/connectors/firewall-metadata/server";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -123,6 +126,7 @@ function optionalAgentSetting(value: string | null): string | undefined {
 
 interface ZeroRunPromptContext {
   readonly userInfo: UserInfo;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly relationshipMemoryEnabled: boolean;
   readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
   readonly zeroScrapeEnabled: boolean;
@@ -672,6 +676,7 @@ async function loadZeroRunFeatureSwitchState(
     readonly orgId: string;
   },
 ): Promise<{
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly relationshipMemoryEnabled: boolean;
   readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
   readonly zeroScrapeEnabled: boolean;
@@ -686,6 +691,7 @@ async function loadZeroRunFeatureSwitchState(
     context,
   );
   return {
+    featureSwitchContext: context,
     relationshipMemoryEnabled,
     relationshipMemoryRuntimeInjectionEnabled:
       relationshipMemoryEnabled &&
@@ -1180,6 +1186,7 @@ async function settleZeroRunPreparation<T>(
 interface ZeroRunAfterPreCreateBase {
   readonly agent: ZeroAgentRunRecord;
   readonly userInfo: UserInfo;
+  readonly featureSwitchContext: FeatureSwitchContext;
   readonly relationshipMemoryEnabled: boolean;
   readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
   readonly zeroScrapeEnabled: boolean;
@@ -1253,7 +1260,11 @@ const createAgentRunAfterZeroPreCreate$ = command(
     })();
     const preparedAgentRunPromise = set(
       prepareAgentRun$,
-      { args: provisionalCreateAgentRunArgs, timing: input.timing },
+      {
+        args: provisionalCreateAgentRunArgs,
+        timing: input.timing,
+        preloadedFeatureSwitchContext: input.featureSwitchContext,
+      },
       signal,
     );
     const [finalAppendSystemPrompt, preparedAgentRunResult] =
@@ -1307,6 +1318,7 @@ export const createZeroIntegrationRun$ = command(
 
     const {
       userInfo,
+      featureSwitchContext,
       relationshipMemoryEnabled,
       relationshipMemoryRuntimeInjectionEnabled,
       zeroScrapeEnabled,
@@ -1373,6 +1385,7 @@ export const createZeroIntegrationRun$ = command(
         command: args,
         agent,
         userInfo,
+        featureSwitchContext,
         relationshipMemoryEnabled,
         relationshipMemoryRuntimeInjectionEnabled,
         zeroScrapeEnabled,
@@ -1428,6 +1441,7 @@ export const createZeroRun$ = command(
 
     const {
       userInfo,
+      featureSwitchContext,
       relationshipMemoryEnabled,
       relationshipMemoryRuntimeInjectionEnabled,
       zeroScrapeEnabled,
@@ -1506,6 +1520,7 @@ export const createZeroRun$ = command(
         command: args,
         agent,
         userInfo,
+        featureSwitchContext,
         relationshipMemoryEnabled,
         relationshipMemoryRuntimeInjectionEnabled,
         zeroScrapeEnabled,


### PR DESCRIPTION
## Summary

- preserve the complete feature-switch context already loaded after Zero agent access checks
- pass that request-local snapshot through the private Zero coordinator into run preparation, removing the repeated user/org override queries
- keep direct and non-Zero preparation on the existing database path
- retain `api_dispatch_prepare_context_feature_switches` and add the low-cardinality `feature_switch_context_source=preloaded|database` dimension
- cover regular Zero, Zero integration, and direct source selection through public-route integration tests

The production sample in #21547 measured the duplicate preparation read at p95 207 ms overall and p95 249 ms for the goal-continuation/workflow-event cohort. This change removes that repeated pair of row queries while making one request use one internally consistent feature-switch snapshot.

## Compatibility and exclusions

- no schema, migration, or persisted-data change
- no public API, queue payload, runner protocol, frontend, or guest change
- no process-global, cross-request, LRU, or TTL cache
- feature switches remain non-authorization controls; updates committed during a request apply to the next request

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts --silent=passed-only` — 107 passed
- `pnpm knip --workspace api`
- pre-commit hook: Prettier, full Knip, 13-workspace typecheck, and commitlint passed

Closes #21547

Parent context: #18746
