### PR TITLE
fix: improve teams bot validation responses

### DIFF
--- a/turbo/apps/api/src/lib/teams-bot-activity.ts
+++ b/turbo/apps/api/src/lib/teams-bot-activity.ts
@@ -297,6 +297,7 @@ function conversationUpdateActivity(
   activity: Record<string, unknown>,
   base: ActivityBase,
 ): TeamsInboundActivity {
+  const sender = normalizeActor(activity.from);
   const membersAdded = normalizeActorArray(readArray(activity, "membersAdded"));
   const membersRemoved = normalizeActorArray(
     readArray(activity, "membersRemoved"),
@@ -329,6 +330,7 @@ function conversationUpdateActivity(
     ...base,
     kind: "conversation_update",
     action,
+    sender,
     recipient,
     membersAdded,
     membersRemoved,
@@ -339,6 +341,7 @@ function installationUpdateActivity(
   activity: Record<string, unknown>,
   base: ActivityBase,
 ): TeamsInboundActivity {
+  const sender = normalizeActor(activity.from);
   const action = readString(activity, "action");
   if (action === "remove") {
     return {
@@ -354,6 +357,7 @@ function installationUpdateActivity(
     ...base,
     kind: "installation_update",
     action: action === "add" ? "add" : "unknown",
+    sender,
     recipient: activity.recipient ? normalizeActor(activity.recipient) : null,
   };
 }

--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -165,12 +165,22 @@ type TeamsActivityAttachment =
   | TeamsAdaptiveCardAttachment
   | TeamsFileAttachment;
 
+export interface TeamsMentionEntity {
+  readonly type: "mention";
+  readonly text: string;
+  readonly mentioned: {
+    readonly id: string;
+    readonly name?: string;
+  };
+}
+
 interface TeamsActivityBody {
   readonly type: "message" | "typing";
   readonly text?: string;
   readonly textFormat?: "markdown";
   readonly summary?: string;
   readonly replyToId?: string;
+  readonly entities?: readonly TeamsMentionEntity[];
   readonly attachments?: readonly TeamsActivityAttachment[];
   readonly channelData?: {
     readonly tenant?: { readonly id: string };
@@ -817,6 +827,7 @@ export function sendTeamsMessageReply(args: {
   readonly tenantId: string;
   readonly text: string;
   readonly card?: TeamsAdaptiveCard;
+  readonly entities?: readonly TeamsMentionEntity[];
   readonly signal: AbortSignal;
 }): Promise<SendTeamsActivityResult> {
   return sendTeamsMessage({
@@ -826,6 +837,7 @@ export function sendTeamsMessageReply(args: {
     tenantId: args.tenantId,
     text: args.text,
     card: args.card,
+    ...(args.entities ? { entities: args.entities } : {}),
     signal: args.signal,
   });
 }
@@ -837,6 +849,7 @@ export function sendTeamsMessage(args: {
   readonly tenantId: string;
   readonly text: string;
   readonly card?: TeamsAdaptiveCard;
+  readonly entities?: readonly TeamsMentionEntity[];
   readonly attachments?: readonly TeamsActivityAttachment[];
   readonly signal: AbortSignal;
 }): Promise<SendTeamsActivityResult> {
@@ -864,6 +877,7 @@ export function sendTeamsMessage(args: {
         ? { summary: args.text }
         : { text: args.text, textFormat: "markdown" }),
       replyToId: args.activityId,
+      ...(args.entities ? { entities: args.entities } : {}),
       ...(attachments.length > 0 ? { attachments } : {}),
       channelData: {
         tenant: { id: args.tenantId },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -59,8 +59,13 @@ const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
   "Please connect your account to use Okou in this Teams workspace.";
 const TEAMS_LOGIN_PROMPT_CARD_TEXT =
   "Please connect your account to use Okou in this Teams workspace.";
-const TEAMS_WELCOME_TEXT =
-  "Hi, I'm Okou. Use `help` to see commands, or `connect` to link this Teams workspace to Okou.";
+const TEAMS_WELCOME_TEXT = [
+  "Hi, I'm Okou. I connect Teams conversations to AI agents for research, triage, reports, engineering work, operations, and support.",
+  "",
+  "To get started, use `connect` to link this Teams workspace to Okou. An org admin may need to complete workspace setup first.",
+  "",
+  "Commands: `help`, `connect`, `disconnect`, `switch`, `model`. Mention `@Okou` with a task or send a DM to work privately.",
+].join("\n");
 const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
 const BOT_FRAMEWORK_KEYS_URL =
@@ -542,6 +547,12 @@ function teamsBotInstalledActivity(
       channel: { id: "19:channel@thread.tacv2", name: "General" },
       teamsAppId: "teams-app-test",
     },
+    from: {
+      id: fixture.teamsUserId,
+      name: "Ada Lovelace",
+      aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: "ada@example.com",
+    },
     recipient: { id: "28:bot-1", name: "Zero" },
     membersAdded: [{ id: "28:bot-1", name: "Zero" }],
   };
@@ -961,8 +972,20 @@ describe("POST /api/zero/teams/bot", () => {
       activityId: null,
       body: {
         type: "message",
-        text: TEAMS_WELCOME_TEXT,
+        text: expect.stringContaining(
+          "<at>Ada Lovelace</at> added Okou to this Teams workspace.",
+        ),
         textFormat: "markdown",
+        entities: [
+          {
+            type: "mention",
+            text: "<at>Ada Lovelace</at>",
+            mentioned: {
+              id: "29:user-1",
+              name: "Ada Lovelace",
+            },
+          },
+        ],
         channelData: {
           tenant: { id: "tenant-1" },
         },
@@ -971,7 +994,47 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests[0]?.body).not.toHaveProperty("replyToId");
   });
 
-  it("ignores Teams help, slash help, and greeting messages without a mention", async () => {
+  it("sends a personal welcome message when Teams adds the bot in personal scope", async () => {
+    botFrameworkHandlers();
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+
+    const response = await postTeamsActivity({
+      activity: {
+        ...teamsBotInstalledActivity(),
+        id: "activity-install-personal",
+        conversation: {
+          id: "a:personal-29:user-1",
+          conversationType: "personal",
+        },
+        channelData: {
+          tenant: { id: "tenant-1", name: "Tenant One" },
+          teamsAppId: "teams-app-test",
+        },
+      },
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    await response.json();
+    await flushWaitUntilForTest();
+    expect(outboundRequests).toHaveLength(1);
+    expect(outboundRequests[0]).toMatchObject({
+      conversationId: "a:personal-29:user-1",
+      activityId: null,
+      body: {
+        type: "message",
+        text: TEAMS_WELCOME_TEXT,
+        textFormat: "markdown",
+        channelData: {
+          tenant: { id: "tenant-1" },
+        },
+      },
+    });
+    expect(outboundRequests[0]?.body).not.toHaveProperty("entities");
+    expect(outboundRequests[0]?.body).not.toHaveProperty("replyToId");
+  });
+
+  it("responds to Teams validation help and greeting messages without a mention", async () => {
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
 
@@ -997,6 +1060,28 @@ describe("POST /api/zero/teams/bot", () => {
     const slashHelpBody = await readTeamsBotResponseAndFlush(slashHelpResponse);
     expect(slashHelpBody).not.toHaveProperty("dispatch");
 
+    const groupChatHelpResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(botFixture(), {
+        id: "activity-validation-group-chat-help",
+        conversation: {
+          id: "19:group-chat@thread.v2",
+          conversationType: "groupChat",
+        },
+        channelData: {
+          tenant: { id: "tenant-1", name: "Tenant One" },
+          teamsAppId: "teams-app-test",
+        },
+        text: "help",
+        entities: [],
+        replyToId: null,
+      }),
+      token: teamsToken(),
+    });
+    const groupChatHelpBody = await readTeamsBotResponseAndFlush(
+      groupChatHelpResponse,
+    );
+    expect(groupChatHelpBody).not.toHaveProperty("dispatch");
+
     const greetingResponse = await postTeamsActivity({
       activity: teamsMessageActivity(botFixture(), {
         id: "activity-validation-hi",
@@ -1007,7 +1092,26 @@ describe("POST /api/zero/teams/bot", () => {
     });
     const greetingBody = await readTeamsBotResponseAndFlush(greetingResponse);
     expect(greetingBody).not.toHaveProperty("dispatch");
-    expect(outboundRequests).toHaveLength(0);
+    expect(outboundRequests).toHaveLength(4);
+    expect(
+      outboundRequests.map((request) => {
+        return request.activityId;
+      }),
+    ).toStrictEqual([
+      "activity-validation-help",
+      "activity-validation-slash-help",
+      "activity-validation-group-chat-help",
+      "activity-validation-hi",
+    ]);
+    expect(outboundRequests[0]?.body).toMatchObject({
+      text: expect.stringContaining("Okou Teams Bot Help"),
+    });
+    expect(outboundRequests[2]?.body).toMatchObject({
+      text: expect.stringContaining("Okou Teams Bot Help"),
+    });
+    expect(outboundRequests[3]?.body).toMatchObject({
+      text: TEAMS_WELCOME_TEXT,
+    });
   });
 
   it("responds to Teams greeting messages with a mention", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -20,6 +20,7 @@ import {
   sendTeamsMessage,
   sendTeamsMessageReply,
   type TeamsAdaptiveCard,
+  type TeamsMentionEntity,
 } from "../external/teams-bot-client";
 import { now } from "../external/time";
 import type { RouteEntry } from "../route-entry";
@@ -39,6 +40,8 @@ const L = logger("TeamsBot");
 const TEAMS_LOGIN_PROMPT_CARD_TEXT =
   "Please connect your account to use Okou in this Teams workspace.";
 const TEAMS_THINKING_REACTION_TYPE = "1f4ad_thoughtballoon";
+const TEAMS_SUPPORTED_COMMANDS_TEXT =
+  "`help`, `connect`, `disconnect`, `switch`, `model`";
 
 function errorResponse(
   status: 400 | 401 | 403 | 503,
@@ -189,6 +192,49 @@ function teamsInstallWelcomeActivity(
   return botAdded ? activity : null;
 }
 
+function buildTeamsInstallWelcomeMention(
+  activity: TeamsInstallWelcomeActivity,
+): TeamsMentionEntity | null {
+  if (activity.conversationType === "personal" || activity.sender.id === "") {
+    return null;
+  }
+
+  const name = activity.sender.name ?? "the person who added Okou";
+  return {
+    type: "mention",
+    text: `<at>${name}</at>`,
+    mentioned: {
+      id: activity.sender.id,
+      name,
+    },
+  };
+}
+
+function buildTeamsInstallWelcomeContent(
+  activity: TeamsInstallWelcomeActivity,
+): {
+  readonly text: string;
+  readonly entities?: readonly TeamsMentionEntity[];
+} {
+  const mention = buildTeamsInstallWelcomeMention(activity);
+  if (!mention) {
+    return { text: TEAMS_WELCOME_TEXT };
+  }
+
+  return {
+    text: [
+      `${mention.text} added Okou to this Teams workspace.`,
+      "",
+      "Okou connects Teams conversations to AI agents for research, triage, reports, engineering work, operations, and support.",
+      "",
+      "To get started, use `connect` to link this Teams workspace to Okou. An org admin may need to complete workspace setup first.",
+      "",
+      `Commands: ${TEAMS_SUPPORTED_COMMANDS_TEXT}. Mention \`@Okou\` with a task or send a DM to work privately.`,
+    ].join("\n"),
+    entities: [mention],
+  };
+}
+
 const sendTeamsInstallWelcome$ = command(
   async (
     _,
@@ -200,11 +246,13 @@ const sendTeamsInstallWelcome$ = command(
       return;
     }
 
+    const welcome = buildTeamsInstallWelcomeContent(welcomeActivity);
     const reply = await sendTeamsMessage({
       serviceUrl: welcomeActivity.serviceUrl,
       conversationId: welcomeActivity.conversationId,
       tenantId: welcomeActivity.tenantId,
-      text: TEAMS_WELCOME_TEXT,
+      text: welcome.text,
+      ...(welcome.entities ? { entities: welcome.entities } : {}),
       signal,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -70,8 +70,15 @@ import { createZeroRun$ } from "./zero-runs-create.service";
 const L = logger("TeamsDispatch");
 const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
   "Please connect your account to use Okou in this Teams workspace.";
-export const TEAMS_WELCOME_TEXT =
-  "Hi, I'm Okou. Use `help` to see commands, or `connect` to link this Teams workspace to Okou.";
+const TEAMS_SUPPORTED_COMMANDS_TEXT =
+  "`help`, `connect`, `disconnect`, `switch`, `model`";
+export const TEAMS_WELCOME_TEXT = [
+  "Hi, I'm Okou. I connect Teams conversations to AI agents for research, triage, reports, engineering work, operations, and support.",
+  "",
+  "To get started, use `connect` to link this Teams workspace to Okou. An org admin may need to complete workspace setup first.",
+  "",
+  `Commands: ${TEAMS_SUPPORTED_COMMANDS_TEXT}. Mention \`@Okou\` with a task or send a DM to work privately.`,
+].join("\n");
 const TEAMS_AGENT_PICKER_MAX_OPTIONS = 100;
 const TEAMS_MODEL_PICKER_MAX_OPTIONS = 100;
 const TEAMS_CARD_ACTION_KEY = "zeroTeamsAction";
@@ -234,7 +241,7 @@ function modelLabel(option: TeamsModelPickerOption): string {
 function parseTeamsBotCommand(prompt: string): TeamsBotCommand | null {
   const parts = prompt.trim().split(/\s+/u);
   const first = parts[0]?.toLowerCase().replace(/^\//u, "") ?? "";
-  const prefixed = first === "zero";
+  const prefixed = first === "zero" || first === "okou";
   const command = prefixed
     ? (parts[1]?.toLowerCase().replace(/^\//u, "") ?? "")
     : first;
@@ -1474,6 +1481,19 @@ function shouldDispatchTeamsMessage(activity: TeamsMessageActivity): boolean {
   return isTeamsDirectMessage(activity) || activity.mentionsRecipient;
 }
 
+function teamsValidationFallbackNotice(args: {
+  readonly command: TeamsBotCommand | null;
+  readonly isGreeting: boolean;
+}): TeamsMessageDispatchResult | null {
+  if (args.command === "help") {
+    return commandHelpNotice({ canSwitch: false, canModel: false });
+  }
+  if (args.isGreeting) {
+    return greetingNotice();
+  }
+  return null;
+}
+
 async function fetchTeamsPromptContext(args: {
   readonly activity: TeamsMessageActivity;
   readonly signal: AbortSignal;
@@ -2121,13 +2141,17 @@ export const dispatchTeamsMessageToAgent$ = command(
     }
 
     const cardAction = teamsCardAction(activity.value);
-    if (!cardAction && !shouldDispatchTeamsMessage(activity)) {
-      return { kind: "ignored" };
-    }
-
     const prompt = activity.text.trim();
     const command = cardAction ? null : parseTeamsBotCommand(prompt);
     const isGreeting = !cardAction && isTeamsBotGreeting(prompt);
+    if (!cardAction && !shouldDispatchTeamsMessage(activity)) {
+      return (
+        teamsValidationFallbackNotice({ command, isGreeting }) ?? {
+          kind: "ignored",
+        }
+      );
+    }
+
     const promptFiles = cardAction ? [] : teamsPromptFiles(activity);
     if (!prompt && promptFiles.length === 0 && !cardAction) {
       return {

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
@@ -53,6 +53,7 @@ export const teamsConversationUpdateActivitySchema =
   teamsActivityBaseSchema.extend({
     kind: z.literal("conversation_update"),
     action: z.enum(["members_added", "members_removed", "unknown"]),
+    sender: teamsActorSchema,
     recipient: teamsActorSchema,
     membersAdded: z.array(teamsActorSchema),
     membersRemoved: z.array(teamsActorSchema),
@@ -69,6 +70,7 @@ export const teamsInstallationUpdateActivitySchema =
   teamsActivityBaseSchema.extend({
     kind: z.literal("installation_update"),
     action: z.enum(["add", "unknown"]),
+    sender: teamsActorSchema,
     recipient: teamsActorSchema.nullable(),
   });
 


### PR DESCRIPTION
## Summary
- Send richer Okou welcome messages for Teams install events, including an installer mention in team/group chat scope and a personal-scope welcome without a mention entity.
- Reply to Teams validation-safe unmentioned `help`, `/help`, and greeting messages without dispatching arbitrary channel messages to agents.
- Carry the Teams activity sender through install activity normalization and allow outbound Teams mention entities.
- Update Teams bot tests for personal/team welcome and validation help/greeting coverage.

## Teams app config
- Updated Okou command descriptions in Developer Portal: Okou v1.0.9, Okou-test v1.0.20.
- Developer Portal currently discards `groupChat` commandList entries on save, even with manifest v1.29; the code still handles groupChat validation-safe help/greeting activities when they reach the bot endpoint.

## Tests
- `pnpm -C turbo -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts`
- `pnpm -C turbo -F api check-types`
- `pnpm -C turbo -F api lint`
- pre-commit: `pnpm check-types`, `pnpm knip --cache`, prettier