### PR TITLE
feat: materialize dynamic presentation HTML server-side

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -46,6 +46,7 @@
     "hono": "^4.12.25",
     "html-to-text": "^9.0.5",
     "music-metadata": "^11.13.0",
+    "parse5": "^7.3.0",
     "pg": "^8.20.0",
     "resend": "^6.12.4",
     "signal-timers": "^1.0.4",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-host-maps.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-host-maps.ts
@@ -8,6 +8,7 @@ import {
   type HostedSitePrepareResponse,
   type HostedSiteRedeployHtmlRequest,
   type HostedSiteRedeployPresentationHtmlRequest,
+  type MaterializePresentationHtmlRequest,
 } from "@vm0/api-contracts/contracts/zero-host";
 import { zeroMapsContract } from "@vm0/api-contracts/contracts/zero-maps";
 
@@ -37,6 +38,17 @@ type HostPrepareStatus = 200 | 400 | 401 | 402 | 403 | 409 | 500;
 type HostCompleteStatus = 200 | 400 | 401 | 402 | 403 | 404 | 409 | 500;
 type HostFilesStatus = 200 | 400 | 401 | 403 | 404 | 409 | 500;
 type HostRedeployStatus = 200 | 400 | 401 | 402 | 403 | 404 | 409 | 500;
+type HostMaterializePresentationStatus =
+  | 200
+  | 400
+  | 401
+  | 403
+  | 404
+  | 409
+  | 413
+  | 422
+  | 500
+  | 503;
 type HostSpeakerNotesStatus = 200 | 400 | 401 | 402 | 403 | 500;
 type HostHtmlDomEditStatus = 200 | 400 | 401 | 402 | 403 | 500 | 503;
 type MapsStatus = 200 | 400 | 401 | 402 | 403 | 502 | 503;
@@ -276,6 +288,20 @@ export function createHostMapsBddApi(context: TestContext) {
     ) {
       return await accept(
         hostClient().redeployPresentationHtml({
+          headers: authenticate(context, actor),
+          body,
+        }),
+        statuses,
+      );
+    },
+
+    async requestMaterializePresentationHtml(
+      actor: ApiTestUser | null,
+      body: MaterializePresentationHtmlRequest,
+      statuses: readonly HostMaterializePresentationStatus[],
+    ) {
+      return await accept(
+        hostClient().materializePresentationHtml({
           headers: authenticate(context, actor),
           body,
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import {
@@ -50,6 +50,9 @@ const GOOGLE_PLACE_DETAILS_URL =
 const OPENSTREETMAP_OVERPASS_URL = "https://overpass-api.de/api/interpreter";
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
+const CLOUDFLARE_SNAPSHOT_URL =
+  "https://api.cloudflare.com/client/v4/accounts/test-account/browser-rendering/snapshot";
+const PRESENTATION_WAF_SECRET = "test-presentation-waf-secret-32-chars";
 const OPENROUTER_HTML_EDIT_STARTING_CREDITS = 1000;
 const OPENROUTER_HTML_EDIT_EXPECTED_CHARGE = 4;
 
@@ -142,6 +145,37 @@ function geocodeOkHandler(requests: URL[]) {
       ],
     });
   });
+}
+
+interface PresentationSnapshotRequest {
+  readonly authorization: string | null;
+  readonly body: unknown;
+  readonly url: string;
+}
+
+function mockPresentationSnapshots(
+  renderedDocuments: readonly string[],
+): PresentationSnapshotRequest[] {
+  const requests: PresentationSnapshotRequest[] = [];
+  server.use(
+    http.post(CLOUDFLARE_SNAPSHOT_URL, async ({ request }) => {
+      const index = requests.length;
+      requests.push({
+        authorization: request.headers.get("authorization"),
+        body: await request.json(),
+        url: request.url,
+      });
+      return HttpResponse.json({
+        meta: { status: 200, title: "Presentation" },
+        success: true,
+        errors: [],
+        result: {
+          content: renderedDocuments[index] ?? renderedDocuments.at(-1),
+        },
+      });
+    }),
+  );
+  return requests;
 }
 
 describe("FILE-01: hosted-site deployments through host APIs", () => {
@@ -373,6 +407,168 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(rejected.body.error.message).toBe(
       "Hosted site is not a presentation HTML artifact",
     );
+  });
+
+  it("materializes the current presentation deployment without persisting a snapshot [HOST-C]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    api.captureHostedSitesS3();
+    mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "materialize-token");
+    mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", PRESENTATION_WAF_SECRET);
+    mockEnv("R2_ACCOUNT_ID", "test-account");
+
+    const snapshotRequests = mockPresentationSnapshots([
+      `<!doctype html><html><head>
+        <script id="vm0-deck-metadata" type="application/json">{"slides":{"slide-1":{"speakerNotes":"Opening"}}}</script>
+        <script>globalThis.unsafe = true</script>
+      </head><body onload="alert('unsafe')">
+        <section class="slide" data-slide-id="slide-1"><a href="javascript:alert('unsafe')">Rendered once</a></section>
+        <iframe src="https://example.com"></iframe>
+      </body></html>`,
+      `<!doctype html><html><body>
+        <section class="slide">Rendered again</section>
+        <section class="slide">Current deployment</section>
+      </body></html>`,
+    ]);
+
+    const site = `bdd-materialize-${randomUUID().slice(0, 8)}`;
+    const prepared = await api.prepareHostedSite(actor, {
+      site,
+      artifactKind: "presentation-html",
+      spaFallback: false,
+      files: [
+        hostedTextFile(
+          "/index.html",
+          '<div id="deck"></div><script>buildDeck()</script>',
+        ),
+      ],
+    });
+    await api.completeHostedSite(actor, prepared.deploymentId);
+
+    const first = await api.requestMaterializePresentationHtml(
+      actor,
+      { url: prepared.url },
+      [200],
+    );
+    if ("error" in first.body) {
+      throw new Error(first.body.error.message);
+    }
+    expect(first.headers.get("cache-control")).toBe("no-store");
+    expect(first.body).toMatchObject({
+      version: 1,
+      sourceUrl: prepared.url,
+      sourceDeploymentId: prepared.deploymentId,
+      slideCount: 1,
+    });
+    expect(first.body.html).toContain(
+      '<script id="vm0-deck-metadata" type="application/json">',
+    );
+    expect(first.body.html).toContain("Content-Security-Policy");
+    expect(first.body.html).toContain(`<base href="${prepared.url}">`);
+    expect(first.body.html).not.toContain("globalThis.unsafe");
+    expect(first.body.html).not.toContain("onload=");
+    expect(first.body.html).not.toContain("javascript:");
+    expect(first.body.html).not.toContain("<iframe");
+
+    const outsider = bdd.user();
+    const hidden = await api.requestMaterializePresentationHtml(
+      outsider,
+      { url: prepared.url },
+      [404],
+    );
+    expectApiError(hidden.body);
+    expect(hidden.body.error.message).toBe("Hosted site not found");
+    expect(snapshotRequests).toHaveLength(1);
+
+    const redeployed = await api.redeployPresentationHtml(actor, {
+      url: prepared.url,
+      html: "<!doctype html><html><body>redeployed source</body></html>",
+    });
+    const second = await api.requestMaterializePresentationHtml(
+      actor,
+      { url: prepared.url },
+      [200],
+    );
+    if ("error" in second.body) {
+      throw new Error(second.body.error.message);
+    }
+    expect(second.body).toMatchObject({
+      sourceDeploymentId: redeployed.deploymentId,
+      slideCount: 2,
+    });
+    expect(second.body.html).toContain("Current deployment");
+    expect(snapshotRequests).toHaveLength(2);
+    expect(snapshotRequests[0]).toMatchObject({
+      authorization: "Bearer materialize-token",
+      url: `${CLOUDFLARE_SNAPSHOT_URL}?cacheTTL=0`,
+      body: {
+        actionTimeout: 15_000,
+        bestAttempt: true,
+        url: prepared.url,
+        cookies: [
+          {
+            name: "vm0_artifact_preview",
+            value: PRESENTATION_WAF_SECRET,
+            url: new URL(prepared.url).origin,
+            httpOnly: true,
+            secure: true,
+            sameSite: "Strict",
+          },
+        ],
+        formats: ["content"],
+        viewport: {
+          width: 1280,
+          height: 800,
+          deviceScaleFactor: 0.5,
+        },
+        gotoOptions: { waitUntil: "networkidle0" },
+        rejectResourceTypes: [
+          "xhr",
+          "fetch",
+          "eventsource",
+          "websocket",
+          "ping",
+        ],
+        waitForSelector: {
+          selector: expect.stringContaining(".slide"),
+          timeout: 10_000,
+        },
+      },
+    });
+  });
+
+  it("rejects rendered HTML that still has no presentation slides [HOST-C]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    api.captureHostedSitesS3();
+    mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "materialize-token");
+    mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", PRESENTATION_WAF_SECRET);
+    mockEnv("R2_ACCOUNT_ID", "test-account");
+    mockPresentationSnapshots([
+      "<!doctype html><html><body><main>No slides</main></body></html>",
+    ]);
+
+    const prepared = await api.prepareHostedSite(actor, {
+      site: `bdd-empty-deck-${randomUUID().slice(0, 8)}`,
+      artifactKind: "presentation-html",
+      spaFallback: false,
+      files: [hostedTextFile("/index.html", '<div id="deck"></div>')],
+    });
+    await api.completeHostedSite(actor, prepared.deploymentId);
+
+    const response = await api.requestMaterializePresentationHtml(
+      actor,
+      { url: prepared.url },
+      [422],
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      code: "PRESENTATION_NOT_FOUND",
+      message: "No presentation slides were found after rendering",
+    });
   });
 
   it("redeploys hosted-site HTML in place and rejects presentation sites [HOST-C]", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -17,6 +17,7 @@ import {
   redeployHtml$,
   redeployPresentationHtml$,
 } from "../services/zero-host.service";
+import { materializePresentationHtml$ } from "../services/presentation-html-materialization.service";
 import { checkBillableOperationCredits$ } from "../services/billable-operation-admission.service";
 import { checkOpenRouterUsagePricing$ } from "../services/openrouter-usage.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
@@ -26,7 +27,10 @@ import {
   insufficientCredits,
   notFound,
   notConfigured,
+  payloadTooLarge,
+  providerUnavailable,
 } from "../../lib/error";
+import { setResHeader$ } from "../context/hono";
 import type { RouteEntry } from "../route-entry";
 
 function internalError(message: string) {
@@ -34,6 +38,15 @@ function internalError(message: string) {
     status: 500 as const,
     body: {
       error: { message, code: "INTERNAL_SERVER_ERROR" },
+    },
+  };
+}
+
+function presentationNotFound(message: string) {
+  return {
+    status: 422 as const,
+    body: {
+      error: { message, code: "PRESENTATION_NOT_FOUND" },
     },
   };
 }
@@ -82,6 +95,9 @@ const completeParams$ = pathParamsOf(zeroHostContract.complete);
 const filesParams$ = pathParamsOf(zeroHostContract.files);
 const redeployPresentationHtmlBody$ = bodyResultOf(
   zeroHostContract.redeployPresentationHtml,
+);
+const materializePresentationHtmlBody$ = bodyResultOf(
+  zeroHostContract.materializePresentationHtml,
 );
 const redeployHtmlBody$ = bodyResultOf(zeroHostContract.redeployHtml);
 const generateSpeakerNotesBody$ = bodyResultOf(
@@ -151,6 +167,49 @@ const filesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   return { status: 200 as const, body: result.body };
 });
+
+const materializePresentationHtmlInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(setResHeader$, "Cache-Control", "no-store");
+    const auth = get(organizationAuthContext$);
+    const bodyResult = await get(materializePresentationHtmlBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      materializePresentationHtml$,
+      { orgId: auth.orgId, body: bodyResult.data },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status === "bad_request") {
+      return badRequestMessage(result.message);
+    }
+    if (result.status === "conflict") {
+      return conflict(result.message);
+    }
+    if (result.status === "not_found") {
+      return notFound(result.message);
+    }
+    if (result.status === "not_configured") {
+      return notConfigured(result.message);
+    }
+    if (result.status === "payload_too_large") {
+      return payloadTooLarge(result.message);
+    }
+    if (result.status === "presentation_not_found") {
+      return presentationNotFound(result.message);
+    }
+    if (result.status === "provider_unavailable") {
+      return providerUnavailable(result.message);
+    }
+
+    return { status: 200 as const, body: result.body };
+  },
+);
 
 const redeployPresentationHtmlInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -376,6 +435,17 @@ export const zeroHostRoutes: readonly RouteEntry[] = [
         missingOrganizationStatus: 401,
       },
       redeployPresentationHtmlInner$,
+    ),
+  },
+  {
+    route: zeroHostContract.materializePresentationHtml,
+    handler: authRoute(
+      {
+        requiredCapability: "host:read",
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+      },
+      materializePresentationHtmlInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -2,7 +2,6 @@ import { command } from "ccstate";
 import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
-import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
@@ -16,6 +15,7 @@ import {
   loadUserFeatureSwitchContext,
   userFeatureSwitchContext,
 } from "./feature-switches.service";
+import { renderHostedBrowserSnapshot } from "./hosted-browser-renderer.service";
 import { publishArtifactsChangedForRun } from "./run-uploaded-files.service";
 
 const log = logger("artifacts:preview");
@@ -26,30 +26,9 @@ const log = logger("artifacts:preview");
 // batches are tiny.
 const PREVIEW_BATCH_SIZE = 10;
 const PREVIEW_SCAN_PAGE_SIZE = 50;
-// Render at a full 1280-wide desktop layout for fidelity, but rasterize at half
-// resolution (deviceScaleFactor 0.5 -> 640x400) since the grid only shows the
-// image a few hundred px wide. WebP keeps the file small (~tens of KB).
-const PREVIEW_VIEWPORT = {
-  width: 1280,
-  height: 800,
-  deviceScaleFactor: 0.5,
-} as const;
 const PREVIEW_IMAGE_CONTENT_TYPE = "image/webp";
 const PREVIEW_IMAGE_EXTENSION = "webp";
 const PREVIEW_IMAGE_BASENAME = "preview-v2";
-const PREVIEW_WAF_COOKIE_NAME = "vm0_artifact_preview";
-
-const browserSnapshotSchema = z.object({
-  meta: z.object({
-    status: z.number().optional(),
-    title: z.string().optional(),
-  }),
-  success: z.literal(true),
-  result: z.object({
-    content: z.string().min(1),
-    screenshot: z.string().min(1),
-  }),
-});
 
 // Videos are immutable, so a fixed poster key (no versioning) is fine. The
 // Cloudflare Media Transformations frame endpoint only outputs jpg/png.
@@ -160,94 +139,25 @@ function previewCandidateWhere(cursor?: PreviewCandidateCursor) {
   return and(...conditions);
 }
 
-function isCloudflareChallenge(content: string, title?: string): boolean {
-  const page = `${title ?? ""}\n${content}`.toLowerCase();
-  const hasChallengeCopy = [
-    "performing security verification",
-    "incompatible browser extension or network configuration",
-    "verify you are human",
-    "checking your browser",
-    "just a moment",
-  ].some((marker) => {
-    return page.includes(marker);
-  });
-  const hasChallengeImplementation = [
-    "challenges.cloudflare.com",
-    "/cdn-cgi/challenge-platform/",
-    "challenge-platform",
-    "cf-chl-",
-    "__cf_chl_",
-  ].some((marker) => {
-    return page.includes(marker);
-  });
-  return hasChallengeCopy && hasChallengeImplementation;
-}
-
 async function renderArtifactSnapshot(
   token: string,
   wafSecret: string,
   url: string,
   signal: AbortSignal,
 ): Promise<Buffer> {
-  const previewUrl = new URL(url);
-  const hostDomain = env("ZERO_HOST_DOMAIN");
-  if (
-    previewUrl.protocol !== "https:" ||
-    !previewUrl.hostname.endsWith(`.${hostDomain}`)
-  ) {
-    throw new Error(
-      `artifact preview URL must be a subdomain of ${hostDomain}`,
-    );
-  }
-
-  const accountId = env("R2_ACCOUNT_ID");
-  const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${accountId}/browser-rendering/snapshot?cacheTTL=0`,
+  const snapshot = await renderHostedBrowserSnapshot(
     {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        url,
-        cookies: [
-          {
-            name: PREVIEW_WAF_COOKIE_NAME,
-            value: wafSecret,
-            url: previewUrl.origin,
-            httpOnly: true,
-            secure: true,
-            sameSite: "Strict",
-          },
-        ],
-        formats: ["content", "screenshot"],
-        viewport: PREVIEW_VIEWPORT,
-        gotoOptions: { waitUntil: "networkidle0" },
-        screenshotOptions: { type: "webp", quality: 80 },
-      }),
-      signal,
+      token,
+      wafSecret,
+      url,
+      formats: ["content", "screenshot"],
     },
+    signal,
   );
-  if (!response.ok) {
-    throw new Error(
-      `browser-rendering snapshot failed (${response.status}): ${await response.text()}`,
-    );
+  if (!snapshot.screenshot) {
+    throw new Error("browser-rendering snapshot did not return a screenshot");
   }
-
-  const responseBody: unknown = await response.json();
-  const snapshot = browserSnapshotSchema.parse(responseBody);
-  if (snapshot.meta.status !== undefined && snapshot.meta.status >= 400) {
-    throw new Error(
-      `browser-rendering snapshot returned page status ${snapshot.meta.status}`,
-    );
-  }
-  if (isCloudflareChallenge(snapshot.result.content, snapshot.meta.title)) {
-    throw new Error(
-      "browser-rendering snapshot returned a Cloudflare challenge",
-    );
-  }
-  return Buffer.from(snapshot.result.screenshot, "base64");
+  return Buffer.from(snapshot.screenshot, "base64");
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/hosted-browser-renderer.service.ts
+++ b/turbo/apps/api/src/signals/services/hosted-browser-renderer.service.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+
+import { env } from "../../lib/env";
+
+const HOSTED_BROWSER_VIEWPORT = {
+  width: 1280,
+  height: 800,
+  deviceScaleFactor: 0.5,
+} as const;
+const HOSTED_BROWSER_WAF_COOKIE_NAME = "vm0_artifact_preview";
+
+const browserSnapshotSchema = z.object({
+  meta: z.object({
+    status: z.number().optional(),
+    title: z.string().optional(),
+  }),
+  success: z.literal(true),
+  result: z.object({
+    content: z.string().min(1),
+    screenshot: z.string().min(1).optional(),
+  }),
+});
+
+type HostedBrowserSnapshotFormat = "content" | "screenshot";
+type HostedBrowserRejectedResourceType =
+  | "eventsource"
+  | "fetch"
+  | "ping"
+  | "websocket"
+  | "xhr";
+
+interface HostedBrowserSnapshotRequest {
+  readonly actionTimeout?: number;
+  readonly bestAttempt?: true;
+  readonly cookies: readonly {
+    readonly httpOnly: true;
+    readonly name: string;
+    readonly sameSite: "Strict";
+    readonly secure: true;
+    readonly url: string;
+    readonly value: string;
+  }[];
+  readonly formats: readonly HostedBrowserSnapshotFormat[];
+  readonly gotoOptions: { readonly waitUntil: "networkidle0" };
+  readonly rejectResourceTypes?: readonly HostedBrowserRejectedResourceType[];
+  readonly screenshotOptions?: {
+    readonly quality: 80;
+    readonly type: "webp";
+  };
+  readonly url: string;
+  readonly viewport: typeof HOSTED_BROWSER_VIEWPORT;
+  readonly waitForSelector?: {
+    readonly selector: string;
+    readonly timeout: number;
+  };
+}
+
+interface HostedBrowserSnapshot {
+  readonly content: string;
+  readonly screenshot?: string;
+}
+
+interface RenderHostedBrowserSnapshotArgs {
+  readonly actionTimeout?: number;
+  readonly formats: readonly HostedBrowserSnapshotFormat[];
+  readonly rejectResourceTypes?: readonly HostedBrowserRejectedResourceType[];
+  readonly token: string;
+  readonly url: string;
+  readonly wafSecret: string;
+  readonly waitForSelector?: {
+    readonly selector: string;
+    readonly timeout: number;
+  };
+}
+
+export class HostedBrowserRenderingError extends Error {
+  override readonly name = "HostedBrowserRenderingError";
+}
+
+function isCloudflareChallenge(content: string, title?: string): boolean {
+  const page = `${title ?? ""}\n${content}`.toLowerCase();
+  const hasChallengeCopy = [
+    "performing security verification",
+    "incompatible browser extension or network configuration",
+    "verify you are human",
+    "checking your browser",
+    "just a moment",
+  ].some((marker) => {
+    return page.includes(marker);
+  });
+  const hasChallengeImplementation = [
+    "challenges.cloudflare.com",
+    "/cdn-cgi/challenge-platform/",
+    "challenge-platform",
+    "cf-chl-",
+    "__cf_chl_",
+  ].some((marker) => {
+    return page.includes(marker);
+  });
+  return hasChallengeCopy && hasChallengeImplementation;
+}
+
+export async function renderHostedBrowserSnapshot(
+  args: RenderHostedBrowserSnapshotArgs,
+  signal: AbortSignal,
+): Promise<HostedBrowserSnapshot> {
+  const previewUrl = new URL(args.url);
+  const hostDomain = env("ZERO_HOST_DOMAIN");
+  if (
+    previewUrl.protocol !== "https:" ||
+    !previewUrl.hostname.endsWith(`.${hostDomain}`)
+  ) {
+    throw new Error(
+      `artifact preview URL must be a subdomain of ${hostDomain}`,
+    );
+  }
+
+  const requestBody: HostedBrowserSnapshotRequest = {
+    actionTimeout: args.actionTimeout,
+    bestAttempt: args.waitForSelector ? true : undefined,
+    url: args.url,
+    cookies: [
+      {
+        name: HOSTED_BROWSER_WAF_COOKIE_NAME,
+        value: args.wafSecret,
+        url: previewUrl.origin,
+        httpOnly: true,
+        secure: true,
+        sameSite: "Strict",
+      },
+    ],
+    formats: args.formats,
+    viewport: HOSTED_BROWSER_VIEWPORT,
+    gotoOptions: { waitUntil: "networkidle0" },
+    rejectResourceTypes: args.rejectResourceTypes,
+    screenshotOptions: args.formats.includes("screenshot")
+      ? { type: "webp", quality: 80 }
+      : undefined,
+    waitForSelector: args.waitForSelector,
+  };
+
+  const accountId = env("R2_ACCOUNT_ID");
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/browser-rendering/snapshot?cacheTTL=0`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${args.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+      signal,
+    },
+  );
+  if (!response.ok) {
+    throw new HostedBrowserRenderingError(
+      `browser-rendering snapshot failed (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  const responseBody: unknown = await response.json();
+  const snapshot = browserSnapshotSchema.parse(responseBody);
+  if (snapshot.meta.status !== undefined && snapshot.meta.status >= 400) {
+    throw new HostedBrowserRenderingError(
+      `browser-rendering snapshot returned page status ${snapshot.meta.status}`,
+    );
+  }
+  if (isCloudflareChallenge(snapshot.result.content, snapshot.meta.title)) {
+    throw new HostedBrowserRenderingError(
+      "browser-rendering snapshot returned a Cloudflare challenge",
+    );
+  }
+  return snapshot.result;
+}

--- a/turbo/apps/api/src/signals/services/presentation-html-materialization.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-html-materialization.service.ts
@@ -1,0 +1,219 @@
+import { command } from "ccstate";
+import { and, eq, isNull } from "drizzle-orm";
+import type {
+  MaterializedPresentationHtmlResponse,
+  MaterializePresentationHtmlRequest,
+} from "@vm0/api-contracts/contracts/zero-host";
+import { hostedDeployments, hostedSites } from "@vm0/db/schema/hosted-site";
+
+import { env } from "../../lib/env";
+import { db$ } from "../external/db";
+import { settle } from "../utils";
+import {
+  HostedBrowserRenderingError,
+  renderHostedBrowserSnapshot,
+} from "./hosted-browser-renderer.service";
+import { sanitizeMaterializedPresentationHtml } from "./presentation-html-sanitizer.service";
+
+const MAX_MATERIALIZED_HTML_BYTES = 5 * 1024 * 1024;
+const MAX_PRESENTATION_SLIDES = 500;
+const PRESENTATION_SLIDE_SELECTOR = [
+  "[data-vm0-slide]",
+  "[data-slide]",
+  "[data-slide-index]",
+  "[data-page]",
+  ".ppt-slide",
+  ".presentation-slide",
+  ".deck-slide",
+  ".slide-page",
+  ".slide",
+  "section",
+].join(",");
+
+interface MaterializePresentationHtmlArgs {
+  readonly body: MaterializePresentationHtmlRequest;
+  readonly orgId: string;
+}
+
+type MaterializePresentationHtmlResult =
+  | {
+      readonly status: "ok";
+      readonly body: MaterializedPresentationHtmlResponse;
+    }
+  | { readonly status: "bad_request"; readonly message: string }
+  | { readonly status: "conflict"; readonly message: string }
+  | { readonly status: "not_found"; readonly message: string }
+  | { readonly status: "not_configured"; readonly message: string }
+  | { readonly status: "payload_too_large"; readonly message: string }
+  | { readonly status: "presentation_not_found"; readonly message: string }
+  | { readonly status: "provider_unavailable"; readonly message: string };
+
+function publicSlugFromHostedSiteUrl(value: string): string | null {
+  const url = new URL(value);
+  const hostDomain = env("ZERO_HOST_DOMAIN");
+  if (url.hostname === hostDomain || !url.hostname.endsWith(`.${hostDomain}`)) {
+    return null;
+  }
+  const publicSlug = url.hostname.slice(0, -(hostDomain.length + 1));
+  return publicSlug || null;
+}
+
+async function materializeDeploymentHtml(
+  deployment: { readonly id: string; readonly url: string },
+  signal: AbortSignal,
+): Promise<MaterializePresentationHtmlResult> {
+  const token = env("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN");
+  const wafSecret = env("ARTIFACT_PREVIEW_WAF_SECRET");
+  if (!token || !wafSecret) {
+    return {
+      status: "not_configured",
+      message: "Presentation HTML rendering is not configured",
+    };
+  }
+
+  const snapshotResult = await settle(
+    renderHostedBrowserSnapshot(
+      {
+        token,
+        wafSecret,
+        url: deployment.url,
+        formats: ["content"],
+        actionTimeout: 15_000,
+        waitForSelector: {
+          selector: PRESENTATION_SLIDE_SELECTOR,
+          timeout: 10_000,
+        },
+        rejectResourceTypes: [
+          "xhr",
+          "fetch",
+          "eventsource",
+          "websocket",
+          "ping",
+        ],
+      },
+      signal,
+    ),
+    signal,
+  );
+  if (!snapshotResult.ok) {
+    if (!(snapshotResult.error instanceof HostedBrowserRenderingError)) {
+      throw snapshotResult.error;
+    }
+    return {
+      status: "provider_unavailable",
+      message: snapshotResult.error.message,
+    };
+  }
+
+  const sanitized = sanitizeMaterializedPresentationHtml(
+    snapshotResult.value.content,
+    deployment.url,
+  );
+  if (Buffer.byteLength(sanitized.html, "utf8") > MAX_MATERIALIZED_HTML_BYTES) {
+    return {
+      status: "payload_too_large",
+      message: "Materialized presentation HTML exceeds 5 MB",
+    };
+  }
+  if (sanitized.slideCount === 0) {
+    return {
+      status: "presentation_not_found",
+      message: "No presentation slides were found after rendering",
+    };
+  }
+  if (sanitized.slideCount > MAX_PRESENTATION_SLIDES) {
+    return {
+      status: "payload_too_large",
+      message: "Materialized presentation exceeds 500 slides",
+    };
+  }
+
+  return {
+    status: "ok",
+    body: {
+      version: 1,
+      html: sanitized.html,
+      sourceUrl: deployment.url,
+      sourceDeploymentId: deployment.id,
+      slideCount: sanitized.slideCount,
+    },
+  };
+}
+
+export const materializePresentationHtml$ = command(
+  async (
+    { get },
+    args: MaterializePresentationHtmlArgs,
+    signal: AbortSignal,
+  ): Promise<MaterializePresentationHtmlResult> => {
+    const publicSlug = publicSlugFromHostedSiteUrl(args.body.url);
+    if (!publicSlug) {
+      return {
+        status: "bad_request",
+        message: "URL is not a hosted site URL",
+      };
+    }
+
+    const db = get(db$);
+    const [site] = await db
+      .select({ activeDeploymentId: hostedSites.activeDeploymentId })
+      .from(hostedSites)
+      .where(
+        and(
+          eq(hostedSites.publicSlug, publicSlug),
+          eq(hostedSites.orgId, args.orgId),
+          isNull(hostedSites.deletedAt),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!site) {
+      return { status: "not_found", message: "Hosted site not found" };
+    }
+    if (!site.activeDeploymentId) {
+      return {
+        status: "conflict",
+        message: "Hosted site has no active deployment",
+      };
+    }
+
+    const [deployment] = await db
+      .select({
+        id: hostedDeployments.id,
+        manifest: hostedDeployments.manifest,
+        status: hostedDeployments.status,
+        url: hostedDeployments.url,
+      })
+      .from(hostedDeployments)
+      .where(
+        and(
+          eq(hostedDeployments.id, site.activeDeploymentId),
+          eq(hostedDeployments.orgId, args.orgId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!deployment) {
+      return {
+        status: "not_found",
+        message: "Active hosted deployment not found",
+      };
+    }
+    if (deployment.status !== "ready") {
+      return {
+        status: "conflict",
+        message: "Active hosted deployment is not ready",
+      };
+    }
+    if (deployment.manifest.artifactKind !== "presentation-html") {
+      return {
+        status: "bad_request",
+        message: "Hosted site is not a presentation HTML artifact",
+      };
+    }
+
+    return materializeDeploymentHtml(deployment, signal);
+  },
+);

--- a/turbo/apps/api/src/signals/services/presentation-html-sanitizer.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-html-sanitizer.service.ts
@@ -1,0 +1,288 @@
+import {
+  defaultTreeAdapter,
+  html as parse5Html,
+  parse,
+  serialize,
+  type DefaultTreeAdapterTypes,
+} from "parse5";
+
+import { safeJsonParse } from "../utils";
+
+const DECK_METADATA_SCRIPT_ID = "vm0-deck-metadata";
+const PRESENTATION_CSP = [
+  "default-src 'none'",
+  "base-uri https:",
+  "connect-src 'none'",
+  "font-src 'self' https: data:",
+  "form-action 'none'",
+  "frame-src 'none'",
+  "img-src 'self' https: data:",
+  "media-src 'self' https: data:",
+  "object-src 'none'",
+  "script-src 'none'",
+  "style-src 'self' 'unsafe-inline' https: data:",
+  "worker-src 'none'",
+].join("; ");
+
+const BLOCKED_ELEMENTS = [
+  "applet",
+  "base",
+  "embed",
+  "frame",
+  "frameset",
+  "iframe",
+  "noscript",
+  "object",
+] as const;
+const ACTIVE_URL_ATTRIBUTES = [
+  "action",
+  "background",
+  "cite",
+  "data",
+  "formaction",
+  "href",
+  "poster",
+  "src",
+  "xlink:href",
+] as const;
+const BLOCKED_META_HTTP_EQUIV = ["content-security-policy", "refresh"] as const;
+const UNSAFE_PROTOCOLS = ["data:", "javascript:", "vbscript:"] as const;
+
+const SLIDE_MATCHERS = [
+  { attribute: "data-vm0-slide" },
+  { attribute: "data-slide" },
+  { attribute: "data-slide-index" },
+  { attribute: "data-page" },
+  { className: "ppt-slide" },
+  { className: "presentation-slide" },
+  { className: "deck-slide" },
+  { className: "slide-page" },
+  { className: "slide" },
+  { tagName: "section" },
+] as const;
+
+type HtmlDocument = DefaultTreeAdapterTypes.Document;
+type HtmlElement = DefaultTreeAdapterTypes.Element;
+type HtmlNode = DefaultTreeAdapterTypes.Node;
+type HtmlParentNode = DefaultTreeAdapterTypes.ParentNode;
+
+interface SlideMatcher {
+  readonly attribute?: string;
+  readonly className?: string;
+  readonly tagName?: string;
+}
+
+interface SanitizedPresentationHtml {
+  readonly html: string;
+  readonly slideCount: number;
+}
+
+function isElement(node: HtmlNode): node is HtmlElement {
+  return "tagName" in node;
+}
+
+function includesString(values: readonly string[], value: string): boolean {
+  return values.includes(value);
+}
+
+function attributeValue(element: HtmlElement, name: string): string | null {
+  return (
+    element.attrs.find((attribute) => {
+      return attribute.name.toLowerCase() === name;
+    })?.value ?? null
+  );
+}
+
+function textContent(node: HtmlParentNode): string {
+  return node.childNodes
+    .map((child) => {
+      if (child.nodeName === "#text" && "value" in child) {
+        return child.value;
+      }
+      return "childNodes" in child ? textContent(child) : "";
+    })
+    .join("");
+}
+
+function isDeckMetadataScript(element: HtmlElement): boolean {
+  if (element.tagName !== "script") {
+    return false;
+  }
+  if (
+    attributeValue(element, "id") !== DECK_METADATA_SCRIPT_ID ||
+    attributeValue(element, "type")?.toLowerCase() !== "application/json" ||
+    attributeValue(element, "src") !== null
+  ) {
+    return false;
+  }
+  return safeJsonParse(textContent(element)) !== undefined;
+}
+
+function shouldRemoveElement(element: HtmlElement): boolean {
+  if (element.tagName === "script") {
+    return !isDeckMetadataScript(element);
+  }
+  if (includesString(BLOCKED_ELEMENTS, element.tagName)) {
+    return true;
+  }
+  if (element.tagName !== "meta") {
+    return false;
+  }
+  const httpEquiv = attributeValue(element, "http-equiv")?.toLowerCase();
+  return httpEquiv ? includesString(BLOCKED_META_HTTP_EQUIV, httpEquiv) : false;
+}
+
+function isUnsafeUrl(value: string, sourceUrl: string): boolean {
+  if (!URL.canParse(value, sourceUrl)) {
+    return true;
+  }
+  return includesString(
+    UNSAFE_PROTOCOLS,
+    new URL(value, sourceUrl).protocol.toLowerCase(),
+  );
+}
+
+function isUnsafeSrcset(value: string, sourceUrl: string): boolean {
+  return value.split(",").some((candidate) => {
+    const [url] = candidate.trim().split(/\s+/, 1);
+    return !url || isUnsafeUrl(url, sourceUrl);
+  });
+}
+
+function sanitizeAttributes(element: HtmlElement, sourceUrl: string): void {
+  if (isDeckMetadataScript(element)) {
+    element.attrs = [
+      { name: "id", value: DECK_METADATA_SCRIPT_ID },
+      { name: "type", value: "application/json" },
+    ];
+    return;
+  }
+
+  element.attrs = element.attrs.filter((attribute) => {
+    const name = attribute.name.toLowerCase();
+    if (name.startsWith("on") || name === "ping" || name === "srcdoc") {
+      return false;
+    }
+    if (name === "srcset") {
+      return !isUnsafeSrcset(attribute.value, sourceUrl);
+    }
+    if (includesString(ACTIVE_URL_ATTRIBUTES, name)) {
+      return !isUnsafeUrl(attribute.value, sourceUrl);
+    }
+    return true;
+  });
+}
+
+function sanitizeChildren(parent: HtmlParentNode, sourceUrl: string): void {
+  const children = parent.childNodes.filter((child) => {
+    return !isElement(child) || !shouldRemoveElement(child);
+  });
+  parent.childNodes = children;
+
+  for (const child of children) {
+    child.parentNode = parent;
+    if (!isElement(child)) {
+      continue;
+    }
+    sanitizeAttributes(child, sourceUrl);
+    sanitizeChildren(child, sourceUrl);
+    if (child.tagName === "template" && "content" in child) {
+      sanitizeChildren(child.content, sourceUrl);
+    }
+  }
+}
+
+function findElement(
+  node: HtmlParentNode,
+  tagName: string,
+): HtmlElement | null {
+  for (const child of node.childNodes) {
+    if (isElement(child)) {
+      if (child.tagName === tagName) {
+        return child;
+      }
+      const nested = findElement(child, tagName);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
+function prependSecurityElements(
+  document: HtmlDocument,
+  sourceUrl: string,
+): void {
+  const head = findElement(document, "head");
+  if (!head) {
+    throw new Error("Rendered presentation HTML has no head element");
+  }
+  const csp = defaultTreeAdapter.createElement("meta", parse5Html.NS.HTML, [
+    { name: "http-equiv", value: "Content-Security-Policy" },
+    { name: "content", value: PRESENTATION_CSP },
+  ]);
+  const base = defaultTreeAdapter.createElement("base", parse5Html.NS.HTML, [
+    { name: "href", value: sourceUrl },
+  ]);
+  csp.parentNode = head;
+  base.parentNode = head;
+  head.childNodes.unshift(csp, base);
+}
+
+function matchesSlide(element: HtmlElement, matcher: SlideMatcher): boolean {
+  if (matcher.tagName && element.tagName === matcher.tagName) {
+    return true;
+  }
+  if (
+    matcher.attribute &&
+    element.attrs.some((attribute) => {
+      return attribute.name.toLowerCase() === matcher.attribute;
+    })
+  ) {
+    return true;
+  }
+  const className = attributeValue(element, "class");
+  return Boolean(
+    matcher.className && className?.split(/\s+/).includes(matcher.className),
+  );
+}
+
+function countMatchingElements(
+  node: HtmlParentNode,
+  matcher: SlideMatcher,
+): number {
+  return node.childNodes.reduce((count, child) => {
+    if (!isElement(child)) {
+      return count;
+    }
+    return (
+      count +
+      (matchesSlide(child, matcher) ? 1 : 0) +
+      countMatchingElements(child, matcher)
+    );
+  }, 0);
+}
+
+function countSlides(document: HtmlDocument): number {
+  for (const matcher of SLIDE_MATCHERS) {
+    const count = countMatchingElements(document, matcher);
+    if (count > 0) {
+      return count;
+    }
+  }
+  return 0;
+}
+
+export function sanitizeMaterializedPresentationHtml(
+  sourceHtml: string,
+  sourceUrl: string,
+): SanitizedPresentationHtml {
+  const document = parse(sourceHtml);
+  sanitizeChildren(document, sourceUrl);
+  prependSecurityElements(document, sourceUrl);
+  return {
+    html: serialize(document),
+    slideCount: countSlides(document),
+  };
+}

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -93,6 +93,21 @@ export const hostedSiteRedeployPresentationHtmlRequestSchema = z.object({
   html: z.string().min(1),
 });
 
+export const materializePresentationHtmlRequestSchema = z.object({
+  url: z.string().url(),
+});
+
+export const materializedPresentationHtmlResponseSchema = z.object({
+  version: z.literal(1),
+  html: z
+    .string()
+    .min(1)
+    .max(5 * 1024 * 1024),
+  sourceUrl: z.string().url(),
+  sourceDeploymentId: z.string().uuid(),
+  slideCount: z.number().int().positive().max(500),
+});
+
 export const hostedSiteRedeployHtmlRequestSchema = z.object({
   url: z.string().url(),
   html: z.string().min(1),
@@ -241,6 +256,25 @@ export const zeroHostContract = c.router({
     },
     summary: "Redeploy an existing presentation HTML hosted site",
   },
+  materializePresentationHtml: {
+    method: "POST",
+    path: "/api/zero/host/presentation-html/materialize",
+    headers: authHeadersSchema,
+    body: materializePresentationHtmlRequestSchema,
+    responses: {
+      200: materializedPresentationHtmlResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      413: apiErrorSchema,
+      422: apiErrorSchema,
+      503: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Materialize presentation HTML after executing its scripts",
+  },
   redeployHtml: {
     method: "POST",
     path: "/api/zero/host/html/redeploy",
@@ -297,6 +331,12 @@ export type HostedSitePrepareRequest = z.infer<
 >;
 export type HostedSiteRedeployPresentationHtmlRequest = z.infer<
   typeof hostedSiteRedeployPresentationHtmlRequestSchema
+>;
+export type MaterializePresentationHtmlRequest = z.infer<
+  typeof materializePresentationHtmlRequestSchema
+>;
+export type MaterializedPresentationHtmlResponse = z.infer<
+  typeof materializedPresentationHtmlResponseSchema
 >;
 export type HostedSiteRedeployHtmlRequest = z.infer<
   typeof hostedSiteRedeployHtmlRequestSchema

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       music-metadata:
         specifier: ^11.13.0
         version: 11.13.0
+      parse5:
+        specifier: ^7.3.0
+        version: 7.3.0
       pg:
         specifier: ^8.20.0
         version: 8.20.0


### PR DESCRIPTION
## Summary

- add an authenticated presentation materialization endpoint that resolves the caller's current active deployment on every request
- execute dynamic presentation HTML through the existing isolated Cloudflare Browser Rendering boundary, then sanitize and validate the rendered DOM before returning it
- return `Cache-Control: no-store` and persist no derived snapshot, so redeploying the same website URL is reflected on the next conversion
- share the browser snapshot client with artifact preview without changing its existing output

## Security boundaries

- accept only organization-owned `presentation-html` deployments under the configured vm0 host domain
- render the canonical deployment URL from the database instead of the caller-provided URL
- remove executable scripts, event handlers, embedded browsing contexts, refresh directives, and unsafe URLs from the returned HTML
- preserve only validated JSON deck metadata and inject a no-script CSP

## Verification

- `pnpm --dir turbo -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F @vm0/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo -F api lint`
- `pnpm --dir turbo knip --workspace api --workspace @vm0/api-contracts`
- materialization BDD tests: 2 passed
- artifact preview regression tests: 14 passed

## Follow-up

A stacked frontend PR will route the Presentation Editor, PPTX export, and Google Slides export through this endpoint.