### PR TITLE
fix(runner): qualify guest rootfs before idle reuse

### DIFF
--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -28,6 +28,7 @@ pub mod masker;
 pub mod metrics;
 mod nofollow_fs;
 pub mod paths;
+pub mod reuse_preparation;
 pub mod run_context;
 pub mod session_history;
 pub mod session_history_identity;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -12,6 +12,7 @@ use guest_agent::http::HttpClient;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
+use guest_agent::reuse_preparation;
 use guest_agent::run_context::GuestRuntime;
 use guest_agent::session_history_identity;
 use guest_agent::session_metadata;
@@ -107,6 +108,28 @@ fn helper_exit_code_from_args() -> Option<i32> {
                     Err(error) => session_history_identity_helper_exit_code(&error),
                 },
             )
+        }
+        "prepare-for-reuse" => {
+            if args.next().is_some() {
+                return Some(
+                    guest_contracts::reuse_preparation::REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+                );
+            }
+            Some(match reuse_preparation::prepare_from_stdin() {
+                Ok(report) => match serde_json::to_string(&report) {
+                    Ok(json) => {
+                        println!("{json}");
+                        guest_contracts::reuse_preparation::REUSE_PREPARATION_EXIT_SUCCESS
+                    }
+                    Err(_) => {
+                        guest_contracts::reuse_preparation::REUSE_PREPARATION_EXIT_INSPECTION_FAILED
+                    }
+                },
+                Err(error) => {
+                    eprintln!("{error}");
+                    error.exit_code()
+                }
+            })
         }
         _ => None,
     }

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -16,13 +16,32 @@ use std::fs::{self, File, OpenOptions};
 #[cfg(target_os = "linux")]
 use std::io;
 #[cfg(target_os = "linux")]
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 #[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(target_os = "linux")]
 use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileIdentity {
+    device: libc::dev_t,
+    inode: libc::ino_t,
+    mount_id: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl FileIdentity {
+    pub(crate) fn device(self) -> libc::dev_t {
+        self.device
+    }
+
+    pub(crate) fn mount_id(self) -> u64 {
+        self.mount_id
+    }
+}
 
 #[cfg(target_os = "linux")]
 pub(crate) struct Dir(File);
@@ -44,6 +63,52 @@ impl Dir {
         )))
     }
 
+    pub(crate) fn open_absolute(path: &Path) -> io::Result<Self> {
+        if !path.is_absolute() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "directory path must be absolute",
+            ));
+        }
+
+        let mut current = Self::open(Path::new("/"))?;
+        for component in path.components() {
+            match component {
+                std::path::Component::RootDir => {}
+                std::path::Component::Normal(name) => {
+                    current = current.open_child_dir(name)?;
+                }
+                std::path::Component::CurDir
+                | std::path::Component::ParentDir
+                | std::path::Component::Prefix(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "directory path must contain only normal components",
+                    ));
+                }
+            }
+        }
+        Ok(current)
+    }
+
+    pub(crate) fn identity(&self) -> io::Result<FileIdentity> {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `stat` points to writable memory and the directory owns a
+        // live descriptor for the duration of the call.
+        let result = unsafe { libc::fstat(self.0.as_raw_fd(), stat.as_mut_ptr()) };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: successful `fstat` initialized the full structure.
+        let stat = unsafe { stat.assume_init() };
+        let mount_id = mount_id_for_fd(self.0.as_raw_fd())?;
+        Ok(FileIdentity {
+            device: stat.st_dev,
+            inode: stat.st_ino,
+            mount_id,
+        })
+    }
+
     pub(crate) fn open_child_dir(&self, name: &OsStr) -> io::Result<Self> {
         open_child(
             &self.0,
@@ -60,6 +125,69 @@ impl Dir {
             libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
         )
     }
+
+    pub(crate) fn remove_child_tree(
+        &self,
+        name: &OsStr,
+        filesystem: FileIdentity,
+        protected: &[FileIdentity],
+    ) -> io::Result<()> {
+        match self.open_child_dir(name) {
+            Ok(child) => {
+                let identity = child.identity()?;
+                if identity.device != filesystem.device || identity.mount_id != filesystem.mount_id
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "refusing to cross a mount or filesystem boundary during cleanup",
+                    ));
+                }
+                if protected.contains(&identity) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "refusing to remove a protected runtime directory",
+                    ));
+                }
+                let entries = child
+                    .read_dir()?
+                    .map(|entry| entry.map(|entry| entry.file_name()))
+                    .collect::<io::Result<Vec<_>>>()?;
+                for child_name in entries {
+                    child.remove_child_tree(&child_name, filesystem, protected)?;
+                }
+                unlink_child(&self.0, name, libc::AT_REMOVEDIR)
+            }
+            Err(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(libc::ENOTDIR) | Some(libc::ELOOP)
+                ) =>
+            {
+                unlink_child(&self.0, name, 0)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn mount_id_for_fd(fd: RawFd) -> io::Result<u64> {
+    let fdinfo = fs::read_to_string(format!("/proc/self/fdinfo/{fd}"))?;
+    let value = fdinfo
+        .lines()
+        .find_map(|line| line.strip_prefix("mnt_id:"))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                "filesystem mount identity is unavailable",
+            )
+        })?;
+    value.trim().parse().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid filesystem mount identity: {error}"),
+        )
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -82,6 +210,26 @@ fn open_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<File> {
     // SAFETY: a non-negative `openat` result is a newly owned fd. Converting
     // it into `File` transfers close responsibility to Rust.
     Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(target_os = "linux")]
+fn unlink_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<()> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes == b"." || bytes == b".." || bytes.contains(&b'/') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child name must be a non-empty basename",
+        ));
+    }
+    let name = CString::new(bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: the parent is a live directory descriptor, `name` is a
+    // NUL-terminated basename, and `flags` is either zero or AT_REMOVEDIR.
+    let result = unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), flags) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -34,12 +34,15 @@ pub(crate) struct FileIdentity {
 
 #[cfg(target_os = "linux")]
 impl FileIdentity {
-    pub(crate) fn device(self) -> libc::dev_t {
-        self.device
-    }
-
-    pub(crate) fn mount_id(self) -> u64 {
-        self.mount_id
+    pub(crate) fn ensure_same_mount(self, expected: Self) -> io::Result<()> {
+        if self.device == expected.device && self.mount_id == expected.mount_id {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "refusing to cross a mount or filesystem boundary during cleanup",
+            ))
+        }
     }
 }
 
@@ -92,21 +95,7 @@ impl Dir {
     }
 
     pub(crate) fn identity(&self) -> io::Result<FileIdentity> {
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: `stat` points to writable memory and the directory owns a
-        // live descriptor for the duration of the call.
-        let result = unsafe { libc::fstat(self.0.as_raw_fd(), stat.as_mut_ptr()) };
-        if result != 0 {
-            return Err(io::Error::last_os_error());
-        }
-        // SAFETY: successful `fstat` initialized the full structure.
-        let stat = unsafe { stat.assume_init() };
-        let mount_id = mount_id_for_fd(self.0.as_raw_fd())?;
-        Ok(FileIdentity {
-            device: stat.st_dev,
-            inode: stat.st_ino,
-            mount_id,
-        })
+        file_identity(&self.0)
     }
 
     pub(crate) fn open_child_dir(&self, name: &OsStr) -> io::Result<Self> {
@@ -135,13 +124,7 @@ impl Dir {
         match self.open_child_dir(name) {
             Ok(child) => {
                 let identity = child.identity()?;
-                if identity.device != filesystem.device || identity.mount_id != filesystem.mount_id
-                {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        "refusing to cross a mount or filesystem boundary during cleanup",
-                    ));
-                }
+                identity.ensure_same_mount(filesystem)?;
                 if protected.contains(&identity) {
                     return Err(io::Error::new(
                         io::ErrorKind::PermissionDenied,
@@ -168,6 +151,25 @@ impl Dir {
             Err(error) => Err(error),
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn file_identity(file: &File) -> io::Result<FileIdentity> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `file` owns a live
+    // descriptor for the duration of the call.
+    let result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful `fstat` initialized the full structure.
+    let stat = unsafe { stat.assume_init() };
+    let mount_id = mount_id_for_fd(file.as_raw_fd())?;
+    Ok(FileIdentity {
+        device: stat.st_dev,
+        inode: stat.st_ino,
+        mount_id,
+    })
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -1,0 +1,226 @@
+//! Safe reclamation of runner-owned runtime state before idle reuse.
+
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use guest_contracts::reuse_preparation::{
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
+    REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
+    RootFilesystemCapacity,
+};
+
+use crate::nofollow_fs::{Dir, FileIdentity};
+
+const MAX_REQUEST_BYTES: u64 = 64 * 1024;
+
+/// Failure returned by the reuse-preparation helper.
+#[derive(Debug)]
+pub enum ReusePreparationError {
+    /// The typed request or protected runtime paths were invalid.
+    InvalidRequest(io::Error),
+    /// Rootfs capacity could not be inspected.
+    Inspection(io::Error),
+    /// Stale runtime entries could not be safely removed.
+    Cleanup(io::Error),
+}
+
+impl ReusePreparationError {
+    /// Return the stable process exit code for this failure category.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::InvalidRequest(_) => REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+            Self::Inspection(_) => REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
+            Self::Cleanup(_) => REUSE_PREPARATION_EXIT_CLEANUP_FAILED,
+        }
+    }
+}
+
+impl std::fmt::Display for ReusePreparationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(error) => write!(f, "invalid reuse-preparation request: {error}"),
+            Self::Inspection(error) => write!(f, "rootfs capacity inspection failed: {error}"),
+            Self::Cleanup(error) => write!(f, "runtime cleanup failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ReusePreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidRequest(error) | Self::Inspection(error) | Self::Cleanup(error) => {
+                Some(error)
+            }
+        }
+    }
+}
+
+struct ProtectedRuntime {
+    name: OsString,
+    identity: FileIdentity,
+}
+
+/// Read a bounded request from stdin and prepare the guest for reuse.
+pub fn prepare_from_stdin() -> Result<ReusePreparationReport, ReusePreparationError> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take(MAX_REQUEST_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(ReusePreparationError::InvalidRequest)?;
+    if bytes.len() as u64 > MAX_REQUEST_BYTES {
+        return Err(ReusePreparationError::InvalidRequest(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "request exceeds size limit",
+        )));
+    }
+    let request = serde_json::from_slice(&bytes).map_err(|error| {
+        ReusePreparationError::InvalidRequest(io::Error::new(io::ErrorKind::InvalidData, error))
+    })?;
+    prepare(&request)
+}
+
+fn prepare(
+    request: &ReusePreparationRequest,
+) -> Result<ReusePreparationReport, ReusePreparationError> {
+    let current_path = Path::new(&request.current_runtime_dir);
+    let (runtime_parent, current_name) = split_runtime_path(current_path)?;
+    let retained_name = request
+        .retained_runtime_dir
+        .as_deref()
+        .map(Path::new)
+        .map(|path| split_retained_runtime_path(path, &runtime_parent))
+        .transpose()?;
+
+    let parent = Dir::open_absolute(&runtime_parent).map_err(ReusePreparationError::Cleanup)?;
+    let parent_identity = parent.identity().map_err(ReusePreparationError::Cleanup)?;
+    let mut protected = vec![open_protected(&parent, current_name, parent_identity)?];
+    if let Some(retained_name) = retained_name {
+        let retained = open_protected(&parent, retained_name, parent_identity)?;
+        if !protected
+            .iter()
+            .any(|entry| entry.identity == retained.identity)
+        {
+            protected.push(retained);
+        }
+    }
+
+    let before = rootfs_capacity().map_err(ReusePreparationError::Inspection)?;
+    let protected_identities = protected
+        .iter()
+        .map(|entry| entry.identity)
+        .collect::<Vec<_>>();
+    let protected_names = protected
+        .iter()
+        .map(|entry| entry.name.clone())
+        .collect::<Vec<_>>();
+    let entries = parent
+        .read_dir()
+        .map_err(ReusePreparationError::Cleanup)?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<io::Result<Vec<_>>>()
+        .map_err(ReusePreparationError::Cleanup)?;
+    let mut removed_entries = 0u64;
+    for name in entries {
+        if protected_names.contains(&name) {
+            continue;
+        }
+        parent
+            .remove_child_tree(&name, parent_identity, &protected_identities)
+            .map_err(ReusePreparationError::Cleanup)?;
+        removed_entries = removed_entries.saturating_add(1);
+    }
+
+    for entry in &protected {
+        let identity = parent
+            .open_child_dir(&entry.name)
+            .and_then(|directory| directory.identity())
+            .map_err(ReusePreparationError::Cleanup)?;
+        if identity != entry.identity {
+            return Err(ReusePreparationError::Cleanup(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "protected runtime directory identity changed during cleanup",
+            )));
+        }
+    }
+
+    let after = rootfs_capacity().map_err(ReusePreparationError::Inspection)?;
+    Ok(ReusePreparationReport {
+        before,
+        after,
+        removed_entries,
+    })
+}
+
+fn split_runtime_path(path: &Path) -> Result<(PathBuf, &OsStr), ReusePreparationError> {
+    if !path.is_absolute() {
+        return Err(invalid_path("current runtime directory must be absolute"));
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| *parent != Path::new("/"))
+        .ok_or_else(|| invalid_path("current runtime directory must have a non-root parent"))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| invalid_path("current runtime directory must have a basename"))?;
+    Ok((parent.to_path_buf(), name))
+}
+
+fn split_retained_runtime_path<'a>(
+    path: &'a Path,
+    expected_parent: &Path,
+) -> Result<&'a OsStr, ReusePreparationError> {
+    let (parent, name) = split_runtime_path(path)?;
+    if parent != expected_parent {
+        return Err(invalid_path(
+            "retained runtime directory must share the current runtime parent",
+        ));
+    }
+    Ok(name)
+}
+
+fn open_protected(
+    parent: &Dir,
+    name: &OsStr,
+    parent_identity: FileIdentity,
+) -> Result<ProtectedRuntime, ReusePreparationError> {
+    let directory = parent
+        .open_child_dir(name)
+        .map_err(ReusePreparationError::Cleanup)?;
+    let identity = directory
+        .identity()
+        .map_err(ReusePreparationError::Cleanup)?;
+    if identity.device() != parent_identity.device()
+        || identity.mount_id() != parent_identity.mount_id()
+    {
+        return Err(ReusePreparationError::Cleanup(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "protected runtime directory crosses a mount or filesystem boundary",
+        )));
+    }
+    Ok(ProtectedRuntime {
+        name: name.to_os_string(),
+        identity,
+    })
+}
+
+fn invalid_path(message: &'static str) -> ReusePreparationError {
+    ReusePreparationError::InvalidRequest(io::Error::new(io::ErrorKind::InvalidInput, message))
+}
+
+fn rootfs_capacity() -> io::Result<RootFilesystemCapacity> {
+    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: the path is a static NUL-terminated string and `stats` points to
+    // writable memory for the duration of the call.
+    let result = unsafe { libc::statvfs(c"/".as_ptr(), stats.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful `statvfs` initialized the full structure.
+    let stats = unsafe { stats.assume_init() };
+    Ok(RootFilesystemCapacity {
+        available_bytes: stats.f_bavail.saturating_mul(stats.f_frsize),
+        available_inodes: stats.f_favail,
+    })
+}

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -191,14 +191,9 @@ fn open_protected(
     let identity = directory
         .identity()
         .map_err(ReusePreparationError::Cleanup)?;
-    if identity.device() != parent_identity.device()
-        || identity.mount_id() != parent_identity.mount_id()
-    {
-        return Err(ReusePreparationError::Cleanup(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "protected runtime directory crosses a mount or filesystem boundary",
-        )));
-    }
+    identity
+        .ensure_same_mount(parent_identity)
+        .map_err(ReusePreparationError::Cleanup)?;
     Ok(ProtectedRuntime {
         name: name.to_os_string(),
         identity,

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "linux")]
 
 use std::io::Write;
-use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
@@ -118,27 +118,26 @@ fn prepare_for_reuse_rejects_retained_runtime_from_another_parent() -> TestResul
 }
 
 #[test]
-fn prepare_for_reuse_fails_closed_when_stale_directory_cannot_be_opened() -> TestResult {
+fn prepare_for_reuse_fails_closed_when_runtime_parent_is_not_a_directory() -> TestResult {
     let dir = tempfile::tempdir()?;
     let runs = dir.path().join("runs");
     let current = runs.join("current");
-    let stale = runs.join("stale");
-    std::fs::create_dir_all(&current)?;
-    std::fs::create_dir_all(&stale)?;
-    std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o000))?;
+    let outside = dir.path().join("outside");
+    std::fs::write(&runs, b"not-a-directory")?;
+    std::fs::create_dir_all(&outside)?;
+    std::fs::write(outside.join("keep"), b"outside")?;
 
     let output = run_helper(&ReusePreparationRequest {
         current_runtime_dir: path_string(&current),
         retained_runtime_dir: None,
     })?;
 
-    std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o700))?;
     assert_eq!(
         output.status.code(),
         Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED)
     );
-    assert!(current.exists());
-    assert!(stale.exists());
+    assert_eq!(std::fs::read(&runs)?, b"not-a-directory");
+    assert_eq!(std::fs::read(outside.join("keep"))?, b"outside");
     Ok(())
 }
 

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -1,8 +1,11 @@
 #![cfg(target_os = "linux")]
 
+use std::fs::File;
 use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::symlink;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 use guest_contracts::reuse_preparation::{
@@ -143,31 +146,17 @@ fn prepare_for_reuse_fails_closed_when_runtime_parent_is_not_a_directory() -> Te
 
 #[test]
 fn prepare_for_reuse_rejects_nested_filesystem_without_touching_it() -> TestResult {
-    let dir = tempfile::tempdir()?;
-    let mounted_source = tempfile::tempdir_in("/dev/shm")?;
-    let runs = dir.path().join("runs");
-    let current = runs.join("current");
-    let stale_mount = runs.join("stale/nested-mount");
-    std::fs::create_dir_all(&current)?;
-    std::fs::create_dir_all(&stale_mount)?;
-    std::fs::write(mounted_source.path().join("keep"), b"mounted-data")?;
-    let request = ReusePreparationRequest {
-        current_runtime_dir: path_string(&current),
-        retained_runtime_dir: None,
-    };
-    let output = run_helper_with_bind_mount(&request, mounted_source.path(), &stale_mount)?;
+    let mounted_data = tempfile::tempdir_in("/dev/shm")?;
+    std::fs::write(mounted_data.path().join("keep"), b"mounted-data")?;
 
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: "/dev/shm".into(),
+        retained_runtime_dir: None,
+    })?;
+
+    assert_mount_boundary_failure(&output);
     assert_eq!(
-        output.status.code(),
-        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED),
-        "stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(current.exists());
-    assert!(runs.join("stale").exists());
-    assert_eq!(
-        std::fs::read(mounted_source.path().join("keep"))?,
+        std::fs::read(mounted_data.path().join("keep"))?,
         b"mounted-data"
     );
     Ok(())
@@ -175,6 +164,17 @@ fn prepare_for_reuse_rejects_nested_filesystem_without_touching_it() -> TestResu
 
 #[test]
 fn prepare_for_reuse_rejects_same_filesystem_bind_mount() -> TestResult {
+    if let Some(mount_path) = find_existing_same_filesystem_nested_mount()? {
+        let output = run_helper(&ReusePreparationRequest {
+            current_runtime_dir: path_string(&mount_path),
+            retained_runtime_dir: None,
+        })?;
+
+        assert_mount_boundary_failure(&output);
+        assert!(mount_path.exists());
+        return Ok(());
+    }
+
     let dir = tempfile::tempdir()?;
     let mounted_source = dir.path().join("outside");
     let runs = dir.path().join("runs");
@@ -191,13 +191,7 @@ fn prepare_for_reuse_rejects_same_filesystem_bind_mount() -> TestResult {
 
     let output = run_helper_with_bind_mount(&request, &mounted_source, &stale_mount)?;
 
-    assert_eq!(
-        output.status.code(),
-        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED),
-        "stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    assert_mount_boundary_failure(&output);
     assert!(current.exists());
     assert!(runs.join("stale").exists());
     assert_eq!(std::fs::read(mounted_source.join("keep"))?, b"mounted-data");
@@ -248,6 +242,51 @@ fn run_helper_with_bind_mount(
         .ok_or_else(|| std::io::Error::other("helper stdin was not piped"))?
         .write_all(&serde_json::to_vec(request)?)?;
     Ok(child.wait_with_output()?)
+}
+
+fn find_existing_same_filesystem_nested_mount() -> TestResult<Option<PathBuf>> {
+    for candidate in ["/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys"] {
+        let path = Path::new(candidate);
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        if !path.is_dir() {
+            continue;
+        }
+        let parent_identity = path_mount_identity(parent)?;
+        let candidate_identity = path_mount_identity(path)?;
+        if parent_identity.0 == candidate_identity.0 && parent_identity.1 != candidate_identity.1 {
+            return Ok(Some(path.to_path_buf()));
+        }
+    }
+    Ok(None)
+}
+
+fn path_mount_identity(path: &Path) -> TestResult<(u64, u64)> {
+    let file = File::open(path)?;
+    let device = file.metadata()?.dev();
+    let fdinfo = std::fs::read_to_string(format!("/proc/self/fdinfo/{}", file.as_raw_fd()))?;
+    let mount_id = fdinfo
+        .lines()
+        .find_map(|line| line.strip_prefix("mnt_id:"))
+        .ok_or_else(|| std::io::Error::other("mount identity is unavailable"))?
+        .trim()
+        .parse()?;
+    Ok((device, mount_id))
+}
+
+fn assert_mount_boundary_failure(output: &Output) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED),
+        "stdout={}, stderr={stderr}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    assert!(
+        stderr.contains("mount or filesystem boundary"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 fn path_string(path: &Path) -> String {

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -1,0 +1,256 @@
+#![cfg(target_os = "linux")]
+
+use std::io::Write;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use guest_contracts::reuse_preparation::{
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+    ReusePreparationReport, ReusePreparationRequest,
+};
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let current = runs.join("current");
+    let retained = runs.join("retained");
+    let stale = runs.join("stale/nested");
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(current.join("logs"))?;
+    std::fs::create_dir_all(retained.join("logs"))?;
+    std::fs::create_dir_all(&stale)?;
+    std::fs::create_dir_all(&outside)?;
+    std::fs::write(
+        current.join("final-session-history-identity.json"),
+        b"current",
+    )?;
+    std::fs::write(
+        retained.join("final-session-history-identity.json"),
+        b"retained",
+    )?;
+    std::fs::write(stale.join("agent.jsonl"), b"stale")?;
+    std::fs::write(runs.join("stale-file"), b"stale")?;
+    std::fs::write(outside.join("keep"), b"outside")?;
+    symlink(&outside, runs.join("stale-link"))?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: Some(path_string(&retained)),
+    })?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
+    assert_eq!(report.removed_entries, 3);
+    assert!(report.before.available_bytes > 0);
+    assert!(report.after.available_bytes > 0);
+    assert_eq!(
+        std::fs::read(current.join("final-session-history-identity.json"))?,
+        b"current"
+    );
+    assert_eq!(
+        std::fs::read(retained.join("final-session-history-identity.json"))?,
+        b"retained"
+    );
+    assert!(!runs.join("stale").exists());
+    assert!(!runs.join("stale-file").exists());
+    assert!(!runs.join("stale-link").exists());
+    assert_eq!(std::fs::read(outside.join("keep"))?, b"outside");
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_symlinked_runtime_parent_without_touching_target() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let real_parent = dir.path().join("real/runs");
+    let current = real_parent.join("current");
+    let stale = real_parent.join("stale");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale)?;
+    std::fs::create_dir_all(dir.path().join("linked"))?;
+    symlink(&real_parent, dir.path().join("linked/runs"))?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&dir.path().join("linked/runs/current")),
+        retained_runtime_dir: None,
+    })?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED)
+    );
+    assert!(current.exists());
+    assert!(stale.exists());
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_retained_runtime_from_another_parent() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let current = dir.path().join("runs/current");
+    let retained = dir.path().join("other/retained");
+    let stale = dir.path().join("runs/stale");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&retained)?;
+    std::fs::create_dir_all(&stale)?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: Some(path_string(&retained)),
+    })?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_INVALID_REQUEST)
+    );
+    assert!(current.exists());
+    assert!(retained.exists());
+    assert!(stale.exists());
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_fails_closed_when_stale_directory_cannot_be_opened() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runs");
+    let current = runs.join("current");
+    let stale = runs.join("stale");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale)?;
+    std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o000))?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    })?;
+
+    std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o700))?;
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED)
+    );
+    assert!(current.exists());
+    assert!(stale.exists());
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_nested_filesystem_without_touching_it() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let mounted_source = tempfile::tempdir_in("/dev/shm")?;
+    let runs = dir.path().join("runs");
+    let current = runs.join("current");
+    let stale_mount = runs.join("stale/nested-mount");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale_mount)?;
+    std::fs::write(mounted_source.path().join("keep"), b"mounted-data")?;
+    let request = ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    };
+    let output = run_helper_with_bind_mount(&request, mounted_source.path(), &stale_mount)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(current.exists());
+    assert!(runs.join("stale").exists());
+    assert_eq!(
+        std::fs::read(mounted_source.path().join("keep"))?,
+        b"mounted-data"
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_same_filesystem_bind_mount() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let mounted_source = dir.path().join("outside");
+    let runs = dir.path().join("runs");
+    let current = runs.join("current");
+    let stale_mount = runs.join("stale/nested-mount");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale_mount)?;
+    std::fs::create_dir_all(&mounted_source)?;
+    std::fs::write(mounted_source.join("keep"), b"mounted-data")?;
+    let request = ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    };
+
+    let output = run_helper_with_bind_mount(&request, &mounted_source, &stale_mount)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(current.exists());
+    assert!(runs.join("stale").exists());
+    assert_eq!(std::fs::read(mounted_source.join("keep"))?, b"mounted-data");
+    Ok(())
+}
+
+fn run_helper(request: &ReusePreparationRequest) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env_clear()
+        .arg("prepare-for-reuse")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("helper stdin was not piped"))?
+        .write_all(&serde_json::to_vec(request)?)?;
+    Ok(child.wait_with_output()?)
+}
+
+fn run_helper_with_bind_mount(
+    request: &ReusePreparationRequest,
+    mount_source: &Path,
+    mount_target: &Path,
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut child = Command::new("/usr/bin/unshare")
+        .env_clear()
+        .env("VM0_MOUNT_SOURCE", mount_source)
+        .env("VM0_MOUNT_TARGET", mount_target)
+        .env("VM0_HELPER", env!("CARGO_BIN_EXE_guest-agent"))
+        .args([
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "/bin/sh",
+            "-c",
+            "/usr/bin/mount --bind \"$VM0_MOUNT_SOURCE\" \"$VM0_MOUNT_TARGET\" && exec \"$VM0_HELPER\" prepare-for-reuse",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("helper stdin was not piped"))?
+        .write_all(&serde_json::to_vec(request)?)?;
+    Ok(child.wait_with_output()?)
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -9,6 +9,7 @@ pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;
 pub mod exec_limits;
+pub mod reuse_preparation;
 pub mod runtime_paths;
 pub mod session_history_identity;
 pub mod storage_manifest;

--- a/crates/guest-contracts/src/reuse_preparation.rs
+++ b/crates/guest-contracts/src/reuse_preparation.rs
@@ -1,0 +1,45 @@
+//! Contract for preparing a completed guest for idle reuse.
+
+use serde::{Deserialize, Serialize};
+
+/// Helper completed successfully and emitted a reuse-preparation report.
+pub const REUSE_PREPARATION_EXIT_SUCCESS: i32 = 0;
+/// The helper request was missing or invalid.
+pub const REUSE_PREPARATION_EXIT_INVALID_REQUEST: i32 = 2;
+/// Root filesystem capacity could not be inspected.
+pub const REUSE_PREPARATION_EXIT_INSPECTION_FAILED: i32 = 3;
+/// Stale runner-owned runtime state could not be safely removed.
+pub const REUSE_PREPARATION_EXIT_CLEANUP_FAILED: i32 = 4;
+
+/// Runtime directories that must remain available after reuse preparation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReusePreparationRequest {
+    /// Runtime directory created for the completed run.
+    pub current_runtime_dir: String,
+    /// Earlier runtime directory still referenced by a retained session identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retained_runtime_dir: Option<String>,
+}
+
+/// User-available capacity on the guest root filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootFilesystemCapacity {
+    /// Bytes available to an unprivileged guest process.
+    pub available_bytes: u64,
+    /// Inodes available to an unprivileged guest process.
+    pub available_inodes: u64,
+}
+
+/// Result emitted after stale runner-owned runtime state is reclaimed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReusePreparationReport {
+    /// Rootfs capacity observed before cleanup.
+    pub before: RootFilesystemCapacity,
+    /// Rootfs capacity observed after cleanup.
+    pub after: RootFilesystemCapacity,
+    /// Number of unprotected entries removed directly below the runtime parent.
+    pub removed_entries: u64,
+}

--- a/crates/runner/scripts/agent-abnormal-exit-diagnostics.sh
+++ b/crates/runner/scripts/agent-abnormal-exit-diagnostics.sh
@@ -29,10 +29,17 @@ fi
 section resources
 ulimit -a 2>&1
 df -h 2>&1
+echo "VM0_DF_BLOCKS_V1"
 if [ -e /home/user/workspace ]; then
   df -P -k / /home/user/workspace 2>&1
 else
   df -P -k / 2>&1
+fi
+echo "VM0_DF_INODES_V1"
+if [ -e /home/user/workspace ]; then
+  df -P -i / /home/user/workspace 2>&1
+else
+  df -P -i / 2>&1
 fi
 if command -v free >/dev/null 2>&1; then
   free -m 2>&1

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -213,6 +213,7 @@ mod tests {
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult,
     };
+    use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
     use crate::resource_budget::ResourceBudget;
     use crate::storage_fingerprints::StorageFingerprints;
     use crate::workspace_promotion::test_support::{TEST_COMPLETED_AT, WorkspacePromotionFixture};
@@ -225,7 +226,10 @@ mod tests {
     #[tokio::test]
     async fn destroy_idle_jobs_and_wait_reports_workspace_cache_promotion() {
         let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-cache").await;
-        let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(MockSandboxFactory::new()));
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        add_healthy_reuse_preparation_matcher(&overrides);
+        let factory: Arc<Box<dyn SandboxFactory>> =
+            Arc::new(Box::new(MockSandboxFactory::with_overrides(overrides)));
         let sandbox = factory
             .create(SandboxConfig {
                 id: fixture.sandbox_id,
@@ -241,6 +245,7 @@ mod tests {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         let request = IdleParkRequest::new(IdleParkRequestParts {
+            run_id: crate::ids::RunId::new_v4(),
             sandbox,
             factory,
             cli_agent_session_id: fixture.session_id.clone(),

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1090,6 +1090,7 @@ mod tests {
     use crate::http::HttpClientConfig;
     use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
     use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult, ParkingGate};
+    use crate::idle_reuse_preparation::mock_sandbox_ready_for_idle_reuse;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
     use crate::provider::CompletionAuth;
     use crate::resource_budget::ResourceBudget;
@@ -1106,7 +1107,7 @@ mod tests {
         },
     };
     use sandbox::SandboxFactory;
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sandbox_mock::MockSandboxFactory;
     use sha2::{Digest, Sha256};
 
     fn read_active_run_phase(path: &std::path::Path) -> String {
@@ -1230,7 +1231,9 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("restore-plan-finalizer"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "restore-plan-finalizer",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -174,6 +174,11 @@ impl CompletionReady {
         self.session_affinity_changed
     }
 
+    #[cfg(test)]
+    pub(super) fn result_for_test(&self) -> (i32, Option<&str>) {
+        (self.payload.exit_code, self.payload.error.as_deref())
+    }
+
     pub(super) async fn complete_and_release(
         self,
         provider: &dyn JobProvider,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -793,6 +793,9 @@ fn log_job_execution_failed(
                 resource_failure_kind = resource_fields.resource_failure_kind,
                 guest_root_fs_used_percent = resource_fields.guest_root_fs_used_percent,
                 guest_root_fs_available_kb = resource_fields.guest_root_fs_available_kb,
+                guest_root_fs_inode_used_percent =
+                    resource_fields.guest_root_fs_inode_used_percent,
+                guest_root_fs_available_inodes = resource_fields.guest_root_fs_available_inodes,
                 guest_workspace_fs_used_percent = resource_fields.guest_workspace_fs_used_percent,
                 guest_memory_available_mb = resource_fields.guest_memory_available_mb,
                 $message
@@ -817,6 +820,8 @@ struct JobResourceLogFields {
     resource_failure_kind: Option<&'static str>,
     guest_root_fs_used_percent: Option<u64>,
     guest_root_fs_available_kb: Option<u64>,
+    guest_root_fs_inode_used_percent: Option<u64>,
+    guest_root_fs_available_inodes: Option<u64>,
     guest_workspace_fs_used_percent: Option<u64>,
     guest_memory_available_mb: Option<u64>,
 }
@@ -887,6 +892,11 @@ impl From<Option<executor::ResourceFailureDiagnostics>> for JobResourceLogFields
                 .map(u64::from),
             guest_root_fs_available_kb: diagnostics
                 .and_then(|diagnostics| diagnostics.guest_root_fs_available_kb),
+            guest_root_fs_inode_used_percent: diagnostics
+                .and_then(|diagnostics| diagnostics.guest_root_fs_inode_used_percent)
+                .map(u64::from),
+            guest_root_fs_available_inodes: diagnostics
+                .and_then(|diagnostics| diagnostics.guest_root_fs_available_inodes),
             guest_workspace_fs_used_percent: diagnostics
                 .and_then(|diagnostics| diagnostics.guest_workspace_fs_used_percent)
                 .map(u64::from),
@@ -980,7 +990,6 @@ mod tests {
         SessionHistoryStatus,
     };
     use sandbox::SandboxId;
-    use sandbox_mock::MockSandbox;
     use tracing::Level;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -993,6 +1002,7 @@ mod tests {
         IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult,
         test_support::ParkedIdleCandidateBuilder,
     };
+    use crate::idle_reuse_preparation::mock_sandbox_ready_for_idle_reuse;
     use crate::ids::RunId;
     use crate::provider::JobCandidate;
     use crate::resource_budget::ResourceBudget;
@@ -1202,7 +1212,7 @@ mod tests {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
-                sandbox: Some(Box::new(MockSandbox::new(sandbox_name))),
+                sandbox: Some(Box::new(mock_sandbox_ready_for_idle_reuse(sandbox_name))),
                 source_ip: "10.0.0.1".into(),
                 network_log_session: None,
                 workspace_image: None,
@@ -1682,6 +1692,8 @@ mod tests {
                 failure_kind: Some(executor::ResourceFailureKind::GuestRootFilesystemFull),
                 guest_root_fs_used_percent: Some(100),
                 guest_root_fs_available_kb: Some(20),
+                guest_root_fs_inode_used_percent: Some(99),
+                guest_root_fs_available_inodes: Some(42),
                 guest_workspace_fs_used_percent: Some(1),
                 guest_memory_available_mb: Some(624),
             }));
@@ -1703,6 +1715,8 @@ mod tests {
         );
         assert_field_eq(&event, "guest_root_fs_used_percent", "100");
         assert_field_eq(&event, "guest_root_fs_available_kb", "20");
+        assert_field_eq(&event, "guest_root_fs_inode_used_percent", "99");
+        assert_field_eq(&event, "guest_root_fs_available_inodes", "42");
         assert_field_eq(&event, "guest_workspace_fs_used_percent", "1");
         assert_field_eq(&event, "guest_memory_available_mb", "624");
     }
@@ -1768,6 +1782,8 @@ mod tests {
             failure_kind: Some(executor::ResourceFailureKind::GuestRootFilesystemFull),
             guest_root_fs_used_percent: Some(100),
             guest_root_fs_available_kb: Some(20),
+            guest_root_fs_inode_used_percent: Some(99),
+            guest_root_fs_available_inodes: Some(42),
             guest_workspace_fs_used_percent: Some(1),
             guest_memory_available_mb: Some(624),
         };

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -180,6 +180,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
         let park_request = IdleParkRequest::new(IdleParkRequestParts {
+            run_id,
             sandbox,
             factory: Arc::clone(&factory),
             cli_agent_session_id: cli_agent_session_id.clone(),
@@ -207,8 +208,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                 warn!(
                     run_id = %run_id,
                     session_id = %cli_agent_session_id,
+                    reason = failure.reason,
                     error = %failure.error,
-                    "sandbox park failed, destroying instead of parking"
+                    "sandbox idle admission failed, destroying instead of parking"
                 );
                 let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                     &held_session_snapshot,
@@ -217,7 +219,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     promote_workspace_image_from_active_sandbox(
                         sandbox.as_ref(),
                         workspace_promotion,
-                        "park_failed",
+                        failure.reason,
                     )
                     .await,
                 );
@@ -229,7 +231,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         sandbox_id,
                         profile_name: &profile_name,
                         cli_agent_session_id: Some(&cli_agent_session_id),
-                        reason: "park_failed",
+                        reason: failure.reason,
                         network_log_session: network_log_session.take(),
                         network_log_drain: network_log_drain.clone(),
                     },
@@ -629,6 +631,7 @@ mod tests {
     use std::time::Duration;
 
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+    use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
@@ -639,6 +642,9 @@ mod tests {
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
         RestoreReservedIdleResult, test_support::ParkedIdleCandidateBuilder,
+    };
+    use crate::idle_reuse_preparation::{
+        add_healthy_reuse_preparation_matcher, mock_sandbox_ready_for_idle_reuse,
     };
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -824,7 +830,9 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("network-log-park"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "network-log-park",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -868,6 +876,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finalizer_preserves_success_when_reuse_preparation_rejects_guest() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let workspace_dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(workspace_dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let workspace_image = prepare_test_workspace_image_lease(
+            &paths,
+            &cache,
+            run_id,
+            sandbox_id,
+            "sess-reuse-rejected",
+        )
+        .await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+            pattern: "prepare-for-reuse".into(),
+            exit_code: 0,
+            stdout: serde_json::to_vec(&ReusePreparationReport {
+                before: RootFilesystemCapacity {
+                    available_bytes: 64 * 1024 * 1024,
+                    available_inodes: 4096,
+                },
+                after: RootFilesystemCapacity {
+                    available_bytes: 64 * 1024 * 1024,
+                    available_inodes: 4096,
+                },
+                removed_entries: 0,
+            })
+            .unwrap(),
+            stderr: Vec::new(),
+        });
+        let (factory, sandbox) = sandbox_with_overrides(sandbox_id, Arc::clone(&overrides)).await;
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-reuse-rejected",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.factory = factory;
+        context.cleanup_state = cleanup_state.clone();
+        context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64;
+
+        let completion_ready = finalize_sandbox_for_completion(
+            Some(sandbox),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(completion_ready.result_for_test(), (0, None));
+        assert_eq!(overrides.park_call_count(), 0);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(fixture.idle_pool.lock().await.len(), 0);
+        let cache_states = cache.held_session_states().await;
+        assert_eq!(cache_states.len(), 1);
+        assert_eq!(cache_states[0].session_id, "sess-reuse-rejected");
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::DestroyCompleted
+        );
+    }
+
+    #[tokio::test]
     async fn finalizer_parking_log_uses_session_id() {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;
@@ -886,7 +973,9 @@ mod tests {
         context.test_observer = observer.clone();
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("finalizer-redaction"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "finalizer-redaction",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -925,7 +1014,9 @@ mod tests {
         context.cleanup_state = cleanup_state.clone();
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("cancel-after-transfer"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "cancel-after-transfer",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -1148,7 +1239,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("guest-session-promotion"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "guest-session-promotion",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -1365,7 +1458,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
 
         let _completion_ready = finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("rejected-workspace-promotion"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "rejected-workspace-promotion",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 run_id,
@@ -1416,6 +1511,7 @@ mod tests {
         );
         let destroy_gate = MockLifecycleGate::new();
         let existing_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        add_healthy_reuse_preparation_matcher(&existing_overrides);
         existing_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
         let existing_factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
             MockSandboxFactory::with_overrides(Arc::clone(&existing_overrides)),
@@ -1434,6 +1530,7 @@ mod tests {
             .expect("create existing sandbox");
         let (_existing_budget, existing_lease) = test_budget_lease();
         let existing_candidate = IdleParkRequest::new(IdleParkRequestParts {
+            run_id: old_run_id,
             source_ip: existing_sandbox.source_ip().to_owned(),
             sandbox: existing_sandbox,
             factory: existing_factory,
@@ -1475,7 +1572,9 @@ mod tests {
         context.park_notify = Arc::clone(&park_notify);
 
         let finalize_task = tokio::spawn(finalize_sandbox_for_completion(
-            Some(Box::new(MockSandbox::new("replacement-sandbox"))),
+            Some(Box::new(mock_sandbox_ready_for_idle_reuse(
+                "replacement-sandbox",
+            ))),
             ActiveBudgetLease::new(lease),
             CompletionPayload::new(
                 new_run_id,
@@ -1567,6 +1666,7 @@ mod tests {
         let cancel = RunCancellationHandle::new();
         let cleanup_state = RunCleanupState::new();
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        add_healthy_reuse_preparation_matcher(&overrides);
         let park_gate = MockLifecycleGate::new();
         let destroy_gate = MockLifecycleGate::new();
         overrides.set_park_lifecycle_gate(park_gate.clone());
@@ -1646,6 +1746,7 @@ mod tests {
         let cleanup_state = RunCleanupState::new();
         let observer = StartLoopTestObserver::default();
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        add_healthy_reuse_preparation_matcher(&overrides);
         let destroy_gate = MockLifecycleGate::new();
         overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
         let (factory, sandbox) = sandbox_with_overrides(sandbox_id, Arc::clone(&overrides)).await;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -106,7 +106,7 @@ fn build_mock_run_config(
         budget_memory_mb,
         max_concurrent,
         make_provider,
-        Box::new(MockSandboxRuntime::new()),
+        healthy_mock_sandbox_runtime(),
         "http://localhost:0",
     )
 }
@@ -144,9 +144,15 @@ pub(in super::super) fn mock_run_config_with_api_url(
         budget_memory_mb,
         max_concurrent,
         MockJobProvider::new,
-        Box::new(MockSandboxRuntime::new()),
+        healthy_mock_sandbox_runtime(),
         api_url,
     )
+}
+
+fn healthy_mock_sandbox_runtime() -> Box<dyn sandbox::SandboxRuntime> {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    Box::new(MockSandboxRuntime::with_overrides(overrides))
 }
 
 fn build_mock_run_config_with_runtime(
@@ -339,6 +345,7 @@ pub(in super::super) fn mock_run_config_with_overrides(
     max_concurrent: usize,
     overrides: Arc<sandbox_mock::MockSandboxOverrides>,
 ) -> (RunConfig, MockRunEnv) {
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
     build_mock_run_config_with_runtime(
         profiles,
         budget_vcpu,

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -2,6 +2,7 @@ use super::super::super::*;
 use super::TEST_SESSION_LAST_COMPLETED_AT;
 
 use crate::idle_pool::{ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder};
+use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
@@ -23,6 +24,14 @@ fn make_synthetic_parked_candidate(
         .build()
 }
 
+struct IdlePoolSeedSpec<'a> {
+    session_id: &'a str,
+    profile_name: &'a str,
+    vcpu: u32,
+    memory_mb: u32,
+    history_generation_run_id: Option<RunId>,
+}
+
 /// Pre-populate idle pool with an entry and reserve its budget. Returns
 /// the entry's sandbox id so reuse tests can assert it propagates through
 /// to the completion payload.
@@ -34,14 +43,19 @@ pub(in super::super) async fn seed_idle_pool(
     vcpu: u32,
     memory_mb: u32,
 ) -> SandboxId {
-    seed_idle_pool_with_generation(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    seed_idle_pool_with_overrides_and_generation(
         pool,
         budget,
-        session_id,
-        profile_name,
-        vcpu,
-        memory_mb,
-        None,
+        &overrides,
+        IdlePoolSeedSpec {
+            session_id,
+            profile_name,
+            vcpu,
+            memory_mb,
+            history_generation_run_id: None,
+        },
     )
     .await
 }
@@ -55,40 +69,21 @@ pub(in super::super) async fn seed_idle_pool_with_history_generation(
     memory_mb: u32,
     history_generation_run_id: RunId,
 ) -> SandboxId {
-    seed_idle_pool_with_generation(
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    seed_idle_pool_with_overrides_and_generation(
         pool,
         budget,
-        session_id,
-        profile_name,
-        vcpu,
-        memory_mb,
-        Some(history_generation_run_id),
+        &overrides,
+        IdlePoolSeedSpec {
+            session_id,
+            profile_name,
+            vcpu,
+            memory_mb,
+            history_generation_run_id: Some(history_generation_run_id),
+        },
     )
     .await
-}
-
-async fn seed_idle_pool_with_generation(
-    pool: &SharedIdlePool,
-    budget: &Arc<ResourceBudget>,
-    session_id: &str,
-    profile_name: &str,
-    vcpu: u32,
-    memory_mb: u32,
-    history_generation_run_id: Option<RunId>,
-) -> SandboxId {
-    let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-    let builder = ParkedIdleCandidateBuilder::new(session_id, budget_lease)
-        .with_profile_name(profile_name)
-        .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string());
-    let candidate = match history_generation_run_id {
-        Some(run_id) => builder.with_history_generation_run_id(run_id).build(),
-        None => builder.build(),
-    };
-    let sandbox_id = candidate.sandbox_id();
-    let mut guard = pool.lock().await;
-    let result = guard.park(candidate);
-    assert!(matches!(result, ParkResult::Parked));
-    sandbox_id
 }
 
 pub(in super::super) async fn seed_idle_pool_with_overrides(
@@ -100,6 +95,34 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
     vcpu: u32,
     memory_mb: u32,
 ) -> SandboxId {
+    seed_idle_pool_with_overrides_and_generation(
+        pool,
+        budget,
+        overrides,
+        IdlePoolSeedSpec {
+            session_id,
+            profile_name,
+            vcpu,
+            memory_mb,
+            history_generation_run_id: None,
+        },
+    )
+    .await
+}
+
+async fn seed_idle_pool_with_overrides_and_generation(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    overrides: &Arc<sandbox_mock::MockSandboxOverrides>,
+    spec: IdlePoolSeedSpec<'_>,
+) -> SandboxId {
+    let IdlePoolSeedSpec {
+        session_id,
+        profile_name,
+        vcpu,
+        memory_mb,
+        history_generation_run_id,
+    } = spec;
     let runtime = sandbox_mock::MockSandboxRuntime::with_overrides(Arc::clone(overrides));
     let factory = runtime
         .create_factory(sandbox::FactoryConfig {
@@ -129,16 +152,18 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
     let budget_lease =
         ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).expect("reserve budget");
 
+    let builder = ParkedIdleCandidateBuilder::new(session_id, budget_lease)
+        .with_sandbox(sandbox)
+        .with_factory(factory_arc)
+        .with_sandbox_id(sandbox_id)
+        .with_profile_name(profile_name)
+        .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT);
+    let candidate = match history_generation_run_id {
+        Some(run_id) => builder.with_history_generation_run_id(run_id).build(),
+        None => builder.build(),
+    };
     let mut guard = pool.lock().await;
-    let result = guard.park(
-        ParkedIdleCandidateBuilder::new(session_id, budget_lease)
-            .with_sandbox(sandbox)
-            .with_factory(factory_arc)
-            .with_sandbox_id(sandbox_id)
-            .with_profile_name(profile_name)
-            .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT)
-            .build(),
-    );
+    let result = guard.park(candidate);
     assert!(matches!(result, ParkResult::Parked));
     sandbox_id
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -802,6 +802,16 @@ impl AgentExecutionResult {
         self
     }
 
+    pub(super) fn with_resource_diagnostics(
+        mut self,
+        resource_diagnostics: Option<ResourceFailureDiagnostics>,
+    ) -> Self {
+        if let Some(failure) = self.failure.take() {
+            self.failure = Some(failure.with_resource_diagnostics(resource_diagnostics));
+        }
+        self
+    }
+
     #[must_use]
     pub(super) fn with_resource_failure_kind(mut self, kind: ResourceFailureKind) -> Self {
         if let Some(failure) = self.failure.take() {

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -36,9 +36,9 @@ pub(super) use environment::{
     AgentEnvDiagnostics, build_agent_env_diagnostics, build_agent_env_key_diagnostics,
 };
 pub(super) use exit::{
-    AgentBootstrapAbnormalExitLogContext, log_agent_abnormal_exit_env_diagnostics,
-    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
-    should_collect_agent_abnormal_exit_diagnostics,
+    AgentBootstrapAbnormalExitLogContext, explicit_enospc_evidence,
+    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
+    log_agent_process_exit_summary, should_collect_agent_abnormal_exit_diagnostics,
     should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };

--- a/crates/runner/src/executor/diagnostics/exit.rs
+++ b/crates/runner/src/executor/diagnostics/exit.rs
@@ -17,12 +17,26 @@ pub(in crate::executor) fn should_collect_agent_abnormal_exit_diagnostics(
     failure_diagnostic: Option<&FailureDiagnostic>,
     guest_error: Option<&str>,
 ) -> bool {
-    !wait_cancelled
-        && process_failed(exit)
-        && exit.diagnostic.is_empty()
+    let unexplained_failure = exit.diagnostic.is_empty()
         && stderr.is_empty()
         && failure_diagnostic.is_none()
-        && guest_error.is_none()
+        && guest_error.is_none();
+    let explicit_enospc = explicit_enospc_evidence([
+        stderr,
+        exit.diagnostic.as_str(),
+        guest_error.unwrap_or_default(),
+    ]);
+
+    !wait_cancelled && process_failed(exit) && (unexplained_failure || explicit_enospc)
+}
+
+pub(in crate::executor) fn explicit_enospc_evidence<'a>(
+    values: impl IntoIterator<Item = &'a str>,
+) -> bool {
+    values.into_iter().any(|value| {
+        let value = value.to_ascii_lowercase();
+        value.contains("no space left on device") || value.contains("os error 28")
+    })
 }
 
 pub(in crate::executor) fn should_collect_unattributed_sigkill_resource_diagnostics(

--- a/crates/runner/src/executor/diagnostics/resource.rs
+++ b/crates/runner/src/executor/diagnostics/resource.rs
@@ -9,23 +9,49 @@ use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::ids::RunId;
 
 const ROOTFS_FULL_AVAILABLE_KB_THRESHOLD: u64 = 1024;
+const DF_BLOCKS_MARKER: &str = "VM0_DF_BLOCKS_V1";
+const DF_INODES_MARKER: &str = "VM0_DF_INODES_V1";
+
+#[derive(Clone, Copy)]
+enum FilesystemTable {
+    Blocks,
+    Inodes,
+}
 
 pub(in crate::executor) fn parse_agent_abnormal_exit_resource_diagnostics(
     stdout: &str,
 ) -> Option<ResourceFailureDiagnostics> {
     let mut diagnostics = ResourceFailureDiagnostics::default();
+    let mut filesystem_table = FilesystemTable::Blocks;
 
     for line in stdout.lines() {
+        match line.trim() {
+            DF_BLOCKS_MARKER => {
+                filesystem_table = FilesystemTable::Blocks;
+                continue;
+            }
+            DF_INODES_MARKER => {
+                filesystem_table = FilesystemTable::Inodes;
+                continue;
+            }
+            _ => {}
+        }
+
         if let Some(filesystem) = parse_filesystem_usage_line(line) {
-            match filesystem.mount_point {
-                "/" => {
+            match (filesystem_table, filesystem.mount_point) {
+                (FilesystemTable::Blocks, "/") => {
                     diagnostics.guest_root_fs_used_percent = Some(filesystem.used_percent);
-                    diagnostics.guest_root_fs_available_kb = filesystem.available_kb;
+                    diagnostics.guest_root_fs_available_kb = filesystem.available;
                 }
-                "/home/user/workspace" => {
+                (FilesystemTable::Blocks, "/home/user/workspace") => {
                     diagnostics.guest_workspace_fs_used_percent = Some(filesystem.used_percent);
                 }
-                _ => {}
+                (FilesystemTable::Inodes, "/") => {
+                    diagnostics.guest_root_fs_inode_used_percent = Some(filesystem.used_percent);
+                    diagnostics.guest_root_fs_available_inodes = filesystem.available;
+                }
+                (FilesystemTable::Inodes, "/home/user/workspace") => {}
+                (_, _) => {}
             }
         }
 
@@ -44,7 +70,7 @@ pub(in crate::executor) fn parse_agent_abnormal_exit_resource_diagnostics(
 struct FilesystemUsage<'a> {
     mount_point: &'a str,
     used_percent: u16,
-    available_kb: Option<u64>,
+    available: Option<u64>,
 }
 
 fn parse_filesystem_usage_line(line: &str) -> Option<FilesystemUsage<'_>> {
@@ -61,14 +87,14 @@ fn parse_filesystem_usage_line(line: &str) -> Option<FilesystemUsage<'_>> {
     let used_percent = columns
         .get(columns.len().saturating_sub(2))
         .and_then(|value| parse_percent(value))?;
-    let available_kb = columns
+    let available = columns
         .get(columns.len().saturating_sub(3))
-        .and_then(|value| parse_available_kb(value));
+        .and_then(|value| parse_available_value(value));
 
     Some(FilesystemUsage {
         mount_point,
         used_percent,
-        available_kb,
+        available,
     })
 }
 
@@ -76,7 +102,7 @@ fn parse_percent(value: &str) -> Option<u16> {
     value.strip_suffix('%')?.parse().ok()
 }
 
-fn parse_available_kb(value: &str) -> Option<u64> {
+fn parse_available_value(value: &str) -> Option<u64> {
     if let Ok(kb) = value.parse() {
         return Some(kb);
     }
@@ -115,6 +141,10 @@ fn rootfs_is_clearly_full(diagnostics: &ResourceFailureDiagnostics) -> bool {
         || diagnostics
             .guest_root_fs_available_kb
             .is_some_and(|available_kb| available_kb <= ROOTFS_FULL_AVAILABLE_KB_THRESHOLD)
+        || diagnostics
+            .guest_root_fs_inode_used_percent
+            .is_some_and(|percent| percent >= 100)
+        || diagnostics.guest_root_fs_available_inodes == Some(0)
 }
 
 pub(in crate::executor) async fn collect_agent_abnormal_exit_diagnostics(
@@ -141,9 +171,7 @@ pub(in crate::executor) async fn collect_agent_abnormal_exit_diagnostics(
             let stdout = String::from_utf8_lossy(&result.stdout);
             let stderr = String::from_utf8_lossy(&result.stderr);
             let diagnostic_succeeded = helper_exec_succeeded(&result);
-            let resource_diagnostics = diagnostic_succeeded
-                .then(|| parse_agent_abnormal_exit_resource_diagnostics(&stdout))
-                .flatten();
+            let resource_diagnostics = parse_agent_abnormal_exit_resource_diagnostics(&stdout);
             let resource_failure_kind = resource_diagnostics
                 .and_then(|diagnostics| diagnostics.failure_kind)
                 .map(ResourceFailureKind::as_str);
@@ -152,6 +180,11 @@ pub(in crate::executor) async fn collect_agent_abnormal_exit_diagnostics(
                 .map(u64::from);
             let guest_root_fs_available_kb =
                 resource_diagnostics.and_then(|diagnostics| diagnostics.guest_root_fs_available_kb);
+            let guest_root_fs_inode_used_percent = resource_diagnostics
+                .and_then(|diagnostics| diagnostics.guest_root_fs_inode_used_percent)
+                .map(u64::from);
+            let guest_root_fs_available_inodes = resource_diagnostics
+                .and_then(|diagnostics| diagnostics.guest_root_fs_available_inodes);
             let guest_workspace_fs_used_percent = resource_diagnostics
                 .and_then(|diagnostics| diagnostics.guest_workspace_fs_used_percent)
                 .map(u64::from);
@@ -171,6 +204,8 @@ pub(in crate::executor) async fn collect_agent_abnormal_exit_diagnostics(
                 resource_failure_kind,
                 guest_root_fs_used_percent,
                 guest_root_fs_available_kb,
+                guest_root_fs_inode_used_percent,
+                guest_root_fs_available_inodes,
                 guest_workspace_fs_used_percent,
                 guest_memory_available_mb,
                 diagnostic_stdout = %stdout,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -304,6 +304,8 @@ pub struct ResourceFailureDiagnostics {
     pub failure_kind: Option<ResourceFailureKind>,
     pub guest_root_fs_used_percent: Option<u16>,
     pub guest_root_fs_available_kb: Option<u64>,
+    pub guest_root_fs_inode_used_percent: Option<u16>,
+    pub guest_root_fs_available_inodes: Option<u64>,
     pub guest_workspace_fs_used_percent: Option<u16>,
     pub guest_memory_available_mb: Option<u64>,
 }
@@ -322,6 +324,8 @@ impl ResourceFailureDiagnostics {
         self.failure_kind.is_none()
             && self.guest_root_fs_used_percent.is_none()
             && self.guest_root_fs_available_kb.is_none()
+            && self.guest_root_fs_inode_used_percent.is_none()
+            && self.guest_root_fs_available_inodes.is_none()
             && self.guest_workspace_fs_used_percent.is_none()
             && self.guest_memory_available_mb.is_none()
     }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -19,7 +19,8 @@ use super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::diagnostics::{
-    AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log, copy_guest_logs,
+    AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log,
+    collect_agent_abnormal_exit_diagnostics, copy_guest_logs, explicit_enospc_evidence,
     read_guest_cli_agent_session_id,
 };
 use super::session_id::{
@@ -970,6 +971,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         network_log_session,
     } = run;
     let cleanup_cancel = controls.cancel.clone();
+    let reuse_result = start.reuse_result;
 
     let result = run_in_sandbox(
         sandbox.as_ref(),
@@ -980,6 +982,20 @@ pub(super) async fn execute_prepared_sandbox_run(
         controls,
     )
     .await;
+
+    let pre_process_resource_diagnostics = match result.as_ref() {
+        Err(error) if explicit_enospc_evidence([error.to_string().as_str()]) => {
+            collect_agent_abnormal_exit_diagnostics(
+                sandbox.as_ref(),
+                context.run_id,
+                sandbox.id(),
+                reuse_result,
+                1,
+            )
+            .await
+        }
+        Ok(_) | Err(_) => None,
+    };
 
     let stdout_stream_diagnostics = result.as_ref().map_or_else(
         |_| AgentStdoutStreamDiagnostics::default(),
@@ -1002,7 +1018,8 @@ pub(super) async fn execute_prepared_sandbox_run(
 
     let mut agent_result = match result {
         Ok(result) => result,
-        Err(e) => AgentExecutionResult::failure_from_error(e.to_string()),
+        Err(e) => AgentExecutionResult::failure_from_error(e.to_string())
+            .with_resource_diagnostics(pre_process_resource_diagnostics),
     };
     if let Err(e) = cleanup_result {
         warn!(

--- a/crates/runner/src/executor/tests/diagnostics_tests/exit.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/exit.rs
@@ -60,6 +60,34 @@ fn bootstrap_abnormal_exit_diagnostics_allow_captured_stderr_without_resource_pr
     ));
 }
 
+#[test]
+fn explicit_enospc_collects_resources_even_with_structured_failure() {
+    let exit = ProcessExit::new(1, 1, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(1);
+
+    assert!(should_collect_agent_abnormal_exit_diagnostics(
+        false,
+        &exit,
+        "",
+        Some(&diagnostic),
+        Some("thread store initialization failed: No space left on device (os error 28)"),
+    ));
+}
+
+#[test]
+fn unrelated_structured_failure_does_not_collect_resources() {
+    let exit = ProcessExit::new(1, 1, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(1);
+
+    assert!(!should_collect_agent_abnormal_exit_diagnostics(
+        false,
+        &exit,
+        "",
+        Some(&diagnostic),
+        Some("authentication failed"),
+    ));
+}
+
 fn fallback_cli_nonzero_diagnostic(exit_code: i32) -> FailureDiagnostic {
     FailureDiagnostic::new(
         FailureClass::CliNonzero,

--- a/crates/runner/src/executor/tests/diagnostics_tests/resource.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/resource.rs
@@ -19,8 +19,57 @@ Swap:              0           0           0
     );
     assert_eq!(diagnostics.guest_root_fs_used_percent, Some(100));
     assert_eq!(diagnostics.guest_root_fs_available_kb, Some(20));
+    assert_eq!(diagnostics.guest_root_fs_inode_used_percent, None);
+    assert_eq!(diagnostics.guest_root_fs_available_inodes, None);
     assert_eq!(diagnostics.guest_workspace_fs_used_percent, Some(1));
     assert_eq!(diagnostics.guest_memory_available_mb, Some(624));
+}
+
+#[test]
+fn abnormal_exit_resource_diagnostics_classifies_rootfs_inode_exhaustion() {
+    let diagnostics = parse_agent_abnormal_exit_resource_diagnostics(
+        r#"
+VM0_DF_BLOCKS_V1
+Filesystem     1024-blocks    Used Available Capacity Mounted on
+/dev/root          8388608 4194304   4194304      50% /
+/dev/vdb          16777216      24  16777192       1% /home/user/workspace
+VM0_DF_INODES_V1
+Filesystem       Inodes   IUsed   IFree IUse% Mounted on
+/dev/root        524288  524288       0  100% /
+/dev/vdb        1048576      32 1048544    1% /home/user/workspace
+"#,
+    )
+    .expect("inode diagnostics should parse");
+
+    assert_eq!(
+        diagnostics.failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
+    );
+    assert_eq!(diagnostics.guest_root_fs_used_percent, Some(50));
+    assert_eq!(diagnostics.guest_root_fs_available_kb, Some(4_194_304));
+    assert_eq!(diagnostics.guest_root_fs_inode_used_percent, Some(100));
+    assert_eq!(diagnostics.guest_root_fs_available_inodes, Some(0));
+}
+
+#[test]
+fn abnormal_exit_resource_diagnostics_keeps_sections_before_later_failure_output() {
+    let diagnostics = parse_agent_abnormal_exit_resource_diagnostics(
+        r#"
+VM0_DF_BLOCKS_V1
+/dev/root 8388608 8388608 0 100% /
+VM0_DF_INODES_V1
+/dev/root 524288 524280 8 100% /
+/home/user: du timed out or failed
+"#,
+    )
+    .expect("valid resource sections should survive later helper failure output");
+
+    assert_eq!(
+        diagnostics.failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
+    );
+    assert_eq!(diagnostics.guest_root_fs_available_kb, Some(0));
+    assert_eq!(diagnostics.guest_root_fs_available_inodes, Some(8));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -657,6 +657,7 @@ async fn execute_inner_abnormal_exit_collects_guest_diagnostics() {
         "diagnostic command must not collect raw environment output"
     );
     assert!(active_diagnostic_cmd.contains("df -P -k / /home/user/workspace"));
+    assert!(active_diagnostic_cmd.contains("df -P -i / /home/user/workspace"));
     assert!(active_diagnostic_cmd.contains("section rootfs-usage"));
     assert!(active_diagnostic_cmd.contains("timeout 1s du -sxh -- \"$target_path\""));
     assert!(active_diagnostic_cmd.contains("du -sxh -- \"$target_path\""));
@@ -670,7 +671,7 @@ async fn execute_inner_abnormal_exit_collects_guest_diagnostics() {
 }
 
 #[tokio::test]
-async fn execute_inner_ignores_non_exited_abnormal_exit_diagnostics() {
+async fn execute_inner_keeps_partial_resource_output_when_diagnostic_helper_fails() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -695,7 +696,13 @@ async fn execute_inner_ignores_non_exited_abnormal_exit_diagnostics() {
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(failure.exit_code, 126);
     assert_eq!(failure.error, "Agent exited with code 126");
-    assert!(failure.resource_diagnostics.is_none());
+    assert_eq!(
+        failure
+            .resource_diagnostics
+            .expect("valid partial resource output should be retained")
+            .failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
+    );
 }
 
 #[tokio::test]
@@ -831,6 +838,62 @@ async fn execute_inner_nonzero_with_failure_diagnostic_skips_abnormal_exit_diagn
             .exec_calls()
             .iter()
             .all(|call| !call.cmd.contains("guest-agent-binary"))
+    );
+}
+
+#[tokio::test]
+async fn execute_inner_codex_enospc_preserves_structured_failure_and_collects_resources() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("continue"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(FailureDetailSource::CodexJsonl);
+    overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+    let guest_error = "thread store initialization failed: No space left on device (os error 28)";
+    overrides.push_read_file_result(Ok(Some(guest_error.as_bytes().to_vec())));
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "guest-agent-binary".into(),
+        exit_code: 0,
+        stdout: b"VM0_DF_BLOCKS_V1\n/dev/root 8388608 8388608 0 100% /\nVM0_DF_INODES_V1\n/dev/root 524288 524288 0 100% /\n".to_vec(),
+        stderr: Vec::new(),
+    });
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let outcome = run_new_sandbox_outcome(&factory, &minimal_context(), &config, &default_params())
+        .await
+        .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 1);
+    assert_eq!(failure.error, guest_error);
+    let retained_diagnostic = failure
+        .diagnostic
+        .as_ref()
+        .expect("structured Codex diagnostic should be retained");
+    assert_eq!(retained_diagnostic.failure_class, FailureClass::CliNonzero);
+    assert_eq!(retained_diagnostic.framework, AgentFramework::Codex);
+    assert_eq!(retained_diagnostic.cli_exit_code, Some(1));
+    assert_eq!(
+        failure
+            .resource_diagnostics
+            .expect("expected ENOSPC resource diagnostics")
+            .failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
+    );
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(
+        overrides
+            .exec_calls()
+            .iter()
+            .filter(|call| call.cmd.contains("guest-agent-binary"))
+            .count(),
+        1
     );
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -292,25 +292,39 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
 }
 
 #[tokio::test]
-async fn execute_inner_run_payload_private_write_failure_does_not_start_agent() {
+async fn execute_inner_run_payload_enospc_collects_resources_without_starting_agent() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.push_private_write_file_result(Err(sandbox_write_file_error(
-        "payload private write failed",
+        "No space left on device (os error 28)",
     )));
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "guest-agent-binary".into(),
+        exit_code: 0,
+        stdout: b"VM0_DF_BLOCKS_V1\n/dev/root 8388608 8388608 0 100% /\nVM0_DF_INODES_V1\n/dev/root 524288 524280 8 100% /\n".to_vec(),
+        stderr: Vec::new(),
+    });
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
-    let (exit_code, error_msg) =
-        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
-            .await
-            .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &minimal_context(), &config, &default_params())
+        .await
+        .unwrap();
 
-    assert_eq!(exit_code, 1);
-    let error = error_msg.unwrap();
+    assert_eq!(outcome.exit_code(), 1);
+    let failure = outcome.failure.as_ref().expect("expected failure");
     assert!(
-        error.contains("payload private write failed"),
-        "got: {error}"
+        failure
+            .error
+            .contains("No space left on device (os error 28)"),
+        "got: {failure:?}"
+    );
+    assert_eq!(
+        failure
+            .resource_diagnostics
+            .expect("expected resource diagnostics")
+            .failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
     );
     let private_writes = overrides.private_write_file_calls();
     assert_eq!(private_writes.len(), 1);
@@ -324,6 +338,14 @@ async fn execute_inner_run_payload_private_write_failure_does_not_start_agent() 
     assert!(
         overrides.start_process_calls().is_empty(),
         "agent must not start after run payload write failure"
+    );
+    assert_eq!(
+        overrides
+            .exec_calls()
+            .iter()
+            .filter(|call| call.cmd.contains("guest-agent-binary"))
+            .count(),
+        1
     );
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -519,7 +519,10 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
             .contains("failed to invalidate workspace image cache before unconfigured-cache reuse")
     );
     assert!(
-        overrides.exec_calls().is_empty(),
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| call.cmd.contains("prepare-for-reuse")),
         "reused sandbox must not run after stale cache invalidation fails"
     );
 }
@@ -582,7 +585,10 @@ async fn unconfigured_cache_reuse_stops_when_required_cache_invalidation_lock_is
         "lock contention should be surfaced, got: {error}"
     );
     assert!(
-        overrides.exec_calls().is_empty(),
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| call.cmd.contains("prepare-for-reuse")),
         "reused sandbox must not run when required stale cache invalidation cannot get the entry lock"
     );
     assert!(
@@ -809,6 +815,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         .unwrap();
 
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
     let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
         MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
     ));
@@ -826,6 +833,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         .expect("create sandbox");
     let source_ip = sandbox.source_ip().to_owned();
     let candidate = IdleParkRequest::new(IdleParkRequestParts {
+        run_id,
         sandbox,
         factory,
         cli_agent_session_id: session_id.to_owned(),
@@ -917,6 +925,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         .unwrap();
 
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
     let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
         MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
     ));
@@ -934,6 +943,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         .expect("create sandbox");
     let source_ip = sandbox.source_ip().to_owned();
     let candidate = IdleParkRequest::new(IdleParkRequestParts {
+        run_id,
         sandbox,
         factory,
         cli_agent_session_id: session_id.to_owned(),

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -10,6 +10,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
+use crate::idle_reuse_preparation::prepare_sandbox_for_idle_reuse;
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
@@ -136,6 +137,7 @@ pub(crate) struct IdleParkRequest {
 
 #[must_use = "idle park request parts own active sandbox and budget"]
 pub(crate) struct IdleParkRequestParts {
+    pub(crate) run_id: RunId,
     pub(crate) sandbox: Box<dyn Sandbox>,
     pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
     pub(crate) cli_agent_session_id: String,
@@ -232,6 +234,7 @@ pub struct ParkedIdleCandidate {
 pub(crate) struct IdleParkFailure {
     resources: IdleSandboxResources,
     budget_lease: BudgetLease,
+    reason: &'static str,
     error: String,
 }
 
@@ -246,6 +249,7 @@ pub(crate) struct IdleParkActiveParts {
 #[must_use = "idle park failure parts must be logged and cleaned up"]
 pub(crate) struct IdleParkFailureParts {
     pub(crate) active: IdleParkActiveParts,
+    pub(crate) reason: &'static str,
     pub(crate) error: String,
 }
 
@@ -256,6 +260,7 @@ impl IdleParkRequest {
 
     pub(crate) async fn park_for_idle(self) -> Result<ParkedIdleCandidate, IdleParkFailure> {
         let IdleParkRequestParts {
+            run_id,
             mut sandbox,
             factory,
             cli_agent_session_id,
@@ -270,6 +275,11 @@ impl IdleParkRequest {
             workspace_image_size_bytes,
             workspace_promotion,
         } = self.parts;
+
+        let retained_runtime_dir = restored_session_identity
+            .as_ref()
+            .and_then(RestoredSessionIdentity::final_metadata_verification)
+            .map(|verification| verification.runtime_dir.to_owned());
 
         let metadata = IdleSandboxMetadata {
             cli_agent_session_id,
@@ -311,7 +321,27 @@ impl IdleParkRequest {
                     workspace_promotion: None,
                 },
                 budget_lease,
+                reason: "promotion_identity_mismatch",
                 error: format!("workspace promotion identity mismatch: {mismatch}"),
+            });
+        }
+
+        if let Err(error) = prepare_sandbox_for_idle_reuse(
+            sandbox.as_ref(),
+            run_id,
+            retained_runtime_dir.as_deref(),
+        )
+        .await
+        {
+            return Err(IdleParkFailure {
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion,
+                },
+                budget_lease,
+                reason: "reuse_preparation_failed",
+                error: error.to_string(),
             });
         }
 
@@ -332,6 +362,7 @@ impl IdleParkRequest {
                     workspace_promotion,
                 },
                 budget_lease,
+                reason: "park_failed",
                 error: e.to_string(),
             }),
             Err(_) => {
@@ -345,6 +376,7 @@ impl IdleParkRequest {
                         workspace_promotion: None,
                     },
                     budget_lease,
+                    reason: "park_panicked",
                     error: "sandbox park panicked".into(),
                 })
             }
@@ -357,6 +389,7 @@ impl IdleParkFailure {
         let Self {
             resources,
             budget_lease,
+            reason,
             error,
         } = self;
         let IdleSandboxResources {
@@ -371,6 +404,7 @@ impl IdleParkFailure {
                 budget_lease,
                 workspace_promotion,
             },
+            reason,
             error,
         }
     }
@@ -1170,6 +1204,13 @@ mod tests {
 
     use std::time::Duration;
 
+    use guest_contracts::reuse_preparation::ReusePreparationRequest;
+    use guest_contracts::session_history_identity::{
+        FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    };
+    use sha2::{Digest, Sha256};
+
+    use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
     use crate::resource_budget::ResourceBudget;
     use crate::storage_fingerprints::StorageFingerprint;
 
@@ -1218,6 +1259,7 @@ mod tests {
         session_id: &str,
         budget_lease: BudgetLease,
     ) -> IdleParkRequest {
+        add_healthy_reuse_preparation_matcher(&overrides);
         let sandbox_id = SandboxId::new_v4();
         let factory: Arc<Box<dyn SandboxFactory>> =
             Arc::new(Box::new(MockSandboxFactory::with_overrides(overrides)));
@@ -1234,6 +1276,7 @@ mod tests {
             .await
             .expect("create sandbox");
         IdleParkRequest::new(IdleParkRequestParts {
+            run_id: RunId::new_v4(),
             sandbox,
             factory,
             cli_agent_session_id: session_id.into(),
@@ -1270,6 +1313,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idle_park_request_protects_retained_identity_runtime_directory() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let session_id = "session-retained-runtime";
+        let mut request = make_idle_park_request(
+            Arc::clone(&overrides),
+            session_id,
+            make_budget_lease(2, 2048),
+        )
+        .await;
+        let run_id = request.parts.run_id;
+        let retained_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous-run";
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(session_id.as_bytes())),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(b"history")),
+            b"history".len() as u64,
+            "/home/user/.claude/projects/session.jsonl",
+        )
+        .unwrap();
+        request.parts.restored_session_identity = Some(
+            RestoredSessionIdentity::from_final_metadata(
+                metadata,
+                format!("{retained_runtime_dir}/final-session-history-identity.json"),
+                retained_runtime_dir,
+            )
+            .unwrap(),
+        );
+
+        let _candidate = request
+            .park_for_idle()
+            .await
+            .unwrap_or_else(|_| panic!("healthy guest should park"));
+
+        let calls = overrides.exec_calls();
+        let call = calls
+            .iter()
+            .find(|call| call.cmd.contains("prepare-for-reuse"))
+            .expect("reuse preparation call");
+        let reuse_request: ReusePreparationRequest = serde_json::from_slice(
+            call.stdin_bytes
+                .as_deref()
+                .expect("reuse request should be sent on stdin"),
+        )
+        .unwrap();
+        assert_eq!(
+            reuse_request.current_runtime_dir,
+            format!("/home/user/.vm0/guest-agent/runs/{run_id}")
+        );
+        assert_eq!(
+            reuse_request.retained_runtime_dir.as_deref(),
+            Some(retained_runtime_dir)
+        );
+    }
+
+    #[tokio::test]
     async fn idle_park_request_success_preserves_reuse_metadata() {
         let overrides = Arc::new(MockSandboxOverrides::new());
         let sandbox_id = SandboxId::new_v4();
@@ -1278,6 +1377,7 @@ mod tests {
         let source_ip = "10.99.0.42";
         let history_generation_run_id = RunId::new_v4();
         let budget_lease = make_budget_lease(2, 2048);
+        add_healthy_reuse_preparation_matcher(&overrides);
         let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
             MockSandboxFactory::with_overrides(Arc::clone(&overrides)),
         ));
@@ -1307,6 +1407,7 @@ mod tests {
         let restored_session_identity =
             RestoredSessionIdentity::claude_code_for_test("history-hash-a");
         let request = IdleParkRequest::new(IdleParkRequestParts {
+            run_id: RunId::new_v4(),
             sandbox,
             factory,
             cli_agent_session_id: session_id.into(),

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -1,0 +1,515 @@
+//! Guest cleanup and rootfs admission policy before idle parking.
+
+use std::time::Duration;
+
+use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
+use guest_contracts::reuse_preparation::{
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
+    REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
+};
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecResult, ExecTermination, Sandbox};
+use tracing::{info, warn};
+
+use crate::helper_exec::{
+    format_helper_exec_failure, helper_exec_succeeded, helper_exec_termination_label,
+};
+use crate::ids::RunId;
+use crate::paths::guest;
+
+const REUSE_PREPARATION_TIMEOUT: Duration = Duration::from_secs(10);
+const MIN_REUSE_ROOTFS_AVAILABLE_BYTES: u64 = 128 * 1024 * 1024;
+const MIN_REUSE_ROOTFS_AVAILABLE_INODES: u64 = 1024;
+
+#[derive(Clone, Copy)]
+enum ReuseRejectionReason {
+    InvalidRequest,
+    InspectionFailed,
+    CleanupFailed,
+    HelperFailed,
+    InvalidReport,
+    LowBytes,
+    LowInodes,
+    LowBytesAndInodes,
+}
+
+impl ReuseRejectionReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::InspectionFailed => "inspection_failed",
+            Self::CleanupFailed => "cleanup_failed",
+            Self::HelperFailed => "helper_failed",
+            Self::InvalidReport => "invalid_report",
+            Self::LowBytes => "low_bytes",
+            Self::LowInodes => "low_inodes",
+            Self::LowBytesAndInodes => "low_bytes_and_inodes",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IdleReusePreparationFailure {
+    error: String,
+}
+
+impl std::fmt::Display for IdleReusePreparationFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.error)
+    }
+}
+
+pub(crate) async fn prepare_sandbox_for_idle_reuse(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    retained_runtime_dir: Option<&str>,
+) -> Result<(), IdleReusePreparationFailure> {
+    let current_runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(
+        CANONICAL_GUEST_HOME_DIR,
+        &run_id.to_string(),
+    )
+    .map_err(|error| {
+        reject_without_exec(
+            sandbox,
+            run_id,
+            ReuseRejectionReason::InvalidRequest,
+            format!("resolve current runtime directory: {error}"),
+        )
+    })?
+    .to_string_lossy()
+    .into_owned();
+    let request = ReusePreparationRequest {
+        current_runtime_dir,
+        retained_runtime_dir: retained_runtime_dir.map(str::to_owned),
+    };
+    let request_bytes = serde_json::to_vec(&request).map_err(|error| {
+        reject_without_exec(
+            sandbox,
+            run_id,
+            ReuseRejectionReason::InvalidRequest,
+            format!("serialize reuse-preparation request: {error}"),
+        )
+    })?;
+    let command = format!("{} prepare-for-reuse", guest::RUN_AGENT);
+    let result = sandbox
+        .exec_with_diagnostic_label(
+            &ExecRequest {
+                cmd: &command,
+                timeout: REUSE_PREPARATION_TIMEOUT,
+                env: &[],
+                sudo: true,
+                stdin_bytes: Some(&request_bytes),
+                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+            },
+            "idle-reuse-preparation",
+        )
+        .await
+        .map_err(|error| {
+            reject_without_exec(
+                sandbox,
+                run_id,
+                ReuseRejectionReason::HelperFailed,
+                format!("reuse-preparation exec failed: {error}"),
+            )
+        })?;
+
+    if !helper_exec_succeeded(&result) {
+        let reason = helper_failure_reason(&result);
+        return Err(reject_with_result(
+            sandbox,
+            run_id,
+            reason,
+            &result,
+            format_helper_exec_failure("reuse preparation", &result),
+        ));
+    }
+
+    let report =
+        serde_json::from_slice::<ReusePreparationReport>(&result.stdout).map_err(|error| {
+            reject_with_result(
+                sandbox,
+                run_id,
+                ReuseRejectionReason::InvalidReport,
+                &result,
+                format!("reuse preparation returned an invalid report: {error}"),
+            )
+        })?;
+    let low_bytes = report.after.available_bytes < MIN_REUSE_ROOTFS_AVAILABLE_BYTES;
+    let low_inodes = report.after.available_inodes < MIN_REUSE_ROOTFS_AVAILABLE_INODES;
+    if low_bytes || low_inodes {
+        let reason = if low_bytes && low_inodes {
+            ReuseRejectionReason::LowBytesAndInodes
+        } else if low_bytes {
+            ReuseRejectionReason::LowBytes
+        } else {
+            ReuseRejectionReason::LowInodes
+        };
+        log_report(sandbox, run_id, reason.as_str(), &result, report, false);
+        return Err(IdleReusePreparationFailure {
+            error: format!(
+                "guest rootfs below reuse reserve: {} bytes and {} inodes available",
+                report.after.available_bytes, report.after.available_inodes
+            ),
+        });
+    }
+
+    log_report(sandbox, run_id, "ready", &result, report, true);
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn healthy_reuse_preparation_report() -> ReusePreparationReport {
+    use guest_contracts::reuse_preparation::RootFilesystemCapacity;
+
+    ReusePreparationReport {
+        before: RootFilesystemCapacity {
+            available_bytes: 256 * 1024 * 1024,
+            available_inodes: 2048,
+        },
+        after: RootFilesystemCapacity {
+            available_bytes: 256 * 1024 * 1024,
+            available_inodes: 2048,
+        },
+        removed_entries: 0,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn add_healthy_reuse_preparation_matcher(
+    overrides: &sandbox_mock::MockSandboxOverrides,
+) {
+    overrides.add_persistent_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "prepare-for-reuse".to_string(),
+        exit_code: 0,
+        stdout: serde_json::to_vec(&healthy_reuse_preparation_report()).unwrap(),
+        stderr: Vec::new(),
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn mock_sandbox_ready_for_idle_reuse(
+    name: impl Into<String>,
+) -> sandbox_mock::MockSandbox {
+    let overrides = std::sync::Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    add_healthy_reuse_preparation_matcher(&overrides);
+    sandbox_mock::MockSandbox::with_overrides(name, overrides)
+}
+
+fn helper_failure_reason(result: &ExecResult) -> ReuseRejectionReason {
+    match result.termination {
+        ExecTermination::Exited {
+            exit_code: REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+        } => ReuseRejectionReason::InvalidRequest,
+        ExecTermination::Exited {
+            exit_code: REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
+        } => ReuseRejectionReason::InspectionFailed,
+        ExecTermination::Exited {
+            exit_code: REUSE_PREPARATION_EXIT_CLEANUP_FAILED,
+        } => ReuseRejectionReason::CleanupFailed,
+        ExecTermination::Exited { .. }
+        | ExecTermination::TimedOut
+        | ExecTermination::Cancelled
+        | ExecTermination::StartFailed
+        | ExecTermination::WaitFailed => ReuseRejectionReason::HelperFailed,
+    }
+}
+
+fn reject_without_exec(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    reason: ReuseRejectionReason,
+    error: String,
+) -> IdleReusePreparationFailure {
+    warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox.id(),
+        reason = reason.as_str(),
+        error = %error,
+        "sandbox rejected from idle reuse"
+    );
+    IdleReusePreparationFailure { error }
+}
+
+fn reject_with_result(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    reason: ReuseRejectionReason,
+    result: &ExecResult,
+    error: String,
+) -> IdleReusePreparationFailure {
+    warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox.id(),
+        reason = reason.as_str(),
+        helper_termination = helper_exec_termination_label(result),
+        helper_stdout_len = result.stdout.len(),
+        helper_stderr_len = result.stderr.len(),
+        helper_stdout_truncated = result.stdout_truncated,
+        helper_stderr_truncated = result.stderr_truncated,
+        error = %error,
+        "sandbox rejected from idle reuse"
+    );
+    IdleReusePreparationFailure { error }
+}
+
+fn log_report(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    reason: &'static str,
+    result: &ExecResult,
+    report: ReusePreparationReport,
+    ready: bool,
+) {
+    let reclaimed_bytes = report
+        .after
+        .available_bytes
+        .saturating_sub(report.before.available_bytes);
+    let reclaimed_inodes = report
+        .after
+        .available_inodes
+        .saturating_sub(report.before.available_inodes);
+    if ready {
+        info!(
+            run_id = %run_id,
+            sandbox_id = %sandbox.id(),
+            reason,
+            helper_termination = helper_exec_termination_label(result),
+            removed_entries = report.removed_entries,
+            before_available_bytes = report.before.available_bytes,
+            after_available_bytes = report.after.available_bytes,
+            reclaimed_bytes,
+            before_available_inodes = report.before.available_inodes,
+            after_available_inodes = report.after.available_inodes,
+            reclaimed_inodes,
+            "sandbox prepared for idle reuse"
+        );
+    } else {
+        warn!(
+            run_id = %run_id,
+            sandbox_id = %sandbox.id(),
+            reason,
+            helper_termination = helper_exec_termination_label(result),
+            removed_entries = report.removed_entries,
+            before_available_bytes = report.before.available_bytes,
+            after_available_bytes = report.after.available_bytes,
+            reclaimed_bytes,
+            before_available_inodes = report.before.available_inodes,
+            after_available_inodes = report.after.available_inodes,
+            reclaimed_inodes,
+            "sandbox rejected from idle reuse"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
+    use sandbox_mock::MockSandbox;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
+
+    fn report(
+        before_bytes: u64,
+        after_bytes: u64,
+        before_inodes: u64,
+        after_inodes: u64,
+    ) -> ReusePreparationReport {
+        use guest_contracts::reuse_preparation::RootFilesystemCapacity;
+
+        ReusePreparationReport {
+            before: RootFilesystemCapacity {
+                available_bytes: before_bytes,
+                available_inodes: before_inodes,
+            },
+            after: RootFilesystemCapacity {
+                available_bytes: after_bytes,
+                available_inodes: after_inodes,
+            },
+            removed_entries: 3,
+        }
+    }
+
+    async fn capture_preparation(
+        sandbox: &MockSandbox,
+        run_id: RunId,
+    ) -> (Result<(), IdleReusePreparationFailure>, Vec<CapturedEvent>) {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        let result = prepare_sandbox_for_idle_reuse(sandbox, run_id, None).await;
+        drop(guard);
+        (result, captured.entries())
+    }
+
+    fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+        events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|actual| actual == message)
+            })
+            .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+    }
+
+    #[tokio::test]
+    async fn preparation_sends_canonical_current_and_retained_runtime_directories() {
+        let sandbox = MockSandbox::new("reuse-request");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            serde_json::to_vec(&healthy_reuse_preparation_report()).unwrap(),
+            Vec::new(),
+        )));
+        let run_id = RunId::new_v4();
+        let retained = "/home/user/.vm0/guest-agent/runs/previous";
+
+        prepare_sandbox_for_idle_reuse(&sandbox, run_id, Some(retained))
+            .await
+            .expect("healthy guest should be prepared");
+
+        let calls = sandbox.exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].sudo);
+        assert!(calls[0].cmd.ends_with("guest-agent prepare-for-reuse"));
+        let request: ReusePreparationRequest = serde_json::from_slice(
+            calls[0]
+                .stdin_bytes
+                .as_deref()
+                .expect("reuse request should be sent on stdin"),
+        )
+        .unwrap();
+        assert_eq!(
+            request.current_runtime_dir,
+            format!("/home/user/.vm0/guest-agent/runs/{run_id}")
+        );
+        assert_eq!(request.retained_runtime_dir.as_deref(), Some(retained));
+    }
+
+    #[tokio::test]
+    async fn preparation_rejects_low_bytes_with_capacity_telemetry() {
+        let sandbox = MockSandbox::new("low-bytes");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            serde_json::to_vec(&report(64, 96, 4096, 4090)).unwrap(),
+            Vec::new(),
+        )));
+
+        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+        assert!(result.is_err());
+        let event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(
+            event.fields.get("reason").map(String::as_str),
+            Some("low_bytes")
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("before_available_bytes")
+                .map(String::as_str),
+            Some("64")
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("after_available_bytes")
+                .map(String::as_str),
+            Some("96")
+        );
+        assert_eq!(
+            event.fields.get("reclaimed_bytes").map(String::as_str),
+            Some("32")
+        );
+    }
+
+    #[tokio::test]
+    async fn preparation_rejects_low_inodes_with_capacity_telemetry() {
+        let sandbox = MockSandbox::new("low-inodes");
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            serde_json::to_vec(&report(256 * 1024 * 1024, 257 * 1024 * 1024, 500, 600)).unwrap(),
+            Vec::new(),
+        )));
+
+        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+        assert!(result.is_err());
+        let event = captured_event(&events, "sandbox rejected from idle reuse");
+        assert_eq!(
+            event.fields.get("reason").map(String::as_str),
+            Some("low_inodes")
+        );
+        assert_eq!(
+            event
+                .fields
+                .get("after_available_inodes")
+                .map(String::as_str),
+            Some("600")
+        );
+        assert_eq!(
+            event.fields.get("reclaimed_inodes").map(String::as_str),
+            Some("100")
+        );
+    }
+
+    #[tokio::test]
+    async fn preparation_distinguishes_helper_inspection_and_cleanup_failures() {
+        for (exit_code, expected_reason) in [
+            (
+                REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
+                "inspection_failed",
+            ),
+            (REUSE_PREPARATION_EXIT_CLEANUP_FAILED, "cleanup_failed"),
+        ] {
+            let sandbox = MockSandbox::new(expected_reason);
+            sandbox.push_exec_result(Ok(ExecResult::new(
+                exit_code,
+                Vec::new(),
+                b"helper failed".to_vec(),
+            )));
+
+            let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+            assert!(result.is_err());
+            let event = captured_event(&events, "sandbox rejected from idle reuse");
+            assert_eq!(
+                event.fields.get("reason").map(String::as_str),
+                Some(expected_reason)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn preparation_fails_closed_for_malformed_report_and_transport_failure() {
+        let malformed = MockSandbox::new("malformed-report");
+        malformed.push_exec_result(Ok(ExecResult::new(0, b"not-json".to_vec(), Vec::new())));
+        let (result, events) = capture_preparation(&malformed, RunId::new_v4()).await;
+        assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse")
+                .fields
+                .get("reason")
+                .map(String::as_str),
+            Some("invalid_report")
+        );
+
+        let transport = MockSandbox::new("transport-failure");
+        transport.push_exec_result(Err(SandboxError::Operation {
+            operation: SandboxOperation::Exec,
+            reason: SandboxOperationReason::Guest,
+            message: "vsock disconnected".into(),
+        }));
+        let (result, events) = capture_preparation(&transport, RunId::new_v4()).await;
+        assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse")
+                .fields
+                .get("reason")
+                .map(String::as_str),
+            Some("helper_failed")
+        );
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -16,6 +16,7 @@ mod host_env;
 mod host_file;
 mod http;
 mod idle_pool;
+mod idle_reuse_preparation;
 mod ids;
 mod image_hash;
 mod io_limits;

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -21,6 +21,9 @@ pub(crate) struct ExecOverrideState {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
     pub(crate) matchers: Mutex<Vec<ExecMatcherResult>>,
+    /// Pattern-matched exec results that remain available for every matching
+    /// call after one-shot matchers have been checked.
+    pub(crate) persistent_matchers: Mutex<Vec<ExecMatcherResult>>,
     /// Recorded exec calls across all sandboxes built from this override set.
     pub(crate) calls: Mutex<Vec<ExecCall>>,
 }
@@ -270,6 +273,21 @@ impl MockSandboxOverrides {
             .push(ExecMatcherResult {
                 pattern: pattern.into(),
                 result,
+            });
+    }
+
+    /// Register a persistent matcher for an ordinary exited result.
+    ///
+    /// One-shot matchers registered with [`Self::add_exec_matcher`] or
+    /// [`Self::add_exec_result_matcher`] take precedence. The persistent
+    /// matcher is not consumed and can serve repeated calls across sandboxes.
+    pub fn add_persistent_exec_matcher(&self, matcher: ExecMatcher) {
+        self.exec
+            .persistent_matchers
+            .lock_ignoring_poison()
+            .push(ExecMatcherResult {
+                pattern: matcher.pattern,
+                result: ExecResult::new(matcher.exit_code, matcher.stdout, matcher.stderr),
             });
     }
 

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -58,10 +58,11 @@ impl MockSandbox {
         Self::build(id, None)
     }
 
-    pub(crate) fn with_overrides(
-        id: impl Into<String>,
-        overrides: Arc<MockSandboxOverrides>,
-    ) -> Self {
+    /// Create a sandbox attached directly to shared behavior overrides.
+    ///
+    /// This is useful when a test does not need to construct a runtime and
+    /// factory but still needs command matchers or shared observations.
+    pub fn with_overrides(id: impl Into<String>, overrides: Arc<MockSandboxOverrides>) -> Self {
         Self::build(id, Some(overrides))
     }
 
@@ -345,6 +346,14 @@ impl Sandbox for MockSandbox {
                 .position(|m| request.cmd.contains(&m.pattern))
             {
                 Ok(matchers.remove(idx).result)
+            } else if let Some(matcher) = overrides
+                .exec
+                .persistent_matchers
+                .lock_ignoring_poison()
+                .iter()
+                .find(|matcher| request.cmd.contains(&matcher.pattern))
+            {
+                Ok(clone_exec_result(&matcher.result))
             } else {
                 self.exec_results
                     .lock_ignoring_poison()
@@ -786,5 +795,16 @@ impl Sandbox for MockSandbox {
             Vec::new(),
             Vec::new(),
         ))
+    }
+}
+
+fn clone_exec_result(result: &ExecResult) -> ExecResult {
+    ExecResult {
+        termination: result.termination,
+        stdout: result.stdout.clone(),
+        stderr: result.stderr.clone(),
+        diagnostic: result.diagnostic.clone(),
+        stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
     }
 }

--- a/crates/sandbox-mock/src/tests/exec.rs
+++ b/crates/sandbox-mock/src/tests/exec.rs
@@ -101,6 +101,39 @@ async fn sandbox_queued_exec_results() {
 }
 
 #[tokio::test]
+async fn sandbox_persistent_exec_matcher_serves_repeated_calls_after_one_shot_override() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.add_persistent_exec_matcher(ExecMatcher {
+        pattern: "prepare".into(),
+        exit_code: 0,
+        stdout: b"healthy".to_vec(),
+        stderr: Vec::new(),
+    });
+    overrides.add_exec_matcher(ExecMatcher {
+        pattern: "prepare".into(),
+        exit_code: 4,
+        stdout: Vec::new(),
+        stderr: b"cleanup failed".to_vec(),
+    });
+    let sandbox = MockSandbox::with_overrides("persistent", overrides);
+    let request = ExecRequest {
+        cmd: "prepare",
+        timeout: Duration::from_secs(5),
+        env: &[],
+        sudo: false,
+        stdin_bytes: None,
+        output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
+    };
+
+    assert_eq!(
+        sandbox.exec(&request).await.unwrap().termination,
+        ExecTermination::Exited { exit_code: 4 }
+    );
+    assert_eq!(sandbox.exec(&request).await.unwrap().stdout, b"healthy");
+    assert_eq!(sandbox.exec(&request).await.unwrap().stdout, b"healthy");
+}
+
+#[tokio::test]
 async fn sandbox_exec_applies_mock_capture_budget() {
     let sandbox = MockSandbox::new("test-1");
     sandbox.push_exec_result(Ok(ExecResult::new(


### PR DESCRIPTION
## Summary

- add a typed guest-agent reuse-preparation helper that safely removes stale runner-owned run state while preserving the current run and any earlier runtime directory referenced by a verified retained identity
- require at least 128 MiB of user-available rootfs capacity and 1,024 available inodes before a successful guest can enter the idle pool; reject and destroy guests that cannot be cleaned, inspected, or qualified without changing the completed run result
- extend explicit ENOSPC diagnostics to startup guest-write failures and structured agent failures, including inode exhaustion, while preserving the original error and never replaying agent or user work

## Safety and compatibility

- cleanup uses fd-relative no-follow traversal and refuses symlinks, nested filesystem boundaries, and same-filesystem bind mounts
- framework state, declared storage, workspace data, and arbitrary home-directory content are not deleted
- runner and guest-agent ship in the same runner artifact; no persisted or independently deployed protocol changes are introduced
- no database schema, API, queue payload, TypeScript, workflow, or configuration changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-contracts -p guest-agent -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-contracts -p guest-agent -p sandbox-mock -p runner --no-deps --all-features`
- `cargo test -p guest-contracts -p guest-agent -p sandbox-mock -p runner --quiet`
- repository pre-commit and commit-message hooks

Closes #21527
