### PR TITLE
feat(api): sync connector catalog snapshots from r2

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -8,6 +8,7 @@ import {
   cronAggregateUsageContract,
   cronCompactChatThreadSnapshotsContract,
   cronCleanupSandboxesContract,
+  cronConnectorCatalogContract,
   cronComputerUseScreenshotCleanupContract,
   cronDrainEmailOutboxContract,
   cronDrainRelationshipMemoryContract,
@@ -93,6 +94,10 @@ const expectedVercelCrons = [
   },
   {
     path: cronSyncSkillsContract.sync.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronConnectorCatalogContract.sync.path,
     schedule: "* * * * *",
   },
   {

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -69,7 +69,6 @@ const SCHEMA = {
   R2_USER_ARTIFACTS_BUCKET_NAME: z.string().min(1),
   R2_USER_ARTIFACTS_ACCESS_KEY_ID: z.string().min(1),
   R2_USER_ARTIFACTS_SECRET_ACCESS_KEY: z.string().min(1),
-  R2_CONNECTOR_CATALOG_BUCKET_NAME: z.string().min(1).optional(),
   PUBLIC_ARTIFACTS_BASE_URL: z.url(),
   R2_HOSTED_SITES_BUCKET_NAME: z.string().min(1).optional(),
   R2_HOSTED_SITES_ACCESS_KEY_ID: z.string().min(1).optional(),

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -69,6 +69,7 @@ const SCHEMA = {
   R2_USER_ARTIFACTS_BUCKET_NAME: z.string().min(1),
   R2_USER_ARTIFACTS_ACCESS_KEY_ID: z.string().min(1),
   R2_USER_ARTIFACTS_SECRET_ACCESS_KEY: z.string().min(1),
+  R2_CONNECTOR_CATALOG_BUCKET_NAME: z.string().min(1).optional(),
   PUBLIC_ARTIFACTS_BASE_URL: z.url(),
   R2_HOSTED_SITES_BUCKET_NAME: z.string().min(1).optional(),
   R2_HOSTED_SITES_ACCESS_KEY_ID: z.string().min(1).optional(),

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -3,6 +3,7 @@ import {
   CopyObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
+  type GetObjectCommandOutput,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
@@ -46,6 +47,14 @@ interface S3Credentials {
 interface DownloadS3BufferOptions {
   readonly maxBytes?: number;
 }
+
+export type ConditionalS3BufferDownload =
+  | { readonly kind: "not-modified" }
+  | {
+      readonly kind: "downloaded";
+      readonly buffer: Buffer;
+      readonly etag: string | null;
+    };
 
 export class S3ObjectSizeLimitError extends Error {
   constructor(
@@ -245,6 +254,38 @@ export function downloadS3BufferWithMaxBytes(
   });
 }
 
+export function downloadS3BufferWithMaxBytesIfChanged(
+  bucket: string,
+  key: string,
+  maxBytes: number,
+  ifNoneMatch: string | null,
+): Computed<Promise<ConditionalS3BufferDownload>> {
+  return computed(async (get): Promise<ConditionalS3BufferDownload> => {
+    const client = get(s3ClientForBucket(bucket));
+    const downloaded = await settle(
+      client.send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          IfNoneMatch: ifNoneMatch ?? undefined,
+        }),
+      ),
+    );
+    if (!downloaded.ok) {
+      if (isS3NotModifiedError(downloaded.error)) {
+        return { kind: "not-modified" };
+      }
+      throw downloaded.error;
+    }
+    const response: GetObjectCommandOutput = downloaded.value;
+    return {
+      kind: "downloaded",
+      buffer: await readS3ObjectBody(response, key, { maxBytes }),
+      etag: response.ETag ?? null,
+    };
+  });
+}
+
 function isAsyncIterableByteStream(
   value: unknown,
 ): value is AsyncIterable<Uint8Array> {
@@ -263,6 +304,19 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   }
   const then = (value as { then?: unknown }).then;
   return typeof then === "function";
+}
+
+function isS3NotModifiedError(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || !("$metadata" in value)) {
+    return false;
+  }
+  const metadata = value.$metadata;
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "httpStatusCode" in metadata &&
+    metadata.httpStatusCode === 304
+  );
 }
 
 function closeS3Body(body: unknown): void {
@@ -300,46 +354,57 @@ function downloadS3BufferWithClient(
     const response = await client.send(
       new GetObjectCommand({ Bucket: bucket, Key: key }),
     );
-    if (!response.Body) {
-      throw new Error("S3 object body is empty");
-    }
-    if (!isAsyncIterableByteStream(response.Body)) {
-      closeS3Body(response.Body);
-      throw new Error("S3 object body is not an async byte stream");
-    }
-    if (
-      options.maxBytes !== undefined &&
-      response.ContentLength !== undefined &&
-      response.ContentLength > options.maxBytes
-    ) {
-      closeS3Body(response.Body);
-      throw new S3ObjectSizeLimitError(
-        key,
-        response.ContentLength,
-        options.maxBytes,
-      );
-    }
-    const chunks: Uint8Array[] = [];
-    let totalLength = 0;
-    for await (const chunk of response.Body) {
-      if (!(chunk instanceof Uint8Array)) {
-        closeS3Body(response.Body);
-        throw new Error("S3 object body yielded a non-byte chunk");
-      }
-      totalLength += chunk.length;
-      if (options.maxBytes !== undefined && totalLength > options.maxBytes) {
-        closeS3Body(response.Body);
-        throw new S3ObjectSizeLimitError(key, totalLength, options.maxBytes);
-      }
-      chunks.push(chunk);
-    }
-    return Buffer.concat(
-      chunks.map((c) => {
-        return Buffer.from(c);
-      }),
-      totalLength,
-    );
+    return await readS3ObjectBody(response, key, options);
   });
+}
+
+async function readS3ObjectBody(
+  response: {
+    readonly Body?: unknown;
+    readonly ContentLength?: number;
+  },
+  key: string,
+  options: DownloadS3BufferOptions,
+): Promise<Buffer> {
+  if (!response.Body) {
+    throw new Error("S3 object body is empty");
+  }
+  if (!isAsyncIterableByteStream(response.Body)) {
+    closeS3Body(response.Body);
+    throw new Error("S3 object body is not an async byte stream");
+  }
+  if (
+    options.maxBytes !== undefined &&
+    response.ContentLength !== undefined &&
+    response.ContentLength > options.maxBytes
+  ) {
+    closeS3Body(response.Body);
+    throw new S3ObjectSizeLimitError(
+      key,
+      response.ContentLength,
+      options.maxBytes,
+    );
+  }
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+  for await (const chunk of response.Body) {
+    if (!(chunk instanceof Uint8Array)) {
+      closeS3Body(response.Body);
+      throw new Error("S3 object body yielded a non-byte chunk");
+    }
+    totalLength += chunk.length;
+    if (options.maxBytes !== undefined && totalLength > options.maxBytes) {
+      closeS3Body(response.Body);
+      throw new S3ObjectSizeLimitError(key, totalLength, options.maxBytes);
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(
+    chunks.map((chunk) => {
+      return Buffer.from(chunk);
+    }),
+    totalLength,
+  );
 }
 
 export function downloadHostedSitesS3Buffer(

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -46,6 +46,7 @@ interface S3Credentials {
 
 interface DownloadS3BufferOptions {
   readonly maxBytes?: number;
+  readonly signal?: AbortSignal;
 }
 
 export type ConditionalS3BufferDownload =
@@ -61,6 +62,7 @@ export class S3ObjectSizeLimitError extends Error {
     readonly key: string,
     readonly size: number,
     readonly maxBytes: number,
+    readonly etag: string | null = null,
   ) {
     super(`S3 object is too large: ${size} bytes exceeds ${maxBytes} bytes`);
     this.name = "S3ObjectSizeLimitError";
@@ -248,9 +250,11 @@ export function downloadS3BufferWithMaxBytes(
   bucket: string,
   key: string,
   maxBytes: number,
+  signal?: AbortSignal,
 ): Computed<Promise<Buffer>> {
   return downloadS3BufferWithClient(s3ClientForBucket(bucket), bucket, key, {
     maxBytes,
+    signal,
   });
 }
 
@@ -259,6 +263,7 @@ export function downloadS3BufferWithMaxBytesIfChanged(
   key: string,
   maxBytes: number,
   ifNoneMatch: string | null,
+  signal?: AbortSignal,
 ): Computed<Promise<ConditionalS3BufferDownload>> {
   return computed(async (get): Promise<ConditionalS3BufferDownload> => {
     const client = get(s3ClientForBucket(bucket));
@@ -269,6 +274,7 @@ export function downloadS3BufferWithMaxBytesIfChanged(
           Key: key,
           IfNoneMatch: ifNoneMatch ?? undefined,
         }),
+        { abortSignal: signal },
       ),
     );
     if (!downloaded.ok) {
@@ -280,7 +286,7 @@ export function downloadS3BufferWithMaxBytesIfChanged(
     const response: GetObjectCommandOutput = downloaded.value;
     return {
       kind: "downloaded",
-      buffer: await readS3ObjectBody(response, key, { maxBytes }),
+      buffer: await readS3ObjectBody(response, key, { maxBytes, signal }),
       etag: response.ETag ?? null,
     };
   });
@@ -353,6 +359,7 @@ function downloadS3BufferWithClient(
     const client = get(client$);
     const response = await client.send(
       new GetObjectCommand({ Bucket: bucket, Key: key }),
+      { abortSignal: options.signal },
     );
     return await readS3ObjectBody(response, key, options);
   });
@@ -362,6 +369,7 @@ async function readS3ObjectBody(
   response: {
     readonly Body?: unknown;
     readonly ContentLength?: number;
+    readonly ETag?: string;
   },
   key: string,
   options: DownloadS3BufferOptions,
@@ -373,6 +381,10 @@ async function readS3ObjectBody(
     closeS3Body(response.Body);
     throw new Error("S3 object body is not an async byte stream");
   }
+  if (options.signal?.aborted) {
+    closeS3Body(response.Body);
+    options.signal.throwIfAborted();
+  }
   if (
     options.maxBytes !== undefined &&
     response.ContentLength !== undefined &&
@@ -383,11 +395,16 @@ async function readS3ObjectBody(
       key,
       response.ContentLength,
       options.maxBytes,
+      response.ETag ?? null,
     );
   }
   const chunks: Uint8Array[] = [];
   let totalLength = 0;
   for await (const chunk of response.Body) {
+    if (options.signal?.aborted) {
+      closeS3Body(response.Body);
+      options.signal.throwIfAborted();
+    }
     if (!(chunk instanceof Uint8Array)) {
       closeS3Body(response.Body);
       throw new Error("S3 object body yielded a non-byte chunk");
@@ -395,7 +412,12 @@ async function readS3ObjectBody(
     totalLength += chunk.length;
     if (options.maxBytes !== undefined && totalLength > options.maxBytes) {
       closeS3Body(response.Body);
-      throw new S3ObjectSizeLimitError(key, totalLength, options.maxBytes);
+      throw new S3ObjectSizeLimitError(
+        key,
+        totalLength,
+        options.maxBytes,
+        response.ETag ?? null,
+      );
     }
     chunks.push(chunk);
   }

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -22,6 +22,7 @@ import { cronArtifactPreviewRoutes } from "./routes/cron-artifact-preview";
 import { cronAggregateUsageRoutes } from "./routes/cron-aggregate-usage";
 import { cronCompactChatThreadSnapshotsRoutes } from "./routes/cron-compact-chat-thread-snapshots";
 import { cronCleanupSandboxesRoutes } from "./routes/cron-cleanup-sandboxes";
+import { cronConnectorCatalogRoutes } from "./routes/cron-connector-catalog";
 import { cronDrainRelationshipMemoryRoutes } from "./routes/cron-drain-relationship-memory";
 import { cronDrainEmailOutboxRoutes } from "./routes/cron-drain-email-outbox";
 import { cronExecuteWorkflowAutomationsRoutes } from "./routes/cron-execute-workflow-automations";
@@ -251,6 +252,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronAggregateUsageRoutes,
   ...cronCompactChatThreadSnapshotsRoutes,
   ...cronCleanupSandboxesRoutes,
+  ...cronConnectorCatalogRoutes,
   ...cronDrainRelationshipMemoryRoutes,
   ...cronDrainEmailOutboxRoutes,
   ...cronExecuteWorkflowAutomationsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -14,7 +14,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const zeroMocks = createZeroRouteMocks(context);
 const CRON_SECRET = "connector-catalog-cron-secret";
-const ACTIVE_KEY = "catalog-v1/active.json";
+const ACTIVE_KEY = "connectors/v1/active.json";
 const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
 const PRIVATE_VALUE = "SECRET_TOKEN";
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
@@ -112,7 +112,7 @@ function releaseKeys(version: string): {
   readonly privateFirewalls: string;
   readonly runnerFirewalls: string;
 } {
-  const prefix = `catalog-v1/releases/${version}`;
+  const prefix = `connectors/v1/releases/${version}`;
   return {
     integrity: `${prefix}/integrity/catalog.json`,
     publicCatalog: `${prefix}/public/catalog.json`,
@@ -892,7 +892,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           version: "wrong-pointer-reference",
           mutatePointer: (pointer) => {
             recordValue(pointer.integrity, "pointer.integrity").key =
-              "catalog-v1/releases/other/integrity/catalog.json";
+              "connectors/v1/releases/other/integrity/catalog.json";
           },
         });
       },
@@ -1026,7 +1026,35 @@ describe("connector catalog rejection and latest-valid retention", () => {
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connectors/catalog-v1/releases/staging-key/public/catalog.json";
+              "generated/connectors/v1/releases/staging-key/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "legacy catalog key",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "legacy-key",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "catalog-v1/releases/legacy-key/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "discarded connector catalog namespace",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "discarded-namespace",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "connector-catalog/v1/releases/discarded-namespace/public/catalog.json";
           },
         });
       },
@@ -1040,7 +1068,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "catalog-v1/releases/other/public/catalog.json";
+              "connectors/v1/releases/other/public/catalog.json";
           },
         });
       },
@@ -1054,7 +1082,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "catalog-v1/public/catalog.json";
+              "connectors/public/catalog.json";
           },
         });
       },
@@ -1068,7 +1096,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "catalog-v2/releases/wrong-schema-key/public/catalog.json";
+              "connectors/v2/releases/wrong-schema-key/public/catalog.json";
           },
         });
       },
@@ -1082,7 +1110,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "catalog-v1/releases/traversal-key/../public/catalog.json";
+              "connectors/v1/releases/traversal-key/../public/catalog.json";
           },
         });
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -93,6 +93,10 @@ function digest(bytes: Uint8Array): string {
   return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }
 
+function objectEtag(bytes: Uint8Array): string {
+  return `"${createHash("sha256").update(bytes).digest("hex")}"`;
+}
+
 function catalogTemplate(reference: string): string {
   return `\${{ ${reference} }}`;
 }
@@ -411,9 +415,18 @@ function serveObjects(objects: ReadonlyMap<string, Buffer>): void {
     if (!bytes) {
       return Promise.reject(new Error("Object unavailable"));
     }
+    const etag = objectEtag(bytes);
+    if (input.IfNoneMatch === etag) {
+      return Promise.reject(
+        Object.assign(new Error("Not modified"), {
+          $metadata: { httpStatusCode: 304 },
+        }),
+      );
+    }
     return Promise.resolve({
       ContentLength: bytes.length,
       Body: s3Body(bytes),
+      ETag: etag,
     });
   });
 }
@@ -548,6 +561,13 @@ describe("connector catalog valid lifecycle", () => {
     expect(context.mocks.s3.send.mock.calls.length - callsBeforeUnchanged).toBe(
       1,
     );
+    expect(
+      commandInput(context.mocks.s3.send.mock.calls[callsBeforeUnchanged]?.[0]),
+    ).toMatchObject({
+      Bucket: bucket,
+      Key: ACTIVE_KEY,
+      IfNoneMatch: objectEtag(first.pointer),
+    });
 
     serveObjects(catalogObjects([first, second], second));
     expect((await syncCatalog()).body).toMatchObject({
@@ -562,6 +582,7 @@ describe("connector catalog valid lifecycle", () => {
     });
 
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const callsBeforePublicCatalog = context.mocks.s3.send.mock.calls.length;
     const publicCatalog = await accept(
       setupApp({ context })(zeroConnectorCatalogContract).list({
         headers: { authorization: "Bearer clerk-session" },
@@ -573,6 +594,9 @@ describe("connector catalog valid lifecycle", () => {
         return connector.connectorRef === first.connectorRef;
       }),
     ).toBeFalsy();
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(
+      callsBeforePublicCatalog,
+    );
   });
 
   it("accepts a complete generated firewall projection", async () => {
@@ -608,7 +632,7 @@ describe("connector catalog valid lifecycle", () => {
     });
   });
 
-  it("rolls back a release identity when its state compare-and-swap loses", async () => {
+  it("rolls back a candidate snapshot when its state compare-and-swap loses", async () => {
     configureSource();
     const losing = buildRelease({
       version: "2026-07-15.losing",
@@ -1091,26 +1115,130 @@ describe("connector catalog rejection and latest-valid retention", () => {
     expect(JSON.stringify(rejected.body)).not.toContain(PRIVATE_VALUE);
   });
 
-  it("rejects immutable catalog version reuse after acceptance", async () => {
+  it("skips large artifacts for a deterministically rejected candidate", async () => {
+    configureSource();
+    const accepted = buildRelease({ version: "2026-07-15.cache-valid" });
+    serveObjects(catalogObjects([accepted], accepted));
+    await syncCatalog();
+
+    const invalid = buildRelease({
+      version: "2026-07-15.cache-invalid",
+      mutatePublic: (artifact) => {
+        artifact.extra = true;
+      },
+    });
+    serveObjects(catalogObjects([accepted, invalid], invalid));
+    const callsBeforeFirstRejection = context.mocks.s3.send.mock.calls.length;
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      state: "stale",
+      lastAttempt: { failureCode: "invalid-artifact" },
+    });
+    expect(
+      context.mocks.s3.send.mock.calls.length - callsBeforeFirstRejection,
+    ).toBe(6);
+
+    const callsBeforeCachedRejection = context.mocks.s3.send.mock.calls.length;
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      state: "stale",
+      lastAttempt: { failureCode: "invalid-artifact" },
+    });
+    expect(
+      context.mocks.s3.send.mock.calls.length - callsBeforeCachedRejection,
+    ).toBe(1);
+    expect(
+      commandInput(
+        context.mocks.s3.send.mock.calls[callsBeforeCachedRejection]?.[0],
+      ),
+    ).toMatchObject({
+      Key: ACTIVE_KEY,
+      IfNoneMatch: objectEtag(invalid.pointer),
+    });
+  });
+
+  it("caches a malformed active pointer by its observed ETag", async () => {
+    configureSource();
+    const invalid = buildRelease({
+      version: "2026-07-15.malformed-pointer-cache",
+      mutatePointer: (pointer) => {
+        pointer.extra = true;
+      },
+    });
+    serveObjects(catalogObjects([invalid], invalid));
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "invalid-pointer",
+    );
+
+    const callsBeforeCachedRejection = context.mocks.s3.send.mock.calls.length;
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "invalid-pointer",
+    );
+    expect(
+      context.mocks.s3.send.mock.calls.length - callsBeforeCachedRejection,
+    ).toBe(1);
+    expect(
+      commandInput(
+        context.mocks.s3.send.mock.calls[callsBeforeCachedRejection]?.[0],
+      ),
+    ).toMatchObject({
+      Key: ACTIVE_KEY,
+      IfNoneMatch: objectEtag(invalid.pointer),
+    });
+  });
+
+  it("retries transient candidate download failures", async () => {
+    configureSource();
+    const candidate = buildRelease({
+      version: "2026-07-15.transient-candidate",
+    });
+    const unavailableObjects = new Map(catalogObjects([candidate], candidate));
+    unavailableObjects.delete(releaseKeys(candidate.version).publicCatalog);
+    serveObjects(unavailableObjects);
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      state: "never-synced",
+      lastAttempt: { failureCode: "source-unavailable" },
+    });
+
+    serveObjects(catalogObjects([candidate], candidate));
+    const callsBeforeRetry = context.mocks.s3.send.mock.calls.length;
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: candidate.version },
+    });
+    expect(context.mocks.s3.send.mock.calls.length - callsBeforeRetry).toBe(6);
+    expect(
+      commandInput(context.mocks.s3.send.mock.calls[callsBeforeRetry]?.[0]),
+    ).toMatchObject({
+      Key: ACTIVE_KEY,
+      IfNoneMatch: objectEtag(candidate.pointer),
+    });
+  });
+
+  it("replaces current content when a catalog version is reused", async () => {
     configureSource();
     const original = buildRelease({ version: "2026-07-15.conflict" });
     serveObjects(catalogObjects([original], original));
-    await syncCatalog();
+    const originalResponse = await syncCatalog();
 
     const conflicting = buildRelease({
       version: original.version,
       label: "Conflicting Content",
     });
     serveObjects(catalogObjects([conflicting], conflicting));
-    expect((await syncCatalog()).body).toMatchObject({
-      outcome: "rejected",
-      state: "stale",
+    const replacementResponse = await syncCatalog();
+    expect(replacementResponse.body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
       active: { catalogVersion: original.version },
-      lastAttempt: {
-        outcome: "rejected",
-        failureCode: "conflicting-release",
-      },
     });
+    expect(replacementResponse.body.active?.integrityDigest).not.toBe(
+      originalResponse.body.active?.integrityDigest,
+    );
   });
 
   it("does not return or log raw source failures", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -283,6 +283,17 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   const privateBytes = jsonBytes(privateArtifact);
   const privateFirewallsBytes = jsonBytes(privateFirewallsArtifact);
   const runnerFirewallsBytes = jsonBytes(runnerFirewallsArtifact);
+  const staticFilesPublicationArtifact: JsonRecord = {
+    artifactSchemaVersion: 1,
+    files: [
+      {
+        key: iconKey,
+        digest: iconDigest,
+        contentType: "image/svg+xml",
+        size: iconBytes.length,
+      },
+    ],
+  };
   const integrity: JsonRecord = {
     artifactSchemaVersion: 1,
     catalogVersion: options.version,
@@ -305,10 +316,10 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
         key: keys.runnerFirewalls,
         digest: digest(runnerFirewallsBytes),
       },
-      staticFilesPublication: artifactReference(
-        "icons/static-files.json",
-        "static-files",
-      ),
+      staticFilesPublication: {
+        key: "icons/static-files.json",
+        digest: valueDigest(staticFilesPublicationArtifact),
+      },
     },
     assets: [
       {
@@ -840,6 +851,50 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
             recordValue(artifacts.publicCatalog, "publicCatalog").digest =
               ZERO_DIGEST;
+          },
+        });
+      },
+    },
+    {
+      name: "static publication digest mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "bad-static-publication-digest",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(
+              artifacts.staticFilesPublication,
+              "staticFilesPublication",
+            ).digest = ZERO_DIGEST;
+          },
+        });
+      },
+    },
+    {
+      name: "unreferenced icon asset",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "unreferenced-icon",
+          mutateIntegrity: (integrity) => {
+            const extraBytes = Buffer.from("<svg>extra</svg>");
+            const extraDigest = digest(extraBytes);
+            const extraKey =
+              "platform/views/zero-page/components/settings/icons/" +
+              `zz-extra-${extraDigest.slice("sha256:".length, 19)}.svg`;
+            const assets = arrayValue(integrity.assets, "assets");
+            assets.push({
+              key: extraKey,
+              digest: extraDigest,
+              contentType: "image/svg+xml",
+              size: extraBytes.length,
+            });
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(
+              artifacts.staticFilesPublication,
+              "staticFilesPublication",
+            ).digest = valueDigest({ artifactSchemaVersion: 1, files: assets });
           },
         });
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -749,6 +749,13 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
+      name: "overlong catalog version",
+      expected: "invalid-pointer",
+      release: () => {
+        return buildRelease({ version: "a".repeat(256) });
+      },
+    },
+    {
       name: "wrong pointer reference",
       expected: "invalid-reference",
       release: () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -93,16 +93,8 @@ function digest(bytes: Uint8Array): string {
   return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }
 
-function valueDigest(value: unknown): string {
-  return digest(jsonBytes(value));
-}
-
 function catalogTemplate(reference: string): string {
   return `\${{ ${reference} }}`;
-}
-
-function artifactReference(key: string, content: string): JsonRecord {
-  return { key, digest: digest(Buffer.from(content)) };
 }
 
 function releaseKeys(version: string): {
@@ -190,24 +182,6 @@ function buildPrivateConnector(connectorRef: string): JsonRecord {
       },
     ],
   };
-}
-
-function requiredCapabilities(generatedFirewall: boolean): readonly string[] {
-  const capabilities = [
-    "bundle.required-resources@1",
-    "catalog.public@1",
-    "catalog.private@1",
-    "firewall.private@1",
-    "firewall.runner@1",
-    "icon.static-files-path@1",
-    "skill-none@1",
-    generatedFirewall ? "firewall-generated@1" : "firewall-none@1",
-  ];
-  if (generatedFirewall) {
-    capabilities.push("firewall.categories@1", "firewall.defaults@1");
-  }
-  capabilities.push("grant.manual@1", "access.static@1");
-  return capabilities;
 }
 
 function buildGeneratedFirewall(args: {
@@ -348,115 +322,25 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   options.mutatePrivate?.(privateArtifact);
   options.mutatePrivateFirewalls?.(privateFirewallsArtifact);
   options.mutateRunnerFirewalls?.(runnerFirewallsArtifact);
-  const currentPublicConnector = firstRecord(
-    publicArtifact.connectors,
-    "public connectors",
-  );
-  const currentPrivateConnector = firstRecord(
-    privateArtifact.connectors,
-    "private connectors",
-  );
-  const privateFirewallConnectors = arrayValue(
-    privateFirewallsArtifact.connectors,
-    "private firewall connectors",
-  );
-  const runnerFirewalls = arrayValue(
-    runnerFirewallsArtifact.firewalls,
-    "runner firewalls",
-  );
-  const integrityConnector: JsonRecord = {
-    connectorRef,
-    sourceFiles: [
-      artifactReference(
-        `catalog/connectors/${connectorRef}/connector.yaml`,
-        "a",
-      ),
-      artifactReference(`catalog/connectors/${connectorRef}/setup.yaml`, "b"),
-      artifactReference(`catalog/connectors/${connectorRef}/icon.svg`, "c"),
-      artifactReference(
-        `catalog/connectors/${connectorRef}/firewall.yaml`,
-        "d",
-      ),
-      artifactReference(
-        `catalog/connectors/${connectorRef}/metadata.yaml`,
-        "e",
-      ),
-    ],
-    publicDigest: valueDigest(currentPublicConnector),
-    privateDigest: valueDigest(currentPrivateConnector),
-    privateFirewallDigest:
-      privateFirewallConnectors.length === 0
-        ? null
-        : valueDigest(
-            firstRecord(privateFirewallConnectors, "private firewalls"),
-          ),
-    runnerFirewallDigest:
-      runnerFirewalls.length === 0
-        ? null
-        : valueDigest(firstRecord(runnerFirewalls, "runner firewalls")),
-    skill: { kind: "none" },
-    icon: { key: iconKey, digest: iconDigest },
-  };
   const publicBytes = options.publicBytes ?? jsonBytes(publicArtifact);
   const privateBytes = jsonBytes(privateArtifact);
   const privateFirewallsBytes = jsonBytes(privateFirewallsArtifact);
   const runnerFirewallsBytes = jsonBytes(runnerFirewallsArtifact);
-  const staticFilesPublicationArtifact: JsonRecord = {
-    artifactSchemaVersion: 1,
-    files: [
-      {
-        key: iconKey,
-        digest: iconDigest,
-        contentType: "image/svg+xml",
-        size: iconBytes.length,
-      },
-    ],
-  };
   const integrity: JsonRecord = {
     artifactSchemaVersion: 1,
     catalogVersion: options.version,
-    requiredCapabilities: requiredCapabilities(
-      options.generatedFirewall === true,
-    ),
-    catalogSource: artifactReference("catalog/catalog.yaml", "catalog"),
-    generatorSources: [
-      artifactReference("compiler/firewall-generator.ts", "generator"),
-    ],
     artifacts: {
-      publicCatalog: { key: keys.publicCatalog, digest: digest(publicBytes) },
-      privateCatalog: {
-        key: keys.privateCatalog,
-        digest: digest(privateBytes),
-      },
-      privateFirewalls: {
-        key: keys.privateFirewalls,
-        digest: digest(privateFirewallsBytes),
-      },
-      runnerFirewalls: {
-        key: keys.runnerFirewalls,
-        digest: digest(runnerFirewallsBytes),
-      },
-      staticFilesPublication: {
-        key: "icons/static-files.json",
-        digest: valueDigest(staticFilesPublicationArtifact),
-      },
+      publicCatalog: digest(publicBytes),
+      privateCatalog: digest(privateBytes),
+      privateFirewalls: digest(privateFirewallsBytes),
+      runnerFirewalls: digest(runnerFirewallsBytes),
     },
-    assets: [
-      {
-        key: iconKey,
-        digest: iconDigest,
-        contentType: "image/svg+xml",
-        size: iconBytes.length,
-      },
-    ],
-    skillArtifacts: [],
-    connectors: [integrityConnector],
   };
   options.mutateIntegrity?.(integrity);
   const integrityBytes = jsonBytes(integrity);
   const pointer: JsonRecord = {
     catalogVersion: options.version,
-    integrity: { key: keys.integrity, digest: digest(integrityBytes) },
+    integrityDigest: digest(integrityBytes),
   };
   options.mutatePointer?.(pointer);
 
@@ -883,14 +767,17 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
-      name: "wrong pointer reference",
-      expected: "invalid-reference",
+      name: "legacy pointer reference",
+      expected: "invalid-pointer",
       release: () => {
         return buildRelease({
-          version: "wrong-pointer-reference",
+          version: "legacy-pointer-reference",
           mutatePointer: (pointer) => {
-            recordValue(pointer.integrity, "pointer.integrity").key =
-              "connectors/v1/releases/other/integrity/catalog.json";
+            pointer.integrity = {
+              key: "connectors/v1/releases/legacy-pointer-reference/integrity/catalog.json",
+              digest: pointer.integrityDigest,
+            };
+            delete pointer.integrityDigest;
           },
         });
       },
@@ -902,8 +789,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
         return buildRelease({
           version: "bad-integrity-digest",
           mutatePointer: (pointer) => {
-            recordValue(pointer.integrity, "pointer.integrity").digest =
-              ZERO_DIGEST;
+            pointer.integrityDigest = ZERO_DIGEST;
           },
         });
       },
@@ -921,16 +807,16 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
-      name: "unsupported capability",
-      expected: "unsupported-capability",
+      name: "legacy integrity property",
+      expected: "invalid-artifact",
       release: () => {
         return buildRelease({
-          version: "unsupported-capability",
+          version: "legacy-integrity-property",
           mutateIntegrity: (integrity) => {
-            arrayValue(
-              integrity.requiredCapabilities,
-              "requiredCapabilities",
-            ).push("catalog.future@2");
+            integrity.catalogSource = {
+              key: "catalog/catalog.yaml",
+              digest: ZERO_DIGEST,
+            };
           },
         });
       },
@@ -965,150 +851,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           version: "bad-view-digest",
           mutateIntegrity: (integrity) => {
             const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").digest =
-              ZERO_DIGEST;
-          },
-        });
-      },
-    },
-    {
-      name: "static publication digest mismatch",
-      expected: "relationship-mismatch",
-      release: () => {
-        return buildRelease({
-          version: "bad-static-publication-digest",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(
-              artifacts.staticFilesPublication,
-              "staticFilesPublication",
-            ).digest = ZERO_DIGEST;
-          },
-        });
-      },
-    },
-    {
-      name: "unreferenced icon asset",
-      expected: "relationship-mismatch",
-      release: () => {
-        return buildRelease({
-          version: "unreferenced-icon",
-          mutateIntegrity: (integrity) => {
-            const extraBytes = Buffer.from("<svg>extra</svg>");
-            const extraDigest = digest(extraBytes);
-            const extraKey =
-              "platform/views/zero-page/components/settings/icons/" +
-              `zz-extra-${extraDigest.slice("sha256:".length, 19)}.svg`;
-            const assets = arrayValue(integrity.assets, "assets");
-            assets.push({
-              key: extraKey,
-              digest: extraDigest,
-              contentType: "image/svg+xml",
-              size: extraBytes.length,
-            });
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(
-              artifacts.staticFilesPublication,
-              "staticFilesPublication",
-            ).digest = valueDigest({ artifactSchemaVersion: 1, files: assets });
-          },
-        });
-      },
-    },
-    {
-      name: "local staging key",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "staging-key",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "generated/connectors/v1/releases/staging-key/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "legacy catalog key",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "legacy-key",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "catalog-v1/releases/legacy-key/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "discarded connector catalog namespace",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "discarded-namespace",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connector-catalog/v1/releases/discarded-namespace/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "cross-release key",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "cross-release",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connectors/v1/releases/other/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "unversioned key",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "unversioned-key",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connectors/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "wrong schema generation key",
-      expected: "invalid-reference",
-      release: () => {
-        return buildRelease({
-          version: "wrong-schema-key",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connectors/v2/releases/wrong-schema-key/public/catalog.json";
-          },
-        });
-      },
-    },
-    {
-      name: "traversal key",
-      expected: "invalid-artifact",
-      release: () => {
-        return buildRelease({
-          version: "traversal-key",
-          mutateIntegrity: (integrity) => {
-            const artifacts = recordValue(integrity.artifacts, "artifacts");
-            recordValue(artifacts.publicCatalog, "publicCatalog").key =
-              "connectors/v1/releases/traversal-key/../public/catalog.json";
+            artifacts.publicCatalog = ZERO_DIGEST;
           },
         });
       },
@@ -1165,31 +908,32 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
-      name: "cross-view icon mismatch",
-      expected: "relationship-mismatch",
+      name: "invalid icon reference",
+      expected: "invalid-artifact",
       release: () => {
         return buildRelease({
-          version: "icon-mismatch",
-          mutateIntegrity: (integrity) => {
-            const connector = firstRecord(integrity.connectors, "connectors");
-            recordValue(connector.icon, "icon").digest = ZERO_DIGEST;
+          version: "invalid-icon-reference",
+          mutatePublic: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            const icon = recordValue(connector.icon, "icon");
+            recordValue(icon.asset, "icon asset").digest = ZERO_DIGEST;
           },
         });
       },
     },
     {
-      name: "cross-view skill mismatch",
-      expected: "relationship-mismatch",
+      name: "invalid skill reference",
+      expected: "invalid-artifact",
       release: () => {
         return buildRelease({
-          version: "skill-mismatch",
-          mutateIntegrity: (integrity) => {
-            const connector = firstRecord(integrity.connectors, "connectors");
+          version: "invalid-skill-reference",
+          mutatePrivate: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
             const versionId = "a".repeat(64);
-            const prefix = `__system__/volume/connector-skill@external-test/${versionId}`;
+            const prefix = `__system__/volume/connector-skill@wrong/${versionId}`;
             connector.skill = {
               kind: "bundled",
-              storageName: "connector-skill@external-test",
+              storageName: "connector-skill@wrong",
               versionId,
               manifest: {
                 key: `${prefix}/manifest.json`,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -188,6 +188,42 @@ function buildPrivateConnector(connectorRef: string): JsonRecord {
   };
 }
 
+function buildBundledSkill(connectorRef: string): JsonRecord {
+  const versionId = "a".repeat(64);
+  const storageName = `connector-skill@${connectorRef}`;
+  const prefix = `__system__/volume/${storageName}/${versionId}`;
+  return {
+    kind: "bundled",
+    storageName,
+    versionId,
+    frontmatter: {
+      name: `${connectorRef} skill`,
+      description: `Use the ${connectorRef} connector`,
+    },
+    manifest: {
+      key: `${prefix}/manifest.json`,
+      digest: ZERO_DIGEST,
+    },
+    archive: {
+      key: `${prefix}/archive.tar.gz`,
+      digest: ZERO_DIGEST,
+    },
+  };
+}
+
+function setPrivateFirewallBase(artifact: JsonRecord, base: string): void {
+  const connector = firstRecord(artifact.connectors, "connectors");
+  const firewall = recordValue(connector.firewall, "firewall");
+  firstRecord(firewall.apis, "firewall.apis").base = base;
+  const routing = recordValue(connector.routing, "routing");
+  firstRecord(routing.apis, "routing.apis").base = base;
+}
+
+function setRunnerFirewallBase(artifact: JsonRecord, base: string): void {
+  const firewall = firstRecord(artifact.firewalls, "firewalls");
+  firstRecord(firewall.apis, "firewall.apis").base = base;
+}
+
 function buildGeneratedFirewall(args: {
   readonly connectorRef: string;
   readonly label: string;
@@ -614,6 +650,77 @@ describe("connector catalog valid lifecycle", () => {
     });
   });
 
+  it("accepts canonical firewall bases with authority parameters", async () => {
+    configureSource();
+    const base = "https://{awsHost+}.amazonaws.com";
+    const release = buildRelease({
+      version: "2026-07-15.parameterized-firewall",
+      generatedFirewall: true,
+      mutatePrivateFirewalls: (artifact) => {
+        setPrivateFirewallBase(artifact, base);
+        const connector = firstRecord(artifact.connectors, "connectors");
+        const routing = recordValue(connector.routing, "routing");
+        routing.fixedHosts = ["{awshost+}.amazonaws.com"];
+      },
+      mutateRunnerFirewalls: (artifact) => {
+        setRunnerFirewallBase(artifact, base);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
+  });
+
+  it("accepts a complete bundled skill descriptor", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.bundled-skill",
+      mutatePrivate: (artifact) => {
+        const connector = firstRecord(artifact.connectors, "connectors");
+        connector.skill = buildBundledSkill("external-test");
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
+  });
+
+  it("accepts source identities and platform requirements without local support", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.future-capability",
+      mutatePublic: (artifact) => {
+        const connector = firstRecord(artifact.connectors, "connectors");
+        firstRecord(connector.authMethods, "authMethods").id =
+          "service-account";
+      },
+      mutatePrivate: (artifact) => {
+        const connector = firstRecord(artifact.connectors, "connectors");
+        const method = firstRecord(connector.authMethods, "authMethods");
+        method.id = "service-account";
+        const access = recordValue(method.access, "access");
+        access.platformSecrets = ["FUTURE_PLATFORM_KEY"];
+        recordValue(access.envBindings, "envBindings").PLATFORM_KEY =
+          "$secrets.FUTURE_PLATFORM_KEY";
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
+  });
+
   it("serializes overlapping syncs without a mixed snapshot", async () => {
     configureSource();
     const release = buildRelease({ version: "2026-07-15.concurrent" });
@@ -953,21 +1060,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
           version: "invalid-skill-reference",
           mutatePrivate: (artifact) => {
             const connector = firstRecord(artifact.connectors, "connectors");
-            const versionId = "a".repeat(64);
-            const prefix = `__system__/volume/connector-skill@wrong/${versionId}`;
-            connector.skill = {
-              kind: "bundled",
-              storageName: "connector-skill@wrong",
-              versionId,
-              manifest: {
-                key: `${prefix}/manifest.json`,
-                digest: ZERO_DIGEST,
-              },
-              archive: {
-                key: `${prefix}/archive.tar.gz`,
-                digest: ZERO_DIGEST,
-              },
-            };
+            connector.skill = buildBundledSkill("wrong");
           },
         });
       },
@@ -1003,6 +1096,85 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const firewall = recordValue(connector.firewall, "firewall");
             firstRecord(firewall.apis, "firewall.apis").base =
               "http://api.example.test/v1";
+          },
+        });
+      },
+    },
+    {
+      name: "non-canonical firewall base hostname",
+      expected: "relationship-mismatch",
+      release: () => {
+        const base = "https://API.EXAMPLE.TEST/v1";
+        return buildRelease({
+          version: "firewall-noncanonical-hostname",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            setPrivateFirewallBase(artifact, base);
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            setRunnerFirewallBase(artifact, base);
+          },
+        });
+      },
+    },
+    {
+      name: "unsafe firewall base path",
+      expected: "relationship-mismatch",
+      release: () => {
+        const base = "https://api.example.test/v1/../admin";
+        return buildRelease({
+          version: "firewall-unsafe-base-path",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            setPrivateFirewallBase(artifact, base);
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            setRunnerFirewallBase(artifact, base);
+          },
+        });
+      },
+    },
+    {
+      name: "non-canonical firewall host policy",
+      expected: "invalid-artifact",
+      release: () => {
+        const hostPolicy = {
+          kind: "providerOwned",
+          exactHosts: ["API.EXAMPLE.TEST"],
+        };
+        return buildRelease({
+          version: "firewall-noncanonical-host-policy",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            const firewall = recordValue(connector.firewall, "firewall");
+            firstRecord(firewall.apis, "firewall.apis").hostPolicy = hostPolicy;
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            const firewall = firstRecord(artifact.firewalls, "firewalls");
+            firstRecord(firewall.apis, "firewall.apis").hostPolicy = hostPolicy;
+          },
+        });
+      },
+    },
+    {
+      name: "invalid firewall auth base URL",
+      expected: "relationship-mismatch",
+      release: () => {
+        const authBase = "http://webhook.example.test/token";
+        return buildRelease({
+          version: "firewall-invalid-auth-base",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            const firewall = recordValue(connector.firewall, "firewall");
+            const api = firstRecord(firewall.apis, "firewall.apis");
+            recordValue(api.auth, "firewall auth").base = authBase;
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            const firewall = firstRecord(artifact.firewalls, "firewalls");
+            const api = firstRecord(firewall.apis, "firewall.apis");
+            recordValue(api.auth, "firewall auth").base = authBase;
           },
         });
       },
@@ -1154,6 +1326,84 @@ describe("connector catalog rejection and latest-valid retention", () => {
     ).toMatchObject({
       Key: ACTIVE_KEY,
       IfNoneMatch: objectEtag(invalid.pointer),
+    });
+  });
+
+  it("re-evaluates a rejected identity when the pointer ETag changes", async () => {
+    configureSource();
+    const invalid = buildRelease({
+      version: "2026-07-15.changed-rejection-etag",
+      mutatePublic: (artifact) => {
+        artifact.extra = true;
+      },
+    });
+    serveObjects(catalogObjects([invalid], invalid));
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "invalid-artifact",
+    );
+
+    const changedPointer = Buffer.concat([invalid.pointer, Buffer.from("\n")]);
+    const changedObjects = new Map(catalogObjects([invalid], invalid));
+    changedObjects.set(ACTIVE_KEY, changedPointer);
+    serveObjects(changedObjects);
+    const callsBeforeReevaluation = context.mocks.s3.send.mock.calls.length;
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "invalid-artifact",
+    );
+    expect(
+      context.mocks.s3.send.mock.calls.length - callsBeforeReevaluation,
+    ).toBe(6);
+    expect(
+      commandInput(
+        context.mocks.s3.send.mock.calls[callsBeforeReevaluation]?.[0],
+      ),
+    ).toMatchObject({
+      Key: ACTIVE_KEY,
+      IfNoneMatch: objectEtag(invalid.pointer),
+    });
+  });
+
+  it("caches an oversized active pointer by its observed ETag", async () => {
+    configureSource();
+    const oversizedPointer = Buffer.alloc(16 * 1024 + 1);
+    const etag = objectEtag(oversizedPointer);
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const input = commandInput(command);
+      if (input.IfNoneMatch === etag) {
+        return Promise.reject(
+          Object.assign(new Error("Not modified"), {
+            $metadata: { httpStatusCode: 304 },
+          }),
+        );
+      }
+      return Promise.resolve({
+        ContentLength: oversizedPointer.length,
+        Body: s3Body(oversizedPointer),
+        ETag: etag,
+      });
+    });
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "object-too-large",
+    );
+
+    const callsBeforeCachedRejection = context.mocks.s3.send.mock.calls.length;
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "object-too-large",
+    );
+    expect(
+      context.mocks.s3.send.mock.calls.length - callsBeforeCachedRejection,
+    ).toBe(1);
+    expect(
+      commandInput(
+        context.mocks.s3.send.mock.calls[callsBeforeCachedRejection]?.[0],
+      ),
+    ).toMatchObject({
+      Key: ACTIVE_KEY,
+      IfNoneMatch: etag,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1,0 +1,1108 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { cronConnectorCatalogContract } from "@vm0/api-contracts/contracts/cron";
+import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { clearMockNow, mockNow } from "../../../lib/time";
+import { createDeferredPromise, settle } from "../../utils";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const zeroMocks = createZeroRouteMocks(context);
+const CRON_SECRET = "connector-catalog-cron-secret";
+const ACTIVE_KEY = "catalog-v1/active.json";
+const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
+const PRIVATE_VALUE = "SECRET_TOKEN";
+const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
+
+type JsonRecord = Record<string, unknown>;
+type JsonMutation = (value: JsonRecord) => void;
+
+interface ReleaseFixtureOptions {
+  readonly version: string;
+  readonly connectorRef?: string;
+  readonly label?: string;
+  readonly publicBytes?: Buffer;
+  readonly mutatePublic?: JsonMutation;
+  readonly mutatePrivate?: JsonMutation;
+  readonly mutatePrivateFirewalls?: JsonMutation;
+  readonly mutateRunnerFirewalls?: JsonMutation;
+  readonly mutateIntegrity?: JsonMutation;
+  readonly mutatePointer?: JsonMutation;
+}
+
+interface ReleaseFixture {
+  readonly version: string;
+  readonly connectorRef: string;
+  readonly pointer: Buffer;
+  readonly integrityKey: string;
+  readonly objects: ReadonlyMap<string, Buffer>;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown, label: string): JsonRecord {
+  if (!isJsonRecord(value)) {
+    throw new Error(`Expected ${label} to be an object`);
+  }
+  return value;
+}
+
+function arrayValue(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected ${label} to be an array`);
+  }
+  return value;
+}
+
+function firstRecord(value: unknown, label: string): JsonRecord {
+  const first = arrayValue(value, label)[0];
+  return recordValue(first, `${label}[0]`);
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      return canonicalJsonValue(item);
+    });
+  }
+  if (!isJsonRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => {
+        return [key, canonicalJsonValue(value[key])];
+      }),
+  );
+}
+
+function jsonBytes(value: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(canonicalJsonValue(value), null, 2)}\n`);
+}
+
+function digest(bytes: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function valueDigest(value: unknown): string {
+  return digest(jsonBytes(value));
+}
+
+function artifactReference(key: string, content: string): JsonRecord {
+  return { key, digest: digest(Buffer.from(content)) };
+}
+
+function releaseKeys(version: string): {
+  readonly integrity: string;
+  readonly publicCatalog: string;
+  readonly privateCatalog: string;
+  readonly privateFirewalls: string;
+  readonly runnerFirewalls: string;
+} {
+  const prefix = `catalog-v1/releases/${version}`;
+  return {
+    integrity: `${prefix}/integrity/catalog.json`,
+    publicCatalog: `${prefix}/public/catalog.json`,
+    privateCatalog: `${prefix}/private/catalog.json`,
+    privateFirewalls: `${prefix}/private/firewalls.json`,
+    runnerFirewalls: `${prefix}/runner/firewalls.json`,
+  };
+}
+
+function buildPublicConnector(args: {
+  readonly connectorRef: string;
+  readonly label: string;
+  readonly iconKey: string;
+  readonly iconDigest: string;
+}): JsonRecord {
+  return {
+    connectorRef: args.connectorRef,
+    label: args.label,
+    description: "An external connector used only by the sync fixture",
+    category: "testing",
+    generation: [],
+    tags: ["fixture"],
+    authMethods: [
+      {
+        id: "api-token",
+        label: "API Token",
+        description: null,
+        defaultVisible: true,
+        grantKind: "manual",
+        manualFields: [
+          {
+            id: "credential",
+            label: "Credential",
+            required: true,
+            placeholder: null,
+            inputType: "password",
+          },
+        ],
+        startOptions: [],
+      },
+    ],
+    icon: {
+      asset: { key: args.iconKey, digest: args.iconDigest },
+      contentType: "image/svg+xml",
+      invertInDarkMode: false,
+    },
+    firewall: { kind: "none" },
+  };
+}
+
+function buildPrivateConnector(connectorRef: string): JsonRecord {
+  return {
+    connectorRef,
+    skill: { kind: "none" },
+    authMethods: [
+      {
+        id: "api-token",
+        storage: { secrets: [PRIVATE_VALUE], variables: [] },
+        grant: {
+          kind: "manual",
+          fields: [
+            {
+              privateName: PRIVATE_VALUE,
+              publicId: "credential",
+              storage: "secret",
+            },
+          ],
+        },
+        access: {
+          kind: "static",
+          envBindings: { SERVICE_TOKEN: `$secrets.${PRIVATE_VALUE}` },
+        },
+        revoke: { kind: "none" },
+      },
+    ],
+  };
+}
+
+function requiredCapabilities(): readonly string[] {
+  return [
+    "bundle.required-resources@1",
+    "catalog.public@1",
+    "catalog.private@1",
+    "firewall.private@1",
+    "firewall.runner@1",
+    "icon.static-files-path@1",
+    "skill-none@1",
+    "firewall-none@1",
+    "grant.manual@1",
+    "access.static@1",
+  ];
+}
+
+function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
+  const connectorRef = options.connectorRef ?? "external-test";
+  const label = options.label ?? "External Test";
+  const keys = releaseKeys(options.version);
+  const iconBytes = Buffer.from(`<svg>${connectorRef}</svg>`);
+  const iconDigest = digest(iconBytes);
+  const iconKey =
+    "platform/views/zero-page/components/settings/icons/" +
+    `${connectorRef}-${iconDigest.slice("sha256:".length, 19)}.svg`;
+  const publicConnector = buildPublicConnector({
+    connectorRef,
+    label,
+    iconKey,
+    iconDigest,
+  });
+  const privateConnector = buildPrivateConnector(connectorRef);
+  const publicArtifact: JsonRecord = {
+    artifactSchemaVersion: 1,
+    catalogVersion: options.version,
+    categoryMetadata: {
+      categories: [
+        {
+          id: "testing",
+          label: "Testing",
+          menuLabel: "Testing",
+          groupId: null,
+        },
+      ],
+      groups: [],
+    },
+    connectors: [publicConnector],
+  };
+  const privateArtifact: JsonRecord = {
+    artifactSchemaVersion: 1,
+    catalogVersion: options.version,
+    connectors: [privateConnector],
+  };
+  const privateFirewallsArtifact: JsonRecord = {
+    artifactSchemaVersion: 1,
+    catalogVersion: options.version,
+    connectors: [],
+  };
+  const runnerFirewallsArtifact: JsonRecord = {
+    artifactSchemaVersion: 1,
+    catalogVersion: options.version,
+    firewalls: [],
+  };
+
+  const integrityConnector: JsonRecord = {
+    connectorRef,
+    sourceFiles: [
+      artifactReference(
+        `catalog/connectors/${connectorRef}/connector.yaml`,
+        "a",
+      ),
+      artifactReference(`catalog/connectors/${connectorRef}/setup.yaml`, "b"),
+      artifactReference(`catalog/connectors/${connectorRef}/icon.svg`, "c"),
+      artifactReference(
+        `catalog/connectors/${connectorRef}/firewall.yaml`,
+        "d",
+      ),
+      artifactReference(
+        `catalog/connectors/${connectorRef}/metadata.yaml`,
+        "e",
+      ),
+    ],
+    publicDigest: valueDigest(publicConnector),
+    privateDigest: valueDigest(privateConnector),
+    privateFirewallDigest: null,
+    runnerFirewallDigest: null,
+    skill: { kind: "none" },
+    icon: { key: iconKey, digest: iconDigest },
+  };
+
+  options.mutatePublic?.(publicArtifact);
+  options.mutatePrivate?.(privateArtifact);
+  options.mutatePrivateFirewalls?.(privateFirewallsArtifact);
+  options.mutateRunnerFirewalls?.(runnerFirewallsArtifact);
+  const publicBytes = options.publicBytes ?? jsonBytes(publicArtifact);
+  const privateBytes = jsonBytes(privateArtifact);
+  const privateFirewallsBytes = jsonBytes(privateFirewallsArtifact);
+  const runnerFirewallsBytes = jsonBytes(runnerFirewallsArtifact);
+  const integrity: JsonRecord = {
+    artifactSchemaVersion: 1,
+    catalogVersion: options.version,
+    requiredCapabilities: requiredCapabilities(),
+    catalogSource: artifactReference("catalog/catalog.yaml", "catalog"),
+    generatorSources: [
+      artifactReference("compiler/firewall-generator.ts", "generator"),
+    ],
+    artifacts: {
+      publicCatalog: { key: keys.publicCatalog, digest: digest(publicBytes) },
+      privateCatalog: {
+        key: keys.privateCatalog,
+        digest: digest(privateBytes),
+      },
+      privateFirewalls: {
+        key: keys.privateFirewalls,
+        digest: digest(privateFirewallsBytes),
+      },
+      runnerFirewalls: {
+        key: keys.runnerFirewalls,
+        digest: digest(runnerFirewallsBytes),
+      },
+      staticFilesPublication: artifactReference(
+        "icons/static-files.json",
+        "static-files",
+      ),
+    },
+    assets: [
+      {
+        key: iconKey,
+        digest: iconDigest,
+        contentType: "image/svg+xml",
+        size: iconBytes.length,
+      },
+    ],
+    skillArtifacts: [],
+    connectors: [integrityConnector],
+  };
+  options.mutateIntegrity?.(integrity);
+  const integrityBytes = jsonBytes(integrity);
+  const pointer: JsonRecord = {
+    catalogVersion: options.version,
+    integrity: { key: keys.integrity, digest: digest(integrityBytes) },
+  };
+  options.mutatePointer?.(pointer);
+
+  return {
+    version: options.version,
+    connectorRef,
+    pointer: jsonBytes(pointer),
+    integrityKey: keys.integrity,
+    objects: new Map([
+      [keys.integrity, integrityBytes],
+      [keys.publicCatalog, publicBytes],
+      [keys.privateCatalog, privateBytes],
+      [keys.privateFirewalls, privateFirewallsBytes],
+      [keys.runnerFirewalls, runnerFirewallsBytes],
+    ]),
+  };
+}
+
+function catalogObjects(
+  releases: readonly ReleaseFixture[],
+  active: ReleaseFixture,
+): ReadonlyMap<string, Buffer> {
+  const objects = new Map<string, Buffer>();
+  for (const release of releases) {
+    for (const [key, bytes] of release.objects) {
+      objects.set(key, bytes);
+    }
+  }
+  objects.set(ACTIVE_KEY, active.pointer);
+  return objects;
+}
+
+function commandInput(command: unknown): JsonRecord {
+  if (!isJsonRecord(command)) {
+    return {};
+  }
+  return isJsonRecord(command.input) ? command.input : {};
+}
+
+function s3Body(bytes: Uint8Array): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield bytes;
+    },
+  };
+}
+
+function deferredGate(): {
+  readonly promise: Promise<void>;
+  readonly release: () => void;
+} {
+  const deferred = createDeferredPromise<void>(context.signal);
+  return {
+    promise: deferred.promise,
+    release: () => {
+      if (!deferred.settled()) {
+        deferred.resolve(undefined);
+      }
+    },
+  };
+}
+
+function serveObjects(objects: ReadonlyMap<string, Buffer>): void {
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    const input = commandInput(command);
+    const key = typeof input.Key === "string" ? input.Key : undefined;
+    const bytes = key ? objects.get(key) : undefined;
+    if (!bytes) {
+      return Promise.reject(new Error("Object unavailable"));
+    }
+    return Promise.resolve({
+      ContentLength: bytes.length,
+      Body: s3Body(bytes),
+    });
+  });
+}
+
+function configureSource(): string {
+  const bucket = `connector-catalog-test-${randomUUID()}`;
+  mockEnv("R2_CONNECTOR_CATALOG_BUCKET_NAME", bucket);
+  return bucket;
+}
+
+function cronHeaders(secret = CRON_SECRET): { readonly authorization: string } {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function cronClient() {
+  return setupApp({ context })(cronConnectorCatalogContract);
+}
+
+async function syncCatalog() {
+  return await accept(cronClient().sync({ headers: cronHeaders() }), [200]);
+}
+
+async function readStatus() {
+  return await accept(cronClient().status({ headers: cronHeaders() }), [200]);
+}
+
+async function rawCronRequest(path: string): Promise<Response> {
+  return await createApp({ signal: context.signal }).request(path, {
+    method: "GET",
+  });
+}
+
+function expectRejectedBeforeAcceptance(
+  body: Awaited<ReturnType<typeof syncCatalog>>["body"],
+  failureCode: string,
+): void {
+  expect(body).toMatchObject({
+    outcome: "rejected",
+    configured: true,
+    state: "never-synced",
+    active: null,
+    lastAttempt: {
+      outcome: "rejected",
+      failureCode,
+    },
+    lastSuccessAt: null,
+  });
+}
+
+beforeEach(() => {
+  mockEnv("CRON_SECRET", CRON_SECRET);
+  mockEnv("R2_CONNECTOR_CATALOG_BUCKET_NAME", undefined);
+  mockNow(new Date(FIRST_SYNC_TIME));
+});
+
+afterEach(() => {
+  clearMockNow();
+});
+
+describe("connector catalog cron authentication and inactive state", () => {
+  it("rejects missing and invalid cron credentials for both operations", async () => {
+    for (const operation of [cronClient().sync, cronClient().status]) {
+      const response = await accept(
+        operation({ headers: cronHeaders("wrong-secret") }),
+        [401],
+      );
+      expect(response.body).toStrictEqual({
+        error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+      });
+    }
+    for (const path of [
+      "/api/cron/sync-connector-catalog",
+      "/api/cron/connector-catalog-status",
+    ]) {
+      const response = await rawCronRequest(path);
+      expect(response.status).toBe(401);
+    }
+  });
+
+  it("returns a disabled no-op without a configured bucket", async () => {
+    expect((await readStatus()).body).toStrictEqual({
+      configured: false,
+      state: "never-synced",
+      active: null,
+      lastAttempt: null,
+      lastSuccessAt: null,
+    });
+    expect((await syncCatalog()).body).toStrictEqual({
+      outcome: "disabled",
+      configured: false,
+      state: "never-synced",
+      active: null,
+      lastAttempt: null,
+      lastSuccessAt: null,
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("reports never-synced without reading R2 for a configured source", async () => {
+    configureSource();
+    expect((await readStatus()).body).toStrictEqual({
+      configured: true,
+      state: "never-synced",
+      active: null,
+      lastAttempt: null,
+      lastSuccessAt: null,
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("connector catalog valid lifecycle", () => {
+  it("accepts, advances, rolls back, and leaves the public catalog static", async () => {
+    configureSource();
+    const first = buildRelease({ version: "2026-07-15.1" });
+    const second = buildRelease({
+      version: "2026-07-15.2",
+      label: "External Test Updated",
+    });
+    serveObjects(catalogObjects([first, second], first));
+    const acceptedFirst = await syncCatalog();
+    expect(acceptedFirst.body).toMatchObject({
+      outcome: "accepted",
+      configured: true,
+      state: "current",
+      active: { catalogVersion: first.version },
+      lastAttempt: { outcome: "accepted", failureCode: null },
+      lastSuccessAt: FIRST_SYNC_TIME,
+    });
+
+    const callsBeforeStatus = context.mocks.s3.send.mock.calls.length;
+    expect((await readStatus()).body).toStrictEqual(
+      (({ outcome: _outcome, ...status }) => {
+        return status;
+      })(acceptedFirst.body),
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeStatus);
+
+    mockNow(new Date("2026-07-15T08:01:00.000Z"));
+    const callsBeforeUnchanged = context.mocks.s3.send.mock.calls.length;
+    const unchanged = await syncCatalog();
+    expect(unchanged.body).toMatchObject({
+      outcome: "unchanged",
+      state: "current",
+      active: { catalogVersion: first.version },
+      lastAttempt: { outcome: "unchanged", failureCode: null },
+      lastSuccessAt: "2026-07-15T08:01:00.000Z",
+    });
+    expect(context.mocks.s3.send.mock.calls.length - callsBeforeUnchanged).toBe(
+      1,
+    );
+
+    serveObjects(catalogObjects([first, second], second));
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      active: { catalogVersion: second.version },
+    });
+
+    serveObjects(catalogObjects([first, second], first));
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      active: { catalogVersion: first.version },
+    });
+
+    zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const publicCatalog = await accept(
+      setupApp({ context })(zeroConnectorCatalogContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      publicCatalog.body.connectors.some((connector) => {
+        return connector.connectorRef === first.connectorRef;
+      }),
+    ).toBeFalsy();
+  });
+
+  it("serializes overlapping syncs without a mixed snapshot", async () => {
+    configureSource();
+    const release = buildRelease({ version: "2026-07-15.concurrent" });
+    serveObjects(catalogObjects([release], release));
+    const results = await Promise.all([syncCatalog(), syncCatalog()]);
+    expect(
+      results
+        .map((result) => {
+          return result.body.outcome;
+        })
+        .sort(),
+    ).toStrictEqual(["accepted", "unchanged"]);
+    expect((await readStatus()).body).toMatchObject({
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
+  });
+
+  it("rolls back a release identity when its state compare-and-swap loses", async () => {
+    configureSource();
+    const losing = buildRelease({
+      version: "2026-07-15.losing",
+      label: "Losing Candidate",
+    });
+    const winning = buildRelease({
+      version: "2026-07-15.winning",
+      label: "Winning Candidate",
+    });
+    const replacement = buildRelease({
+      version: losing.version,
+      label: "Replacement Candidate",
+    });
+    const objects = catalogObjects([losing, winning], winning);
+    const losingPublicKey = releaseKeys(losing.version).publicCatalog;
+    const blocked = deferredGate();
+    const resume = deferredGate();
+    const activePointers = [
+      losing.pointer,
+      winning.pointer,
+      winning.pointer,
+      losing.pointer,
+      winning.pointer,
+    ];
+    let activeReads = 0;
+    let blockedLosingPublic = false;
+    context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+      const key = commandInput(command).Key;
+      if (key === losingPublicKey && !blockedLosingPublic) {
+        blockedLosingPublic = true;
+        blocked.release();
+        await resume.promise;
+      }
+      const bytes =
+        key === ACTIVE_KEY
+          ? activePointers[activeReads++]
+          : typeof key === "string"
+            ? objects.get(key)
+            : undefined;
+      if (!bytes) {
+        throw new Error("Object unavailable");
+      }
+      return {
+        ContentLength: bytes.length,
+        Body: s3Body(bytes),
+      };
+    });
+
+    const losingSync = syncCatalog();
+    await blocked.promise;
+    const settledWinningResult = await settle(syncCatalog(), context.signal);
+    resume.release();
+    if (!settledWinningResult.ok) {
+      throw settledWinningResult.error;
+    }
+    const winningResult = settledWinningResult.value;
+    const losingResult = await losingSync;
+    expect(winningResult.body.outcome).toBe("accepted");
+    expect(losingResult.body.outcome).toBe("unchanged");
+
+    serveObjects(catalogObjects([replacement], replacement));
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      active: { catalogVersion: replacement.version },
+    });
+  });
+
+  it("restarts when active changes during validation", async () => {
+    configureSource();
+    const superseded = buildRelease({ version: "2026-07-15.old" });
+    const current = buildRelease({ version: "2026-07-15.current" });
+    const objects = catalogObjects([superseded, current], current);
+    let activeReads = 0;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const key = commandInput(command).Key;
+      const bytes =
+        key === ACTIVE_KEY
+          ? ++activeReads === 1
+            ? superseded.pointer
+            : current.pointer
+          : typeof key === "string"
+            ? objects.get(key)
+            : undefined;
+      if (!bytes) {
+        return Promise.reject(new Error("Object unavailable"));
+      }
+      return Promise.resolve({
+        ContentLength: bytes.length,
+        Body: s3Body(bytes),
+      });
+    });
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      active: { catalogVersion: current.version },
+    });
+    expect(activeReads).toBe(4);
+  });
+});
+
+describe("connector catalog rejection and latest-valid retention", () => {
+  it("classifies unavailable and oversized objects before acceptance", async () => {
+    configureSource();
+    context.mocks.s3.send.mockRejectedValue(
+      new Error("private source credentials and URL must stay private"),
+    );
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "source-unavailable",
+    );
+
+    configureSource();
+    context.mocks.s3.send.mockResolvedValue({
+      ContentLength: 16 * 1024 + 1,
+      Body: s3Body(Buffer.from("oversized")),
+    });
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "object-too-large",
+    );
+
+    configureSource();
+    context.mocks.s3.send.mockResolvedValue({
+      Body: s3Body(Buffer.alloc(16 * 1024 + 1)),
+    });
+    expectRejectedBeforeAcceptance(
+      (await syncCatalog()).body,
+      "object-too-large",
+    );
+  });
+
+  it.each([
+    {
+      name: "invalid JSON",
+      expected: "invalid-json",
+      release: () => {
+        const fixture = buildRelease({ version: "invalid-json" });
+        return { ...fixture, pointer: Buffer.from("{") };
+      },
+    },
+    {
+      name: "strict pointer property",
+      expected: "invalid-pointer",
+      release: () => {
+        return buildRelease({
+          version: "invalid-pointer",
+          mutatePointer: (pointer) => {
+            pointer.extra = true;
+          },
+        });
+      },
+    },
+    {
+      name: "wrong pointer reference",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "wrong-pointer-reference",
+          mutatePointer: (pointer) => {
+            recordValue(pointer.integrity, "pointer.integrity").key =
+              "catalog-v1/releases/other/integrity/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "integrity digest mismatch",
+      expected: "digest-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "bad-integrity-digest",
+          mutatePointer: (pointer) => {
+            recordValue(pointer.integrity, "pointer.integrity").digest =
+              ZERO_DIGEST;
+          },
+        });
+      },
+    },
+    {
+      name: "unsupported schema",
+      expected: "unsupported-schema",
+      release: () => {
+        return buildRelease({
+          version: "unsupported-schema",
+          mutateIntegrity: (integrity) => {
+            integrity.artifactSchemaVersion = 2;
+          },
+        });
+      },
+    },
+    {
+      name: "unsupported capability",
+      expected: "unsupported-capability",
+      release: () => {
+        return buildRelease({
+          version: "unsupported-capability",
+          mutateIntegrity: (integrity) => {
+            arrayValue(
+              integrity.requiredCapabilities,
+              "requiredCapabilities",
+            ).push("catalog.future@2");
+          },
+        });
+      },
+    },
+    {
+      name: "strict artifact property",
+      expected: "invalid-artifact",
+      release: () => {
+        return buildRelease({
+          version: "invalid-artifact",
+          mutatePublic: (artifact) => {
+            artifact.extra = true;
+          },
+        });
+      },
+    },
+    {
+      name: "invalid UTF-8 artifact",
+      expected: "invalid-json",
+      release: () => {
+        return buildRelease({
+          version: "invalid-utf8",
+          publicBytes: Buffer.from([0xc3, 0x28]),
+        });
+      },
+    },
+    {
+      name: "view digest mismatch",
+      expected: "digest-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "bad-view-digest",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").digest =
+              ZERO_DIGEST;
+          },
+        });
+      },
+    },
+    {
+      name: "local staging key",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "staging-key",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "connectors/catalog-v1/releases/staging-key/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "cross-release key",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "cross-release",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "catalog-v1/releases/other/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "unversioned key",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "unversioned-key",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "catalog-v1/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "wrong schema generation key",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "wrong-schema-key",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "catalog-v2/releases/wrong-schema-key/public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "traversal key",
+      expected: "invalid-artifact",
+      release: () => {
+        return buildRelease({
+          version: "traversal-key",
+          mutateIntegrity: (integrity) => {
+            const artifacts = recordValue(integrity.artifacts, "artifacts");
+            recordValue(artifacts.publicCatalog, "publicCatalog").key =
+              "catalog-v1/releases/traversal-key/../public/catalog.json";
+          },
+        });
+      },
+    },
+    {
+      name: "header mismatch",
+      expected: "invalid-reference",
+      release: () => {
+        return buildRelease({
+          version: "header-mismatch",
+          mutatePublic: (artifact) => {
+            artifact.catalogVersion = "other";
+          },
+        });
+      },
+    },
+    {
+      name: "public private-value leak",
+      expected: "public-leakage",
+      release: () => {
+        return buildRelease({
+          version: "public-leak",
+          mutatePublic: (artifact) => {
+            firstRecord(artifact.connectors, "connectors").description =
+              PRIVATE_VALUE;
+          },
+        });
+      },
+    },
+    {
+      name: "cross-view auth mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "relationship-mismatch",
+          mutatePublic: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            firstRecord(connector.authMethods, "authMethods").id = "oauth";
+          },
+        });
+      },
+    },
+    {
+      name: "reserved model-provider identity",
+      expected: "invalid-artifact",
+      release: () => {
+        return buildRelease({
+          version: "model-provider-ref",
+          mutatePublic: (artifact) => {
+            firstRecord(artifact.connectors, "connectors").connectorRef =
+              "model-provider:external";
+          },
+        });
+      },
+    },
+    {
+      name: "cross-view icon mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "icon-mismatch",
+          mutateIntegrity: (integrity) => {
+            const connector = firstRecord(integrity.connectors, "connectors");
+            recordValue(connector.icon, "icon").digest = ZERO_DIGEST;
+          },
+        });
+      },
+    },
+    {
+      name: "cross-view skill mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "skill-mismatch",
+          mutateIntegrity: (integrity) => {
+            const connector = firstRecord(integrity.connectors, "connectors");
+            const versionId = "a".repeat(64);
+            const prefix = `__system__/volume/connector-skill@external-test/${versionId}`;
+            connector.skill = {
+              kind: "bundled",
+              storageName: "connector-skill@external-test",
+              versionId,
+              manifest: {
+                key: `${prefix}/manifest.json`,
+                digest: ZERO_DIGEST,
+              },
+              archive: {
+                key: `${prefix}/archive.tar.gz`,
+                digest: ZERO_DIGEST,
+              },
+            };
+          },
+        });
+      },
+    },
+    {
+      name: "cross-view firewall mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-mismatch",
+          mutatePublic: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            connector.firewall = {
+              kind: "generated",
+              permissions: [],
+              categories: null,
+              defaultAllowed: null,
+              defaultUnknownPolicy: "allow",
+            };
+          },
+        });
+      },
+    },
+  ])("rejects $name", async ({ expected, release }) => {
+    configureSource();
+    const fixture = release();
+    serveObjects(catalogObjects([fixture], fixture));
+    expectRejectedBeforeAcceptance((await syncCatalog()).body, expected);
+  });
+
+  it("retains the latest valid snapshot and exposes sanitized status", async () => {
+    configureSource();
+    const accepted = buildRelease({ version: "2026-07-15.valid" });
+    serveObjects(catalogObjects([accepted], accepted));
+    const acceptedResponse = await syncCatalog();
+    const acceptedDigest = acceptedResponse.body.active?.integrityDigest;
+
+    const invalid = buildRelease({
+      version: "2026-07-15.invalid",
+      mutatePointer: (pointer) => {
+        pointer.extra = `private-${PRIVATE_VALUE}`;
+      },
+    });
+    serveObjects(catalogObjects([accepted, invalid], invalid));
+    const rejected = await syncCatalog();
+    expect(rejected.body).toMatchObject({
+      outcome: "rejected",
+      state: "stale",
+      active: {
+        catalogVersion: accepted.version,
+        integrityDigest: acceptedDigest,
+      },
+      lastAttempt: {
+        outcome: "rejected",
+        failureCode: "invalid-pointer",
+      },
+      lastSuccessAt: FIRST_SYNC_TIME,
+    });
+
+    const callsBeforeStatus = context.mocks.s3.send.mock.calls.length;
+    expect((await readStatus()).body).toStrictEqual(
+      (({ outcome: _outcome, ...status }) => {
+        return status;
+      })(rejected.body),
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeStatus);
+    expect(JSON.stringify(rejected.body)).not.toContain(PRIVATE_VALUE);
+  });
+
+  it("rejects immutable catalog version reuse after acceptance", async () => {
+    configureSource();
+    const original = buildRelease({ version: "2026-07-15.conflict" });
+    serveObjects(catalogObjects([original], original));
+    await syncCatalog();
+
+    const conflicting = buildRelease({
+      version: original.version,
+      label: "Conflicting Content",
+    });
+    serveObjects(catalogObjects([conflicting], conflicting));
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "rejected",
+      state: "stale",
+      active: { catalogVersion: original.version },
+      lastAttempt: {
+        outcome: "rejected",
+        failureCode: "conflicting-release",
+      },
+    });
+  });
+
+  it("does not return or log raw source failures", async () => {
+    const bucket = configureSource();
+    const privateError =
+      `credential=${PRIVATE_VALUE} bucket=${bucket} key=${ACTIVE_KEY} ` +
+      "url=https://signed.example.test/private";
+    context.mocks.s3.send.mockRejectedValue(new Error(privateError));
+    const response = await syncCatalog();
+    const logged = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+
+    expectRejectedBeforeAcceptance(response.body, "source-unavailable");
+    for (const privateText of [
+      PRIVATE_VALUE,
+      bucket,
+      ACTIVE_KEY,
+      "signed.example.test",
+    ]) {
+      expect(JSON.stringify(response.body)).not.toContain(privateText);
+      expect(logged).not.toContain(privateText);
+    }
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -536,7 +536,7 @@ function serveObjects(objects: ReadonlyMap<string, Buffer>): void {
 
 function configureSource(): string {
   const bucket = `connector-catalog-test-${randomUUID()}`;
-  mockEnv("R2_CONNECTOR_CATALOG_BUCKET_NAME", bucket);
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", bucket);
   return bucket;
 }
 
@@ -568,7 +568,6 @@ function expectRejectedBeforeAcceptance(
 ): void {
   expect(body).toMatchObject({
     outcome: "rejected",
-    configured: true,
     state: "never-synced",
     active: null,
     lastAttempt: {
@@ -581,7 +580,6 @@ function expectRejectedBeforeAcceptance(
 
 beforeEach(() => {
   mockEnv("CRON_SECRET", CRON_SECRET);
-  mockEnv("R2_CONNECTOR_CATALOG_BUCKET_NAME", undefined);
   mockNow(new Date(FIRST_SYNC_TIME));
 });
 
@@ -589,7 +587,7 @@ afterEach(() => {
   clearMockNow();
 });
 
-describe("connector catalog cron authentication and inactive state", () => {
+describe("connector catalog cron authentication and initial state", () => {
   it("rejects missing and invalid cron credentials for both operations", async () => {
     for (const operation of [cronClient().sync, cronClient().status]) {
       const response = await accept(
@@ -609,29 +607,9 @@ describe("connector catalog cron authentication and inactive state", () => {
     }
   });
 
-  it("returns a disabled no-op without a configured bucket", async () => {
-    expect((await readStatus()).body).toStrictEqual({
-      configured: false,
-      state: "never-synced",
-      active: null,
-      lastAttempt: null,
-      lastSuccessAt: null,
-    });
-    expect((await syncCatalog()).body).toStrictEqual({
-      outcome: "disabled",
-      configured: false,
-      state: "never-synced",
-      active: null,
-      lastAttempt: null,
-      lastSuccessAt: null,
-    });
-    expect(context.mocks.s3.send).not.toHaveBeenCalled();
-  });
-
-  it("reports never-synced without reading R2 for a configured source", async () => {
+  it("reports never-synced without reading the shared storage bucket", async () => {
     configureSource();
     expect((await readStatus()).body).toStrictEqual({
-      configured: true,
       state: "never-synced",
       active: null,
       lastAttempt: null,
@@ -643,7 +621,7 @@ describe("connector catalog cron authentication and inactive state", () => {
 
 describe("connector catalog valid lifecycle", () => {
   it("accepts, advances, rolls back, and leaves the public catalog static", async () => {
-    configureSource();
+    const bucket = configureSource();
     const first = buildRelease({ version: "2026-07-15.1" });
     const second = buildRelease({
       version: "2026-07-15.2",
@@ -653,11 +631,16 @@ describe("connector catalog valid lifecycle", () => {
     const acceptedFirst = await syncCatalog();
     expect(acceptedFirst.body).toMatchObject({
       outcome: "accepted",
-      configured: true,
       state: "current",
       active: { catalogVersion: first.version },
       lastAttempt: { outcome: "accepted", failureCode: null },
       lastSuccessAt: FIRST_SYNC_TIME,
+    });
+    expect(
+      commandInput(context.mocks.s3.send.mock.calls[0]?.[0]),
+    ).toMatchObject({
+      Bucket: bucket,
+      Key: ACTIVE_KEY,
     });
 
     const callsBeforeStatus = context.mocks.s3.send.mock.calls.length;

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -26,6 +26,7 @@ interface ReleaseFixtureOptions {
   readonly version: string;
   readonly connectorRef?: string;
   readonly label?: string;
+  readonly generatedFirewall?: boolean;
   readonly publicBytes?: Buffer;
   readonly mutatePublic?: JsonMutation;
   readonly mutatePrivate?: JsonMutation;
@@ -96,6 +97,10 @@ function valueDigest(value: unknown): string {
   return digest(jsonBytes(value));
 }
 
+function catalogTemplate(reference: string): string {
+  return `\${{ ${reference} }}`;
+}
+
 function artifactReference(key: string, content: string): JsonRecord {
   return { key, digest: digest(Buffer.from(content)) };
 }
@@ -122,6 +127,7 @@ function buildPublicConnector(args: {
   readonly label: string;
   readonly iconKey: string;
   readonly iconDigest: string;
+  readonly firewall?: JsonRecord;
 }): JsonRecord {
   return {
     connectorRef: args.connectorRef,
@@ -154,7 +160,7 @@ function buildPublicConnector(args: {
       contentType: "image/svg+xml",
       invertInDarkMode: false,
     },
-    firewall: { kind: "none" },
+    firewall: args.firewall ?? { kind: "none" },
   };
 }
 
@@ -186,8 +192,8 @@ function buildPrivateConnector(connectorRef: string): JsonRecord {
   };
 }
 
-function requiredCapabilities(): readonly string[] {
-  return [
+function requiredCapabilities(generatedFirewall: boolean): readonly string[] {
+  const capabilities = [
     "bundle.required-resources@1",
     "catalog.public@1",
     "catalog.private@1",
@@ -195,10 +201,89 @@ function requiredCapabilities(): readonly string[] {
     "firewall.runner@1",
     "icon.static-files-path@1",
     "skill-none@1",
-    "firewall-none@1",
-    "grant.manual@1",
-    "access.static@1",
+    generatedFirewall ? "firewall-generated@1" : "firewall-none@1",
   ];
+  if (generatedFirewall) {
+    capabilities.push("firewall.categories@1", "firewall.defaults@1");
+  }
+  capabilities.push("grant.manual@1", "access.static@1");
+  return capabilities;
+}
+
+function buildGeneratedFirewall(args: {
+  readonly connectorRef: string;
+  readonly label: string;
+}): {
+  readonly publicFirewall: JsonRecord;
+  readonly privateFirewall: JsonRecord;
+  readonly runnerFirewall: JsonRecord;
+} {
+  const base = "https://api.example.test/v1";
+  const auth = (): JsonRecord => {
+    return {
+      headers: {
+        Authorization: `Bearer ${catalogTemplate("secrets.SERVICE_TOKEN")}`,
+      },
+    };
+  };
+  const permissions = [
+    {
+      name: "items.read",
+      description: "Read items",
+      rules: ["GET /items"],
+    },
+  ];
+  return {
+    publicFirewall: {
+      kind: "generated",
+      permissions: [{ name: "items.read", description: "Read items" }],
+      categories: {
+        byPermission: { "items.read": "Items" },
+        displayOrder: ["Items"],
+      },
+      defaultAllowed: ["items.read"],
+      defaultUnknownPolicy: "deny",
+    },
+    privateFirewall: {
+      connectorRef: args.connectorRef,
+      label: args.label,
+      billable: false,
+      firewall: {
+        name: args.connectorRef,
+        placeholders: { SERVICE_TOKEN: "placeholder-token" },
+        apis: [{ base, auth: auth(), permissions }],
+      },
+      categories: {
+        byPermission: { "items.read": "Items" },
+        displayOrder: ["Items"],
+      },
+      defaultAllowed: ["items.read"],
+      defaultUnknownPolicy: "deny",
+      routing: {
+        fixedHosts: ["api.example.test"],
+        baseUrlVarNames: [],
+        baseUrlTemplates: [],
+        apis: [
+          {
+            base,
+            environmentNames: ["SERVICE_TOKEN"],
+            routes: [{ permissionName: "items.read", rule: "GET /items" }],
+          },
+        ],
+      },
+      diagnostics: { apiCount: 1, permissionCount: 1, ruleCount: 1 },
+    },
+    runnerFirewall: {
+      name: args.connectorRef,
+      apis: [
+        {
+          base,
+          auth: auth(),
+          permissions: [{ name: "items.read", rules: ["GET /items"] }],
+        },
+      ],
+    },
+  };
 }
 
 function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
@@ -210,11 +295,17 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   const iconKey =
     "platform/views/zero-page/components/settings/icons/" +
     `${connectorRef}-${iconDigest.slice("sha256:".length, 19)}.svg`;
+  const generatedFirewall = options.generatedFirewall
+    ? buildGeneratedFirewall({ connectorRef, label })
+    : undefined;
   const publicConnector = buildPublicConnector({
     connectorRef,
     label,
     iconKey,
     iconDigest,
+    ...(generatedFirewall === undefined
+      ? {}
+      : { firewall: generatedFirewall.publicFirewall }),
   });
   const privateConnector = buildPrivateConnector(connectorRef);
   const publicArtifact: JsonRecord = {
@@ -241,14 +332,38 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   const privateFirewallsArtifact: JsonRecord = {
     artifactSchemaVersion: 1,
     catalogVersion: options.version,
-    connectors: [],
+    connectors:
+      generatedFirewall === undefined
+        ? []
+        : [generatedFirewall.privateFirewall],
   };
   const runnerFirewallsArtifact: JsonRecord = {
     artifactSchemaVersion: 1,
     catalogVersion: options.version,
-    firewalls: [],
+    firewalls:
+      generatedFirewall === undefined ? [] : [generatedFirewall.runnerFirewall],
   };
 
+  options.mutatePublic?.(publicArtifact);
+  options.mutatePrivate?.(privateArtifact);
+  options.mutatePrivateFirewalls?.(privateFirewallsArtifact);
+  options.mutateRunnerFirewalls?.(runnerFirewallsArtifact);
+  const currentPublicConnector = firstRecord(
+    publicArtifact.connectors,
+    "public connectors",
+  );
+  const currentPrivateConnector = firstRecord(
+    privateArtifact.connectors,
+    "private connectors",
+  );
+  const privateFirewallConnectors = arrayValue(
+    privateFirewallsArtifact.connectors,
+    "private firewall connectors",
+  );
+  const runnerFirewalls = arrayValue(
+    runnerFirewallsArtifact.firewalls,
+    "runner firewalls",
+  );
   const integrityConnector: JsonRecord = {
     connectorRef,
     sourceFiles: [
@@ -267,18 +382,21 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
         "e",
       ),
     ],
-    publicDigest: valueDigest(publicConnector),
-    privateDigest: valueDigest(privateConnector),
-    privateFirewallDigest: null,
-    runnerFirewallDigest: null,
+    publicDigest: valueDigest(currentPublicConnector),
+    privateDigest: valueDigest(currentPrivateConnector),
+    privateFirewallDigest:
+      privateFirewallConnectors.length === 0
+        ? null
+        : valueDigest(
+            firstRecord(privateFirewallConnectors, "private firewalls"),
+          ),
+    runnerFirewallDigest:
+      runnerFirewalls.length === 0
+        ? null
+        : valueDigest(firstRecord(runnerFirewalls, "runner firewalls")),
     skill: { kind: "none" },
     icon: { key: iconKey, digest: iconDigest },
   };
-
-  options.mutatePublic?.(publicArtifact);
-  options.mutatePrivate?.(privateArtifact);
-  options.mutatePrivateFirewalls?.(privateFirewallsArtifact);
-  options.mutateRunnerFirewalls?.(runnerFirewallsArtifact);
   const publicBytes = options.publicBytes ?? jsonBytes(publicArtifact);
   const privateBytes = jsonBytes(privateArtifact);
   const privateFirewallsBytes = jsonBytes(privateFirewallsArtifact);
@@ -297,7 +415,9 @@ function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   const integrity: JsonRecord = {
     artifactSchemaVersion: 1,
     catalogVersion: options.version,
-    requiredCapabilities: requiredCapabilities(),
+    requiredCapabilities: requiredCapabilities(
+      options.generatedFirewall === true,
+    ),
     catalogSource: artifactReference("catalog/catalog.yaml", "catalog"),
     generatorSources: [
       artifactReference("compiler/firewall-generator.ts", "generator"),
@@ -586,6 +706,21 @@ describe("connector catalog valid lifecycle", () => {
         return connector.connectorRef === first.connectorRef;
       }),
     ).toBeFalsy();
+  });
+
+  it("accepts a complete generated firewall projection", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.generated-firewall",
+      generatedFirewall: true,
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
   });
 
   it("serializes overlapping syncs without a mixed snapshot", async () => {
@@ -1075,6 +1210,84 @@ describe("connector catalog rejection and latest-valid retention", () => {
               defaultAllowed: null,
               defaultUnknownPolicy: "allow",
             };
+          },
+        });
+      },
+    },
+    {
+      name: "non-HTTPS firewall base URL",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-http-base",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            const firewall = recordValue(connector.firewall, "firewall");
+            firstRecord(firewall.apis, "firewall.apis").base =
+              "http://api.example.test/v1";
+          },
+        });
+      },
+    },
+    {
+      name: "unknown firewall environment binding",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-unknown-binding",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            const firewall = recordValue(connector.firewall, "firewall");
+            const api = firstRecord(firewall.apis, "firewall.apis");
+            const auth = recordValue(api.auth, "firewall api auth");
+            recordValue(auth.headers, "firewall auth headers")["X-Unknown"] =
+              catalogTemplate("secrets.UNKNOWN_SECRET");
+          },
+        });
+      },
+    },
+    {
+      name: "stale firewall routing metadata",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-routing-mismatch",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            recordValue(connector.routing, "routing").fixedHosts = [
+              "stale.example.test",
+            ];
+          },
+        });
+      },
+    },
+    {
+      name: "stale firewall diagnostics",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-diagnostics-mismatch",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            const connector = firstRecord(artifact.connectors, "connectors");
+            recordValue(connector.diagnostics, "diagnostics").ruleCount = 2;
+          },
+        });
+      },
+    },
+    {
+      name: "cross-view firewall label mismatch",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-label-mismatch",
+          generatedFirewall: true,
+          mutatePrivateFirewalls: (artifact) => {
+            firstRecord(artifact.connectors, "connectors").label =
+              "Stale Label";
           },
         });
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -742,13 +742,7 @@ describe("connector catalog valid lifecycle", () => {
     const losingPublicKey = releaseKeys(losing.version).publicCatalog;
     const blocked = deferredGate();
     const resume = deferredGate();
-    const activePointers = [
-      losing.pointer,
-      winning.pointer,
-      winning.pointer,
-      losing.pointer,
-      winning.pointer,
-    ];
+    const activePointers = [losing.pointer, winning.pointer, winning.pointer];
     let activeReads = 0;
     let blockedLosingPublic = false;
     context.mocks.s3.send.mockImplementation(async (command: unknown) => {
@@ -792,19 +786,20 @@ describe("connector catalog valid lifecycle", () => {
     });
   });
 
-  it("restarts when active changes during validation", async () => {
+  it("advances on the next sync when active changes during validation", async () => {
     configureSource();
-    const superseded = buildRelease({ version: "2026-07-15.old" });
+    const observed = buildRelease({ version: "2026-07-15.observed" });
     const current = buildRelease({ version: "2026-07-15.current" });
-    const objects = catalogObjects([superseded, current], current);
-    let activeReads = 0;
+    const objects = catalogObjects([observed, current], current);
+    let activePointer = observed.pointer;
     context.mocks.s3.send.mockImplementation((command: unknown) => {
       const key = commandInput(command).Key;
+      if (key === observed.integrityKey) {
+        activePointer = current.pointer;
+      }
       const bytes =
         key === ACTIVE_KEY
-          ? ++activeReads === 1
-            ? superseded.pointer
-            : current.pointer
+          ? activePointer
           : typeof key === "string"
             ? objects.get(key)
             : undefined;
@@ -819,9 +814,12 @@ describe("connector catalog valid lifecycle", () => {
 
     expect((await syncCatalog()).body).toMatchObject({
       outcome: "accepted",
+      active: { catalogVersion: observed.version },
+    });
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
       active: { catalogVersion: current.version },
     });
-    expect(activeReads).toBe(4);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/cron-connector-catalog.ts
@@ -1,0 +1,50 @@
+import { cronConnectorCatalogContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route-entry";
+import {
+  connectorCatalogStatus$,
+  syncConnectorCatalog$,
+} from "../services/connector-catalog-sync.service";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const syncConnectorCatalogRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const result = await set(syncConnectorCatalog$, signal);
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: result,
+    };
+  },
+);
+
+const connectorCatalogStatusRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const result = await set(connectorCatalogStatus$, signal);
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: result,
+    };
+  },
+);
+
+export const cronConnectorCatalogRoutes: readonly RouteEntry[] = [
+  {
+    route: cronConnectorCatalogContract.sync,
+    handler: syncConnectorCatalogRoute$,
+  },
+  {
+    route: cronConnectorCatalogContract.status,
+    handler: connectorCatalogStatusRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -27,6 +27,7 @@ import {
 export { connectorCatalogVersionSchema } from "./common";
 
 export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 1;
+export const CONNECTOR_CATALOG_ACTIVE_KEY = `connectors/v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/active.json`;
 
 interface ConnectorCatalogReleaseArtifactKeys {
   readonly releasePrefix: string;
@@ -43,7 +44,7 @@ export function connectorCatalogReleaseArtifactKeys(
   const parsedCatalogVersion =
     connectorCatalogVersionSchema.parse(catalogVersion);
   const releasePrefix =
-    `catalog-v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/releases/` +
+    `connectors/v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/releases/` +
     parsedCatalogVersion;
   return {
     releasePrefix,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -59,49 +59,12 @@ export function connectorCatalogReleaseArtifactKeys(
 const CONNECTOR_SKILL_STORAGE_NAME_PREFIX = "connector-skill@";
 const CONNECTOR_SKILL_STORAGE_PATH_PREFIX = "__system__/volume";
 
-export const SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES = [
-  "bundle.required-resources@1",
-  "catalog.public@1",
-  "catalog.private@1",
-  "firewall.private@1",
-  "firewall.runner@1",
-  "icon.static-files-path@1",
-  "skill-bundled@1",
-  "skill-none@1",
-  "firewall-generated@1",
-  "firewall-none@1",
-  "firewall.categories@1",
-  "firewall.defaults@1",
-  "firewall.host-policy@1",
-  "firewall.auth-base@1",
-  "firewall.sigv4@1",
-  "firewall.billing@1",
-  "client.static-confidential-env@1",
-  "client.static-public-literal@1",
-  "client.dynamic-public@1",
-  "grant.manual@1",
-  "grant.auth-code@1",
-  "grant.openid-auth@1",
-  "grant.external-code@1",
-  "grant.device-auth@1",
-  "access.static@1",
-  "access.refresh-token@1",
-  "binding.optional@1",
-  "binding.platform-secret@1",
-  "manual.normalize-host@1",
-  "revoke.token@1",
-  "revoke.previous-on-replace@1",
-] as const;
-
-export type ConnectorCatalogCapability =
-  (typeof SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES)[number];
-
 const artifactHeaderShape = Object.freeze({
   artifactSchemaVersion: z.literal(SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION),
   catalogVersion: connectorCatalogVersionSchema,
 });
 
-export const artifactReferenceSchema = z
+const artifactReferenceSchema = z
   .object({
     key: artifactKeySchema,
     digest: digestSchema,
@@ -145,64 +108,6 @@ const connectorSkillFrontmatterSchema = z
     description: z.string().trim().min(1),
   })
   .strict();
-
-const staticFilesPublicationFileSchema = z
-  .object({
-    key: publicConnectorIconKeySchema,
-    digest: digestSchema,
-    size: z.number().int().positive(),
-    contentType: z.enum(["image/svg+xml", "image/png"]),
-  })
-  .strict()
-  .superRefine((file, context) => {
-    const expectedSuffix = file.contentType === "image/png" ? ".png" : ".svg";
-    const digestHex = file.digest.slice("sha256:".length);
-    const keyDigest = /-([a-f0-9]{12})\.(?:png|svg)$/u.exec(file.key)?.[1];
-    if (
-      !file.key.endsWith(expectedSuffix) ||
-      keyDigest === undefined ||
-      !digestHex.startsWith(keyDigest)
-    ) {
-      context.addIssue({
-        code: "custom",
-        message: "Static-files key must match its digest prefix and media type",
-        path: ["key"],
-      });
-    }
-  });
-
-export const staticFilesPublicationManifestSchema = z
-  .object({
-    artifactSchemaVersion: z.literal(
-      SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-    ),
-    files: z.array(staticFilesPublicationFileSchema).min(1),
-  })
-  .strict()
-  .superRefine((manifest, context) => {
-    const keys = manifest.files.map((file) => {
-      return file.key;
-    });
-    const sortedKeys = [...keys].sort(compareStrings);
-    if (
-      keys.some((key, index) => {
-        return key !== sortedKeys[index];
-      })
-    ) {
-      context.addIssue({
-        code: "custom",
-        message: "Static-files publication entries must be alphabetical",
-        path: ["files"],
-      });
-    }
-    if (new Set(keys).size !== keys.length) {
-      context.addIssue({
-        code: "custom",
-        message: "Static-files publication keys must be unique",
-        path: ["files"],
-      });
-    }
-  });
 
 const publicManualFieldSchema = z
   .object({
@@ -534,62 +439,17 @@ export const connectorCatalogRunnerFirewallsArtifactSchema = z
   })
   .strict();
 
-const assetIntegritySchema = publicConnectorIconReferenceSchema.extend({
-  contentType: z.enum(["image/svg+xml", "image/png"]),
-  size: z.number().int().positive(),
-});
-
-const skillArtifactIntegritySchema = artifactReferenceSchema.extend({
-  kind: z.enum(["archive", "manifest"]),
-  size: z.number().int().positive(),
-});
-
-const connectorSkillIntegritySchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("none") }).strict(),
-  z
-    .object({
-      kind: z.literal("bundled"),
-      storageName: connectorSkillStorageNameSchema,
-      versionId: connectorSkillVersionIdSchema,
-      manifest: artifactReferenceSchema,
-      archive: artifactReferenceSchema,
-    })
-    .strict(),
-]);
-
-const connectorIntegritySchema = z
-  .object({
-    connectorRef: connectorRefSchema,
-    sourceFiles: z.array(artifactReferenceSchema).min(5),
-    publicDigest: digestSchema,
-    privateDigest: digestSchema,
-    privateFirewallDigest: digestSchema.nullable(),
-    runnerFirewallDigest: digestSchema.nullable(),
-    skill: connectorSkillIntegritySchema,
-    icon: publicConnectorIconReferenceSchema,
-  })
-  .strict();
-
 export const connectorCatalogIntegrityArtifactSchema = z
   .object({
     ...artifactHeaderShape,
-    requiredCapabilities: z.array(
-      z.enum(SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES),
-    ),
-    catalogSource: artifactReferenceSchema,
-    generatorSources: z.array(artifactReferenceSchema).min(1),
     artifacts: z
       .object({
-        publicCatalog: artifactReferenceSchema,
-        privateCatalog: artifactReferenceSchema,
-        privateFirewalls: artifactReferenceSchema,
-        runnerFirewalls: artifactReferenceSchema,
-        staticFilesPublication: artifactReferenceSchema,
+        publicCatalog: digestSchema,
+        privateCatalog: digestSchema,
+        privateFirewalls: digestSchema,
+        runnerFirewalls: digestSchema,
       })
       .strict(),
-    assets: z.array(assetIntegritySchema).min(1),
-    skillArtifacts: z.array(skillArtifactIntegritySchema),
-    connectors: z.array(connectorIntegritySchema).min(1),
   })
   .strict();
 
@@ -619,9 +479,6 @@ type RunnerFirewallArtifactConnector = z.infer<
 >;
 export type ConnectorCatalogIntegrityArtifact = z.infer<
   typeof connectorCatalogIntegrityArtifactSchema
->;
-type StaticFilesPublicationManifest = z.infer<
-  typeof staticFilesPublicationManifestSchema
 >;
 
 function compareStrings(left: string, right: string): number {
@@ -676,139 +533,7 @@ interface ConnectorCatalogArtifacts {
   readonly privateArtifact: ConnectorCatalogPrivateArtifact;
   readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
   readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
-  readonly staticFilesPublicationArtifact: StaticFilesPublicationManifest;
   readonly integrity: ConnectorCatalogIntegrityArtifact;
-}
-
-function addPublicCapabilities(
-  capabilities: Set<ConnectorCatalogCapability>,
-  artifact: ConnectorCatalogPublicArtifact,
-): void {
-  for (const connector of artifact.connectors) {
-    const firewall = connector.firewall;
-    if (firewall.kind === "none") {
-      capabilities.add("firewall-none@1");
-      continue;
-    }
-    capabilities.add("firewall-generated@1");
-    if (firewall.categories !== null) {
-      capabilities.add("firewall.categories@1");
-    }
-    if (
-      firewall.defaultAllowed !== null ||
-      firewall.defaultUnknownPolicy !== "allow"
-    ) {
-      capabilities.add("firewall.defaults@1");
-    }
-  }
-}
-
-function addClientCapability(
-  capabilities: Set<ConnectorCatalogCapability>,
-  authMethod: ConnectorCatalogPrivateArtifactConnector["authMethods"][number],
-): void {
-  const client = authMethod.client;
-  if (!client) {
-    return;
-  }
-  if (client.clientRegistration === "dynamic") {
-    capabilities.add("client.dynamic-public@1");
-  } else if (client.clientType === "confidential") {
-    capabilities.add("client.static-confidential-env@1");
-  } else {
-    capabilities.add("client.static-public-literal@1");
-  }
-}
-
-function addAuthMethodCapabilities(
-  capabilities: Set<ConnectorCatalogCapability>,
-  authMethod: ConnectorCatalogPrivateArtifactConnector["authMethods"][number],
-): void {
-  addClientCapability(capabilities, authMethod);
-  capabilities.add(`grant.${authMethod.grant.kind}@1`);
-  capabilities.add(`access.${authMethod.access.kind}@1`);
-  if (
-    Object.values(authMethod.access.envBindings).some((binding) => {
-      return typeof binding !== "string" && binding.optional;
-    })
-  ) {
-    capabilities.add("binding.optional@1");
-  }
-  if ((authMethod.access.platformSecrets?.length ?? 0) > 0) {
-    capabilities.add("binding.platform-secret@1");
-  }
-  if (
-    authMethod.grant.kind === "manual" &&
-    authMethod.grant.fields.some((field) => {
-      return field.normalize === "host";
-    })
-  ) {
-    capabilities.add("manual.normalize-host@1");
-  }
-  if (authMethod.revoke.kind === "token-revoke") {
-    capabilities.add("revoke.token@1");
-    if (authMethod.revoke.revokePreviousOnReplace === true) {
-      capabilities.add("revoke.previous-on-replace@1");
-    }
-  }
-}
-
-function addPrivateCapabilities(
-  capabilities: Set<ConnectorCatalogCapability>,
-  artifact: ConnectorCatalogPrivateArtifact,
-): void {
-  for (const connector of artifact.connectors) {
-    capabilities.add(
-      connector.skill.kind === "bundled" ? "skill-bundled@1" : "skill-none@1",
-    );
-    for (const authMethod of connector.authMethods) {
-      addAuthMethodCapabilities(capabilities, authMethod);
-    }
-  }
-}
-
-function addFirewallCapabilities(
-  capabilities: Set<ConnectorCatalogCapability>,
-  artifact: ConnectorCatalogPrivateFirewallsArtifact,
-): void {
-  for (const connector of artifact.connectors) {
-    if (connector.billable) {
-      capabilities.add("firewall.billing@1");
-    }
-    for (const api of connector.firewall.apis) {
-      if (api.hostPolicy !== undefined) {
-        capabilities.add("firewall.host-policy@1");
-      }
-      if (api.auth.base !== undefined) {
-        capabilities.add("firewall.auth-base@1");
-      }
-      if (api.auth.awsSigv4 !== undefined) {
-        capabilities.add("firewall.sigv4@1");
-      }
-    }
-  }
-}
-
-function deriveConnectorCatalogCapabilities(
-  args: Pick<
-    ConnectorCatalogArtifacts,
-    "publicArtifact" | "privateArtifact" | "privateFirewallsArtifact"
-  >,
-): ConnectorCatalogCapability[] {
-  const capabilities = new Set<ConnectorCatalogCapability>([
-    "bundle.required-resources@1",
-    "catalog.public@1",
-    "catalog.private@1",
-    "firewall.private@1",
-    "firewall.runner@1",
-    "icon.static-files-path@1",
-  ]);
-  addPublicCapabilities(capabilities, args.publicArtifact);
-  addPrivateCapabilities(capabilities, args.privateArtifact);
-  addFirewallCapabilities(capabilities, args.privateFirewallsArtifact);
-  return SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES.filter((capability) => {
-    return capabilities.has(capability);
-  });
 }
 
 function assertHeaderAlignment(args: ConnectorCatalogArtifacts): void {
@@ -840,15 +565,11 @@ function assertReferenceAlignment(args: ConnectorCatalogArtifacts): void {
   const runnerRefs = args.runnerFirewallsArtifact.firewalls.map((firewall) => {
     return firewall.name;
   });
-  const integrityRefs = args.integrity.connectors.map((connector) => {
-    return connector.connectorRef;
-  });
   for (const [values, label] of [
     [publicRefs, "public connector refs"],
     [privateRefs, "private connector refs"],
     [generatedRefs, "private firewall refs"],
     [runnerRefs, "runner firewall refs"],
-    [integrityRefs, "integrity connector refs"],
   ] as const) {
     assertUnique(values, label);
     assertAlphabetical(values, label);
@@ -857,11 +578,6 @@ function assertReferenceAlignment(args: ConnectorCatalogArtifacts): void {
     expected: new Set(publicRefs),
     actual: new Set(privateRefs),
     label: "private connector refs",
-  });
-  assertSameValues({
-    expected: new Set(publicRefs),
-    actual: new Set(integrityRefs),
-    label: "integrity connector refs",
   });
   const expectedGenerated = new Set(
     args.publicArtifact.connectors.flatMap((connector) => {
@@ -882,41 +598,6 @@ function assertReferenceAlignment(args: ConnectorCatalogArtifacts): void {
   });
 }
 
-function assertCapabilityAlignment(args: ConnectorCatalogArtifacts): void {
-  const expectedCapabilities = deriveConnectorCatalogCapabilities(args);
-  if (
-    expectedCapabilities.length !==
-      args.integrity.requiredCapabilities.length ||
-    expectedCapabilities.some((capability, index) => {
-      return capability !== args.integrity.requiredCapabilities[index];
-    })
-  ) {
-    throw new Error("Connector catalog requiredCapabilities mismatch");
-  }
-}
-
-function assertArtifactKeyAlignment(args: ConnectorCatalogArtifacts): void {
-  const releaseKeys = connectorCatalogReleaseArtifactKeys(
-    args.publicArtifact.catalogVersion,
-  );
-  const expectedArtifactKeys = {
-    publicCatalog: releaseKeys.publicCatalog,
-    privateCatalog: releaseKeys.privateCatalog,
-    privateFirewalls: releaseKeys.privateFirewalls,
-    runnerFirewalls: releaseKeys.runnerFirewalls,
-    staticFilesPublication: "icons/static-files.json",
-  };
-  for (const [name, key] of Object.entries(expectedArtifactKeys)) {
-    const reference =
-      args.integrity.artifacts[name as keyof typeof expectedArtifactKeys];
-    if (reference.key !== key) {
-      throw new Error(
-        `Connector catalog integrity artifact key mismatch: ${name}`,
-      );
-    }
-  }
-}
-
 interface ConnectorRelationshipMaps {
   readonly privateByRef: ReadonlyMap<
     string,
@@ -929,10 +610,6 @@ interface ConnectorRelationshipMaps {
   readonly runnerFirewallByRef: ReadonlyMap<
     string,
     RunnerFirewallArtifactConnector
-  >;
-  readonly integrityByRef: ReadonlyMap<
-    string,
-    ConnectorCatalogIntegrityArtifact["connectors"][number]
   >;
 }
 
@@ -955,45 +632,13 @@ function connectorRelationshipMaps(
         return [firewall.name, firewall];
       }),
     ),
-    integrityByRef: new Map(
-      args.integrity.connectors.map((connector) => {
-        return [connector.connectorRef, connector];
-      }),
-    ),
   };
 }
 
-function assertSkillIconAndAuthAlignment(args: {
+function assertAuthAlignment(args: {
   readonly publicConnector: ConnectorCatalogPublicArtifactConnector;
   readonly privateConnector: ConnectorCatalogPrivateArtifactConnector;
-  readonly integrityConnector: ConnectorCatalogIntegrityArtifact["connectors"][number];
 }): void {
-  const expectedSkillIntegrity =
-    args.privateConnector.skill.kind === "none"
-      ? { kind: "none" as const }
-      : {
-          kind: "bundled" as const,
-          storageName: args.privateConnector.skill.storageName,
-          versionId: args.privateConnector.skill.versionId,
-          manifest: args.privateConnector.skill.manifest,
-          archive: args.privateConnector.skill.archive,
-        };
-  if (
-    JSON.stringify(args.integrityConnector.skill) !==
-    JSON.stringify(expectedSkillIntegrity)
-  ) {
-    throw new Error(
-      `Skill integrity mismatch: ${args.publicConnector.connectorRef}`,
-    );
-  }
-  if (
-    JSON.stringify(args.integrityConnector.icon) !==
-    JSON.stringify(args.publicConnector.icon.asset)
-  ) {
-    throw new Error(
-      `Icon integrity mismatch: ${args.publicConnector.connectorRef}`,
-    );
-  }
   const publicMethodIds = args.publicConnector.authMethods.map((method) => {
     return method.id;
   });
@@ -1116,14 +761,9 @@ function assertConnectorRelationship(
   if (!privateConnector) {
     throw new Error(`Missing private connector ${connector.connectorRef}`);
   }
-  const integrityConnector = maps.integrityByRef.get(connector.connectorRef);
-  if (!integrityConnector) {
-    throw new Error(`Missing integrity connector ${connector.connectorRef}`);
-  }
-  assertSkillIconAndAuthAlignment({
+  assertAuthAlignment({
     publicConnector: connector,
     privateConnector,
-    integrityConnector,
   });
   if (connector.firewall.kind === "none") {
     return;
@@ -1147,71 +787,14 @@ function assertConnectorRelationships(args: ConnectorCatalogArtifacts): void {
   }
 }
 
-function assertAssetAlignment(args: ConnectorCatalogArtifacts): void {
-  const publicIconKeys = args.publicArtifact.connectors.map((connector) => {
-    return connector.icon.asset.key;
-  });
-  assertUnique(publicIconKeys, "public connector icon key");
-  const assetByKey = new Map(
-    args.integrity.assets.map((asset) => {
-      return [asset.key, asset] as const;
-    }),
-  );
-  assertUnique(
-    args.integrity.assets.map((asset) => {
-      return asset.key;
-    }),
-    "integrity asset key",
-  );
-  const publicationKeys = args.staticFilesPublicationArtifact.files.map(
-    (file) => {
-      return file.key;
-    },
-  );
-  assertUnique(publicationKeys, "static-files publication key");
-  assertAlphabetical(publicationKeys, "static-files publication keys");
-  assertSameValues({
-    expected: new Set(assetByKey.keys()),
-    actual: new Set(publicationKeys),
-    label: "static-files publication keys",
-  });
-  assertSameValues({
-    expected: new Set(publicIconKeys),
-    actual: new Set(assetByKey.keys()),
-    label: "integrity asset keys",
-  });
-  const publicationByKey = new Map(
-    args.staticFilesPublicationArtifact.files.map((file) => {
-      return [file.key, file];
-    }),
-  );
-  for (const connector of args.publicArtifact.connectors) {
-    const asset = assetByKey.get(connector.icon.asset.key);
-    const publication = publicationByKey.get(connector.icon.asset.key);
-    if (
-      !asset ||
-      asset.digest !== connector.icon.asset.digest ||
-      asset.contentType !== connector.icon.contentType ||
-      !publication ||
-      publication.digest !== asset.digest ||
-      publication.size !== asset.size ||
-      publication.contentType !== asset.contentType
-    ) {
-      throw new Error(
-        `Icon integrity alignment mismatch: ${connector.connectorRef}`,
-      );
-    }
-  }
-}
-
 interface ExpectedSkillArtifact {
   readonly digest: string;
   readonly kind: "archive" | "manifest";
 }
 
-function expectedSkillArtifacts(
+function assertSkillArtifactReferencesConsistent(
   artifact: ConnectorCatalogPrivateArtifact,
-): ReadonlyMap<string, ExpectedSkillArtifact> {
+): void {
   const expected = new Map<string, ExpectedSkillArtifact>();
   for (const connector of artifact.connectors) {
     if (connector.skill.kind === "none") {
@@ -1231,30 +814,6 @@ function expectedSkillArtifacts(
       expected.set(reference.key, { digest: reference.digest, kind });
     }
   }
-  return expected;
-}
-
-function assertSkillArtifactAlignment(args: ConnectorCatalogArtifacts): void {
-  const expected = expectedSkillArtifacts(args.privateArtifact);
-  const actualKeys = args.integrity.skillArtifacts.map((artifact) => {
-    return artifact.key;
-  });
-  assertUnique(actualKeys, "integrity skill artifact key");
-  assertSameValues({
-    expected: new Set(expected.keys()),
-    actual: new Set(actualKeys),
-    label: "integrity skill artifact keys",
-  });
-  for (const artifact of args.integrity.skillArtifacts) {
-    const expectedArtifact = expected.get(artifact.key);
-    if (
-      !expectedArtifact ||
-      artifact.digest !== expectedArtifact.digest ||
-      artifact.kind !== expectedArtifact.kind
-    ) {
-      throw new Error(`Skill artifact integrity mismatch: ${artifact.key}`);
-    }
-  }
 }
 
 export function validateConnectorCatalogArtifacts(
@@ -1262,9 +821,6 @@ export function validateConnectorCatalogArtifacts(
 ): void {
   assertHeaderAlignment(args);
   assertReferenceAlignment(args);
-  assertCapabilityAlignment(args);
-  assertArtifactKeyAlignment(args);
   assertConnectorRelationships(args);
-  assertAssetAlignment(args);
-  assertSkillArtifactAlignment(args);
+  assertSkillArtifactReferencesConsistent(args.privateArtifact);
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -1,0 +1,1260 @@
+import { z } from "zod";
+import {
+  artifactKeySchema,
+  connectorCatalogVersionSchema,
+  connectorRefSchema,
+  digestSchema,
+  privateNameSchema,
+} from "./common";
+import {
+  firewallAuthSchema,
+  firewallCategoriesSchema,
+  firewallConfigSchema,
+  firewallHostPolicySchema,
+  firewallPermissionSchema,
+  firewallPolicyValueSchema,
+} from "./firewall";
+import {
+  catalogSourceSchema,
+  connectorAuthMethodIdSchema,
+  connectorAuthMethodSourceSchema,
+  connectorStaticIconPathSchema,
+  connectorValueRefSchema,
+  internalOptionNameSchema,
+  publicFieldIdSchema,
+} from "./source";
+
+export { connectorCatalogVersionSchema } from "./common";
+
+export const SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION = 1;
+
+interface ConnectorCatalogReleaseArtifactKeys {
+  readonly releasePrefix: string;
+  readonly publicCatalog: string;
+  readonly privateCatalog: string;
+  readonly privateFirewalls: string;
+  readonly runnerFirewalls: string;
+  readonly integrityCatalog: string;
+}
+
+export function connectorCatalogReleaseArtifactKeys(
+  catalogVersion: string,
+): ConnectorCatalogReleaseArtifactKeys {
+  const parsedCatalogVersion =
+    connectorCatalogVersionSchema.parse(catalogVersion);
+  const releasePrefix =
+    `catalog-v${SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION}/releases/` +
+    parsedCatalogVersion;
+  return {
+    releasePrefix,
+    publicCatalog: `${releasePrefix}/public/catalog.json`,
+    privateCatalog: `${releasePrefix}/private/catalog.json`,
+    privateFirewalls: `${releasePrefix}/private/firewalls.json`,
+    runnerFirewalls: `${releasePrefix}/runner/firewalls.json`,
+    integrityCatalog: `${releasePrefix}/integrity/catalog.json`,
+  };
+}
+
+const CONNECTOR_SKILL_STORAGE_NAME_PREFIX = "connector-skill@";
+const CONNECTOR_SKILL_STORAGE_PATH_PREFIX = "__system__/volume";
+
+export const SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES = [
+  "bundle.required-resources@1",
+  "catalog.public@1",
+  "catalog.private@1",
+  "firewall.private@1",
+  "firewall.runner@1",
+  "icon.static-files-path@1",
+  "skill-bundled@1",
+  "skill-none@1",
+  "firewall-generated@1",
+  "firewall-none@1",
+  "firewall.categories@1",
+  "firewall.defaults@1",
+  "firewall.host-policy@1",
+  "firewall.auth-base@1",
+  "firewall.sigv4@1",
+  "firewall.billing@1",
+  "client.static-confidential-env@1",
+  "client.static-public-literal@1",
+  "client.dynamic-public@1",
+  "grant.manual@1",
+  "grant.auth-code@1",
+  "grant.openid-auth@1",
+  "grant.external-code@1",
+  "grant.device-auth@1",
+  "access.static@1",
+  "access.refresh-token@1",
+  "binding.optional@1",
+  "binding.platform-secret@1",
+  "manual.normalize-host@1",
+  "revoke.token@1",
+  "revoke.previous-on-replace@1",
+] as const;
+
+export type ConnectorCatalogCapability =
+  (typeof SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES)[number];
+
+const artifactHeaderShape = Object.freeze({
+  artifactSchemaVersion: z.literal(SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION),
+  catalogVersion: connectorCatalogVersionSchema,
+});
+
+export const artifactReferenceSchema = z
+  .object({
+    key: artifactKeySchema,
+    digest: digestSchema,
+  })
+  .strict();
+
+const publicConnectorIconKeySchema = connectorStaticIconPathSchema;
+
+const publicConnectorIconReferenceSchema = artifactReferenceSchema.extend({
+  key: publicConnectorIconKeySchema,
+});
+
+const connectorSkillStorageNameSchema = z
+  .string()
+  .max(256)
+  .regex(/^connector-skill@[a-z0-9][a-z0-9-]*$/u);
+
+const privateSkillManifestReferenceSchema = artifactReferenceSchema.refine(
+  (reference) => {
+    return /^__system__\/volume\/connector-skill@[a-z0-9][a-z0-9-]*\/[a-f0-9]{64}\/manifest\.json$/u.test(
+      reference.key,
+    );
+  },
+  "Skill manifest key must use its final system volume path",
+);
+
+const privateSkillArchiveReferenceSchema = artifactReferenceSchema.refine(
+  (reference) => {
+    return /^__system__\/volume\/connector-skill@[a-z0-9][a-z0-9-]*\/[a-f0-9]{64}\/archive\.tar\.gz$/u.test(
+      reference.key,
+    );
+  },
+  "Skill archive key must use its final system volume path",
+);
+
+const connectorSkillVersionIdSchema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+const connectorSkillFrontmatterSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    description: z.string().trim().min(1),
+  })
+  .strict();
+
+const staticFilesPublicationFileSchema = z
+  .object({
+    key: publicConnectorIconKeySchema,
+    digest: digestSchema,
+    size: z.number().int().positive(),
+    contentType: z.enum(["image/svg+xml", "image/png"]),
+  })
+  .strict()
+  .superRefine((file, context) => {
+    const expectedSuffix = file.contentType === "image/png" ? ".png" : ".svg";
+    const digestHex = file.digest.slice("sha256:".length);
+    const keyDigest = /-([a-f0-9]{12})\.(?:png|svg)$/u.exec(file.key)?.[1];
+    if (
+      !file.key.endsWith(expectedSuffix) ||
+      keyDigest === undefined ||
+      !digestHex.startsWith(keyDigest)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Static-files key must match its digest prefix and media type",
+        path: ["key"],
+      });
+    }
+  });
+
+export const staticFilesPublicationManifestSchema = z
+  .object({
+    artifactSchemaVersion: z.literal(
+      SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+    ),
+    files: z.array(staticFilesPublicationFileSchema).min(1),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const keys = manifest.files.map((file) => {
+      return file.key;
+    });
+    const sortedKeys = [...keys].sort(compareStrings);
+    if (
+      keys.some((key, index) => {
+        return key !== sortedKeys[index];
+      })
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Static-files publication entries must be alphabetical",
+        path: ["files"],
+      });
+    }
+    if (new Set(keys).size !== keys.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Static-files publication keys must be unique",
+        path: ["files"],
+      });
+    }
+  });
+
+const publicManualFieldSchema = z
+  .object({
+    id: publicFieldIdSchema,
+    label: z.string().min(1),
+    required: z.boolean(),
+    placeholder: z.string().nullable(),
+    inputType: z.enum(["password", "text"]),
+  })
+  .strict();
+
+const publicStartOptionChoiceSchema = z
+  .object({
+    value: z.string().min(1),
+    label: z.string().min(1),
+  })
+  .strict();
+
+const publicStartOptionSchema = z
+  .object({
+    id: publicFieldIdSchema,
+    kind: z.literal("select"),
+    label: z.string().min(1),
+    required: z.boolean(),
+    defaultValue: z.string().nullable(),
+    options: z.array(publicStartOptionChoiceSchema).min(1),
+  })
+  .strict();
+
+const publicAuthMethodSchema = z
+  .object({
+    id: connectorAuthMethodIdSchema,
+    label: z.string().min(1),
+    description: z.string().min(1).nullable(),
+    defaultVisible: z.boolean(),
+    grantKind: z.enum([
+      "manual",
+      "auth-code",
+      "openid-auth",
+      "external-code",
+      "device-auth",
+    ]),
+    manualFields: z.array(publicManualFieldSchema),
+    startOptions: z.array(publicStartOptionSchema),
+  })
+  .strict();
+
+const publicConnectorCatalogIconSchema = z
+  .object({
+    asset: publicConnectorIconReferenceSchema,
+    contentType: z.enum(["image/svg+xml", "image/png"]),
+    invertInDarkMode: z.boolean(),
+    scale: z.number().min(1).max(3).optional(),
+  })
+  .strict()
+  .superRefine((icon, context) => {
+    const expectedSuffix = icon.contentType === "image/png" ? ".png" : ".svg";
+    const digestHex = icon.asset.digest.slice("sha256:".length);
+    const keyDigest = /-([a-f0-9]{12})\.(?:png|svg)$/u.exec(
+      icon.asset.key,
+    )?.[1];
+    if (
+      !icon.asset.key.endsWith(expectedSuffix) ||
+      keyDigest === undefined ||
+      !digestHex.startsWith(keyDigest)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Icon key must match its digest prefix and media type",
+        path: ["asset", "key"],
+      });
+    }
+  });
+
+const publicFirewallPermissionSchema = firewallPermissionSchema
+  .omit({ rules: true })
+  .strict();
+
+const publicFirewallMetadataSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("none") }).strict(),
+  z
+    .object({
+      kind: z.literal("generated"),
+      permissions: z.array(publicFirewallPermissionSchema),
+      categories: firewallCategoriesSchema.nullable(),
+      defaultAllowed: z.array(z.string().min(1)).nullable(),
+      defaultUnknownPolicy: firewallPolicyValueSchema,
+    })
+    .strict(),
+]);
+
+const publicConnectorCatalogArtifactConnectorSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    label: z.string().min(1),
+    description: z.string().min(1),
+    category: z.string().min(1),
+    generation: z.array(z.string().min(1)),
+    tags: z.array(z.string().min(1)),
+    authMethods: z.array(publicAuthMethodSchema).min(1),
+    icon: publicConnectorCatalogIconSchema,
+    firewall: publicFirewallMetadataSchema,
+  })
+  .strict();
+
+export const connectorCatalogPublicArtifactSchema = z
+  .object({
+    ...artifactHeaderShape,
+    categoryMetadata: catalogSourceSchema.shape.categoryMetadata,
+    connectors: z.array(publicConnectorCatalogArtifactConnectorSchema).min(1),
+  })
+  .strict();
+
+const privateOutputBindingsSchema = z.record(
+  z.string().min(1),
+  connectorValueRefSchema,
+);
+
+const privateGrantSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("manual"),
+      fields: z.array(
+        z
+          .object({
+            privateName: privateNameSchema,
+            publicId: publicFieldIdSchema,
+            storage: z.enum(["secret", "variable"]),
+            normalize: z.literal("host").optional(),
+          })
+          .strict(),
+      ),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("auth-code"),
+      scopes: z.array(z.string()),
+      callbackOrigin: z.enum(["web", "api"]),
+      outputs: privateOutputBindingsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("openid-auth"),
+      callbackOrigin: z.enum(["web", "api"]),
+      outputs: privateOutputBindingsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("external-code"),
+      scopes: z.array(z.string()),
+      outputs: privateOutputBindingsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("device-auth"),
+      scopes: z.array(z.string()),
+      outputs: privateOutputBindingsSchema,
+      startOptionMappings: z.array(
+        z
+          .object({
+            privateName: internalOptionNameSchema,
+            publicId: publicFieldIdSchema,
+          })
+          .strict(),
+      ),
+    })
+    .strict(),
+]);
+
+const privateAuthMethodSchema = z
+  .object({
+    id: connectorAuthMethodSourceSchema.shape.id,
+    client: connectorAuthMethodSourceSchema.shape.client,
+    storage: connectorAuthMethodSourceSchema.shape.storage,
+    grant: privateGrantSchema,
+    access: connectorAuthMethodSourceSchema.shape.access,
+    revoke: connectorAuthMethodSourceSchema.shape.revoke,
+  })
+  .strict();
+
+const privateConnectorSkillSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("none") }).strict(),
+  z
+    .object({
+      kind: z.literal("bundled"),
+      storageName: connectorSkillStorageNameSchema,
+      versionId: connectorSkillVersionIdSchema,
+      frontmatter: connectorSkillFrontmatterSchema,
+      manifest: privateSkillManifestReferenceSchema,
+      archive: privateSkillArchiveReferenceSchema,
+    })
+    .strict(),
+]);
+
+const privateConnectorCatalogArtifactConnectorSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    skill: privateConnectorSkillSchema,
+    authMethods: z.array(privateAuthMethodSchema).min(1),
+  })
+  .strict()
+  .superRefine((connector, context) => {
+    if (connector.skill.kind === "none") {
+      return;
+    }
+    const expectedStorageName = `${CONNECTOR_SKILL_STORAGE_NAME_PREFIX}${connector.connectorRef}`;
+    if (connector.skill.storageName !== expectedStorageName) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill storage name must match connector ref",
+        path: ["skill", "storageName"],
+      });
+    }
+    const prefix =
+      `${CONNECTOR_SKILL_STORAGE_PATH_PREFIX}/${expectedStorageName}/` +
+      `${connector.skill.versionId}/`;
+    if (connector.skill.manifest.key !== `${prefix}manifest.json`) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill manifest key must match storage name and version id",
+        path: ["skill", "manifest", "key"],
+      });
+    }
+    if (connector.skill.archive.key !== `${prefix}archive.tar.gz`) {
+      context.addIssue({
+        code: "custom",
+        message: "Skill archive key must match storage name and version id",
+        path: ["skill", "archive", "key"],
+      });
+    }
+  });
+
+export const connectorCatalogPrivateArtifactSchema = z
+  .object({
+    ...artifactHeaderShape,
+    connectors: z.array(privateConnectorCatalogArtifactConnectorSchema).min(1),
+  })
+  .strict();
+
+const firewallExecutionBaseTemplateSchema = z
+  .object({
+    base: z.string().min(1),
+    credentialed: z.boolean(),
+    hostPolicy: firewallHostPolicySchema.optional(),
+  })
+  .strict();
+
+const firewallRoutingRouteSchema = z
+  .object({
+    permissionName: z.string().min(1),
+    rule: z.string().min(1),
+  })
+  .strict();
+
+const firewallRoutingApiSchema = z
+  .object({
+    base: z.string().min(1),
+    environmentNames: z.array(privateNameSchema),
+    routes: z.array(firewallRoutingRouteSchema),
+  })
+  .strict();
+
+const firewallRoutingSchema = z
+  .object({
+    fixedHosts: z.array(z.string().min(1)),
+    baseUrlVarNames: z.array(privateNameSchema),
+    baseUrlTemplates: z.array(firewallExecutionBaseTemplateSchema),
+    apis: z.array(firewallRoutingApiSchema).min(1),
+  })
+  .strict();
+
+const firewallDiagnosticsSchema = z
+  .object({
+    apiCount: z.number().int().positive(),
+    permissionCount: z.number().int().nonnegative(),
+    ruleCount: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const privateFirewallArtifactConnectorSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    label: z.string().min(1),
+    billable: z.boolean(),
+    firewall: firewallConfigSchema,
+    categories: firewallCategoriesSchema.nullable(),
+    defaultAllowed: z.array(z.string().min(1)).nullable(),
+    defaultUnknownPolicy: firewallPolicyValueSchema,
+    routing: firewallRoutingSchema,
+    diagnostics: firewallDiagnosticsSchema,
+  })
+  .strict();
+
+export const connectorCatalogPrivateFirewallsArtifactSchema = z
+  .object({
+    ...artifactHeaderShape,
+    connectors: z.array(privateFirewallArtifactConnectorSchema),
+  })
+  .strict();
+
+const runnerFirewallPermissionSchema = firewallPermissionSchema
+  .omit({ description: true })
+  .strict();
+
+const runnerFirewallApiSchema = z
+  .object({
+    base: z.string().min(1),
+    hostPolicy: firewallHostPolicySchema.optional(),
+    auth: firewallAuthSchema,
+    permissions: z.array(runnerFirewallPermissionSchema),
+  })
+  .strict();
+
+const runnerFirewallArtifactConnectorSchema = z
+  .object({
+    name: connectorRefSchema,
+    apis: z.array(runnerFirewallApiSchema).min(1),
+  })
+  .strict();
+
+export const connectorCatalogRunnerFirewallsArtifactSchema = z
+  .object({
+    ...artifactHeaderShape,
+    firewalls: z.array(runnerFirewallArtifactConnectorSchema),
+  })
+  .strict();
+
+const assetIntegritySchema = publicConnectorIconReferenceSchema.extend({
+  contentType: z.enum(["image/svg+xml", "image/png"]),
+  size: z.number().int().positive(),
+});
+
+const skillArtifactIntegritySchema = artifactReferenceSchema.extend({
+  kind: z.enum(["archive", "manifest"]),
+  size: z.number().int().positive(),
+});
+
+const connectorSkillIntegritySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("none") }).strict(),
+  z
+    .object({
+      kind: z.literal("bundled"),
+      storageName: connectorSkillStorageNameSchema,
+      versionId: connectorSkillVersionIdSchema,
+      manifest: artifactReferenceSchema,
+      archive: artifactReferenceSchema,
+    })
+    .strict(),
+]);
+
+const connectorIntegritySchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    sourceFiles: z.array(artifactReferenceSchema).min(5),
+    publicDigest: digestSchema,
+    privateDigest: digestSchema,
+    privateFirewallDigest: digestSchema.nullable(),
+    runnerFirewallDigest: digestSchema.nullable(),
+    skill: connectorSkillIntegritySchema,
+    icon: publicConnectorIconReferenceSchema,
+  })
+  .strict();
+
+export const connectorCatalogIntegrityArtifactSchema = z
+  .object({
+    ...artifactHeaderShape,
+    requiredCapabilities: z.array(
+      z.enum(SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES),
+    ),
+    catalogSource: artifactReferenceSchema,
+    generatorSources: z.array(artifactReferenceSchema).min(1),
+    artifacts: z
+      .object({
+        publicCatalog: artifactReferenceSchema,
+        privateCatalog: artifactReferenceSchema,
+        privateFirewalls: artifactReferenceSchema,
+        runnerFirewalls: artifactReferenceSchema,
+        staticFilesPublication: artifactReferenceSchema,
+      })
+      .strict(),
+    assets: z.array(assetIntegritySchema).min(1),
+    skillArtifacts: z.array(skillArtifactIntegritySchema),
+    connectors: z.array(connectorIntegritySchema).min(1),
+  })
+  .strict();
+
+export type ConnectorCatalogPublicArtifact = z.infer<
+  typeof connectorCatalogPublicArtifactSchema
+>;
+type ConnectorCatalogPublicArtifactConnector = z.infer<
+  typeof publicConnectorCatalogArtifactConnectorSchema
+>;
+export type ConnectorCatalogPrivateArtifact = z.infer<
+  typeof connectorCatalogPrivateArtifactSchema
+>;
+type ConnectorCatalogPrivateArtifactConnector = z.infer<
+  typeof privateConnectorCatalogArtifactConnectorSchema
+>;
+export type ConnectorCatalogPrivateFirewallsArtifact = z.infer<
+  typeof connectorCatalogPrivateFirewallsArtifactSchema
+>;
+type PrivateFirewallArtifactConnector = z.infer<
+  typeof privateFirewallArtifactConnectorSchema
+>;
+export type ConnectorCatalogRunnerFirewallsArtifact = z.infer<
+  typeof connectorCatalogRunnerFirewallsArtifactSchema
+>;
+type RunnerFirewallArtifactConnector = z.infer<
+  typeof runnerFirewallArtifactConnectorSchema
+>;
+export type ConnectorCatalogIntegrityArtifact = z.infer<
+  typeof connectorCatalogIntegrityArtifactSchema
+>;
+export type StaticFilesPublicationManifest = z.infer<
+  typeof staticFilesPublicationManifestSchema
+>;
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sorted(values: Iterable<string>): string {
+  return [...values].sort(compareStrings).join(", ");
+}
+
+function assertUnique(values: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new Error(`Duplicate connector catalog ${label}: ${value}`);
+    }
+    seen.add(value);
+  }
+}
+
+function assertAlphabetical(values: readonly string[], label: string): void {
+  const expected = [...values].sort(compareStrings);
+  if (
+    expected.some((value, index) => {
+      return value !== values[index];
+    })
+  ) {
+    throw new Error(`Connector catalog ${label} must be alphabetical`);
+  }
+}
+
+function assertSameValues(args: {
+  readonly expected: ReadonlySet<string>;
+  readonly actual: ReadonlySet<string>;
+  readonly label: string;
+}): void {
+  const missing = [...args.expected].filter((value) => {
+    return !args.actual.has(value);
+  });
+  const unexpected = [...args.actual].filter((value) => {
+    return !args.expected.has(value);
+  });
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Connector catalog ${args.label} mismatch: missing [${sorted(missing)}], unexpected [${sorted(unexpected)}]`,
+    );
+  }
+}
+
+interface ConnectorCatalogArtifacts {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
+  readonly staticFilesPublicationArtifact: StaticFilesPublicationManifest;
+  readonly integrity: ConnectorCatalogIntegrityArtifact;
+}
+
+function addPublicCapabilities(
+  capabilities: Set<ConnectorCatalogCapability>,
+  artifact: ConnectorCatalogPublicArtifact,
+): void {
+  for (const connector of artifact.connectors) {
+    const firewall = connector.firewall;
+    if (firewall.kind === "none") {
+      capabilities.add("firewall-none@1");
+      continue;
+    }
+    capabilities.add("firewall-generated@1");
+    if (firewall.categories !== null) {
+      capabilities.add("firewall.categories@1");
+    }
+    if (
+      firewall.defaultAllowed !== null ||
+      firewall.defaultUnknownPolicy !== "allow"
+    ) {
+      capabilities.add("firewall.defaults@1");
+    }
+  }
+}
+
+function addClientCapability(
+  capabilities: Set<ConnectorCatalogCapability>,
+  authMethod: ConnectorCatalogPrivateArtifactConnector["authMethods"][number],
+): void {
+  const client = authMethod.client;
+  if (!client) {
+    return;
+  }
+  if (client.clientRegistration === "dynamic") {
+    capabilities.add("client.dynamic-public@1");
+  } else if (client.clientType === "confidential") {
+    capabilities.add("client.static-confidential-env@1");
+  } else {
+    capabilities.add("client.static-public-literal@1");
+  }
+}
+
+function addAuthMethodCapabilities(
+  capabilities: Set<ConnectorCatalogCapability>,
+  authMethod: ConnectorCatalogPrivateArtifactConnector["authMethods"][number],
+): void {
+  addClientCapability(capabilities, authMethod);
+  capabilities.add(`grant.${authMethod.grant.kind}@1`);
+  capabilities.add(`access.${authMethod.access.kind}@1`);
+  if (
+    Object.values(authMethod.access.envBindings).some((binding) => {
+      return typeof binding !== "string" && binding.optional;
+    })
+  ) {
+    capabilities.add("binding.optional@1");
+  }
+  if ((authMethod.access.platformSecrets?.length ?? 0) > 0) {
+    capabilities.add("binding.platform-secret@1");
+  }
+  if (
+    authMethod.grant.kind === "manual" &&
+    authMethod.grant.fields.some((field) => {
+      return field.normalize === "host";
+    })
+  ) {
+    capabilities.add("manual.normalize-host@1");
+  }
+  if (authMethod.revoke.kind === "token-revoke") {
+    capabilities.add("revoke.token@1");
+    if (authMethod.revoke.revokePreviousOnReplace === true) {
+      capabilities.add("revoke.previous-on-replace@1");
+    }
+  }
+}
+
+function addPrivateCapabilities(
+  capabilities: Set<ConnectorCatalogCapability>,
+  artifact: ConnectorCatalogPrivateArtifact,
+): void {
+  for (const connector of artifact.connectors) {
+    capabilities.add(
+      connector.skill.kind === "bundled" ? "skill-bundled@1" : "skill-none@1",
+    );
+    for (const authMethod of connector.authMethods) {
+      addAuthMethodCapabilities(capabilities, authMethod);
+    }
+  }
+}
+
+function addFirewallCapabilities(
+  capabilities: Set<ConnectorCatalogCapability>,
+  artifact: ConnectorCatalogPrivateFirewallsArtifact,
+): void {
+  for (const connector of artifact.connectors) {
+    if (connector.billable) {
+      capabilities.add("firewall.billing@1");
+    }
+    for (const api of connector.firewall.apis) {
+      if (api.hostPolicy !== undefined) {
+        capabilities.add("firewall.host-policy@1");
+      }
+      if (api.auth.base !== undefined) {
+        capabilities.add("firewall.auth-base@1");
+      }
+      if (api.auth.awsSigv4 !== undefined) {
+        capabilities.add("firewall.sigv4@1");
+      }
+    }
+  }
+}
+
+function deriveConnectorCatalogCapabilities(
+  args: Pick<
+    ConnectorCatalogArtifacts,
+    "publicArtifact" | "privateArtifact" | "privateFirewallsArtifact"
+  >,
+): ConnectorCatalogCapability[] {
+  const capabilities = new Set<ConnectorCatalogCapability>([
+    "bundle.required-resources@1",
+    "catalog.public@1",
+    "catalog.private@1",
+    "firewall.private@1",
+    "firewall.runner@1",
+    "icon.static-files-path@1",
+  ]);
+  addPublicCapabilities(capabilities, args.publicArtifact);
+  addPrivateCapabilities(capabilities, args.privateArtifact);
+  addFirewallCapabilities(capabilities, args.privateFirewallsArtifact);
+  return SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES.filter((capability) => {
+    return capabilities.has(capability);
+  });
+}
+
+function assertHeaderAlignment(args: ConnectorCatalogArtifacts): void {
+  const headers = [
+    args.privateArtifact,
+    args.privateFirewallsArtifact,
+    args.runnerFirewallsArtifact,
+    args.integrity,
+  ];
+  for (const artifact of headers) {
+    if (artifact.catalogVersion !== args.publicArtifact.catalogVersion) {
+      throw new Error("Connector catalog artifact header mismatch");
+    }
+  }
+}
+
+function assertReferenceAlignment(args: ConnectorCatalogArtifacts): void {
+  const publicRefs = args.publicArtifact.connectors.map((connector) => {
+    return connector.connectorRef;
+  });
+  const privateRefs = args.privateArtifact.connectors.map((connector) => {
+    return connector.connectorRef;
+  });
+  const generatedRefs = args.privateFirewallsArtifact.connectors.map(
+    (connector) => {
+      return connector.connectorRef;
+    },
+  );
+  const runnerRefs = args.runnerFirewallsArtifact.firewalls.map((firewall) => {
+    return firewall.name;
+  });
+  const integrityRefs = args.integrity.connectors.map((connector) => {
+    return connector.connectorRef;
+  });
+  for (const [values, label] of [
+    [publicRefs, "public connector refs"],
+    [privateRefs, "private connector refs"],
+    [generatedRefs, "private firewall refs"],
+    [runnerRefs, "runner firewall refs"],
+    [integrityRefs, "integrity connector refs"],
+  ] as const) {
+    assertUnique(values, label);
+    assertAlphabetical(values, label);
+  }
+  assertSameValues({
+    expected: new Set(publicRefs),
+    actual: new Set(privateRefs),
+    label: "private connector refs",
+  });
+  assertSameValues({
+    expected: new Set(publicRefs),
+    actual: new Set(integrityRefs),
+    label: "integrity connector refs",
+  });
+  const expectedGenerated = new Set(
+    args.publicArtifact.connectors.flatMap((connector) => {
+      return connector.firewall.kind === "generated"
+        ? [connector.connectorRef]
+        : [];
+    }),
+  );
+  assertSameValues({
+    expected: expectedGenerated,
+    actual: new Set(generatedRefs),
+    label: "private firewall refs",
+  });
+  assertSameValues({
+    expected: expectedGenerated,
+    actual: new Set(runnerRefs),
+    label: "runner firewall refs",
+  });
+}
+
+function assertCapabilityAlignment(args: ConnectorCatalogArtifacts): void {
+  const expectedCapabilities = deriveConnectorCatalogCapabilities(args);
+  if (
+    expectedCapabilities.length !==
+      args.integrity.requiredCapabilities.length ||
+    expectedCapabilities.some((capability, index) => {
+      return capability !== args.integrity.requiredCapabilities[index];
+    })
+  ) {
+    throw new Error("Connector catalog requiredCapabilities mismatch");
+  }
+}
+
+function assertArtifactKeyAlignment(args: ConnectorCatalogArtifacts): void {
+  const releaseKeys = connectorCatalogReleaseArtifactKeys(
+    args.publicArtifact.catalogVersion,
+  );
+  const expectedArtifactKeys = {
+    publicCatalog: releaseKeys.publicCatalog,
+    privateCatalog: releaseKeys.privateCatalog,
+    privateFirewalls: releaseKeys.privateFirewalls,
+    runnerFirewalls: releaseKeys.runnerFirewalls,
+    staticFilesPublication: "icons/static-files.json",
+  };
+  for (const [name, key] of Object.entries(expectedArtifactKeys)) {
+    const reference =
+      args.integrity.artifacts[name as keyof typeof expectedArtifactKeys];
+    if (reference.key !== key) {
+      throw new Error(
+        `Connector catalog integrity artifact key mismatch: ${name}`,
+      );
+    }
+  }
+}
+
+interface ConnectorRelationshipMaps {
+  readonly privateByRef: ReadonlyMap<
+    string,
+    ConnectorCatalogPrivateArtifactConnector
+  >;
+  readonly serverFirewallByRef: ReadonlyMap<
+    string,
+    PrivateFirewallArtifactConnector
+  >;
+  readonly runnerFirewallByRef: ReadonlyMap<
+    string,
+    RunnerFirewallArtifactConnector
+  >;
+  readonly integrityByRef: ReadonlyMap<
+    string,
+    ConnectorCatalogIntegrityArtifact["connectors"][number]
+  >;
+}
+
+function connectorRelationshipMaps(
+  args: ConnectorCatalogArtifacts,
+): ConnectorRelationshipMaps {
+  return {
+    privateByRef: new Map(
+      args.privateArtifact.connectors.map((connector) => {
+        return [connector.connectorRef, connector];
+      }),
+    ),
+    serverFirewallByRef: new Map(
+      args.privateFirewallsArtifact.connectors.map((connector) => {
+        return [connector.connectorRef, connector];
+      }),
+    ),
+    runnerFirewallByRef: new Map(
+      args.runnerFirewallsArtifact.firewalls.map((firewall) => {
+        return [firewall.name, firewall];
+      }),
+    ),
+    integrityByRef: new Map(
+      args.integrity.connectors.map((connector) => {
+        return [connector.connectorRef, connector];
+      }),
+    ),
+  };
+}
+
+function assertSkillIconAndAuthAlignment(args: {
+  readonly publicConnector: ConnectorCatalogPublicArtifactConnector;
+  readonly privateConnector: ConnectorCatalogPrivateArtifactConnector;
+  readonly integrityConnector: ConnectorCatalogIntegrityArtifact["connectors"][number];
+}): void {
+  const expectedSkillIntegrity =
+    args.privateConnector.skill.kind === "none"
+      ? { kind: "none" as const }
+      : {
+          kind: "bundled" as const,
+          storageName: args.privateConnector.skill.storageName,
+          versionId: args.privateConnector.skill.versionId,
+          manifest: args.privateConnector.skill.manifest,
+          archive: args.privateConnector.skill.archive,
+        };
+  if (
+    JSON.stringify(args.integrityConnector.skill) !==
+    JSON.stringify(expectedSkillIntegrity)
+  ) {
+    throw new Error(
+      `Skill integrity mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  if (
+    JSON.stringify(args.integrityConnector.icon) !==
+    JSON.stringify(args.publicConnector.icon.asset)
+  ) {
+    throw new Error(
+      `Icon integrity mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  const publicMethodIds = args.publicConnector.authMethods.map((method) => {
+    return method.id;
+  });
+  const privateMethodIds = args.privateConnector.authMethods.map((method) => {
+    return method.id;
+  });
+  if (
+    publicMethodIds.length !== privateMethodIds.length ||
+    publicMethodIds.some((methodId, index) => {
+      return methodId !== privateMethodIds[index];
+    })
+  ) {
+    throw new Error(
+      `Auth method alignment mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  for (const [
+    index,
+    publicMethod,
+  ] of args.publicConnector.authMethods.entries()) {
+    const privateMethod = args.privateConnector.authMethods[index];
+    if (
+      privateMethod === undefined ||
+      publicMethod.grantKind !== privateMethod.grant.kind
+    ) {
+      throw new Error(
+        `Grant alignment mismatch: ${args.publicConnector.connectorRef}`,
+      );
+    }
+  }
+}
+
+function publicFirewallPermissions(
+  firewall: PrivateFirewallArtifactConnector,
+): readonly { readonly name: string; readonly description?: string }[] {
+  const permissions = new Map<
+    string,
+    { readonly name: string; readonly description?: string }
+  >();
+  for (const api of firewall.firewall.apis) {
+    for (const permission of api.permissions ?? []) {
+      if (!permissions.has(permission.name)) {
+        permissions.set(permission.name, {
+          name: permission.name,
+          ...(permission.description === undefined
+            ? {}
+            : { description: permission.description }),
+        });
+      }
+    }
+  }
+  return [...permissions.values()].sort((left, right) => {
+    return compareStrings(left.name, right.name);
+  });
+}
+
+function expectedRunnerFirewall(
+  firewall: PrivateFirewallArtifactConnector,
+): RunnerFirewallArtifactConnector {
+  return {
+    name: firewall.connectorRef,
+    apis: firewall.firewall.apis.map((api) => {
+      return {
+        base: api.base,
+        ...(api.hostPolicy === undefined ? {} : { hostPolicy: api.hostPolicy }),
+        auth: api.auth,
+        permissions: (api.permissions ?? []).map((permission) => {
+          return { name: permission.name, rules: permission.rules };
+        }),
+      };
+    }),
+  };
+}
+
+function assertFirewallAlignment(args: {
+  readonly publicConnector: ConnectorCatalogPublicArtifactConnector;
+  readonly serverFirewall: PrivateFirewallArtifactConnector;
+  readonly runnerFirewall: RunnerFirewallArtifactConnector;
+}): void {
+  if (args.publicConnector.firewall.kind !== "generated") {
+    throw new Error(
+      `Unexpected generated firewall ${args.publicConnector.connectorRef}`,
+    );
+  }
+  if (
+    JSON.stringify(args.publicConnector.firewall.categories) !==
+      JSON.stringify(args.serverFirewall.categories) ||
+    JSON.stringify(args.publicConnector.firewall.defaultAllowed) !==
+      JSON.stringify(args.serverFirewall.defaultAllowed) ||
+    args.publicConnector.firewall.defaultUnknownPolicy !==
+      args.serverFirewall.defaultUnknownPolicy
+  ) {
+    throw new Error(
+      `Firewall metadata alignment mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  if (
+    JSON.stringify(args.publicConnector.firewall.permissions) !==
+    JSON.stringify(publicFirewallPermissions(args.serverFirewall))
+  ) {
+    throw new Error(
+      `Firewall permission alignment mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  if (
+    JSON.stringify(args.runnerFirewall) !==
+    JSON.stringify(expectedRunnerFirewall(args.serverFirewall))
+  ) {
+    throw new Error(
+      `Runner firewall alignment mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+}
+
+function assertConnectorRelationship(
+  connector: ConnectorCatalogPublicArtifactConnector,
+  maps: ConnectorRelationshipMaps,
+): void {
+  const privateConnector = maps.privateByRef.get(connector.connectorRef);
+  if (!privateConnector) {
+    throw new Error(`Missing private connector ${connector.connectorRef}`);
+  }
+  const integrityConnector = maps.integrityByRef.get(connector.connectorRef);
+  if (!integrityConnector) {
+    throw new Error(`Missing integrity connector ${connector.connectorRef}`);
+  }
+  assertSkillIconAndAuthAlignment({
+    publicConnector: connector,
+    privateConnector,
+    integrityConnector,
+  });
+  if (connector.firewall.kind === "none") {
+    return;
+  }
+  const serverFirewall = maps.serverFirewallByRef.get(connector.connectorRef);
+  const runnerFirewall = maps.runnerFirewallByRef.get(connector.connectorRef);
+  if (!serverFirewall || !runnerFirewall) {
+    throw new Error(`Missing generated firewall ${connector.connectorRef}`);
+  }
+  assertFirewallAlignment({
+    publicConnector: connector,
+    serverFirewall,
+    runnerFirewall,
+  });
+}
+
+function assertConnectorRelationships(args: ConnectorCatalogArtifacts): void {
+  const maps = connectorRelationshipMaps(args);
+  for (const connector of args.publicArtifact.connectors) {
+    assertConnectorRelationship(connector, maps);
+  }
+}
+
+function assertAssetAlignment(args: ConnectorCatalogArtifacts): void {
+  const assetByKey = new Map(
+    args.integrity.assets.map((asset) => {
+      return [asset.key, asset] as const;
+    }),
+  );
+  assertUnique(
+    args.integrity.assets.map((asset) => {
+      return asset.key;
+    }),
+    "integrity asset key",
+  );
+  const publicationKeys = args.staticFilesPublicationArtifact.files.map(
+    (file) => {
+      return file.key;
+    },
+  );
+  assertUnique(publicationKeys, "static-files publication key");
+  assertAlphabetical(publicationKeys, "static-files publication keys");
+  assertSameValues({
+    expected: new Set(assetByKey.keys()),
+    actual: new Set(publicationKeys),
+    label: "static-files publication keys",
+  });
+  const publicationByKey = new Map(
+    args.staticFilesPublicationArtifact.files.map((file) => {
+      return [file.key, file];
+    }),
+  );
+  for (const connector of args.publicArtifact.connectors) {
+    const asset = assetByKey.get(connector.icon.asset.key);
+    const publication = publicationByKey.get(connector.icon.asset.key);
+    if (
+      !asset ||
+      asset.digest !== connector.icon.asset.digest ||
+      asset.contentType !== connector.icon.contentType ||
+      !publication ||
+      publication.digest !== asset.digest ||
+      publication.size !== asset.size ||
+      publication.contentType !== asset.contentType
+    ) {
+      throw new Error(
+        `Icon integrity alignment mismatch: ${connector.connectorRef}`,
+      );
+    }
+  }
+}
+
+interface ExpectedSkillArtifact {
+  readonly digest: string;
+  readonly kind: "archive" | "manifest";
+}
+
+function expectedSkillArtifacts(
+  artifact: ConnectorCatalogPrivateArtifact,
+): ReadonlyMap<string, ExpectedSkillArtifact> {
+  const expected = new Map<string, ExpectedSkillArtifact>();
+  for (const connector of artifact.connectors) {
+    if (connector.skill.kind === "none") {
+      continue;
+    }
+    for (const [kind, reference] of [
+      ["archive", connector.skill.archive],
+      ["manifest", connector.skill.manifest],
+    ] as const) {
+      const existing = expected.get(reference.key);
+      if (
+        existing &&
+        (existing.digest !== reference.digest || existing.kind !== kind)
+      ) {
+        throw new Error(`Conflicting private skill artifact: ${reference.key}`);
+      }
+      expected.set(reference.key, { digest: reference.digest, kind });
+    }
+  }
+  return expected;
+}
+
+function assertSkillArtifactAlignment(args: ConnectorCatalogArtifacts): void {
+  const expected = expectedSkillArtifacts(args.privateArtifact);
+  const actualKeys = args.integrity.skillArtifacts.map((artifact) => {
+    return artifact.key;
+  });
+  assertUnique(actualKeys, "integrity skill artifact key");
+  assertSameValues({
+    expected: new Set(expected.keys()),
+    actual: new Set(actualKeys),
+    label: "integrity skill artifact keys",
+  });
+  for (const artifact of args.integrity.skillArtifacts) {
+    const expectedArtifact = expected.get(artifact.key);
+    if (
+      !expectedArtifact ||
+      artifact.digest !== expectedArtifact.digest ||
+      artifact.kind !== expectedArtifact.kind
+    ) {
+      throw new Error(`Skill artifact integrity mismatch: ${artifact.key}`);
+    }
+  }
+}
+
+export function validateConnectorCatalogArtifacts(
+  args: ConnectorCatalogArtifacts,
+): void {
+  assertHeaderAlignment(args);
+  assertReferenceAlignment(args);
+  assertCapabilityAlignment(args);
+  assertArtifactKeyAlignment(args);
+  assertConnectorRelationships(args);
+  assertAssetAlignment(args);
+  assertSkillArtifactAlignment(args);
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -619,7 +619,7 @@ type RunnerFirewallArtifactConnector = z.infer<
 export type ConnectorCatalogIntegrityArtifact = z.infer<
   typeof connectorCatalogIntegrityArtifactSchema
 >;
-export type StaticFilesPublicationManifest = z.infer<
+type StaticFilesPublicationManifest = z.infer<
   typeof staticFilesPublicationManifestSchema
 >;
 
@@ -1147,6 +1147,10 @@ function assertConnectorRelationships(args: ConnectorCatalogArtifacts): void {
 }
 
 function assertAssetAlignment(args: ConnectorCatalogArtifacts): void {
+  const publicIconKeys = args.publicArtifact.connectors.map((connector) => {
+    return connector.icon.asset.key;
+  });
+  assertUnique(publicIconKeys, "public connector icon key");
   const assetByKey = new Map(
     args.integrity.assets.map((asset) => {
       return [asset.key, asset] as const;
@@ -1169,6 +1173,11 @@ function assertAssetAlignment(args: ConnectorCatalogArtifacts): void {
     expected: new Set(assetByKey.keys()),
     actual: new Set(publicationKeys),
     label: "static-files publication keys",
+  });
+  assertSameValues({
+    expected: new Set(publicIconKeys),
+    actual: new Set(assetByKey.keys()),
+    label: "integrity asset keys",
   });
   const publicationByKey = new Map(
     args.staticFilesPublicationArtifact.files.map((file) => {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
@@ -8,6 +8,7 @@ export const privateNameSchema = z.string().regex(/^[A-Z][A-Z0-9_]*$/u);
 
 export const connectorCatalogVersionSchema = z
   .string()
+  .max(255)
   .regex(/^[a-z0-9][a-z0-9._-]*$/u);
 
 export const artifactKeySchema = z

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
@@ -1,8 +1,9 @@
+import { connectorCatalogRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 
 export const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
 
-export const connectorRefSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/u);
+export const connectorRefSchema = connectorCatalogRefSchema;
 
 export const privateNameSchema = z.string().regex(/^[A-Z][A-Z0-9_]*$/u);
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+
+export const connectorRefSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/u);
+
+export const privateNameSchema = z.string().regex(/^[A-Z][A-Z0-9_]*$/u);
+
+export const connectorCatalogVersionSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9._-]*$/u);
+
+export const artifactKeySchema = z
+  .string()
+  .min(1)
+  .refine((key) => {
+    const segments = key.split("/");
+    return (
+      !key.startsWith("/") &&
+      !key.includes("\\") &&
+      segments.every((segment) => {
+        return segment.length > 0 && segment !== "." && segment !== "..";
+      })
+    );
+  }, "Artifact keys must be relative object keys");

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -1,0 +1,309 @@
+import { isIP } from "node:net";
+import { z } from "zod";
+
+import { safeUrlParse } from "../../utils";
+import { connectorRefSchema, privateNameSchema } from "./common";
+
+const BASE_VARIABLE_PATTERN = /\$\{\{\s*vars\.[A-Z][A-Z0-9_]*\s*\}\}/u;
+const HOST_FORBIDDEN_CHARACTERS = String.raw`%*[]\/?:#@{}`;
+const HOST_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
+
+export const firewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
+
+export const firewallPermissionSchema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().min(1).optional(),
+    rules: z.array(z.string().regex(/^[A-Z]+ \/\S*$/u)),
+  })
+  .strict();
+
+const firewallAwsSigv4AuthSchema = z
+  .object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    sessionToken: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const firewallAuthSchema = z
+  .object({
+    headers: z.record(z.string().min(1), z.string()).optional(),
+    base: z.string().min(1).optional(),
+    query: z.record(z.string().min(1), z.string()).optional(),
+    awsSigv4: firewallAwsSigv4AuthSchema.optional(),
+  })
+  .strict()
+  .superRefine((auth, context) => {
+    if (auth.awsSigv4 === undefined) {
+      return;
+    }
+    if (auth.headers !== undefined && Object.keys(auth.headers).length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["headers"],
+        message: "auth.headers cannot be combined with auth.awsSigv4",
+      });
+    }
+    if (auth.query !== undefined && Object.keys(auth.query).length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["query"],
+        message: "auth.query cannot be combined with auth.awsSigv4",
+      });
+    }
+    if (auth.base !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["base"],
+        message: "auth.base cannot be combined with auth.awsSigv4",
+      });
+    }
+  });
+
+function hostHasFixedOwnership(
+  value: string,
+  allowLeadingDot: boolean,
+): boolean {
+  if (!allowLeadingDot && value.startsWith(".")) {
+    return false;
+  }
+  const withoutLeadingDot =
+    allowLeadingDot && value.startsWith(".") ? value.slice(1) : value;
+  const normalized = withoutLeadingDot.endsWith(".")
+    ? withoutLeadingDot.slice(0, -1).toLowerCase()
+    : withoutLeadingDot.toLowerCase();
+  if (
+    normalized === "" ||
+    !/^[\x21-\x7e]+$/u.test(value) ||
+    [...HOST_FORBIDDEN_CHARACTERS].some((character) => {
+      return normalized.includes(character);
+    }) ||
+    isIP(normalized) !== 0 ||
+    /^[0-9.]+$/u.test(normalized)
+  ) {
+    return false;
+  }
+  const labels = normalized.split(".");
+  return (
+    labels.length >= 2 &&
+    labels.every((label) => {
+      return HOST_LABEL_PATTERN.test(label) && label.length <= 63;
+    })
+  );
+}
+
+const providerOwnedHostPolicySchema = z
+  .object({
+    kind: z.literal("providerOwned"),
+    exactHosts: z.array(z.string().min(1)).optional(),
+    suffixes: z.array(z.string().min(1)).optional(),
+    allowNonDefaultPort: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((policy, context) => {
+    if (
+      (policy.exactHosts?.length ?? 0) === 0 &&
+      (policy.suffixes?.length ?? 0) === 0
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "providerOwned host policy requires exactHosts or suffixes",
+      });
+    }
+    for (const [index, host] of (policy.exactHosts ?? []).entries()) {
+      if (!hostHasFixedOwnership(host, false)) {
+        context.addIssue({
+          code: "custom",
+          path: ["exactHosts", index],
+          message:
+            "providerOwned exactHosts must contain fixed hostnames with at least two labels",
+        });
+      }
+    }
+    for (const [index, suffix] of (policy.suffixes ?? []).entries()) {
+      if (!hostHasFixedOwnership(suffix, true)) {
+        context.addIssue({
+          code: "custom",
+          path: ["suffixes", index],
+          message:
+            "providerOwned suffixes must contain fixed hostnames with at least two labels",
+        });
+      }
+    }
+  });
+
+const publicDestinationHostPolicySchema = z
+  .object({ kind: z.literal("publicDestination") })
+  .strict();
+
+export const firewallHostPolicySchema = z.discriminatedUnion("kind", [
+  providerOwnedHostPolicySchema,
+  publicDestinationHostPolicySchema,
+]);
+
+const firewallApiSchema = z
+  .object({
+    base: z.string().min(1),
+    hostPolicy: firewallHostPolicySchema.optional(),
+    auth: firewallAuthSchema,
+    permissions: z.array(firewallPermissionSchema).optional(),
+  })
+  .strict();
+
+export const firewallConfigSchema = z
+  .object({
+    name: connectorRefSchema,
+    description: z.string().min(1).optional(),
+    placeholders: z.record(privateNameSchema, z.string()).optional(),
+    apis: z.array(firewallApiSchema).min(1),
+  })
+  .strict();
+
+export const firewallCategoriesSchema = z
+  .object({
+    byPermission: z.record(z.string().min(1), z.string().min(1)),
+    displayOrder: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
+const firewallGeneratorResultSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    firewall: firewallConfigSchema,
+    categories: firewallCategoriesSchema.nullable(),
+    defaultAllowed: z.array(z.string().min(1)).nullable(),
+    defaultUnknownPolicy: firewallPolicyValueSchema,
+  })
+  .strict();
+
+type FirewallAuth = z.infer<typeof firewallAuthSchema>;
+type FirewallApi = z.infer<typeof firewallApiSchema>;
+type FirewallConfig = z.infer<typeof firewallConfigSchema>;
+type FirewallGeneratorResult = z.infer<typeof firewallGeneratorResultSchema>;
+
+function duplicateStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+function firewallPermissionNames(firewall: FirewallConfig): Set<string> {
+  const names = new Set<string>();
+  for (const api of firewall.apis) {
+    for (const permission of api.permissions ?? []) {
+      names.add(permission.name);
+      const duplicateRules = duplicateStrings(permission.rules);
+      if (duplicateRules.length > 0) {
+        throw new Error(
+          `Duplicate rules for firewall permission ${permission.name}: ${duplicateRules.join(", ")}`,
+        );
+      }
+    }
+  }
+  return names;
+}
+
+function isFixedProviderHost(base: string): boolean {
+  if (!BASE_VARIABLE_PATTERN.test(base)) {
+    return true;
+  }
+  const normalized = base.replace(
+    /\$\{\{\s*vars\.[A-Z][A-Z0-9_]*\s*\}\}/gu,
+    "variable",
+  );
+  const parsed = safeUrlParse(normalized);
+  if (!parsed) {
+    return false;
+  }
+  const labels = parsed.hostname.split(".");
+  const variableIndex = labels.indexOf("variable");
+  return variableIndex !== -1 && labels.length - variableIndex - 1 >= 2;
+}
+
+function authInjectsCredentials(auth: FirewallAuth): boolean {
+  return (
+    auth.base !== undefined ||
+    Object.keys(auth.headers ?? {}).length > 0 ||
+    Object.keys(auth.query ?? {}).length > 0 ||
+    auth.awsSigv4 !== undefined
+  );
+}
+
+function validateHostPolicy(connectorRef: string, api: FirewallApi): void {
+  if (
+    BASE_VARIABLE_PATTERN.test(api.base) &&
+    authInjectsCredentials(api.auth) &&
+    !isFixedProviderHost(api.base)
+  ) {
+    if (api.hostPolicy === undefined) {
+      throw new Error(
+        `Credentialed dynamic base URL requires hostPolicy for ${connectorRef}: ${api.base}`,
+      );
+    }
+  }
+}
+
+export function validateFirewallGeneratorResult(
+  result: FirewallGeneratorResult,
+): void {
+  if (result.connectorRef !== result.firewall.name) {
+    throw new Error(
+      `Firewall result ref mismatch: ${result.connectorRef} != ${result.firewall.name}`,
+    );
+  }
+  const permissionNames = firewallPermissionNames(result.firewall);
+  for (const api of result.firewall.apis) {
+    validateHostPolicy(result.connectorRef, api);
+  }
+
+  if (result.categories !== null) {
+    const categorized = new Set(Object.keys(result.categories.byPermission));
+    const missing = [...permissionNames].filter((name) => {
+      return !categorized.has(name);
+    });
+    const unknown = [...categorized].filter((name) => {
+      return !permissionNames.has(name);
+    });
+    if (missing.length > 0 || unknown.length > 0) {
+      throw new Error(
+        `Firewall categories do not match permissions for ${result.connectorRef}`,
+      );
+    }
+    const categoryNames = new Set(
+      Object.values(result.categories.byPermission),
+    );
+    const displayNames = result.categories.displayOrder;
+    if (
+      duplicateStrings(displayNames).length > 0 ||
+      displayNames.some((name) => {
+        return !categoryNames.has(name);
+      }) ||
+      [...categoryNames].some((name) => {
+        return !displayNames.includes(name);
+      })
+    ) {
+      throw new Error(
+        `Firewall category order does not match categories for ${result.connectorRef}`,
+      );
+    }
+  }
+
+  if (result.defaultAllowed !== null) {
+    const duplicates = duplicateStrings(result.defaultAllowed);
+    const unknown = result.defaultAllowed.filter((name) => {
+      return !permissionNames.has(name);
+    });
+    if (duplicates.length > 0 || unknown.length > 0) {
+      throw new Error(
+        `Firewall default allowlist is invalid for ${result.connectorRef}`,
+      );
+    }
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -4,7 +4,15 @@ import { z } from "zod";
 import { safeUrlParse } from "../../utils";
 import { connectorRefSchema, privateNameSchema } from "./common";
 
+const TEMPLATE_REFERENCE_PATTERN = /\b(secrets|vars)\.([A-Z][A-Z0-9_]*)\b/gu;
+const DIRECT_TEMPLATE_PATTERN =
+  /\$\{\{\s*(?:secrets|vars)\.[A-Z][A-Z0-9_]*\s*\}\}/gu;
 const BASE_VARIABLE_PATTERN = /\$\{\{\s*vars\.[A-Z][A-Z0-9_]*\s*\}\}/u;
+const BASE_VARIABLE_CAPTURE_PATTERN =
+  /\$\{\{\s*vars\.([A-Z][A-Z0-9_]*)\s*\}\}/gu;
+const FULL_BASE_VARIABLE_PATTERN =
+  /^\$\{\{\s*vars\.[A-Z][A-Z0-9_]*\s*\}\}(\/.*)?$/u;
+const BASE_SECRET_PATTERN = /\$\{\{\s*secrets\.[A-Z][A-Z0-9_]*\s*\}\}/u;
 const HOST_FORBIDDEN_CHARACTERS = String.raw`%*[]\/?:#@{}`;
 const HOST_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
 
@@ -177,7 +185,6 @@ const firewallGeneratorResultSchema = z
   })
   .strict();
 
-type FirewallAuth = z.infer<typeof firewallAuthSchema>;
 type FirewallApi = z.infer<typeof firewallApiSchema>;
 type FirewallConfig = z.infer<typeof firewallConfigSchema>;
 type FirewallGeneratorResult = z.infer<typeof firewallGeneratorResultSchema>;
@@ -210,6 +217,90 @@ function firewallPermissionNames(firewall: FirewallConfig): Set<string> {
   return names;
 }
 
+export function firewallTemplateReferences(value: unknown): {
+  readonly secrets: ReadonlySet<string>;
+  readonly vars: ReadonlySet<string>;
+} {
+  const secrets = new Set<string>();
+  const vars = new Set<string>();
+  function visit(candidate: unknown): void {
+    if (typeof candidate === "string") {
+      for (const match of candidate.matchAll(TEMPLATE_REFERENCE_PATTERN)) {
+        const kind = match[1];
+        const name = match[2];
+        if (kind === undefined || name === undefined) {
+          continue;
+        }
+        (kind === "secrets" ? secrets : vars).add(name);
+      }
+      return;
+    }
+    if (Array.isArray(candidate)) {
+      for (const child of candidate) {
+        visit(child);
+      }
+      return;
+    }
+    if (typeof candidate === "object" && candidate !== null) {
+      for (const child of Object.values(candidate)) {
+        visit(child);
+      }
+    }
+  }
+  visit(value);
+  return { secrets, vars };
+}
+
+function normalizedFirewallBaseUrl(base: string): string {
+  const fullVariableMatch = base.match(FULL_BASE_VARIABLE_PATTERN);
+  if (fullVariableMatch !== null) {
+    return `https://variable.invalid${fullVariableMatch[1] ?? ""}`;
+  }
+  return base.replace(DIRECT_TEMPLATE_PATTERN, "variable");
+}
+
+export function parseFirewallBaseUrl(base: string): URL {
+  if (BASE_SECRET_PATTERN.test(base)) {
+    throw new Error("Firewall API base URLs must use connector variables");
+  }
+  const parsed = safeUrlParse(normalizedFirewallBaseUrl(base));
+  if (
+    parsed === undefined ||
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error(`Firewall base URL must be a clean HTTPS URL: ${base}`);
+  }
+  return parsed;
+}
+
+export function firewallBaseVariableNames(base: string): string[] {
+  return [
+    ...new Set(
+      [...base.matchAll(BASE_VARIABLE_CAPTURE_PATTERN)].flatMap((match) => {
+        return match[1] === undefined ? [] : [match[1]];
+      }),
+    ),
+  ].sort();
+}
+
+export function firewallAuthInjectsCredentials(auth: {
+  readonly base?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly query?: Readonly<Record<string, string>>;
+  readonly awsSigv4?: unknown;
+}): boolean {
+  return (
+    auth.base !== undefined ||
+    Object.keys(auth.headers ?? {}).length > 0 ||
+    Object.keys(auth.query ?? {}).length > 0 ||
+    auth.awsSigv4 !== undefined
+  );
+}
+
 function isFixedProviderHost(base: string): boolean {
   if (!BASE_VARIABLE_PATTERN.test(base)) {
     return true;
@@ -227,19 +318,10 @@ function isFixedProviderHost(base: string): boolean {
   return variableIndex !== -1 && labels.length - variableIndex - 1 >= 2;
 }
 
-function authInjectsCredentials(auth: FirewallAuth): boolean {
-  return (
-    auth.base !== undefined ||
-    Object.keys(auth.headers ?? {}).length > 0 ||
-    Object.keys(auth.query ?? {}).length > 0 ||
-    auth.awsSigv4 !== undefined
-  );
-}
-
 function validateHostPolicy(connectorRef: string, api: FirewallApi): void {
   if (
     BASE_VARIABLE_PATTERN.test(api.base) &&
-    authInjectsCredentials(api.auth) &&
+    firewallAuthInjectsCredentials(api.auth) &&
     !isFixedProviderHost(api.base)
   ) {
     if (api.hostPolicy === undefined) {
@@ -260,6 +342,7 @@ export function validateFirewallGeneratorResult(
   }
   const permissionNames = firewallPermissionNames(result.firewall);
   for (const api of result.firewall.apis) {
+    parseFirewallBaseUrl(api.base);
     validateHostPolicy(result.connectorRef, api);
   }
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -1,4 +1,10 @@
 import { isIP } from "node:net";
+
+import {
+  validateAuthBaseUrl,
+  validateBaseUrl,
+  validateBaseUrlHostPolicy,
+} from "@vm0/connectors/firewall-types";
 import { z } from "zod";
 
 import { safeUrlParse } from "../../utils";
@@ -7,6 +13,7 @@ import { connectorRefSchema, privateNameSchema } from "./common";
 const TEMPLATE_REFERENCE_PATTERN = /\b(secrets|vars)\.([A-Z][A-Z0-9_]*)\b/gu;
 const DIRECT_TEMPLATE_PATTERN =
   /\$\{\{\s*(?:secrets|vars)\.[A-Z][A-Z0-9_]*\s*\}\}/gu;
+const BASE_URL_PARAMETER_PATTERN = /\{[A-Za-z][A-Za-z0-9]*(?:[+*])?\}/gu;
 const BASE_VARIABLE_PATTERN = /\$\{\{\s*vars\.[A-Z][A-Z0-9_]*\s*\}\}/u;
 const BASE_VARIABLE_CAPTURE_PATTERN =
   /\$\{\{\s*vars\.([A-Z][A-Z0-9_]*)\s*\}\}/gu;
@@ -83,6 +90,7 @@ function hostHasFixedOwnership(
     : withoutLeadingDot.toLowerCase();
   if (
     normalized === "" ||
+    withoutLeadingDot !== normalized ||
     !/^[\x21-\x7e]+$/u.test(value) ||
     [...HOST_FORBIDDEN_CHARACTERS].some((character) => {
       return normalized.includes(character);
@@ -259,11 +267,54 @@ function normalizedFirewallBaseUrl(base: string): string {
   return base.replace(DIRECT_TEMPLATE_PATTERN, "variable");
 }
 
-export function parseFirewallBaseUrl(base: string): URL {
+function rawUrlHostname(value: string): string | undefined {
+  const schemeEnd = value.indexOf("://");
+  if (schemeEnd === -1) {
+    return undefined;
+  }
+  const authorityStart = schemeEnd + 3;
+  const pathStart = value.indexOf("/", authorityStart);
+  const authority = value.slice(
+    authorityStart,
+    pathStart === -1 ? value.length : pathStart,
+  );
+  if (authority.startsWith("[")) {
+    const bracketEnd = authority.indexOf("]");
+    return bracketEnd === -1 ? undefined : authority.slice(0, bracketEnd + 1);
+  }
+  const portSeparator = authority.lastIndexOf(":");
+  return portSeparator === -1 ? authority : authority.slice(0, portSeparator);
+}
+
+function assertCanonicalFirewallBaseHostname(normalizedBase: string): void {
+  const comparableBase = normalizedBase.replace(
+    BASE_URL_PARAMETER_PATTERN,
+    "variable",
+  );
+  const parsedComparableBase = safeUrlParse(comparableBase);
+  const rawHostname = rawUrlHostname(comparableBase);
+  if (
+    parsedComparableBase === undefined ||
+    rawHostname === undefined ||
+    rawHostname.endsWith(".") ||
+    rawHostname !== parsedComparableBase.hostname
+  ) {
+    throw new Error(
+      "Firewall API base hostname literals must use canonical lowercase ASCII",
+    );
+  }
+}
+
+export function parseFirewallBaseUrl(
+  base: string,
+  connectorRef = "connector-catalog",
+): URL {
   if (BASE_SECRET_PATTERN.test(base)) {
     throw new Error("Firewall API base URLs must use connector variables");
   }
-  const parsed = safeUrlParse(normalizedFirewallBaseUrl(base));
+  validateBaseUrl(base, connectorRef);
+  const normalizedBase = normalizedFirewallBaseUrl(base);
+  const parsed = safeUrlParse(normalizedBase);
   if (
     parsed === undefined ||
     parsed.protocol !== "https:" ||
@@ -274,6 +325,7 @@ export function parseFirewallBaseUrl(base: string): URL {
   ) {
     throw new Error(`Firewall base URL must be a clean HTTPS URL: ${base}`);
   }
+  assertCanonicalFirewallBaseHostname(normalizedBase);
   return parsed;
 }
 
@@ -342,7 +394,15 @@ export function validateFirewallGeneratorResult(
   }
   const permissionNames = firewallPermissionNames(result.firewall);
   for (const api of result.firewall.apis) {
-    parseFirewallBaseUrl(api.base);
+    parseFirewallBaseUrl(api.base, result.connectorRef);
+    validateBaseUrlHostPolicy({
+      base: api.base,
+      serviceName: result.connectorRef,
+      hostPolicy: api.hostPolicy,
+    });
+    if (api.auth.base !== undefined) {
+      validateAuthBaseUrl(api.auth.base, result.connectorRef);
+    }
     validateHostPolicy(result.connectorRef, api);
   }
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -1,0 +1,475 @@
+import { createHash } from "node:crypto";
+
+import type { ConnectorCatalogSyncFailureCode } from "@vm0/api-contracts/contracts/cron";
+import { z } from "zod";
+
+import { safeJsonParse, safeSync } from "../../utils";
+import {
+  artifactReferenceSchema,
+  connectorCatalogIntegrityArtifactSchema,
+  connectorCatalogPrivateArtifactSchema,
+  connectorCatalogPrivateFirewallsArtifactSchema,
+  connectorCatalogPublicArtifactSchema,
+  connectorCatalogReleaseArtifactKeys,
+  connectorCatalogRunnerFirewallsArtifactSchema,
+  connectorCatalogVersionSchema,
+  SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES,
+  SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+  type ConnectorCatalogCapability,
+  type ConnectorCatalogIntegrityArtifact,
+  type ConnectorCatalogPrivateArtifact,
+  type ConnectorCatalogPrivateFirewallsArtifact,
+  type ConnectorCatalogPublicArtifact,
+  type ConnectorCatalogRunnerFirewallsArtifact,
+} from "./artifacts";
+import {
+  assertPublicCatalogArtifactHasNoPrivateFields,
+  privateCatalogArtifactSensitiveValues,
+} from "./public-leak";
+import { validateConnectorCatalogRelationships } from "./relationships";
+
+const CONNECTOR_CATALOG_ACTIVE_KEY = "catalog-v1/active.json";
+
+const CONNECTOR_CATALOG_OBJECT_MAX_BYTES = {
+  active: 16 * 1024,
+  integrity: 4 * 1024 * 1024,
+  publicCatalog: 8 * 1024 * 1024,
+  privateCatalog: 8 * 1024 * 1024,
+  privateFirewalls: 32 * 1024 * 1024,
+  runnerFirewalls: 16 * 1024 * 1024,
+} as const;
+
+const connectorCatalogActivePointerSchema = z
+  .object({
+    catalogVersion: connectorCatalogVersionSchema,
+    integrity: artifactReferenceSchema,
+  })
+  .strict();
+
+export type ConnectorCatalogActivePointer = z.infer<
+  typeof connectorCatalogActivePointerSchema
+>;
+
+interface ConnectorCatalogArtifactReference {
+  readonly key: string;
+  readonly digest: string;
+}
+
+export interface ConnectorCatalogReleaseIdentity {
+  readonly schemaVersion: number;
+  readonly catalogVersion: string;
+  readonly integrity: ConnectorCatalogArtifactReference;
+  readonly publicCatalog: ConnectorCatalogArtifactReference;
+  readonly privateCatalog: ConnectorCatalogArtifactReference;
+  readonly privateFirewalls: ConnectorCatalogArtifactReference;
+  readonly runnerFirewalls: ConnectorCatalogArtifactReference;
+  readonly requiredCapabilities: readonly ConnectorCatalogCapability[];
+}
+
+export interface ValidatedConnectorCatalogCandidate {
+  readonly identity: ConnectorCatalogReleaseIdentity;
+  readonly publicCatalogText: string;
+}
+
+export interface ConnectorCatalogArtifactReader {
+  readArtifact(key: string, maxBytes: number): Promise<Uint8Array>;
+}
+
+class ConnectorCatalogArtifactError extends Error {
+  constructor(readonly code: ConnectorCatalogSyncFailureCode) {
+    super(code);
+    this.name = "ConnectorCatalogArtifactError";
+  }
+}
+
+export function connectorCatalogArtifactFailureCode(
+  value: unknown,
+): ConnectorCatalogSyncFailureCode | undefined {
+  return value instanceof ConnectorCatalogArtifactError
+    ? value.code
+    : undefined;
+}
+
+function fail(code: ConnectorCatalogSyncFailureCode): never {
+  throw new ConnectorCatalogArtifactError(code);
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function digest(bytes: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function assertDigest(bytes: Uint8Array, expectedDigest: string): void {
+  if (digest(bytes) !== expectedDigest) {
+    fail("digest-mismatch");
+  }
+}
+
+async function readBoundedArtifact(
+  reader: ConnectorCatalogArtifactReader,
+  key: string,
+  maxBytes: number,
+): Promise<Buffer> {
+  const bytes = Buffer.from(await reader.readArtifact(key, maxBytes));
+  if (bytes.length > maxBytes) {
+    fail("object-too-large");
+  }
+  return bytes;
+}
+
+function decodedJson(bytes: Uint8Array): {
+  readonly text: string;
+  readonly value: unknown;
+} {
+  const decoded = safeSync(() => {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  });
+  if (!("ok" in decoded)) {
+    fail("invalid-json");
+  }
+  const value = safeJsonParse(decoded.ok);
+  if (value === undefined) {
+    fail("invalid-json");
+  }
+  return { text: decoded.ok, value };
+}
+
+function parseStrict<T>(
+  value: unknown,
+  schema: z.ZodType<T>,
+  code: ConnectorCatalogSyncFailureCode,
+): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    fail(code);
+  }
+  return parsed.data;
+}
+
+function assertSupportedArtifactSchema(value: unknown): void {
+  if (
+    isRecord(value) &&
+    typeof value.artifactSchemaVersion === "number" &&
+    value.artifactSchemaVersion !== SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION
+  ) {
+    fail("unsupported-schema");
+  }
+}
+
+function assertSupportedCapabilities(value: unknown): void {
+  if (!isRecord(value) || !Array.isArray(value.requiredCapabilities)) {
+    return;
+  }
+  if (
+    value.requiredCapabilities.some((capability) => {
+      return (
+        typeof capability === "string" &&
+        !SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES.some((supported) => {
+          return supported === capability;
+        })
+      );
+    })
+  ) {
+    fail("unsupported-capability");
+  }
+}
+
+function assertPointerIntegrityKey(
+  pointer: ConnectorCatalogActivePointer,
+): void {
+  const expected = connectorCatalogReleaseArtifactKeys(
+    pointer.catalogVersion,
+  ).integrityCatalog;
+  if (pointer.integrity.key !== expected) {
+    fail("invalid-reference");
+  }
+}
+
+function assertIntegrityReferences(args: {
+  readonly pointer: ConnectorCatalogActivePointer;
+  readonly integrity: ConnectorCatalogIntegrityArtifact;
+}): void {
+  if (args.integrity.catalogVersion !== args.pointer.catalogVersion) {
+    fail("invalid-reference");
+  }
+  const expected = connectorCatalogReleaseArtifactKeys(
+    args.pointer.catalogVersion,
+  );
+  const references = args.integrity.artifacts;
+  if (
+    references.publicCatalog.key !== expected.publicCatalog ||
+    references.privateCatalog.key !== expected.privateCatalog ||
+    references.privateFirewalls.key !== expected.privateFirewalls ||
+    references.runnerFirewalls.key !== expected.runnerFirewalls ||
+    references.staticFilesPublication.key !== "icons/static-files.json"
+  ) {
+    fail("invalid-reference");
+  }
+}
+
+function assertCatalogVersion(
+  value: { readonly catalogVersion: string },
+  expected: string,
+): void {
+  if (value.catalogVersion !== expected) {
+    fail("invalid-reference");
+  }
+}
+
+function assertNoReservedModelProviderRefs(args: {
+  readonly publicRefs: readonly string[];
+  readonly privateRefs: readonly string[];
+  readonly privateFirewallRefs: readonly string[];
+  readonly runnerFirewallRefs: readonly string[];
+  readonly integrityRefs: readonly string[];
+}): void {
+  const refs = [
+    ...args.publicRefs,
+    ...args.privateRefs,
+    ...args.privateFirewallRefs,
+    ...args.runnerFirewallRefs,
+    ...args.integrityRefs,
+  ];
+  if (
+    refs.some((ref) => {
+      return ref.startsWith("model-provider:");
+    })
+  ) {
+    fail("invalid-artifact");
+  }
+}
+
+export function connectorCatalogPointersEqual(
+  left: ConnectorCatalogActivePointer,
+  right: ConnectorCatalogActivePointer,
+): boolean {
+  return (
+    left.catalogVersion === right.catalogVersion &&
+    left.integrity.key === right.integrity.key &&
+    left.integrity.digest === right.integrity.digest
+  );
+}
+
+export async function loadConnectorCatalogActivePointer(
+  reader: ConnectorCatalogArtifactReader,
+): Promise<ConnectorCatalogActivePointer> {
+  const bytes = await readBoundedArtifact(
+    reader,
+    CONNECTOR_CATALOG_ACTIVE_KEY,
+    CONNECTOR_CATALOG_OBJECT_MAX_BYTES.active,
+  );
+  const parsed = decodedJson(bytes);
+  const pointer = parseStrict(
+    parsed.value,
+    connectorCatalogActivePointerSchema,
+    "invalid-pointer",
+  );
+  assertPointerIntegrityKey(pointer);
+  return pointer;
+}
+
+interface ConnectorCatalogViewBytes {
+  readonly publicCatalog: Buffer;
+  readonly privateCatalog: Buffer;
+  readonly privateFirewalls: Buffer;
+  readonly runnerFirewalls: Buffer;
+}
+
+interface ParsedConnectorCatalogViews {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly publicCatalogText: string;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
+}
+
+async function loadIntegrityArtifact(args: {
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly pointer: ConnectorCatalogActivePointer;
+}): Promise<ConnectorCatalogIntegrityArtifact> {
+  const bytes = await readBoundedArtifact(
+    args.reader,
+    args.pointer.integrity.key,
+    CONNECTOR_CATALOG_OBJECT_MAX_BYTES.integrity,
+  );
+  assertDigest(bytes, args.pointer.integrity.digest);
+  const json = decodedJson(bytes);
+  assertSupportedArtifactSchema(json.value);
+  assertSupportedCapabilities(json.value);
+  const integrity = parseStrict(
+    json.value,
+    connectorCatalogIntegrityArtifactSchema,
+    "invalid-artifact",
+  );
+  assertIntegrityReferences({ pointer: args.pointer, integrity });
+  return integrity;
+}
+
+async function loadCatalogViewBytes(args: {
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly integrity: ConnectorCatalogIntegrityArtifact;
+}): Promise<ConnectorCatalogViewBytes> {
+  const references = args.integrity.artifacts;
+  const [publicCatalog, privateCatalog, privateFirewalls, runnerFirewalls] =
+    await Promise.all([
+      readBoundedArtifact(
+        args.reader,
+        references.publicCatalog.key,
+        CONNECTOR_CATALOG_OBJECT_MAX_BYTES.publicCatalog,
+      ),
+      readBoundedArtifact(
+        args.reader,
+        references.privateCatalog.key,
+        CONNECTOR_CATALOG_OBJECT_MAX_BYTES.privateCatalog,
+      ),
+      readBoundedArtifact(
+        args.reader,
+        references.privateFirewalls.key,
+        CONNECTOR_CATALOG_OBJECT_MAX_BYTES.privateFirewalls,
+      ),
+      readBoundedArtifact(
+        args.reader,
+        references.runnerFirewalls.key,
+        CONNECTOR_CATALOG_OBJECT_MAX_BYTES.runnerFirewalls,
+      ),
+    ]);
+  assertDigest(publicCatalog, references.publicCatalog.digest);
+  assertDigest(privateCatalog, references.privateCatalog.digest);
+  assertDigest(privateFirewalls, references.privateFirewalls.digest);
+  assertDigest(runnerFirewalls, references.runnerFirewalls.digest);
+  return { publicCatalog, privateCatalog, privateFirewalls, runnerFirewalls };
+}
+
+function parseCatalogViews(
+  bytes: ConnectorCatalogViewBytes,
+  catalogVersion: string,
+): ParsedConnectorCatalogViews {
+  const publicJson = decodedJson(bytes.publicCatalog);
+  const privateJson = decodedJson(bytes.privateCatalog);
+  const privateFirewallsJson = decodedJson(bytes.privateFirewalls);
+  const runnerFirewallsJson = decodedJson(bytes.runnerFirewalls);
+  for (const value of [
+    publicJson.value,
+    privateJson.value,
+    privateFirewallsJson.value,
+    runnerFirewallsJson.value,
+  ]) {
+    assertSupportedArtifactSchema(value);
+  }
+  const publicArtifact = parseStrict(
+    publicJson.value,
+    connectorCatalogPublicArtifactSchema,
+    "invalid-artifact",
+  );
+  const privateArtifact = parseStrict(
+    privateJson.value,
+    connectorCatalogPrivateArtifactSchema,
+    "invalid-artifact",
+  );
+  const privateFirewallsArtifact = parseStrict(
+    privateFirewallsJson.value,
+    connectorCatalogPrivateFirewallsArtifactSchema,
+    "invalid-artifact",
+  );
+  const runnerFirewallsArtifact = parseStrict(
+    runnerFirewallsJson.value,
+    connectorCatalogRunnerFirewallsArtifactSchema,
+    "invalid-artifact",
+  );
+  for (const artifact of [
+    publicArtifact,
+    privateArtifact,
+    privateFirewallsArtifact,
+    runnerFirewallsArtifact,
+  ]) {
+    assertCatalogVersion(artifact, catalogVersion);
+  }
+  return {
+    publicArtifact,
+    publicCatalogText: publicJson.text,
+    privateArtifact,
+    privateFirewallsArtifact,
+    runnerFirewallsArtifact,
+  };
+}
+
+function validateCatalogViews(
+  views: ParsedConnectorCatalogViews,
+  integrity: ConnectorCatalogIntegrityArtifact,
+): void {
+  assertNoReservedModelProviderRefs({
+    publicRefs: views.publicArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+    privateRefs: views.privateArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+    privateFirewallRefs: views.privateFirewallsArtifact.connectors.map(
+      (connector) => {
+        return connector.connectorRef;
+      },
+    ),
+    runnerFirewallRefs: views.runnerFirewallsArtifact.firewalls.map(
+      (firewall) => {
+        return firewall.name;
+      },
+    ),
+    integrityRefs: integrity.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+  });
+  const publicLeak = safeSync(() => {
+    assertPublicCatalogArtifactHasNoPrivateFields(
+      views.publicArtifact,
+      privateCatalogArtifactSensitiveValues(views.privateArtifact),
+    );
+  });
+  if (!("ok" in publicLeak)) {
+    fail("public-leakage");
+  }
+  const relationships = safeSync(() => {
+    validateConnectorCatalogRelationships({
+      ...views,
+      integrity,
+    });
+  });
+  if (!("ok" in relationships)) {
+    fail("relationship-mismatch");
+  }
+}
+
+function releaseIdentity(
+  pointer: ConnectorCatalogActivePointer,
+  integrity: ConnectorCatalogIntegrityArtifact,
+): ConnectorCatalogReleaseIdentity {
+  return {
+    schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+    catalogVersion: pointer.catalogVersion,
+    integrity: { ...pointer.integrity },
+    publicCatalog: { ...integrity.artifacts.publicCatalog },
+    privateCatalog: { ...integrity.artifacts.privateCatalog },
+    privateFirewalls: { ...integrity.artifacts.privateFirewalls },
+    runnerFirewalls: { ...integrity.artifacts.runnerFirewalls },
+    requiredCapabilities: [...integrity.requiredCapabilities],
+  };
+}
+
+export async function loadConnectorCatalogCandidate(args: {
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly pointer: ConnectorCatalogActivePointer;
+}): Promise<ValidatedConnectorCatalogCandidate> {
+  const integrity = await loadIntegrityArtifact(args);
+  const bytes = await loadCatalogViewBytes({
+    reader: args.reader,
+    integrity,
+  });
+  const views = parseCatalogViews(bytes, args.pointer.catalogVersion);
+  validateCatalogViews(views, integrity);
+  return {
+    identity: releaseIdentity(args.pointer, integrity),
+    publicCatalogText: views.publicCatalogText,
+  };
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { safeJsonParse, safeSync } from "../../utils";
 import {
   artifactReferenceSchema,
+  CONNECTOR_CATALOG_ACTIVE_KEY,
   connectorCatalogIntegrityArtifactSchema,
   connectorCatalogPrivateArtifactSchema,
   connectorCatalogPrivateFirewallsArtifactSchema,
@@ -27,8 +28,6 @@ import {
   privateCatalogArtifactSensitiveValues,
 } from "./public-leak";
 import { validateConnectorCatalogRelationships } from "./relationships";
-
-const CONNECTOR_CATALOG_ACTIVE_KEY = "catalog-v1/active.json";
 
 const CONNECTOR_CATALOG_OBJECT_MAX_BYTES = {
   active: 16 * 1024,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 
 import { safeJsonParse, safeSync } from "../../utils";
 import {
-  artifactReferenceSchema,
   CONNECTOR_CATALOG_ACTIVE_KEY,
   connectorCatalogIntegrityArtifactSchema,
   connectorCatalogPrivateArtifactSchema,
@@ -14,15 +13,14 @@ import {
   connectorCatalogReleaseArtifactKeys,
   connectorCatalogRunnerFirewallsArtifactSchema,
   connectorCatalogVersionSchema,
-  SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES,
   SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-  type ConnectorCatalogCapability,
   type ConnectorCatalogIntegrityArtifact,
   type ConnectorCatalogPrivateArtifact,
   type ConnectorCatalogPrivateFirewallsArtifact,
   type ConnectorCatalogPublicArtifact,
   type ConnectorCatalogRunnerFirewallsArtifact,
 } from "./artifacts";
+import { digestSchema } from "./common";
 import {
   assertPublicCatalogArtifactHasNoPrivateFields,
   privateCatalogArtifactSensitiveValues,
@@ -31,7 +29,7 @@ import { validateConnectorCatalogRelationships } from "./relationships";
 
 const CONNECTOR_CATALOG_OBJECT_MAX_BYTES = {
   active: 16 * 1024,
-  integrity: 4 * 1024 * 1024,
+  integrity: 16 * 1024,
   publicCatalog: 8 * 1024 * 1024,
   privateCatalog: 8 * 1024 * 1024,
   privateFirewalls: 32 * 1024 * 1024,
@@ -41,7 +39,7 @@ const CONNECTOR_CATALOG_OBJECT_MAX_BYTES = {
 const connectorCatalogActivePointerSchema = z
   .object({
     catalogVersion: connectorCatalogVersionSchema,
-    integrity: artifactReferenceSchema,
+    integrityDigest: digestSchema,
   })
   .strict();
 
@@ -49,20 +47,14 @@ export type ConnectorCatalogActivePointer = z.infer<
   typeof connectorCatalogActivePointerSchema
 >;
 
-interface ConnectorCatalogArtifactReference {
-  readonly key: string;
-  readonly digest: string;
-}
-
 export interface ConnectorCatalogReleaseIdentity {
   readonly schemaVersion: number;
   readonly catalogVersion: string;
-  readonly integrity: ConnectorCatalogArtifactReference;
-  readonly publicCatalog: ConnectorCatalogArtifactReference;
-  readonly privateCatalog: ConnectorCatalogArtifactReference;
-  readonly privateFirewalls: ConnectorCatalogArtifactReference;
-  readonly runnerFirewalls: ConnectorCatalogArtifactReference;
-  readonly requiredCapabilities: readonly ConnectorCatalogCapability[];
+  readonly integrityDigest: string;
+  readonly publicCatalogDigest: string;
+  readonly privateCatalogDigest: string;
+  readonly privateFirewallsDigest: string;
+  readonly runnerFirewallsDigest: string;
 }
 
 export interface ValidatedConnectorCatalogCandidate {
@@ -158,53 +150,11 @@ function assertSupportedArtifactSchema(value: unknown): void {
   }
 }
 
-function assertSupportedCapabilities(value: unknown): void {
-  if (!isRecord(value) || !Array.isArray(value.requiredCapabilities)) {
-    return;
-  }
-  if (
-    value.requiredCapabilities.some((capability) => {
-      return (
-        typeof capability === "string" &&
-        !SUPPORTED_CONNECTOR_CATALOG_CAPABILITIES.some((supported) => {
-          return supported === capability;
-        })
-      );
-    })
-  ) {
-    fail("unsupported-capability");
-  }
-}
-
-function assertPointerIntegrityKey(
-  pointer: ConnectorCatalogActivePointer,
-): void {
-  const expected = connectorCatalogReleaseArtifactKeys(
-    pointer.catalogVersion,
-  ).integrityCatalog;
-  if (pointer.integrity.key !== expected) {
-    fail("invalid-reference");
-  }
-}
-
-function assertIntegrityReferences(args: {
+function assertIntegrityCatalogVersion(args: {
   readonly pointer: ConnectorCatalogActivePointer;
   readonly integrity: ConnectorCatalogIntegrityArtifact;
 }): void {
   if (args.integrity.catalogVersion !== args.pointer.catalogVersion) {
-    fail("invalid-reference");
-  }
-  const expected = connectorCatalogReleaseArtifactKeys(
-    args.pointer.catalogVersion,
-  );
-  const references = args.integrity.artifacts;
-  if (
-    references.publicCatalog.key !== expected.publicCatalog ||
-    references.privateCatalog.key !== expected.privateCatalog ||
-    references.privateFirewalls.key !== expected.privateFirewalls ||
-    references.runnerFirewalls.key !== expected.runnerFirewalls ||
-    references.staticFilesPublication.key !== "icons/static-files.json"
-  ) {
     fail("invalid-reference");
   }
 }
@@ -223,14 +173,12 @@ function assertNoReservedModelProviderRefs(args: {
   readonly privateRefs: readonly string[];
   readonly privateFirewallRefs: readonly string[];
   readonly runnerFirewallRefs: readonly string[];
-  readonly integrityRefs: readonly string[];
 }): void {
   const refs = [
     ...args.publicRefs,
     ...args.privateRefs,
     ...args.privateFirewallRefs,
     ...args.runnerFirewallRefs,
-    ...args.integrityRefs,
   ];
   if (
     refs.some((ref) => {
@@ -255,7 +203,6 @@ export async function loadConnectorCatalogActivePointer(
     connectorCatalogActivePointerSchema,
     "invalid-pointer",
   );
-  assertPointerIntegrityKey(pointer);
   return pointer;
 }
 
@@ -280,54 +227,56 @@ async function loadIntegrityArtifact(args: {
 }): Promise<ConnectorCatalogIntegrityArtifact> {
   const bytes = await readBoundedArtifact(
     args.reader,
-    args.pointer.integrity.key,
+    connectorCatalogReleaseArtifactKeys(args.pointer.catalogVersion)
+      .integrityCatalog,
     CONNECTOR_CATALOG_OBJECT_MAX_BYTES.integrity,
   );
-  assertDigest(bytes, args.pointer.integrity.digest);
+  assertDigest(bytes, args.pointer.integrityDigest);
   const json = decodedJson(bytes);
   assertSupportedArtifactSchema(json.value);
-  assertSupportedCapabilities(json.value);
   const integrity = parseStrict(
     json.value,
     connectorCatalogIntegrityArtifactSchema,
     "invalid-artifact",
   );
-  assertIntegrityReferences({ pointer: args.pointer, integrity });
+  assertIntegrityCatalogVersion({ pointer: args.pointer, integrity });
   return integrity;
 }
 
 async function loadCatalogViewBytes(args: {
   readonly reader: ConnectorCatalogArtifactReader;
+  readonly catalogVersion: string;
   readonly integrity: ConnectorCatalogIntegrityArtifact;
 }): Promise<ConnectorCatalogViewBytes> {
-  const references = args.integrity.artifacts;
+  const keys = connectorCatalogReleaseArtifactKeys(args.catalogVersion);
+  const digests = args.integrity.artifacts;
   const [publicCatalog, privateCatalog, privateFirewalls, runnerFirewalls] =
     await Promise.all([
       readBoundedArtifact(
         args.reader,
-        references.publicCatalog.key,
+        keys.publicCatalog,
         CONNECTOR_CATALOG_OBJECT_MAX_BYTES.publicCatalog,
       ),
       readBoundedArtifact(
         args.reader,
-        references.privateCatalog.key,
+        keys.privateCatalog,
         CONNECTOR_CATALOG_OBJECT_MAX_BYTES.privateCatalog,
       ),
       readBoundedArtifact(
         args.reader,
-        references.privateFirewalls.key,
+        keys.privateFirewalls,
         CONNECTOR_CATALOG_OBJECT_MAX_BYTES.privateFirewalls,
       ),
       readBoundedArtifact(
         args.reader,
-        references.runnerFirewalls.key,
+        keys.runnerFirewalls,
         CONNECTOR_CATALOG_OBJECT_MAX_BYTES.runnerFirewalls,
       ),
     ]);
-  assertDigest(publicCatalog, references.publicCatalog.digest);
-  assertDigest(privateCatalog, references.privateCatalog.digest);
-  assertDigest(privateFirewalls, references.privateFirewalls.digest);
-  assertDigest(runnerFirewalls, references.runnerFirewalls.digest);
+  assertDigest(publicCatalog, digests.publicCatalog);
+  assertDigest(privateCatalog, digests.privateCatalog);
+  assertDigest(privateFirewalls, digests.privateFirewalls);
+  assertDigest(runnerFirewalls, digests.runnerFirewalls);
   return { publicCatalog, privateCatalog, privateFirewalls, runnerFirewalls };
 }
 
@@ -405,9 +354,6 @@ function validateCatalogViews(
         return firewall.name;
       },
     ),
-    integrityRefs: integrity.connectors.map((connector) => {
-      return connector.connectorRef;
-    }),
   });
   const publicLeak = safeSync(() => {
     assertPublicCatalogArtifactHasNoPrivateFields(
@@ -436,12 +382,11 @@ function releaseIdentity(
   return {
     schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
     catalogVersion: pointer.catalogVersion,
-    integrity: { ...pointer.integrity },
-    publicCatalog: { ...integrity.artifacts.publicCatalog },
-    privateCatalog: { ...integrity.artifacts.privateCatalog },
-    privateFirewalls: { ...integrity.artifacts.privateFirewalls },
-    runnerFirewalls: { ...integrity.artifacts.runnerFirewalls },
-    requiredCapabilities: [...integrity.requiredCapabilities],
+    integrityDigest: pointer.integrityDigest,
+    publicCatalogDigest: integrity.artifacts.publicCatalog,
+    privateCatalogDigest: integrity.artifacts.privateCatalog,
+    privateFirewallsDigest: integrity.artifacts.privateFirewalls,
+    runnerFirewallsDigest: integrity.artifacts.runnerFirewalls,
   };
 }
 
@@ -452,6 +397,7 @@ export async function loadConnectorCatalogCandidate(args: {
   const integrity = await loadIntegrityArtifact(args);
   const bytes = await loadCatalogViewBytes({
     reader: args.reader,
+    catalogVersion: args.pointer.catalogVersion,
     integrity,
   });
   const views = parseCatalogViews(bytes, args.pointer.catalogVersion);

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -241,17 +241,6 @@ function assertNoReservedModelProviderRefs(args: {
   }
 }
 
-export function connectorCatalogPointersEqual(
-  left: ConnectorCatalogActivePointer,
-  right: ConnectorCatalogActivePointer,
-): boolean {
-  return (
-    left.catalogVersion === right.catalogVersion &&
-    left.integrity.key === right.integrity.key &&
-    left.integrity.digest === right.integrity.digest
-  );
-}
-
 export async function loadConnectorCatalogActivePointer(
   reader: ConnectorCatalogArtifactReader,
 ): Promise<ConnectorCatalogActivePointer> {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 
 import { safeJsonParse, safeSync } from "../../utils";
 import {
-  CONNECTOR_CATALOG_ACTIVE_KEY,
   connectorCatalogIntegrityArtifactSchema,
   connectorCatalogPrivateArtifactSchema,
   connectorCatalogPrivateFirewallsArtifactSchema,
@@ -60,6 +59,9 @@ export interface ConnectorCatalogReleaseIdentity {
 export interface ValidatedConnectorCatalogCandidate {
   readonly identity: ConnectorCatalogReleaseIdentity;
   readonly publicCatalogText: string;
+  readonly privateCatalogText: string;
+  readonly privateFirewallsText: string;
+  readonly runnerFirewallsText: string;
 }
 
 export interface ConnectorCatalogArtifactReader {
@@ -189,14 +191,15 @@ function assertNoReservedModelProviderRefs(args: {
   }
 }
 
-export async function loadConnectorCatalogActivePointer(
-  reader: ConnectorCatalogArtifactReader,
-): Promise<ConnectorCatalogActivePointer> {
-  const bytes = await readBoundedArtifact(
-    reader,
-    CONNECTOR_CATALOG_ACTIVE_KEY,
-    CONNECTOR_CATALOG_OBJECT_MAX_BYTES.active,
-  );
+export const CONNECTOR_CATALOG_ACTIVE_MAX_BYTES =
+  CONNECTOR_CATALOG_OBJECT_MAX_BYTES.active;
+
+export function parseConnectorCatalogActivePointer(
+  bytes: Uint8Array,
+): ConnectorCatalogActivePointer {
+  if (bytes.length > CONNECTOR_CATALOG_ACTIVE_MAX_BYTES) {
+    fail("object-too-large");
+  }
   const parsed = decodedJson(bytes);
   const pointer = parseStrict(
     parsed.value,
@@ -217,8 +220,11 @@ interface ParsedConnectorCatalogViews {
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
   readonly publicCatalogText: string;
   readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateCatalogText: string;
   readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly privateFirewallsText: string;
   readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
+  readonly runnerFirewallsText: string;
 }
 
 async function loadIntegrityArtifact(args: {
@@ -328,8 +334,11 @@ function parseCatalogViews(
     publicArtifact,
     publicCatalogText: publicJson.text,
     privateArtifact,
+    privateCatalogText: privateJson.text,
     privateFirewallsArtifact,
+    privateFirewallsText: privateFirewallsJson.text,
     runnerFirewallsArtifact,
+    runnerFirewallsText: runnerFirewallsJson.text,
   };
 }
 
@@ -405,5 +414,8 @@ export async function loadConnectorCatalogCandidate(args: {
   return {
     identity: releaseIdentity(args.pointer, integrity),
     publicCatalogText: views.publicCatalogText,
+    privateCatalogText: views.privateCatalogText,
+    privateFirewallsText: views.privateFirewallsText,
+    runnerFirewallsText: views.runnerFirewallsText,
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/private-token-patterns.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/private-token-patterns.ts
@@ -1,0 +1,34 @@
+const uppercasePrivateTokenPattern = /\b[A-Z][A-Z0-9_]{3,}\b/g;
+// Private objects may use credential-like keys; avoid collecting generic keys such as "id".
+const credentialTermPattern =
+  "(?:secret|token|credential|password|private|api[-_]?key|access[-_]?key|client[-_]?secret|refresh[-_]?token)";
+const credentialPrefixPattern =
+  "(?:sk|pk|rk|xaat|gh[pousr]|github_pat|xox[a-z]?)";
+function credentialTokenPattern(): RegExp {
+  return new RegExp(
+    `\\b(?:${credentialPrefixPattern}[-_][A-Za-z0-9._-]{8,}|(?=[A-Za-z0-9._-]{8,}\\b)(?=[A-Za-z0-9._-]*${credentialTermPattern})[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*)\\b`,
+    "gi",
+  );
+}
+
+function credentialKeyPattern(): RegExp {
+  return new RegExp(
+    `^(?:${credentialPrefixPattern}[-_][A-Za-z0-9._-]{8,}|(?=[A-Za-z0-9._-]{8,}$)(?=[A-Za-z0-9._-]*${credentialTermPattern})[A-Za-z0-9]+(?:[._-]?[A-Za-z0-9]+)*)$`,
+    "i",
+  );
+}
+
+export function privateTokenMatches(value: string): readonly string[] {
+  const matches = new Set<string>();
+  for (const match of value.matchAll(uppercasePrivateTokenPattern)) {
+    matches.add(match[0]);
+  }
+  for (const match of value.matchAll(credentialTokenPattern())) {
+    matches.add(match[0]);
+  }
+  return [...matches];
+}
+
+export function isPrivateTokenLikeKey(key: string): boolean {
+  return /^[A-Z][A-Z0-9_]{3,}$/.test(key) || credentialKeyPattern().test(key);
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -1,0 +1,170 @@
+import type { ConnectorCatalogPrivateArtifact } from "./artifacts";
+import {
+  isPrivateTokenLikeKey,
+  privateTokenMatches,
+} from "./private-token-patterns";
+
+const forbiddenPublicPropertyNamePattern =
+  /^(access|client|clientId|clientIdEnv|clientSecret|clientSecretEnv|envBindings|featureFlag|inputs|objectKey|outputs|platformSecrets|privateName|refreshableSecrets|revoke|r2Key|scopes|secret|secrets|showExperimentalLabel|skillRef|sourcePath|storage|variables|valueRef)$/u;
+
+function normalizeSensitiveString(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/gu, "").toLowerCase();
+}
+
+function shouldCheckDerivedSensitiveValue(path: string): boolean {
+  return (
+    path.endsWith(".placeholder") ||
+    path.endsWith(".defaultValue") ||
+    path.endsWith(".value")
+  );
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function addSensitiveValue(value: string, values: Set<string>): void {
+  values.add(value);
+  for (const match of privateTokenMatches(value)) {
+    values.add(match);
+  }
+}
+
+function addValueRef(valueRef: string, values: Set<string>): void {
+  addSensitiveValue(valueRef, values);
+  const separator = valueRef.indexOf(".");
+  addSensitiveValue(valueRef.slice(separator + 1), values);
+}
+
+function addBindingValues(
+  bindings: Readonly<Record<string, string>>,
+  values: Set<string>,
+): void {
+  for (const valueRef of Object.values(bindings)) {
+    addValueRef(valueRef, values);
+  }
+}
+
+export function privateCatalogArtifactSensitiveValues(
+  artifact: ConnectorCatalogPrivateArtifact,
+): ReadonlySet<string> {
+  const values = new Set<string>();
+  for (const connector of artifact.connectors) {
+    for (const authMethod of connector.authMethods) {
+      for (const name of authMethod.storage.secrets) {
+        addSensitiveValue(name, values);
+      }
+      for (const name of authMethod.storage.variables) {
+        addSensitiveValue(name, values);
+      }
+      if (authMethod.client?.clientRegistration === "static") {
+        if (authMethod.client.clientType === "confidential") {
+          addSensitiveValue(authMethod.client.clientIdEnv, values);
+          addSensitiveValue(authMethod.client.clientSecretEnv, values);
+        } else {
+          addSensitiveValue(authMethod.client.clientId, values);
+        }
+      }
+      if (authMethod.grant.kind === "manual") {
+        for (const field of authMethod.grant.fields) {
+          addSensitiveValue(field.privateName, values);
+        }
+      } else {
+        addBindingValues(authMethod.grant.outputs, values);
+      }
+      for (const [name, binding] of Object.entries(
+        authMethod.access.envBindings,
+      )) {
+        addSensitiveValue(name, values);
+        addValueRef(
+          typeof binding === "string" ? binding : binding.valueRef,
+          values,
+        );
+      }
+      for (const name of authMethod.access.platformSecrets ?? []) {
+        addSensitiveValue(name, values);
+      }
+      if (authMethod.access.kind === "refresh-token") {
+        addBindingValues(authMethod.access.inputs, values);
+        addBindingValues(authMethod.access.outputs, values);
+        for (const name of authMethod.access.refreshableSecrets) {
+          addSensitiveValue(name, values);
+        }
+      }
+      if (authMethod.revoke.kind === "token-revoke") {
+        addBindingValues(authMethod.revoke.inputs, values);
+      }
+    }
+  }
+  return values;
+}
+
+function assertNoSensitiveString(args: {
+  readonly value: string;
+  readonly path: string;
+  readonly sensitiveValues: ReadonlySet<string>;
+}): void {
+  const normalizedValue = normalizeSensitiveString(args.value);
+  for (const sensitiveValue of args.sensitiveValues) {
+    if (sensitiveValue.length === 0) {
+      continue;
+    }
+    if (args.value.includes(sensitiveValue)) {
+      throw new Error(
+        `Public connector catalog artifact leaked private value at ${args.path}`,
+      );
+    }
+    const normalizedSensitiveValue = normalizeSensitiveString(sensitiveValue);
+    if (
+      shouldCheckDerivedSensitiveValue(args.path) &&
+      sensitiveValue.includes("_") &&
+      normalizedSensitiveValue.length >= 8 &&
+      normalizedValue.includes(normalizedSensitiveValue)
+    ) {
+      throw new Error(
+        `Public connector catalog artifact leaked private value at ${args.path}`,
+      );
+    }
+  }
+}
+
+export function assertPublicCatalogArtifactHasNoPrivateFields(
+  value: unknown,
+  sensitiveValues: ReadonlySet<string>,
+  path = "$",
+): void {
+  if (typeof value === "string") {
+    assertNoSensitiveString({ value, path, sensitiveValues });
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const [index, child] of value.entries()) {
+      assertPublicCatalogArtifactHasNoPrivateFields(
+        child,
+        sensitiveValues,
+        `${path}[${index}]`,
+      );
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  const allowsPublicMapKeys = path.endsWith(".byPermission");
+  for (const [key, child] of Object.entries(value)) {
+    if (
+      !allowsPublicMapKeys &&
+      (forbiddenPublicPropertyNamePattern.test(key) ||
+        isPrivateTokenLikeKey(key))
+    ) {
+      throw new Error(
+        `Public connector catalog artifact leaked private property ${key} at ${path}`,
+      );
+    }
+    assertPublicCatalogArtifactHasNoPrivateFields(
+      child,
+      sensitiveValues,
+      `${path}.${key}`,
+    );
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -6,7 +6,7 @@ import {
   type ConnectorCatalogPrivateFirewallsArtifact,
   type ConnectorCatalogPublicArtifact,
   type ConnectorCatalogRunnerFirewallsArtifact,
-  type StaticFilesPublicationManifest,
+  staticFilesPublicationManifestSchema,
   validateConnectorCatalogArtifacts,
 } from "./artifacts";
 import { validateFirewallGeneratorResult } from "./firewall";
@@ -333,12 +333,19 @@ export function validateConnectorCatalogRelationships(args: {
   readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
   readonly integrity: ConnectorCatalogIntegrityArtifact;
 }): void {
-  const staticFilesPublicationArtifact: StaticFilesPublicationManifest = {
-    artifactSchemaVersion: 1,
-    files: args.integrity.assets.map((asset) => {
-      return { ...asset };
-    }),
-  };
+  const staticFilesPublicationArtifact =
+    staticFilesPublicationManifestSchema.parse({
+      artifactSchemaVersion: 1,
+      files: args.integrity.assets.map((asset) => {
+        return { ...asset };
+      }),
+    });
+  if (
+    canonicalDigest(staticFilesPublicationArtifact) !==
+    args.integrity.artifacts.staticFilesPublication.digest
+  ) {
+    throw new Error("Static-files publication digest mismatch");
+  }
   validateConnectorCatalogArtifacts({
     ...args,
     staticFilesPublicationArtifact,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -9,7 +9,13 @@ import {
   staticFilesPublicationManifestSchema,
   validateConnectorCatalogArtifacts,
 } from "./artifacts";
-import { validateFirewallGeneratorResult } from "./firewall";
+import {
+  firewallAuthInjectsCredentials,
+  firewallBaseVariableNames,
+  firewallTemplateReferences,
+  parseFirewallBaseUrl,
+  validateFirewallGeneratorResult,
+} from "./firewall";
 import {
   catalogSourceSchema,
   connectorSourceSchema,
@@ -256,16 +262,177 @@ function validateCatalogAndConnectorSemantics(args: {
   }
 }
 
-function validateFirewallSemantics(
-  privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact,
-): void {
-  for (const connector of privateFirewallsArtifact.connectors) {
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortedUniqueStrings(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort(compareStrings);
+}
+
+function validateFirewallBindings(args: {
+  readonly privateConnector: ConnectorCatalogPrivateArtifact["connectors"][number];
+  readonly privateFirewall: ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
+}): void {
+  const knownEnvironmentNames = new Set<string>();
+  for (const method of args.privateConnector.authMethods) {
+    for (const name of Object.keys(method.access.envBindings)) {
+      knownEnvironmentNames.add(name);
+    }
+    for (const name of method.access.platformSecrets ?? []) {
+      knownEnvironmentNames.add(name);
+    }
+  }
+  const references = firewallTemplateReferences(
+    args.privateFirewall.firewall.apis,
+  );
+  const unknown = [...references.secrets, ...references.vars].filter((name) => {
+    return !knownEnvironmentNames.has(name);
+  });
+  if (unknown.length > 0) {
+    throw new Error(
+      `Firewall references unknown connector bindings: ${sortedUniqueStrings(unknown).join(", ")}`,
+    );
+  }
+  const unusedPlaceholders = Object.keys(
+    args.privateFirewall.firewall.placeholders ?? {},
+  ).filter((name) => {
+    return !references.secrets.has(name);
+  });
+  if (unusedPlaceholders.length > 0) {
+    throw new Error(
+      `Firewall has unused placeholders: ${sortedUniqueStrings(unusedPlaceholders).join(", ")}`,
+    );
+  }
+}
+
+function expectedFirewallRouting(
+  privateFirewall: ConnectorCatalogPrivateFirewallsArtifact["connectors"][number],
+): ConnectorCatalogPrivateFirewallsArtifact["connectors"][number]["routing"] {
+  const apis = privateFirewall.firewall.apis;
+  return {
+    fixedHosts: sortedUniqueStrings(
+      apis.flatMap((api) => {
+        const parsed = parseFirewallBaseUrl(api.base);
+        return api.base.includes("${{") ? [] : [parsed.host];
+      }),
+    ),
+    baseUrlVarNames: sortedUniqueStrings(
+      apis.flatMap((api) => {
+        return firewallBaseVariableNames(api.base);
+      }),
+    ),
+    baseUrlTemplates: apis
+      .filter((api) => {
+        return api.base.includes("${{");
+      })
+      .map((api) => {
+        parseFirewallBaseUrl(api.base);
+        return {
+          base: api.base,
+          credentialed: firewallAuthInjectsCredentials(api.auth),
+          ...(api.hostPolicy === undefined
+            ? {}
+            : { hostPolicy: api.hostPolicy }),
+        };
+      })
+      .sort((left, right) => {
+        return compareStrings(left.base, right.base);
+      }),
+    apis: apis.map((api) => {
+      const references = firewallTemplateReferences(api);
+      return {
+        base: api.base,
+        environmentNames: sortedUniqueStrings([
+          ...references.secrets,
+          ...references.vars,
+        ]),
+        routes: (api.permissions ?? []).flatMap((permission) => {
+          return permission.rules.map((rule) => {
+            return { permissionName: permission.name, rule };
+          });
+        }),
+      };
+    }),
+  };
+}
+
+function expectedFirewallDiagnostics(
+  privateFirewall: ConnectorCatalogPrivateFirewallsArtifact["connectors"][number],
+): ConnectorCatalogPrivateFirewallsArtifact["connectors"][number]["diagnostics"] {
+  const permissions = privateFirewall.firewall.apis.flatMap((api) => {
+    return api.permissions ?? [];
+  });
+  return {
+    apiCount: privateFirewall.firewall.apis.length,
+    permissionCount: new Set(
+      permissions.map((permission) => {
+        return permission.name;
+      }),
+    ).size,
+    ruleCount: permissions.reduce((count, permission) => {
+      return count + permission.rules.length;
+    }, 0),
+  };
+}
+
+function validateFirewallProjection(args: {
+  readonly publicConnector: ConnectorCatalogPublicArtifact["connectors"][number];
+  readonly privateConnector: ConnectorCatalogPrivateArtifact["connectors"][number];
+  readonly privateFirewall: ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
+}): void {
+  if (args.privateFirewall.label !== args.publicConnector.label) {
+    throw new Error(
+      `Firewall label mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+  validateFirewallBindings(args);
+  if (
+    JSON.stringify(args.privateFirewall.routing) !==
+      JSON.stringify(expectedFirewallRouting(args.privateFirewall)) ||
+    JSON.stringify(args.privateFirewall.diagnostics) !==
+      JSON.stringify(expectedFirewallDiagnostics(args.privateFirewall))
+  ) {
+    throw new Error(
+      `Firewall derived metadata mismatch: ${args.publicConnector.connectorRef}`,
+    );
+  }
+}
+
+function validateFirewallSemantics(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+}): void {
+  const publicByRef = new Map(
+    args.publicArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  const privateByRef = new Map(
+    args.privateArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  for (const connector of args.privateFirewallsArtifact.connectors) {
     validateFirewallGeneratorResult({
       connectorRef: connector.connectorRef,
       firewall: connector.firewall,
       categories: connector.categories,
       defaultAllowed: connector.defaultAllowed,
       defaultUnknownPolicy: connector.defaultUnknownPolicy,
+    });
+    const publicConnector = publicByRef.get(connector.connectorRef);
+    const privateConnector = privateByRef.get(connector.connectorRef);
+    if (publicConnector === undefined || privateConnector === undefined) {
+      throw new Error(
+        `Missing connector for firewall ${connector.connectorRef}`,
+      );
+    }
+    validateFirewallProjection({
+      publicConnector,
+      privateConnector,
+      privateFirewall: connector,
     });
   }
 }
@@ -351,6 +518,6 @@ export function validateConnectorCatalogRelationships(args: {
     staticFilesPublicationArtifact,
   });
   validateCatalogAndConnectorSemantics(args);
-  validateFirewallSemantics(args.privateFirewallsArtifact);
+  validateFirewallSemantics(args);
   validateSliceDigests(args);
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -1,12 +1,9 @@
-import { createHash } from "node:crypto";
-
 import {
   type ConnectorCatalogIntegrityArtifact,
   type ConnectorCatalogPrivateArtifact,
   type ConnectorCatalogPrivateFirewallsArtifact,
   type ConnectorCatalogPublicArtifact,
   type ConnectorCatalogRunnerFirewallsArtifact,
-  staticFilesPublicationManifestSchema,
   validateConnectorCatalogArtifacts,
 } from "./artifacts";
 import {
@@ -24,35 +21,6 @@ import {
   type ConnectorAuthMethodSource,
   type ConnectorGrantSource,
 } from "./source";
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function canonicalJsonValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => {
-      return canonicalJsonValue(item);
-    });
-  }
-  if (!isRecord(value)) {
-    return value;
-  }
-  return Object.fromEntries(
-    Object.keys(value)
-      .sort()
-      .map((key) => {
-        return [key, canonicalJsonValue(value[key])];
-      }),
-  );
-}
-
-function canonicalDigest(value: unknown): string {
-  const bytes = Buffer.from(
-    `${JSON.stringify(canonicalJsonValue(value), null, 2)}\n`,
-  );
-  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
-}
 
 function assertEqualValues(
   expected: readonly string[],
@@ -437,62 +405,6 @@ function validateFirewallSemantics(args: {
   }
 }
 
-function validateSliceDigests(args: {
-  readonly publicArtifact: ConnectorCatalogPublicArtifact;
-  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
-  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
-  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
-  readonly integrity: ConnectorCatalogIntegrityArtifact;
-}): void {
-  const privateByRef = new Map(
-    args.privateArtifact.connectors.map((connector) => {
-      return [connector.connectorRef, connector];
-    }),
-  );
-  const privateFirewallByRef = new Map(
-    args.privateFirewallsArtifact.connectors.map((connector) => {
-      return [connector.connectorRef, connector];
-    }),
-  );
-  const runnerByRef = new Map(
-    args.runnerFirewallsArtifact.firewalls.map((firewall) => {
-      return [firewall.name, firewall];
-    }),
-  );
-  const integrityByRef = new Map(
-    args.integrity.connectors.map((connector) => {
-      return [connector.connectorRef, connector];
-    }),
-  );
-
-  for (const publicConnector of args.publicArtifact.connectors) {
-    const connectorRef = publicConnector.connectorRef;
-    const privateConnector = privateByRef.get(connectorRef);
-    const integrityConnector = integrityByRef.get(connectorRef);
-    if (privateConnector === undefined || integrityConnector === undefined) {
-      throw new Error(`Missing integrity slice for ${connectorRef}`);
-    }
-    if (
-      integrityConnector.publicDigest !== canonicalDigest(publicConnector) ||
-      integrityConnector.privateDigest !== canonicalDigest(privateConnector)
-    ) {
-      throw new Error(`Catalog slice digest mismatch for ${connectorRef}`);
-    }
-    const privateFirewall = privateFirewallByRef.get(connectorRef);
-    const runnerFirewall = runnerByRef.get(connectorRef);
-    const privateFirewallDigest =
-      privateFirewall === undefined ? null : canonicalDigest(privateFirewall);
-    const runnerFirewallDigest =
-      runnerFirewall === undefined ? null : canonicalDigest(runnerFirewall);
-    if (
-      integrityConnector.privateFirewallDigest !== privateFirewallDigest ||
-      integrityConnector.runnerFirewallDigest !== runnerFirewallDigest
-    ) {
-      throw new Error(`Firewall slice digest mismatch for ${connectorRef}`);
-    }
-  }
-}
-
 export function validateConnectorCatalogRelationships(args: {
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
   readonly privateArtifact: ConnectorCatalogPrivateArtifact;
@@ -500,24 +412,7 @@ export function validateConnectorCatalogRelationships(args: {
   readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
   readonly integrity: ConnectorCatalogIntegrityArtifact;
 }): void {
-  const staticFilesPublicationArtifact =
-    staticFilesPublicationManifestSchema.parse({
-      artifactSchemaVersion: 1,
-      files: args.integrity.assets.map((asset) => {
-        return { ...asset };
-      }),
-    });
-  if (
-    canonicalDigest(staticFilesPublicationArtifact) !==
-    args.integrity.artifacts.staticFilesPublication.digest
-  ) {
-    throw new Error("Static-files publication digest mismatch");
-  }
-  validateConnectorCatalogArtifacts({
-    ...args,
-    staticFilesPublicationArtifact,
-  });
+  validateConnectorCatalogArtifacts(args);
   validateCatalogAndConnectorSemantics(args);
   validateFirewallSemantics(args);
-  validateSliceDigests(args);
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -1,0 +1,349 @@
+import { createHash } from "node:crypto";
+
+import {
+  type ConnectorCatalogIntegrityArtifact,
+  type ConnectorCatalogPrivateArtifact,
+  type ConnectorCatalogPrivateFirewallsArtifact,
+  type ConnectorCatalogPublicArtifact,
+  type ConnectorCatalogRunnerFirewallsArtifact,
+  type StaticFilesPublicationManifest,
+  validateConnectorCatalogArtifacts,
+} from "./artifacts";
+import { validateFirewallGeneratorResult } from "./firewall";
+import {
+  catalogSourceSchema,
+  connectorSourceSchema,
+  validateCatalogSourceSemantics,
+  validateConnectorSourceSemantics,
+  type ConnectorAuthMethodSource,
+  type ConnectorGrantSource,
+} from "./source";
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      return canonicalJsonValue(item);
+    });
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => {
+        return [key, canonicalJsonValue(value[key])];
+      }),
+  );
+}
+
+function canonicalDigest(value: unknown): string {
+  const bytes = Buffer.from(
+    `${JSON.stringify(canonicalJsonValue(value), null, 2)}\n`,
+  );
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function assertEqualValues(
+  expected: readonly string[],
+  actual: readonly string[],
+  label: string,
+): void {
+  if (
+    expected.length !== actual.length ||
+    expected.some((value, index) => {
+      return value !== actual[index];
+    })
+  ) {
+    throw new Error(`${label} mismatch`);
+  }
+}
+
+function reconstructedGrant(args: {
+  readonly connectorRef: string;
+  readonly publicMethod: ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
+  readonly privateMethod: ConnectorCatalogPrivateArtifact["connectors"][number]["authMethods"][number];
+}): ConnectorGrantSource {
+  const { connectorRef, publicMethod, privateMethod } = args;
+  const label = `${connectorRef}/${privateMethod.id}`;
+  if (privateMethod.grant.kind !== publicMethod.grantKind) {
+    throw new Error(`${label} grant kind mismatch`);
+  }
+  switch (privateMethod.grant.kind) {
+    case "manual": {
+      if (publicMethod.startOptions.length > 0) {
+        throw new Error(`${label} manual grant has start options`);
+      }
+      assertEqualValues(
+        publicMethod.manualFields.map((field) => {
+          return field.id;
+        }),
+        privateMethod.grant.fields.map((field) => {
+          return field.publicId;
+        }),
+        `${label} manual fields`,
+      );
+      return {
+        kind: "manual",
+        fields: privateMethod.grant.fields.map((privateField, index) => {
+          const publicField = publicMethod.manualFields[index];
+          if (publicField === undefined) {
+            throw new Error(`${label} missing public manual field`);
+          }
+          const expectedInputType =
+            privateField.storage === "secret" ? "password" : "text";
+          if (publicField.inputType !== expectedInputType) {
+            throw new Error(`${label} manual field input type mismatch`);
+          }
+          return {
+            privateName: privateField.privateName,
+            publicId: privateField.publicId,
+            label: publicField.label,
+            required: publicField.required,
+            ...(publicField.placeholder === null
+              ? {}
+              : { placeholder: publicField.placeholder }),
+            storage: privateField.storage,
+            ...(privateField.normalize === undefined
+              ? {}
+              : { normalize: privateField.normalize }),
+          };
+        }),
+      };
+    }
+    case "device-auth": {
+      if (publicMethod.manualFields.length > 0) {
+        throw new Error(`${label} device grant has manual fields`);
+      }
+      assertEqualValues(
+        publicMethod.startOptions.map((option) => {
+          return option.id;
+        }),
+        privateMethod.grant.startOptionMappings.map((mapping) => {
+          return mapping.publicId;
+        }),
+        `${label} start options`,
+      );
+      return {
+        kind: "device-auth",
+        scopes: privateMethod.grant.scopes,
+        outputs: privateMethod.grant.outputs,
+        startOptions: privateMethod.grant.startOptionMappings.map(
+          (mapping, index) => {
+            const publicOption = publicMethod.startOptions[index];
+            if (publicOption === undefined) {
+              throw new Error(`${label} missing public start option`);
+            }
+            return {
+              privateName: mapping.privateName,
+              publicId: mapping.publicId,
+              kind: publicOption.kind,
+              label: publicOption.label,
+              required: publicOption.required,
+              ...(publicOption.defaultValue === null
+                ? {}
+                : { defaultValue: publicOption.defaultValue }),
+              options: publicOption.options,
+            };
+          },
+        ),
+      };
+    }
+    case "auth-code":
+    case "openid-auth":
+    case "external-code": {
+      if (
+        publicMethod.manualFields.length > 0 ||
+        publicMethod.startOptions.length > 0
+      ) {
+        throw new Error(`${label} grant has unexpected public fields`);
+      }
+      return privateMethod.grant;
+    }
+  }
+}
+
+function reconstructedAuthMethod(args: {
+  readonly connectorRef: string;
+  readonly publicMethod: ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
+  readonly privateMethod: ConnectorCatalogPrivateArtifact["connectors"][number]["authMethods"][number];
+}): ConnectorAuthMethodSource {
+  return {
+    id: args.privateMethod.id,
+    label: args.publicMethod.label,
+    description: args.publicMethod.description,
+    defaultVisible: args.publicMethod.defaultVisible,
+    ...(args.privateMethod.client === undefined
+      ? {}
+      : { client: args.privateMethod.client }),
+    storage: args.privateMethod.storage,
+    grant: reconstructedGrant(args),
+    access: args.privateMethod.access,
+    revoke: args.privateMethod.revoke,
+  };
+}
+
+function validateCatalogAndConnectorSemantics(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+}): void {
+  const catalogSource = catalogSourceSchema.parse({
+    catalogVersion: args.publicArtifact.catalogVersion,
+    connectorRefs: args.publicArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+    categoryMetadata: args.publicArtifact.categoryMetadata,
+  });
+  validateCatalogSourceSemantics(catalogSource);
+  const categoryIds = new Set(
+    args.publicArtifact.categoryMetadata.categories.map((category) => {
+      return category.id;
+    }),
+  );
+  const privateByRef = new Map(
+    args.privateArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+
+  for (const publicConnector of args.publicArtifact.connectors) {
+    if (!categoryIds.has(publicConnector.category)) {
+      throw new Error(
+        `Unknown category for connector ${publicConnector.connectorRef}`,
+      );
+    }
+    const privateConnector = privateByRef.get(publicConnector.connectorRef);
+    if (privateConnector === undefined) {
+      throw new Error(
+        `Missing private connector ${publicConnector.connectorRef}`,
+      );
+    }
+    assertEqualValues(
+      publicConnector.authMethods.map((method) => {
+        return method.id;
+      }),
+      privateConnector.authMethods.map((method) => {
+        return method.id;
+      }),
+      `${publicConnector.connectorRef} auth methods`,
+    );
+    const connectorSource = connectorSourceSchema.parse({
+      ref: publicConnector.connectorRef,
+      label: publicConnector.label,
+      description: publicConnector.description,
+      category: publicConnector.category,
+      generation: publicConnector.generation,
+      tags: publicConnector.tags,
+      authMethods: privateConnector.authMethods.map((privateMethod, index) => {
+        const publicMethod = publicConnector.authMethods[index];
+        if (publicMethod === undefined) {
+          throw new Error(
+            `Missing public auth method ${publicConnector.connectorRef}/${privateMethod.id}`,
+          );
+        }
+        return reconstructedAuthMethod({
+          connectorRef: publicConnector.connectorRef,
+          publicMethod,
+          privateMethod,
+        });
+      }),
+    });
+    validateConnectorSourceSemantics(connectorSource);
+  }
+}
+
+function validateFirewallSemantics(
+  privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact,
+): void {
+  for (const connector of privateFirewallsArtifact.connectors) {
+    validateFirewallGeneratorResult({
+      connectorRef: connector.connectorRef,
+      firewall: connector.firewall,
+      categories: connector.categories,
+      defaultAllowed: connector.defaultAllowed,
+      defaultUnknownPolicy: connector.defaultUnknownPolicy,
+    });
+  }
+}
+
+function validateSliceDigests(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
+  readonly integrity: ConnectorCatalogIntegrityArtifact;
+}): void {
+  const privateByRef = new Map(
+    args.privateArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  const privateFirewallByRef = new Map(
+    args.privateFirewallsArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  const runnerByRef = new Map(
+    args.runnerFirewallsArtifact.firewalls.map((firewall) => {
+      return [firewall.name, firewall];
+    }),
+  );
+  const integrityByRef = new Map(
+    args.integrity.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+
+  for (const publicConnector of args.publicArtifact.connectors) {
+    const connectorRef = publicConnector.connectorRef;
+    const privateConnector = privateByRef.get(connectorRef);
+    const integrityConnector = integrityByRef.get(connectorRef);
+    if (privateConnector === undefined || integrityConnector === undefined) {
+      throw new Error(`Missing integrity slice for ${connectorRef}`);
+    }
+    if (
+      integrityConnector.publicDigest !== canonicalDigest(publicConnector) ||
+      integrityConnector.privateDigest !== canonicalDigest(privateConnector)
+    ) {
+      throw new Error(`Catalog slice digest mismatch for ${connectorRef}`);
+    }
+    const privateFirewall = privateFirewallByRef.get(connectorRef);
+    const runnerFirewall = runnerByRef.get(connectorRef);
+    const privateFirewallDigest =
+      privateFirewall === undefined ? null : canonicalDigest(privateFirewall);
+    const runnerFirewallDigest =
+      runnerFirewall === undefined ? null : canonicalDigest(runnerFirewall);
+    if (
+      integrityConnector.privateFirewallDigest !== privateFirewallDigest ||
+      integrityConnector.runnerFirewallDigest !== runnerFirewallDigest
+    ) {
+      throw new Error(`Firewall slice digest mismatch for ${connectorRef}`);
+    }
+  }
+}
+
+export function validateConnectorCatalogRelationships(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
+  readonly integrity: ConnectorCatalogIntegrityArtifact;
+}): void {
+  const staticFilesPublicationArtifact: StaticFilesPublicationManifest = {
+    artifactSchemaVersion: 1,
+    files: args.integrity.assets.map((asset) => {
+      return { ...asset };
+    }),
+  };
+  validateConnectorCatalogArtifacts({
+    ...args,
+    staticFilesPublicationArtifact,
+  });
+  validateCatalogAndConnectorSemantics(args);
+  validateFirewallSemantics(args.privateFirewallsArtifact);
+  validateSliceDigests(args);
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -1,0 +1,574 @@
+import { z } from "zod";
+import {
+  connectorCatalogVersionSchema,
+  connectorRefSchema,
+  privateNameSchema,
+} from "./common";
+
+export const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/u);
+export const internalOptionNameSchema = z
+  .string()
+  .regex(/^[a-zA-Z][a-zA-Z0-9_]*$/u);
+export const connectorAuthMethodIdSchema = z.enum([
+  "api",
+  "api-token",
+  "cli",
+  "oauth",
+  "openid",
+]);
+const connectorCategoryIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/u);
+const connectorGenerationTypeSchema = z.enum([
+  "audio",
+  "code",
+  "document",
+  "image",
+  "presentation",
+  "text",
+  "video",
+  "website",
+]);
+export const connectorValueRefSchema = z
+  .string()
+  .regex(/^\$(?:secrets|vars)\.[A-Z][A-Z0-9_]*$/u);
+const connectorSecretRefSchema = z
+  .string()
+  .regex(/^\$secrets\.[A-Z][A-Z0-9_]*$/u);
+const connectorPlatformSecretSchema = z.enum([
+  "GOOGLE_ADS_DEVELOPER_TOKEN",
+  "STEAM_WEB_API_KEY",
+]);
+
+const categoryGroupSourceSchema = z
+  .object({
+    id: connectorCategoryIdSchema,
+    label: z.string().min(1),
+    menuLabel: z.string().min(1),
+  })
+  .strict();
+
+const categorySourceSchema = z
+  .object({
+    id: connectorCategoryIdSchema,
+    label: z.string().min(1),
+    menuLabel: z.string().min(1),
+    groupId: connectorCategoryIdSchema.nullable(),
+  })
+  .strict();
+
+export const catalogSourceSchema = z
+  .object({
+    catalogVersion: connectorCatalogVersionSchema,
+    connectorRefs: z.array(connectorRefSchema).min(1),
+    categoryMetadata: z
+      .object({
+        categories: z.array(categorySourceSchema).min(1),
+        groups: z.array(categoryGroupSourceSchema),
+      })
+      .strict(),
+  })
+  .strict();
+
+const staticConfidentialClientSourceSchema = z
+  .object({
+    clientRegistration: z.literal("static"),
+    clientType: z.literal("confidential"),
+    clientIdEnv: privateNameSchema,
+    clientSecretEnv: privateNameSchema,
+  })
+  .strict();
+
+const staticPublicClientSourceSchema = z
+  .object({
+    clientRegistration: z.literal("static"),
+    clientType: z.literal("public"),
+    clientId: z.string().min(1),
+  })
+  .strict();
+
+const dynamicPublicClientSourceSchema = z
+  .object({
+    clientRegistration: z.literal("dynamic"),
+    clientType: z.literal("public"),
+  })
+  .strict();
+
+const connectorAuthClientSourceSchema = z.union([
+  staticConfidentialClientSourceSchema,
+  staticPublicClientSourceSchema,
+  dynamicPublicClientSourceSchema,
+]);
+
+const connectorStorageSourceSchema = z
+  .object({
+    secrets: z.array(privateNameSchema),
+    variables: z.array(privateNameSchema),
+  })
+  .strict();
+
+const manualGrantFieldSourceSchema = z
+  .object({
+    privateName: privateNameSchema,
+    publicId: publicFieldIdSchema,
+    label: z.string().min(1),
+    required: z.boolean(),
+    placeholder: z.string().min(1).optional(),
+    storage: z.enum(["secret", "variable"]),
+    normalize: z.literal("host").optional(),
+  })
+  .strict();
+
+const deviceStartOptionChoiceSourceSchema = z
+  .object({
+    value: z.string().min(1),
+    label: z.string().min(1),
+  })
+  .strict();
+
+const deviceStartOptionSourceSchema = z
+  .object({
+    privateName: internalOptionNameSchema,
+    publicId: publicFieldIdSchema,
+    kind: z.literal("select"),
+    label: z.string().min(1),
+    required: z.boolean(),
+    defaultValue: z.string().min(1).optional(),
+    options: z.array(deviceStartOptionChoiceSourceSchema).min(1),
+  })
+  .strict();
+
+const outputBindingsSchema = z.record(
+  z.string().min(1),
+  connectorValueRefSchema,
+);
+
+const manualGrantSourceSchema = z
+  .object({
+    kind: z.literal("manual"),
+    fields: z.array(manualGrantFieldSourceSchema).min(1),
+  })
+  .strict();
+
+const authCodeGrantSourceSchema = z
+  .object({
+    kind: z.literal("auth-code"),
+    scopes: z.array(z.string()),
+    callbackOrigin: z.enum(["web", "api"]),
+    outputs: outputBindingsSchema,
+  })
+  .strict();
+
+const openIdGrantSourceSchema = z
+  .object({
+    kind: z.literal("openid-auth"),
+    callbackOrigin: z.enum(["web", "api"]),
+    outputs: outputBindingsSchema,
+  })
+  .strict();
+
+const externalCodeGrantSourceSchema = z
+  .object({
+    kind: z.literal("external-code"),
+    scopes: z.array(z.string()),
+    outputs: outputBindingsSchema,
+  })
+  .strict();
+
+const deviceAuthGrantSourceSchema = z
+  .object({
+    kind: z.literal("device-auth"),
+    scopes: z.array(z.string()),
+    outputs: outputBindingsSchema,
+    startOptions: z.array(deviceStartOptionSourceSchema),
+  })
+  .strict();
+
+const connectorGrantSourceSchema = z.discriminatedUnion("kind", [
+  manualGrantSourceSchema,
+  authCodeGrantSourceSchema,
+  openIdGrantSourceSchema,
+  externalCodeGrantSourceSchema,
+  deviceAuthGrantSourceSchema,
+]);
+
+const envBindingSourceSchema = z.union([
+  connectorValueRefSchema,
+  z
+    .object({
+      valueRef: connectorValueRefSchema,
+      optional: z.literal(true),
+    })
+    .strict(),
+]);
+
+const staticAccessSourceSchema = z
+  .object({
+    kind: z.literal("static"),
+    envBindings: z.record(z.string().min(1), envBindingSourceSchema),
+    platformSecrets: z.array(connectorPlatformSecretSchema).optional(),
+  })
+  .strict();
+
+const refreshTokenAccessSourceSchema = z
+  .object({
+    kind: z.literal("refresh-token"),
+    envBindings: z.record(z.string().min(1), envBindingSourceSchema),
+    platformSecrets: z.array(connectorPlatformSecretSchema).optional(),
+    inputs: z.record(z.string().min(1), connectorValueRefSchema),
+    outputs: z.record(z.string().min(1), connectorValueRefSchema),
+    refreshableSecrets: z.array(privateNameSchema),
+  })
+  .strict();
+
+const connectorAccessSourceSchema = z.discriminatedUnion("kind", [
+  staticAccessSourceSchema,
+  refreshTokenAccessSourceSchema,
+]);
+
+const noRevokeSourceSchema = z.object({ kind: z.literal("none") }).strict();
+const tokenRevokeSourceSchema = z
+  .object({
+    kind: z.literal("token-revoke"),
+    inputs: z.record(z.string().min(1), connectorSecretRefSchema),
+    revokePreviousOnReplace: z.boolean().optional(),
+  })
+  .strict();
+
+const connectorRevokeSourceSchema = z.discriminatedUnion("kind", [
+  noRevokeSourceSchema,
+  tokenRevokeSourceSchema,
+]);
+
+export const connectorAuthMethodSourceSchema = z
+  .object({
+    id: connectorAuthMethodIdSchema,
+    label: z.string().min(1),
+    description: z.string().min(1).nullable(),
+    defaultVisible: z.boolean(),
+    client: connectorAuthClientSourceSchema.optional(),
+    storage: connectorStorageSourceSchema,
+    grant: connectorGrantSourceSchema,
+    access: connectorAccessSourceSchema,
+    revoke: connectorRevokeSourceSchema,
+  })
+  .strict();
+
+export const connectorSourceSchema = z
+  .object({
+    ref: connectorRefSchema,
+    label: z.string().min(1),
+    description: z.string().min(1),
+    category: connectorCategoryIdSchema,
+    generation: z.array(connectorGenerationTypeSchema),
+    tags: z.array(z.string().min(1)),
+    authMethods: z.array(connectorAuthMethodSourceSchema).min(1),
+  })
+  .strict();
+
+export const connectorStaticIconPathSchema = z
+  .string()
+  .regex(
+    /^platform\/views\/zero-page\/components\/settings\/icons\/[a-z0-9]+(?:-[a-z0-9]+)*-[a-f0-9]{12}\.(?:png|svg)$/u,
+  );
+
+type CatalogSource = z.infer<typeof catalogSourceSchema>;
+type ConnectorSource = z.infer<typeof connectorSourceSchema>;
+export type ConnectorAuthMethodSource = ConnectorSource["authMethods"][number];
+export type ConnectorGrantSource = ConnectorAuthMethodSource["grant"];
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assertUnique(args: {
+  readonly values: readonly string[];
+  readonly label: string;
+}): void {
+  const seen = new Set<string>();
+  for (const value of args.values) {
+    if (seen.has(value)) {
+      throw new Error(`Duplicate ${args.label}: ${value}`);
+    }
+    seen.add(value);
+  }
+}
+
+function assertAlphabetical(args: {
+  readonly values: readonly string[];
+  readonly label: string;
+}): void {
+  const expected = [...args.values].sort(compareStrings);
+  if (
+    expected.some((value, index) => {
+      return value !== args.values[index];
+    })
+  ) {
+    throw new Error(`${args.label} must be alphabetical`);
+  }
+}
+
+function normalizePublicId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/gu, "").toLowerCase();
+}
+
+function valueRefName(valueRef: string): string {
+  const separator = valueRef.indexOf(".");
+  return valueRef.slice(separator + 1);
+}
+
+function authMethodValueRefs(
+  authMethod: ConnectorAuthMethodSource,
+): readonly string[] {
+  const refs: string[] = [];
+  if (authMethod.grant.kind !== "manual") {
+    refs.push(...Object.values(authMethod.grant.outputs));
+  }
+  for (const binding of Object.values(authMethod.access.envBindings)) {
+    refs.push(typeof binding === "string" ? binding : binding.valueRef);
+  }
+  if (authMethod.access.kind === "refresh-token") {
+    refs.push(...Object.values(authMethod.access.inputs));
+    refs.push(...Object.values(authMethod.access.outputs));
+  }
+  if (authMethod.revoke.kind === "token-revoke") {
+    refs.push(...Object.values(authMethod.revoke.inputs));
+  }
+  return refs;
+}
+
+interface AuthStorageSets {
+  readonly secretNames: ReadonlySet<string>;
+  readonly variableNames: ReadonlySet<string>;
+  readonly platformSecrets: ReadonlySet<string>;
+}
+
+function authStorageSets(
+  authMethod: ConnectorAuthMethodSource,
+): AuthStorageSets {
+  return {
+    secretNames: new Set(authMethod.storage.secrets),
+    variableNames: new Set(authMethod.storage.variables),
+    platformSecrets: new Set(authMethod.access.platformSecrets ?? []),
+  };
+}
+
+function validateStorageDeclarations(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+  storage: AuthStorageSets,
+): void {
+  assertUnique({
+    values: authMethod.storage.secrets,
+    label: `${methodRef} storage secret`,
+  });
+  assertUnique({
+    values: authMethod.storage.variables,
+    label: `${methodRef} storage variable`,
+  });
+  for (const name of storage.secretNames) {
+    if (storage.variableNames.has(name)) {
+      throw new Error(`${methodRef} declares ${name} in both storage classes`);
+    }
+  }
+  for (const name of storage.platformSecrets) {
+    if (storage.secretNames.has(name) || storage.variableNames.has(name)) {
+      throw new Error(
+        `${methodRef} declares platform secret ${name} in connector storage`,
+      );
+    }
+  }
+}
+
+function validateManualGrant(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+  storage: AuthStorageSets,
+): void {
+  if (authMethod.grant.kind !== "manual") {
+    return;
+  }
+  assertUnique({
+    values: authMethod.grant.fields.map((field) => {
+      return field.privateName;
+    }),
+    label: `${methodRef} manual private name`,
+  });
+  assertUnique({
+    values: authMethod.grant.fields.map((field) => {
+      return field.publicId;
+    }),
+    label: `${methodRef} manual public id`,
+  });
+  for (const field of authMethod.grant.fields) {
+    const expectedNames =
+      field.storage === "secret" ? storage.secretNames : storage.variableNames;
+    if (!expectedNames.has(field.privateName)) {
+      throw new Error(
+        `${methodRef} manual field ${field.privateName} is missing from ${field.storage} storage`,
+      );
+    }
+    const normalizedPublicId = normalizePublicId(field.publicId);
+    const normalizedPrivateName = normalizePublicId(field.privateName);
+    if (
+      normalizedPublicId === normalizedPrivateName ||
+      normalizedPublicId.includes(normalizedPrivateName)
+    ) {
+      throw new Error(
+        `${methodRef} public field id ${field.publicId} derives from a private name`,
+      );
+    }
+  }
+}
+
+function validateDeviceGrant(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+): void {
+  if (authMethod.grant.kind !== "device-auth") {
+    return;
+  }
+  assertUnique({
+    values: authMethod.grant.startOptions.map((option) => {
+      return option.privateName;
+    }),
+    label: `${methodRef} start option private name`,
+  });
+  assertUnique({
+    values: authMethod.grant.startOptions.map((option) => {
+      return option.publicId;
+    }),
+    label: `${methodRef} start option public id`,
+  });
+  for (const option of authMethod.grant.startOptions) {
+    assertUnique({
+      values: option.options.map((choice) => {
+        return choice.value;
+      }),
+      label: `${methodRef}/${option.publicId} option value`,
+    });
+    if (
+      option.defaultValue !== undefined &&
+      !option.options.some((choice) => {
+        return choice.value === option.defaultValue;
+      })
+    ) {
+      throw new Error(
+        `${methodRef}/${option.publicId} defaultValue is not an option`,
+      );
+    }
+  }
+}
+
+function validateClientGrantAlignment(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+): void {
+  const grantNeedsClient = [
+    "auth-code",
+    "external-code",
+    "device-auth",
+  ].includes(authMethod.grant.kind);
+  if (grantNeedsClient !== (authMethod.client !== undefined)) {
+    throw new Error(`${methodRef} client does not match its grant kind`);
+  }
+  if (
+    authMethod.grant.kind === "auth-code" &&
+    authMethod.client?.clientType !== "confidential"
+  ) {
+    throw new Error(
+      `${methodRef} auth-code grant requires a confidential client`,
+    );
+  }
+  if (
+    (authMethod.grant.kind === "external-code" ||
+      authMethod.grant.kind === "device-auth") &&
+    authMethod.client?.clientType !== "public"
+  ) {
+    throw new Error(`${methodRef} grant requires a public client`);
+  }
+}
+
+function validateValueReferences(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+  storage: AuthStorageSets,
+): void {
+  for (const valueRef of authMethodValueRefs(authMethod)) {
+    const name = valueRefName(valueRef);
+    const known = valueRef.startsWith("$secrets.")
+      ? storage.secretNames.has(name) || storage.platformSecrets.has(name)
+      : storage.variableNames.has(name);
+    if (!known) {
+      throw new Error(`${methodRef} references undeclared storage ${valueRef}`);
+    }
+  }
+}
+
+function validateRefreshableSecrets(
+  methodRef: string,
+  authMethod: ConnectorAuthMethodSource,
+  storage: AuthStorageSets,
+): void {
+  if (authMethod.access.kind !== "refresh-token") {
+    return;
+  }
+  for (const name of authMethod.access.refreshableSecrets) {
+    if (!storage.secretNames.has(name)) {
+      throw new Error(`${methodRef} refreshable secret ${name} is not stored`);
+    }
+  }
+}
+
+function validateAuthMethodSemantics(args: {
+  readonly connectorRef: string;
+  readonly authMethod: ConnectorAuthMethodSource;
+}): void {
+  const methodRef = `${args.connectorRef}/${args.authMethod.id}`;
+  const storage = authStorageSets(args.authMethod);
+  validateStorageDeclarations(methodRef, args.authMethod, storage);
+  validateManualGrant(methodRef, args.authMethod, storage);
+  validateDeviceGrant(methodRef, args.authMethod);
+  validateClientGrantAlignment(methodRef, args.authMethod);
+  validateValueReferences(methodRef, args.authMethod, storage);
+  validateRefreshableSecrets(methodRef, args.authMethod, storage);
+}
+
+export function validateConnectorSourceSemantics(
+  source: ConnectorSource,
+): void {
+  assertUnique({
+    values: source.authMethods.map((authMethod) => {
+      return authMethod.id;
+    }),
+    label: `${source.ref} auth method id`,
+  });
+  for (const authMethod of source.authMethods) {
+    validateAuthMethodSemantics({ connectorRef: source.ref, authMethod });
+  }
+}
+
+export function validateCatalogSourceSemantics(source: CatalogSource): void {
+  assertUnique({
+    values: source.connectorRefs,
+    label: "catalog connector ref",
+  });
+  assertAlphabetical({
+    values: source.connectorRefs,
+    label: "catalog connector refs",
+  });
+  const groupIds = source.categoryMetadata.groups.map((group) => {
+    return group.id;
+  });
+  const categoryIds = source.categoryMetadata.categories.map((category) => {
+    return category.id;
+  });
+  assertUnique({ values: groupIds, label: "catalog category group id" });
+  assertUnique({ values: categoryIds, label: "catalog category id" });
+  const knownGroups = new Set(groupIds);
+  for (const category of source.categoryMetadata.categories) {
+    if (category.groupId !== null && !knownGroups.has(category.groupId)) {
+      throw new Error(
+        `Catalog category ${category.id} references unknown group ${category.groupId}`,
+      );
+    }
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -1,3 +1,4 @@
+import { connectorCatalogAuthMethodIdSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 import {
   connectorCatalogVersionSchema,
@@ -9,13 +10,7 @@ export const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/u);
 export const internalOptionNameSchema = z
   .string()
   .regex(/^[a-zA-Z][a-zA-Z0-9_]*$/u);
-export const connectorAuthMethodIdSchema = z.enum([
-  "api",
-  "api-token",
-  "cli",
-  "oauth",
-  "openid",
-]);
+export const connectorAuthMethodIdSchema = connectorCatalogAuthMethodIdSchema;
 const connectorCategoryIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/u);
 const connectorGenerationTypeSchema = z.enum([
   "audio",
@@ -33,10 +28,6 @@ export const connectorValueRefSchema = z
 const connectorSecretRefSchema = z
   .string()
   .regex(/^\$secrets\.[A-Z][A-Z0-9_]*$/u);
-const connectorPlatformSecretSchema = z.enum([
-  "GOOGLE_ADS_DEVELOPER_TOKEN",
-  "STEAM_WEB_API_KEY",
-]);
 
 const categoryGroupSourceSchema = z
   .object({
@@ -204,7 +195,7 @@ const staticAccessSourceSchema = z
   .object({
     kind: z.literal("static"),
     envBindings: z.record(z.string().min(1), envBindingSourceSchema),
-    platformSecrets: z.array(connectorPlatformSecretSchema).optional(),
+    platformSecrets: z.array(privateNameSchema).optional(),
   })
   .strict();
 
@@ -212,7 +203,7 @@ const refreshTokenAccessSourceSchema = z
   .object({
     kind: z.literal("refresh-token"),
     envBindings: z.record(z.string().min(1), envBindingSourceSchema),
-    platformSecrets: z.array(connectorPlatformSecretSchema).optional(),
+    platformSecrets: z.array(privateNameSchema).optional(),
     inputs: z.record(z.string().min(1), connectorValueRefSchema),
     outputs: z.record(z.string().min(1), connectorValueRefSchema),
     refreshableSecrets: z.array(privateNameSchema),

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -22,7 +22,7 @@ import {
   S3ObjectSizeLimitError,
   type ConditionalS3BufferDownload,
 } from "../external/s3";
-import { safeSync, settle } from "../utils";
+import { safeSync, safeUrlParse, settle } from "../utils";
 import {
   CONNECTOR_CATALOG_ACTIVE_KEY,
   SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
@@ -77,12 +77,26 @@ type CandidateCommitResult = "accepted" | "retry";
 
 class CandidateCommitRetry extends Error {}
 
+class ConnectorCatalogPersistenceError extends Error {
+  constructor() {
+    super("Connector catalog snapshot persistence failed");
+    this.name = "ConnectorCatalogPersistenceError";
+  }
+}
+
 function connectorCatalogSource(): ConnectorCatalogSource {
   const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
   const endpoint =
     env("S3_ENDPOINT") ??
     `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
-  const authority = new URL(endpoint).origin;
+  const endpointUrl = safeUrlParse(endpoint);
+  if (
+    endpointUrl === undefined ||
+    (endpointUrl.protocol !== "http:" && endpointUrl.protocol !== "https:")
+  ) {
+    throw new Error("Connector catalog source endpoint is invalid");
+  }
+  const authority = endpointUrl.origin;
   const sourceId = createHash("sha256")
     .update(authority)
     .update("\0")
@@ -213,12 +227,16 @@ function observedPointerFromState(
 }
 
 function cachedRejectionForPointer(
-  pointer: ConnectorCatalogActivePointer,
+  observation: PointerObservation & {
+    readonly pointer: ConnectorCatalogActivePointer;
+  },
   state: SyncStateSnapshot | undefined,
 ): ConnectorCatalogSyncFailureCode | undefined {
   if (
-    pointer.catalogVersion !== state?.lastRejectedCatalogVersion ||
-    pointer.integrityDigest !== state.lastRejectedIntegrityDigest
+    observation.pointer.catalogVersion !== state?.lastRejectedCatalogVersion ||
+    observation.pointer.integrityDigest !== state.lastRejectedIntegrityDigest ||
+    ((observation.etag !== null || state.lastRejectedPointerEtag !== null) &&
+      observation.etag !== state.lastRejectedPointerEtag)
   ) {
     return undefined;
   }
@@ -481,7 +499,7 @@ async function commitCandidate(args: {
   if (result.error instanceof CandidateCommitRetry) {
     return "retry";
   }
-  throw result.error;
+  throw new ConnectorCatalogPersistenceError();
 }
 
 async function responseFromState(args: {
@@ -594,10 +612,16 @@ async function loadPointerForSync(
   );
   runtime.signal.throwIfAborted();
   if (!downloaded.ok) {
+    const pointerObservation =
+      downloaded.error instanceof S3ObjectSizeLimitError &&
+      downloaded.error.etag !== null
+        ? { pointer: null, etag: downloaded.error.etag }
+        : undefined;
     return await rejectSyncAttempt(
       runtime,
       baseline,
       classifySyncFailure(downloaded.error),
+      pointerObservation,
     );
   }
   if (downloaded.value.kind === "not-modified") {
@@ -752,7 +776,7 @@ async function syncConnectorCatalogAttempt(
     return await completeUnchangedSync(runtime, baseline, pointerObservation);
   }
 
-  const cachedFailure = cachedRejectionForPointer(pointer, baseline);
+  const cachedFailure = cachedRejectionForPointer(pointerObservation, baseline);
   if (cachedFailure) {
     return await rejectSyncAttempt(
       runtime,
@@ -804,6 +828,7 @@ export const syncConnectorCatalog$ = command(
             CONNECTOR_CATALOG_ACTIVE_KEY,
             CONNECTOR_CATALOG_ACTIVE_MAX_BYTES,
             ifNoneMatch,
+            signal,
           ),
         );
         signal.throwIfAborted();
@@ -812,7 +837,7 @@ export const syncConnectorCatalog$ = command(
       reader: {
         readArtifact: async (key, maxBytes) => {
           const bytes = await get(
-            downloadS3BufferWithMaxBytes(source.bucket, key, maxBytes),
+            downloadS3BufferWithMaxBytes(source.bucket, key, maxBytes, signal),
           );
           signal.throwIfAborted();
           return bytes;

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -48,22 +48,15 @@ interface SyncStateSnapshot {
   readonly lastAttemptOutcome: "accepted" | "unchanged" | "rejected" | null;
   readonly lastSuccessAt: Date | null;
   readonly lastFailureCode: ConnectorCatalogSyncFailureCode | null;
-  readonly activeIntegrityKey: string | null;
   readonly activeIntegrityDigest: string | null;
 }
 
 interface StoredReleaseIdentity {
-  readonly integrityKey: string;
   readonly integrityDigest: string;
-  readonly publicCatalogKey: string;
   readonly publicCatalogDigest: string;
-  readonly privateCatalogKey: string;
   readonly privateCatalogDigest: string;
-  readonly privateFirewallsKey: string;
   readonly privateFirewallsDigest: string;
-  readonly runnerFirewallsKey: string;
   readonly runnerFirewallsDigest: string;
-  readonly requiredCapabilities: readonly string[];
 }
 
 type CandidateCommitResult = "accepted" | "rejected" | "retry";
@@ -98,7 +91,6 @@ async function readSyncState(
       lastAttemptOutcome: connectorCatalogSyncState.lastAttemptOutcome,
       lastSuccessAt: connectorCatalogSyncState.lastSuccessAt,
       lastFailureCode: connectorCatalogSyncState.lastFailureCode,
-      activeIntegrityKey: connectorCatalogReleaseIdentities.integrityKey,
       activeIntegrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
     })
     .from(connectorCatalogSyncState)
@@ -139,23 +131,15 @@ async function readReleaseIdentity(
 ): Promise<StoredReleaseIdentity | undefined> {
   const [identity] = await db
     .select({
-      integrityKey: connectorCatalogReleaseIdentities.integrityKey,
       integrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
-      publicCatalogKey: connectorCatalogReleaseIdentities.publicCatalogKey,
       publicCatalogDigest:
         connectorCatalogReleaseIdentities.publicCatalogDigest,
-      privateCatalogKey: connectorCatalogReleaseIdentities.privateCatalogKey,
       privateCatalogDigest:
         connectorCatalogReleaseIdentities.privateCatalogDigest,
-      privateFirewallsKey:
-        connectorCatalogReleaseIdentities.privateFirewallsKey,
       privateFirewallsDigest:
         connectorCatalogReleaseIdentities.privateFirewallsDigest,
-      runnerFirewallsKey: connectorCatalogReleaseIdentities.runnerFirewallsKey,
       runnerFirewallsDigest:
         connectorCatalogReleaseIdentities.runnerFirewallsDigest,
-      requiredCapabilities:
-        connectorCatalogReleaseIdentities.requiredCapabilities,
     })
     .from(connectorCatalogReleaseIdentities)
     .where(
@@ -221,8 +205,7 @@ function pointerMatchesActiveState(
   }
   return (
     pointer.catalogVersion === state.activeCatalogVersion &&
-    pointer.integrity.key === state.activeIntegrityKey &&
-    pointer.integrity.digest === state.activeIntegrityDigest
+    pointer.integrityDigest === state.activeIntegrityDigest
   );
 }
 
@@ -232,8 +215,7 @@ function pointerConflictsWithStoredIdentity(
 ): boolean {
   return (
     identity !== undefined &&
-    (pointer.integrity.key !== identity.integrityKey ||
-      pointer.integrity.digest !== identity.integrityDigest)
+    pointer.integrityDigest !== identity.integrityDigest
   );
 }
 
@@ -242,21 +224,11 @@ function storedIdentityMatches(
   candidate: ConnectorCatalogReleaseIdentity,
 ): boolean {
   return (
-    stored.integrityKey === candidate.integrity.key &&
-    stored.integrityDigest === candidate.integrity.digest &&
-    stored.publicCatalogKey === candidate.publicCatalog.key &&
-    stored.publicCatalogDigest === candidate.publicCatalog.digest &&
-    stored.privateCatalogKey === candidate.privateCatalog.key &&
-    stored.privateCatalogDigest === candidate.privateCatalog.digest &&
-    stored.privateFirewallsKey === candidate.privateFirewalls.key &&
-    stored.privateFirewallsDigest === candidate.privateFirewalls.digest &&
-    stored.runnerFirewallsKey === candidate.runnerFirewalls.key &&
-    stored.runnerFirewallsDigest === candidate.runnerFirewalls.digest &&
-    stored.requiredCapabilities.length ===
-      candidate.requiredCapabilities.length &&
-    stored.requiredCapabilities.every((capability, index) => {
-      return capability === candidate.requiredCapabilities[index];
-    })
+    stored.integrityDigest === candidate.integrityDigest &&
+    stored.publicCatalogDigest === candidate.publicCatalogDigest &&
+    stored.privateCatalogDigest === candidate.privateCatalogDigest &&
+    stored.privateFirewallsDigest === candidate.privateFirewallsDigest &&
+    stored.runnerFirewallsDigest === candidate.runnerFirewallsDigest
   );
 }
 
@@ -358,17 +330,11 @@ async function persistReleaseIdentity(args: {
       sourceId: args.sourceId,
       schemaVersion: identity.schemaVersion,
       catalogVersion: identity.catalogVersion,
-      integrityKey: identity.integrity.key,
-      integrityDigest: identity.integrity.digest,
-      publicCatalogKey: identity.publicCatalog.key,
-      publicCatalogDigest: identity.publicCatalog.digest,
-      privateCatalogKey: identity.privateCatalog.key,
-      privateCatalogDigest: identity.privateCatalog.digest,
-      privateFirewallsKey: identity.privateFirewalls.key,
-      privateFirewallsDigest: identity.privateFirewalls.digest,
-      runnerFirewallsKey: identity.runnerFirewalls.key,
-      runnerFirewallsDigest: identity.runnerFirewalls.digest,
-      requiredCapabilities: [...identity.requiredCapabilities],
+      integrityDigest: identity.integrityDigest,
+      publicCatalogDigest: identity.publicCatalogDigest,
+      privateCatalogDigest: identity.privateCatalogDigest,
+      privateFirewallsDigest: identity.privateFirewallsDigest,
+      runnerFirewallsDigest: identity.runnerFirewallsDigest,
       firstValidatedAt: args.attemptedAt,
     })
     .onConflictDoNothing();
@@ -648,7 +614,7 @@ async function commitValidatedCandidate(
       sourceId: runtime.source.sourceId,
       schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
       catalogVersion: candidate.identity.catalogVersion,
-      integrityDigest: candidate.identity.integrity.digest,
+      integrityDigest: candidate.identity.integrityDigest,
       outcome,
     });
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -23,7 +23,6 @@ import {
 import { settle } from "../utils";
 import { SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION } from "./connector-catalog-artifacts/artifacts";
 import {
-  connectorCatalogPointersEqual,
   connectorCatalogArtifactFailureCode,
   loadConnectorCatalogActivePointer,
   loadConnectorCatalogCandidate,
@@ -696,13 +695,6 @@ async function syncConnectorCatalogAttempt(
   );
   if (candidateResult.kind !== "loaded") {
     return candidateResult;
-  }
-  const currentPointerResult = await loadPointerForSync(runtime, baseline);
-  if (currentPointerResult.kind !== "loaded") {
-    return currentPointerResult;
-  }
-  if (!connectorCatalogPointersEqual(pointer, currentPointerResult.value)) {
-    return { kind: "retry" };
   }
   return await commitValidatedCandidate(
     runtime,

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -6,7 +6,7 @@ import type {
   ConnectorCatalogSyncStatus,
 } from "@vm0/api-contracts/contracts/cron";
 import {
-  connectorCatalogReleaseIdentities,
+  connectorCatalogActiveSnapshot,
   connectorCatalogSyncState,
 } from "@vm0/db/schema/connector-catalog";
 import { command } from "ccstate";
@@ -18,17 +18,22 @@ import { nowDate } from "../../lib/time";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import {
   downloadS3BufferWithMaxBytes,
+  downloadS3BufferWithMaxBytesIfChanged,
   S3ObjectSizeLimitError,
+  type ConditionalS3BufferDownload,
 } from "../external/s3";
-import { settle } from "../utils";
-import { SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION } from "./connector-catalog-artifacts/artifacts";
+import { safeSync, settle } from "../utils";
 import {
+  CONNECTOR_CATALOG_ACTIVE_KEY,
+  SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+} from "./connector-catalog-artifacts/artifacts";
+import {
+  CONNECTOR_CATALOG_ACTIVE_MAX_BYTES,
   connectorCatalogArtifactFailureCode,
-  loadConnectorCatalogActivePointer,
   loadConnectorCatalogCandidate,
+  parseConnectorCatalogActivePointer,
   type ConnectorCatalogActivePointer,
   type ConnectorCatalogArtifactReader,
-  type ConnectorCatalogReleaseIdentity,
   type ValidatedConnectorCatalogCandidate,
 } from "./connector-catalog-artifacts/loader";
 
@@ -41,25 +46,34 @@ interface ConnectorCatalogSource {
 
 interface SyncStateSnapshot {
   readonly revision: number;
-  readonly activeCatalogVersion: string | null;
-  readonly publicCatalog: string | null;
-  readonly activatedAt: Date | null;
+  readonly lastObservedCatalogVersion: string | null;
+  readonly lastObservedIntegrityDigest: string | null;
+  readonly lastObservedPointerEtag: string | null;
   readonly lastAttemptAt: Date | null;
   readonly lastAttemptOutcome: "accepted" | "unchanged" | "rejected" | null;
   readonly lastSuccessAt: Date | null;
   readonly lastFailureCode: ConnectorCatalogSyncFailureCode | null;
+  readonly lastRejectedCatalogVersion: string | null;
+  readonly lastRejectedIntegrityDigest: string | null;
+  readonly lastRejectedPointerEtag: string | null;
+  readonly lastRejectedFailureCode: ConnectorCatalogSyncFailureCode | null;
+  readonly activeCatalogVersion: string | null;
   readonly activeIntegrityDigest: string | null;
+  readonly activatedAt: Date | null;
 }
 
-interface StoredReleaseIdentity {
-  readonly integrityDigest: string;
-  readonly publicCatalogDigest: string;
-  readonly privateCatalogDigest: string;
-  readonly privateFirewallsDigest: string;
-  readonly runnerFirewallsDigest: string;
+interface PointerObservation {
+  readonly pointer: ConnectorCatalogActivePointer | null;
+  readonly etag: string | null;
 }
 
-type CandidateCommitResult = "accepted" | "rejected" | "retry";
+interface RejectedCandidate {
+  readonly pointer: ConnectorCatalogActivePointer | null;
+  readonly pointerEtag: string | null;
+  readonly failureCode: ConnectorCatalogSyncFailureCode;
+}
+
+type CandidateCommitResult = "accepted" | "retry";
 
 class CandidateCommitRetry extends Error {}
 
@@ -84,30 +98,39 @@ async function readSyncState(
   const [state] = await db
     .select({
       revision: connectorCatalogSyncState.revision,
-      activeCatalogVersion: connectorCatalogSyncState.activeCatalogVersion,
-      publicCatalog: connectorCatalogSyncState.publicCatalog,
-      activatedAt: connectorCatalogSyncState.activatedAt,
+      lastObservedCatalogVersion:
+        connectorCatalogSyncState.lastObservedCatalogVersion,
+      lastObservedIntegrityDigest:
+        connectorCatalogSyncState.lastObservedIntegrityDigest,
+      lastObservedPointerEtag:
+        connectorCatalogSyncState.lastObservedPointerEtag,
       lastAttemptAt: connectorCatalogSyncState.lastAttemptAt,
       lastAttemptOutcome: connectorCatalogSyncState.lastAttemptOutcome,
       lastSuccessAt: connectorCatalogSyncState.lastSuccessAt,
       lastFailureCode: connectorCatalogSyncState.lastFailureCode,
-      activeIntegrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
+      lastRejectedCatalogVersion:
+        connectorCatalogSyncState.lastRejectedCatalogVersion,
+      lastRejectedIntegrityDigest:
+        connectorCatalogSyncState.lastRejectedIntegrityDigest,
+      lastRejectedPointerEtag:
+        connectorCatalogSyncState.lastRejectedPointerEtag,
+      lastRejectedFailureCode:
+        connectorCatalogSyncState.lastRejectedFailureCode,
+      activeCatalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
+      activeIntegrityDigest: connectorCatalogActiveSnapshot.integrityDigest,
+      activatedAt: connectorCatalogActiveSnapshot.activatedAt,
     })
     .from(connectorCatalogSyncState)
     .leftJoin(
-      connectorCatalogReleaseIdentities,
+      connectorCatalogActiveSnapshot,
       and(
         eq(
-          connectorCatalogReleaseIdentities.sourceId,
+          connectorCatalogActiveSnapshot.sourceId,
           connectorCatalogSyncState.sourceId,
         ),
         eq(
-          connectorCatalogReleaseIdentities.schemaVersion,
+          connectorCatalogActiveSnapshot.schemaVersion,
           connectorCatalogSyncState.schemaVersion,
-        ),
-        eq(
-          connectorCatalogReleaseIdentities.catalogVersion,
-          connectorCatalogSyncState.activeCatalogVersion,
         ),
       ),
     )
@@ -124,45 +147,13 @@ async function readSyncState(
   return state;
 }
 
-async function readReleaseIdentity(
-  db: ReadonlyDb,
-  sourceId: string,
-  catalogVersion: string,
-): Promise<StoredReleaseIdentity | undefined> {
-  const [identity] = await db
-    .select({
-      integrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
-      publicCatalogDigest:
-        connectorCatalogReleaseIdentities.publicCatalogDigest,
-      privateCatalogDigest:
-        connectorCatalogReleaseIdentities.privateCatalogDigest,
-      privateFirewallsDigest:
-        connectorCatalogReleaseIdentities.privateFirewallsDigest,
-      runnerFirewallsDigest:
-        connectorCatalogReleaseIdentities.runnerFirewallsDigest,
-    })
-    .from(connectorCatalogReleaseIdentities)
-    .where(
-      and(
-        eq(connectorCatalogReleaseIdentities.sourceId, sourceId),
-        eq(
-          connectorCatalogReleaseIdentities.schemaVersion,
-          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-        ),
-        eq(connectorCatalogReleaseIdentities.catalogVersion, catalogVersion),
-      ),
-    )
-    .limit(1);
-  return identity;
-}
-
 function statusFromState(
   state: SyncStateSnapshot | undefined,
 ): ConnectorCatalogSyncStatus {
   let active: ConnectorCatalogSyncStatus["active"] = null;
   if (state?.activeCatalogVersion) {
     if (!state.activatedAt || !state.activeIntegrityDigest) {
-      throw new Error("Connector catalog active state is incomplete");
+      throw new Error("Connector catalog active snapshot is incomplete");
     }
     active = {
       catalogVersion: state.activeCatalogVersion,
@@ -200,36 +191,50 @@ function pointerMatchesActiveState(
   pointer: ConnectorCatalogActivePointer,
   state: SyncStateSnapshot | undefined,
 ): boolean {
-  if (!state) {
-    return false;
-  }
   return (
-    pointer.catalogVersion === state.activeCatalogVersion &&
+    pointer.catalogVersion === state?.activeCatalogVersion &&
     pointer.integrityDigest === state.activeIntegrityDigest
   );
 }
 
-function pointerConflictsWithStoredIdentity(
-  pointer: ConnectorCatalogActivePointer,
-  identity: StoredReleaseIdentity | undefined,
-): boolean {
-  return (
-    identity !== undefined &&
-    pointer.integrityDigest !== identity.integrityDigest
-  );
+function observedPointerFromState(
+  state: SyncStateSnapshot | undefined,
+): ConnectorCatalogActivePointer | undefined {
+  if (
+    !state?.lastObservedCatalogVersion ||
+    !state.lastObservedIntegrityDigest
+  ) {
+    return undefined;
+  }
+  return {
+    catalogVersion: state.lastObservedCatalogVersion,
+    integrityDigest: state.lastObservedIntegrityDigest,
+  };
 }
 
-function storedIdentityMatches(
-  stored: StoredReleaseIdentity,
-  candidate: ConnectorCatalogReleaseIdentity,
-): boolean {
-  return (
-    stored.integrityDigest === candidate.integrityDigest &&
-    stored.publicCatalogDigest === candidate.publicCatalogDigest &&
-    stored.privateCatalogDigest === candidate.privateCatalogDigest &&
-    stored.privateFirewallsDigest === candidate.privateFirewallsDigest &&
-    stored.runnerFirewallsDigest === candidate.runnerFirewallsDigest
-  );
+function cachedRejectionForPointer(
+  pointer: ConnectorCatalogActivePointer,
+  state: SyncStateSnapshot | undefined,
+): ConnectorCatalogSyncFailureCode | undefined {
+  if (
+    pointer.catalogVersion !== state?.lastRejectedCatalogVersion ||
+    pointer.integrityDigest !== state.lastRejectedIntegrityDigest
+  ) {
+    return undefined;
+  }
+  return state.lastRejectedFailureCode ?? undefined;
+}
+
+function cachedRejectionForObservedEtag(
+  state: SyncStateSnapshot | undefined,
+): ConnectorCatalogSyncFailureCode | undefined {
+  if (
+    !state?.lastObservedPointerEtag ||
+    state.lastObservedPointerEtag !== state.lastRejectedPointerEtag
+  ) {
+    return undefined;
+  }
+  return state.lastRejectedFailureCode ?? undefined;
 }
 
 function classifySyncFailure(error: unknown): ConnectorCatalogSyncFailureCode {
@@ -243,13 +248,57 @@ function classifySyncFailure(error: unknown): ConnectorCatalogSyncFailureCode {
   return "source-unavailable";
 }
 
+function cacheableRejectedCandidate(
+  observation: PointerObservation | undefined,
+  failureCode: ConnectorCatalogSyncFailureCode,
+): RejectedCandidate | undefined {
+  if (
+    failureCode === "source-unavailable" ||
+    (!observation?.pointer && !observation?.etag)
+  ) {
+    return undefined;
+  }
+  return {
+    pointer: observation.pointer,
+    pointerEtag: observation.etag,
+    failureCode,
+  };
+}
+
+function rejectedCandidateValues(candidate: RejectedCandidate | undefined) {
+  if (!candidate) {
+    return {};
+  }
+  return {
+    lastRejectedCatalogVersion: candidate.pointer?.catalogVersion ?? null,
+    lastRejectedIntegrityDigest: candidate.pointer?.integrityDigest ?? null,
+    lastRejectedPointerEtag: candidate.pointerEtag,
+    lastRejectedFailureCode: candidate.failureCode,
+  };
+}
+
+function pointerObservationValues(observation: PointerObservation | undefined) {
+  if (!observation) {
+    return {};
+  }
+  return {
+    lastObservedCatalogVersion: observation.pointer?.catalogVersion ?? null,
+    lastObservedIntegrityDigest: observation.pointer?.integrityDigest ?? null,
+    lastObservedPointerEtag: observation.etag,
+  };
+}
+
 async function recordRejectedAttempt(args: {
   readonly db: Db;
   readonly sourceId: string;
   readonly baseline: SyncStateSnapshot | undefined;
   readonly attemptedAt: Date;
   readonly failureCode: ConnectorCatalogSyncFailureCode;
+  readonly rejectedCandidate?: RejectedCandidate;
+  readonly pointerObservation?: PointerObservation;
 }): Promise<boolean> {
+  const rejectedValues = rejectedCandidateValues(args.rejectedCandidate);
+  const observationValues = pointerObservationValues(args.pointerObservation);
   if (!args.baseline) {
     const inserted = await args.db
       .insert(connectorCatalogSyncState)
@@ -260,6 +309,8 @@ async function recordRejectedAttempt(args: {
         lastAttemptAt: args.attemptedAt,
         lastAttemptOutcome: "rejected",
         lastFailureCode: args.failureCode,
+        ...observationValues,
+        ...rejectedValues,
       })
       .onConflictDoNothing()
       .returning({ sourceId: connectorCatalogSyncState.sourceId });
@@ -273,6 +324,8 @@ async function recordRejectedAttempt(args: {
       lastAttemptAt: args.attemptedAt,
       lastAttemptOutcome: "rejected",
       lastFailureCode: args.failureCode,
+      ...observationValues,
+      ...rejectedValues,
     })
     .where(
       and(
@@ -293,7 +346,9 @@ async function recordUnchangedAttempt(args: {
   readonly sourceId: string;
   readonly baseline: SyncStateSnapshot;
   readonly attemptedAt: Date;
+  readonly pointerObservation?: PointerObservation;
 }): Promise<boolean> {
+  const observationValues = pointerObservationValues(args.pointerObservation);
   const updated = await args.db
     .update(connectorCatalogSyncState)
     .set({
@@ -302,6 +357,7 @@ async function recordUnchangedAttempt(args: {
       lastAttemptOutcome: "unchanged",
       lastSuccessAt: args.attemptedAt,
       lastFailureCode: null,
+      ...observationValues,
     })
     .where(
       and(
@@ -317,37 +373,23 @@ async function recordUnchangedAttempt(args: {
   return updated.length === 1;
 }
 
-async function persistReleaseIdentity(args: {
-  readonly db: Db;
-  readonly sourceId: string;
-  readonly identity: ConnectorCatalogReleaseIdentity;
-  readonly attemptedAt: Date;
-}): Promise<StoredReleaseIdentity> {
-  const identity = args.identity;
-  await args.db
-    .insert(connectorCatalogReleaseIdentities)
-    .values({
-      sourceId: args.sourceId,
-      schemaVersion: identity.schemaVersion,
-      catalogVersion: identity.catalogVersion,
-      integrityDigest: identity.integrityDigest,
-      publicCatalogDigest: identity.publicCatalogDigest,
-      privateCatalogDigest: identity.privateCatalogDigest,
-      privateFirewallsDigest: identity.privateFirewallsDigest,
-      runnerFirewallsDigest: identity.runnerFirewallsDigest,
-      firstValidatedAt: args.attemptedAt,
-    })
-    .onConflictDoNothing();
-
-  const stored = await readReleaseIdentity(
-    args.db,
-    args.sourceId,
-    identity.catalogVersion,
-  );
-  if (!stored) {
-    throw new Error("Connector catalog release identity was not persisted");
-  }
-  return stored;
+function activeSnapshotValues(
+  candidate: ValidatedConnectorCatalogCandidate,
+  activatedAt: Date,
+) {
+  return {
+    catalogVersion: candidate.identity.catalogVersion,
+    integrityDigest: candidate.identity.integrityDigest,
+    publicCatalogDigest: candidate.identity.publicCatalogDigest,
+    privateCatalogDigest: candidate.identity.privateCatalogDigest,
+    privateFirewallsDigest: candidate.identity.privateFirewallsDigest,
+    runnerFirewallsDigest: candidate.identity.runnerFirewallsDigest,
+    publicCatalog: candidate.publicCatalogText,
+    privateCatalog: candidate.privateCatalogText,
+    privateFirewalls: candidate.privateFirewallsText,
+    runnerFirewalls: candidate.runnerFirewallsText,
+    activatedAt,
+  };
 }
 
 async function activateCandidate(args: {
@@ -355,12 +397,11 @@ async function activateCandidate(args: {
   readonly sourceId: string;
   readonly baseline: SyncStateSnapshot | undefined;
   readonly candidate: ValidatedConnectorCatalogCandidate;
+  readonly pointerObservation: PointerObservation;
   readonly attemptedAt: Date;
 }): Promise<void> {
   const stateValues = {
-    activeCatalogVersion: args.candidate.identity.catalogVersion,
-    publicCatalog: args.candidate.publicCatalogText,
-    activatedAt: args.attemptedAt,
+    ...pointerObservationValues(args.pointerObservation),
     lastAttemptAt: args.attemptedAt,
     lastAttemptOutcome: "accepted" as const,
     lastSuccessAt: args.attemptedAt,
@@ -380,29 +421,44 @@ async function activateCandidate(args: {
     if (inserted.length === 0) {
       throw new CandidateCommitRetry();
     }
-    return;
+  } else {
+    const updated = await args.db
+      .update(connectorCatalogSyncState)
+      .set({
+        revision: sql`${connectorCatalogSyncState.revision} + 1`,
+        ...stateValues,
+      })
+      .where(
+        and(
+          eq(connectorCatalogSyncState.sourceId, args.sourceId),
+          eq(
+            connectorCatalogSyncState.schemaVersion,
+            SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+          ),
+          eq(connectorCatalogSyncState.revision, args.baseline.revision),
+        ),
+      )
+      .returning({ sourceId: connectorCatalogSyncState.sourceId });
+    if (updated.length === 0) {
+      throw new CandidateCommitRetry();
+    }
   }
 
-  const updated = await args.db
-    .update(connectorCatalogSyncState)
-    .set({
-      revision: sql`${connectorCatalogSyncState.revision} + 1`,
-      ...stateValues,
+  const snapshotValues = activeSnapshotValues(args.candidate, args.attemptedAt);
+  await args.db
+    .insert(connectorCatalogActiveSnapshot)
+    .values({
+      sourceId: args.sourceId,
+      schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+      ...snapshotValues,
     })
-    .where(
-      and(
-        eq(connectorCatalogSyncState.sourceId, args.sourceId),
-        eq(
-          connectorCatalogSyncState.schemaVersion,
-          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-        ),
-        eq(connectorCatalogSyncState.revision, args.baseline.revision),
-      ),
-    )
-    .returning({ sourceId: connectorCatalogSyncState.sourceId });
-  if (updated.length === 0) {
-    throw new CandidateCommitRetry();
-  }
+    .onConflictDoUpdate({
+      target: [
+        connectorCatalogActiveSnapshot.sourceId,
+        connectorCatalogActiveSnapshot.schemaVersion,
+      ],
+      set: snapshotValues,
+    });
 }
 
 async function commitCandidate(args: {
@@ -410,31 +466,13 @@ async function commitCandidate(args: {
   readonly sourceId: string;
   readonly baseline: SyncStateSnapshot | undefined;
   readonly candidate: ValidatedConnectorCatalogCandidate;
+  readonly pointerObservation: PointerObservation;
   readonly attemptedAt: Date;
 }): Promise<CandidateCommitResult> {
   const result = await settle(
     args.db.transaction(async (tx) => {
-      const stored = await persistReleaseIdentity({
-        db: tx,
-        sourceId: args.sourceId,
-        identity: args.candidate.identity,
-        attemptedAt: args.attemptedAt,
-      });
-      if (!storedIdentityMatches(stored, args.candidate.identity)) {
-        const committed = await recordRejectedAttempt({
-          db: tx,
-          sourceId: args.sourceId,
-          baseline: args.baseline,
-          attemptedAt: args.attemptedAt,
-          failureCode: "conflicting-release",
-        });
-        if (!committed) {
-          throw new CandidateCommitRetry();
-        }
-        return "rejected";
-      }
       await activateCandidate({ ...args, db: tx });
-      return "accepted";
+      return "accepted" as const;
     }),
   );
   if (result.ok) {
@@ -463,6 +501,8 @@ async function rejectCandidate(args: {
   readonly source: ConnectorCatalogSource;
   readonly baseline: SyncStateSnapshot | undefined;
   readonly failureCode: ConnectorCatalogSyncFailureCode;
+  readonly rejectedCandidate?: RejectedCandidate;
+  readonly pointerObservation?: PointerObservation;
 }): Promise<ConnectorCatalogSyncResponse | undefined> {
   const committed = await recordRejectedAttempt({
     db: args.db,
@@ -470,6 +510,8 @@ async function rejectCandidate(args: {
     baseline: args.baseline,
     attemptedAt: nowDate(),
     failureCode: args.failureCode,
+    rejectedCandidate: args.rejectedCandidate,
+    pointerObservation: args.pointerObservation,
   });
   if (!committed) {
     return undefined;
@@ -479,9 +521,7 @@ async function rejectCandidate(args: {
     sourceId: args.source.sourceId,
     schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
     failureCode: args.failureCode,
-    retainedActiveSnapshot:
-      args.baseline !== undefined &&
-      args.baseline.activeCatalogVersion !== null,
+    retainedActiveSnapshot: Boolean(args.baseline?.activeCatalogVersion),
   });
   return await responseFromState({
     db: args.db,
@@ -493,6 +533,9 @@ async function rejectCandidate(args: {
 interface ConnectorCatalogSyncRuntime {
   readonly db: Db;
   readonly reader: ConnectorCatalogArtifactReader;
+  readonly readActivePointer: (
+    ifNoneMatch: string | null,
+  ) => Promise<ConditionalS3BufferDownload>;
   readonly source: ConnectorCatalogSource;
   readonly signal: AbortSignal;
 }
@@ -504,20 +547,38 @@ type SyncAttemptResult =
       readonly response: ConnectorCatalogSyncResponse;
     };
 
-type SyncLoadResult<T> =
+type CandidateLoadResult =
   | SyncAttemptResult
-  | { readonly kind: "loaded"; readonly value: T };
+  | {
+      readonly kind: "loaded";
+      readonly candidate: ValidatedConnectorCatalogCandidate;
+    };
+
+type PointerLoadResult =
+  | SyncAttemptResult
+  | { readonly kind: "not-modified" }
+  | {
+      readonly kind: "loaded";
+      readonly pointer: ConnectorCatalogActivePointer;
+      readonly etag: string | null;
+    };
 
 async function rejectSyncAttempt(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot | undefined,
   failureCode: ConnectorCatalogSyncFailureCode,
+  pointerObservation?: PointerObservation,
 ): Promise<SyncAttemptResult> {
   const response = await rejectCandidate({
     db: runtime.db,
     source: runtime.source,
     baseline,
     failureCode,
+    rejectedCandidate: cacheableRejectedCandidate(
+      pointerObservation,
+      failureCode,
+    ),
+    pointerObservation,
   });
   runtime.signal.throwIfAborted();
   return response ? { kind: "complete", response } : { kind: "retry" };
@@ -526,29 +587,54 @@ async function rejectSyncAttempt(
 async function loadPointerForSync(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot | undefined,
-): Promise<SyncLoadResult<ConnectorCatalogActivePointer>> {
-  const result = await settle(
-    loadConnectorCatalogActivePointer(runtime.reader),
+): Promise<PointerLoadResult> {
+  const downloaded = await settle(
+    runtime.readActivePointer(baseline?.lastObservedPointerEtag ?? null),
     runtime.signal,
   );
   runtime.signal.throwIfAborted();
-  if (!result.ok) {
+  if (!downloaded.ok) {
     return await rejectSyncAttempt(
       runtime,
       baseline,
-      classifySyncFailure(result.error),
+      classifySyncFailure(downloaded.error),
     );
   }
-  return { kind: "loaded", value: result.value };
+  if (downloaded.value.kind === "not-modified") {
+    return downloaded.value;
+  }
+
+  const { buffer, etag } = downloaded.value;
+  const parsed = safeSync(() => {
+    return parseConnectorCatalogActivePointer(buffer);
+  });
+  if (!("ok" in parsed)) {
+    return await rejectSyncAttempt(
+      runtime,
+      baseline,
+      classifySyncFailure(parsed.error),
+      { pointer: null, etag },
+    );
+  }
+  return {
+    kind: "loaded",
+    pointer: parsed.ok,
+    etag,
+  };
 }
 
 async function loadCandidateForSync(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot | undefined,
-  pointer: ConnectorCatalogActivePointer,
-): Promise<SyncLoadResult<ValidatedConnectorCatalogCandidate>> {
+  pointerObservation: PointerObservation & {
+    readonly pointer: ConnectorCatalogActivePointer;
+  },
+): Promise<CandidateLoadResult> {
   const result = await settle(
-    loadConnectorCatalogCandidate({ reader: runtime.reader, pointer }),
+    loadConnectorCatalogCandidate({
+      reader: runtime.reader,
+      pointer: pointerObservation.pointer,
+    }),
     runtime.signal,
   );
   runtime.signal.throwIfAborted();
@@ -557,20 +643,23 @@ async function loadCandidateForSync(
       runtime,
       baseline,
       classifySyncFailure(result.error),
+      pointerObservation,
     );
   }
-  return { kind: "loaded", value: result.value };
+  return { kind: "loaded", candidate: result.value };
 }
 
 async function completeUnchangedSync(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot,
+  pointerObservation?: PointerObservation,
 ): Promise<SyncAttemptResult> {
   const committed = await recordUnchangedAttempt({
     db: runtime.db,
     sourceId: runtime.source.sourceId,
     baseline,
     attemptedAt: nowDate(),
+    pointerObservation,
   });
   runtime.signal.throwIfAborted();
   if (!committed) {
@@ -589,35 +678,27 @@ async function commitValidatedCandidate(
   runtime: ConnectorCatalogSyncRuntime,
   baseline: SyncStateSnapshot | undefined,
   candidate: ValidatedConnectorCatalogCandidate,
+  pointerObservation: PointerObservation,
 ): Promise<SyncAttemptResult> {
   const outcome = await commitCandidate({
     db: runtime.db,
     sourceId: runtime.source.sourceId,
     baseline,
     candidate,
+    pointerObservation,
     attemptedAt: nowDate(),
   });
   runtime.signal.throwIfAborted();
   if (outcome === "retry") {
     return { kind: "retry" };
   }
-  if (outcome === "rejected") {
-    log.warn("Connector catalog candidate rejected", {
-      sourceId: runtime.source.sourceId,
-      schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-      failureCode: "conflicting-release",
-      retainedActiveSnapshot:
-        baseline !== undefined && baseline.activeCatalogVersion !== null,
-    });
-  } else {
-    log.debug("Connector catalog sync completed", {
-      sourceId: runtime.source.sourceId,
-      schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-      catalogVersion: candidate.identity.catalogVersion,
-      integrityDigest: candidate.identity.integrityDigest,
-      outcome,
-    });
-  }
+  log.debug("Connector catalog sync completed", {
+    sourceId: runtime.source.sourceId,
+    schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+    catalogVersion: candidate.identity.catalogVersion,
+    integrityDigest: candidate.identity.integrityDigest,
+    outcome,
+  });
   const response = await responseFromState({
     db: runtime.db,
     sourceId: runtime.source.sourceId,
@@ -633,31 +714,58 @@ async function syncConnectorCatalogAttempt(
   const baseline = await readSyncState(runtime.db, runtime.source.sourceId);
   runtime.signal.throwIfAborted();
   const pointerResult = await loadPointerForSync(runtime, baseline);
-  if (pointerResult.kind !== "loaded") {
+  if (pointerResult.kind === "retry" || pointerResult.kind === "complete") {
     return pointerResult;
   }
-  const pointer = pointerResult.value;
-  if (pointerMatchesActiveState(pointer, baseline)) {
+
+  let pointerObservation: PointerObservation & {
+    readonly pointer: ConnectorCatalogActivePointer;
+  };
+  if (pointerResult.kind === "not-modified") {
     if (!baseline) {
-      throw new Error("Connector catalog active state disappeared");
+      return await rejectSyncAttempt(runtime, baseline, "source-unavailable");
     }
-    return await completeUnchangedSync(runtime, baseline);
+    const cachedFailure = cachedRejectionForObservedEtag(baseline);
+    if (cachedFailure) {
+      return await rejectSyncAttempt(runtime, baseline, cachedFailure);
+    }
+    const observedPointer = observedPointerFromState(baseline);
+    if (!observedPointer) {
+      return await rejectSyncAttempt(runtime, baseline, "source-unavailable");
+    }
+    pointerObservation = {
+      pointer: observedPointer,
+      etag: baseline.lastObservedPointerEtag,
+    };
+  } else {
+    pointerObservation = {
+      pointer: pointerResult.pointer,
+      etag: pointerResult.etag,
+    };
   }
 
-  const historicalIdentity = await readReleaseIdentity(
-    runtime.db,
-    runtime.source.sourceId,
-    pointer.catalogVersion,
-  );
-  runtime.signal.throwIfAborted();
-  if (pointerConflictsWithStoredIdentity(pointer, historicalIdentity)) {
-    return await rejectSyncAttempt(runtime, baseline, "conflicting-release");
+  const { pointer } = pointerObservation;
+  if (pointerMatchesActiveState(pointer, baseline)) {
+    if (!baseline) {
+      throw new Error("Connector catalog active snapshot disappeared");
+    }
+    return await completeUnchangedSync(runtime, baseline, pointerObservation);
+  }
+
+  const cachedFailure = cachedRejectionForPointer(pointer, baseline);
+  if (cachedFailure) {
+    return await rejectSyncAttempt(
+      runtime,
+      baseline,
+      cachedFailure,
+      pointerObservation,
+    );
   }
 
   const candidateResult = await loadCandidateForSync(
     runtime,
     baseline,
-    pointer,
+    pointerObservation,
   );
   if (candidateResult.kind !== "loaded") {
     return candidateResult;
@@ -665,7 +773,8 @@ async function syncConnectorCatalogAttempt(
   return await commitValidatedCandidate(
     runtime,
     baseline,
-    candidateResult.value,
+    candidateResult.candidate,
+    pointerObservation,
   );
 }
 
@@ -688,6 +797,18 @@ export const syncConnectorCatalog$ = command(
       db: set(writeDb$),
       source,
       signal,
+      readActivePointer: async (ifNoneMatch) => {
+        const result = await get(
+          downloadS3BufferWithMaxBytesIfChanged(
+            source.bucket,
+            CONNECTOR_CATALOG_ACTIVE_KEY,
+            CONNECTOR_CATALOG_ACTIVE_MAX_BYTES,
+            ifNoneMatch,
+          ),
+        );
+        signal.throwIfAborted();
+        return result;
+      },
       reader: {
         readArtifact: async (key, maxBytes) => {
           const bytes = await get(

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -71,12 +71,8 @@ type CandidateCommitResult = "accepted" | "rejected" | "retry";
 
 class CandidateCommitRetry extends Error {}
 
-function connectorCatalogSource(): ConnectorCatalogSource | undefined {
-  const bucket = env("R2_CONNECTOR_CATALOG_BUCKET_NAME");
-  if (!bucket) {
-    return undefined;
-  }
-
+function connectorCatalogSource(): ConnectorCatalogSource {
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
   const endpoint =
     env("S3_ENDPOINT") ??
     `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
@@ -178,7 +174,6 @@ async function readReleaseIdentity(
 }
 
 function statusFromState(
-  configured: boolean,
   state: SyncStateSnapshot | undefined,
 ): ConnectorCatalogSyncStatus {
   let active: ConnectorCatalogSyncStatus["active"] = null;
@@ -206,7 +201,6 @@ function statusFromState(
   }
 
   return {
-    configured,
     state:
       active === null
         ? "never-synced"
@@ -495,7 +489,7 @@ async function responseFromState(args: {
   const state = await readSyncState(args.db, args.sourceId);
   return {
     outcome: args.outcome,
-    ...statusFromState(true, state),
+    ...statusFromState(state),
   };
 }
 
@@ -720,13 +714,9 @@ async function syncConnectorCatalogAttempt(
 export const connectorCatalogStatus$ = command(
   async ({ get }, signal: AbortSignal): Promise<ConnectorCatalogSyncStatus> => {
     const source = connectorCatalogSource();
-    if (!source) {
-      return statusFromState(false, undefined);
-    }
-
     const state = await readSyncState(get(db$), source.sourceId);
     signal.throwIfAborted();
-    return statusFromState(true, state);
+    return statusFromState(state);
   },
 );
 
@@ -736,13 +726,6 @@ export const syncConnectorCatalog$ = command(
     signal: AbortSignal,
   ): Promise<ConnectorCatalogSyncResponse> => {
     const source = connectorCatalogSource();
-    if (!source) {
-      return {
-        outcome: "disabled",
-        ...statusFromState(false, undefined),
-      };
-    }
-
     const runtime: ConnectorCatalogSyncRuntime = {
       db: set(writeDb$),
       source,

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -1,0 +1,771 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ConnectorCatalogSyncFailureCode,
+  ConnectorCatalogSyncResponse,
+  ConnectorCatalogSyncStatus,
+} from "@vm0/api-contracts/contracts/cron";
+import {
+  connectorCatalogReleaseIdentities,
+  connectorCatalogSyncState,
+} from "@vm0/db/schema/connector-catalog";
+import { command } from "ccstate";
+import { and, eq, sql } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import {
+  downloadS3BufferWithMaxBytes,
+  S3ObjectSizeLimitError,
+} from "../external/s3";
+import { settle } from "../utils";
+import { SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION } from "./connector-catalog-artifacts/artifacts";
+import {
+  connectorCatalogPointersEqual,
+  connectorCatalogArtifactFailureCode,
+  loadConnectorCatalogActivePointer,
+  loadConnectorCatalogCandidate,
+  type ConnectorCatalogActivePointer,
+  type ConnectorCatalogArtifactReader,
+  type ConnectorCatalogReleaseIdentity,
+  type ValidatedConnectorCatalogCandidate,
+} from "./connector-catalog-artifacts/loader";
+
+const log = logger("connector-catalog:sync");
+
+interface ConnectorCatalogSource {
+  readonly bucket: string;
+  readonly sourceId: string;
+}
+
+interface SyncStateSnapshot {
+  readonly revision: number;
+  readonly activeCatalogVersion: string | null;
+  readonly publicCatalog: string | null;
+  readonly activatedAt: Date | null;
+  readonly lastAttemptAt: Date | null;
+  readonly lastAttemptOutcome: "accepted" | "unchanged" | "rejected" | null;
+  readonly lastSuccessAt: Date | null;
+  readonly lastFailureCode: ConnectorCatalogSyncFailureCode | null;
+  readonly activeIntegrityKey: string | null;
+  readonly activeIntegrityDigest: string | null;
+}
+
+interface StoredReleaseIdentity {
+  readonly integrityKey: string;
+  readonly integrityDigest: string;
+  readonly publicCatalogKey: string;
+  readonly publicCatalogDigest: string;
+  readonly privateCatalogKey: string;
+  readonly privateCatalogDigest: string;
+  readonly privateFirewallsKey: string;
+  readonly privateFirewallsDigest: string;
+  readonly runnerFirewallsKey: string;
+  readonly runnerFirewallsDigest: string;
+  readonly requiredCapabilities: readonly string[];
+}
+
+type CandidateCommitResult = "accepted" | "rejected" | "retry";
+
+class CandidateCommitRetry extends Error {}
+
+function connectorCatalogSource(): ConnectorCatalogSource | undefined {
+  const bucket = env("R2_CONNECTOR_CATALOG_BUCKET_NAME");
+  if (!bucket) {
+    return undefined;
+  }
+
+  const endpoint =
+    env("S3_ENDPOINT") ??
+    `https://${env("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
+  const authority = new URL(endpoint).origin;
+  const sourceId = createHash("sha256")
+    .update(authority)
+    .update("\0")
+    .update(bucket)
+    .digest("hex");
+  return { bucket, sourceId };
+}
+
+async function readSyncState(
+  db: ReadonlyDb,
+  sourceId: string,
+): Promise<SyncStateSnapshot | undefined> {
+  const [state] = await db
+    .select({
+      revision: connectorCatalogSyncState.revision,
+      activeCatalogVersion: connectorCatalogSyncState.activeCatalogVersion,
+      publicCatalog: connectorCatalogSyncState.publicCatalog,
+      activatedAt: connectorCatalogSyncState.activatedAt,
+      lastAttemptAt: connectorCatalogSyncState.lastAttemptAt,
+      lastAttemptOutcome: connectorCatalogSyncState.lastAttemptOutcome,
+      lastSuccessAt: connectorCatalogSyncState.lastSuccessAt,
+      lastFailureCode: connectorCatalogSyncState.lastFailureCode,
+      activeIntegrityKey: connectorCatalogReleaseIdentities.integrityKey,
+      activeIntegrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
+    })
+    .from(connectorCatalogSyncState)
+    .leftJoin(
+      connectorCatalogReleaseIdentities,
+      and(
+        eq(
+          connectorCatalogReleaseIdentities.sourceId,
+          connectorCatalogSyncState.sourceId,
+        ),
+        eq(
+          connectorCatalogReleaseIdentities.schemaVersion,
+          connectorCatalogSyncState.schemaVersion,
+        ),
+        eq(
+          connectorCatalogReleaseIdentities.catalogVersion,
+          connectorCatalogSyncState.activeCatalogVersion,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(connectorCatalogSyncState.sourceId, sourceId),
+        eq(
+          connectorCatalogSyncState.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+      ),
+    )
+    .limit(1);
+  return state;
+}
+
+async function readReleaseIdentity(
+  db: ReadonlyDb,
+  sourceId: string,
+  catalogVersion: string,
+): Promise<StoredReleaseIdentity | undefined> {
+  const [identity] = await db
+    .select({
+      integrityKey: connectorCatalogReleaseIdentities.integrityKey,
+      integrityDigest: connectorCatalogReleaseIdentities.integrityDigest,
+      publicCatalogKey: connectorCatalogReleaseIdentities.publicCatalogKey,
+      publicCatalogDigest:
+        connectorCatalogReleaseIdentities.publicCatalogDigest,
+      privateCatalogKey: connectorCatalogReleaseIdentities.privateCatalogKey,
+      privateCatalogDigest:
+        connectorCatalogReleaseIdentities.privateCatalogDigest,
+      privateFirewallsKey:
+        connectorCatalogReleaseIdentities.privateFirewallsKey,
+      privateFirewallsDigest:
+        connectorCatalogReleaseIdentities.privateFirewallsDigest,
+      runnerFirewallsKey: connectorCatalogReleaseIdentities.runnerFirewallsKey,
+      runnerFirewallsDigest:
+        connectorCatalogReleaseIdentities.runnerFirewallsDigest,
+      requiredCapabilities:
+        connectorCatalogReleaseIdentities.requiredCapabilities,
+    })
+    .from(connectorCatalogReleaseIdentities)
+    .where(
+      and(
+        eq(connectorCatalogReleaseIdentities.sourceId, sourceId),
+        eq(
+          connectorCatalogReleaseIdentities.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(connectorCatalogReleaseIdentities.catalogVersion, catalogVersion),
+      ),
+    )
+    .limit(1);
+  return identity;
+}
+
+function statusFromState(
+  configured: boolean,
+  state: SyncStateSnapshot | undefined,
+): ConnectorCatalogSyncStatus {
+  let active: ConnectorCatalogSyncStatus["active"] = null;
+  if (state?.activeCatalogVersion) {
+    if (!state.activatedAt || !state.activeIntegrityDigest) {
+      throw new Error("Connector catalog active state is incomplete");
+    }
+    active = {
+      catalogVersion: state.activeCatalogVersion,
+      integrityDigest: state.activeIntegrityDigest,
+      activatedAt: state.activatedAt.toISOString(),
+    };
+  }
+
+  let lastAttempt: ConnectorCatalogSyncStatus["lastAttempt"] = null;
+  if (state?.lastAttemptAt || state?.lastAttemptOutcome) {
+    if (!state.lastAttemptAt || !state.lastAttemptOutcome) {
+      throw new Error("Connector catalog attempt state is incomplete");
+    }
+    lastAttempt = {
+      at: state.lastAttemptAt.toISOString(),
+      outcome: state.lastAttemptOutcome,
+      failureCode: state.lastFailureCode,
+    };
+  }
+
+  return {
+    configured,
+    state:
+      active === null
+        ? "never-synced"
+        : state?.lastAttemptOutcome === "rejected"
+          ? "stale"
+          : "current",
+    active,
+    lastAttempt,
+    lastSuccessAt: state?.lastSuccessAt?.toISOString() ?? null,
+  };
+}
+
+function pointerMatchesActiveState(
+  pointer: ConnectorCatalogActivePointer,
+  state: SyncStateSnapshot | undefined,
+): boolean {
+  if (!state) {
+    return false;
+  }
+  return (
+    pointer.catalogVersion === state.activeCatalogVersion &&
+    pointer.integrity.key === state.activeIntegrityKey &&
+    pointer.integrity.digest === state.activeIntegrityDigest
+  );
+}
+
+function pointerConflictsWithStoredIdentity(
+  pointer: ConnectorCatalogActivePointer,
+  identity: StoredReleaseIdentity | undefined,
+): boolean {
+  return (
+    identity !== undefined &&
+    (pointer.integrity.key !== identity.integrityKey ||
+      pointer.integrity.digest !== identity.integrityDigest)
+  );
+}
+
+function storedIdentityMatches(
+  stored: StoredReleaseIdentity,
+  candidate: ConnectorCatalogReleaseIdentity,
+): boolean {
+  return (
+    stored.integrityKey === candidate.integrity.key &&
+    stored.integrityDigest === candidate.integrity.digest &&
+    stored.publicCatalogKey === candidate.publicCatalog.key &&
+    stored.publicCatalogDigest === candidate.publicCatalog.digest &&
+    stored.privateCatalogKey === candidate.privateCatalog.key &&
+    stored.privateCatalogDigest === candidate.privateCatalog.digest &&
+    stored.privateFirewallsKey === candidate.privateFirewalls.key &&
+    stored.privateFirewallsDigest === candidate.privateFirewalls.digest &&
+    stored.runnerFirewallsKey === candidate.runnerFirewalls.key &&
+    stored.runnerFirewallsDigest === candidate.runnerFirewalls.digest &&
+    stored.requiredCapabilities.length ===
+      candidate.requiredCapabilities.length &&
+    stored.requiredCapabilities.every((capability, index) => {
+      return capability === candidate.requiredCapabilities[index];
+    })
+  );
+}
+
+function classifySyncFailure(error: unknown): ConnectorCatalogSyncFailureCode {
+  const artifactFailureCode = connectorCatalogArtifactFailureCode(error);
+  if (artifactFailureCode) {
+    return artifactFailureCode;
+  }
+  if (error instanceof S3ObjectSizeLimitError) {
+    return "object-too-large";
+  }
+  return "source-unavailable";
+}
+
+async function recordRejectedAttempt(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly baseline: SyncStateSnapshot | undefined;
+  readonly attemptedAt: Date;
+  readonly failureCode: ConnectorCatalogSyncFailureCode;
+}): Promise<boolean> {
+  if (!args.baseline) {
+    const inserted = await args.db
+      .insert(connectorCatalogSyncState)
+      .values({
+        sourceId: args.sourceId,
+        schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        revision: 1,
+        lastAttemptAt: args.attemptedAt,
+        lastAttemptOutcome: "rejected",
+        lastFailureCode: args.failureCode,
+      })
+      .onConflictDoNothing()
+      .returning({ sourceId: connectorCatalogSyncState.sourceId });
+    return inserted.length === 1;
+  }
+
+  const updated = await args.db
+    .update(connectorCatalogSyncState)
+    .set({
+      revision: sql`${connectorCatalogSyncState.revision} + 1`,
+      lastAttemptAt: args.attemptedAt,
+      lastAttemptOutcome: "rejected",
+      lastFailureCode: args.failureCode,
+    })
+    .where(
+      and(
+        eq(connectorCatalogSyncState.sourceId, args.sourceId),
+        eq(
+          connectorCatalogSyncState.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(connectorCatalogSyncState.revision, args.baseline.revision),
+      ),
+    )
+    .returning({ sourceId: connectorCatalogSyncState.sourceId });
+  return updated.length === 1;
+}
+
+async function recordUnchangedAttempt(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly baseline: SyncStateSnapshot;
+  readonly attemptedAt: Date;
+}): Promise<boolean> {
+  const updated = await args.db
+    .update(connectorCatalogSyncState)
+    .set({
+      revision: sql`${connectorCatalogSyncState.revision} + 1`,
+      lastAttemptAt: args.attemptedAt,
+      lastAttemptOutcome: "unchanged",
+      lastSuccessAt: args.attemptedAt,
+      lastFailureCode: null,
+    })
+    .where(
+      and(
+        eq(connectorCatalogSyncState.sourceId, args.sourceId),
+        eq(
+          connectorCatalogSyncState.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(connectorCatalogSyncState.revision, args.baseline.revision),
+      ),
+    )
+    .returning({ sourceId: connectorCatalogSyncState.sourceId });
+  return updated.length === 1;
+}
+
+async function persistReleaseIdentity(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly identity: ConnectorCatalogReleaseIdentity;
+  readonly attemptedAt: Date;
+}): Promise<StoredReleaseIdentity> {
+  const identity = args.identity;
+  await args.db
+    .insert(connectorCatalogReleaseIdentities)
+    .values({
+      sourceId: args.sourceId,
+      schemaVersion: identity.schemaVersion,
+      catalogVersion: identity.catalogVersion,
+      integrityKey: identity.integrity.key,
+      integrityDigest: identity.integrity.digest,
+      publicCatalogKey: identity.publicCatalog.key,
+      publicCatalogDigest: identity.publicCatalog.digest,
+      privateCatalogKey: identity.privateCatalog.key,
+      privateCatalogDigest: identity.privateCatalog.digest,
+      privateFirewallsKey: identity.privateFirewalls.key,
+      privateFirewallsDigest: identity.privateFirewalls.digest,
+      runnerFirewallsKey: identity.runnerFirewalls.key,
+      runnerFirewallsDigest: identity.runnerFirewalls.digest,
+      requiredCapabilities: [...identity.requiredCapabilities],
+      firstValidatedAt: args.attemptedAt,
+    })
+    .onConflictDoNothing();
+
+  const stored = await readReleaseIdentity(
+    args.db,
+    args.sourceId,
+    identity.catalogVersion,
+  );
+  if (!stored) {
+    throw new Error("Connector catalog release identity was not persisted");
+  }
+  return stored;
+}
+
+async function activateCandidate(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly baseline: SyncStateSnapshot | undefined;
+  readonly candidate: ValidatedConnectorCatalogCandidate;
+  readonly attemptedAt: Date;
+}): Promise<void> {
+  const stateValues = {
+    activeCatalogVersion: args.candidate.identity.catalogVersion,
+    publicCatalog: args.candidate.publicCatalogText,
+    activatedAt: args.attemptedAt,
+    lastAttemptAt: args.attemptedAt,
+    lastAttemptOutcome: "accepted" as const,
+    lastSuccessAt: args.attemptedAt,
+    lastFailureCode: null,
+  };
+  if (!args.baseline) {
+    const inserted = await args.db
+      .insert(connectorCatalogSyncState)
+      .values({
+        sourceId: args.sourceId,
+        schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        revision: 1,
+        ...stateValues,
+      })
+      .onConflictDoNothing()
+      .returning({ sourceId: connectorCatalogSyncState.sourceId });
+    if (inserted.length === 0) {
+      throw new CandidateCommitRetry();
+    }
+    return;
+  }
+
+  const updated = await args.db
+    .update(connectorCatalogSyncState)
+    .set({
+      revision: sql`${connectorCatalogSyncState.revision} + 1`,
+      ...stateValues,
+    })
+    .where(
+      and(
+        eq(connectorCatalogSyncState.sourceId, args.sourceId),
+        eq(
+          connectorCatalogSyncState.schemaVersion,
+          SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+        ),
+        eq(connectorCatalogSyncState.revision, args.baseline.revision),
+      ),
+    )
+    .returning({ sourceId: connectorCatalogSyncState.sourceId });
+  if (updated.length === 0) {
+    throw new CandidateCommitRetry();
+  }
+}
+
+async function commitCandidate(args: {
+  readonly db: Db;
+  readonly sourceId: string;
+  readonly baseline: SyncStateSnapshot | undefined;
+  readonly candidate: ValidatedConnectorCatalogCandidate;
+  readonly attemptedAt: Date;
+}): Promise<CandidateCommitResult> {
+  const result = await settle(
+    args.db.transaction(async (tx) => {
+      const stored = await persistReleaseIdentity({
+        db: tx,
+        sourceId: args.sourceId,
+        identity: args.candidate.identity,
+        attemptedAt: args.attemptedAt,
+      });
+      if (!storedIdentityMatches(stored, args.candidate.identity)) {
+        const committed = await recordRejectedAttempt({
+          db: tx,
+          sourceId: args.sourceId,
+          baseline: args.baseline,
+          attemptedAt: args.attemptedAt,
+          failureCode: "conflicting-release",
+        });
+        if (!committed) {
+          throw new CandidateCommitRetry();
+        }
+        return "rejected";
+      }
+      await activateCandidate({ ...args, db: tx });
+      return "accepted";
+    }),
+  );
+  if (result.ok) {
+    return result.value;
+  }
+  if (result.error instanceof CandidateCommitRetry) {
+    return "retry";
+  }
+  throw result.error;
+}
+
+async function responseFromState(args: {
+  readonly db: ReadonlyDb;
+  readonly sourceId: string;
+  readonly outcome: ConnectorCatalogSyncResponse["outcome"];
+}): Promise<ConnectorCatalogSyncResponse> {
+  const state = await readSyncState(args.db, args.sourceId);
+  return {
+    outcome: args.outcome,
+    ...statusFromState(true, state),
+  };
+}
+
+async function rejectCandidate(args: {
+  readonly db: Db;
+  readonly source: ConnectorCatalogSource;
+  readonly baseline: SyncStateSnapshot | undefined;
+  readonly failureCode: ConnectorCatalogSyncFailureCode;
+}): Promise<ConnectorCatalogSyncResponse | undefined> {
+  const committed = await recordRejectedAttempt({
+    db: args.db,
+    sourceId: args.source.sourceId,
+    baseline: args.baseline,
+    attemptedAt: nowDate(),
+    failureCode: args.failureCode,
+  });
+  if (!committed) {
+    return undefined;
+  }
+
+  log.warn("Connector catalog candidate rejected", {
+    sourceId: args.source.sourceId,
+    schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+    failureCode: args.failureCode,
+    retainedActiveSnapshot:
+      args.baseline !== undefined &&
+      args.baseline.activeCatalogVersion !== null,
+  });
+  return await responseFromState({
+    db: args.db,
+    sourceId: args.source.sourceId,
+    outcome: "rejected",
+  });
+}
+
+interface ConnectorCatalogSyncRuntime {
+  readonly db: Db;
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly source: ConnectorCatalogSource;
+  readonly signal: AbortSignal;
+}
+
+type SyncAttemptResult =
+  | { readonly kind: "retry" }
+  | {
+      readonly kind: "complete";
+      readonly response: ConnectorCatalogSyncResponse;
+    };
+
+type SyncLoadResult<T> =
+  | SyncAttemptResult
+  | { readonly kind: "loaded"; readonly value: T };
+
+async function rejectSyncAttempt(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot | undefined,
+  failureCode: ConnectorCatalogSyncFailureCode,
+): Promise<SyncAttemptResult> {
+  const response = await rejectCandidate({
+    db: runtime.db,
+    source: runtime.source,
+    baseline,
+    failureCode,
+  });
+  runtime.signal.throwIfAborted();
+  return response ? { kind: "complete", response } : { kind: "retry" };
+}
+
+async function loadPointerForSync(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot | undefined,
+): Promise<SyncLoadResult<ConnectorCatalogActivePointer>> {
+  const result = await settle(
+    loadConnectorCatalogActivePointer(runtime.reader),
+    runtime.signal,
+  );
+  runtime.signal.throwIfAborted();
+  if (!result.ok) {
+    return await rejectSyncAttempt(
+      runtime,
+      baseline,
+      classifySyncFailure(result.error),
+    );
+  }
+  return { kind: "loaded", value: result.value };
+}
+
+async function loadCandidateForSync(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot | undefined,
+  pointer: ConnectorCatalogActivePointer,
+): Promise<SyncLoadResult<ValidatedConnectorCatalogCandidate>> {
+  const result = await settle(
+    loadConnectorCatalogCandidate({ reader: runtime.reader, pointer }),
+    runtime.signal,
+  );
+  runtime.signal.throwIfAborted();
+  if (!result.ok) {
+    return await rejectSyncAttempt(
+      runtime,
+      baseline,
+      classifySyncFailure(result.error),
+    );
+  }
+  return { kind: "loaded", value: result.value };
+}
+
+async function completeUnchangedSync(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot,
+): Promise<SyncAttemptResult> {
+  const committed = await recordUnchangedAttempt({
+    db: runtime.db,
+    sourceId: runtime.source.sourceId,
+    baseline,
+    attemptedAt: nowDate(),
+  });
+  runtime.signal.throwIfAborted();
+  if (!committed) {
+    return { kind: "retry" };
+  }
+  const response = await responseFromState({
+    db: runtime.db,
+    sourceId: runtime.source.sourceId,
+    outcome: "unchanged",
+  });
+  runtime.signal.throwIfAborted();
+  return { kind: "complete", response };
+}
+
+async function commitValidatedCandidate(
+  runtime: ConnectorCatalogSyncRuntime,
+  baseline: SyncStateSnapshot | undefined,
+  candidate: ValidatedConnectorCatalogCandidate,
+): Promise<SyncAttemptResult> {
+  const outcome = await commitCandidate({
+    db: runtime.db,
+    sourceId: runtime.source.sourceId,
+    baseline,
+    candidate,
+    attemptedAt: nowDate(),
+  });
+  runtime.signal.throwIfAborted();
+  if (outcome === "retry") {
+    return { kind: "retry" };
+  }
+  if (outcome === "rejected") {
+    log.warn("Connector catalog candidate rejected", {
+      sourceId: runtime.source.sourceId,
+      schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+      failureCode: "conflicting-release",
+      retainedActiveSnapshot:
+        baseline !== undefined && baseline.activeCatalogVersion !== null,
+    });
+  } else {
+    log.debug("Connector catalog sync completed", {
+      sourceId: runtime.source.sourceId,
+      schemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
+      catalogVersion: candidate.identity.catalogVersion,
+      integrityDigest: candidate.identity.integrity.digest,
+      outcome,
+    });
+  }
+  const response = await responseFromState({
+    db: runtime.db,
+    sourceId: runtime.source.sourceId,
+    outcome,
+  });
+  runtime.signal.throwIfAborted();
+  return { kind: "complete", response };
+}
+
+async function syncConnectorCatalogAttempt(
+  runtime: ConnectorCatalogSyncRuntime,
+): Promise<SyncAttemptResult> {
+  const baseline = await readSyncState(runtime.db, runtime.source.sourceId);
+  runtime.signal.throwIfAborted();
+  const pointerResult = await loadPointerForSync(runtime, baseline);
+  if (pointerResult.kind !== "loaded") {
+    return pointerResult;
+  }
+  const pointer = pointerResult.value;
+  if (pointerMatchesActiveState(pointer, baseline)) {
+    if (!baseline) {
+      throw new Error("Connector catalog active state disappeared");
+    }
+    return await completeUnchangedSync(runtime, baseline);
+  }
+
+  const historicalIdentity = await readReleaseIdentity(
+    runtime.db,
+    runtime.source.sourceId,
+    pointer.catalogVersion,
+  );
+  runtime.signal.throwIfAborted();
+  if (pointerConflictsWithStoredIdentity(pointer, historicalIdentity)) {
+    return await rejectSyncAttempt(runtime, baseline, "conflicting-release");
+  }
+
+  const candidateResult = await loadCandidateForSync(
+    runtime,
+    baseline,
+    pointer,
+  );
+  if (candidateResult.kind !== "loaded") {
+    return candidateResult;
+  }
+  const currentPointerResult = await loadPointerForSync(runtime, baseline);
+  if (currentPointerResult.kind !== "loaded") {
+    return currentPointerResult;
+  }
+  if (!connectorCatalogPointersEqual(pointer, currentPointerResult.value)) {
+    return { kind: "retry" };
+  }
+  return await commitValidatedCandidate(
+    runtime,
+    baseline,
+    candidateResult.value,
+  );
+}
+
+export const connectorCatalogStatus$ = command(
+  async ({ get }, signal: AbortSignal): Promise<ConnectorCatalogSyncStatus> => {
+    const source = connectorCatalogSource();
+    if (!source) {
+      return statusFromState(false, undefined);
+    }
+
+    const state = await readSyncState(get(db$), source.sourceId);
+    signal.throwIfAborted();
+    return statusFromState(true, state);
+  },
+);
+
+export const syncConnectorCatalog$ = command(
+  async (
+    { get, set },
+    signal: AbortSignal,
+  ): Promise<ConnectorCatalogSyncResponse> => {
+    const source = connectorCatalogSource();
+    if (!source) {
+      return {
+        outcome: "disabled",
+        ...statusFromState(false, undefined),
+      };
+    }
+
+    const runtime: ConnectorCatalogSyncRuntime = {
+      db: set(writeDb$),
+      source,
+      signal,
+      reader: {
+        readArtifact: async (key, maxBytes) => {
+          const bytes = await get(
+            downloadS3BufferWithMaxBytes(source.bucket, key, maxBytes),
+          );
+          signal.throwIfAborted();
+          return bytes;
+        },
+      },
+    };
+
+    while (true) {
+      signal.throwIfAborted();
+      const result = await syncConnectorCatalogAttempt(runtime);
+      signal.throwIfAborted();
+      if (result.kind === "retry") {
+        continue;
+      }
+      return result.response;
+    }
+  },
+);

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -57,6 +57,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/sync-connector-catalog",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/process-usage-events",
       "schedule": "* * * * *"
     },

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -100,6 +100,56 @@ const cronSyncSkillsResponseSchema = z.object({
   total: z.number(),
 });
 
+export const connectorCatalogSyncFailureCodeSchema = z.enum([
+  "source-unavailable",
+  "object-too-large",
+  "invalid-json",
+  "invalid-pointer",
+  "invalid-reference",
+  "digest-mismatch",
+  "unsupported-schema",
+  "unsupported-capability",
+  "invalid-artifact",
+  "public-leakage",
+  "relationship-mismatch",
+  "conflicting-release",
+]);
+
+const connectorCatalogSyncStatusSchema = z.object({
+  configured: z.boolean(),
+  state: z.enum(["never-synced", "current", "stale"]),
+  active: z
+    .object({
+      catalogVersion: z.string(),
+      integrityDigest: z.string(),
+      activatedAt: z.string().datetime(),
+    })
+    .nullable(),
+  lastAttempt: z
+    .object({
+      at: z.string().datetime(),
+      outcome: z.enum(["accepted", "unchanged", "rejected"]),
+      failureCode: connectorCatalogSyncFailureCodeSchema.nullable(),
+    })
+    .nullable(),
+  lastSuccessAt: z.string().datetime().nullable(),
+});
+
+const connectorCatalogSyncResponseSchema =
+  connectorCatalogSyncStatusSchema.extend({
+    outcome: z.enum(["disabled", "accepted", "unchanged", "rejected"]),
+  });
+
+export type ConnectorCatalogSyncFailureCode = z.infer<
+  typeof connectorCatalogSyncFailureCodeSchema
+>;
+export type ConnectorCatalogSyncStatus = z.infer<
+  typeof connectorCatalogSyncStatusSchema
+>;
+export type ConnectorCatalogSyncResponse = z.infer<
+  typeof connectorCatalogSyncResponseSchema
+>;
+
 const cronExecuteWorkflowAutomationsResponseSchema = z.object({
   success: z.literal(true),
   executed: z.number(),
@@ -344,6 +394,29 @@ export const cronSyncSkillsContract = c.router({
   },
 });
 
+export const cronConnectorCatalogContract = c.router({
+  sync: {
+    method: "GET",
+    path: "/api/cron/sync-connector-catalog",
+    headers: authHeadersSchema,
+    responses: {
+      200: connectorCatalogSyncResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Sync the validated connector catalog snapshot",
+  },
+  status: {
+    method: "GET",
+    path: "/api/cron/connector-catalog-status",
+    headers: authHeadersSchema,
+    responses: {
+      200: connectorCatalogSyncStatusSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Read connector catalog sync status",
+  },
+});
+
 export const cronExecuteWorkflowAutomationsContract = c.router({
   execute: {
     method: "GET",
@@ -452,6 +525,7 @@ export type CronComputerUseScreenshotCleanupContract =
 export type CronArtifactPreviewContract = typeof cronArtifactPreviewContract;
 export type CronDrainEmailOutboxContract = typeof cronDrainEmailOutboxContract;
 export type CronSyncSkillsContract = typeof cronSyncSkillsContract;
+export type CronConnectorCatalogContract = typeof cronConnectorCatalogContract;
 export type CronRenewGmailWatchesContract =
   typeof cronRenewGmailWatchesContract;
 export type CronRenewGoogleCalendarWatchesContract =

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -111,7 +111,6 @@ export const connectorCatalogSyncFailureCodeSchema = z.enum([
   "invalid-artifact",
   "public-leakage",
   "relationship-mismatch",
-  "conflicting-release",
 ]);
 
 const connectorCatalogSyncStatusSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -108,7 +108,6 @@ export const connectorCatalogSyncFailureCodeSchema = z.enum([
   "invalid-reference",
   "digest-mismatch",
   "unsupported-schema",
-  "unsupported-capability",
   "invalid-artifact",
   "public-leakage",
   "relationship-mismatch",

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -116,7 +116,6 @@ export const connectorCatalogSyncFailureCodeSchema = z.enum([
 ]);
 
 const connectorCatalogSyncStatusSchema = z.object({
-  configured: z.boolean(),
   state: z.enum(["never-synced", "current", "stale"]),
   active: z
     .object({
@@ -137,7 +136,7 @@ const connectorCatalogSyncStatusSchema = z.object({
 
 const connectorCatalogSyncResponseSchema =
   connectorCatalogSyncStatusSchema.extend({
-    outcome: z.enum(["disabled", "accepted", "unchanged", "rejected"]),
+    outcome: z.enum(["accepted", "unchanged", "rejected"]),
   });
 
 export type ConnectorCatalogSyncFailureCode = z.infer<

--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -263,12 +263,12 @@ function compareConstraints(
 } {
   const map1 = new Map(
     constraints1.map((c) => {
-      return [c.constraint_name, c];
+      return [`${c.table_name}.${c.constraint_name}`, c];
     }),
   );
   const map2 = new Map(
     constraints2.map((c) => {
-      return [c.constraint_name, c];
+      return [`${c.table_name}.${c.constraint_name}`, c];
     }),
   );
 

--- a/turbo/packages/db/scripts/compare-schemas-normalized.ts
+++ b/turbo/packages/db/scripts/compare-schemas-normalized.ts
@@ -79,35 +79,25 @@ async function getIndexes(client: Client): Promise<IndexInfo[]> {
 async function getConstraints(client: Client): Promise<ConstraintInfo[]> {
   const result = await client.query<ConstraintInfo>(`
     SELECT
-      tc.table_name,
-      tc.constraint_name,
-      tc.constraint_type,
-      CASE
-        WHEN tc.constraint_type = 'FOREIGN KEY' THEN
-          'FOREIGN KEY (' || kcu.column_name || ') REFERENCES ' ||
-          ccu.table_name || '(' || ccu.column_name || ')' ||
-          COALESCE(' ON DELETE ' || rc.delete_rule, '') ||
-          COALESCE(' ON UPDATE ' || rc.update_rule, '')
-        WHEN tc.constraint_type = 'UNIQUE' THEN
-          'UNIQUE (' || kcu.column_name || ')'
-        WHEN tc.constraint_type = 'PRIMARY KEY' THEN
-          'PRIMARY KEY (' || kcu.column_name || ')'
-        ELSE
-          ''
-      END as constraint_def
-    FROM information_schema.table_constraints tc
-    LEFT JOIN information_schema.key_column_usage kcu
-      ON tc.constraint_name = kcu.constraint_name
-      AND tc.table_schema = kcu.table_schema
-    LEFT JOIN information_schema.constraint_column_usage ccu
-      ON ccu.constraint_name = tc.constraint_name
-      AND ccu.table_schema = tc.table_schema
-    LEFT JOIN information_schema.referential_constraints rc
-      ON rc.constraint_name = tc.constraint_name
-      AND rc.constraint_schema = tc.table_schema
-    WHERE tc.table_schema = 'public'
-      AND tc.constraint_type != 'CHECK'  -- Ignore CHECK constraints
-    ORDER BY tc.table_name, tc.constraint_type, kcu.column_name
+      relation.relname as table_name,
+      catalog_constraint.conname as constraint_name,
+      CASE catalog_constraint.contype
+        WHEN 'p' THEN 'PRIMARY KEY'
+        WHEN 'f' THEN 'FOREIGN KEY'
+        WHEN 'u' THEN 'UNIQUE'
+        WHEN 'x' THEN 'EXCLUDE'
+        ELSE catalog_constraint.contype::text
+      END as constraint_type,
+      pg_get_constraintdef(catalog_constraint.oid) as constraint_def
+    FROM pg_constraint catalog_constraint
+    JOIN pg_class relation ON relation.oid = catalog_constraint.conrelid
+    JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND catalog_constraint.contype != 'c'  -- Ignore CHECK constraints
+    ORDER BY
+      relation.relname,
+      catalog_constraint.contype,
+      catalog_constraint.conname
   `);
   return result.rows;
 }

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -106,6 +106,7 @@ import * as gmailEventSchema from "./schema/gmail-event";
 import * as notionEventSchema from "./schema/notion-event";
 import * as googleCalendarEventSchema from "./schema/google-calendar-event";
 import * as googleWorkspaceEventSchema from "./schema/google-workspace-event";
+import * as connectorCatalogSchema from "./schema/connector-catalog";
 
 export const schema = {
   ...userSchema,
@@ -216,6 +217,7 @@ export const schema = {
   ...notionEventSchema,
   ...googleCalendarEventSchema,
   ...googleWorkspaceEventSchema,
+  ...connectorCatalogSchema,
 };
 
 export type DatabaseSchema = typeof schema;

--- a/turbo/packages/db/src/migrations/0605_luxuriant_ender_wiggin.sql
+++ b/turbo/packages/db/src/migrations/0605_luxuriant_ender_wiggin.sql
@@ -1,0 +1,83 @@
+CREATE TABLE "connector_catalog_active_snapshot" (
+	"source_id" varchar(64) NOT NULL,
+	"schema_version" integer NOT NULL,
+	"catalog_version" varchar(255) NOT NULL,
+	"integrity_digest" varchar(71) NOT NULL,
+	"public_catalog_digest" varchar(71) NOT NULL,
+	"private_catalog_digest" varchar(71) NOT NULL,
+	"private_firewalls_digest" varchar(71) NOT NULL,
+	"runner_firewalls_digest" varchar(71) NOT NULL,
+	"public_catalog" text NOT NULL,
+	"private_catalog" text NOT NULL,
+	"private_firewalls" text NOT NULL,
+	"runner_firewalls" text NOT NULL,
+	"activated_at" timestamp NOT NULL,
+	CONSTRAINT "connector_catalog_active_snapshot_pk" PRIMARY KEY("source_id","schema_version"),
+	CONSTRAINT "connector_catalog_active_snapshot_schema_version_positive" CHECK ("connector_catalog_active_snapshot"."schema_version" > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "connector_catalog_sync_state" (
+	"source_id" varchar(64) NOT NULL,
+	"schema_version" integer NOT NULL,
+	"revision" integer DEFAULT 0 NOT NULL,
+	"last_observed_catalog_version" varchar(255),
+	"last_observed_integrity_digest" varchar(71),
+	"last_observed_pointer_etag" text,
+	"last_attempt_at" timestamp,
+	"last_attempt_outcome" varchar(32),
+	"last_success_at" timestamp,
+	"last_failure_code" varchar(64),
+	"last_rejected_catalog_version" varchar(255),
+	"last_rejected_integrity_digest" varchar(71),
+	"last_rejected_pointer_etag" text,
+	"last_rejected_failure_code" varchar(64),
+	CONSTRAINT "connector_catalog_sync_state_pk" PRIMARY KEY("source_id","schema_version"),
+	CONSTRAINT "connector_catalog_sync_state_schema_version_positive" CHECK ("connector_catalog_sync_state"."schema_version" > 0),
+	CONSTRAINT "connector_catalog_sync_state_revision_nonnegative" CHECK ("connector_catalog_sync_state"."revision" >= 0),
+	CONSTRAINT "connector_catalog_sync_state_observed_identity_complete" CHECK ((
+          "connector_catalog_sync_state"."last_observed_catalog_version" IS NULL
+          AND "connector_catalog_sync_state"."last_observed_integrity_digest" IS NULL
+        ) OR (
+          "connector_catalog_sync_state"."last_observed_catalog_version" IS NOT NULL
+          AND "connector_catalog_sync_state"."last_observed_integrity_digest" IS NOT NULL
+        )),
+	CONSTRAINT "connector_catalog_sync_state_attempt_complete" CHECK ((
+          "connector_catalog_sync_state"."last_attempt_outcome" IS NULL
+          AND "connector_catalog_sync_state"."last_attempt_at" IS NULL
+          AND "connector_catalog_sync_state"."last_failure_code" IS NULL
+        ) OR (
+          "connector_catalog_sync_state"."last_attempt_outcome" = 'rejected'
+          AND "connector_catalog_sync_state"."last_attempt_at" IS NOT NULL
+          AND "connector_catalog_sync_state"."last_failure_code" IS NOT NULL
+        ) OR (
+          "connector_catalog_sync_state"."last_attempt_outcome" IN ('accepted', 'unchanged')
+          AND "connector_catalog_sync_state"."last_attempt_at" IS NOT NULL
+          AND "connector_catalog_sync_state"."last_failure_code" IS NULL
+        )),
+	CONSTRAINT "connector_catalog_sync_state_rejected_candidate_complete" CHECK ((
+          "connector_catalog_sync_state"."last_rejected_catalog_version" IS NULL
+          AND "connector_catalog_sync_state"."last_rejected_integrity_digest" IS NULL
+          AND "connector_catalog_sync_state"."last_rejected_pointer_etag" IS NULL
+          AND "connector_catalog_sync_state"."last_rejected_failure_code" IS NULL
+        ) OR (
+          "connector_catalog_sync_state"."last_rejected_failure_code" IS NOT NULL
+          AND "connector_catalog_sync_state"."last_rejected_failure_code" <> 'source-unavailable'
+          AND (
+            (
+              "connector_catalog_sync_state"."last_rejected_catalog_version" IS NOT NULL
+              AND "connector_catalog_sync_state"."last_rejected_integrity_digest" IS NOT NULL
+            ) OR "connector_catalog_sync_state"."last_rejected_pointer_etag" IS NOT NULL
+          )
+          AND (
+            (
+              "connector_catalog_sync_state"."last_rejected_catalog_version" IS NULL
+              AND "connector_catalog_sync_state"."last_rejected_integrity_digest" IS NULL
+            ) OR (
+              "connector_catalog_sync_state"."last_rejected_catalog_version" IS NOT NULL
+              AND "connector_catalog_sync_state"."last_rejected_integrity_digest" IS NOT NULL
+            )
+          )
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "connector_catalog_active_snapshot" ADD CONSTRAINT "connector_catalog_active_snapshot_sync_state_fk" FOREIGN KEY ("source_id","schema_version") REFERENCES "public"."connector_catalog_sync_state"("source_id","schema_version") ON DELETE no action ON UPDATE no action;

--- a/turbo/packages/db/src/migrations/meta/0605_snapshot.json
+++ b/turbo/packages/db/src/migrations/meta/0605_snapshot.json
@@ -1,0 +1,21979 @@
+{
+  "id": "5e9e3b89-95ba-48b0-8265-66daa86d3ba5",
+  "prevId": "f3537474-06e7-4ebd-b04b-51cf4c16d657",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_kind": {
+          "name": "internal_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_custom_connector_auth_refs": {
+      "name": "agent_run_custom_connector_auth_refs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_custom_connector_auth_refs_expires": {
+          "name": "idx_agent_run_custom_connector_auth_refs_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_custom_connector_auth_refs_run_id_agent_runs_id_fk": {
+          "name": "agent_run_custom_connector_auth_refs_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_custom_connector_auth_refs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_run_custom_connector_auth_refs_run_id_secret_name_pk": {
+          "name": "agent_run_custom_connector_auth_refs_run_id_secret_name_pk",
+          "columns": [
+            "run_id",
+            "secret_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_volumes": {
+          "name": "additional_volumes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_completed_org_user": {
+          "name": "idx_agent_runs_completed_org_user",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"completed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose": {
+          "name": "idx_agent_sessions_user_compose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_thread_sessions": {
+      "name": "agentphone_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_thread_sessions_link_root": {
+          "name": "idx_agentphone_thread_sessions_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_thread_sessions_user_link": {
+          "name": "idx_agentphone_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_thread_sessions_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "agentphone_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "agentphone_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_pkey": {
+          "name": "agentphone_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_vm0_org": {
+          "name": "idx_agentphone_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_access_audit_events": {
+      "name": "banking_access_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_access_audit_org_user": {
+          "name": "idx_banking_access_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_run": {
+          "name": "idx_banking_access_audit_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_created": {
+          "name": "idx_banking_access_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_accounts": {
+      "name": "banking_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number_last4": {
+          "name": "account_number_last4",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_accounts_connection_provider_account": {
+          "name": "idx_banking_accounts_connection_provider_account",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_accounts_org_user": {
+          "name": "idx_banking_accounts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_accounts_connection_id_banking_connections_id_fk": {
+          "name": "banking_accounts_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_accounts",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_agent_enablements": {
+      "name": "banking_agent_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_provider_ids": {
+          "name": "account_provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "operation_scopes": {
+          "name": "operation_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"accounts.read\",\"balances.read\",\"transactions.read\"]'::jsonb"
+        },
+        "allow_automation_runs": {
+          "name": "allow_automation_runs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_agent_enablements_unique": {
+          "name": "idx_banking_agent_enablements_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_agent_enablements_agent_user": {
+          "name": "idx_banking_agent_enablements_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_agent_enablements_agent_id_zero_agents_id_fk": {
+          "name": "banking_agent_enablements_agent_id_zero_agents_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banking_agent_enablements_connection_id_banking_connections_id_fk": {
+          "name": "banking_agent_enablements_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connections": {
+      "name": "banking_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consent_expires_at": {
+          "name": "consent_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_metadata": {
+          "name": "audit_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connections_owner_provider": {
+          "name": "idx_banking_connections_owner_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connections_org_user": {
+          "name": "idx_banking_connections_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raw_size": {
+          "name": "raw_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoded_size": {
+          "name": "encoded_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message_queue": {
+      "name": "chat_message_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "chat_message_queue_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_message_id": {
+          "name": "chat_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_message_queue_thread_created": {
+          "name": "idx_chat_message_queue_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_message_queue_trigger": {
+          "name": "idx_chat_message_queue_trigger",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_message_queue\".\"trigger_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_queue_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_message_queue_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_message_queue",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_message_queue_chat_message_id_chat_messages_id_fk": {
+          "name": "chat_message_queue_chat_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_message_queue",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "chat_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_message_queue_trigger_id_zero_workflow_automations_id_fk": {
+          "name": "chat_message_queue_trigger_id_zero_workflow_automations_id_fk",
+          "tableFrom": "chat_message_queue",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_payload": {
+          "name": "usage_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_message_id": {
+          "name": "revokes_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interrupts_run_id": {
+          "name": "interrupts_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_group_id": {
+          "name": "run_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_lifecycle_event": {
+          "name": "run_lifecycle_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_event": {
+          "name": "goal_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_snapshot": {
+          "name": "goal_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_files": {
+          "name": "attach_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attach_file_metadata": {
+          "name": "attach_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_template": {
+          "name": "generation_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_draft": {
+          "name": "mail_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_followups": {
+          "name": "recommended_followups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_thread_created": {
+          "name": "idx_chat_messages_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_thread_run_finish_created": {
+          "name": "idx_chat_messages_thread_run_finish_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_messages\".\"run_lifecycle_event\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_run_id": {
+          "name": "idx_chat_messages_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_usage_run_id_idx": {
+          "name": "chat_messages_usage_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_messages\".\"usage_payload\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_revokes_message_id_unique": {
+          "name": "chat_messages_revokes_message_id_unique",
+          "columns": [
+            {
+              "expression": "revokes_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_interrupts_run_id_unique": {
+          "name": "chat_messages_interrupts_run_id_unique",
+          "columns": [
+            {
+              "expression": "interrupts_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_run_group_id": {
+          "name": "idx_chat_messages_run_group_id",
+          "columns": [
+            {
+              "expression": "run_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_messages\".\"run_group_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_seq_unique": {
+          "name": "chat_messages_run_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_lifecycle_unique": {
+          "name": "chat_messages_run_lifecycle_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_messages\".\"run_lifecycle_event\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_run_thinking_unique": {
+          "name": "chat_messages_run_thinking_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_messages\".\"thinking\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_revokes_message_id_chat_messages_id_fk": {
+          "name": "chat_messages_revokes_message_id_chat_messages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "revokes_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_messages_interrupts_run_id_agent_runs_id_fk": {
+          "name": "chat_messages_interrupts_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "interrupts_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_output_materializations": {
+      "name": "chat_output_materializations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "processed_through_sequence": {
+          "name": "processed_through_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "latest_result_sequence": {
+          "name": "latest_result_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_output_materializations_run_id_agent_runs_id_fk": {
+          "name": "chat_output_materializations_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_output_materializations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_events": {
+      "name": "chat_thread_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "chat_thread_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_events_user_org_created": {
+          "name": "idx_chat_thread_events_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_events_thread_created": {
+          "name": "idx_chat_thread_events_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_snapshots": {
+      "name": "chat_thread_snapshots",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_threads": {
+          "name": "chat_threads",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_thread_snapshots_user_id_org_id_pk": {
+          "name": "chat_thread_snapshots_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier": {
+          "name": "codex_service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_template": {
+          "name": "generation_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queue_paused_at": {
+          "name": "queue_paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_pinned": {
+          "name": "idx_chat_threads_user_compose_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_compose_last_message": {
+          "name": "idx_chat_threads_user_compose_last_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_computer_use_host_id_computer_use_hosts_id_fk": {
+          "name": "chat_threads_computer_use_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "computer_use_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshots": {
+          "name": "artifact_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_authorization_requests": {
+      "name": "computer_use_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_token_hash": {
+          "name": "request_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_connection_id": {
+          "name": "slack_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_connection_id": {
+          "name": "teams_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_conversation_id": {
+          "name": "teams_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_thread_id": {
+          "name": "teams_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_auth_requests_token_hash": {
+          "name": "idx_computer_use_auth_requests_token_hash",
+          "columns": [
+            {
+              "expression": "request_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_org_user": {
+          "name": "idx_computer_use_auth_requests_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_expires": {
+          "name": "idx_computer_use_auth_requests_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "computer_use_auth_requests_source_check": {
+          "name": "computer_use_auth_requests_source_check",
+          "value": "source IN ('chat', 'slack', 'teams')"
+        },
+        "computer_use_auth_requests_scope_check": {
+          "name": "computer_use_auth_requests_scope_check",
+          "value": "(\n          source = 'chat'\n          AND chat_thread_id IS NOT NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'slack'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NOT NULL\n          AND slack_channel_id IS NOT NULL\n          AND slack_thread_ts IS NOT NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'teams'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NOT NULL\n          AND teams_conversation_id IS NOT NULL\n          AND teams_thread_id IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_active_installation": {
+          "name": "idx_computer_use_hosts_active_installation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_active_snapshot": {
+      "name": "connector_catalog_active_snapshot",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity_digest": {
+          "name": "integrity_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_catalog_digest": {
+          "name": "public_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_catalog_digest": {
+          "name": "private_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_firewalls_digest": {
+          "name": "private_firewalls_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_firewalls_digest": {
+          "name": "runner_firewalls_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_catalog": {
+          "name": "public_catalog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_catalog": {
+          "name": "private_catalog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_firewalls": {
+          "name": "private_firewalls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_firewalls": {
+          "name": "runner_firewalls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_active_snapshot_sync_state_fk": {
+          "name": "connector_catalog_active_snapshot_sync_state_fk",
+          "tableFrom": "connector_catalog_active_snapshot",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_active_snapshot_pk": {
+          "name": "connector_catalog_active_snapshot_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_active_snapshot_schema_version_positive": {
+          "name": "connector_catalog_active_snapshot_schema_version_positive",
+          "value": "\"connector_catalog_active_snapshot\".\"schema_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_sync_state": {
+      "name": "connector_catalog_sync_state",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_observed_catalog_version": {
+          "name": "last_observed_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_integrity_digest": {
+          "name": "last_observed_integrity_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_pointer_etag": {
+          "name": "last_observed_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_outcome": {
+          "name": "last_attempt_outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_version": {
+          "name": "last_rejected_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_integrity_digest": {
+          "name": "last_rejected_integrity_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_pointer_etag": {
+          "name": "last_rejected_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_failure_code": {
+          "name": "last_rejected_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_catalog_sync_state_pk": {
+          "name": "connector_catalog_sync_state_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_sync_state_schema_version_positive": {
+          "name": "connector_catalog_sync_state_schema_version_positive",
+          "value": "\"connector_catalog_sync_state\".\"schema_version\" > 0"
+        },
+        "connector_catalog_sync_state_revision_nonnegative": {
+          "name": "connector_catalog_sync_state_revision_nonnegative",
+          "value": "\"connector_catalog_sync_state\".\"revision\" >= 0"
+        },
+        "connector_catalog_sync_state_observed_identity_complete": {
+          "name": "connector_catalog_sync_state_observed_identity_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_integrity_digest\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_integrity_digest\" IS NOT NULL\n        )"
+        },
+        "connector_catalog_sync_state_attempt_complete": {
+          "name": "connector_catalog_sync_state_attempt_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" = 'rejected'\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NOT NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IN ('accepted', 'unchanged')\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        )"
+        },
+        "connector_catalog_sync_state_rejected_candidate_complete": {
+          "name": "connector_catalog_sync_state_rejected_candidate_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_integrity_digest\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" <> 'source-unavailable'\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_integrity_digest\" IS NOT NULL\n            ) OR \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NOT NULL\n          )\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_integrity_digest\" IS NULL\n            ) OR (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_integrity_digest\" IS NOT NULL\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_external_code_sessions": {
+      "name": "connector_external_code_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_external_code_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_external_code_sessions_token": {
+          "name": "idx_connector_external_code_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_owner_status": {
+          "name": "idx_connector_external_code_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_expiration": {
+          "name": "idx_connector_external_code_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_owner_status": {
+          "name": "idx_connector_oauth_device_authorization_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconnect_reason": {
+          "name": "reconnect_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ble_session_nonce": {
+          "name": "ble_session_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_token_hash": {
+          "name": "poll_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_token_id": {
+          "name": "cli_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_slack_mock_call_log": {
+      "name": "e2e_slack_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_slack_mock_call_log_created_at": {
+          "name": "idx_e2e_slack_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_slack_mock_call_log_method": {
+          "name": "idx_e2e_slack_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_teams_mock_call_log": {
+      "name": "e2e_teams_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_teams_mock_call_log_created_at": {
+          "name": "idx_e2e_teams_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_teams_mock_call_log_method": {
+          "name": "idx_e2e_teams_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_teams_mock_call_log_tenant": {
+          "name": "idx_e2e_teams_mock_call_log_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_teams_mock_call_log_conversation": {
+          "name": "idx_e2e_teams_mock_call_log_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.e2e_telegram_mock_call_log": {
+      "name": "e2e_telegram_mock_call_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_json": {
+          "name": "body_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_e2e_telegram_mock_call_log_created_at": {
+          "name": "idx_e2e_telegram_mock_call_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_method": {
+          "name": "idx_e2e_telegram_mock_call_log_method",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_e2e_telegram_mock_call_log_chat_id": {
+          "name": "idx_e2e_telegram_mock_call_log_chat_id",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_processed_events": {
+      "name": "gmail_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_processed_events_automation_event": {
+          "name": "idx_gmail_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_processed_events_pubsub_message": {
+          "name": "idx_gmail_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk": {
+          "name": "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "gmail_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_processed_events_automation_id_zero_workflow_automations_id_fk": {
+          "name": "gmail_processed_events_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_watch_states": {
+      "name": "gmail_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_history_id": {
+          "name": "last_history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_watch_states_connector_topic": {
+          "name": "idx_gmail_watch_states_connector_topic",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_email_topic": {
+          "name": "idx_gmail_watch_states_email_topic",
+          "columns": [
+            {
+              "expression": "email_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_renewal": {
+          "name": "idx_gmail_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_watch_states_connector_id_connectors_id_fk": {
+          "name": "gmail_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "gmail_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_event_snapshots": {
+      "name": "google_calendar_event_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_event_snapshots_event": {
+          "name": "idx_google_calendar_event_snapshots_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_event_snapshots_updated": {
+          "name": "idx_google_calendar_event_snapshots_updated",
+          "columns": [
+            {
+              "expression": "event_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_event_snapshots",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_processed_events": {
+      "name": "google_calendar_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_state": {
+          "name": "resource_state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_change_key": {
+          "name": "event_change_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_processed_events_automation_event": {
+          "name": "idx_google_calendar_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_change_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_processed_events_channel": {
+          "name": "idx_google_calendar_processed_events_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_processed_events_automation_id_zero_workflow_automations_id_fk": {
+          "name": "google_calendar_processed_events_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_watch_states": {
+      "name": "google_calendar_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_token": {
+          "name": "channel_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_uri": {
+          "name": "resource_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_watch_states_connector_calendar": {
+          "name": "idx_google_calendar_watch_states_connector_calendar",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_channel": {
+          "name": "idx_google_calendar_watch_states_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_resource": {
+          "name": "idx_google_calendar_watch_states_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_renewal": {
+          "name": "idx_google_calendar_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_watch_states_connector_id_connectors_id_fk": {
+          "name": "google_calendar_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_calendar_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_event_subscription_states": {
+      "name": "google_workspace_event_subscription_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_resource": {
+          "name": "target_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types_key": {
+          "name": "event_types_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_name": {
+          "name": "subscription_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_topic": {
+          "name": "pubsub_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expire_time": {
+          "name": "expire_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_repair": {
+          "name": "needs_repair",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_event_subscription_scope": {
+          "name": "idx_google_workspace_event_subscription_scope",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pubsub_topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_types_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_name": {
+          "name": "idx_google_workspace_event_subscription_name",
+          "columns": [
+            {
+              "expression": "subscription_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_owner": {
+          "name": "idx_google_workspace_event_subscription_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_renewal": {
+          "name": "idx_google_workspace_event_subscription_renewal",
+          "columns": [
+            {
+              "expression": "expire_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_event_subscription_states_connector_id_connectors_id_fk": {
+          "name": "google_workspace_event_subscription_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_workspace_event_subscription_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_processed_events": {
+      "name": "google_workspace_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_state_id": {
+          "name": "subscription_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_event_id": {
+          "name": "cloud_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_event_type": {
+          "name": "cloud_event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference_record_name": {
+          "name": "conference_record_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_name": {
+          "name": "transcript_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_processed_events_automation_cloudevent": {
+          "name": "idx_google_workspace_processed_events_automation_cloudevent",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cloud_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_automation_transcript": {
+          "name": "idx_google_workspace_processed_events_automation_transcript",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcript_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_pubsub_message": {
+          "name": "idx_google_workspace_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk": {
+          "name": "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "google_workspace_event_subscription_states",
+          "columnsFrom": [
+            "subscription_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_workspace_processed_events_automation_id_zero_workflow_automations_id_fk": {
+          "name": "google_workspace_processed_events_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.html_artifact_edit_drafts": {
+      "name": "html_artifact_edit_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_html_artifact_edit_drafts_thread_artifact": {
+          "name": "idx_html_artifact_edit_drafts_thread_artifact",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_html_artifact_edit_drafts_thread": {
+          "name": "idx_html_artifact_edit_drafts_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "html_artifact_edit_drafts_chat_thread_id_chat_threads_id_fk": {
+          "name": "html_artifact_edit_drafts_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "html_artifact_edit_drafts",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_artifact_edit_snapshots": {
+      "name": "image_artifact_edit_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_image_artifact_edit_snapshots_owner_artifact": {
+          "name": "idx_image_artifact_edit_snapshots_owner_artifact",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_daily": {
+      "name": "insights_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_insights_daily_org_user_date": {
+          "name": "uq_insights_daily_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insights_daily_org_user_date_desc": {
+          "name": "idx_insights_daily_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_change_items": {
+      "name": "memory_change_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_change_items_summary": {
+          "name": "idx_memory_change_items_summary",
+          "columns": [
+            {
+              "expression": "summary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_change_items_summary_id_memory_change_summaries_id_fk": {
+          "name": "memory_change_items_summary_id_memory_change_summaries_id_fk",
+          "tableFrom": "memory_change_items",
+          "tableTo": "memory_change_summaries",
+          "columnsFrom": [
+            "summary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_change_summaries": {
+      "name": "memory_change_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_memory_change_summaries_org_user_date": {
+          "name": "uq_memory_change_summaries_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_change_summaries_org_user_date_desc": {
+          "name": "idx_memory_change_summaries_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "source_count": {
+          "name": "source_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memories_scope_kind": {
+          "name": "idx_memories_scope_kind",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_context_status": {
+          "name": "idx_memories_context_status",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_entity_status": {
+          "name": "idx_memories_entity_status",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memories_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memories_entity_id_memory_entities_id_fk": {
+          "name": "memories_entity_id_memory_entities_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "memory_entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_context_spaces": {
+      "name": "memory_context_spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_context_spaces_key": {
+          "name": "idx_memory_context_spaces_key",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_context_spaces_scope_type": {
+          "name": "idx_memory_context_spaces_scope_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_document_chunks": {
+      "name": "memory_document_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation": {
+          "name": "citation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_document_chunks_document_index": {
+          "name": "idx_memory_document_chunks_document_index",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_document_chunks_context_status": {
+          "name": "idx_memory_document_chunks_context_status",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_document_chunks_source": {
+          "name": "idx_memory_document_chunks_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_document_chunks_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_document_chunks_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_document_chunks",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_document_chunks_document_id_memory_documents_id_fk": {
+          "name": "memory_document_chunks_document_id_memory_documents_id_fk",
+          "tableFrom": "memory_document_chunks",
+          "tableTo": "memory_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_document_chunks_source_id_memory_sources_id_fk": {
+          "name": "memory_document_chunks_source_id_memory_sources_id_fk",
+          "tableFrom": "memory_document_chunks",
+          "tableTo": "memory_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_document_search_entries": {
+      "name": "memory_document_search_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_document_search_entries_chunk": {
+          "name": "idx_memory_document_search_entries_chunk",
+          "columns": [
+            {
+              "expression": "chunk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_document_search_entries_scope_status": {
+          "name": "idx_memory_document_search_entries_scope_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_document_search_entries_context": {
+          "name": "idx_memory_document_search_entries_context",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_document_search_entries_embedding_hnsw": {
+          "name": "idx_memory_document_search_entries_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_document_search_entries_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_document_search_entries_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_document_search_entries",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_document_search_entries_document_id_memory_documents_id_fk": {
+          "name": "memory_document_search_entries_document_id_memory_documents_id_fk",
+          "tableFrom": "memory_document_search_entries",
+          "tableTo": "memory_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_document_search_entries_chunk_id_memory_document_chunks_id_fk": {
+          "name": "memory_document_search_entries_chunk_id_memory_document_chunks_id_fk",
+          "tableFrom": "memory_document_search_entries",
+          "tableTo": "memory_document_chunks",
+          "columnsFrom": [
+            "chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_documents": {
+      "name": "memory_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_documents_external": {
+          "name": "idx_memory_documents_external",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_documents_context_status": {
+          "name": "idx_memory_documents_context_status",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_documents_scope_provider": {
+          "name": "idx_memory_documents_scope_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_documents_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_documents_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_documents",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_documents_source_id_memory_sources_id_fk": {
+          "name": "memory_documents_source_id_memory_sources_id_fk",
+          "tableFrom": "memory_documents",
+          "tableTo": "memory_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_edges": {
+      "name": "memory_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_memory_id": {
+          "name": "from_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_memory_id": {
+          "name": "to_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_type": {
+          "name": "edge_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_edges_unique": {
+          "name": "idx_memory_edges_unique",
+          "columns": [
+            {
+              "expression": "from_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_edges_to": {
+          "name": "idx_memory_edges_to",
+          "columns": [
+            {
+              "expression": "to_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_edges_from_memory_id_memories_id_fk": {
+          "name": "memory_edges_from_memory_id_memories_id_fk",
+          "tableFrom": "memory_edges",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "from_memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_edges_to_memory_id_memories_id_fk": {
+          "name": "memory_edges_to_memory_id_memories_id_fk",
+          "tableFrom": "memory_edges",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "to_memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_entities": {
+      "name": "memory_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_entities_scope_type": {
+          "name": "idx_memory_entities_scope_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_entity_aliases": {
+      "name": "memory_entity_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_type": {
+          "name": "alias_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_value": {
+          "name": "alias_value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_entity_aliases_alias": {
+          "name": "idx_memory_entity_aliases_alias",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entity_aliases_entity": {
+          "name": "idx_memory_entity_aliases_entity",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entity_aliases_entity_id_memory_entities_id_fk": {
+          "name": "memory_entity_aliases_entity_id_memory_entities_id_fk",
+          "tableFrom": "memory_entity_aliases",
+          "tableTo": "memory_entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_profiles": {
+      "name": "memory_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_memory_count": {
+          "name": "source_memory_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_profiles_entity_section": {
+          "name": "idx_memory_profiles_entity_section",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_profiles_scope": {
+          "name": "idx_memory_profiles_scope",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_profiles_context": {
+          "name": "idx_memory_profiles_context",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_profiles_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_profiles_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_profiles",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memory_profiles_entity_id_memory_entities_id_fk": {
+          "name": "memory_profiles_entity_id_memory_entities_id_fk",
+          "tableFrom": "memory_profiles",
+          "tableTo": "memory_entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_search_entries": {
+      "name": "memory_search_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_kind": {
+          "name": "entry_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_kind": {
+          "name": "memory_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_search_entries_memory_kind": {
+          "name": "idx_memory_search_entries_memory_kind",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_search_entries_scope_status_kind": {
+          "name": "idx_memory_search_entries_scope_status_kind",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_search_entries_context": {
+          "name": "idx_memory_search_entries_context",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_search_entries_entity": {
+          "name": "idx_memory_search_entries_entity",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_search_entries_embedding_hnsw": {
+          "name": "idx_memory_search_entries_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_search_entries_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_search_entries_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_search_entries",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memory_search_entries_memory_id_memories_id_fk": {
+          "name": "memory_search_entries_memory_id_memories_id_fk",
+          "tableFrom": "memory_search_entries",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_search_entries_entity_id_memory_entities_id_fk": {
+          "name": "memory_search_entries_entity_id_memory_entities_id_fk",
+          "tableFrom": "memory_search_entries",
+          "tableTo": "memory_entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_source_links": {
+      "name": "memory_source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_source_links_pair": {
+          "name": "idx_memory_source_links_pair",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_source_links_source": {
+          "name": "idx_memory_source_links_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_source_links_memory_id_memories_id_fk": {
+          "name": "memory_source_links_memory_id_memories_id_fk",
+          "tableFrom": "memory_source_links",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_source_links_source_id_memory_sources_id_fk": {
+          "name": "memory_source_links_source_id_memory_sources_id_fk",
+          "tableFrom": "memory_source_links",
+          "tableTo": "memory_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_sources": {
+      "name": "memory_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_sources_external": {
+          "name": "idx_memory_sources_external",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_sources_scope_provider": {
+          "name": "idx_memory_sources_scope_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_sources_context_space": {
+          "name": "idx_memory_sources_context_space",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_sources_occurred": {
+          "name": "idx_memory_sources_occurred",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_sources_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_sources_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_sources",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_tombstones": {
+      "name": "memory_tombstones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_tombstones_fingerprint": {
+          "name": "idx_memory_tombstones_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_tombstones_context": {
+          "name": "idx_memory_tombstones_context",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_tombstones_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_tombstones_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_tombstones",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_versions": {
+      "name": "memory_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_space_id": {
+          "name": "context_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_versions_target_version": {
+          "name": "idx_memory_versions_target_version",
+          "columns": [
+            {
+              "expression": "target_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_versions_scope": {
+          "name": "idx_memory_versions_scope",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_versions_context": {
+          "name": "idx_memory_versions_context",
+          "columns": [
+            {
+              "expression": "context_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_versions_context_space_id_memory_context_spaces_id_fk": {
+          "name": "memory_versions_context_space_id_memory_context_spaces_id_fk",
+          "tableFrom": "memory_versions",
+          "tableTo": "memory_context_spaces",
+          "columnsFrom": [
+            "context_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_auth_sessions": {
+      "name": "model_provider_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "model_provider_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_provider_auth_sessions_owner_status": {
+          "name": "idx_model_provider_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_expiration": {
+          "name": "idx_model_provider_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_sandbox": {
+          "name": "idx_model_provider_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_reset_period": {
+          "name": "subscription_reset_period",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_next_reset_at": {
+          "name": "subscription_next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stat": {
+      "name": "model_stat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hour_start": {
+          "name": "hour_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "org_count": {
+          "name": "org_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_count": {
+          "name": "user_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_stat_hour_model_provider": {
+          "name": "uq_model_stat_hour_model_provider",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_hour_start": {
+          "name": "idx_model_stat_hour_start",
+          "columns": [
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_stat_model_hour": {
+          "name": "idx_model_stat_model_hour",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hour_start",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_usage_observation": {
+      "name": "model_usage_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_model_usage_observation_idempotency_key": {
+          "name": "uq_model_usage_observation_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_run_id": {
+          "name": "idx_model_usage_observation_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_observed_at": {
+          "name": "idx_model_usage_observation_observed_at",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_model_observed_at": {
+          "name": "idx_model_usage_observation_model_observed_at",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_observation_org_observed_at": {
+          "name": "idx_model_usage_observation_org_observed_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_usage_observation_run_id_agent_runs_id_fk": {
+          "name": "model_usage_observation_run_id_agent_runs_id_fk",
+          "tableFrom": "model_usage_observation",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_events": {
+      "name": "notion_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notion_event_id": {
+          "name": "notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_events_event_id": {
+          "name": "idx_notion_webhook_events_event_id",
+          "columns": [
+            {
+              "expression": "notion_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_events_page": {
+          "name": "idx_notion_webhook_events_page",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_secrets": {
+      "name": "notion_webhook_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_verification_token": {
+          "name": "encrypted_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_secrets_active": {
+          "name": "idx_notion_webhook_secrets_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_secrets_active_single": {
+          "name": "idx_notion_webhook_secrets_active_single",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "active = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_workflow_pending_events": {
+      "name": "notion_workflow_pending_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_family": {
+          "name": "event_family",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new_child_page'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "first_notion_event_id": {
+          "name": "first_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_notion_event_id": {
+          "name": "latest_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_at": {
+          "name": "first_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_at": {
+          "name": "latest_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_context": {
+          "name": "latest_event_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_after": {
+          "name": "run_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_url": {
+          "name": "parent_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_pending_events_automation_page_family_active": {
+          "name": "idx_notion_pending_events_automation_page_family_active",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_due": {
+          "name": "idx_notion_pending_events_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_page_pending": {
+          "name": "idx_notion_pending_events_page_pending",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_scope": {
+          "name": "idx_notion_pending_events_scope",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notion_workflow_pending_events_automation_id_zero_workflow_automations_id_fk": {
+          "name": "notion_workflow_pending_events_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "notion_workflow_pending_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_entitlements": {
+      "name": "org_concurrency_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_line_id": {
+          "name": "stripe_invoice_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_concurrency_entitlements_invoice_line": {
+          "name": "uq_org_concurrency_entitlements_invoice_line",
+          "columns": [
+            {
+              "expression": "stripe_invoice_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_entitlements_org_active": {
+          "name": "idx_org_concurrency_entitlements_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_entitlements_slots": {
+          "name": "chk_org_concurrency_entitlements_slots",
+          "value": "\"org_concurrency_entitlements\".\"slots\" > 0"
+        },
+        "chk_org_concurrency_entitlements_window": {
+          "name": "chk_org_concurrency_entitlements_window",
+          "value": "\"org_concurrency_entitlements\".\"expires_at\" > \"org_concurrency_entitlements\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_subscriptions": {
+      "name": "org_concurrency_subscriptions",
+      "schema": "",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_concurrency_subscriptions_org": {
+          "name": "idx_org_concurrency_subscriptions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_subscriptions_status_period": {
+          "name": "idx_org_concurrency_subscriptions_status_period",
+          "columns": [
+            {
+              "expression": "subscription_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_subscriptions_slots": {
+          "name": "chk_org_concurrency_subscriptions_slots",
+          "value": "\"org_concurrency_subscriptions\".\"slots\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_secrets": {
+      "name": "org_custom_connector_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_secrets_connector": {
+          "name": "idx_org_custom_connector_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_user": {
+          "name": "idx_org_custom_connector_secrets_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_secrets_connector_user": {
+          "name": "idx_org_custom_connector_secrets_connector_user",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_values": {
+      "name": "org_custom_connector_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_values_connector": {
+          "name": "idx_org_custom_connector_values_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_values_user": {
+          "name": "idx_org_custom_connector_values_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connector_values_unique": {
+          "name": "idx_org_custom_connector_values_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_custom_connector_values_connector_id_org_custom_connectors_id_fk": {
+          "name": "org_custom_connector_values_connector_id_org_custom_connectors_id_fk",
+          "tableFrom": "org_custom_connector_values",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefixes": {
+          "name": "prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_template": {
+          "name": "header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix_templates": {
+          "name": "prefix_templates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "header_injections": {
+          "name": "header_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "query_injections": {
+          "name": "query_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_role": {
+          "name": "onboarding_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'limited-free-1'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_payment_pending": {
+          "name": "onboarding_payment_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_subscription_schedule_id": {
+          "name": "pending_subscription_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_target_tier": {
+          "name": "pending_subscription_target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_change_at": {
+          "name": "pending_subscription_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'vm0' OR model_provider_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_plan_entitlements": {
+      "name": "org_plan_entitlements",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_rank": {
+          "name": "plan_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "base_concurrency_limit": {
+          "name": "base_concurrency_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "can_buy_concurrency": {
+          "name": "can_buy_concurrency",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_allowed": {
+          "name": "auto_recharge_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support_byok": {
+          "name": "support_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restricted_vm0_models": {
+          "name": "restricted_vm0_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "video_generation_allowed": {
+          "name": "video_generation_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflow_webhook_trigger_allowed": {
+          "name": "workflow_webhook_trigger_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_lifetime_limit": {
+          "name": "audio_lifetime_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_daily_rate_limit": {
+          "name": "audio_daily_rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_daily_duration_seconds": {
+          "name": "audio_daily_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_version": {
+          "name": "metadata_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_plan_entitlements_stripe_subscription": {
+          "name": "uq_org_plan_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_status": {
+          "name": "idx_org_plan_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_source": {
+          "name": "idx_org_plan_entitlements_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_expires": {
+          "name": "idx_org_plan_entitlements_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_plan_entitlements_plan_rank": {
+          "name": "chk_org_plan_entitlements_plan_rank",
+          "value": "\"org_plan_entitlements\".\"plan_rank\" >= 0"
+        },
+        "chk_org_plan_entitlements_base_concurrency": {
+          "name": "chk_org_plan_entitlements_base_concurrency",
+          "value": "\"org_plan_entitlements\".\"base_concurrency_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_lifetime": {
+          "name": "chk_org_plan_entitlements_audio_lifetime",
+          "value": "\"org_plan_entitlements\".\"audio_lifetime_limit\" IS NULL OR \"org_plan_entitlements\".\"audio_lifetime_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_rate": {
+          "name": "chk_org_plan_entitlements_audio_daily_rate",
+          "value": "\"org_plan_entitlements\".\"audio_daily_rate_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_duration": {
+          "name": "chk_org_plan_entitlements_audio_daily_duration",
+          "value": "\"org_plan_entitlements\".\"audio_daily_duration_seconds\" >= 0"
+        },
+        "chk_org_plan_entitlements_period": {
+          "name": "chk_org_plan_entitlements_period",
+          "value": "\"org_plan_entitlements\".\"current_period_start\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" > \"org_plan_entitlements\".\"current_period_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_entitlements": {
+      "name": "org_usage_allowance_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "short_window_seconds": {
+          "name": "short_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_window_units": {
+          "name": "short_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_seconds": {
+          "name": "weekly_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "weekly_window_units": {
+          "name": "weekly_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_usage_allowance_entitlements_org": {
+          "name": "uq_org_usage_allowance_entitlements_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_status": {
+          "name": "idx_org_usage_allowance_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_stripe_subscription": {
+          "name": "idx_org_usage_allowance_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_short_window_seconds": {
+          "name": "chk_org_usage_allowance_short_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_short_window_units": {
+          "name": "chk_org_usage_allowance_short_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_seconds": {
+          "name": "chk_org_usage_allowance_weekly_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_units": {
+          "name": "chk_org_usage_allowance_weekly_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_entitlement_time": {
+          "name": "chk_org_usage_allowance_entitlement_time",
+          "value": "\"org_usage_allowance_entitlements\".\"expires_at\" IS NULL OR \"org_usage_allowance_entitlements\".\"expires_at\" > \"org_usage_allowance_entitlements\".\"effective_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_windows": {
+      "name": "org_usage_allowance_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_limit": {
+          "name": "unit_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_units": {
+          "name": "consumed_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_usage_allowance_windows_org_kind_starts": {
+          "name": "idx_org_usage_allowance_windows_org_kind_starts",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_windows_org_kind_expires": {
+          "name": "idx_org_usage_allowance_windows_org_kind_expires",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk": {
+          "name": "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "org_usage_allowance_entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk": {
+          "name": "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_windows_kind": {
+          "name": "chk_org_usage_allowance_windows_kind",
+          "value": "\"org_usage_allowance_windows\".\"kind\" IN ('short', 'weekly')"
+        },
+        "chk_org_usage_allowance_windows_limit": {
+          "name": "chk_org_usage_allowance_windows_limit",
+          "value": "\"org_usage_allowance_windows\".\"unit_limit\" > 0"
+        },
+        "chk_org_usage_allowance_windows_consumed": {
+          "name": "chk_org_usage_allowance_windows_consumed",
+          "value": "\"org_usage_allowance_windows\".\"consumed_units\" >= 0"
+        },
+        "chk_org_usage_allowance_windows_time": {
+          "name": "chk_org_usage_allowance_windows_time",
+          "value": "\"org_usage_allowance_windows\".\"expires_at\" > \"org_usage_allowance_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_allowance_allocations": {
+      "name": "usage_allowance_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_event_id": {
+          "name": "usage_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_window_id": {
+          "name": "short_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_id": {
+          "name": "weekly_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units_applied": {
+          "name": "units_applied",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_allowance_allocations_usage_event": {
+          "name": "uq_usage_allowance_allocations_usage_event",
+          "columns": [
+            {
+              "expression": "usage_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_org": {
+          "name": "idx_usage_allowance_allocations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_run": {
+          "name": "idx_usage_allowance_allocations_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_allowance_allocations_usage_event_id_usage_event_id_fk": {
+          "name": "usage_allowance_allocations_usage_event_id_usage_event_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "usage_event",
+          "columnsFrom": [
+            "usage_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_run_id_agent_runs_id_fk": {
+          "name": "usage_allowance_allocations_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "short_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "weekly_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_allowance_allocations_units": {
+          "name": "chk_usage_allowance_allocations_units",
+          "value": "\"usage_allowance_allocations\".\"units_applied\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relationship_backfill_jobs": {
+      "name": "relationship_backfill_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_page_token": {
+          "name": "next_page_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_total": {
+          "name": "estimated_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_count": {
+          "name": "scanned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enqueued_count": {
+          "name": "enqueued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_relationship_backfill_jobs_provider": {
+          "name": "idx_relationship_backfill_jobs_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationship_backfill_jobs_status": {
+          "name": "idx_relationship_backfill_jobs_status",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relationship_memory_settings": {
+      "name": "relationship_memory_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bootstrap_status": {
+          "name": "bootstrap_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_relationship_memory_settings_provider": {
+          "name": "idx_relationship_memory_settings_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationship_memory_settings_enabled": {
+          "name": "idx_relationship_memory_settings_enabled",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relationship_sync_jobs": {
+      "name": "relationship_sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after_at": {
+          "name": "run_after_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_relationship_sync_jobs_dedupe": {
+          "name": "idx_relationship_sync_jobs_dedupe",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationship_sync_jobs_pending": {
+          "name": "idx_relationship_sync_jobs_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_after_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationship_sync_jobs_scope_provider": {
+          "name": "idx_relationship_sync_jobs_scope_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_idx": {
+          "name": "runner_job_queue_group_profile_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "admittable_profiles": {
+          "name": "admittable_profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "held_session_states": {
+          "name": "held_session_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_computer_use_host": {
+          "name": "idx_slack_org_thread_sessions_computer_use_host",
+          "columns": [
+            {
+              "expression": "computer_use_host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_computer_use_host_id_computer_use_hosts_id_fk": {
+          "name": "slack_org_thread_sessions_computer_use_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "computer_use_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "slack_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_pkey": {
+          "name": "slack_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_storage_presigned_url_cache": {
+      "name": "system_storage_presigned_url_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_storage'"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version_id": {
+          "name": "storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_org_id": {
+          "name": "resolved_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_endpoint": {
+          "name": "public_endpoint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presigned_url": {
+          "name": "presigned_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_after": {
+          "name": "refresh_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_requested_at": {
+          "name": "last_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_system_storage_presigned_url_cache_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_refresh_after",
+          "columns": [
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_last_requested_at": {
+          "name": "idx_system_storage_presigned_url_cache_last_requested_at",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_active_refresh",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_scope_refresh_after",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_scope_active_refresh",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_connections": {
+      "name": "teams_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "teams_user_id": {
+          "name": "teams_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_aad_object_id": {
+          "name": "teams_aad_object_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_user_display_name": {
+          "name": "teams_user_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_user_principal_name": {
+          "name": "teams_user_principal_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_connections_user_tenant": {
+          "name": "idx_teams_org_connections_user_tenant",
+          "columns": [
+            {
+              "expression": "teams_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_aad_tenant": {
+          "name": "idx_teams_org_connections_aad_tenant",
+          "columns": [
+            {
+              "expression": "teams_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_aad_object_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_vm0_tenant": {
+          "name": "idx_teams_org_connections_vm0_tenant",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_tenant": {
+          "name": "idx_teams_org_connections_tenant",
+          "columns": [
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk": {
+          "name": "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk",
+          "tableFrom": "teams_org_connections",
+          "tableTo": "teams_org_installations",
+          "columnsFrom": [
+            "teams_tenant_id"
+          ],
+          "columnsTo": [
+            "teams_tenant_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_installations": {
+      "name": "teams_org_installations",
+      "schema": "",
+      "columns": {
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teams_tenant_name": {
+          "name": "teams_tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_name": {
+          "name": "teams_team_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_app_id": {
+          "name": "teams_app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_installations_org": {
+          "name": "idx_teams_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_installations_org_unique": {
+          "name": "idx_teams_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_thread_sessions": {
+      "name": "teams_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_conversation_id": {
+          "name": "teams_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_channel_id": {
+          "name": "teams_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_thread_id": {
+          "name": "teams_thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_thread_sessions_conn_conversation_thread": {
+          "name": "idx_teams_org_thread_sessions_conn_conversation_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_thread_sessions_connection": {
+          "name": "idx_teams_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_thread_sessions_computer_use_host": {
+          "name": "idx_teams_org_thread_sessions_computer_use_host",
+          "columns": [
+            {
+              "expression": "computer_use_host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_org_thread_sessions_connection_id_teams_org_connections_id_fk": {
+          "name": "teams_org_thread_sessions_connection_id_teams_org_connections_id_fk",
+          "tableFrom": "teams_org_thread_sessions",
+          "tableTo": "teams_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "teams_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "teams_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "teams_org_thread_sessions_computer_use_host_id_computer_use_hosts_id_fk": {
+          "name": "teams_org_thread_sessions_computer_use_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "teams_org_thread_sessions",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "computer_use_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_user_agent_preferences": {
+      "name": "teams_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "teams_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "teams_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teams_user_agent_preferences_pkey": {
+          "name": "teams_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_vm0_org": {
+          "name": "idx_telegram_official_user_links_vm0_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_chat_official_link": {
+          "name": "idx_telegram_thread_sessions_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_official_user_link": {
+          "name": "idx_telegram_thread_sessions_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_thread_sessions_one_owner": {
+          "name": "chk_telegram_thread_sessions_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_compose_id": {
+          "name": "selected_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "selected_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_pkey": {
+          "name": "telegram_user_agent_preferences_pkey",
+          "columns": [
+            "vm0_user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_vm0_installation": {
+          "name": "idx_telegram_user_links_vm0_installation",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_goal_memory_embeddings": {
+      "name": "thread_goal_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_hash": {
+          "name": "query_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_goal_memory_embeddings_goal_id_thread_goals_id_fk": {
+          "name": "thread_goal_memory_embeddings_goal_id_thread_goals_id_fk",
+          "tableFrom": "thread_goal_memory_embeddings",
+          "tableTo": "thread_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_goal_memory_embeddings_dimensions_check": {
+          "name": "thread_goal_memory_embeddings_dimensions_check",
+          "value": "cardinality(\"thread_goal_memory_embeddings\".\"embedding\") = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_goals": {
+      "name": "thread_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_brief": {
+          "name": "objective_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_thread_goals_chat_thread_unique": {
+          "name": "idx_thread_goals_chat_thread_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_owner": {
+          "name": "idx_thread_goals_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_status": {
+          "name": "idx_thread_goals_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_goals_agent_id_zero_agents_id_fk": {
+          "name": "thread_goals_agent_id_zero_agents_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_goals_chat_thread_id_chat_threads_id_fk": {
+          "name": "thread_goals_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_goals_status_check": {
+          "name": "thread_goals_status_check",
+          "value": "status IN ('active', 'paused', 'blocked', 'complete')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_sku": {
+          "name": "billing_sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_artifact_favorites": {
+      "name": "user_artifact_favorites",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_artifact_favorites_org_id_user_id_artifact_url_pk": {
+          "name": "user_artifact_favorites_org_id_user_id_artifact_url_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "artifact_url"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique": {
+          "name": "idx_user_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk": {
+          "name": "user_custom_connectors_custom_connector_id_org_custom_connectors_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_grants": {
+      "name": "user_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_ref": {
+          "name": "connector_ref",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_permission_grants_grant": {
+          "name": "uq_user_permission_grants_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_lookup": {
+          "name": "idx_user_permission_grants_lookup",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_user_id": {
+          "name": "idx_user_permission_grants_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_agent_id": {
+          "name": "idx_user_permission_grants_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_grants_agent_id_zero_agents_id_fk": {
+          "name": "user_permission_grants_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_permission_grants",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_user_permission_grants_action": {
+          "name": "chk_user_permission_grants_action",
+          "value": "\"user_permission_grants\".\"action\" IN ('allow', 'deny')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_type_name": {
+          "name": "idx_variables_org_user_type_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_drafts": {
+      "name": "zero_agent_drafts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_drafts_user_org_agent": {
+          "name": "idx_zero_agent_drafts_user_org_agent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_drafts_agent_id_zero_agents_id_fk": {
+          "name": "zero_agent_drafts_agent_id_zero_agents_id_fk",
+          "tableFrom": "zero_agent_drafts",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agents_model_provider_id_model_providers_id_fk": {
+          "name": "zero_agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_runs": {
+      "name": "zero_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_group_id": {
+          "name": "run_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_id": {
+          "name": "trigger_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_zero_runs_chat_thread_id": {
+          "name": "idx_zero_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "chat_thread_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_workflow_automation": {
+          "name": "idx_zero_runs_workflow_automation",
+          "columns": [
+            {
+              "expression": "workflow_automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "workflow_automation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_run_group": {
+          "name": "idx_zero_runs_run_group",
+          "columns": [
+            {
+              "expression": "run_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "run_group_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_runs_goal": {
+          "name": "idx_zero_runs_goal",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "goal_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_runs_id_agent_runs_id_fk": {
+          "name": "zero_runs_id_agent_runs_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_runs_workflow_automation_id_zero_workflow_automations_id_fk": {
+          "name": "zero_runs_workflow_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "workflow_automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_goal_id_thread_goals_id_fk": {
+          "name": "zero_runs_goal_id_thread_goals_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "thread_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_trigger_agent_id_agent_composes_id_fk": {
+          "name": "zero_runs_trigger_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "trigger_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_queue_events": {
+      "name": "zero_workflow_queue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflow_queue_events_fifo": {
+          "name": "idx_zero_workflow_queue_events_fifo",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_queue_events_trigger": {
+          "name": "idx_zero_workflow_queue_events_trigger",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_queue_events_chat_thread": {
+          "name": "idx_zero_workflow_queue_events_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflow_queue_events_workflow_id_zero_workflows_id_fk": {
+          "name": "zero_workflow_queue_events_workflow_id_zero_workflows_id_fk",
+          "tableFrom": "zero_workflow_queue_events",
+          "tableTo": "zero_workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_workflow_queue_events_trigger_id_zero_workflow_automations_id_fk": {
+          "name": "zero_workflow_queue_events_trigger_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_workflow_queue_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_workflow_queue_events_chat_thread_id_chat_threads_id_fk": {
+          "name": "zero_workflow_queue_events_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "zero_workflow_queue_events",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_user_automation_threads": {
+      "name": "workflow_user_automation_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_paused_at": {
+          "name": "queue_paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_user_automation_threads_unique": {
+          "name": "idx_workflow_user_automation_threads_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_chat_thread": {
+          "name": "idx_workflow_user_automation_threads_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_workflow_user": {
+          "name": "idx_workflow_user_automation_threads_workflow_user",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_user_automation_threads_workflow_id_zero_workflows_id_fk": {
+          "name": "workflow_user_automation_threads_workflow_id_zero_workflows_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "zero_workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk": {
+          "name": "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_automation_memory_embeddings": {
+      "name": "zero_workflow_automation_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_hash": {
+          "name": "query_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zero_workflow_automation_memory_embeddings_workflow_automation_id_zero_workflow_automations_id_fk": {
+          "name": "zero_workflow_automation_memory_embeddings_workflow_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_workflow_automation_memory_embeddings",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "workflow_automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zero_workflow_automation_memory_embeddings_dimensions_check": {
+          "name": "zero_workflow_automation_memory_embeddings_dimensions_check",
+          "value": "cardinality(\"zero_workflow_automation_memory_embeddings\".\"embedding\") = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_automations": {
+      "name": "zero_workflow_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'schedule'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_config": {
+          "name": "event_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflow_automations_workflow": {
+          "name": "idx_zero_workflow_automations_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_automations_org": {
+          "name": "idx_zero_workflow_automations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_automations_next_run": {
+          "name": "idx_zero_workflow_automations_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflow_automations_workflow_id_zero_workflows_id_fk": {
+          "name": "zero_workflow_automations_workflow_id_zero_workflows_id_fk",
+          "tableFrom": "zero_workflow_automations",
+          "tableTo": "zero_workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zero_workflow_automations_schedule_config_check": {
+          "name": "zero_workflow_automations_schedule_config_check",
+          "value": "(\n            kind = 'schedule'\n            AND event_type IS NULL\n            AND event_config IS NULL\n            AND (\n              (schedule_type = 'cron' AND cron_expression IS NOT NULL AND interval_seconds IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'loop' AND interval_seconds IS NOT NULL AND cron_expression IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'once' AND at_time IS NOT NULL AND cron_expression IS NULL AND interval_seconds IS NULL)\n            )\n          )\n          OR (\n            kind = 'event'\n            AND event_type IN ('gmail-new-message', 'gmail-label-applied', 'github-label-applied', 'google-calendar-event-created', 'google-calendar-event-updated', 'google-calendar-event-cancelled', 'google-meet-transcript-generated', 'notion-child-page-created', 'notion-database-item-created', 'notion-page-content-updated', 'webhook-received')\n            AND event_config IS NOT NULL\n            AND schedule_type IS NULL\n            AND cron_expression IS NULL\n            AND interval_seconds IS NULL\n            AND at_time IS NULL\n          )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_github_processed_events": {
+      "name": "zero_workflow_github_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_delivery_id": {
+          "name": "github_delivery_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflow_github_processed_automation_delivery": {
+          "name": "idx_zero_workflow_github_processed_automation_delivery",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_github_processed_subject": {
+          "name": "idx_zero_workflow_github_processed_subject",
+          "columns": [
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflow_github_processed_events_automation_id_zero_workflow_automations_id_fk": {
+          "name": "zero_workflow_github_processed_events_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_workflow_github_processed_events",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_webhook_automations": {
+      "name": "zero_workflow_webhook_automations",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_last_four": {
+          "name": "secret_last_four",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflow_webhook_automations_token_hash": {
+          "name": "idx_zero_workflow_webhook_automations_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflow_webhook_automations_automation_id_zero_workflow_automations_id_fk": {
+          "name": "zero_workflow_webhook_automations_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_workflow_webhook_automations",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_workflow_webhook_deliveries": {
+      "name": "zero_workflow_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflow_webhook_deliveries_automation_key": {
+          "name": "idx_zero_workflow_webhook_deliveries_automation_key",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflow_webhook_deliveries_automation_received": {
+          "name": "idx_zero_workflow_webhook_deliveries_automation_received",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflow_webhook_deliveries_automation_id_zero_workflow_automations_id_fk": {
+          "name": "zero_workflow_webhook_deliveries_automation_id_zero_workflow_automations_id_fk",
+          "tableFrom": "zero_workflow_webhook_deliveries",
+          "tableTo": "zero_workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_workflows": {
+      "name": "zero_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_workflows_agent": {
+          "name": "idx_zero_workflows_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflows_public_agent_name_unique": {
+          "name": "idx_zero_workflows_public_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'public'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflows_private_owner_agent_name_unique": {
+          "name": "idx_zero_workflows_private_owner_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'private'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflows_org": {
+          "name": "idx_zero_workflows_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_workflows_org_owner": {
+          "name": "idx_zero_workflows_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_workflows_agent_id_zero_agents_id_fk": {
+          "name": "zero_workflows_agent_id_zero_agents_id_fk",
+          "tableFrom": "zero_workflows",
+          "tableTo": "zero_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chat_message_queue_item_type": {
+      "name": "chat_message_queue_item_type",
+      "schema": "public",
+      "values": [
+        "user_message",
+        "workflow_event"
+      ]
+    },
+    "public.chat_thread_event_kind": {
+      "name": "chat_thread_event_kind",
+      "schema": "public",
+      "values": [
+        "created",
+        "renamed",
+        "deleted",
+        "pinned",
+        "unpinned",
+        "model_selection_updated",
+        "sort_touched"
+      ]
+    },
+    "public.connector_external_code_session_status": {
+      "name": "connector_external_code_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completing",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.model_provider_auth_session_status": {
+      "name": "model_provider_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/packages/db/src/migrations/meta/_journal.json
+++ b/turbo/packages/db/src/migrations/meta/_journal.json
@@ -4236,6 +4236,13 @@
       "when": 1784112668382,
       "tag": "0604_add_vm0_model_pricing",
       "breakpoints": true
+    },
+    {
+      "idx": 605,
+      "version": "7",
+      "when": 1784125478257,
+      "tag": "0605_luxuriant_ender_wiggin",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/packages/db/src/schema/connector-catalog.ts
+++ b/turbo/packages/db/src/schema/connector-catalog.ts
@@ -1,0 +1,154 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const CONNECTOR_CATALOG_ATTEMPT_OUTCOMES = [
+  "accepted",
+  "unchanged",
+  "rejected",
+] as const;
+export type ConnectorCatalogAttemptOutcome =
+  (typeof CONNECTOR_CATALOG_ATTEMPT_OUTCOMES)[number];
+
+export const CONNECTOR_CATALOG_FAILURE_CODES = [
+  "source-unavailable",
+  "object-too-large",
+  "invalid-json",
+  "invalid-pointer",
+  "invalid-reference",
+  "digest-mismatch",
+  "unsupported-schema",
+  "unsupported-capability",
+  "invalid-artifact",
+  "public-leakage",
+  "relationship-mismatch",
+  "conflicting-release",
+] as const;
+export type ConnectorCatalogFailureCode =
+  (typeof CONNECTOR_CATALOG_FAILURE_CODES)[number];
+
+export const connectorCatalogReleaseIdentities = pgTable(
+  "connector_catalog_release_identities",
+  {
+    sourceId: varchar("source_id", { length: 64 }).notNull(),
+    schemaVersion: integer("schema_version").notNull(),
+    catalogVersion: varchar("catalog_version", { length: 255 }).notNull(),
+    integrityKey: text("integrity_key").notNull(),
+    integrityDigest: varchar("integrity_digest", { length: 71 }).notNull(),
+    publicCatalogKey: text("public_catalog_key").notNull(),
+    publicCatalogDigest: varchar("public_catalog_digest", {
+      length: 71,
+    }).notNull(),
+    privateCatalogKey: text("private_catalog_key").notNull(),
+    privateCatalogDigest: varchar("private_catalog_digest", {
+      length: 71,
+    }).notNull(),
+    privateFirewallsKey: text("private_firewalls_key").notNull(),
+    privateFirewallsDigest: varchar("private_firewalls_digest", {
+      length: 71,
+    }).notNull(),
+    runnerFirewallsKey: text("runner_firewalls_key").notNull(),
+    runnerFirewallsDigest: varchar("runner_firewalls_digest", {
+      length: 71,
+    }).notNull(),
+    requiredCapabilities: text("required_capabilities").array().notNull(),
+    firstValidatedAt: timestamp("first_validated_at").notNull(),
+  },
+  (table) => {
+    return [
+      primaryKey({
+        name: "connector_catalog_release_identities_pk",
+        columns: [table.sourceId, table.schemaVersion, table.catalogVersion],
+      }),
+      check(
+        "connector_catalog_release_schema_version_positive",
+        sql`${table.schemaVersion} > 0`,
+      ),
+    ];
+  },
+);
+
+export const connectorCatalogSyncState = pgTable(
+  "connector_catalog_sync_state",
+  {
+    sourceId: varchar("source_id", { length: 64 }).notNull(),
+    schemaVersion: integer("schema_version").notNull(),
+    revision: integer("revision").default(0).notNull(),
+    activeCatalogVersion: varchar("active_catalog_version", { length: 255 }),
+    publicCatalog: text("public_catalog"),
+    activatedAt: timestamp("activated_at"),
+    lastAttemptAt: timestamp("last_attempt_at"),
+    lastAttemptOutcome: varchar("last_attempt_outcome", {
+      length: 32,
+    }).$type<ConnectorCatalogAttemptOutcome>(),
+    lastSuccessAt: timestamp("last_success_at"),
+    lastFailureCode: varchar("last_failure_code", {
+      length: 64,
+    }).$type<ConnectorCatalogFailureCode>(),
+  },
+  (table) => {
+    return [
+      primaryKey({
+        name: "connector_catalog_sync_state_pk",
+        columns: [table.sourceId, table.schemaVersion],
+      }),
+      foreignKey({
+        name: "connector_catalog_sync_state_active_release_fk",
+        columns: [
+          table.sourceId,
+          table.schemaVersion,
+          table.activeCatalogVersion,
+        ],
+        foreignColumns: [
+          connectorCatalogReleaseIdentities.sourceId,
+          connectorCatalogReleaseIdentities.schemaVersion,
+          connectorCatalogReleaseIdentities.catalogVersion,
+        ],
+      }),
+      check(
+        "connector_catalog_sync_state_schema_version_positive",
+        sql`${table.schemaVersion} > 0`,
+      ),
+      check(
+        "connector_catalog_sync_state_revision_nonnegative",
+        sql`${table.revision} >= 0`,
+      ),
+      check(
+        "connector_catalog_sync_state_active_snapshot_complete",
+        sql`(
+          ${table.activeCatalogVersion} IS NULL
+          AND ${table.publicCatalog} IS NULL
+          AND ${table.activatedAt} IS NULL
+        ) OR (
+          ${table.activeCatalogVersion} IS NOT NULL
+          AND ${table.publicCatalog} IS NOT NULL
+          AND ${table.activatedAt} IS NOT NULL
+        )`,
+      ),
+      check(
+        "connector_catalog_sync_state_attempt_complete",
+        sql`(
+          ${table.lastAttemptOutcome} IS NULL
+          AND ${table.lastAttemptAt} IS NULL
+          AND ${table.lastFailureCode} IS NULL
+        ) OR (
+          ${table.lastAttemptOutcome} = 'rejected'
+          AND ${table.lastAttemptAt} IS NOT NULL
+          AND ${table.lastFailureCode} IS NOT NULL
+        ) OR (
+          ${table.lastAttemptOutcome} IN ('accepted', 'unchanged')
+          AND ${table.lastAttemptAt} IS NOT NULL
+          AND ${table.lastFailureCode} IS NULL
+        )`,
+      ),
+    ];
+  },
+);

--- a/turbo/packages/db/src/schema/connector-catalog.ts
+++ b/turbo/packages/db/src/schema/connector-catalog.ts
@@ -26,7 +26,6 @@ export const CONNECTOR_CATALOG_FAILURE_CODES = [
   "invalid-reference",
   "digest-mismatch",
   "unsupported-schema",
-  "unsupported-capability",
   "invalid-artifact",
   "public-leakage",
   "relationship-mismatch",
@@ -41,25 +40,19 @@ export const connectorCatalogReleaseIdentities = pgTable(
     sourceId: varchar("source_id", { length: 64 }).notNull(),
     schemaVersion: integer("schema_version").notNull(),
     catalogVersion: varchar("catalog_version", { length: 255 }).notNull(),
-    integrityKey: text("integrity_key").notNull(),
     integrityDigest: varchar("integrity_digest", { length: 71 }).notNull(),
-    publicCatalogKey: text("public_catalog_key").notNull(),
     publicCatalogDigest: varchar("public_catalog_digest", {
       length: 71,
     }).notNull(),
-    privateCatalogKey: text("private_catalog_key").notNull(),
     privateCatalogDigest: varchar("private_catalog_digest", {
       length: 71,
     }).notNull(),
-    privateFirewallsKey: text("private_firewalls_key").notNull(),
     privateFirewallsDigest: varchar("private_firewalls_digest", {
       length: 71,
     }).notNull(),
-    runnerFirewallsKey: text("runner_firewalls_key").notNull(),
     runnerFirewallsDigest: varchar("runner_firewalls_digest", {
       length: 71,
     }).notNull(),
-    requiredCapabilities: text("required_capabilities").array().notNull(),
     firstValidatedAt: timestamp("first_validated_at").notNull(),
   },
   (table) => {

--- a/turbo/packages/db/src/schema/connector-catalog.ts
+++ b/turbo/packages/db/src/schema/connector-catalog.ts
@@ -29,45 +29,9 @@ export const CONNECTOR_CATALOG_FAILURE_CODES = [
   "invalid-artifact",
   "public-leakage",
   "relationship-mismatch",
-  "conflicting-release",
 ] as const;
 export type ConnectorCatalogFailureCode =
   (typeof CONNECTOR_CATALOG_FAILURE_CODES)[number];
-
-export const connectorCatalogReleaseIdentities = pgTable(
-  "connector_catalog_release_identities",
-  {
-    sourceId: varchar("source_id", { length: 64 }).notNull(),
-    schemaVersion: integer("schema_version").notNull(),
-    catalogVersion: varchar("catalog_version", { length: 255 }).notNull(),
-    integrityDigest: varchar("integrity_digest", { length: 71 }).notNull(),
-    publicCatalogDigest: varchar("public_catalog_digest", {
-      length: 71,
-    }).notNull(),
-    privateCatalogDigest: varchar("private_catalog_digest", {
-      length: 71,
-    }).notNull(),
-    privateFirewallsDigest: varchar("private_firewalls_digest", {
-      length: 71,
-    }).notNull(),
-    runnerFirewallsDigest: varchar("runner_firewalls_digest", {
-      length: 71,
-    }).notNull(),
-    firstValidatedAt: timestamp("first_validated_at").notNull(),
-  },
-  (table) => {
-    return [
-      primaryKey({
-        name: "connector_catalog_release_identities_pk",
-        columns: [table.sourceId, table.schemaVersion, table.catalogVersion],
-      }),
-      check(
-        "connector_catalog_release_schema_version_positive",
-        sql`${table.schemaVersion} > 0`,
-      ),
-    ];
-  },
-);
 
 export const connectorCatalogSyncState = pgTable(
   "connector_catalog_sync_state",
@@ -75,9 +39,13 @@ export const connectorCatalogSyncState = pgTable(
     sourceId: varchar("source_id", { length: 64 }).notNull(),
     schemaVersion: integer("schema_version").notNull(),
     revision: integer("revision").default(0).notNull(),
-    activeCatalogVersion: varchar("active_catalog_version", { length: 255 }),
-    publicCatalog: text("public_catalog"),
-    activatedAt: timestamp("activated_at"),
+    lastObservedCatalogVersion: varchar("last_observed_catalog_version", {
+      length: 255,
+    }),
+    lastObservedIntegrityDigest: varchar("last_observed_integrity_digest", {
+      length: 71,
+    }),
+    lastObservedPointerEtag: text("last_observed_pointer_etag"),
     lastAttemptAt: timestamp("last_attempt_at"),
     lastAttemptOutcome: varchar("last_attempt_outcome", {
       length: 32,
@@ -86,25 +54,22 @@ export const connectorCatalogSyncState = pgTable(
     lastFailureCode: varchar("last_failure_code", {
       length: 64,
     }).$type<ConnectorCatalogFailureCode>(),
+    lastRejectedCatalogVersion: varchar("last_rejected_catalog_version", {
+      length: 255,
+    }),
+    lastRejectedIntegrityDigest: varchar("last_rejected_integrity_digest", {
+      length: 71,
+    }),
+    lastRejectedPointerEtag: text("last_rejected_pointer_etag"),
+    lastRejectedFailureCode: varchar("last_rejected_failure_code", {
+      length: 64,
+    }).$type<ConnectorCatalogFailureCode>(),
   },
   (table) => {
     return [
       primaryKey({
         name: "connector_catalog_sync_state_pk",
         columns: [table.sourceId, table.schemaVersion],
-      }),
-      foreignKey({
-        name: "connector_catalog_sync_state_active_release_fk",
-        columns: [
-          table.sourceId,
-          table.schemaVersion,
-          table.activeCatalogVersion,
-        ],
-        foreignColumns: [
-          connectorCatalogReleaseIdentities.sourceId,
-          connectorCatalogReleaseIdentities.schemaVersion,
-          connectorCatalogReleaseIdentities.catalogVersion,
-        ],
       }),
       check(
         "connector_catalog_sync_state_schema_version_positive",
@@ -115,15 +80,13 @@ export const connectorCatalogSyncState = pgTable(
         sql`${table.revision} >= 0`,
       ),
       check(
-        "connector_catalog_sync_state_active_snapshot_complete",
+        "connector_catalog_sync_state_observed_identity_complete",
         sql`(
-          ${table.activeCatalogVersion} IS NULL
-          AND ${table.publicCatalog} IS NULL
-          AND ${table.activatedAt} IS NULL
+          ${table.lastObservedCatalogVersion} IS NULL
+          AND ${table.lastObservedIntegrityDigest} IS NULL
         ) OR (
-          ${table.activeCatalogVersion} IS NOT NULL
-          AND ${table.publicCatalog} IS NOT NULL
-          AND ${table.activatedAt} IS NOT NULL
+          ${table.lastObservedCatalogVersion} IS NOT NULL
+          AND ${table.lastObservedIntegrityDigest} IS NOT NULL
         )`,
       ),
       check(
@@ -141,6 +104,80 @@ export const connectorCatalogSyncState = pgTable(
           AND ${table.lastAttemptAt} IS NOT NULL
           AND ${table.lastFailureCode} IS NULL
         )`,
+      ),
+      check(
+        "connector_catalog_sync_state_rejected_candidate_complete",
+        sql`(
+          ${table.lastRejectedCatalogVersion} IS NULL
+          AND ${table.lastRejectedIntegrityDigest} IS NULL
+          AND ${table.lastRejectedPointerEtag} IS NULL
+          AND ${table.lastRejectedFailureCode} IS NULL
+        ) OR (
+          ${table.lastRejectedFailureCode} IS NOT NULL
+          AND ${table.lastRejectedFailureCode} <> 'source-unavailable'
+          AND (
+            (
+              ${table.lastRejectedCatalogVersion} IS NOT NULL
+              AND ${table.lastRejectedIntegrityDigest} IS NOT NULL
+            ) OR ${table.lastRejectedPointerEtag} IS NOT NULL
+          )
+          AND (
+            (
+              ${table.lastRejectedCatalogVersion} IS NULL
+              AND ${table.lastRejectedIntegrityDigest} IS NULL
+            ) OR (
+              ${table.lastRejectedCatalogVersion} IS NOT NULL
+              AND ${table.lastRejectedIntegrityDigest} IS NOT NULL
+            )
+          )
+        )`,
+      ),
+    ];
+  },
+);
+
+export const connectorCatalogActiveSnapshot = pgTable(
+  "connector_catalog_active_snapshot",
+  {
+    sourceId: varchar("source_id", { length: 64 }).notNull(),
+    schemaVersion: integer("schema_version").notNull(),
+    catalogVersion: varchar("catalog_version", { length: 255 }).notNull(),
+    integrityDigest: varchar("integrity_digest", { length: 71 }).notNull(),
+    publicCatalogDigest: varchar("public_catalog_digest", {
+      length: 71,
+    }).notNull(),
+    privateCatalogDigest: varchar("private_catalog_digest", {
+      length: 71,
+    }).notNull(),
+    privateFirewallsDigest: varchar("private_firewalls_digest", {
+      length: 71,
+    }).notNull(),
+    runnerFirewallsDigest: varchar("runner_firewalls_digest", {
+      length: 71,
+    }).notNull(),
+    publicCatalog: text("public_catalog").notNull(),
+    privateCatalog: text("private_catalog").notNull(),
+    privateFirewalls: text("private_firewalls").notNull(),
+    runnerFirewalls: text("runner_firewalls").notNull(),
+    activatedAt: timestamp("activated_at").notNull(),
+  },
+  (table) => {
+    return [
+      primaryKey({
+        name: "connector_catalog_active_snapshot_pk",
+        columns: [table.sourceId, table.schemaVersion],
+      }),
+      foreignKey({
+        name: "connector_catalog_active_snapshot_sync_state_fk",
+        columns: [table.sourceId, table.schemaVersion],
+        foreignColumns: [
+          connectorCatalogSyncState.sourceId,
+          connectorCatalogSyncState.schemaVersion,
+        ],
+      }),
+      check(
+        "connector_catalog_active_snapshot_schema_version_positive",
+        sql`${table.schemaVersion} > 0`,
       ),
     ];
   },


### PR DESCRIPTION
## Summary

- Read `connectors/v1/active.json` and its deterministic release objects from the existing private `R2_USER_STORAGES_BUCKET_NAME`.
- Verify raw-byte SHA-256 digests before strict parsing, then validate public/private alignment, auth, icon, skill, firewall, and model-provider ownership boundaries.
- Persist one complete latest-valid snapshot containing the exact public, private, private-firewall, and runner-firewall texts and their identities; rejected candidates retain the previous snapshot.
- Expose `CRON_SECRET`-authenticated sync and DB-only status operations without changing any existing connector consumer.

## Publication contract

The active pointer contains only `catalogVersion` and `integrityDigest`. vm0 derives the integrity and four view keys under `connectors/v1/releases/<catalogVersion>/`; the integrity artifact contains only the schema/catalog identity and the four raw-view digests.

The loader treats every R2 byte as untrusted. It enforces bounded downloads, strict schema-one objects, catalog/ref ordering and uniqueness, public/private leakage rules, complete cross-view relationships, final icon and bundled-skill paths, and the same URL, host-policy, and `auth.base` rules used by the executable firewall boundary. Connector and auth-method identities plus platform-secret names remain open wire identities; local executable support is not a source-validity decision.

## Persistence and synchronization

- `connector_catalog_active_snapshot` has one current row per source/schema and stores all four exact validated texts and digests atomically. There is no historical release ledger.
- `connector_catalog_sync_state` remains small and stores the optimistic revision, observed pointer identity/ETag, bounded outcomes, and deterministic rejection cache metadata.
- Only the sync operation accesses R2. Status and all existing connector APIs read no catalog objects.
- An unchanged ETag transfers no pointer body; an accepted active identity performs no release reads; deterministic rejection caching is invalidated when either pointer identity or ETag changes.
- Transient source failures remain retryable. Oversized or malformed pointers retain their observed ETag when available, avoiding repeated body downloads.
- Candidate validation happens outside the DB transaction; a revision-guarded transaction replaces the complete snapshot and state together.
- Request cancellation propagates through S3 requests and response-body reads, and persistence errors are sanitized so private catalog text cannot enter logs through query parameters.

## Explicit boundaries

- Existing public catalog, auth/materialization, run creation, skill resolution, firewall consumers, and runners remain on their current sources.
- Local executable capability reconciliation and auth-method filtering are deferred to #21654 and will read this PostgreSQL snapshot without accessing R2.
- This PR does not publish artifacts or `active.json`, activate the external snapshot, store model-provider data, or add run-level catalog pinning.

## Validation

- API lint and type checks
- DB lint and type checks
- connector catalog route integration suite: 45 tests passed
- DB migration consistency: all 606 migrations/snapshots and fresh/existing schema comparison passed
- `pnpm knip`
- pre-commit formatting, Knip, and full Turbo type check: 13 tasks passed
- real `vm0-connectors` release `2026-07-14.1` passed the production loader and relationship validator

Closes #19394

Delivery context: vm0-ai/vm0-connectors#1

Producer contract: vm0-ai/vm0-connectors#13