### PR TITLE
fix(runner): enforce firewalls for options asterisk requests

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -117,12 +117,14 @@ def record_allow_context(
     Request-header callers use this before carrying a streamed ``allow``
     classification into ``request()``; request callers use it before immediate
     or deferred diagnostic resolution. A browser flow, existing diagnostic, or
-    incomplete original-URL context is a no-op.
+    asterisk-form target, or incomplete original-URL context is a no-op.
 
     On success, the flow records diagnostic eligibility, active firewall names,
     and one classification-compatible catalog snapshot. Response and error
     phases resolve candidates only from that pinned snapshot.
     """
+    if classification.is_asterisk_form:
+        return
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         return
     if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -19,7 +19,9 @@ Request context
   Read by usage webhook reporters.
 - ``ORIGINAL_URL``: absolute URL written by HTTP request classification from
   trusted authority, or from the authority-validation fallback URL on local
-  denial. Read by response/error logging and connector billing.
+  denial. Asterisk-form contributes an empty URL path while its raw ``*``
+  target remains on the request and firewall decision. Read by response/error
+  logging and connector billing.
 - ``NETWORK_LOG_TARGET``: ``dict`` with ``url``, ``host``, and ``port`` from
   trusted authority or authority-validation fallback URL. Read by network-log
   entry construction.
@@ -68,9 +70,10 @@ Firewall and auth context
 - ``FIREWALL_PARAMS``: ``dict`` firewall params from the match. Read by
   network-log firewall metadata when it has the expected shape.
 - ``FIREWALL_BILLABLE``: ``bool`` computed from runner VM billable firewall
-  context for matched auth flows, or forced ``False`` for browser passthrough.
-  Gates connector billing, model-provider billing, and connector response parser
-  setup; model usage observation still checks model-provider-specific gates.
+  context for matched auth flows, or forced ``False`` for browser passthrough
+  and policy-only asterisk-form allows. Gates connector billing, model-provider
+  billing, and connector response parser setup; model usage observation still
+  checks model-provider-specific gates.
 - ``FIREWALL_ACTION``: ``str`` firewall decision such as ``ALLOW``, ``DENY``,
   or ``BLOCK``. Read by response/error network logging.
 - ``FIREWALL_ERROR``: optional ``str`` error code for auth, forwarding, or

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1030,6 +1030,12 @@ class FirewallAllow(NamedTuple):
     rel_path: str
 
 
+class FirewallPolicyAllow(NamedTuple):
+    """Asterisk-form base matched and unknown policy allowed without auth."""
+
+    firewall_allow: FirewallAllow
+
+
 def _permission_allow(
     api_entry: dict,
     *,
@@ -1595,9 +1601,11 @@ def _match_compiled_firewall_request_with_api_candidates(
     api_candidates: tuple[_CompiledApiCandidate, ...],
     indexed_rules: bool,
     intent: connector_intent.ConnectorIntent,
-) -> FirewallAllow | FirewallBlock | FirewallAmbiguous | None:
+    is_asterisk_form: bool,
+) -> FirewallAllow | FirewallPolicyAllow | FirewallBlock | FirewallAmbiguous | None:
     collection = _FirewallMatchCollection()
-    unsafe_path: bool | None = True if url_has_backslash else None
+    unsafe_path: bool | None = False if is_asterisk_form else (True if url_has_backslash else None)
+    decision_path = "*" if is_asterisk_form else (url_parts.path or "/")
 
     for candidate in api_candidates:
         fw_entry = candidate.firewall
@@ -1606,7 +1614,8 @@ def _match_compiled_firewall_request_with_api_candidates(
         if base_result is None:
             continue
 
-        rel_path, base_params = base_result
+        matched_rel_path, base_params = base_result
+        rel_path = "*" if is_asterisk_form else matched_rel_path
 
         if unsafe_path is None:
             unsafe_path = has_unsafe_path(url_parts.path)
@@ -1638,7 +1647,7 @@ def _match_compiled_firewall_request_with_api_candidates(
         if not collection.accept_api(api_match):
             continue
 
-        if not api_entry.permissions:
+        if is_asterisk_form or not api_entry.permissions:
             continue
 
         rel_path_segs = _split_path_segments(rel_path)
@@ -1659,17 +1668,20 @@ def _match_compiled_firewall_request_with_api_candidates(
         collection,
         intent,
         upper_method=upper_method,
-        path=url_parts.path or "/",
+        path=decision_path,
     )
     if isinstance(selected_name, FirewallAmbiguous):
         return selected_name
-    return _reduce_selected_owner(
+    result = _reduce_selected_owner(
         collection,
         selected_name=selected_name,
         compiled_network_policies=compiled_network_policies,
         upper_method=upper_method,
         indexed_rules=indexed_rules,
     )
+    if is_asterisk_form and isinstance(result, FirewallAllow):
+        return FirewallPolicyAllow(result)
+    return result
 
 
 def _prepare_compiled_request_match(
@@ -1703,7 +1715,9 @@ def _match_compiled_firewall_request_linear(
     compiled_firewalls: CompiledFirewallSet | None,
     network_policies: object | None = None,
     intent: connector_intent.ConnectorIntent | None = None,
-) -> FirewallAllow | FirewallBlock | FirewallAmbiguous | None:
+    *,
+    is_asterisk_form: bool = False,
+) -> FirewallAllow | FirewallPolicyAllow | FirewallBlock | FirewallAmbiguous | None:
     prepared = _prepare_compiled_request_match(
         url,
         method,
@@ -1722,6 +1736,7 @@ def _match_compiled_firewall_request_linear(
         api_candidates=compiled_firewalls.linear_api_candidates(),
         indexed_rules=False,
         intent=intent or connector_intent.ABSENT,
+        is_asterisk_form=is_asterisk_form,
     )
 
 
@@ -1731,7 +1746,9 @@ def match_compiled_firewall_request(
     compiled_firewalls: CompiledFirewallSet | None,
     network_policies: object | None = None,
     intent: connector_intent.ConnectorIntent | None = None,
-) -> FirewallAllow | FirewallBlock | FirewallAmbiguous | None:
+    *,
+    is_asterisk_form: bool = False,
+) -> FirewallAllow | FirewallPolicyAllow | FirewallBlock | FirewallAmbiguous | None:
     """Match request against production precompiled firewall permissions.
 
     Retained malformed state from the compile functions applies only after the
@@ -1747,12 +1764,18 @@ def match_compiled_firewall_request(
 
     Returns:
       FirewallAllow — granted permission matched or unknown endpoint allowed
+      FirewallPolicyAllow — asterisk-form unknown endpoint allowed without auth
       FirewallBlock — permission denied, unknown endpoint blocked, or matched
         malformed firewall/network policy config or unsafe path failed closed
       FirewallAmbiguous — multiple connector owners require a usable intent
       None — no base URL match (not a firewall request)
 
     ``unknownPolicy="ask"`` is treated as block at the proxy layer.
+
+    When ``is_asterisk_form`` is true, the URL contains the reconstructed
+    authority with an empty path. The matcher selects the applicable base and
+    owner but skips endpoint permissions, then reports ``*`` as the decision
+    path while resolving the request through unknown-policy semantics.
     """
     prepared = _prepare_compiled_request_match(
         url,
@@ -1772,4 +1795,5 @@ def match_compiled_firewall_request(
         api_candidates=compiled_firewalls.indexed_api_candidates(url_parts),
         indexed_rules=True,
         intent=intent or connector_intent.ABSENT,
+        is_asterisk_form=is_asterisk_form,
     )

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -695,6 +695,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         classification,
         request_classification.ApiAllow
         | request_classification.BrowserAllow
+        | request_classification.FirewallPolicyAllow
         | request_classification.Allow,
     ) and request_classification.should_stream_capture_request(classification):
         if classification.kind == "api_allow" and not upstream_admission.ensure_bound_destination(
@@ -874,6 +875,23 @@ async def request(flow: http.HTTPFlow) -> None:
             return
         if classification.kind == "public_destination_denied":
             _block_public_destination_denied(flow, classification.public_destination_denial)
+            return
+        if classification.kind == "firewall_policy_allow":
+            public_destination_denial = request_classification.current_public_destination_denial(
+                flow,
+                classification.firewall_allow,
+            )
+            if public_destination_denial is not None:
+                _block_public_destination_denied(flow, public_destination_denial)
+                return
+            prepare_firewall_metadata(
+                flow,
+                classification.firewall_allow,
+                classification.vm_info,
+            )
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+            flow.metadata.pop(metadata_keys.MODEL_USAGE_PROVIDER, None)
+            flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             return
         if classification.kind == "firewall_allow":
             allow = classification.firewall_allow

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -163,6 +163,16 @@ class FirewallAllow:
 
 
 @dataclass(frozen=True)
+class FirewallPolicyAllow:
+    vm_info: dict
+    firewall_allow: matching.FirewallAllow
+    kind: Literal["firewall_policy_allow"] = field(
+        init=False,
+        default="firewall_policy_allow",
+    )
+
+
+@dataclass(frozen=True)
 class PublicDestinationDenied:
     vm_info: dict
     public_destination_denial: PublicDestinationDenial
@@ -176,6 +186,7 @@ class PublicDestinationDenied:
 class Allow:
     vm_info: dict
     builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None
+    is_asterisk_form: bool
     kind: Literal["allow"] = field(init=False, default="allow")
 
 
@@ -191,6 +202,7 @@ RequestClassification: TypeAlias = (
     | FirewallAmbiguous
     | FirewallBlock
     | FirewallAllow
+    | FirewallPolicyAllow
     | PublicDestinationDenied
     | Allow
 )
@@ -345,6 +357,7 @@ def classify_request(
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         return BrowserAllow(vm_info=vm_info)
 
+    is_asterisk_form = flow.request.path == "*"
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
     if compiled_firewalls:
@@ -354,6 +367,7 @@ def classify_request(
             compiled_firewalls,
             compiled_network_policies,
             connector_intent.from_flow(flow),
+            is_asterisk_form=is_asterisk_form,
         )
         if isinstance(result, matching.FirewallAmbiguous):
             return FirewallAmbiguous(
@@ -365,10 +379,15 @@ def classify_request(
                 vm_info=vm_info,
                 firewall_block=result,
             )
-        if isinstance(result, matching.FirewallAllow):
+        if isinstance(result, matching.FirewallAllow | matching.FirewallPolicyAllow):
+            firewall_allow = (
+                result.firewall_allow
+                if isinstance(result, matching.FirewallPolicyAllow)
+                else result
+            )
             public_destination_denial = _public_destination_denial(
                 flow,
-                result,
+                firewall_allow,
                 trusted_authority_host=trusted_authority.host,
                 defer_unresolved_hostnames=defer_unresolved_public_destination,
             )
@@ -377,9 +396,14 @@ def classify_request(
                     vm_info=vm_info,
                     public_destination_denial=public_destination_denial,
                 )
+            if isinstance(result, matching.FirewallPolicyAllow):
+                return FirewallPolicyAllow(
+                    vm_info=vm_info,
+                    firewall_allow=firewall_allow,
+                )
             return FirewallAllow(
                 vm_info=vm_info,
-                firewall_allow=result,
+                firewall_allow=firewall_allow,
                 builtin_firewall_catalog_snapshot=(
                     registry_state.builtin_firewall_catalog_snapshot
                 ),
@@ -388,6 +412,7 @@ def classify_request(
     return Allow(
         vm_info=vm_info,
         builtin_firewall_catalog_snapshot=registry_state.builtin_firewall_catalog_snapshot,
+        is_asterisk_form=is_asterisk_form,
     )
 
 
@@ -399,13 +424,14 @@ def classification_needs_request_timing(classification: RequestClassification) -
         "firewall_ambiguous",
         "firewall_block",
         "firewall_allow",
+        "firewall_policy_allow",
         "public_destination_denied",
         "allow",
     )
 
 
 def should_stream_capture_request(classification: RequestClassification) -> bool:
-    if not isinstance(classification, ApiAllow | BrowserAllow | Allow):
+    if not isinstance(classification, ApiAllow | BrowserAllow | FirewallPolicyAllow | Allow):
         return False
     return bool(classification.vm_info.get("captureNetworkBodies", False))
 

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -136,7 +136,8 @@ def _host_with_port(scheme: str, host: str, port: int) -> str:
 
 
 def _build_url(scheme: str, host: str, port: int, path: str) -> str:
-    return f"{scheme}://{_host_with_port(scheme, host, port)}{path}"
+    uri_path = "" if path == "*" else path
+    return f"{scheme}://{_host_with_port(scheme, host, port)}{uri_path}"
 
 
 def _parse_host_authority(authority: str) -> tuple[str, int | None]:

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
@@ -14,7 +14,15 @@ from tests.firewall_helpers import (
 )
 
 
-def _assert_indexed_matches_linear(url, method, firewalls, network_policies, intent=None):
+def _assert_indexed_matches_linear(
+    url,
+    method,
+    firewalls,
+    network_policies,
+    intent=None,
+    *,
+    is_asterisk_form=False,
+):
     compiled = compile_firewalls_or_fail(firewalls)
 
     indexed = matching.match_compiled_firewall_request(
@@ -23,6 +31,7 @@ def _assert_indexed_matches_linear(url, method, firewalls, network_policies, int
         compiled,
         network_policies,
         intent,
+        is_asterisk_form=is_asterisk_form,
     )
     linear = matching._match_compiled_firewall_request_linear(
         url,
@@ -30,10 +39,70 @@ def _assert_indexed_matches_linear(url, method, firewalls, network_policies, int
         compiled,
         network_policies,
         intent,
+        is_asterisk_form=is_asterisk_form,
     )
 
     assert indexed == linear
     return indexed
+
+
+def test_indexed_matches_linear_for_asterisk_form_unknown_policy():
+    firewalls = [
+        firewall_entry(
+            "example",
+            firewall_api(
+                "https://api.example.com",
+                [firewall_permission("full-access", "ANY /")],
+            ),
+        )
+    ]
+    policies = {
+        "example": network_policy(
+            allow=["full-access"],
+            unknown_policy="deny",
+        )
+    }
+
+    result = _assert_indexed_matches_linear(
+        "https://api.example.com",
+        "OPTIONS",
+        firewalls,
+        policies,
+        is_asterisk_form=True,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.reason == "unknown_endpoint"
+    assert result.path == "*"
+
+
+def test_indexed_matches_linear_for_asterisk_form_owner_ambiguity():
+    firewalls = [
+        firewall_entry(
+            "primary",
+            firewall_api("https://api.example.com", []),
+        ),
+        firewall_entry(
+            "auditor",
+            firewall_api("https://api.example.com", []),
+        ),
+    ]
+    policies = {
+        "primary": network_policy(unknown_policy="allow"),
+        "auditor": network_policy(unknown_policy="allow"),
+    }
+
+    result = _assert_indexed_matches_linear(
+        "https://api.example.com",
+        "OPTIONS",
+        firewalls,
+        policies,
+        is_asterisk_form=True,
+    )
+
+    assert isinstance(result, matching.FirewallAmbiguous)
+    assert result.path == "*"
+    assert result.candidates == ("auditor", "primary")
 
 
 def _long_path(prefix, segment_count=1000):

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
@@ -42,6 +42,115 @@ def test_compiled_matches_unknown_policy_when_api_has_no_permissions():
 
 
 @pytest.mark.parametrize(
+    "rule",
+    [
+        pytest.param("ANY /", id="root"),
+        pytest.param("ANY /{path+}", id="one-or-more-segments"),
+        pytest.param("ANY /{path*}", id="zero-or-more-segments"),
+    ],
+)
+def test_compiled_asterisk_form_skips_endpoint_permissions(rule):
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "full-access", "rules": [rule]}],
+            }
+        ],
+        name="example",
+    )
+    policies = {
+        "example": {
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "deny",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com",
+        "OPTIONS",
+        compile_firewalls_or_fail(fws),
+        policies,
+        is_asterisk_form=True,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.reason == "unknown_endpoint"
+    assert result.path == "*"
+    assert result.permissions == ()
+
+
+def test_compiled_asterisk_form_unknown_allow_preserves_target_identity():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /"]}],
+            }
+        ],
+        name="example",
+    )
+    policies = {
+        "example": {
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com",
+        "OPTIONS",
+        compile_firewalls_or_fail(fws),
+        policies,
+        is_asterisk_form=True,
+    )
+
+    assert isinstance(result, matching.FirewallPolicyAllow)
+    assert result.firewall_allow.permission is None
+    assert result.firewall_allow.rule is None
+    assert result.firewall_allow.rel_path == "*"
+
+
+def test_compiled_asterisk_form_retains_malformed_auth_failure():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": None},
+                "permissions": [],
+            }
+        ],
+        name="example",
+    )
+    policies = {
+        "example": {
+            "allow": [],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com",
+        "OPTIONS",
+        compile_firewalls_or_fail(fws),
+        policies,
+        is_asterisk_form=True,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.reason == "malformed_firewall_config"
+    assert result.path == "*"
+
+
+@pytest.mark.parametrize(
     "url",
     [
         "https://api.example.com/items/../admin",

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -506,6 +506,31 @@ async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidat
     assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
 
 
+async def test_asterisk_form_without_active_firewall_skips_connector_diagnostic(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    write_connector_diagnostic_catalog_cache(tmp_path)
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.openweathermap.org",
+        method="OPTIONS",
+        path="*",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.path == "*"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.openweathermap.org"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
 async def test_active_builtin_connector_url_uses_firewall_path(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -12,6 +12,7 @@ import connector_intent
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import upstream_destination_binding
+from body_limits import STREAM_BUFFER_LIMIT
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
     _shared_route_vm,
@@ -269,6 +270,193 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unknown_endpoint"
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+@pytest.mark.parametrize(
+    "unknown_policy",
+    [
+        pytest.param("deny", id="deny"),
+        pytest.param("ask", id="ask"),
+    ],
+)
+async def test_asterisk_form_enforces_unknown_policy(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    unknown_policy,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="example",
+            api_entry={
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": unknown_policy,
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.example.com",
+        method="OPTIONS",
+        path="*",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    body = json.loads(flow.response.content)
+    assert body["reason"] == "unknown_endpoint"
+    assert body["method"] == "OPTIONS"
+    assert body["path"] == "*"
+    assert body["url"] == "https://api.example.com"
+
+
+async def test_asterisk_form_policy_allow_preserves_target_without_connector_side_effects(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="example",
+            api_entry={
+                "base": "https://api.example.com",
+                "auth": {
+                    "headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"},
+                    "query": {"api_key": "${{ secrets.API_TOKEN }}"},
+                },
+                "permissions": [{"name": "full-access", "rules": ["ANY /"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            billable_firewalls=["example"],
+            vm_fields={
+                "captureNetworkBodies": True,
+                "modelUsageProvider": "anthropic",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.example.com",
+        method="OPTIONS",
+        path="*",
+        request_headers=headers(
+            ("Host", "api.example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is None
+        assert callable(flow.request.stream)
+        assert flow.request.path == "*"
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_awaited()
+    assert flow.response is None
+    assert flow.request.path == "*"
+    assert "Authorization" not in flow.request.headers
+    assert "api_key" not in flow.request.query
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
+async def test_asterisk_form_policy_allow_still_enforces_public_destination(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="example",
+            api_entry={
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+                "hostPolicy": {"kind": "publicDestination"},
+                "permissions": [],
+            },
+            network_policy={
+                "allow": [],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.example.com",
+        method="OPTIONS",
+        path="*",
+        request_headers=headers(
+            ("Host", "api.example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is None
+        assert callable(flow.request.stream)
+        assert flow.response is None
+
+        flow.server_conn.address = ("10.0.0.5", 443)
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_awaited()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.request.path == "*"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_public_destination"
+    assert "Authorization" not in flow.request.headers
 
 
 async def test_firewall_malformed_config_block_reports_reason(

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
@@ -37,6 +37,29 @@ class TestGetOriginalUrl:
         flow = real_flow(host="api.example.com", port=443, path="/v1/data?key=val")
         assert get_original_url(flow) == "https://api.example.com/v1/data?key=val"
 
+    @pytest.mark.parametrize(
+        ("port", "expected_url"),
+        [
+            pytest.param(443, "https://api.example.com", id="default-port"),
+            pytest.param(8443, "https://api.example.com:8443", id="non-default-port"),
+        ],
+    )
+    def test_asterisk_form_contributes_an_empty_uri_path(
+        self,
+        real_flow,
+        port,
+        expected_url,
+    ):
+        flow = real_flow(
+            host="api.example.com",
+            port=port,
+            method="OPTIONS",
+            path="*",
+        )
+
+        assert get_original_url(flow) == expected_url
+        assert flow.request.path == "*"
+
     def test_https_uses_sni_for_transparent_destination(self, real_flow, headers):
         flow = real_flow(
             host="203.0.113.10",


### PR DESCRIPTION
## Summary

- reconstruct HTTP asterisk-form targets as authority URLs with an empty URI path while preserving the raw `*` request target
- classify asterisk-form explicitly so firewall bases, owner ambiguity, malformed state, `publicDestination`, and `unknownPolicy` are enforced without evaluating endpoint permission rules
- keep unknown-policy allows policy-only: preserve `*`, skip connector auth/rewrites/diagnostics/usage, and retain generic network body capture
- preserve request-phase `publicDestination` revalidation for header-phase cached classifications

## Compatibility

- ordinary origin-form firewall matching and connector authentication are unchanged
- no database schema, persisted data, API contract, queue payload, or cross-service protocol changes
- allowed asterisk-form traffic remains unauthenticated and non-billable, matching its pre-fix forwarding behavior

## Validation

- `python3 -m ruff format --check src scripts tests`
- `python3 -m ruff check src scripts tests`
- `python3 -m basedpyright`
- `python3 -m pytest -q tests/test_url_utils_trusted_authority.py tests/test_compiled_firewall_unknown_policy.py tests/test_compiled_firewall_indexed_matching.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_connector_diagnostics.py` (174 passed)
- `python3 -m pytest -q` (3955 passed)

Closes #21540
