### PR TITLE
chore(rust): update which to 8.0.5

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3893,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary

- refresh the Rust workspace lockfile
- update `which` from 8.0.4 to 8.0.5

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available, because `crypto-common` 0.1.7 requires exactly `generic-array = "=0.14.7"` through the AWS S3 dependency graph

## Manual version bumps

- None. All direct workspace dependencies are already at their latest stable compatible versions.

## Verification

- `cargo update --verbose`
- `cargo test --workspace -j 1 -- --test-threads=1` — passed with `CARGO_PROFILE_TEST_DEBUG=0` in the memory-constrained runner
