### PR TITLE
feat(platform): suggest chat threads from @ mentions

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
@@ -1,0 +1,30 @@
+export interface ChatThreadSuggestionRange {
+  readonly start: number;
+  readonly end: number;
+  readonly query: string;
+}
+
+export interface ComposerChatThreadSuggestion {
+  readonly id: string;
+  readonly title: string;
+}
+
+export function findActiveChatThreadSuggestionRange(
+  value: string,
+  caretIndex: number,
+): ChatThreadSuggestionRange | null {
+  if (caretIndex < 0 || caretIndex > value.length) {
+    return null;
+  }
+
+  const beforeCaret = value.slice(0, caretIndex);
+  const match = /(?:^|\s)@(\S*)$/u.exec(beforeCaret);
+  if (!match) {
+    return null;
+  }
+
+  const query = match[1] ?? "";
+  const atOffset = match[0].lastIndexOf("@");
+  const start = beforeCaret.length - match[0].length + atOffset;
+  return { start, end: caretIndex, query };
+}

--- a/turbo/apps/platform/src/signals/zero-page/composer-chat-thread-suggestions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-chat-thread-suggestions.ts
@@ -1,0 +1,65 @@
+import { computed, type Computed } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { eventDrivenChatThreads$ } from "../chat-page/chat-thread-event-sourcing.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import type {
+  ChatThreadSuggestionRange,
+  ComposerChatThreadSuggestion,
+} from "./chat-thread-suggestion-domain.ts";
+
+const MAX_VISIBLE_CHAT_THREAD_SUGGESTIONS = 25;
+
+export interface ComposerChatThreadSuggestionResult {
+  readonly agentId: string | null;
+  readonly query: string | null;
+  readonly chatThreads: readonly ComposerChatThreadSuggestion[];
+}
+
+export const composerChatThreadSuggestionsEnabled$ = computed(
+  (get): boolean => {
+    return (
+      get(featureSwitch$)[FeatureSwitchKey.ComposerChatThreadSuggestions] ??
+      false
+    );
+  },
+);
+
+export function createComposerChatThreadSuggestions(
+  activeRange$: Computed<ChatThreadSuggestionRange | null>,
+): Computed<Promise<ComposerChatThreadSuggestionResult>> {
+  return computed(async (get): Promise<ComposerChatThreadSuggestionResult> => {
+    const range = get(activeRange$);
+    if (!range || !get(composerChatThreadSuggestionsEnabled$)) {
+      return {
+        agentId: null,
+        query: range?.query ?? null,
+        chatThreads: [],
+      };
+    }
+
+    const agentId = await get(currentChatAgentRecordId$);
+    if (!agentId) {
+      return { agentId: null, query: range.query, chatThreads: [] };
+    }
+
+    const query = range.query.toLowerCase();
+    const chatThreads: ComposerChatThreadSuggestion[] = [];
+    for (const thread of await get(eventDrivenChatThreads$)) {
+      const title = thread.title;
+      if (
+        thread.agentId !== agentId ||
+        !title ||
+        !title.toLowerCase().includes(query)
+      ) {
+        continue;
+      }
+      chatThreads.push({ id: thread.id, title });
+      if (chatThreads.length === MAX_VISIBLE_CHAT_THREAD_SUGGESTIONS) {
+        break;
+      }
+    }
+
+    return { agentId, query: range.query, chatThreads };
+  });
+}

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -14,6 +14,15 @@ import { StarterKit } from "@tiptap/starter-kit";
 import { onRef } from "../utils.ts";
 import type { DraftSignals } from "./chat-draft.ts";
 import {
+  findActiveChatThreadSuggestionRange,
+  type ChatThreadSuggestionRange,
+  type ComposerChatThreadSuggestion,
+} from "./chat-thread-suggestion-domain.ts";
+import {
+  createComposerChatThreadSuggestions,
+  type ComposerChatThreadSuggestionResult,
+} from "./composer-chat-thread-suggestions.ts";
+import {
   findActiveSlashWorkflowRange,
   workflowTokenPattern,
   type ComposerSlashWorkflow,
@@ -66,11 +75,16 @@ export interface WorkflowComposerSignals {
   readonly focus$: Command<void, []>;
   readonly hasInput$: Computed<boolean>;
   readonly activeSlashRange$: Computed<SlashWorkflowRange | null>;
-  readonly selectedWorkflowIndex$: Computed<number>;
-  readonly setSelectedWorkflowIndex$: Command<void, [number]>;
-  readonly closeSlashMenu$: Command<void, []>;
+  readonly activeChatThreadSuggestionRange$: Computed<ChatThreadSuggestionRange | null>;
+  readonly chatThreadSuggestions$: Computed<
+    Promise<ComposerChatThreadSuggestionResult>
+  >;
+  readonly selectedSuggestionIndex$: Computed<number>;
+  readonly setSelectedSuggestionIndex$: Command<void, [number]>;
+  readonly closeSuggestionMenu$: Command<void, []>;
   readonly setWorkflowNames$: Command<void, [readonly string[]]>;
   readonly insertWorkflow$: Command<void, [ComposerSlashWorkflow]>;
+  readonly insertChatThread$: Command<void, [ComposerChatThreadSuggestion]>;
   readonly setEventHandlers$: Command<void, [WorkflowComposerEventHandlers]>;
 }
 
@@ -247,7 +261,7 @@ function createMountEditorCommand({
   runtime,
   caretIndex$,
   editorFocusedState$,
-  selectedWorkflowIndexState$,
+  selectedSuggestionIndexState$,
   autoFocus,
   singleLineOnMobile,
 }: {
@@ -256,7 +270,7 @@ function createMountEditorCommand({
   runtime: WorkflowComposerRuntime;
   caretIndex$: State<number>;
   editorFocusedState$: State<boolean>;
-  selectedWorkflowIndexState$: State<number>;
+  selectedSuggestionIndexState$: State<number>;
   autoFocus: boolean;
   singleLineOnMobile: boolean;
 }) {
@@ -264,7 +278,7 @@ function createMountEditorCommand({
     command(({ get, set }, element: HTMLElement, signal: AbortSignal) => {
       runtime.update = (updatedEditor) => {
         set(draft.setInput$, workflowComposerDocToString(updatedEditor));
-        set(selectedWorkflowIndexState$, 0);
+        set(selectedSuggestionIndexState$, 0);
         set(caretIndex$, caretStringIndex(updatedEditor));
         runtime.input();
       };
@@ -359,12 +373,38 @@ function createInsertWorkflowCommand(
   });
 }
 
+function createInsertChatThreadCommand(
+  editor: Editor,
+  draft: DraftSignals,
+  activeRange$: Computed<ChatThreadSuggestionRange | null>,
+) {
+  return command(({ get }, chatThread: ComposerChatThreadSuggestion) => {
+    const range = get(activeRange$);
+    if (!range) {
+      return;
+    }
+    const input = get(draft.input$);
+    const head = editor.state.selection.head;
+    const from = head - (range.end - range.start);
+    const token = `/chats/${chatThread.id}`;
+    const suffix = input.slice(range.end).startsWith(" ") ? "" : " ";
+    editor
+      .chain()
+      .focus()
+      .insertContentAt({ from, to: head }, [
+        { type: "text", text: `${token}${suffix}` },
+      ])
+      .setTextSelection(from + token.length + 1)
+      .run();
+  });
+}
+
 export function createWorkflowComposerSignals(
   draft: DraftSignals,
 ): WorkflowComposerSignals {
   const caretIndex$ = state(-1);
   const editorFocusedState$ = state(false);
-  const selectedWorkflowIndexState$ = state(0);
+  const selectedSuggestionIndexState$ = state(0);
   const runtime: WorkflowComposerRuntime = {
     update(_editor: Editor): void {},
     selectionUpdate(_editor: Editor): void {},
@@ -381,8 +421,8 @@ export function createWorkflowComposerSignals(
 
   const editor = createWorkflowEditor(runtime);
 
-  const selectedWorkflowIndex$ = computed((get) => {
-    return get(selectedWorkflowIndexState$);
+  const selectedSuggestionIndex$ = computed((get) => {
+    return get(selectedSuggestionIndexState$);
   });
   const activeSlashRange$ = computed((get) => {
     if (!get(editorFocusedState$)) {
@@ -390,10 +430,22 @@ export function createWorkflowComposerSignals(
     }
     return findActiveSlashWorkflowRange(get(draft.input$), get(caretIndex$));
   });
-  const setSelectedWorkflowIndex$ = command(({ set }, index: number) => {
-    set(selectedWorkflowIndexState$, index);
+  const activeChatThreadSuggestionRange$ = computed((get) => {
+    if (!get(editorFocusedState$)) {
+      return null;
+    }
+    return findActiveChatThreadSuggestionRange(
+      get(draft.input$),
+      get(caretIndex$),
+    );
   });
-  const closeSlashMenu$ = command(({ set }) => {
+  const chatThreadSuggestions$ = createComposerChatThreadSuggestions(
+    activeChatThreadSuggestionRange$,
+  );
+  const setSelectedSuggestionIndex$ = command(({ set }, index: number) => {
+    set(selectedSuggestionIndexState$, index);
+  });
+  const closeSuggestionMenu$ = command(({ set }) => {
     set(caretIndex$, -1);
   });
   const focus$ = command(() => {
@@ -419,7 +471,7 @@ export function createWorkflowComposerSignals(
       runtime,
       caretIndex$,
       editorFocusedState$,
-      selectedWorkflowIndexState$,
+      selectedSuggestionIndexState$,
       autoFocus,
       singleLineOnMobile,
     });
@@ -428,6 +480,11 @@ export function createWorkflowComposerSignals(
     editor,
     draft,
     activeSlashRange$,
+  );
+  const insertChatThread$ = createInsertChatThreadCommand(
+    editor,
+    draft,
+    activeChatThreadSuggestionRange$,
   );
 
   return {
@@ -438,11 +495,14 @@ export function createWorkflowComposerSignals(
     focus$,
     hasInput$: draft.hasInput$,
     activeSlashRange$,
-    selectedWorkflowIndex$,
-    setSelectedWorkflowIndex$,
-    closeSlashMenu$,
+    activeChatThreadSuggestionRange$,
+    chatThreadSuggestions$,
+    selectedSuggestionIndex$,
+    setSelectedSuggestionIndex$,
+    closeSuggestionMenu$,
     setWorkflowNames$,
     insertWorkflow$,
+    insertChatThread$,
     setEventHandlers$,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -79,6 +79,9 @@ const context = testContext();
 const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
 const OTHER_AGENT_ID = "e0000000-0000-4000-a000-000000000011";
 const THREAD_ID = "b1000000-0000-4000-a000-000000000101";
+const SUGGESTED_THREAD_ID = "b1000000-0000-4000-a000-000000000102";
+const UNTITLED_THREAD_ID = "b1000000-0000-4000-a000-000000000103";
+const OTHER_AGENT_THREAD_ID = "b1000000-0000-4000-a000-000000000104";
 const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
 const ZAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000003";
@@ -429,6 +432,34 @@ function mockThread(options?: {
     return respond(200, {
       messages: options?.messages ?? [],
       hasHistoryBefore: false,
+    });
+  });
+}
+
+function mockComposerThreadSnapshot(
+  threads: readonly {
+    readonly id: string;
+    readonly agentId: string;
+    readonly title: string | null;
+  }[],
+): void {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: threads.map((thread, index) => {
+        const timestamp = new Date(
+          Date.parse("2026-03-10T00:00:00Z") + index * 1000,
+        ).toISOString();
+        return {
+          ...thread,
+          sortAt: timestamp,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          pinnedAt: null,
+          renamedAt: null,
+          selectedModel: null,
+        };
+      }),
+      latestEventId: null,
     });
   });
 }
@@ -1073,6 +1104,126 @@ describe("chat composer models", () => {
         return element.tagName.toLowerCase() === "span";
       });
     expect(highlightedWorkflow).toHaveClass("text-primary");
+  });
+
+  it("inserts a current-agent chat thread URL from @ suggestions", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "My thread" },
+      {
+        id: SUGGESTED_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Project Alpha",
+      },
+      { id: UNTITLED_THREAD_ID, agentId: AGENT_ID, title: null },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: OTHER_AGENT_ID,
+        title: "Other Alpha",
+      },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerChatThreadSuggestions]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Review @ALPHA");
+
+    const menu = await screen.findByTestId("chat-thread-suggestion-menu");
+    expect(within(menu).getByText("Project Alpha")).toBeInTheDocument();
+    expect(within(menu).queryByText("Other Alpha")).not.toBeInTheDocument();
+    expect(within(menu).queryByText("New chat")).not.toBeInTheDocument();
+
+    await user.keyboard("{Enter}next");
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent(
+        `Review /chats/${SUGGESTED_THREAD_ID} next`,
+      );
+    });
+  });
+
+  it("hides @ suggestions when no titled thread matches", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "My thread" },
+      {
+        id: SUGGESTED_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Project Beta",
+      },
+      { id: UNTITLED_THREAD_ID, agentId: AGENT_ID, title: null },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerChatThreadSuggestions]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("@beta");
+
+    const menu = await screen.findByTestId("chat-thread-suggestion-menu");
+    expect(within(menu).getByText("Project Beta")).toBeInTheDocument();
+    expect(within(menu).queryByText("New chat")).not.toBeInTheDocument();
+
+    await user.keyboard("{Backspace>4/}alpha");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("chat-thread-suggestion-menu"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps @ chat thread suggestions behind the feature switch", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "My thread" },
+      {
+        id: SUGGESTED_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Project Alpha",
+      },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerChatThreadSuggestions]: false,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("@alpha");
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent("@alpha");
+      expect(
+        screen.queryByTestId("chat-thread-suggestion-menu"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("shows a workflow created in the current chat without a page refresh", async () => {

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-suggestion.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-suggestion.tsx
@@ -1,0 +1,77 @@
+import { cn, PopoverContent } from "@vm0/ui";
+import type { ComposerChatThreadSuggestion } from "../../signals/zero-page/chat-thread-suggestion-domain.ts";
+import { composerSuggestionCollisionPadding } from "./slash-workflow.tsx";
+
+function chatThreadSuggestionOptionId(threadId: string): string {
+  return `chat-thread-suggestion-option-${threadId}`;
+}
+
+export function scrollChatThreadSuggestionIntoView(
+  chatThread: ComposerChatThreadSuggestion | undefined,
+): void {
+  if (!chatThread) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    const option = document.getElementById(
+      chatThreadSuggestionOptionId(chatThread.id),
+    );
+    if (option && typeof option.scrollIntoView === "function") {
+      option.scrollIntoView({ block: "nearest" });
+    }
+  });
+}
+
+export function ChatThreadSuggestionMenu({
+  chatThreads,
+  selectedIndex,
+  onSelect,
+}: {
+  readonly chatThreads: readonly ComposerChatThreadSuggestion[];
+  readonly selectedIndex: number;
+  readonly onSelect: (chatThread: ComposerChatThreadSuggestion) => void;
+}) {
+  return (
+    <PopoverContent
+      side="top"
+      align="start"
+      sideOffset={8}
+      collisionPadding={composerSuggestionCollisionPadding()}
+      updatePositionStrategy="always"
+      onOpenAutoFocus={(event) => {
+        event.preventDefault();
+      }}
+      className="flex h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--radix-popover-content-available-height))]"
+      data-testid="chat-thread-suggestion-menu"
+    >
+      <div className="px-2.5 pt-2 pb-1 text-xs font-medium text-muted-foreground">
+        Chat threads
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
+        {chatThreads.map((chatThread, index) => {
+          const selected = index === selectedIndex;
+          return (
+            <button
+              id={chatThreadSuggestionOptionId(chatThread.id)}
+              key={chatThread.id}
+              type="button"
+              className={cn(
+                "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
+                selected ? "bg-accent" : "hover:bg-accent/60",
+              )}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onSelect(chatThread);
+              }}
+            >
+              <span className="truncate text-sm text-popover-foreground">
+                {chatThread.title}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </PopoverContent>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -20,9 +20,9 @@ function slashWorkflowOptionId(workflowName: string): string {
   return `slash-workflow-option-${workflowName}`;
 }
 
-const SLASH_WORKFLOW_COLLISION_GAP = 12;
+const COMPOSER_SUGGESTION_COLLISION_GAP = 12;
 
-function safeAreaCollisionPadding():
+export function composerSuggestionCollisionPadding():
   | number
   | { top: number; right: number; bottom: number; left: number } {
   // The global safe-area vars are applied as #root padding, while Radix portals
@@ -30,7 +30,7 @@ function safeAreaCollisionPadding():
   // detection keeps the portal inside the same visible content boundary.
   const root = document.getElementById("root");
   if (!root) {
-    return SLASH_WORKFLOW_COLLISION_GAP;
+    return COMPOSER_SUGGESTION_COLLISION_GAP;
   }
   const styles = window.getComputedStyle(root);
   const inset = (value: string): number => {
@@ -38,10 +38,10 @@ function safeAreaCollisionPadding():
     return Number.isFinite(parsed) ? parsed : 0;
   };
   return {
-    top: SLASH_WORKFLOW_COLLISION_GAP + inset(styles.paddingTop),
-    right: SLASH_WORKFLOW_COLLISION_GAP + inset(styles.paddingRight),
-    bottom: SLASH_WORKFLOW_COLLISION_GAP + inset(styles.paddingBottom),
-    left: SLASH_WORKFLOW_COLLISION_GAP + inset(styles.paddingLeft),
+    top: COMPOSER_SUGGESTION_COLLISION_GAP + inset(styles.paddingTop),
+    right: COMPOSER_SUGGESTION_COLLISION_GAP + inset(styles.paddingRight),
+    bottom: COMPOSER_SUGGESTION_COLLISION_GAP + inset(styles.paddingBottom),
+    left: COMPOSER_SUGGESTION_COLLISION_GAP + inset(styles.paddingLeft),
   };
 }
 
@@ -80,7 +80,7 @@ export function SlashWorkflowMenu({
       side="top"
       align="start"
       sideOffset={8}
-      collisionPadding={safeAreaCollisionPadding()}
+      collisionPadding={composerSuggestionCollisionPadding()}
       updatePositionStrategy="always"
       // Keep focus in the TipTap editor: the menu's keyboard navigation is
       // handled there, so the popover must never steal focus when it opens.

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -8,15 +8,20 @@ import type { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Popover, PopoverAnchor, type KeyboardEventLike } from "@vm0/ui";
 import { currentChatAgentRecordId$ } from "../../signals/agent-chat.ts";
+import type { ComposerChatThreadSuggestion } from "../../signals/zero-page/chat-thread-suggestion-domain.ts";
+import { composerChatThreadSuggestionsEnabled$ } from "../../signals/zero-page/composer-chat-thread-suggestions.ts";
 import type { WorkflowComposerSignals } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import { composerWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
+import {
+  ChatThreadSuggestionMenu,
+  scrollChatThreadSuggestionIntoView,
+} from "./chat-thread-suggestion.tsx";
 import {
   buildComposerSlashWorkflows,
   matchesWorkflowQuery,
   scrollSlashWorkflowIntoView,
   SlashWorkflowMenu,
   type ComposerSlashWorkflow,
-  type SlashWorkflowRange,
 } from "./slash-workflow.tsx";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 
@@ -72,29 +77,34 @@ function resolveMacControlLineNavigation(
   );
 }
 
-interface SlashCaretVirtualRef {
+interface ComposerSuggestionRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+interface ComposerSuggestionCaretVirtualRef {
   current: {
     readonly contextElement: HTMLElement;
     getBoundingClientRect(): DOMRect;
   };
 }
 
-function slashCaretVirtualRef(
+function composerSuggestionCaretVirtualRef(
   editor: Editor,
-  slashRange: SlashWorkflowRange | null,
-): SlashCaretVirtualRef | null {
-  if (!slashRange || !editor.isInitialized) {
+  range: ComposerSuggestionRange | null,
+): ComposerSuggestionCaretVirtualRef | null {
+  if (!range || !editor.isInitialized) {
     return null;
   }
   return {
     current: {
       contextElement: editor.view.dom,
       getBoundingClientRect() {
-        const slashPos = Math.max(
-          editor.state.selection.head - (slashRange.end - slashRange.start),
+        const suggestionStart = Math.max(
+          editor.state.selection.head - (range.end - range.start),
           0,
         );
-        const coords = editor.view.coordsAtPos(slashPos);
+        const coords = editor.view.coordsAtPos(suggestionStart);
         return new DOMRect(
           coords.left,
           coords.top,
@@ -106,14 +116,14 @@ function slashCaretVirtualRef(
   };
 }
 
-function SlashCaretAnchor({
+function ComposerSuggestionCaretAnchor({
   editor,
-  slashRange,
+  range,
 }: {
   readonly editor: Editor;
-  readonly slashRange: SlashWorkflowRange | null;
+  readonly range: ComposerSuggestionRange | null;
 }) {
-  const virtualRef = slashCaretVirtualRef(editor, slashRange);
+  const virtualRef = composerSuggestionCaretVirtualRef(editor, range);
   return virtualRef ? <PopoverAnchor virtualRef={virtualRef} /> : null;
 }
 
@@ -156,12 +166,13 @@ export interface TiptapWorkflowComposerProps {
 
 interface ComposerKeyDownContext {
   readonly composer: WorkflowComposerSignals;
-  readonly suggestions: readonly ComposerSlashWorkflow[];
-  readonly selectedWorkflowIndex: number;
-  readonly showSlashWorkflowMenu: boolean;
-  readonly setSelectedWorkflowIndex: (index: number) => void;
-  readonly closeSlashMenu: () => void;
-  readonly selectWorkflow: (workflow: ComposerSlashWorkflow) => void;
+  readonly suggestionCount: number;
+  readonly selectedSuggestionIndex: number;
+  readonly showSuggestionMenu: boolean;
+  readonly setSelectedSuggestionIndex: (index: number) => void;
+  readonly closeSuggestionMenu: () => void;
+  readonly selectSuggestion: (index: number) => void;
+  readonly scrollSuggestionIntoView: (index: number) => void;
   readonly onKeyDown: (event: KeyboardEventLike) => void;
 }
 
@@ -189,7 +200,7 @@ function handleComposerKeyDownCapture(
     context.composer.editor.commands.setTextSelection(lineNavigationPos);
     return true;
   }
-  if (!context.showSlashWorkflowMenu) {
+  if (!context.showSuggestionMenu) {
     context.onKeyDown(event);
     return event.defaultPrevented;
   }
@@ -199,35 +210,163 @@ function handleComposerKeyDownCapture(
     const next = Math.max(
       0,
       Math.min(
-        context.selectedWorkflowIndex + delta,
-        Math.max(context.suggestions.length - 1, 0),
+        context.selectedSuggestionIndex + delta,
+        Math.max(context.suggestionCount - 1, 0),
       ),
     );
-    context.setSelectedWorkflowIndex(next);
-    scrollSlashWorkflowIntoView(context.suggestions[next]);
+    context.setSelectedSuggestionIndex(next);
+    context.scrollSuggestionIntoView(next);
     return true;
   }
   if (
     (event.key === "Enter" || event.key === "Tab") &&
-    context.suggestions[0]
+    context.suggestionCount > 0
   ) {
     event.preventDefault();
-    const workflow =
-      context.suggestions[
-        Math.min(context.selectedWorkflowIndex, context.suggestions.length - 1)
-      ];
-    if (workflow) {
-      context.selectWorkflow(workflow);
-    }
+    context.selectSuggestion(
+      Math.min(context.selectedSuggestionIndex, context.suggestionCount - 1),
+    );
     return true;
   }
   if (event.key === "Escape") {
     event.preventDefault();
-    context.closeSlashMenu();
+    context.closeSuggestionMenu();
     return true;
   }
   context.onKeyDown(event);
   return event.defaultPrevented;
+}
+
+interface ComposerSuggestionMenuState {
+  readonly open: boolean;
+  readonly range: ComposerSuggestionRange | null;
+  readonly selectedIndex: number;
+  readonly close: () => void;
+  readonly workflowNames: readonly string[];
+  readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly workflowsLoading: boolean;
+  readonly showWorkflows: boolean;
+  readonly chatThreads: readonly ComposerChatThreadSuggestion[];
+  readonly showChatThreads: boolean;
+  readonly selectWorkflow: (workflow: ComposerSlashWorkflow) => void;
+  readonly selectChatThread: (chatThread: ComposerChatThreadSuggestion) => void;
+  readonly handleKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+function useComposerSuggestionMenu({
+  composer,
+  onDraftChange,
+  onKeyDown,
+}: {
+  readonly composer: WorkflowComposerSignals;
+  readonly onDraftChange: (() => void) | undefined;
+  readonly onKeyDown: (event: KeyboardEventLike) => void;
+}): ComposerSuggestionMenuState {
+  const slashRange = useGet(composer.activeSlashRange$);
+  const chatThreadRange = useGet(composer.activeChatThreadSuggestionRange$);
+  const chatThreadResult = useLastResolved(composer.chatThreadSuggestions$);
+  const chatThreadSuggestionsEnabled = useGet(
+    composerChatThreadSuggestionsEnabled$,
+  );
+  const selectedIndex = useGet(composer.selectedSuggestionIndex$);
+  const setSelectedIndex = useSet(composer.setSelectedSuggestionIndex$);
+  const close = useSet(composer.closeSuggestionMenu$);
+  const insertWorkflow = useSet(composer.insertWorkflow$);
+  const insertChatThread = useSet(composer.insertChatThread$);
+  const currentAgentId = useLastResolved(currentChatAgentRecordId$);
+  const workflowsLoadable = useLastLoadable(composerWorkflows$);
+  const workflows = buildComposerSlashWorkflows({
+    agentId: currentAgentId,
+    workflows:
+      workflowsLoadable.state === "hasData" ? workflowsLoadable.data : [],
+  });
+  const workflowSuggestions = slashRange
+    ? workflows.filter((workflow) => {
+        return matchesWorkflowQuery(workflow, slashRange.query);
+      })
+    : [];
+  const showWorkflows = slashRange !== null;
+  const chatThreads =
+    chatThreadSuggestionsEnabled &&
+    chatThreadRange &&
+    chatThreadResult &&
+    chatThreadResult.agentId === currentAgentId &&
+    chatThreadResult.query === chatThreadRange.query
+      ? chatThreadResult.chatThreads
+      : [];
+  const showChatThreads =
+    slashRange === null && chatThreadRange !== null && chatThreads.length > 0;
+  const open = showWorkflows || showChatThreads;
+  const range = showWorkflows
+    ? slashRange
+    : showChatThreads
+      ? chatThreadRange
+      : null;
+  const suggestionCount = showWorkflows
+    ? workflowSuggestions.length
+    : chatThreads.length;
+
+  function selectWorkflow(workflow: ComposerSlashWorkflow): void {
+    insertWorkflow(workflow);
+    onDraftChange?.();
+  }
+
+  function selectChatThread(chatThread: ComposerChatThreadSuggestion): void {
+    insertChatThread(chatThread);
+    onDraftChange?.();
+  }
+
+  function selectSuggestion(index: number): void {
+    if (showWorkflows) {
+      const workflow = workflowSuggestions[index];
+      if (workflow) {
+        selectWorkflow(workflow);
+      }
+      return;
+    }
+    const chatThread = chatThreads[index];
+    if (chatThread) {
+      selectChatThread(chatThread);
+    }
+  }
+
+  function scrollSuggestionIntoView(index: number): void {
+    if (showWorkflows) {
+      scrollSlashWorkflowIntoView(workflowSuggestions[index]);
+      return;
+    }
+    scrollChatThreadSuggestionIntoView(chatThreads[index]);
+  }
+
+  function handleKeyDown(event: KeyboardEvent): boolean {
+    return handleComposerKeyDownCapture(event, {
+      composer,
+      suggestionCount,
+      selectedSuggestionIndex: selectedIndex,
+      showSuggestionMenu: open,
+      setSelectedSuggestionIndex: setSelectedIndex,
+      closeSuggestionMenu: close,
+      selectSuggestion,
+      scrollSuggestionIntoView,
+      onKeyDown,
+    });
+  }
+
+  return {
+    open,
+    range,
+    selectedIndex,
+    close,
+    workflowNames: workflows.map((workflow) => workflow.name),
+    workflows: workflowSuggestions,
+    workflowsLoading: workflowsLoadable.state === "loading",
+    showWorkflows,
+    chatThreads,
+    showChatThreads,
+    selectWorkflow,
+    selectChatThread,
+    handleKeyDown,
+  };
 }
 
 export function TiptapWorkflowComposer({
@@ -239,50 +378,19 @@ export function TiptapWorkflowComposer({
   onPaste,
   singleLineOnMobile,
 }: TiptapWorkflowComposerProps) {
-  const slashRange = useGet(composer.activeSlashRange$);
-  const selectedWorkflowIndex = useGet(composer.selectedWorkflowIndex$);
-  const setSelectedWorkflowIndex = useSet(composer.setSelectedWorkflowIndex$);
-  const closeSlashMenu = useSet(composer.closeSlashMenu$);
+  const suggestionMenu = useComposerSuggestionMenu({
+    composer,
+    onDraftChange,
+    onKeyDown,
+  });
   const setWorkflowNames = useSet(composer.setWorkflowNames$);
   const setEventHandlers = useSet(composer.setEventHandlers$);
-  const insertWorkflow = useSet(composer.insertWorkflow$);
   const containerRefSignal = singleLineOnMobile
     ? composer.setCompactContainerRef$
     : autoFocus
       ? composer.setAutoFocusContainerRef$
       : composer.setContainerRef$;
   const setContainerRef = useSet(containerRefSignal);
-  const currentAgentId = useLastResolved(currentChatAgentRecordId$);
-  const workflowsLoadable = useLastLoadable(composerWorkflows$);
-  const workflows = buildComposerSlashWorkflows({
-    agentId: currentAgentId,
-    workflows:
-      workflowsLoadable.state === "hasData" ? workflowsLoadable.data : [],
-  });
-  const suggestions = slashRange
-    ? workflows.filter((workflow) => {
-        return matchesWorkflowQuery(workflow, slashRange.query);
-      })
-    : [];
-  const showSlashWorkflowMenu = slashRange !== null;
-
-  function selectWorkflow(workflow: ComposerSlashWorkflow): void {
-    insertWorkflow(workflow);
-    onDraftChange?.();
-  }
-
-  function handleKeyDown(event: KeyboardEvent): boolean {
-    return handleComposerKeyDownCapture(event, {
-      composer,
-      suggestions,
-      selectedWorkflowIndex,
-      showSlashWorkflowMenu,
-      setSelectedWorkflowIndex,
-      closeSlashMenu,
-      selectWorkflow,
-      onKeyDown,
-    });
-  }
 
   function handlePaste(
     event: ClipboardEvent,
@@ -310,30 +418,29 @@ export function TiptapWorkflowComposer({
     return event.defaultPrevented;
   }
 
-  const workflowNames = workflows.map((workflow) => {
-    return workflow.name;
-  });
-
   return (
     <Popover
-      open={showSlashWorkflowMenu}
+      open={suggestionMenu.open}
       onOpenChange={(open) => {
         if (!open) {
-          closeSlashMenu();
+          suggestionMenu.close();
         }
       }}
     >
-      <SlashCaretAnchor editor={composer.editor} slashRange={slashRange} />
+      <ComposerSuggestionCaretAnchor
+        editor={composer.editor}
+        range={suggestionMenu.range}
+      />
       <span
         hidden
         ref={(element) => {
           if (element) {
-            setWorkflowNames(workflowNames);
+            setWorkflowNames(suggestionMenu.workflowNames);
             setEventHandlers({
               onInput: () => {
                 onDraftChange?.();
               },
-              onKeyDown: handleKeyDown,
+              onKeyDown: suggestionMenu.handleKeyDown,
               onPaste: handlePaste,
             });
           }
@@ -345,13 +452,20 @@ export function TiptapWorkflowComposer({
         <WorkflowComposerPlaceholder composer={composer} sending={sending} />
         <div ref={setContainerRef} />
       </div>
-      {showSlashWorkflowMenu && (
+      {suggestionMenu.showWorkflows && (
         <SlashWorkflowMenu
-          workflows={suggestions}
-          loading={workflowsLoadable.state === "loading"}
-          selectedIndex={selectedWorkflowIndex}
+          workflows={suggestionMenu.workflows}
+          loading={suggestionMenu.workflowsLoading}
+          selectedIndex={suggestionMenu.selectedIndex}
           showWorkflowsPageLink
-          onSelect={selectWorkflow}
+          onSelect={suggestionMenu.selectWorkflow}
+        />
+      )}
+      {suggestionMenu.showChatThreads && (
+        <ChatThreadSuggestionMenu
+          chatThreads={suggestionMenu.chatThreads}
+          selectedIndex={suggestionMenu.selectedIndex}
+          onSelect={suggestionMenu.selectChatThread}
         />
       )}
     </Popover>

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -357,7 +357,9 @@ function useComposerSuggestionMenu({
     range,
     selectedIndex,
     close,
-    workflowNames: workflows.map((workflow) => workflow.name),
+    workflowNames: workflows.map((workflow) => {
+      return workflow.name;
+    }),
     workflows: workflowSuggestions,
     workflowsLoading: workflowsLoadable.state === "loading",
     showWorkflows,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -66,6 +66,7 @@ export enum FeatureSwitchKey {
   AgentUnreadIndicators = "agentUnreadIndicators",
   MobileUnreadChatThreadShortcuts = "mobileUnreadChatThreadShortcuts",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
+  ComposerChatThreadSuggestions = "composerChatThreadSuggestions",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -132,6 +132,9 @@ describe("getAllFeatureStates", () => {
       staffOrgStates[FeatureSwitchKey.RelationshipMemoryRuntimeInjection],
     ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ComposerChatThreadSuggestions]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
     expect(
       staffOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
@@ -163,6 +166,9 @@ describe("getAllFeatureStates", () => {
       otherOrgStates[FeatureSwitchKey.RelationshipMemoryRuntimeInjection],
     ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
+      false,
+    );
+    expect(otherOrgStates[FeatureSwitchKey.ComposerChatThreadSuggestions]).toBe(
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -387,6 +387,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerChatThreadSuggestions]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Suggest titled chat threads from the current agent when typing @ in the chat composer.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SidebarManageIconCollapse]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add a `ComposerChatThreadSuggestions` feature switch, disabled by default and enabled for staff organizations
- derive an active `@` range from the TipTap draft, caret, and focus state, allowing non-whitespace Unicode keywords
- resolve titled threads from `eventDrivenChatThreads$` for `currentChatAgentRecordId$` and match titles with a case-insensitive substring search
- reuse the composer suggestion keyboard and caret-popover behavior, hiding the thread menu when no titled thread matches
- replace the selected `@keyword` range with `/chats/:threadId` and a trailing space

## User impact

When the switch is enabled, typing `@` at the start of a message or after whitespace shows matching titled chat threads from the current agent. Enter selects the highlighted result and inserts a stable chat URL into the prompt. Untitled threads, threads belonging to other agents, and empty result sets stay hidden.

## Verification

- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- scoped `@vm0/core` and `@vm0/connectors` type-check and lint tasks
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t '@' --maxWorkers=1 --silent=passed-only` (3 passed)
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only` (23 passed)
- `pnpm knip --workspace @vm0/app --workspace @vm0/core --workspace @vm0/connectors`

The local dev server and browser walkthrough were not run, following the repository preference to rely on the PR preview pipeline for vm0 PRs.
