### PR TITLE
test(runner): cover sparse file disk usage

### DIFF
--- a/crates/runner/src/cmd/build/sizes.rs
+++ b/crates/runner/src/cmd/build/sizes.rs
@@ -35,6 +35,8 @@ fn human_bytes(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::MetadataExt;
+
     use super::*;
 
     #[test]
@@ -56,14 +58,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_sizes_existing_file() {
+    async fn file_sizes_reports_sparse_logical_and_disk_usage() {
+        const LOGICAL_BYTES: u64 = 64 * 1024 * 1024;
+        const BYTES_PER_BLOCK: u64 = 512;
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.bin");
-        tokio::fs::write(&path, vec![0u8; 1024]).await.unwrap();
+        tokio::fs::write(&path, [1_u8; 4096]).await.unwrap();
+        let file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .await
+            .unwrap();
+        file.set_len(LOGICAL_BYTES).await.unwrap();
+
+        let metadata = tokio::fs::metadata(&path).await.unwrap();
+        assert!(
+            metadata.blocks() > 0,
+            "sparse fixture must allocate at least one block"
+        );
+        let allocated_bytes = metadata.blocks() * BYTES_PER_BLOCK;
+        assert!(
+            allocated_bytes < metadata.len(),
+            "sparse fixture must use fewer allocated bytes than its logical length"
+        );
 
         let (logical, disk) = file_sizes(&path).await;
-        assert_eq!(logical, "1.0 KiB");
-        assert_ne!(disk, "?");
+        assert_eq!(logical, human_bytes(metadata.len()));
+        assert_eq!(disk, human_bytes(allocated_bytes));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace the weak dense-file size check with a real sparse-file fixture
- require non-zero allocated blocks and a larger logical length before asserting results
- verify logical size from `metadata.len()` and disk usage from `metadata.blocks() * 512`
- preserve the existing human-readable formatting and missing-file coverage

## Scope

Test-only change in the runner build size module. No production behavior, API, schema, persisted data, dependency, protocol, or deployment compatibility changes.

## Validation

- `cargo test -p runner cmd::build::sizes::tests`
- `cargo test -p runner`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- mutation check: changing the production block multiplier from 512 to 4096 made the new test fail (`32.0 KiB` versus `4.0 KiB`); the production value was restored before commit
- repository pre-commit and commit-message hooks

Closes #21580
