### PR TITLE
docs(rust): define create observer semantics

### DIFF
--- a/crates/nbd-cow/src/device/create_timing.rs
+++ b/crates/nbd-cow/src/device/create_timing.rs
@@ -5,24 +5,49 @@ use crate::pool::DeviceAcquireSource;
 const NBD_COW_CREATE_STAGE_COUNT: usize = NbdCowCreateStage::ALL.len();
 const NBD_NETLINK_CONNECT_STAGE_COUNT: usize = NbdNetlinkConnectStage::ALL.len();
 
-/// Fixed stages inside one NBD COW device creation.
+/// Fixed aggregate stages inside one NBD COW device creation.
 ///
-/// [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`]. Every other
-/// stage is a peer contribution to the enclosing NBD create operation.
+/// Repeated attempts contribute to one duration per entered stage. A nested
+/// stage overlaps its parent and must not be added to the parent as independent
+/// time. [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`], and
+/// [`NbdNetlinkConnectStage`] records are nested inside
+/// [`Self::NetlinkConnect`]. Every other stage is a peer contribution to the
+/// enclosing NBD create operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NbdCowCreateStage {
+    /// Constructs the copy-on-write storage layer for the device.
     CowLayerCreate,
+    /// Waits for a device lease from the NBD device pool.
+    ///
+    /// A demand scan, when needed, occurs inside this stage and is also
+    /// reported as [`Self::DeviceScan`].
     DeviceAcquire,
+    /// Scans host NBD devices during a demand-based device acquisition.
+    ///
+    /// This duration is nested inside [`Self::DeviceAcquire`] and is not
+    /// entered when a cooled device claim satisfies the acquisition.
     DeviceScan,
+    /// Creates the socket pairs and starts the request-dispatch tasks for an
+    /// NBD connect attempt.
     DispatchSetup,
+    /// Connects the prepared sockets to the claimed kernel NBD device through
+    /// generic netlink.
+    ///
+    /// [`NbdNetlinkConnectStage`] records provide nested details for this
+    /// stage.
     NetlinkConnect,
+    /// Verifies the kernel-reported device size after a successful connect.
     SizeVerify,
+    /// Cleans up after a retryable `EBUSY` connect or zero-size verification.
     RetryCleanup,
+    /// Waits before retrying a device whose reported size was zero.
     RetryDelay,
 }
 
 impl NbdCowCreateStage {
-    /// All stages in stable telemetry order.
+    /// All stages in stable emission order.
+    ///
+    /// An observer receives only the stages entered by a create operation.
     pub const ALL: [Self; 8] = [
         Self::CowLayerCreate,
         Self::DeviceAcquire,
@@ -35,17 +60,31 @@ impl NbdCowCreateStage {
     ];
 }
 
-/// Fixed stages nested inside [`NbdCowCreateStage::NetlinkConnect`].
+/// Fixed aggregate stages nested inside
+/// [`NbdCowCreateStage::NetlinkConnect`].
+///
+/// Repeated connect attempts contribute to one duration per entered stage.
+/// These durations overlap the enclosing netlink-connect duration and must not
+/// be added to it as independent time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NbdNetlinkConnectStage {
+    /// Waits from submission of the blocking connect work until that work
+    /// begins executing.
     BlockingTaskQueue,
+    /// Validates the socket set and opens and configures the generic-netlink
+    /// socket.
     SocketSetup,
+    /// Resolves the NBD generic-netlink family.
     FamilyResolve,
+    /// Builds, sends, and waits for completion of the NBD connect command.
     ConnectCommand,
 }
 
 impl NbdNetlinkConnectStage {
-    /// All netlink connect stages in stable telemetry order.
+    /// All netlink-connect stages in stable emission order.
+    ///
+    /// An observer receives only the stages entered by at least one connect
+    /// attempt.
     pub const ALL: [Self; 4] = [
         Self::BlockingTaskQueue,
         Self::SocketSetup,
@@ -54,28 +93,79 @@ impl NbdNetlinkConnectStage {
     ];
 }
 
-/// Fixed low-cardinality outcomes for one NBD COW device creation.
+/// Fixed low-cardinality outcome signals for one NBD COW device creation.
+///
+/// This enum contains three independent signal families rather than one
+/// mutually exclusive result. Acquisition-source variants are deduplicated
+/// presence signals: an ordinary completed create can emit neither, either, or
+/// both of them. When both are present, [`Self::AcquireSourceDemandScan`]
+/// precedes [`Self::AcquireSourceCooledClaim`]. Exactly one `EBUSY` retry bucket
+/// and one size-zero retry bucket are emitted after every ordinary success or
+/// error, including their `None` variants.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NbdCowCreateOutcome {
+    /// At least one device acquisition used an on-demand device scan.
     AcquireSourceDemandScan,
+    /// At least one device acquisition reused a claim after its cooldown.
     AcquireSourceCooledClaim,
+    /// No connect retry followed an `EBUSY` result.
     EbusyRetriesNone,
+    /// Exactly one connect retry followed an `EBUSY` result.
     EbusyRetriesOne,
+    /// Two or more connect retries followed `EBUSY` results.
     EbusyRetriesMultiple,
+    /// No retry followed a zero-size device verification.
     SizeZeroRetriesNone,
+    /// Exactly one retry followed a zero-size device verification.
     SizeZeroRetriesOne,
+    /// Two or more retries followed zero-size device verifications.
     SizeZeroRetriesMultiple,
 }
 
 /// Receives aggregate timing and bounded outcomes for one NBD COW create.
 ///
-/// Stage records are emitted once when creation returns normally. Retry work is
-/// accumulated into one contribution per stage instead of emitting one sample
-/// per attempt. Cancellation does not invoke observer code from `Drop`.
+/// Stage records are buffered until creation reaches an ordinary success or
+/// error. Retry work is accumulated into one contribution per entered stage
+/// instead of emitting one sample per attempt. The observer first receives
+/// entered [`NbdCowCreateStage`] records in [`NbdCowCreateStage::ALL`] order,
+/// then entered [`NbdNetlinkConnectStage`] records in
+/// [`NbdNetlinkConnectStage::ALL`] order. Present acquisition-source outcomes
+/// follow, then the `EBUSY` retry bucket, then the size-zero retry bucket. This
+/// callback grouping is not chronological: nested durations overlap their
+/// parents.
+///
+/// If the create eventually succeeds, every aggregate stage is successful even
+/// when it includes a recovered failed attempt. If the create returns an error,
+/// only a stage attributed as the terminal failure is unsuccessful. Dropping or
+/// cancelling the create future before it returns discards the buffered records
+/// and does not invoke observer code from `Drop`.
 pub trait NbdCowCreateObserver: Send {
+    /// Records one entered aggregate NBD create stage.
+    ///
+    /// - `stage` identifies the measured operation.
+    /// - `duration` is the saturating sum of all attempts that entered it.
+    /// - `success` is `false` only when this stage is attributed as the
+    ///   terminal failure of an unsuccessful create. It does not indicate that
+    ///   every contributing attempt succeeded.
+    ///
+    /// This required callback is invoked at most once per entered stage when
+    /// the create reaches an ordinary success or error.
     fn record_stage(&mut self, stage: NbdCowCreateStage, duration: Duration, success: bool);
 
-    /// Record one aggregate stage nested inside netlink connect.
+    /// Records one entered aggregate stage nested inside netlink connect.
+    ///
+    /// - `stage` identifies the measured netlink operation.
+    /// - `duration` is the saturating sum of all connect attempts that entered
+    ///   it.
+    /// - `success` is `false` only when netlink connect is the terminal failed
+    ///   parent and the terminal connect attempt attributes failure to this
+    ///   child. A childless terminal attempt leaves earlier child aggregates
+    ///   successful.
+    ///
+    /// This callback is invoked at most once per entered stage. Its duration is
+    /// nested inside [`NbdCowCreateStage::NetlinkConnect`]. The default
+    /// implementation intentionally ignores the nested detail so existing
+    /// observers only interested in parent stages remain valid.
     fn record_netlink_connect_stage(
         &mut self,
         _stage: NbdNetlinkConnectStage,
@@ -84,6 +174,11 @@ pub trait NbdCowCreateObserver: Send {
     ) {
     }
 
+    /// Records one acquisition-source presence signal or retry bucket.
+    ///
+    /// `outcome` identifies the presence signal or bucket. This required
+    /// callback follows the stage callbacks. See [`NbdCowCreateOutcome`] for
+    /// the independent signal families and their cardinality.
     fn record_outcome(&mut self, outcome: NbdCowCreateOutcome);
 }
 

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -7,23 +7,45 @@ use crate::sandbox::Sandbox;
 
 /// Low-cardinality stages inside sandbox factory creation.
 ///
-/// The current stage set matches the factory boundaries that runner telemetry
-/// needs to attribute. Providers that do not expose a matching internal
-/// boundary can ignore the observer.
+/// A provider can report only the stages that apply to its implementation. The
+/// workspace seed-copy and fresh-format stages are nested inside workspace
+/// drive preparation, and all NBD detail stages are nested inside NBD COW
+/// creation. Nested durations overlap their parent and must not be added to it
+/// as independent time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxCreateStage {
+    /// Acquires a prepared COW workspace slot from the provider pool.
     CowPoolAcquire,
+    /// Moves the allocated workspace into its sandbox-specific location.
     WorkspaceDirRename,
+    /// Prepares the configured workspace drive image.
+    ///
+    /// [`Self::WorkspaceSeedSparseCopy`] and
+    /// [`Self::WorkspaceFreshFormat`] are optional nested details.
     WorkspaceDrivePrepare,
+    /// Copies a workspace seed image while preserving sparse regions.
+    ///
+    /// This duration is nested inside [`Self::WorkspaceDrivePrepare`].
     WorkspaceSeedSparseCopy,
+    /// Formats a newly allocated, unseeded workspace drive image.
+    ///
+    /// This duration is nested inside [`Self::WorkspaceDrivePrepare`].
     WorkspaceFreshFormat,
+    /// Prepares the sandbox runtime socket directory.
     SockDirPrepare,
+    /// Acquires a network namespace from the provider pool.
     NetnsAcquire,
+    /// Creates the pooled NBD copy-on-write device for the sandbox.
+    ///
+    /// [`SandboxNbdCowCreateStage`] records are nested details of this stage.
     NbdCowCreate,
 }
 
 impl SandboxCreateStage {
-    /// All create stages in the stable order used by telemetry tests.
+    /// All create stages in stable catalog order.
+    ///
+    /// This order is used by typed mappings and tests. It does not define a
+    /// universal provider callback sequence.
     pub const ALL: [Self; 8] = [
         Self::CowPoolAcquire,
         Self::WorkspaceDirRename,
@@ -36,24 +58,50 @@ impl SandboxCreateStage {
     ];
 }
 
-/// Fixed NBD COW details nested under [`SandboxCreateStage::NbdCowCreate`].
+/// Fixed aggregate NBD COW details nested under
+/// [`SandboxCreateStage::NbdCowCreate`].
 ///
-/// [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`]. Every other
-/// duration is a peer contribution to the NBD create parent.
+/// Repeated attempts contribute to one duration per entered stage.
+/// [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`], and
+/// [`SandboxNbdNetlinkConnectStage`] records are nested inside
+/// [`Self::NetlinkConnect`]. Nested durations overlap their parent and must not
+/// be added to it as independent time. Every other duration is a peer
+/// contribution to the NBD create parent.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxNbdCowCreateStage {
+    /// Constructs the copy-on-write storage layer for the device.
     CowLayerCreate,
+    /// Waits for a device lease from the NBD device pool.
+    ///
+    /// A demand scan, when needed, occurs inside this stage and is also
+    /// reported as [`Self::DeviceScan`].
     DeviceAcquire,
+    /// Scans host NBD devices during a demand-based device acquisition.
+    ///
+    /// This duration is nested inside [`Self::DeviceAcquire`] and is absent
+    /// when a cooled device claim satisfies the acquisition.
     DeviceScan,
+    /// Creates the socket pairs and starts the request-dispatch tasks for an
+    /// NBD connect attempt.
     DispatchSetup,
+    /// Connects the prepared sockets to the claimed kernel NBD device through
+    /// generic netlink.
+    ///
+    /// [`SandboxNbdNetlinkConnectStage`] records are nested details of this
+    /// stage.
     NetlinkConnect,
+    /// Verifies the kernel-reported device size after a successful connect.
     SizeVerify,
+    /// Cleans up after a retryable `EBUSY` connect or zero-size verification.
     RetryCleanup,
+    /// Waits before retrying a device whose reported size was zero.
     RetryDelay,
 }
 
 impl SandboxNbdCowCreateStage {
-    /// All NBD COW detail stages in stable telemetry order.
+    /// All NBD COW detail stages in stable catalog order.
+    ///
+    /// A provider's observer contract determines which stages are emitted.
     pub const ALL: [Self; 8] = [
         Self::CowLayerCreate,
         Self::DeviceAcquire,
@@ -66,17 +114,30 @@ impl SandboxNbdCowCreateStage {
     ];
 }
 
-/// Fixed details nested under [`SandboxNbdCowCreateStage::NetlinkConnect`].
+/// Fixed aggregate details nested under
+/// [`SandboxNbdCowCreateStage::NetlinkConnect`].
+///
+/// Repeated connect attempts contribute to one duration per entered stage.
+/// These durations overlap the enclosing netlink-connect duration and must not
+/// be added to it as independent time.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxNbdNetlinkConnectStage {
+    /// Waits from submission of the blocking connect work until that work
+    /// begins executing.
     BlockingTaskQueue,
+    /// Validates the socket set and opens and configures the generic-netlink
+    /// socket.
     SocketSetup,
+    /// Resolves the NBD generic-netlink family.
     FamilyResolve,
+    /// Builds, sends, and waits for completion of the NBD connect command.
     ConnectCommand,
 }
 
 impl SandboxNbdNetlinkConnectStage {
-    /// All NBD netlink connect stages in stable telemetry order.
+    /// All NBD netlink-connect stages in stable catalog order.
+    ///
+    /// A provider's observer contract determines which stages are emitted.
     pub const ALL: [Self; 4] = [
         Self::BlockingTaskQueue,
         Self::SocketSetup,
@@ -85,24 +146,81 @@ impl SandboxNbdNetlinkConnectStage {
     ];
 }
 
-/// Fixed low-cardinality NBD COW outcomes for sandbox-create telemetry.
+/// Fixed low-cardinality NBD COW outcome signals for sandbox-create telemetry.
+///
+/// This enum contains three independent signal families rather than one
+/// mutually exclusive result. Acquisition-source variants are deduplicated
+/// presence signals: an ordinary completed NBD create can emit neither, either,
+/// or both. When both are present in the aggregate batch,
+/// [`Self::AcquireSourceDemandScan`] precedes
+/// [`Self::AcquireSourceCooledClaim`]. A provider that reports the aggregate
+/// NBD outcome batch emits exactly one `EBUSY` retry bucket and one size-zero
+/// retry bucket, including their `None` variants.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxNbdCowCreateOutcome {
+    /// At least one device acquisition used an on-demand device scan.
     AcquireSourceDemandScan,
+    /// At least one device acquisition reused a claim after its cooldown.
     AcquireSourceCooledClaim,
+    /// No connect retry followed an `EBUSY` result.
     EbusyRetriesNone,
+    /// Exactly one connect retry followed an `EBUSY` result.
     EbusyRetriesOne,
+    /// Two or more connect retries followed `EBUSY` results.
     EbusyRetriesMultiple,
+    /// No retry followed a zero-size device verification.
     SizeZeroRetriesNone,
+    /// Exactly one retry followed a zero-size device verification.
     SizeZeroRetriesOne,
+    /// Two or more retries followed zero-size device verifications.
     SizeZeroRetriesMultiple,
 }
 
-/// Receives low-cardinality sandbox factory create stage timings.
+/// Receives optional low-cardinality sandbox factory create telemetry.
+///
+/// Factories choose which applicable boundaries they expose; the default
+/// [`SandboxFactory::create_with_observer`] implementation invokes no
+/// callbacks. Consumers must not assume that every stage is present or that
+/// [`SandboxCreateStage::ALL`] defines callback arrival order.
+///
+/// The Firecracker provider reports completed outer stages as they finish, so
+/// cancellation can leave a partial set of outer records. It forwards NBD
+/// detail and outcome callbacks only after NBD creation reaches an ordinary
+/// success or error: entered NBD parent stages in
+/// [`SandboxNbdCowCreateStage::ALL`] order, entered netlink children in
+/// [`SandboxNbdNetlinkConnectStage::ALL`] order, then outcomes. Those NBD
+/// durations aggregate retries, and their callback order is grouping rather
+/// than chronology. Cancelling NBD creation before it reaches an ordinary
+/// result emits no NBD detail or outcome batch, and cleanup `Drop` paths invoke
+/// no observer callbacks. No nested duration is independent of its parent.
 pub trait SandboxCreateObserver: Send {
+    /// Records one completed outer sandbox-create stage.
+    ///
+    /// - `stage` identifies the provider operation.
+    /// - `duration` measures that single outer operation.
+    /// - `success` reports that operation's result, not the final result of the
+    ///   complete sandbox create. Earlier successful stages can precede a later
+    ///   create failure.
+    ///
+    /// A provider invokes this required callback at most once for each outer
+    /// boundary it exposes. Cancellation can leave completed callbacks without
+    /// a complete create-stage sequence.
     fn record_stage(&mut self, stage: SandboxCreateStage, duration: Duration, success: bool);
 
-    /// Record one aggregate NBD COW detail stage.
+    /// Records one entered aggregate NBD COW detail stage.
+    ///
+    /// - `stage` identifies the measured NBD operation.
+    /// - `duration` is the saturating sum across attempts.
+    /// - `success` is `false` only when `stage` is attributed as the terminal
+    ///   failure of an unsuccessful NBD create; it is not the result of every
+    ///   contributing attempt.
+    ///
+    /// An eventually successful create reports recovered attempt failures as
+    /// successful. The callback is invoked at most once per entered stage, and
+    /// its duration is nested inside
+    /// [`SandboxCreateStage::NbdCowCreate`].
+    ///
+    /// The default implementation intentionally ignores NBD detail records.
     fn record_nbd_cow_stage(
         &mut self,
         _stage: SandboxNbdCowCreateStage,
@@ -111,7 +229,17 @@ pub trait SandboxCreateObserver: Send {
     ) {
     }
 
-    /// Record one aggregate stage nested inside NBD netlink connect.
+    /// Records one entered aggregate stage nested inside NBD netlink connect.
+    ///
+    /// - `stage` identifies the measured netlink operation.
+    /// - `duration` is the saturating sum across connect attempts.
+    /// - `success` is `false` only when netlink connect is the terminal failed
+    ///   NBD parent and its terminal attempt attributes failure to `stage`; a
+    ///   childless terminal attempt leaves earlier child aggregates successful.
+    ///
+    /// The callback is invoked at most once per entered stage.
+    ///
+    /// The default implementation intentionally ignores nested netlink detail.
     fn record_nbd_netlink_connect_stage(
         &mut self,
         _stage: SandboxNbdNetlinkConnectStage,
@@ -120,7 +248,12 @@ pub trait SandboxCreateObserver: Send {
     ) {
     }
 
-    /// Record one bounded NBD COW outcome.
+    /// Records one acquisition-source presence signal or retry bucket.
+    ///
+    /// `outcome` identifies the presence signal or bucket. See
+    /// [`SandboxNbdCowCreateOutcome`] for the independent signal families and
+    /// their cardinality. The default implementation intentionally ignores NBD
+    /// outcomes.
     fn record_nbd_cow_outcome(&mut self, _outcome: SandboxNbdCowCreateOutcome) {}
 }
 
@@ -168,8 +301,10 @@ pub trait SandboxFactory: Send + Sync {
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     /// Create a sandbox while reporting create-stage timings to `observer`.
     ///
-    /// The default implementation preserves existing factory behavior for
-    /// providers that do not expose internal create-stage attribution.
+    /// Implementations can report only the boundaries applicable to their
+    /// provider. Callers must not assume a complete callback set after an error
+    /// or cancellation. The default implementation preserves existing factory
+    /// behavior by calling [`Self::create`] and ignoring `observer`.
     async fn create_with_observer(
         &self,
         config: SandboxConfig,


### PR DESCRIPTION
## Summary

- document every exported NBD and sandbox create-observer stage and outcome
- define retry aggregation, terminal failures, parent/child hierarchy, signal grouping, and callback ordering
- clarify cancellation, provider-specific omissions, buffered NBD reporting, and the default factory behavior

## Compatibility

This is a documentation-only change. It does not change runtime behavior, public Rust types, action schemas, persisted data, protocols, or feature switches.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --no-deps -p nbd-cow -p sandbox -p sandbox-fc`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow -p sandbox -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc factory::create_timing`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::telemetry_tests`

Closes #21581
