### PR TITLE
perf(api): load feature switch overrides in one query

### DIFF
--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -8,7 +8,7 @@ import {
   LEGACY_NOTION_WORKFLOW_TRIGGERS_FEATURE_SWITCH_KEY as LEGACY_NOTION_WORKFLOW_AUTOMATIONS_FEATURE_SWITCH_KEY,
 } from "@vm0/core/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
@@ -89,36 +89,38 @@ function mergeScopedFeatureSwitches(
   return merged;
 }
 
-async function loadFeatureSwitchOverrideRow(
-  db: ReadonlyDb,
-  orgId: string,
-  userId: string,
-): Promise<Record<string, boolean>> {
-  const [row] = await db
-    .select({ switches: userFeatureSwitches.switches })
-    .from(userFeatureSwitches)
-    .where(
-      and(
-        eq(userFeatureSwitches.orgId, orgId),
-        eq(userFeatureSwitches.userId, userId),
-      ),
-    )
-    .limit(1);
-
-  return filterUserOverridableFeatureSwitchOverrides(
-    canonicalizeFeatureSwitchAliases(row?.switches ?? {}),
-  );
-}
-
 async function loadUserFeatureSwitchOverrides(
   db: ReadonlyDb,
   orgId: string,
   userId: string,
 ): Promise<Record<string, boolean>> {
-  const [userSwitches, orgSwitches] = await Promise.all([
-    loadFeatureSwitchOverrideRow(db, orgId, userId),
-    loadFeatureSwitchOverrideRow(db, orgId, ORG_SENTINEL_USER_ID),
-  ]);
+  const rows = await db
+    .select({
+      userId: userFeatureSwitches.userId,
+      switches: userFeatureSwitches.switches,
+    })
+    .from(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        inArray(userFeatureSwitches.userId, [userId, ORG_SENTINEL_USER_ID]),
+      ),
+    );
+
+  let userSwitches: Record<string, boolean> = {};
+  let orgSwitches: Record<string, boolean> = {};
+
+  for (const row of rows) {
+    const switches = filterUserOverridableFeatureSwitchOverrides(
+      canonicalizeFeatureSwitchAliases(row.switches),
+    );
+    if (row.userId === userId) {
+      userSwitches = switches;
+    }
+    if (row.userId === ORG_SENTINEL_USER_ID) {
+      orgSwitches = switches;
+    }
+  }
 
   return mergeScopedFeatureSwitches(userSwitches, orgSwitches);
 }


### PR DESCRIPTION
## Summary

- load the requested-user and organization-sentinel feature-switch rows with one indexed database statement
- classify returned rows by `user_id`, preserving unordered results and the `userId === "__org__"` edge
- retain existing alias canonicalization, allowlist filtering, key-scope merge behavior, missing-row behavior, and error propagation

## Compatibility and scope

- no schema, migration, index, or persisted-data change
- no public API, frontend, queue, runner, guest, or deployment-contract change
- no cache, transaction, fallback, new telemetry, or feature-switch write/delete semantic change
- the direct benefit is one fewer SQL statement per context load; latency remains a rollout measurement

## Validation

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` — 161 files, 2,183 tests passed on a clean local database
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks, including repository-wide Knip and TypeScript checks

Closes #21583

Parent: #18746
