### PR TITLE
fix(sandbox-fc): bound firecracker process log records

### DIFF
--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -40,6 +40,7 @@ mod park_coordinator;
 mod paths;
 mod prerequisites;
 mod process;
+mod process_log;
 mod runtime;
 mod runtime_dirs;
 mod sandbox;

--- a/crates/sandbox-fc/src/process_log.rs
+++ b/crates/sandbox-fc/src/process_log.rs
@@ -1,0 +1,235 @@
+//! Bounded record reader for Firecracker process output.
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+pub(crate) const PROCESS_LOG_RECORD_MAX_BYTES: usize = 16 * 1024;
+pub(crate) const PROCESS_LOG_RECORD_TRUNCATED: &str =
+    "firecracker log record omitted: exceeded 16 KiB limit";
+
+const PROCESS_LOG_READ_BUFFER_BYTES: usize = 8 * 1024;
+
+pub(crate) enum ProcessLogRecord<'a> {
+    Line(&'a str),
+    Truncated,
+}
+
+pub(crate) async fn read_process_log_records<R, F>(
+    mut reader: R,
+    mut on_record: F,
+) -> io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    F: for<'a> FnMut(ProcessLogRecord<'a>),
+{
+    let mut buffer = [0u8; PROCESS_LOG_READ_BUFFER_BYTES];
+    let mut line = Vec::with_capacity(PROCESS_LOG_RECORD_MAX_BYTES.min(1024));
+    let mut discarding = false;
+    let mut pending_cr_at_limit = false;
+
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+
+        for &byte in buffer.iter().take(read) {
+            if discarding {
+                if byte == b'\n' {
+                    discarding = false;
+                }
+                continue;
+            }
+
+            if pending_cr_at_limit {
+                pending_cr_at_limit = false;
+                if byte == b'\n' {
+                    emit_line(&line, &mut on_record)?;
+                    line.clear();
+                } else {
+                    on_record(ProcessLogRecord::Truncated);
+                    line.clear();
+                    discarding = true;
+                }
+                continue;
+            }
+
+            if byte == b'\n' {
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+                emit_line(&line, &mut on_record)?;
+                line.clear();
+            } else if line.len() < PROCESS_LOG_RECORD_MAX_BYTES {
+                line.push(byte);
+            } else if byte == b'\r' {
+                pending_cr_at_limit = true;
+            } else {
+                on_record(ProcessLogRecord::Truncated);
+                line.clear();
+                discarding = true;
+            }
+        }
+    }
+
+    if pending_cr_at_limit {
+        on_record(ProcessLogRecord::Truncated);
+    } else if !discarding {
+        emit_line(&line, &mut on_record)?;
+    }
+
+    Ok(())
+}
+
+fn emit_line<F>(line: &[u8], on_record: &mut F) -> io::Result<()>
+where
+    F: for<'a> FnMut(ProcessLogRecord<'a>),
+{
+    if line.is_empty() {
+        return Ok(());
+    }
+
+    let line = std::str::from_utf8(line)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    on_record(ProcessLogRecord::Line(line));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum OwnedProcessLogRecord {
+        Line(String),
+        Truncated,
+    }
+
+    impl From<ProcessLogRecord<'_>> for OwnedProcessLogRecord {
+        fn from(record: ProcessLogRecord<'_>) -> Self {
+            match record {
+                ProcessLogRecord::Line(line) => Self::Line(line.to_owned()),
+                ProcessLogRecord::Truncated => Self::Truncated,
+            }
+        }
+    }
+
+    async fn collect_records(input: &[u8]) -> io::Result<Vec<OwnedProcessLogRecord>> {
+        let mut records = Vec::new();
+        read_process_log_records(input, |record| records.push(record.into())).await?;
+        Ok(records)
+    }
+
+    #[tokio::test]
+    async fn reads_lf_crlf_and_final_partial_records() {
+        let records = collect_records(b"first\nsecond\r\n\nfinal").await.unwrap();
+
+        assert_eq!(
+            records,
+            [
+                OwnedProcessLogRecord::Line("first".to_string()),
+                OwnedProcessLogRecord::Line("second".to_string()),
+                OwnedProcessLogRecord::Line("final".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_records_at_the_payload_limit() {
+        let mut input = vec![b'a'; PROCESS_LOG_RECORD_MAX_BYTES];
+        input.push(b'\n');
+        input.extend(std::iter::repeat_n(b'b', PROCESS_LOG_RECORD_MAX_BYTES));
+        input.extend_from_slice(b"\r\n");
+        input.extend(std::iter::repeat_n(b'c', PROCESS_LOG_RECORD_MAX_BYTES));
+
+        let records = collect_records(&input).await.unwrap();
+
+        assert_eq!(records.len(), 3);
+        assert_eq!(
+            records[0],
+            OwnedProcessLogRecord::Line("a".repeat(PROCESS_LOG_RECORD_MAX_BYTES))
+        );
+        assert_eq!(
+            records[1],
+            OwnedProcessLogRecord::Line("b".repeat(PROCESS_LOG_RECORD_MAX_BYTES))
+        );
+        assert_eq!(
+            records[2],
+            OwnedProcessLogRecord::Line("c".repeat(PROCESS_LOG_RECORD_MAX_BYTES))
+        );
+    }
+
+    #[tokio::test]
+    async fn replaces_each_oversized_record_and_resumes_after_newline() {
+        let mut input = vec![b'a'; PROCESS_LOG_RECORD_MAX_BYTES + 1];
+        input.extend_from_slice(b"\nafter-first\n");
+        input.extend(std::iter::repeat_n(b'b', PROCESS_LOG_RECORD_MAX_BYTES));
+        input.extend_from_slice(b"\rx\nafter-second\n");
+        input.extend(std::iter::repeat_n(b'c', PROCESS_LOG_RECORD_MAX_BYTES));
+        input.push(b'\r');
+
+        let records = collect_records(&input).await.unwrap();
+
+        assert_eq!(
+            records,
+            [
+                OwnedProcessLogRecord::Truncated,
+                OwnedProcessLogRecord::Line("after-first".to_string()),
+                OwnedProcessLogRecord::Truncated,
+                OwnedProcessLogRecord::Line("after-second".to_string()),
+                OwnedProcessLogRecord::Truncated,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drains_continuous_oversized_output_without_waiting_for_eof() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let (record_tx, mut record_rx) = tokio::sync::mpsc::unbounded_channel();
+        let reader_task = tokio::spawn(async move {
+            read_process_log_records(reader, |record| {
+                record_tx.send(record.into()).unwrap();
+            })
+            .await
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            writer.write_all(&vec![b'x'; PROCESS_LOG_RECORD_MAX_BYTES * 4]),
+        )
+        .await
+        .expect("reader should keep draining oversized output")
+        .unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), record_rx.recv())
+                .await
+                .expect("truncation record should be emitted before EOF"),
+            Some(OwnedProcessLogRecord::Truncated)
+        );
+
+        writer.write_all(b"\nafter\n").await.unwrap();
+        drop(writer);
+        reader_task.await.unwrap().unwrap();
+
+        let mut remaining = Vec::new();
+        while let Some(record) = record_rx.recv().await {
+            remaining.push(record);
+        }
+        assert_eq!(
+            remaining,
+            [OwnedProcessLogRecord::Line("after".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_invalid_utf8_failure() {
+        let error = collect_records(b"valid\n\xff\n").await.unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/sandbox-fc/src/process_log.rs
+++ b/crates/sandbox-fc/src/process_log.rs
@@ -1,4 +1,8 @@
 //! Bounded record reader for Firecracker process output.
+//!
+//! Normal records retain at most [`PROCESS_LOG_RECORD_MAX_BYTES`]. Oversized
+//! records produce one [`ProcessLogRecord::Truncated`] event while the reader
+//! continues discarding through the next delimiter or EOF.
 
 use std::io;
 
@@ -127,14 +131,16 @@ mod tests {
 
     #[tokio::test]
     async fn reads_lf_crlf_and_final_partial_records() {
-        let records = collect_records(b"first\nsecond\r\n\nfinal").await.unwrap();
+        let records = collect_records(b"first\nsecond\r\n\nfinal\r")
+            .await
+            .unwrap();
 
         assert_eq!(
             records,
             [
                 OwnedProcessLogRecord::Line("first".to_string()),
                 OwnedProcessLogRecord::Line("second".to_string()),
-                OwnedProcessLogRecord::Line("final".to_string()),
+                OwnedProcessLogRecord::Line("final\r".to_string()),
             ]
         );
     }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -14,7 +14,7 @@ use sandbox::{
     SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
     SandboxOperationReason, StartProcessRequest, WriteFileEntry,
 };
-use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
@@ -46,6 +46,10 @@ use crate::park_coordinator::{
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{ChildExitNotifier, kill_process_group};
+use crate::process_log::{
+    PROCESS_LOG_RECORD_MAX_BYTES, PROCESS_LOG_RECORD_TRUNCATED, ProcessLogRecord,
+    read_process_log_records,
+};
 use crate::runtime_dirs::{prepare_private_runtime_vsock_dir, set_private_runtime_socket_mode};
 
 mod snapshot_restore;
@@ -285,10 +289,16 @@ impl ProcessLogStream {
         }
     }
 
-    fn log(self, id: &str, line: &str) {
-        match self {
-            Self::Stdout => info!(id = %id, "{line}"),
-            Self::Stderr => warn!(id = %id, "stderr: {line}"),
+    fn log(self, id: &str, record: ProcessLogRecord<'_>) {
+        match (self, record) {
+            (Self::Stdout, ProcessLogRecord::Line(line)) => info!(id = %id, "{line}"),
+            (Self::Stderr, ProcessLogRecord::Line(line)) => warn!(id = %id, "stderr: {line}"),
+            (_, ProcessLogRecord::Truncated) => warn!(
+                id = %id,
+                stream = self.name(),
+                limit_bytes = PROCESS_LOG_RECORD_MAX_BYTES,
+                PROCESS_LOG_RECORD_TRUNCATED
+            ),
         }
     }
 }
@@ -339,12 +349,7 @@ where
 {
     let id = id.to_owned();
     tokio::spawn(async move {
-        let mut lines = BufReader::new(reader).lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            if !line.is_empty() {
-                stream.log(&id, &line);
-            }
-        }
+        let _ = read_process_log_records(reader, |record| stream.log(&id, record)).await;
     })
 }
 

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -573,20 +573,13 @@ where
     let id = id.to_owned();
     let (eof_tx, eof_rx) = tokio::sync::oneshot::channel();
     let handle = tokio::spawn(async move {
-        let mut lines = BufReader::new(reader).lines();
-        loop {
-            match lines.next_line().await {
-                Ok(Some(line)) => {
-                    if !line.is_empty() {
-                        ProcessLogStream::Stdout.log(&id, &line);
-                    }
-                }
-                Ok(None) => {
-                    let _ = eof_tx.send(());
-                    break;
-                }
-                Err(_) => break,
-            }
+        if read_process_log_records(reader, |record| {
+            ProcessLogStream::Stdout.log(&id, record);
+        })
+        .await
+        .is_ok()
+        {
+            let _ = eof_tx.send(());
         }
     });
     (handle, eof_rx)

--- a/crates/sandbox-fc/src/snapshot/attempt/process.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/process.rs
@@ -3,12 +3,16 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncRead;
 use tokio::task::JoinHandle;
 use tracing::info;
 
 use crate::config::SnapshotConfig;
 use crate::process::kill_process_group;
+use crate::process_log::{
+    PROCESS_LOG_RECORD_MAX_BYTES, PROCESS_LOG_RECORD_TRUNCATED, ProcessLogRecord,
+    read_process_log_records,
+};
 
 use super::super::SnapshotError;
 
@@ -206,14 +210,7 @@ fn spawn_stdout_forwarder(child: &mut tokio::process::Child) -> Option<JoinHandl
     child.stdout.take().map(|stdout| {
         // Intentionally detached: stdout has no cleanup decision input, and
         // EOF on the child pipe ends the task after Firecracker exits.
-        tokio::spawn(async move {
-            let mut lines = tokio::io::BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if !line.is_empty() {
-                    info!(target: "firecracker", "{line}");
-                }
-            }
-        })
+        tokio::spawn(forward_stdout(stdout))
     })
 }
 
@@ -225,21 +222,55 @@ fn spawn_stderr_forwarder(
         let buf = Arc::clone(stderr_buf);
         // The caller retains this handle only for the early-exit drain path.
         // Otherwise EOF on the child pipe ends the task after Firecracker exits.
-        tokio::spawn(async move {
-            let mut lines = tokio::io::BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if !line.is_empty() {
-                    tracing::warn!(target: "firecracker", "stderr: {line}");
-                    if let Ok(mut g) = buf.lock() {
-                        if g.len() == STDERR_BUF_LINES {
-                            g.pop_front();
-                        }
-                        g.push_back(line);
-                    }
-                }
-            }
-        })
+        tokio::spawn(async move { forward_stderr(stderr, &buf).await })
     })
+}
+
+async fn forward_stdout<R>(reader: R)
+where
+    R: AsyncRead + Unpin,
+{
+    let _ = read_process_log_records(reader, |record| match record {
+        ProcessLogRecord::Line(line) => info!(target: "firecracker", "{line}"),
+        ProcessLogRecord::Truncated => tracing::warn!(
+            target: "firecracker",
+            stream = "stdout",
+            limit_bytes = PROCESS_LOG_RECORD_MAX_BYTES,
+            PROCESS_LOG_RECORD_TRUNCATED
+        ),
+    })
+    .await;
+}
+
+async fn forward_stderr<R>(reader: R, stderr_buf: &StderrBuf)
+where
+    R: AsyncRead + Unpin,
+{
+    let _ = read_process_log_records(reader, |record| {
+        let line = match record {
+            ProcessLogRecord::Line(line) => {
+                tracing::warn!(target: "firecracker", "stderr: {line}");
+                line.to_owned()
+            }
+            ProcessLogRecord::Truncated => {
+                tracing::warn!(
+                    target: "firecracker",
+                    stream = "stderr",
+                    limit_bytes = PROCESS_LOG_RECORD_MAX_BYTES,
+                    PROCESS_LOG_RECORD_TRUNCATED
+                );
+                PROCESS_LOG_RECORD_TRUNCATED.to_string()
+            }
+        };
+
+        if let Ok(mut buffer) = stderr_buf.lock() {
+            if buffer.len() == STDERR_BUF_LINES {
+                buffer.pop_front();
+            }
+            buffer.push_back(line);
+        }
+    })
+    .await;
 }
 
 async fn drain_stderr_forwarder_after_spawn_exit(
@@ -388,6 +419,23 @@ mod tests {
     use crate::config::SnapshotConfig;
 
     use super::*;
+
+    #[tokio::test]
+    async fn stderr_forwarder_bounds_oversized_records_and_keeps_following_output() {
+        let mut input = vec![b'x'; PROCESS_LOG_RECORD_MAX_BYTES + 1];
+        input.extend_from_slice(b"\nafter\n");
+        let buf: StderrBuf = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_BUF_LINES)));
+
+        forward_stderr(input.as_slice(), &buf).await;
+
+        assert_eq!(
+            *buf.lock().expect("lock"),
+            VecDeque::from([
+                PROCESS_LOG_RECORD_TRUNCATED.to_string(),
+                "after".to_string(),
+            ])
+        );
+    }
 
     #[tokio::test]
     async fn drain_stderr_forwarder_after_spawn_exit_waits_for_failed_status() {


### PR DESCRIPTION
## Summary

- replace unbounded Firecracker line reads with a shared 16 KiB bounded record reader
- emit one fixed diagnostic for each oversized record while continuing to drain the pipe
- apply the bound to fresh and restored sandbox processes and snapshot creation forwarders
- retain bounded snapshot stderr diagnostics and resume forwarding after oversized records
- cover LF, CRLF, EOF, exact-limit, oversized, invalid UTF-8, and continuous-output behavior

## Scope

This does not change Firecracker child ownership, process monitoring, post-exit pipe draining, snapshot cancellation, or cleanup behavior. Empty records and valid records retain their existing logging semantics.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc` (710 passed)
- repository pre-commit and commit-message hooks

Closes #21582
