### PR TITLE
fix(platform): show running state for auto-sent queued messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -426,28 +426,27 @@ function nonAssistantRunIndicatorState(
     : runActivityIndicatorState(terminatedRunIds, runId);
 }
 
-function firstIndicatorMessageIndexByRunId(
+function visibleRunStartIndexByRunId(
   raw: readonly ChatMessageProjectionEntry[],
   revokedMessageIds: ReadonlySet<string>,
 ): ReadonlyMap<string, number> {
-  // An in-place claimed queued message keeps its original timestamp, so its
-  // run can start before the previous run's later completion marker.
-  const firstIndexByRunId = new Map<string, number>();
+  // Only a user message proves that a run started inside the loaded window;
+  // the first visible assistant message may be mid-run after pagination.
+  const runStartIndexByRunId = new Map<string, number>();
   for (let index = 0; index < raw.length; index++) {
     const message = raw[index]!.message;
     const runId = message.runId;
     if (
+      message.role !== "user" ||
       runId === undefined ||
-      firstIndexByRunId.has(runId) ||
-      revokedMessageIds.has(message.id) ||
-      isUsageMessage(message) ||
-      isGoalMarkerMessage(message)
+      runStartIndexByRunId.has(runId) ||
+      revokedMessageIds.has(message.id)
     ) {
       continue;
     }
-    firstIndexByRunId.set(runId, index);
+    runStartIndexByRunId.set(runId, index);
   }
-  return firstIndexByRunId;
+  return runStartIndexByRunId;
 }
 
 function laterStartedRunIndicatorState(
@@ -455,10 +454,10 @@ function laterStartedRunIndicatorState(
   terminatedRunId: string,
   terminatedRunIds: ReadonlySet<string>,
   revokedMessageIds: ReadonlySet<string>,
-  firstIndexByRunId: ReadonlyMap<string, number>,
+  runStartIndexByRunId: ReadonlyMap<string, number>,
 ): RunIndicatorState | undefined {
-  const terminatedRunFirstIndex = firstIndexByRunId.get(terminatedRunId);
-  if (terminatedRunFirstIndex === undefined) {
+  const terminatedRunStartIndex = runStartIndexByRunId.get(terminatedRunId);
+  if (terminatedRunStartIndex === undefined) {
     return undefined;
   }
 
@@ -468,7 +467,7 @@ function laterStartedRunIndicatorState(
     const runId = message.runId;
     if (
       runId === undefined ||
-      (firstIndexByRunId.get(runId) ?? -1) <= terminatedRunFirstIndex ||
+      (runStartIndexByRunId.get(runId) ?? -1) <= terminatedRunStartIndex ||
       revokedMessageIds.has(message.id) ||
       isUsageMessage(message) ||
       isGoalMarkerMessage(message)
@@ -491,7 +490,7 @@ function deriveRunIndicatorStateFromRawMessages(
 ): RunIndicatorState {
   const revokedMessageIds = revokedMessageIdsFromRawMessages(raw);
   const terminatedRunIds = terminatedRunIdsFromRawMessages(raw);
-  const firstIndexByRunId = firstIndicatorMessageIndexByRunId(
+  const runStartIndexByRunId = visibleRunStartIndexByRunId(
     raw,
     revokedMessageIds,
   );
@@ -513,7 +512,7 @@ function deriveRunIndicatorStateFromRawMessages(
           message.runId,
           terminatedRunIds,
           revokedMessageIds,
-          firstIndexByRunId,
+          runStartIndexByRunId,
         );
         if (laterRunState !== undefined) {
           return laterRunState;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -426,11 +426,75 @@ function nonAssistantRunIndicatorState(
     : runActivityIndicatorState(terminatedRunIds, runId);
 }
 
+function firstIndicatorMessageIndexByRunId(
+  raw: readonly ChatMessageProjectionEntry[],
+  revokedMessageIds: ReadonlySet<string>,
+): ReadonlyMap<string, number> {
+  // An in-place claimed queued message keeps its original timestamp, so its
+  // run can start before the previous run's later completion marker.
+  const firstIndexByRunId = new Map<string, number>();
+  for (let index = 0; index < raw.length; index++) {
+    const message = raw[index]!.message;
+    const runId = message.runId;
+    if (
+      runId === undefined ||
+      firstIndexByRunId.has(runId) ||
+      revokedMessageIds.has(message.id) ||
+      isUsageMessage(message) ||
+      isGoalMarkerMessage(message)
+    ) {
+      continue;
+    }
+    firstIndexByRunId.set(runId, index);
+  }
+  return firstIndexByRunId;
+}
+
+function laterStartedRunIndicatorState(
+  raw: readonly ChatMessageProjectionEntry[],
+  terminatedRunId: string,
+  terminatedRunIds: ReadonlySet<string>,
+  revokedMessageIds: ReadonlySet<string>,
+  firstIndexByRunId: ReadonlyMap<string, number>,
+): RunIndicatorState | undefined {
+  const terminatedRunFirstIndex = firstIndexByRunId.get(terminatedRunId);
+  if (terminatedRunFirstIndex === undefined) {
+    return undefined;
+  }
+
+  for (let index = raw.length - 1; index >= 0; index--) {
+    const entry = raw[index]!;
+    const { message } = entry;
+    const runId = message.runId;
+    if (
+      runId === undefined ||
+      (firstIndexByRunId.get(runId) ?? -1) <= terminatedRunFirstIndex ||
+      revokedMessageIds.has(message.id) ||
+      isUsageMessage(message) ||
+      isGoalMarkerMessage(message)
+    ) {
+      continue;
+    }
+    const state =
+      message.role === "assistant"
+        ? assistantRunIndicatorState(terminatedRunIds, message)
+        : nonAssistantRunIndicatorState(terminatedRunIds, entry);
+    if (state === "running" || state === "queued") {
+      return state;
+    }
+  }
+  return undefined;
+}
+
 function deriveRunIndicatorStateFromRawMessages(
   raw: readonly ChatMessageProjectionEntry[],
 ): RunIndicatorState {
   const revokedMessageIds = revokedMessageIdsFromRawMessages(raw);
   const terminatedRunIds = terminatedRunIdsFromRawMessages(raw);
+  const firstIndexByRunId = firstIndicatorMessageIndexByRunId(
+    raw,
+    revokedMessageIds,
+  );
 
   for (let index = raw.length - 1; index >= 0; index--) {
     const entry = raw[index]!;
@@ -443,6 +507,18 @@ function deriveRunIndicatorStateFromRawMessages(
     }
     if (message.role === "assistant") {
       const state = assistantRunIndicatorState(terminatedRunIds, message);
+      if (state === null && message.runId !== undefined) {
+        const laterRunState = laterStartedRunIndicatorState(
+          raw,
+          message.runId,
+          terminatedRunIds,
+          revokedMessageIds,
+          firstIndexByRunId,
+        );
+        if (laterRunState !== undefined) {
+          return laterRunState;
+        }
+      }
       if (state !== undefined) {
         return state;
       }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5852,9 +5852,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
-  it("moves an in-place claimed message out of the composer queue after an update event", async () => {
+  it("shows a later in-place claimed run after the previous run completes", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000731";
     const messageId = "00000000-0000-4000-8000-000000004031";
+    const previousRunId = "run-before-queue-first-claim";
     const runId = "run-queue-first-claimed";
     const prompt = "Run this message immediately";
     const queuedMessage: {
@@ -5874,7 +5875,32 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
 
     mockChatLifecycle(context, {
       threadId,
-      chatMessages: [queuedMessage],
+      chatMessages: [
+        {
+          id: "msg-before-queue-first-user",
+          role: "user",
+          content: "Finish the current task first",
+          runId: previousRunId,
+          createdAt: "2026-06-09T09:59:00Z",
+        },
+        queuedMessage,
+        {
+          id: "msg-before-queue-first-assistant",
+          role: "assistant",
+          content: "The current task is complete.",
+          runId: previousRunId,
+          runEventId: "event-before-queue-first-assistant",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-before-queue-first-completed",
+          role: "assistant",
+          content: null,
+          runId: previousRunId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
       activeRunIds: [runId],
       onMessageGet: (fetchedMessageId) => {
         fetchedMessageIds.push(fetchedMessageId);
@@ -5900,6 +5926,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       ).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
       expect(screen.getByText(prompt)).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-thinking-indicator]"),
+      ).not.toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1692,6 +1692,53 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps completion when the loaded window does not include either run start", async () => {
+    const threadId = "thread-run-starts-outside-loaded-window";
+    mockChatLifecycle(context, {
+      threadId,
+      activeRunIds: ["run-window-older-active"],
+      chatMessages: [
+        {
+          id: "msg-window-completed-activity",
+          role: "assistant",
+          content: "The visible completed run activity.",
+          runId: "run-window-completed",
+          runEventId: "event-window-completed-activity",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-window-older-active-activity",
+          role: "assistant",
+          content: "The visible older run activity.",
+          runId: "run-window-older-active",
+          runEventId: "event-window-older-active-activity",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-window-completed-marker",
+          role: "assistant",
+          content: null,
+          runId: "run-window-completed",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The visible completed run activity."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+      expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
+    });
+  });
+
   it("does not use active run ids to revive an older run after a newer run completes", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-concurrent-run-completed-later",


### PR DESCRIPTION
## Summary

- keep the shared chat run state focused on a visibly later run when an older run's terminal marker sorts after an in-place claimed queued message
- restore both the `Tuning in...` indicator and Stop control while the auto-sent queued message is running
- preserve the conservative completed state when the loaded message window does not prove that another run started later
- extend the chat lifecycle integration test with the queue-first timestamp ordering that caused the regression

## Verification

- `pnpm exec prettier --check` on the two changed platform files
- ESLint, Oxlint, and type-aware Oxlint on the two changed platform files
- `pnpm check-types` in `apps/platform`
- `pnpm knip --workspace apps/platform`
- 5 targeted `chat-lifecycle.test.tsx` cases covering the regression, concurrent runs, and partial message windows

Full local Vitest was not run per repository PR guidance; the PR pipeline will run the complete suite.
