### PR TITLE
fix(runner): reject out-of-range sigv4 presigned expiry

### DIFF
--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -48,7 +48,8 @@ _SCOPE_DATE_RE = re.compile(r"^\d{8}$")
 _SCOPE_REGION_RE = re.compile(r"^(?:[A-Za-z0-9._-]+|\*)$")
 _SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
-_PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
+_PRESIGN_EXPIRES_MAX_TEXT = "604800"
+_PRESIGN_EXPIRES_RE = re.compile(r"^[1-9][0-9]*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _LOWER_HEX_DIGITS = frozenset("0123456789abcdef")
 _HEX_DIGITS = frozenset("0123456789ABCDEFabcdef")
@@ -237,7 +238,11 @@ def _classify_query_request(
         raise AwsSigV4SigningError("Malformed AWS presigned query")
     source_access_key_id, scope = _parse_credential(credential)
     _validate_amz_date(amz_date, scope)
-    if not _PRESIGN_EXPIRES_RE.fullmatch(expires):
+    if (
+        len(expires) > len(_PRESIGN_EXPIRES_MAX_TEXT)
+        or not _PRESIGN_EXPIRES_RE.fullmatch(expires)
+        or (len(expires) == len(_PRESIGN_EXPIRES_MAX_TEXT) and expires > _PRESIGN_EXPIRES_MAX_TEXT)
+    ):
         raise AwsSigV4SigningError("Malformed AWS presigned query expiry")
     return _SigningContext(
         location=_AuthLocation.QUERY,

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -326,11 +326,12 @@ async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_u
     )
 
 
-async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
+@pytest.mark.parametrize("expires", ["1", "604800"], ids=["minimum", "maximum"])
+async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx, expires):
     flow = real_flow(
         with_response=False,
         host=STS_HOST,
-        path=aws_sigv4_presigned_query_path(),
+        path=aws_sigv4_presigned_query_path(expires=expires),
         method="GET",
     )
 
@@ -341,6 +342,7 @@ async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
     assert query["X-Amz-Algorithm"] == "AWS4-HMAC-SHA256"
     assert query["X-Amz-Credential"] == "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
+    assert query["X-Amz-Expires"] == expires
     assert query["X-Amz-Security-Token"] == RESOLVED_AWS_SESSION_TOKEN
     assert query["X-Amz-Signature"] != "placeholder"
     assert "PLACEHOLDER" not in flow.request.url
@@ -1035,10 +1037,25 @@ async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
     assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
-async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):
+@pytest.mark.parametrize(
+    "expires",
+    [
+        pytest.param("0", id="zero"),
+        pytest.param("604801", id="above-maximum"),
+        pytest.param("sixty", id="text"),
+        pytest.param("9" * 5000, id="oversized"),
+        pytest.param("1\u0661", id="unicode-digit"),
+    ],
+)
+async def test_query_sigv4_with_invalid_expiry_fails_closed(
+    real_flow,
+    tmp_path,
+    mitm_ctx,
+    expires,
+):
     flow = make_sts_query_sigv4_flow(
         real_flow,
-        path=aws_sigv4_presigned_query_path(expires="sixty"),
+        path=aws_sigv4_presigned_query_path(expires=expires),
     )
 
     result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)


### PR DESCRIPTION
## Summary

- enforce AWS's inclusive 1–604800-second `X-Amz-Expires` range before re-signing placeholder query authentication
- reject oversized and non-ASCII decimal metadata through the existing typed fail-closed response without integer conversion
- cover accepted boundaries and invalid values through the firewall auth integration path

## Scope

- valid expiry text remains unchanged in the re-signed query
- header-based SigV4 behavior is unchanged
- wall-clock freshness, credential lifetime, and non-AWS expiry policies remain out of scope

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_firewall_aws_sigv4_auth.py -v` (45 passed)
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/ -v` (3981 passed)

Closes #21588
