### PR TITLE
docs(mitm-addon): document auth.base forward lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -870,7 +870,21 @@ async def forward_request(
     *,
     admission: AuthBaseForwardingAdmission | None = None,
 ) -> tuple[int, bytes, http.Headers]:
-    """Async wrapper for _forward_request_sync."""
+    """Forward an auth.base request through the synchronous worker lifecycle.
+
+    When this coroutine starts, it reserves admission capacity unless `admission` is supplied.
+    A supplied admission is consumed and resized to the actual request body; the caller must not
+    release or reuse it after scheduling or awaiting this coroutine.
+
+    If the coroutine exits before submitting a worker, it releases the admission. After
+    submission, the future's completion callback releases both admission and concurrency
+    capacity. Cancellation before submission creates no worker, while cancelling a pending worker
+    future prevents it from running. Once synchronous work has started, cancelling the await does
+    not stop it; the worker retains both resources until completion.
+
+    Request body size, admission saturation, shutdown, URL/header/destination validation, upstream
+    forwarding, and response processing failures propagate to the caller.
+    """
     body_bytes = _request_body_size(body)
     try:
         _validate_request_body_size(body)

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -873,8 +873,9 @@ async def forward_request(
     """Forward an auth.base request through the synchronous worker lifecycle.
 
     When this coroutine starts, it reserves admission capacity unless `admission` is supplied.
-    A supplied admission is consumed and resized to the actual request body; the caller must not
-    release or reuse it after scheduling or awaiting this coroutine.
+    A supplied admission is consumed: it is resized to the actual request body or released if
+    validation or resizing fails. The caller must not release or reuse it after scheduling or
+    awaiting this coroutine.
 
     If the coroutine exits before submitting a worker, it releases the admission. After
     submission, the future's completion callback releases both admission and concurrency


### PR DESCRIPTION
## Summary

- document when `forward_request()` creates or consumes auth.base admission
- explain release ownership before and after worker submission
- distinguish pending-worker cancellation from cancellation after synchronous work starts
- record the propagated failure categories callers must account for

## Scope

Documentation only. This PR does not change forwarding, admission accounting, worker submission, cancellation, shutdown, exception handling, tests, or deployment behavior.

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_auth_base_forwarder.py -v` (97 passed)
- `.venv/bin/python -m pytest tests/ -v` (3976 passed)
- `git diff --check`
- `scripts/check-file-size.sh crates/runner/mitm-addon/src/auth_base_forwarder.py`

Closes #21601
