### PR TITLE
perf(mitm-addon): reuse classification catalog snapshots

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -80,29 +80,23 @@ class _OwnershipMatch:
     route_specific: bool
 
 
-_current_snapshot: DiagnosticCatalogSnapshot | None = None
+# Compilation memo only; callers select the raw generation before lookup.
+_cached_snapshot: DiagnosticCatalogSnapshot | None = None
 
 
 def reset_cache_for_tests() -> None:
-    global _current_snapshot
-    _current_snapshot = None
+    global _cached_snapshot
+    _cached_snapshot = None
 
 
 def load_diagnostic_snapshot(
     preferred_catalog_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot | None = None,
 ) -> DiagnosticCatalogSnapshot:
-    """Load one diagnostic snapshot without moving current state backward."""
-    current_raw_snapshot = builtin_firewall_cache.load_configured_catalog_snapshot()
-    # Publish the actual current state first. A stale registry classification
-    # may still use its preferred snapshot flow-locally, but cannot reinstall it
-    # as the process-wide current generation.
-    current_snapshot = _current_diagnostic_snapshot(current_raw_snapshot)
-    if preferred_catalog_snapshot is None or _raw_snapshots_match(
-        preferred_catalog_snapshot,
-        current_raw_snapshot,
-    ):
-        return current_snapshot
-    return _compile_diagnostic_snapshot(preferred_catalog_snapshot)
+    """Compile the preferred flow generation, or the current configured generation."""
+    raw_snapshot = preferred_catalog_snapshot
+    if raw_snapshot is None:
+        raw_snapshot = builtin_firewall_cache.load_configured_catalog_snapshot()
+    return _cached_diagnostic_snapshot(raw_snapshot)
 
 
 def find_candidate(
@@ -323,17 +317,17 @@ def _candidate_from_match(
     )
 
 
-def _current_diagnostic_snapshot(
+def _cached_diagnostic_snapshot(
     raw_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
 ) -> DiagnosticCatalogSnapshot:
-    global _current_snapshot
-    if _current_snapshot is not None and _compiled_snapshot_matches_raw(
-        _current_snapshot,
+    global _cached_snapshot
+    if _cached_snapshot is not None and _compiled_snapshot_matches_raw(
+        _cached_snapshot,
         raw_snapshot,
     ):
-        return _current_snapshot
-    _current_snapshot = _compile_diagnostic_snapshot(raw_snapshot)
-    return _current_snapshot
+        return _cached_snapshot
+    _cached_snapshot = _compile_diagnostic_snapshot(raw_snapshot)
+    return _cached_snapshot
 
 
 def _compile_diagnostic_snapshot(
@@ -373,21 +367,6 @@ def _compiled_snapshot_matches_raw(
             if raw_catalog is not None
             else raw_snapshot.unavailable_reason or "cache_unavailable"
         )
-    )
-
-
-def _raw_snapshots_match(
-    left: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
-    right: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
-) -> bool:
-    left_catalog = left.catalog
-    right_catalog = right.catalog
-    return (
-        left.dependency_file_key == right.dependency_file_key
-        and (left_catalog.identity if left_catalog is not None else None)
-        == (right_catalog.identity if right_catalog is not None else None)
-        and left.cache_path == right.cache_path
-        and left.unavailable_reason == right.unavailable_reason
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -1,12 +1,14 @@
 """Integration tests for server-catalog connector diagnostic lifecycles."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
 import builtin_connector_diagnostics
+import builtin_firewall_cache
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
@@ -220,6 +222,50 @@ def _builtin_shared_registry(tmp_path, *, capture_network_bodies: bool = False):
     )
 
 
+async def test_repeated_preferred_catalog_does_not_reopen_cache(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_shared_catalog("inactive", "INACTIVE_TOKEN"),
+        version="catalog-a",
+    )
+    registry_path = _builtin_shared_registry(tmp_path)
+    first_flow = _flow(real_flow, host="unmatched.example.com")
+    second_flow = _flow(real_flow, host="unmatched.example.com")
+    original_open_cache_for_read = builtin_firewall_cache._open_cache_for_read
+
+    with (
+        mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ),
+        patch.object(
+            builtin_firewall_cache,
+            "_open_cache_for_read",
+            wraps=original_open_cache_for_read,
+        ) as open_cache_for_read,
+    ):
+        await mitm_addon.request(first_flow)
+        await mitm_addon.request(second_flow)
+
+    pinned_snapshots = [
+        value
+        for flow in (first_flow, second_flow)
+        for value in flow.metadata.values()
+        if isinstance(value, builtin_connector_diagnostics.DiagnosticCatalogSnapshot)
+    ]
+    assert first_flow.response is None
+    assert second_flow.response is None
+    assert open_cache_for_read.call_count == 1
+    assert len(pinned_snapshots) == 2
+    assert pinned_snapshots[0] is pinned_snapshots[1]
+    assert pinned_snapshots[0].catalog_identity is not None
+    assert pinned_snapshots[0].catalog_identity[2] == "catalog-a"
+
+
 async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
     tmp_path,
     real_flow,
@@ -266,13 +312,16 @@ async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
             digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             version="catalog-b",
         )
+        current_before_delayed_flow = builtin_connector_diagnostics.load_diagnostic_snapshot()
         await mitm_addon.request(first_flow)
-        current_snapshot = builtin_connector_diagnostics.load_diagnostic_snapshot()
+        current_after_delayed_flow = builtin_connector_diagnostics.load_diagnostic_snapshot()
         await mitm_addon.request(second_flow)
 
     assert _response_connector(first_flow) == "inactive-a"
-    assert current_snapshot.catalog_identity is not None
-    assert current_snapshot.catalog_identity[2] == "catalog-b"
+    assert current_before_delayed_flow.catalog_identity is not None
+    assert current_before_delayed_flow.catalog_identity[2] == "catalog-b"
+    assert current_after_delayed_flow.catalog_identity is not None
+    assert current_after_delayed_flow.catalog_identity[2] == "catalog-b"
     assert _response_connector(second_flow) == "inactive-b"
 
 


### PR DESCRIPTION
## Summary

- use a classification-provided built-in catalog snapshot directly for flow-local connector diagnostics instead of reopening the configured cache
- make the single compiled diagnostic snapshot a generation-matched memo rather than authoritative current state
- cover repeated ordinary allows and B-current-then-delayed-A ordering through real request hooks and temporary catalog files

## Behavior and compatibility

- two unchanged preferred-snapshot requests now perform one catalog open for initial registry resolution instead of three total opens
- no-preferred diagnostics still load the current configured catalog and retain unavailable/recovery behavior
- atomic catalog replacement still pins an existing flow to A while current and later flows observe B
- no registry, catalog schema, API, CLI option, database, persisted state, queue payload, or runner protocol changes

## Validation

- regression on the pre-change implementation: expected 1 catalog open, observed 3
- `.venv/bin/python -m pytest tests/test_connector_diagnostic_catalog_lifecycle.py -v` — 15 passed
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m ruff format --check .` — 235 files already formatted
- `.venv/bin/python -m basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `.venv/bin/python -m pytest tests/ -q` — 3977 passed
- `git diff --check` — passed

Closes #21589
