### PR TITLE
fix(api): require web app version 0.599.19

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -791,13 +791,13 @@ describe("createApp", () => {
     it("keeps the legacy polling endpoint for already-loaded clients", async () => {
       const app = createApp({ signal: context.signal });
       const response = await app.request(
-        "/api/client/compatibility?version=0.0.0-alpha.1",
+        "/api/client/compatibility?version=0.599.18",
         { method: "GET" },
       );
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toStrictEqual({
-        minimumSupportedVersion: "0.0.0",
+        minimumSupportedVersion: "0.599.19",
         supported: false,
       });
       expect(response.headers.get("cache-control")).toBe("no-store");
@@ -809,7 +809,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.0.0-alpha.1",
+          [CLIENT_VERSION_HEADER]: "0.599.18",
         },
       });
 
@@ -826,7 +826,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.0.0",
+          [CLIENT_VERSION_HEADER]: "0.599.19",
         },
       });
 
@@ -839,7 +839,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_CLI,
-          [CLIENT_VERSION_HEADER]: "0.0.0-alpha.1",
+          [CLIENT_VERSION_HEADER]: "0.599.18",
         },
       });
 
@@ -856,7 +856,7 @@ describe("createApp", () => {
         headers: {
           "user-agent": "zero-test-agent",
           "x-forwarded-for": "203.0.113.10, 198.51.100.5",
-          "x-client-version": "0.569.1",
+          "x-client-version": "0.599.19",
           "x-client-type": "App",
           "x-client-session-id": "session-test",
           "x-client-request-id": "request-test",
@@ -874,7 +874,7 @@ describe("createApp", () => {
         path_template: "/health",
         remote_addr: "203.0.113.10",
         user_agent: "zero-test-agent",
-        x_client_version: "0.569.1",
+        x_client_version: "0.599.19",
         x_client_type: "App",
         x_client_session_id: "session-test",
         x_client_request_id: "request-test",

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.0.0"
+  "minimumSupportedVersion": "0.599.19"
 }


### PR DESCRIPTION
## Summary

- raise the minimum supported Web App version from `0.0.0` to `0.599.19`
- force stale App clients to refresh through the existing HTTP 426 and legacy polling flows while leaving CLI and Desktop clients unaffected
- update compatibility boundary and request-logging tests to use supported versions

## User impact

Browser sessions older than `0.599.19` will see the existing non-dismissible update dialog and refresh onto the latest deployed App. This drains stale clients that are still calling workflow-trigger compatibility routes so the terminal cleanup in #21408 can proceed after the zero-traffic gate.

`0.599.19` is a semantic compatibility floor rather than a published App tag; the current App release is newer (`0.600.1`).

## Verification

- `pnpm format`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts` — 37 tests passed

Related to #21408.
