### PR TITLE
fix(mitm-addon): prevent binding after client disconnect

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -355,7 +355,11 @@ async def _bind_api_upstream_destination_from_original_address(
             break
     if original_address is None or original_address_source is None:
         return False
-    if bool(getattr(server, "connected", False)) or getattr(server, "error", None):
+    if (
+        bool(getattr(server, "connected", False))
+        or getattr(server, "error", None)
+        or getattr(client, "timestamp_end", None) is not None
+    ):
         return False
     if connection_endpoints.server_address(server) != starting_server_address:
         return False

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -184,6 +184,7 @@ class _StubTLSClient:
         self.id = client_id or str(uuid.uuid4())
         self.peername = peername
         self.sni = sni
+        self.timestamp_end: float | None = None
 
 
 class _StubTLSServer:

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -635,6 +635,49 @@ async def test_server_connect_does_not_bind_after_connect_error_during_dns(regis
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
+async def test_server_connect_does_not_bind_after_client_disconnect_during_dns(
+    registry_file,
+    mitm_ctx,
+    make_tls_data,
+):
+    tls_data = make_tls_data(
+        client_ip="10.200.0.1",
+        sni="",
+        client_sni="",
+        server_address=("198.18.20.34", 443),
+    )
+    data = _ServerConnectData(
+        client=tls_data.context.client,
+        server=tls_data.context.server,
+    )
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        lookup_started.set()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        mitm_addon.tls_clienthello(tls_data)
+        assert upstream_admission.tls_admission_for_client(data.client) is not None
+        connect_task = asyncio.create_task(mitm_addon.server_connect(data))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        tls_data.context.client.timestamp_end = 1.0
+        mitm_addon.client_disconnected(tls_data.context.client)
+        assert upstream_admission.tls_admission_for_client(data.client) is None
+        release_lookup.set()
+        _ = await connect_task
+
+    assert data.server.address == ("198.18.20.34", 443)
+    assert upstream_admission.tls_admission_for_client(data.client) is None
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
 async def test_server_connect_does_not_bind_when_source_endpoint_changes_during_dns(
     registry_file, mitm_ctx
 ):


### PR DESCRIPTION
## Summary

- reject a suspended no-SNI API binding continuation after mitmproxy records the client connection end
- cover the real TLS admission, `server_connect`, and `client_disconnected` hook sequence during blocked DNS
- preserve the original server destination and empty authorization registries after cleanup

## Behavior and scope

The final post-DNS mutation gate now checks mitmproxy's `client.timestamp_end` before retargeting the server or recording an `api_allow` binding. This preserves live and half-closed connection behavior while making disconnect cleanup terminal.

This change does not alter DNS lookup coalescing, waiter cancellation, persisted data, schemas, APIs, runner protocols, or rollout configuration.

## Validation

- `ruff format --check src tests`
- `ruff check src tests`
- `basedpyright`
- `pytest tests/test_server_connect_hook.py` — 28 passed
- `pytest tests` — 3977 passed
- `git diff --check`

Closes #21605
