### PR TITLE
perf(runner): prefer exact history generations during affinity claims

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -370,6 +370,7 @@ mod tests {
     use crate::idle_pool::{
         IdlePoolConfig, ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder,
     };
+    use crate::ids::RunId;
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
     use crate::workspace_image_cache::{
@@ -903,6 +904,7 @@ mod tests {
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: Some(crate::types::ReusableSandboxState {
                 profile: "vm0/default".into(),
+                history_generation_run_id: Some(RunId::new_v4()),
             }),
         }];
         let cache = vec![HeldSessionState {
@@ -923,6 +925,14 @@ mod tests {
                 .map(|state| state.profile.as_str()),
             Some("vm0/default")
         );
+        assert!(
+            merged[0]
+                .reusable_sandbox
+                .as_ref()
+                .and_then(|state| state.history_generation_run_id)
+                .is_some(),
+            "newer workspace-cache timestamps must preserve idle generation metadata"
+        );
     }
 
     #[test]
@@ -932,6 +942,7 @@ mod tests {
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: Some(crate::types::ReusableSandboxState {
                 profile: "vm0/default".into(),
+                history_generation_run_id: None,
             }),
         }];
         let cache = vec![HeldSessionState {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -103,6 +103,11 @@ struct AdmittedClaim {
     cancel: RunCancellationHandle,
 }
 
+struct PreparedAffinityCandidate {
+    candidate: JobCandidate,
+    exact_generation_reservation: Option<Box<ReservedIdleSandbox>>,
+}
+
 struct ReuseAdmissionRequest<'a> {
     profile_name: &'a str,
     device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
@@ -459,7 +464,10 @@ async fn claim_with_local_admission(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<AdmittedClaim> {
-    let mut candidate = prepare_affinity_protected_candidate(
+    let PreparedAffinityCandidate {
+        mut candidate,
+        exact_generation_reservation,
+    } = prepare_affinity_protected_candidate(
         candidate,
         profile_name,
         job_vcpu,
@@ -472,15 +480,20 @@ async fn claim_with_local_admission(
 
     // Reserve either the exact reusable sandbox or fresh capacity before
     // claiming so a losing claim can restore all local ownership.
-    let resource = acquire_local_admission_resource(
-        &candidate,
-        profile_name,
-        job_vcpu,
-        job_memory,
-        device_rate_limits,
-        ctx,
-    )
-    .await?;
+    let resource = match exact_generation_reservation {
+        Some(reservation) => LocalAdmissionResource::Reusable(reservation),
+        None => {
+            acquire_local_admission_resource(
+                &candidate,
+                profile_name,
+                job_vcpu,
+                job_memory,
+                device_rate_limits,
+                ctx,
+            )
+            .await?
+        }
+    };
 
     // Insert cancel token before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
@@ -562,20 +575,59 @@ async fn prepare_affinity_protected_candidate(
     job_memory: u32,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &DiscoveredJobContext<'_>,
-) -> Option<JobCandidate> {
-    if !candidate.is_affinity_protected() {
-        return Some(
-            candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected),
+) -> Option<PreparedAffinityCandidate> {
+    if candidate.is_history_generation_affinity_protected()
+        && let (Some(cli_agent_session_id), Some(history_generation_run_id)) = (
+            candidate.cli_agent_session_id().map(str::to_owned),
+            candidate.history_generation_run_id(),
+        )
+    {
+        if let Some(reservation) = reserve_reusable_idle(
+            &cli_agent_session_id,
+            profile_name,
+            device_rate_limits,
+            Some(history_generation_run_id),
+            ctx,
+        )
+        .await
+        {
+            return Some(PreparedAffinityCandidate {
+                candidate: candidate
+                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
+                exact_generation_reservation: Some(Box::new(reservation)),
+            });
+        }
+
+        let delay = candidate
+            .history_generation_affinity_protection_remaining()
+            .unwrap_or_default();
+        let session_fingerprint = diagnostic_session_fingerprint(&cli_agent_session_id);
+        info!(
+            run_id = %candidate.run_id(),
+            session_fingerprint = %session_fingerprint,
+            delay_ms = delay.as_millis(),
+            "exact session-history generation protected by another runner, deferring claim"
         );
+        ctx.spawn_ctx.provider.defer_poll_after(delay).await;
+        return None;
+    }
+
+    if !candidate.is_affinity_protected() {
+        return Some(PreparedAffinityCandidate {
+            candidate: candidate
+                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected),
+            exact_generation_reservation: None,
+        });
     }
     let Some(cli_agent_session_id) = candidate.cli_agent_session_id().map(str::to_owned) else {
-        return Some(
-            candidate
+        return Some(PreparedAffinityCandidate {
+            candidate: candidate
                 .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::MissingSessionMetadata),
-        );
+            exact_generation_reservation: None,
+        });
     };
 
-    let has_exact_reusable = ctx.idle_pool.lock().await.has_reusable(
+    let has_reusable = ctx.idle_pool.lock().await.has_reusable(
         &cli_agent_session_id,
         profile_name,
         device_rate_limits,
@@ -585,10 +637,12 @@ async fn prepare_affinity_protected_candidate(
         && held_session_states
             .iter()
             .any(|state| state.session_id == cli_agent_session_id);
-    if has_exact_reusable || has_fresh_affinity {
-        return Some(
-            candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
-        );
+    if has_reusable || has_fresh_affinity {
+        return Some(PreparedAffinityCandidate {
+            candidate: candidate
+                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
+            exact_generation_reservation: None,
+        });
     }
 
     let delay = candidate
@@ -632,7 +686,7 @@ async fn acquire_local_admission_resource(
     loop {
         if let Some(session_id) = candidate.cli_agent_session_id()
             && let Some(reservation) =
-                reserve_reusable_idle(session_id, profile_name, device_rate_limits, ctx).await
+                reserve_reusable_idle(session_id, profile_name, device_rate_limits, None, ctx).await
         {
             return Some(LocalAdmissionResource::Reusable(Box::new(reservation)));
         }
@@ -671,11 +725,20 @@ async fn reserve_reusable_idle(
     session_id: &str,
     profile_name: &str,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    history_generation_run_id: Option<RunId>,
     ctx: &DiscoveredJobContext<'_>,
 ) -> Option<ReservedIdleSandbox> {
     let (reservation, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let reservation = pool.reserve_reusable(session_id, profile_name, device_rate_limits)?;
+        let reservation = match history_generation_run_id {
+            Some(history_generation_run_id) => pool.reserve_reusable_generation(
+                session_id,
+                profile_name,
+                device_rate_limits,
+                history_generation_run_id,
+            )?,
+            None => pool.reserve_reusable(session_id, profile_name, device_rate_limits)?,
+        };
         let snapshot = pool.status_snapshot();
         (reservation, snapshot)
     };

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -22,6 +22,18 @@ fn affinity_protected_candidate(run_id: RunId, session_id: &str) -> crate::provi
     )
 }
 
+fn generation_affinity_protected_candidate(
+    run_id: RunId,
+    session_id: &str,
+    target_generation_run_id: RunId,
+) -> crate::provider::JobCandidate {
+    affinity_protected_candidate(run_id, session_id)
+        .with_history_generation_run_id(Some(target_generation_run_id))
+        .with_history_generation_affinity_protected_until(Some(
+            FUTURE_AFFINITY_PROTECTED_UNTIL.to_string(),
+        ))
+}
+
 /// TOCTOU regression: soft drain can arrive after the main loop has selected
 /// a discovered candidate but before claim. The candidate is still unowned at
 /// that point, so Draining must roll back local admission and skip claim.
@@ -272,10 +284,11 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(conflict_run_id, None);
     env.handle
         .discover_tx
-        .send(
-            affinity_protected_candidate(conflict_run_id, session_id)
-                .with_history_generation_run_id(Some(reserved_generation_run_id)),
-        )
+        .send(generation_affinity_protected_candidate(
+            conflict_run_id,
+            session_id,
+            reserved_generation_run_id,
+        ))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -328,6 +341,60 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         followup_candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::Different)
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn generation_protected_different_idle_sandbox_defers_before_claim() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let session_id = "sess-different-generation";
+    let held_generation_run_id = RunId::new_v4();
+    let target_generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_history_generation(
+        &idle_pool,
+        &budget,
+        session_id,
+        "vm0/default",
+        2,
+        4096,
+        held_generation_run_id,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(generation_affinity_protected_candidate(
+            run_id,
+            session_id,
+            target_generation_run_id,
+        ))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "a different reusable generation must not reach claim during exact protection"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    let pool = idle_pool.lock().await;
+    assert_eq!(pool.held_sessions(), vec![session_id.to_string()]);
+    assert_eq!(
+        pool.held_session_states()[0]
+            .reusable_sandbox
+            .as_ref()
+            .and_then(|sandbox| sandbox.history_generation_run_id),
+        Some(held_generation_run_id),
+        "the different generation must remain available for fallback after expiry"
+    );
+    drop(pool);
 
     shutdown(&env, run_handle).await;
 }
@@ -514,7 +581,7 @@ async fn ready_direct_drain_continues_after_claim_conflict() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn affinity_protected_candidate_with_local_session_claims() {
+async fn expired_generation_protection_preserves_local_session_claim() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
@@ -545,7 +612,10 @@ async fn affinity_protected_candidate_with_local_session_claims() {
         .discover_tx
         .send(
             affinity_protected_candidate(run_id, "sess-held-local")
-                .with_history_generation_run_id(Some(RunId::new_v4())),
+                .with_history_generation_run_id(Some(RunId::new_v4()))
+                .with_history_generation_affinity_protected_until(Some(
+                    "2000-01-01T00:00:00Z".to_string(),
+                )),
         )
         .unwrap();
 
@@ -583,7 +653,7 @@ async fn affinity_protected_candidate_with_local_session_claims() {
 }
 
 #[tokio::test]
-async fn affinity_protected_candidate_with_workspace_cache_session_claims_from_startup_snapshot() {
+async fn generation_protected_workspace_cache_defers_then_legacy_candidate_claims() {
     let session_id = "sess-cache-local";
     let image_size_bytes = 1024 * 1024;
     let mut profiles = test_profiles();
@@ -623,6 +693,29 @@ async fn affinity_protected_candidate_with_workspace_cache_session_claims_from_s
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
     tokio::fs::remove_dir_all(&cache_entry_dir).await.unwrap();
+    let generation_protected_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        generation_protected_run_id,
+        Some(context_with_session(
+            generation_protected_run_id,
+            session_id,
+        )),
+    );
+    env.handle
+        .discover_tx
+        .send(generation_affinity_protected_candidate(
+            generation_protected_run_id,
+            session_id,
+            RunId::new_v4(),
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "workspace-cache state and fresh capacity must not impersonate an exact reusable generation"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+
     let run_id = RunId::new_v4();
     env.provider
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
@@ -649,9 +742,10 @@ async fn affinity_protected_candidate_with_workspace_cache_session_claims_from_s
         claimed_candidate.pre_local_admission_outcome(),
         Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
     );
-    assert!(
-        env.handle.deferred_poll_delays().is_empty(),
-        "snapshot-backed local holders should not defer before claim"
+    assert_eq!(
+        env.handle.deferred_poll_delays().len(),
+        1,
+        "the legacy candidate should not add another deferral"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -981,6 +981,27 @@ impl IdlePool {
         Some(ReservedIdleSandbox { entry })
     }
 
+    pub fn reserve_reusable_generation(
+        &mut self,
+        session_id: &str,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+        history_generation_run_id: RunId,
+    ) -> Option<ReservedIdleSandbox> {
+        if !self.has_reusable(session_id, profile_name, device_rate_limits)
+            || self
+                .entries
+                .get(session_id)
+                .and_then(|entry| entry.metadata.history_generation_run_id)
+                != Some(history_generation_run_id)
+        {
+            return None;
+        }
+        let entry = self.entries.remove(session_id)?;
+        self.bump_revision();
+        Some(ReservedIdleSandbox { entry })
+    }
+
     pub fn restore_reserved(
         &mut self,
         reservation: ReservedIdleSandbox,
@@ -1091,6 +1112,7 @@ impl IdlePool {
                         last_completed_at: last_completed_at.clone(),
                         reusable_sandbox: Some(ReusableSandboxState {
                             profile: entry.metadata.profile_name.clone(),
+                            history_generation_run_id: entry.metadata.history_generation_run_id,
                         }),
                     })
             })
@@ -1471,6 +1493,47 @@ mod tests {
         assert_eq!(pool.status_snapshot().idle_vms[0].sandbox_id, sandbox_id);
     }
 
+    #[test]
+    fn reusable_generation_reservation_requires_exact_generation() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let held_generation_run_id = RunId::new_v4();
+        let requested_generation_run_id = RunId::new_v4();
+        let candidate =
+            ParkedIdleCandidateBuilder::new("session-generation", make_budget_lease(2, 2048))
+                .with_history_generation_run_id(held_generation_run_id)
+                .with_last_completed_at("2026-07-15T00:00:00.000Z")
+                .build();
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let parked_revision = pool.status_snapshot().revision;
+
+        assert!(
+            pool.reserve_reusable_generation(
+                "session-generation",
+                "vm0/default",
+                &None,
+                requested_generation_run_id,
+            )
+            .is_none(),
+            "a different generation must remain parked"
+        );
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.status_snapshot().revision, parked_revision);
+
+        let reservation = pool
+            .reserve_reusable_generation(
+                "session-generation",
+                "vm0/default",
+                &None,
+                held_generation_run_id,
+            )
+            .expect("the exact generation should reserve");
+        assert_eq!(
+            reservation.history_generation_run_id(),
+            Some(held_generation_run_id)
+        );
+        assert_eq!(pool.len(), 0);
+    }
+
     #[tokio::test]
     async fn reserved_restore_preserves_newer_same_session_entry() {
         let mut pool = IdlePool::new(pool_config(0));
@@ -1769,11 +1832,15 @@ mod tests {
     #[test]
     fn held_session_states_include_only_entries_with_timestamps() {
         let mut pool = IdlePool::new(pool_config(0));
+        let history_generation_run_id = RunId::new_v4();
         let unconfirmed = make_candidate_for("sess-unconfirmed", 2, 2048);
         let confirmed_b = make_candidate_for("sess-b", 2, 2048)
             .with_last_completed_at("2026-05-28T00:00:01.000Z".to_string());
-        let confirmed_a = make_candidate_for("sess-a", 2, 2048)
-            .with_last_completed_at("2026-05-28T00:00:00.000Z".to_string());
+        let confirmed_a = ParkedIdleCandidateBuilder::new("sess-a", make_budget_lease(2, 2048))
+            .with_mock_sandbox_name("test")
+            .with_history_generation_run_id(history_generation_run_id)
+            .with_last_completed_at("2026-05-28T00:00:00.000Z")
+            .build();
 
         let _ = pool.park(unconfirmed);
         let _ = pool.park(confirmed_b);
@@ -1787,6 +1854,7 @@ mod tests {
                     last_completed_at: "2026-05-28T00:00:00.000Z".to_string(),
                     reusable_sandbox: Some(ReusableSandboxState {
                         profile: "vm0/default".to_string(),
+                        history_generation_run_id: Some(history_generation_run_id),
                     }),
                 },
                 HeldSessionState {
@@ -1794,6 +1862,7 @@ mod tests {
                     last_completed_at: "2026-05-28T00:00:01.000Z".to_string(),
                     reusable_sandbox: Some(ReusableSandboxState {
                         profile: "vm0/default".to_string(),
+                        history_generation_run_id: None,
                     }),
                 },
             ],

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1177,7 +1177,7 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
-    use tracing::Level;
+    use tracing::{Level, instrument::WithSubscriber};
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
     use uuid::Uuid;
@@ -1404,10 +1404,7 @@ mod tests {
     {
         let captured = CapturedEvents::default();
         let subscriber = tracing_subscriber::registry().with(captured.clone());
-        let guard = tracing::subscriber::set_default(subscriber);
-        tracing::callsite::rebuild_interest_cache();
-        let output = future.await;
-        drop(guard);
+        let output = future.with_subscriber(subscriber).await;
         (output, captured.entries())
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -360,6 +360,8 @@ impl JobProvider for ApiProvider {
                     let run_id = job.run_id;
                     let cli_agent_session_id = job.cli_agent_session_id;
                     let history_generation_run_id = job.history_generation_run_id;
+                    let history_generation_affinity_protected_until =
+                        job.history_generation_affinity_protected_until;
                     let affinity_protected_until = job.affinity_protected_until;
                     let profile = job
                         .experimental_profile
@@ -368,6 +370,9 @@ impl JobProvider for ApiProvider {
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_affinity_metadata(cli_agent_session_id, affinity_protected_until)
                         .with_history_generation_run_id(history_generation_run_id)
+                        .with_history_generation_affinity_protected_until(
+                            history_generation_affinity_protected_until,
+                        )
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -1903,6 +1908,7 @@ mod tests {
                         "experimentalProfile": "vm0/default",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
+                        "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                         "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
                     }
                 }));
@@ -1927,6 +1933,7 @@ mod tests {
             Some(history_generation_run_id)
         );
         assert!(discovered.is_affinity_protected());
+        assert!(discovered.is_history_generation_affinity_protected());
         assert_eq!(
             discovered.discovery_source(),
             Some(JobDiscoverySource::Poll)

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -686,7 +686,12 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.cli_agent_session_id.map(str::to_owned),
                         notif.affinity_protected_until.map(str::to_owned),
                     )
-                    .with_history_generation_run_id(notif.history_generation_run_id),
+                    .with_history_generation_run_id(notif.history_generation_run_id)
+                    .with_history_generation_affinity_protected_until(
+                        notif
+                            .history_generation_affinity_protected_until
+                            .map(str::to_owned),
+                    ),
                 )
             } else {
                 info!(
@@ -727,6 +732,7 @@ struct JobNotification<'a> {
     profile: Option<&'a str>,
     cli_agent_session_id: Option<&'a str>,
     history_generation_run_id: Option<RunId>,
+    history_generation_affinity_protected_until: Option<&'a str>,
     affinity_protected_until: Option<&'a str>,
 }
 
@@ -876,6 +882,11 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("affinityProtectedUntil")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
+    let history_generation_affinity_protected_until = msg
+        .data
+        .get("historyGenerationAffinityProtectedUntil")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty());
     let history_generation_run_id = msg
         .data
         .get("historyGenerationRunId")
@@ -886,6 +897,7 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         profile,
         cli_agent_session_id,
         history_generation_run_id,
+        history_generation_affinity_protected_until,
         affinity_protected_until,
     })
 }
@@ -1735,6 +1747,8 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
                 "cliAgentSessionId": "sess-ably",
+                "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
+                "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
             }),
         );
@@ -1750,6 +1764,7 @@ mod tests {
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert!(candidate.is_affinity_protected());
+        assert!(candidate.is_history_generation_affinity_protected());
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }
@@ -2199,6 +2214,7 @@ mod tests {
                 "targetRunnerId": "00000000-0000-0000-0000-000000000099",
                 "cliAgentSessionId": "sess-target",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
+                "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
             }),
         );
@@ -2208,6 +2224,10 @@ mod tests {
         assert_eq!(
             notif.history_generation_run_id,
             Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
+        );
+        assert_eq!(
+            notif.history_generation_affinity_protected_until,
+            Some("2999-01-01T00:00:00.000Z")
         );
         assert_eq!(
             notif.affinity_protected_until,

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -19,6 +19,7 @@ pub(super) struct DirectJobCandidate {
     enqueued_at: Option<StdInstant>,
     cli_agent_session_id: Option<String>,
     history_generation_run_id: Option<RunId>,
+    history_generation_affinity_protected_until: Option<String>,
     affinity_protected_until: Option<String>,
 }
 
@@ -64,6 +65,7 @@ impl DirectJobCandidate {
             enqueued_at: None,
             cli_agent_session_id,
             history_generation_run_id: None,
+            history_generation_affinity_protected_until: None,
             affinity_protected_until,
         }
     }
@@ -100,6 +102,14 @@ impl DirectJobCandidate {
         self
     }
 
+    pub(super) fn with_history_generation_affinity_protected_until(
+        mut self,
+        protected_until: Option<String>,
+    ) -> Self {
+        self.history_generation_affinity_protected_until = protected_until;
+        self
+    }
+
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -111,6 +121,9 @@ impl DirectJobCandidate {
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
             .with_history_generation_run_id(self.history_generation_run_id)
+            .with_history_generation_affinity_protected_until(
+                self.history_generation_affinity_protected_until,
+            )
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -130,6 +143,13 @@ impl DirectJobCandidate {
         }
         if candidate.affinity_protected_until.is_some() {
             self.affinity_protected_until = candidate.affinity_protected_until;
+        }
+        if candidate
+            .history_generation_affinity_protected_until
+            .is_some()
+        {
+            self.history_generation_affinity_protected_until =
+                candidate.history_generation_affinity_protected_until;
         }
         if candidate.history_generation_run_id.is_some() {
             self.history_generation_run_id = candidate.history_generation_run_id;
@@ -429,7 +449,10 @@ mod tests {
                     None,
                     Some("2999-01-01T00:00:00.000Z".to_string()),
                 )
-                .with_history_generation_run_id(Some(history_generation_run_id)),
+                .with_history_generation_run_id(Some(history_generation_run_id))
+                .with_history_generation_affinity_protected_until(Some(
+                    "2999-01-01T00:00:00.000Z".to_string(),
+                )),
             )
             .await;
         assert!(matches!(
@@ -453,6 +476,7 @@ mod tests {
             Some(history_generation_run_id)
         );
         assert!(candidate.is_affinity_protected());
+        assert!(candidate.is_history_generation_affinity_protected());
         assert!(
             candidate
                 .direct_candidate_notification_to_enqueue_elapsed()

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -105,6 +105,7 @@ pub struct JobCandidate {
     cli_agent_session_id: Option<String>,
     history_generation_run_id: Option<RunId>,
     session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
+    history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
 
@@ -138,6 +139,7 @@ impl JobCandidate {
             cli_agent_session_id: None,
             history_generation_run_id: None,
             session_history_generation_relationship: None,
+            history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
         }
     }
@@ -243,16 +245,23 @@ impl JobCandidate {
     }
 
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
-        let protected_until = self.affinity_protected_until?;
-        let now = Utc::now();
-        if protected_until <= now {
-            return None;
-        }
-        (protected_until - now).to_std().ok()
+        protection_remaining(self.affinity_protected_until)
     }
 
     pub(crate) fn is_affinity_protected(&self) -> bool {
         self.affinity_protection_remaining()
+            .is_some_and(|remaining| !remaining.is_zero())
+    }
+
+    pub(crate) fn history_generation_affinity_protection_remaining(&self) -> Option<Duration> {
+        let generation_remaining =
+            protection_remaining(self.history_generation_affinity_protected_until)?;
+        let session_remaining = self.affinity_protection_remaining()?;
+        Some(generation_remaining.min(session_remaining))
+    }
+
+    pub(crate) fn is_history_generation_affinity_protected(&self) -> bool {
+        self.history_generation_affinity_protection_remaining()
             .is_some_and(|remaining| !remaining.is_zero())
     }
 
@@ -274,6 +283,16 @@ impl JobCandidate {
         history_generation_run_id: Option<RunId>,
     ) -> Self {
         self.history_generation_run_id = history_generation_run_id;
+        self
+    }
+
+    pub(crate) fn with_history_generation_affinity_protected_until(
+        mut self,
+        protected_until: Option<String>,
+    ) -> Self {
+        self.history_generation_affinity_protected_until = protected_until
+            .as_deref()
+            .and_then(parse_affinity_protected_until);
         self
     }
 
@@ -340,6 +359,15 @@ fn parse_affinity_protected_until(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(value)
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+fn protection_remaining(protected_until: Option<DateTime<Utc>>) -> Option<Duration> {
+    let protected_until = protected_until?;
+    let now = Utc::now();
+    if protected_until <= now {
+        return None;
+    }
+    (protected_until - now).to_std().ok()
 }
 
 /// Job claim result with the context and auth required for terminal completion.
@@ -600,5 +628,24 @@ mod tests {
         assert_eq!(context.run_id, run_id);
         assert!(active_input_source.is_none());
         assert!(completion_auth.matches_sandbox_token_for_test(run_id, "sandbox-token"));
+    }
+
+    #[test]
+    fn history_generation_affinity_never_outlives_session_affinity() {
+        let expired_session = JobCandidate::new(RunId::nil(), "vm0/default".into())
+            .with_affinity_metadata(
+                Some("sess-deadline".into()),
+                Some("2000-01-01T00:00:00Z".into()),
+            )
+            .with_history_generation_affinity_protected_until(Some("2999-01-01T00:00:00Z".into()));
+        assert!(!expired_session.is_history_generation_affinity_protected());
+
+        let active_session = JobCandidate::new(RunId::nil(), "vm0/default".into())
+            .with_affinity_metadata(
+                Some("sess-deadline".into()),
+                Some("2999-01-01T00:00:01Z".into()),
+            )
+            .with_history_generation_affinity_protected_until(Some("2999-01-01T00:00:00Z".into()));
+        assert!(active_session.is_history_generation_affinity_protected());
     }
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -37,6 +37,8 @@ pub struct Job {
     #[serde(default)]
     pub history_generation_run_id: Option<RunId>,
     #[serde(default)]
+    pub history_generation_affinity_protected_until: Option<String>,
+    #[serde(default)]
     pub affinity_protected_until: Option<String>,
 }
 
@@ -1192,6 +1194,8 @@ impl ExecutionContext {
 #[serde(rename_all = "camelCase")]
 pub struct ReusableSandboxState {
     pub profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_generation_run_id: Option<RunId>,
 }
 
 /// Runner state snapshot sent to the server via heartbeat.
@@ -1906,6 +1910,9 @@ mod tests {
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
                 reusable_sandbox: Some(ReusableSandboxState {
                     profile: "vm0/default".into(),
+                    history_generation_run_id: Some(
+                        "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                    ),
                 }),
             }],
             mode: "running".into(),
@@ -1928,7 +1935,8 @@ mod tests {
                 "sessionId": "session-abc",
                 "lastCompletedAt": "2026-05-28T00:00:00.000Z",
                 "reusableSandbox": {
-                    "profile": "vm0/default"
+                    "profile": "vm0/default",
+                    "historyGenerationRunId": "11111111-1111-4111-8111-111111111111"
                 }
             }])
         );
@@ -1939,12 +1947,24 @@ mod tests {
     fn held_session_state_accepts_legacy_shape_and_omits_absent_capability() {
         let state: HeldSessionState = serde_json::from_value(json!({
             "sessionId": "session-legacy",
-            "lastCompletedAt": "2026-05-28T00:00:00.000Z"
+            "lastCompletedAt": "2026-05-28T00:00:00.000Z",
+            "reusableSandbox": {
+                "profile": "vm0/default"
+            }
         }))
         .unwrap();
-        assert!(state.reusable_sandbox.is_none());
+        assert!(
+            state
+                .reusable_sandbox
+                .as_ref()
+                .is_some_and(|sandbox| sandbox.history_generation_run_id.is_none())
+        );
 
         let serialized = serde_json::to_value(state).unwrap();
-        assert!(serialized.get("reusableSandbox").is_none());
+        assert!(
+            serialized["reusableSandbox"]
+                .get("historyGenerationRunId")
+                .is_none()
+        );
     }
 }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -275,6 +275,7 @@ export async function publishRunnerJobNotification(
   profile: string,
   metadata?: {
     readonly cliAgentSessionId: string | null;
+    readonly historyGenerationAffinityProtectedUntil: string | null;
     readonly affinityProtectedUntil: string | null;
     readonly historyGenerationRunId: string | undefined;
   },
@@ -290,6 +291,12 @@ export async function publishRunnerJobNotification(
           : {}),
         ...(metadata?.affinityProtectedUntil
           ? { affinityProtectedUntil: metadata.affinityProtectedUntil }
+          : {}),
+        ...(metadata?.historyGenerationAffinityProtectedUntil
+          ? {
+              historyGenerationAffinityProtectedUntil:
+                metadata.historyGenerationAffinityProtectedUntil,
+            }
           : {}),
         ...(metadata?.historyGenerationRunId
           ? { historyGenerationRunId: metadata.historyGenerationRunId }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -12,6 +12,7 @@ import {
   getVm0ConcreteProviderType,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type { Job as RunnerJob } from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -82,6 +83,18 @@ import {
 const context = testContext();
 const ASSISTANT_MESSAGE_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+function sessionAffinityProtectedUntil(
+  job: RunnerJob | null | undefined,
+): string | null {
+  return job?.affinityProtectedUntil ?? null;
+}
+
+function historyGenerationAffinityProtectedUntil(
+  job: RunnerJob | null | undefined,
+): string | null {
+  return job?.historyGenerationAffinityProtectedUntil ?? null;
+}
 
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
@@ -2617,7 +2630,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     async function heartbeatHolder(args: {
       readonly admittableProfiles?: string[];
       readonly mode?: "starting" | "running" | "draining" | "stopping";
-      readonly reusableSandbox?: { readonly profile: string };
+      readonly reusableSandbox?: {
+        readonly profile: string;
+        readonly historyGenerationRunId?: string;
+      };
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
         runnerId: affinityRunnerId,
@@ -2636,13 +2652,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       });
     }
 
-    async function pollFollowUp(prompt: string, cancelAfterPoll = true) {
+    async function pollFollowUp(
+      prompt: string,
+      cancelAfterPoll = true,
+      pollAtMs?: number,
+    ) {
       const run = await api.createRun(actor, {
         agentId,
         sessionId: first.sessionId,
         prompt,
         modelProvider: "anthropic-api-key",
       });
+      if (pollAtMs !== undefined) {
+        mockNow(pollAtMs);
+      }
       const poll = await api.requestPollRunner(
         true,
         { group: runnerGroup, supportedProfiles: ["vm0/default"] },
@@ -2720,9 +2743,46 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue when final heartbeat includes extra legacy fields",
     );
     expect(finalHeartbeatHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(finalHeartbeatHolder.job?.affinityProtectedUntil).toStrictEqual(
-      expect.any(String),
+    expect(
+      sessionAffinityProtectedUntil(finalHeartbeatHolder.job),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      historyGenerationAffinityProtectedUntil(finalHeartbeatHolder.job),
+    ).toBeNull();
+
+    await heartbeatHolder({
+      admittableProfiles: [],
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId: randomUUID(),
+      },
+    });
+    const differentGenerationHolder = await pollFollowUp(
+      "continue with a different reusable generation",
     );
+    expect(
+      sessionAffinityProtectedUntil(differentGenerationHolder.job),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      historyGenerationAffinityProtectedUntil(differentGenerationHolder.job),
+    ).toBeNull();
+
+    await heartbeatHolder({
+      admittableProfiles: [],
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId: first.runId,
+      },
+    });
+    const exactGenerationHolder = await pollFollowUp(
+      "continue with exact reusable generation",
+    );
+    expect(
+      sessionAffinityProtectedUntil(exactGenerationHolder.job),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      historyGenerationAffinityProtectedUntil(exactGenerationHolder.job),
+    ).toStrictEqual(expect.any(String));
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -2732,7 +2792,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is starting",
     );
     expect(startingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(startingHolder.job?.affinityProtectedUntil).toBeNull();
+    expect(sessionAffinityProtectedUntil(startingHolder.job)).toBeNull();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -2742,7 +2802,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       false,
     );
     expect(unavailableHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(unavailableHolder.job?.affinityProtectedUntil).toBeNull();
+    expect(sessionAffinityProtectedUntil(unavailableHolder.job)).toBeNull();
     const unavailableClaim = await api.claimRunnerJob(
       unavailableHolder.run.runId,
     );
@@ -2755,18 +2815,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     await heartbeatHolder({
       admittableProfiles: [],
-      reusableSandbox: { profile: "vm0/default" },
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId: first.runId,
+      },
     });
     clearMockNow();
     const staleHolder = await pollFollowUp(
       "continue after holder heartbeat is stale",
     );
     expect(staleHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(staleHolder.job?.affinityProtectedUntil).toBeNull();
+    expect(sessionAffinityProtectedUntil(staleHolder.job)).toBeNull();
+    expect(historyGenerationAffinityProtectedUntil(staleHolder.job)).toBeNull();
 
     await heartbeatHolder({
       admittableProfiles: [],
-      reusableSandbox: { profile: "vm0/large" },
+      reusableSandbox: {
+        profile: "vm0/large",
+        historyGenerationRunId: first.runId,
+      },
     });
     const profileIncompatibleHolder = await pollFollowUp(
       "continue when holder cannot run requested profile",
@@ -2774,21 +2841,36 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.cliAgentSessionId).toBe(
       cliAgentSessionId,
     );
-    expect(profileIncompatibleHolder.job?.affinityProtectedUntil).toBeNull();
+    expect(
+      sessionAffinityProtectedUntil(profileIncompatibleHolder.job),
+    ).toBeNull();
+    expect(
+      historyGenerationAffinityProtectedUntil(profileIncompatibleHolder.job),
+    ).toBeNull();
 
     await heartbeatHolder({
       admittableProfiles: [],
-      reusableSandbox: { profile: "vm0/default" },
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId: first.runId,
+      },
       mode: "draining",
     });
     const drainingHolder = await pollFollowUp(
       "continue while holder is draining",
     );
     expect(drainingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(drainingHolder.job?.affinityProtectedUntil).toBeNull();
+    expect(sessionAffinityProtectedUntil(drainingHolder.job)).toBeNull();
+    expect(
+      historyGenerationAffinityProtectedUntil(drainingHolder.job),
+    ).toBeNull();
 
     await heartbeatHolder({
-      admittableProfiles: ["vm0/default"],
+      admittableProfiles: [],
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId: first.runId,
+      },
     });
     if (!actor.orgId) {
       throw new Error("Expected affinity actor to have an organization");
@@ -2808,6 +2890,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       })
       .toBe(true);
 
+    context.mocks.ably.publish.mockClear();
     const protectedFollowUpRequest = api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
@@ -2823,6 +2906,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await releaseOrgAdmissionLock(context);
     await admissionLockRequest;
     const protectedFollowUp = await protectedFollowUpRequest;
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: protectedFollowUp.runId,
+        historyGenerationRunId: first.runId,
+        affinityProtectedUntil: new Date(queueInsertedAt + 2000).toISOString(),
+        historyGenerationAffinityProtectedUntil: new Date(
+          queueInsertedAt + 500,
+        ).toISOString(),
+      }),
+    );
 
     const protectedPoll = await api.requestPollRunner(
       true,
@@ -2834,9 +2928,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(protectedPoll.body.job?.affinityProtectedUntil).toBe(
+    expect(sessionAffinityProtectedUntil(protectedPoll.body.job)).toBe(
       new Date(queueInsertedAt + 2000).toISOString(),
     );
+    expect(
+      historyGenerationAffinityProtectedUntil(protectedPoll.body.job),
+    ).toBe(new Date(queueInsertedAt + 500).toISOString());
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
     expect(protectedClaim.prompt).toBe("continue affinity-protected session");
@@ -2878,10 +2975,29 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           profile: "vm0/default",
           notification_target: "broadcast",
           session_affinity: "protected",
+          history_generation_affinity: "protected",
         }),
       );
     }
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
+
+    const generationExpiredAt = now();
+    const generationExpiredFollowUp = await pollFollowUp(
+      "continue after exact generation protection expires",
+      false,
+      generationExpiredAt + 600,
+    );
+    expect(
+      historyGenerationAffinityProtectedUntil(generationExpiredFollowUp.job),
+    ).toBeNull();
+    expect(sessionAffinityProtectedUntil(generationExpiredFollowUp.job)).toBe(
+      new Date(generationExpiredAt + 2000).toISOString(),
+    );
+    await api.requestCancelRun(
+      actor,
+      generationExpiredFollowUp.run.runId,
+      [200],
+    );
 
     const expiredFollowUp = await api.createRun(actor, {
       agentId,
@@ -2949,7 +3065,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         {
           sessionId: cliAgentSessionId,
           lastCompletedAt: nowDate().toISOString(),
-          reusableSandbox: { profile: "vm0/default" },
+          reusableSandbox: {
+            profile: "vm0/default",
+            historyGenerationRunId: first.runId,
+          },
         },
       ],
     });
@@ -3010,6 +3129,34 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-priority poll to return 200");
     }
     expect(reusablePriorityPoll.body.job?.runId).toBe(newerReusable.runId);
+
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: affinityRunnerId,
+      group: runnerGroup,
+      admittableProfiles: [],
+      heldSessionStates: [
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+    });
+    const legacyReusablePriorityPoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: affinityRunnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (legacyReusablePriorityPoll.status !== 200) {
+      throw new Error("Expected legacy reusable-priority poll to return 200");
+    }
+    expect(legacyReusablePriorityPoll.body.job?.runId).toBe(
+      newerReusable.runId,
+    );
 
     mockNow(priorityBase + 60_000);
     const expiredPriorityPoll = await api.requestPollRunner(
@@ -3286,6 +3433,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           profile: "vm0/default",
           notification_target: "broadcast",
           session_affinity: "no_session",
+          history_generation_affinity: "no_session",
         }),
       );
     }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -321,6 +321,12 @@ function canonicalizeHeldSessionStates(
         ? {
             reusableSandbox: {
               profile: state.reusableSandbox.profile,
+              ...(state.reusableSandbox.historyGenerationRunId
+                ? {
+                    historyGenerationRunId:
+                      state.reusableSandbox.historyGenerationRunId,
+                  }
+                : {}),
             },
           }
         : {}),
@@ -410,6 +416,7 @@ function recordPollTimingMetrics(args: {
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
   readonly sessionAffinity: string;
+  readonly historyGenerationAffinity: string;
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
   readonly pendingJobLookupStartedAtMs: number;
@@ -421,6 +428,7 @@ function recordPollTimingMetrics(args: {
     profile: args.profile,
     auth_type: args.authType,
     session_affinity: args.sessionAffinity,
+    history_generation_affinity: args.historyGenerationAffinity,
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -474,8 +482,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return body.response;
   }
 
-  const { group } = body.data;
-  const supportedProfiles = body.data.supportedProfiles;
+  const { group, supportedProfiles } = body.data;
   const whereConditions: SQL<unknown>[] = [
     eq(runnerJobQueue.runnerGroup, group),
     gt(runnerJobQueue.expiresAt, sql`now()`),
@@ -546,6 +553,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         runnerGroup: group,
         profile: pendingJob.profile,
         cliAgentSessionId: pendingJob.cliAgentSessionId,
+        historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         createdAt: pendingJob.createdAt,
         currentDate,
       }),
@@ -567,6 +575,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
     sessionAffinity: affinity.status,
+    historyGenerationAffinity: affinity.historyGenerationStatus,
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
     pendingJobLookupStartedAtMs,
@@ -587,6 +596,8 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         experimentalProfile: pendingJob.profile,
         cliAgentSessionId: pendingJob.cliAgentSessionId,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
+        historyGenerationAffinityProtectedUntil:
+          affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
         affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
       },
     },

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -32,6 +32,7 @@ export async function notifyRunnerJob(
         runnerGroup: args.runnerGroup,
         profile: args.profile,
         cliAgentSessionId: args.cliAgentSessionId,
+        historyGenerationRunId: args.historyGenerationRunId,
         createdAt: args.createdAt,
         currentDate,
       }),
@@ -56,6 +57,8 @@ export async function notifyRunnerJob(
     args.profile,
     {
       cliAgentSessionId: args.cliAgentSessionId,
+      historyGenerationAffinityProtectedUntil:
+        affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
       affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
       historyGenerationRunId: args.historyGenerationRunId,
     },
@@ -67,6 +70,7 @@ export async function notifyRunnerJob(
     profile: args.profile,
     notification_target: "broadcast",
     session_affinity: affinity.status,
+    history_generation_affinity: affinity.historyGenerationStatus,
   };
   // Queue-relative actions are cumulative boundaries. Affinity and publish
   // durations are nested children and must not be added to those boundaries.

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,10 +1,14 @@
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, gt, or, sql, type SQL } from "drizzle-orm";
+import { and, eq, gt, sql, type SQL } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 
 const RUNNER_SESSION_AFFINITY_PROTECTION_MS = 2000;
+const RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS = Math.min(
+  500,
+  RUNNER_SESSION_AFFINITY_PROTECTION_MS,
+);
 const RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS = 30_000;
 
 function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
@@ -21,9 +25,37 @@ export function runnerReusableSessionPollPriority(args: {
   const protectedAfter = new Date(
     args.currentDate.getTime() - RUNNER_SESSION_AFFINITY_PROTECTION_MS,
   );
+  const generationProtectedAfter = new Date(
+    args.currentDate.getTime() -
+      RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS,
+  );
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
-  return sql<number>`CASE WHEN
-    ${runnerJobQueue.createdAt} > ${protectedAfter}
+  const targetGenerationRunId = sql<
+    string | null
+  >`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
+  return sql<number>`CASE
+    WHEN ${runnerJobQueue.createdAt} > ${generationProtectedAfter}
+    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    AND ${targetGenerationRunId} IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM ${runnerState}
+      WHERE ${runnerState.runnerId} = ${args.runnerId}
+        AND ${runnerState.runnerGroup} = ${args.runnerGroup}
+        AND ${runnerState.mode} = 'running'
+        AND ${runnerState.lastSeenAt} > ${freshAfter}
+        AND ${runnerState.heldSessionStates} @> jsonb_build_array(
+          jsonb_build_object(
+            'sessionId', ${runnerJobQueue.cliAgentSessionId},
+            'reusableSandbox', jsonb_build_object(
+              'profile', ${runnerJobQueue.profile},
+              'historyGenerationRunId', ${targetGenerationRunId}
+            )
+          )
+        )
+    )
+    THEN 2
+    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
     AND EXISTS (
       SELECT 1
       FROM ${runnerState}
@@ -40,7 +72,9 @@ export function runnerReusableSessionPollPriority(args: {
           )
         )
     )
-    THEN 1 ELSE 0 END`;
+    THEN 1
+    ELSE 0
+  END`;
 }
 
 type RunnerSessionAffinityStatus =
@@ -53,12 +87,24 @@ type RunnerSessionAffinityStatus =
 interface RunnerSessionAffinityProtection {
   readonly protectedUntil: Date | null;
   readonly status: RunnerSessionAffinityStatus;
+  readonly historyGenerationProtectedUntil: Date | null;
+  readonly historyGenerationStatus: RunnerHistoryGenerationAffinityStatus;
 }
+
+type RunnerHistoryGenerationAffinityStatus =
+  | "no_session"
+  | "no_target"
+  | "expired"
+  | "protected"
+  | "no_exact_holder"
+  | "lookup_error";
 
 export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtection {
   return {
     protectedUntil: null,
     status: "lookup_error",
+    historyGenerationProtectedUntil: null,
+    historyGenerationStatus: "lookup_error",
   };
 }
 
@@ -72,11 +118,25 @@ function affinityProtectedUntil(
   return new Date(createdAt.getTime() + RUNNER_SESSION_AFFINITY_PROTECTION_MS);
 }
 
+function historyGenerationAffinityProtectedUntil(args: {
+  readonly cliAgentSessionId: string | null;
+  readonly historyGenerationRunId: string | undefined;
+  readonly createdAt: Date;
+}): Date | null {
+  if (!args.cliAgentSessionId || !args.historyGenerationRunId) {
+    return null;
+  }
+  return new Date(
+    args.createdAt.getTime() + RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS,
+  );
+}
+
 export async function runnerSessionAffinityProtection(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerGroup: string;
   readonly profile: string;
   readonly cliAgentSessionId: string | null;
+  readonly historyGenerationRunId: string | undefined;
   readonly createdAt: Date;
   readonly currentDate: Date;
 }): Promise<RunnerSessionAffinityProtection> {
@@ -84,11 +144,25 @@ export async function runnerSessionAffinityProtection(args: {
     args.cliAgentSessionId,
     args.createdAt,
   );
+  const historyGenerationProtectedUntil =
+    historyGenerationAffinityProtectedUntil(args);
   if (!args.cliAgentSessionId) {
-    return { protectedUntil: null, status: "no_session" };
+    return {
+      protectedUntil: null,
+      status: "no_session",
+      historyGenerationProtectedUntil: null,
+      historyGenerationStatus: "no_session",
+    };
   }
   if (!protectedUntil || protectedUntil <= args.currentDate) {
-    return { protectedUntil: null, status: "expired" };
+    return {
+      protectedUntil: null,
+      status: "expired",
+      historyGenerationProtectedUntil: null,
+      historyGenerationStatus: args.historyGenerationRunId
+        ? "expired"
+        : "no_target",
+    };
   }
 
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
@@ -101,29 +175,63 @@ export async function runnerSessionAffinityProtection(args: {
       reusableSandbox: { profile: args.profile },
     },
   ]);
+  const shouldLookUpExactGeneration =
+    historyGenerationProtectedUntil !== null &&
+    historyGenerationProtectedUntil > args.currentDate;
+  const exactGenerationProbe = shouldLookUpExactGeneration
+    ? JSON.stringify([
+        {
+          sessionId: args.cliAgentSessionId,
+          reusableSandbox: {
+            profile: args.profile,
+            historyGenerationRunId: args.historyGenerationRunId,
+          },
+        },
+      ])
+    : null;
   const admittableProfileProbe = JSON.stringify([args.profile]);
-  const [holder] = await args.db
-    .select({ runnerId: runnerState.runnerId })
+  const sessionHolderCondition = sql<boolean>`(
+    (
+      ${runnerState.heldSessionStates} @> ${heldSessionProbe}::jsonb
+      AND ${runnerState.admittableProfiles} @> ${admittableProfileProbe}::jsonb
+    )
+    OR ${runnerState.heldSessionStates} @> ${reusableSessionProbe}::jsonb
+  )`;
+  const exactGenerationHolderCondition = exactGenerationProbe
+    ? sql<boolean>`${runnerState.heldSessionStates} @> ${exactGenerationProbe}::jsonb`
+    : sql<boolean>`false`;
+  const [holders] = await args.db
+    .select({
+      hasSessionHolder: sql<boolean>`coalesce(bool_or(${sessionHolderCondition}), false)`,
+      hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationHolderCondition}), false)`,
+    })
     .from(runnerState)
     .where(
       and(
         eq(runnerState.runnerGroup, args.runnerGroup),
         eq(runnerState.mode, "running"),
         gt(runnerState.lastSeenAt, freshAfter),
-        or(
-          and(
-            sql`${runnerState.heldSessionStates} @> ${heldSessionProbe}::jsonb`,
-            sql`${runnerState.admittableProfiles} @> ${admittableProfileProbe}::jsonb`,
-          ),
-          sql`${runnerState.heldSessionStates} @> ${reusableSessionProbe}::jsonb`,
-        ),
+        sessionHolderCondition,
       ),
-    )
-    .limit(1);
+    );
 
-  if (!holder) {
-    return { protectedUntil: null, status: "no_viable_holder" };
-  }
+  const hasSessionHolder = holders?.hasSessionHolder ?? false;
+  const hasExactGenerationHolder = holders?.hasExactGenerationHolder ?? false;
+  const historyGenerationStatus: RunnerHistoryGenerationAffinityStatus =
+    !args.historyGenerationRunId
+      ? "no_target"
+      : !shouldLookUpExactGeneration
+        ? "expired"
+        : hasExactGenerationHolder
+          ? "protected"
+          : "no_exact_holder";
 
-  return { protectedUntil, status: "protected" };
+  return {
+    protectedUntil: hasSessionHolder ? protectedUntil : null,
+    status: hasSessionHolder ? "protected" : "no_viable_holder",
+    historyGenerationProtectedUntil: hasExactGenerationHolder
+      ? historyGenerationProtectedUntil
+      : null,
+    historyGenerationStatus,
+  };
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  heldSessionStateSchema,
   jobSchema,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
@@ -329,6 +330,7 @@ describe("runner resume session contract", () => {
   });
 
   it("keeps generation metadata in stored and discovery shapes only", () => {
+    const historyGenerationAffinityProtectedUntil = "2026-07-15T00:00:00.500Z";
     const storedResumeSession = {
       sessionId: "sess-123",
       historyGenerationRunId,
@@ -357,8 +359,46 @@ describe("runner resume session contract", () => {
       vars: null,
       checkpointId: null,
       historyGenerationRunId,
+      historyGenerationAffinityProtectedUntil,
     });
     expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
+    expect(job.historyGenerationAffinityProtectedUntil).toBe(
+      historyGenerationAffinityProtectedUntil,
+    );
+
+    const heldSessionState = heldSessionStateSchema.parse({
+      sessionId: "sess-123",
+      lastCompletedAt: "2026-07-15T00:00:00.000Z",
+      reusableSandbox: {
+        profile: "vm0/default",
+        historyGenerationRunId,
+      },
+    });
+    expect(heldSessionState.reusableSandbox?.historyGenerationRunId).toBe(
+      historyGenerationRunId,
+    );
+  });
+
+  it("keeps generation-affinity additions optional for legacy runners", () => {
+    const job = jobSchema.parse({
+      runId: "22222222-2222-4222-8222-222222222222",
+      prompt: "continue",
+      appendSystemPrompt: null,
+      agentComposeVersionId: null,
+      vars: null,
+      checkpointId: null,
+      historyGenerationAffinityProtectedUntil: null,
+    });
+    expect(job.historyGenerationAffinityProtectedUntil).toBeNull();
+
+    const heldSessionState = heldSessionStateSchema.parse({
+      sessionId: "sess-legacy",
+      lastCompletedAt: "2026-07-15T00:00:00.000Z",
+      reusableSandbox: { profile: "vm0/default" },
+    });
+    expect(heldSessionState.reusableSandbox).toEqual({
+      profile: "vm0/default",
+    });
   });
 
   it("requires a URL for hash-backed claim resume sessions", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -173,6 +173,11 @@ export const jobSchema = z.object({
   experimentalProfile: z.string().optional(),
   cliAgentSessionId: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
+  historyGenerationAffinityProtectedUntil: z
+    .string()
+    .datetime({ offset: true })
+    .nullable()
+    .optional(),
   affinityProtectedUntil: z
     .string()
     .datetime({ offset: true })
@@ -188,6 +193,7 @@ export const heldSessionStateSchema = z.object({
   reusableSandbox: z
     .object({
       profile: z.string(),
+      historyGenerationRunId: z.uuid().optional(),
     })
     .optional(),
 });

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -7,6 +7,7 @@ export interface RunnerHeldSessionState {
   readonly lastCompletedAt: string;
   readonly reusableSandbox?: {
     readonly profile: string;
+    readonly historyGenerationRunId?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

- advertise the exact reusable session-history generation in runner heartbeats and preserve it in runner state
- add an independent queue-relative 500 ms exact-generation affinity window while retaining the existing 2 s session fallback
- prioritize exact-generation work for the matching runner and atomically reserve the exact idle sandbox before claiming
- report fixed-cardinality generation-affinity outcomes without logging generation identifiers

## Compatibility and scope

- all API, heartbeat, and persisted JSON additions are optional, so old/new API and runner combinations remain functional during deployment overlap
- no physical database migration is required; runner heartbeat JSON is overwritten in place
- mixed deployments may temporarily reduce the optimization when an old runner ignores the new deadline, but claim correctness is unchanged
- this does not change the existing 2 s session-affinity fallback or expose generation identifiers to guest execution or telemetry

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F @vm0/db lint && pnpm -F @vm0/db check-types`
- `cd turbo && pnpm -F api lint && pnpm -F api check-types`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run --maxWorkers=4 --silent=passed-only` (429 passed)
- `cd turbo && pnpm -F @vm0/db exec vitest run --maxWorkers=4 --silent=passed-only` (12 passed)
- `cd turbo && pnpm -F api exec vitest run --maxWorkers=1 --silent=passed-only` (2213 passed)
- `cd turbo && pnpm knip`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets -- -D warnings`
- `cd crates && RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cd crates && cargo test -p runner` (2683 passed, 9 ignored)

Closes #21594

Delivery context: #18746
