### PR TITLE
test(mitm-addon): isolate sse parser gate coverage

### DIFF
--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -1006,10 +1006,13 @@ class TestResponseHeadersSseParser:
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
 
     def test_no_sse_parser_for_non_sse_response(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1017,10 +1020,12 @@ class TestResponseHeadersSseParser:
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
-        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        assert "model_json_usage_finish" in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
 
     def test_no_sse_parser_without_model_usage_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
@@ -1056,11 +1061,14 @@ class TestResponseHeadersSseParser:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        # No firewall_name set (e.g. auto-allowed VM0 API request)
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        # Model metadata alone must not classify the flow as a model provider.
 
         mitm_addon.responseheaders(flow)
 
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
 
     @pytest.mark.parametrize("firewall_name", [None, 42])
     def test_malformed_firewall_name_skips_usage_parsers(self, real_flow, firewall_name):


### PR DESCRIPTION
## Summary

- supply model usage metadata in negative parser fixtures where its absence is unrelated to the scenario
- assert the exact JSON and SSE parser callback state reached through `responseheaders()`
- keep the dedicated missing-provider case as the only scenario intentionally lacking model metadata

## Scope

Test-only change. No production logic, API, schema, persisted data, protocol, or deployment behavior changes.

## Validation

- affected parser-gating tests: 3 passed
- `TestResponseHeadersSseParser`: 15 passed
- firewall-prefix mutation: both non-model and missing-firewall tests failed as expected, then passed after restoration
- content-type mutation: the non-SSE test failed as expected, then passed after restoration
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/`: 3976 passed
- `lefthook run pre-commit`

Closes #21604
