### PR TITLE
fix(runner): preserve removed storage paths after failed workspace promotion

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -661,7 +661,7 @@ mod tests {
     use crate::types::SandboxReuseResult;
     use crate::workspace_image_cache::{
         SessionWorkspaceCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
-        WorkspaceImagePromotionContext,
+        WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityRequest,
     };
 
     fn test_budget_lease() -> (Arc<ResourceBudget>, BudgetLease) {
@@ -1089,38 +1089,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_success_workspace_promotion_preserves_affected_paths_for_next_plan() {
+    async fn non_success_workspace_promotion_preserves_affected_paths_across_cache_sources() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = SessionWorkspaceCache::new(paths.clone());
 
-        for (session_id, terminal_status) in [
-            ("sess-nonzero", WorkspaceCacheTerminalStatus::NonzeroExit),
-            ("sess-cancelled", WorkspaceCacheTerminalStatus::Cancelled),
+        for (terminal_name, terminal_status) in [
+            ("nonzero", WorkspaceCacheTerminalStatus::NonzeroExit),
+            ("cancelled", WorkspaceCacheTerminalStatus::Cancelled),
         ] {
-            let removed_storage_path = format!("{CANONICAL_WORKING_DIR}/removed-storage");
-            let removed_artifact_path = format!("{CANONICAL_WORKING_DIR}/removed-artifact");
-            let current_storage_path = format!("{CANONICAL_WORKING_DIR}/current-storage");
-            let current_artifact_path = format!("{CANONICAL_WORKING_DIR}/current-artifact");
-
-            let seed_run_id = RunId::new_v4();
-            let seed_sandbox_id = SandboxId::new_v4();
-            let seed_lease = prepare_test_workspace_image_lease(
-                &paths,
-                &cache,
-                seed_run_id,
-                seed_sandbox_id,
-                session_id,
-            )
-            .await;
-            let seed_promotion = test_promotion_context(
-                seed_lease,
-                seed_run_id,
-                seed_sandbox_id,
-                session_id,
-                WorkspaceCacheTerminalStatus::Success,
-                StorageFingerprints {
+            for (source_name, publish_seed) in [("cache-hit", true), ("idle-reuse", false)] {
+                let session_id = format!("sess-{terminal_name}-{source_name}");
+                let removed_storage_path = format!("{CANONICAL_WORKING_DIR}/removed-storage");
+                let removed_artifact_path = format!("{CANONICAL_WORKING_DIR}/removed-artifact");
+                let current_storage_path = format!("{CANONICAL_WORKING_DIR}/current-storage");
+                let current_artifact_path = format!("{CANONICAL_WORKING_DIR}/current-artifact");
+                let previous_storage = StorageFingerprints {
                     storages: HashMap::from([(
                         removed_storage_path.clone(),
                         StorageFingerprint::new("removed-storage", "v1"),
@@ -1129,116 +1114,159 @@ mod tests {
                         removed_artifact_path.clone(),
                         StorageFingerprint::new("removed-artifact", "v1"),
                     )]),
-                },
-            );
-            assert!(
-                promote_workspace_image_from_active_sandbox(
-                    &MockSandbox::new(format!("workspace-seed-{session_id}")),
-                    Some(seed_promotion),
-                    "test",
+                };
+
+                let seed_run_id = RunId::new_v4();
+                let seed_sandbox_id = SandboxId::new_v4();
+                let seed_lease = prepare_test_workspace_image_lease(
+                    &paths,
+                    &cache,
+                    seed_run_id,
+                    seed_sandbox_id,
+                    &session_id,
                 )
-                .await
-            );
-
-            let run_id = RunId::new_v4();
-            let sandbox_id = SandboxId::new_v4();
-            let lease =
-                prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, session_id)
-                    .await;
-            assert!(lease.is_cache_hit());
-            let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
-            let current_manifest = StorageManifest {
-                storages: vec![StorageEntry {
-                    name: "current-storage".into(),
-                    mount_path: current_storage_path.clone(),
-                    vas_storage_name: "current-storage".into(),
-                    vas_version_id: "v1".into(),
-                    instructions_target_filename: None,
-                    archive_url: "https://example.com/current-storage.tar.gz".into(),
-                }],
-                artifacts: vec![ArtifactEntry {
-                    mount_path: current_artifact_path.clone(),
-                    vas_storage_name: "current-artifact".into(),
-                    vas_storage_id: "current-artifact-id".into(),
-                    vas_version_id: "v1".into(),
-                    archive_url: Some("https://example.com/current-artifact.tar.gz".into()),
-                    empty: None,
-                    missing_root_policy: None,
-                }],
-            };
-            let promotion = test_promotion_context(
-                lease,
-                run_id,
-                sandbox_id,
-                session_id,
-                terminal_status,
-                StorageFingerprints::from_manifest(&current_manifest),
-            );
-
-            let promoted =
-                promote_workspace_image_from_active_sandbox(&sandbox, Some(promotion), "test")
-                    .await;
-
-            assert!(promoted);
-            let exec_calls = sandbox.exec_calls();
-            assert_eq!(exec_calls.len(), 1);
-            assert!(exec_calls[0].cmd.contains("umount -- \"$workspace_dir\""));
-            assert!(!exec_calls[0].cmd.contains("export-session-history-sidecar"));
-            let checkout = cache
-                .prepare(WorkspaceImagePrepareRequest {
-                    identity: WorkspaceImageLeaseIdentity {
-                        run_id: RunId::new_v4(),
-                        sandbox_id: SandboxId::new_v4(),
-                        profile_name: "vm0/default",
-                        cli_agent_session_id: Some(session_id),
-                        working_dir: CANONICAL_WORKING_DIR,
-                        image_size_bytes: b"image".len() as u64,
-                    },
-                    workspace_drive_required: true,
-                })
                 .await;
+                let seed_promotion = test_promotion_context(
+                    seed_lease,
+                    seed_run_id,
+                    seed_sandbox_id,
+                    &session_id,
+                    WorkspaceCacheTerminalStatus::Success,
+                    previous_storage.clone(),
+                );
 
-            assert!(checkout.is_cache_hit());
-            let previous_storage = checkout
-                .previous_storage()
-                .expect("cache hit should expose previous storage fingerprints");
-            for path in [&removed_storage_path, &current_storage_path] {
-                assert!(
-                    previous_storage
-                        .storages
-                        .get(path)
-                        .is_some_and(StorageFingerprint::is_tainted),
-                    "storage path should be retained as tainted: {path}",
+                let run_id = RunId::new_v4();
+                let (sandbox_id, lease) = if publish_seed {
+                    assert!(
+                        promote_workspace_image_from_active_sandbox(
+                            &MockSandbox::new(format!("workspace-seed-{session_id}")),
+                            Some(seed_promotion),
+                            "test",
+                        )
+                        .await
+                    );
+                    let sandbox_id = SandboxId::new_v4();
+                    let lease = prepare_test_workspace_image_lease(
+                        &paths,
+                        &cache,
+                        run_id,
+                        sandbox_id,
+                        &session_id,
+                    )
+                    .await;
+                    assert!(lease.is_cache_hit());
+                    (sandbox_id, lease)
+                } else {
+                    let expected = cache
+                        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+                            sandbox_id: seed_sandbox_id,
+                            profile_name: "vm0/default",
+                            cli_agent_session_id: &session_id,
+                            working_dir: CANONICAL_WORKING_DIR,
+                            image_size_bytes: b"image".len() as u64,
+                        })
+                        .expect("idle reuse promotion identity should be valid");
+                    let lease = seed_promotion
+                        .try_into_active_lease(&expected, true)
+                        .expect("parked promotion should become an active lease");
+                    (seed_sandbox_id, lease)
+                };
+                assert_eq!(lease.previous_storage(), Some(&previous_storage));
+
+                let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
+                let current_manifest = StorageManifest {
+                    storages: vec![StorageEntry {
+                        name: "current-storage".into(),
+                        mount_path: current_storage_path.clone(),
+                        vas_storage_name: "current-storage".into(),
+                        vas_version_id: "v1".into(),
+                        instructions_target_filename: None,
+                        archive_url: "https://example.com/current-storage.tar.gz".into(),
+                    }],
+                    artifacts: vec![ArtifactEntry {
+                        mount_path: current_artifact_path.clone(),
+                        vas_storage_name: "current-artifact".into(),
+                        vas_storage_id: "current-artifact-id".into(),
+                        vas_version_id: "v1".into(),
+                        archive_url: Some("https://example.com/current-artifact.tar.gz".into()),
+                        empty: None,
+                        missing_root_policy: None,
+                    }],
+                };
+                let promotion = test_promotion_context(
+                    lease,
+                    run_id,
+                    sandbox_id,
+                    &session_id,
+                    terminal_status,
+                    StorageFingerprints::from_manifest(&current_manifest),
+                );
+
+                let promoted =
+                    promote_workspace_image_from_active_sandbox(&sandbox, Some(promotion), "test")
+                        .await;
+
+                assert!(promoted);
+                let exec_calls = sandbox.exec_calls();
+                assert_eq!(exec_calls.len(), 1);
+                assert!(exec_calls[0].cmd.contains("umount -- \"$workspace_dir\""));
+                assert!(!exec_calls[0].cmd.contains("export-session-history-sidecar"));
+                let checkout = cache
+                    .prepare(WorkspaceImagePrepareRequest {
+                        identity: WorkspaceImageLeaseIdentity {
+                            run_id: RunId::new_v4(),
+                            sandbox_id: SandboxId::new_v4(),
+                            profile_name: "vm0/default",
+                            cli_agent_session_id: Some(&session_id),
+                            working_dir: CANONICAL_WORKING_DIR,
+                            image_size_bytes: b"image".len() as u64,
+                        },
+                        workspace_drive_required: true,
+                    })
+                    .await;
+
+                assert!(checkout.is_cache_hit());
+                let previous_storage = checkout
+                    .previous_storage()
+                    .expect("cache hit should expose previous storage fingerprints");
+                for path in [&removed_storage_path, &current_storage_path] {
+                    assert!(
+                        previous_storage
+                            .storages
+                            .get(path)
+                            .is_some_and(StorageFingerprint::is_tainted),
+                        "storage path should be retained as tainted: {path}",
+                    );
+                }
+                for path in [&removed_artifact_path, &current_artifact_path] {
+                    assert!(
+                        previous_storage
+                            .artifacts
+                            .get(path)
+                            .is_some_and(StorageFingerprint::is_tainted),
+                        "artifact path should be retained as tainted: {path}",
+                    );
+                }
+
+                let plan = build_storage_plan(&current_manifest, "/run", Some(previous_storage))
+                    .expect("next storage plan should build from promoted fingerprints");
+                assert_eq!(plan.reused_entries(), 0);
+                let guest_manifest = plan.into_guest_manifest();
+                assert!(!guest_manifest.storages[0].cached);
+                assert!(!guest_manifest.artifacts[0].cached);
+                assert_eq!(
+                    guest_manifest
+                        .cleanup_paths
+                        .into_iter()
+                        .collect::<HashSet<_>>(),
+                    HashSet::from([
+                        removed_storage_path,
+                        removed_artifact_path,
+                        current_storage_path,
+                        current_artifact_path,
+                    ])
                 );
             }
-            for path in [&removed_artifact_path, &current_artifact_path] {
-                assert!(
-                    previous_storage
-                        .artifacts
-                        .get(path)
-                        .is_some_and(StorageFingerprint::is_tainted),
-                    "artifact path should be retained as tainted: {path}",
-                );
-            }
-
-            let plan = build_storage_plan(&current_manifest, "/run", Some(previous_storage))
-                .expect("next storage plan should build from promoted fingerprints");
-            assert_eq!(plan.reused_entries(), 0);
-            let guest_manifest = plan.into_guest_manifest();
-            assert!(!guest_manifest.storages[0].cached);
-            assert!(!guest_manifest.artifacts[0].cached);
-            assert_eq!(
-                guest_manifest
-                    .cleanup_paths
-                    .into_iter()
-                    .collect::<HashSet<_>>(),
-                HashSet::from([
-                    removed_storage_path,
-                    removed_artifact_path,
-                    current_storage_path,
-                    current_artifact_path,
-                ])
-            );
         }
     }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -627,10 +627,14 @@ async fn stop_and_destroy_sandbox(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use std::time::Duration;
 
-    use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+    use api_contracts::generated::{
+        constants::runners::paths::CANONICAL_WORKING_DIR,
+        types::runners::storage::{ArtifactEntry, StorageEntry, StorageManifest},
+    };
     use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -653,6 +657,7 @@ mod tests {
     use crate::resource_budget::{BudgetLease, ResourceBudget};
     use crate::status::StatusTracker;
     use crate::storage_fingerprints::StorageFingerprint;
+    use crate::storage_plan::build_storage_plan;
     use crate::types::SandboxReuseResult;
     use crate::workspace_image_cache::{
         SessionWorkspaceCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
@@ -1084,7 +1089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_success_workspace_promotion_does_not_mark_storages_reusable() {
+    async fn non_success_workspace_promotion_preserves_affected_paths_for_next_plan() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -1094,21 +1099,72 @@ mod tests {
             ("sess-nonzero", WorkspaceCacheTerminalStatus::NonzeroExit),
             ("sess-cancelled", WorkspaceCacheTerminalStatus::Cancelled),
         ] {
+            let removed_storage_path = format!("{CANONICAL_WORKING_DIR}/removed-storage");
+            let removed_artifact_path = format!("{CANONICAL_WORKING_DIR}/removed-artifact");
+            let current_storage_path = format!("{CANONICAL_WORKING_DIR}/current-storage");
+            let current_artifact_path = format!("{CANONICAL_WORKING_DIR}/current-artifact");
+
+            let seed_run_id = RunId::new_v4();
+            let seed_sandbox_id = SandboxId::new_v4();
+            let seed_lease = prepare_test_workspace_image_lease(
+                &paths,
+                &cache,
+                seed_run_id,
+                seed_sandbox_id,
+                session_id,
+            )
+            .await;
+            let seed_promotion = test_promotion_context(
+                seed_lease,
+                seed_run_id,
+                seed_sandbox_id,
+                session_id,
+                WorkspaceCacheTerminalStatus::Success,
+                StorageFingerprints {
+                    storages: HashMap::from([(
+                        removed_storage_path.clone(),
+                        StorageFingerprint::new("removed-storage", "v1"),
+                    )]),
+                    artifacts: HashMap::from([(
+                        removed_artifact_path.clone(),
+                        StorageFingerprint::new("removed-artifact", "v1"),
+                    )]),
+                },
+            );
+            assert!(
+                promote_workspace_image_from_active_sandbox(
+                    &MockSandbox::new(format!("workspace-seed-{session_id}")),
+                    Some(seed_promotion),
+                    "test",
+                )
+                .await
+            );
+
             let run_id = RunId::new_v4();
             let sandbox_id = SandboxId::new_v4();
             let lease =
                 prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, session_id)
                     .await;
+            assert!(lease.is_cache_hit());
             let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
-            let storage_fingerprints = StorageFingerprints {
-                storages: std::collections::HashMap::from([(
-                    CANONICAL_WORKING_DIR.to_owned(),
-                    StorageFingerprint::new("repo", "v1"),
-                )]),
-                artifacts: std::collections::HashMap::from([(
-                    format!("{CANONICAL_WORKING_DIR}/artifact"),
-                    StorageFingerprint::new("artifact", "v1"),
-                )]),
+            let current_manifest = StorageManifest {
+                storages: vec![StorageEntry {
+                    name: "current-storage".into(),
+                    mount_path: current_storage_path.clone(),
+                    vas_storage_name: "current-storage".into(),
+                    vas_version_id: "v1".into(),
+                    instructions_target_filename: None,
+                    archive_url: "https://example.com/current-storage.tar.gz".into(),
+                }],
+                artifacts: vec![ArtifactEntry {
+                    mount_path: current_artifact_path.clone(),
+                    vas_storage_name: "current-artifact".into(),
+                    vas_storage_id: "current-artifact-id".into(),
+                    vas_version_id: "v1".into(),
+                    archive_url: Some("https://example.com/current-artifact.tar.gz".into()),
+                    empty: None,
+                    missing_root_policy: None,
+                }],
             };
             let promotion = test_promotion_context(
                 lease,
@@ -1116,7 +1172,7 @@ mod tests {
                 sandbox_id,
                 session_id,
                 terminal_status,
-                storage_fingerprints,
+                StorageFingerprints::from_manifest(&current_manifest),
             );
 
             let promoted =
@@ -1146,19 +1202,42 @@ mod tests {
             let previous_storage = checkout
                 .previous_storage()
                 .expect("cache hit should expose previous storage fingerprints");
-            assert!(
-                previous_storage
-                    .storages
-                    .get(CANONICAL_WORKING_DIR)
-                    .expect("storage path should be retained for cleanup")
-                    .is_tainted()
-            );
-            assert!(
-                previous_storage
-                    .artifacts
-                    .get(&format!("{CANONICAL_WORKING_DIR}/artifact"))
-                    .expect("artifact path should be retained for cleanup")
-                    .is_tainted()
+            for path in [&removed_storage_path, &current_storage_path] {
+                assert!(
+                    previous_storage
+                        .storages
+                        .get(path)
+                        .is_some_and(StorageFingerprint::is_tainted),
+                    "storage path should be retained as tainted: {path}",
+                );
+            }
+            for path in [&removed_artifact_path, &current_artifact_path] {
+                assert!(
+                    previous_storage
+                        .artifacts
+                        .get(path)
+                        .is_some_and(StorageFingerprint::is_tainted),
+                    "artifact path should be retained as tainted: {path}",
+                );
+            }
+
+            let plan = build_storage_plan(&current_manifest, "/run", Some(previous_storage))
+                .expect("next storage plan should build from promoted fingerprints");
+            assert_eq!(plan.reused_entries(), 0);
+            let guest_manifest = plan.into_guest_manifest();
+            assert!(!guest_manifest.storages[0].cached);
+            assert!(!guest_manifest.artifacts[0].cached);
+            assert_eq!(
+                guest_manifest
+                    .cleanup_paths
+                    .into_iter()
+                    .collect::<HashSet<_>>(),
+                HashSet::from([
+                    removed_storage_path,
+                    removed_artifact_path,
+                    current_storage_path,
+                    current_artifact_path,
+                ])
             );
         }
     }

--- a/crates/runner/src/storage_fingerprints.rs
+++ b/crates/runner/src/storage_fingerprints.rs
@@ -134,8 +134,8 @@ impl StorageFingerprints {
         }
     }
 
-    pub(crate) fn tainted_paths(&self) -> Self {
-        Self {
+    pub(crate) fn tainted_paths_including(&self, previous: Option<&Self>) -> Self {
+        let mut tainted = Self {
             storages: self
                 .storages
                 .keys()
@@ -146,7 +146,22 @@ impl StorageFingerprints {
                 .keys()
                 .map(|path| (path.clone(), StorageFingerprint::tainted()))
                 .collect(),
+        };
+        if let Some(previous) = previous {
+            tainted.storages.extend(
+                previous
+                    .storages
+                    .keys()
+                    .map(|path| (path.clone(), StorageFingerprint::tainted())),
+            );
+            tainted.artifacts.extend(
+                previous
+                    .artifacts
+                    .keys()
+                    .map(|path| (path.clone(), StorageFingerprint::tainted())),
+            );
         }
+        tainted
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1060,24 +1060,39 @@ impl WorkspaceImageLease {
         mut self,
         request: WorkspaceImagePromotionRequest<'_>,
     ) -> Option<WorkspaceImagePromotionContext> {
-        let target = self.promotion_target(request.cli_agent_session_id_override)?;
+        let WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override,
+            restored_session_identity,
+            terminal_status,
+            completed_at,
+            storage_fingerprints,
+        } = request;
+        let target = self.promotion_target(cli_agent_session_id_override)?;
+        let storage_fingerprints = match terminal_status {
+            WorkspaceCacheTerminalStatus::Success => storage_fingerprints,
+            WorkspaceCacheTerminalStatus::NonzeroExit | WorkspaceCacheTerminalStatus::Cancelled => {
+                storage_fingerprints.tainted_paths_including(self.previous_storage.as_ref())
+            }
+        };
 
         Some(WorkspaceImagePromotionContext {
             cache: self.cache.clone(),
             cache_key: target.cache_key,
             entry_lock: self.entry_lock.take(),
-            run_id: request.run_id,
-            sandbox_id: request.sandbox_id,
+            run_id,
+            sandbox_id,
             profile_name: self.profile_name.clone(),
             cli_agent_session_id: target.cli_agent_session_id,
             working_dir: self.working_dir.clone(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,
             consumed_cache_hit: self.consumed_cache_hit,
-            terminal_status: request.terminal_status,
-            completed_at: request.completed_at,
-            storage_fingerprints: request.storage_fingerprints,
-            restored_session_identity: request.restored_session_identity.cloned(),
+            terminal_status,
+            completed_at,
+            storage_fingerprints,
+            restored_session_identity: restored_session_identity.cloned(),
         })
     }
 }
@@ -1186,15 +1201,6 @@ impl WorkspaceImagePromotionContext {
         &self,
         session_history_sidecar: Option<&WorkspaceSessionHistorySidecarPromotionSource>,
     ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
-        let tainted_storage_fingerprints;
-        let promotion_storage_fingerprints = match self.terminal_status {
-            WorkspaceCacheTerminalStatus::Success => &self.storage_fingerprints,
-            WorkspaceCacheTerminalStatus::NonzeroExit | WorkspaceCacheTerminalStatus::Cancelled => {
-                tainted_storage_fingerprints = self.storage_fingerprints.tainted_paths();
-                &tainted_storage_fingerprints
-            }
-        };
-
         let _late_entry_lock_guard = match self.entry_lock.as_ref() {
             Some(_) => None,
             None => {
@@ -1224,7 +1230,7 @@ impl WorkspaceImagePromotionContext {
                 image_size_bytes: self.image_size_bytes,
                 terminal_status: self.terminal_status,
                 completed_at: &self.completed_at,
-                storage_fingerprints: promotion_storage_fingerprints,
+                storage_fingerprints: &self.storage_fingerprints,
                 session_history_sidecar,
             })
             .await

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1348,7 +1348,7 @@ impl WorkspaceImagePromotionContext {
             consumed_cache_hit,
             terminal_status: _,
             completed_at: _,
-            storage_fingerprints: _,
+            storage_fingerprints,
             restored_session_identity: _,
         } = self;
         let base = WorkspaceImageLeaseBase {
@@ -1365,7 +1365,7 @@ impl WorkspaceImagePromotionContext {
                 cache_key: Some(cache_key),
                 source_image: None,
                 consumed_cache_hit,
-                previous_storage: None,
+                previous_storage: Some(storage_fingerprints),
                 entry_lock,
                 workspace_drive_enabled: workspace_drive_available,
                 result: WorkspaceCacheCheckoutResult::Miss,


### PR DESCRIPTION
## Summary

- Preserve both previously cached and currently requested storage and artifact paths as tainted metadata after a failed or cancelled workspace promotion.
- Carry the previous storage baseline across both disk cache hits and parked idle-VM reuse before deriving the conservative non-success union.
- Keep successful workspace promotions unchanged so their current fingerprints remain reusable.
- Add a lifecycle regression that covers both cache sources, both non-success terminal states, both entry kinds, and the next real storage plan.

## Scope

- Changes only runner-internal workspace image cache metadata handling.
- Does not change API contracts, guest protocols, persisted metadata formats, or successful-promotion behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner non_success_workspace_promotion_preserves_affected_paths_across_cache_sources`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_plan`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `git diff --check`

Closes #21603
