### PR TITLE
docs(nbd-cow): clarify device pool cleanup contract

### DIFF
--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -370,7 +370,11 @@ impl DevicePool {
         self.release_claim(claim);
     }
 
-    /// Clean up the pool: reject waiters and clear queues.
+    /// Permanently deactivate the pool.
+    ///
+    /// Cleanup fails queued acquire requests with [`NbdCowError::NoFreeDevice`]
+    /// and causes all subsequent acquire requests to return the same error.
+    /// Repeated cleanup calls are safe and idempotent.
     pub async fn cleanup(&mut self) {
         self.begin_cleanup();
         self.finish_cleanup();


### PR DESCRIPTION
## Summary

- document that `DevicePool::cleanup` permanently deactivates the pool
- clarify that queued and subsequent acquire requests fail with `NbdCowError::NoFreeDevice`
- document repeated cleanup as safe and idempotent

## Scope

This is a documentation-only contract clarification. It does not change runtime behavior, public API signatures, or tests; existing integration tests already cover the documented behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo doc -p nbd-cow --all-features --no-deps`
- `cargo test -p nbd-cow`
- pre-commit Rust workspace formatting, Clippy, and documentation hooks

Closes #21606
