### PR TITLE
fix(guest-agent): redact secrets from event object keys

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -70,13 +70,13 @@ pub fn prepare_event_payload_for_run_id(
     masker: &SecretMasker,
     run_id: &str,
 ) -> Value {
+    // Mask event-controlled content before adding system-owned fields.
+    masker.mask_value(&mut event);
+
     // Add sequence number
     if let Some(obj) = event.as_object_mut() {
         obj.insert("sequenceNumber".to_string(), json!(seq));
     }
-
-    // Mask secrets
-    masker.mask_value(&mut event);
 
     let mut payload = Map::new();
     payload.insert("runId".to_string(), Value::String(run_id.to_string()));

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -253,7 +253,7 @@ impl MaskerState {
         let mut masked_entries = Vec::new();
         for (key, mut value) in entries {
             self.mask_value(&mut value);
-            if let Some(masked_key) = self.masked_string(&key) {
+            if let Some(masked_key) = self.fully_masked_key(&key) {
                 masked_entries.push((masked_key, value));
             } else {
                 map.insert(key, value);
@@ -261,8 +261,34 @@ impl MaskerState {
         }
 
         for (masked_key, value) in masked_entries {
-            let unique_key = unique_masked_key(map, masked_key);
+            let unique_key = self.unique_masked_key(map, masked_key);
             map.insert(unique_key, value);
+        }
+    }
+
+    fn fully_masked_key(&self, key: &str) -> Option<String> {
+        let mut masked = self.masked_string(key)?;
+        // Production patterns are longer than "***", so each pass shortens
+        // the key and the loop terminates after removing cascading matches.
+        while let Some(remasked) = self.masked_string(&masked) {
+            debug_assert!(remasked.len() < masked.len());
+            masked = remasked;
+        }
+        Some(masked)
+    }
+
+    fn unique_masked_key(&self, map: &Map<String, Value>, masked_key: String) -> String {
+        if !map.contains_key(&masked_key) {
+            return masked_key;
+        }
+
+        let mut suffix = 2;
+        loop {
+            let candidate = format!("{masked_key}#{suffix}");
+            if !map.contains_key(&candidate) && self.masked_string(&candidate).is_none() {
+                return candidate;
+            }
+            suffix += 1;
         }
     }
 
@@ -589,21 +615,6 @@ fn redact_ranges(line: String, ranges: &[Range<usize>]) -> String {
     redacted
 }
 
-fn unique_masked_key(map: &Map<String, Value>, masked_key: String) -> String {
-    if !map.contains_key(&masked_key) {
-        return masked_key;
-    }
-
-    let mut suffix = 2;
-    loop {
-        let candidate = format!("{masked_key}#{suffix}");
-        if !map.contains_key(&candidate) {
-            return candidate;
-        }
-        suffix += 1;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -686,6 +697,27 @@ mod tests {
         });
         assert_eq!(first, expected);
         assert_eq!(second, expected);
+    }
+
+    #[test]
+    fn masked_json_keys_do_not_recreate_secret_patterns() {
+        let masker = masker_with(vec!["secret123", "prefix-***-suffix", "***#2"]);
+        let mut val = json!({
+            "***": "reserved base",
+            "***#2": "collision candidate",
+            "prefix-secret123-suffix": "cascading match"
+        });
+
+        masker.mask_value(&mut val);
+
+        assert_eq!(
+            val,
+            json!({
+                "***": "reserved base",
+                "***#3": "collision candidate",
+                "***#4": "cascading match"
+            })
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -8,7 +8,7 @@
 use crate::env;
 use aho_corasick::{AhoCorasick, MatchKind};
 use base64::Engine;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::{collections::HashSet, ops::Range};
 
 /// Minimum secret length to avoid false-positive masking.
@@ -132,7 +132,7 @@ impl SecretMasker {
         Self { state }
     }
 
-    /// Recursively mask secrets in a JSON value tree (in-place).
+    /// Recursively mask secrets in JSON object keys and string values (in-place).
     pub fn mask_value(&self, val: &mut Value) {
         self.state.mask_value(val);
     }
@@ -234,11 +234,35 @@ impl MaskerState {
                 }
             }
             Value::Object(map) => {
-                for v in map.values_mut() {
-                    self.mask_value(v);
-                }
+                self.mask_object(map);
             }
             _ => {}
+        }
+    }
+
+    fn mask_object(&self, map: &mut Map<String, Value>) {
+        let has_masked_key = map.keys().any(|key| self.masked_string(key).is_some());
+        if !has_masked_key {
+            for value in map.values_mut() {
+                self.mask_value(value);
+            }
+            return;
+        }
+
+        let entries = std::mem::take(map);
+        let mut masked_entries = Vec::new();
+        for (key, mut value) in entries {
+            self.mask_value(&mut value);
+            if let Some(masked_key) = self.masked_string(&key) {
+                masked_entries.push((masked_key, value));
+            } else {
+                map.insert(key, value);
+            }
+        }
+
+        for (masked_key, value) in masked_entries {
+            let unique_key = unique_masked_key(map, masked_key);
+            map.insert(unique_key, value);
         }
     }
 
@@ -565,6 +589,21 @@ fn redact_ranges(line: String, ranges: &[Range<usize>]) -> String {
     redacted
 }
 
+fn unique_masked_key(map: &Map<String, Value>, masked_key: String) -> String {
+    if !map.contains_key(&masked_key) {
+        return masked_key;
+    }
+
+    let mut suffix = 2;
+    loop {
+        let candidate = format!("{masked_key}#{suffix}");
+        if !map.contains_key(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,6 +640,52 @@ mod tests {
         masker.mask_value(&mut val);
         assert_eq!(val["outer"]["inner"], "has *** inside");
         assert_eq!(val["list"][1], "***");
+    }
+
+    #[test]
+    fn masks_nested_json_keys() {
+        let masker = masker_with(vec!["secret123"]);
+        let mut val = json!({
+            "prefix-secret123-suffix": {
+                "list": [{"secret123": "value has secret123"}]
+            }
+        });
+
+        masker.mask_value(&mut val);
+
+        assert_eq!(
+            val,
+            json!({
+                "prefix-***-suffix": {
+                    "list": [{"***": "value has ***"}]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn masked_json_key_collisions_preserve_every_entry() {
+        let masker = masker_with(vec!["secret-one", "secret-two"]);
+        let original = json!({
+            "***": "reserved base",
+            "***#2": "reserved suffix",
+            "secret-one": {"secret-two": "first"},
+            "secret-two": "second"
+        });
+        let mut first = original.clone();
+        let mut second = original;
+
+        masker.mask_value(&mut first);
+        masker.mask_value(&mut second);
+
+        let expected = json!({
+            "***": "reserved base",
+            "***#2": "reserved suffix",
+            "***#3": {"***": "first"},
+            "***#4": "second"
+        });
+        assert_eq!(first, expected);
+        assert_eq!(second, expected);
     }
 
     #[test]

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -56,7 +56,8 @@ async fn send_event_masks_secrets() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""data":"contains *** here""#);
+            .body_includes(r#""tool_input":{"***":"contains *** here"}"#)
+            .body_excludes("super-secret-value");
         then.status(200);
     });
 
@@ -64,11 +65,34 @@ async fn send_event_masks_secrets() {
     let encoded_secret = engine.encode("super-secret-value");
     let masker = SecretMasker::from_raw(&encoded_secret);
 
-    let event = json!({"type": "test", "data": "contains super-secret-value here"});
+    let event = json!({
+        "type": "test",
+        "tool_input": {"super-secret-value": "contains super-secret-value here"}
+    });
     let result = send_shared_event(event, 1, &masker).await;
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
+}
+
+#[test]
+fn prepare_event_keeps_system_sequence_field_when_name_is_secret() {
+    let engine = base64::engine::general_purpose::STANDARD;
+    let encoded_secret = engine.encode("sequenceNumber");
+    let masker = SecretMasker::from_raw(&encoded_secret);
+    let event = json!({
+        "type": "test",
+        "nested": {"sequenceNumber": "event-controlled"}
+    });
+
+    let payload =
+        guest_agent::events::prepare_event_payload_for_run_id(event, 7, &masker, TEST_RUN_ID);
+
+    assert_eq!(payload["runId"], TEST_RUN_ID);
+    assert_eq!(payload["events"][0]["type"], "test");
+    assert_eq!(payload["events"][0]["sequenceNumber"], 7);
+    assert_eq!(payload["events"][0]["nested"]["***"], "event-controlled");
+    assert!(payload["events"][0]["nested"]["sequenceNumber"].is_null());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- redact secrets recursively from JSON object keys as well as string values
- preserve every object entry when multiple keys redact to the same value by assigning deterministic, non-secret-derived suffixes
- prevent cascading replacements and generated collision suffixes from recreating a configured secret pattern
- redact event-controlled content before adding the system-owned sequence number
- cover nested keys, collisions, outbound request bodies, and protocol-field preservation

## Exclusions

- no API, database, or schema changes
- system-owned envelope and sequence fields remain unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- targeted masker and event integration tests
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`

Closes #21609
