### PR TITLE
fix(sandbox-mock): align write input semantics

### DIFF
--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -159,9 +159,10 @@ impl MockSandbox {
     ///
     /// Results are consumed in FIFO order by both
     /// [`write_file`](Sandbox::write_file) and [`write_files`](Sandbox::write_files).
-    /// When the queue is empty, both operations return `Ok(())`.
-    /// Each `write_files` invocation consumes one queued result for the whole
-    /// batch, not one result per file.
+    /// When the queue is empty, valid operations return `Ok(())`.
+    /// Each non-empty `write_files` invocation consumes one queued result for
+    /// the whole batch, not one result per file. Empty batches are recorded but
+    /// do not consume a result.
     pub fn push_write_file_result(&self, result: Result<()>) {
         self.write_file_results
             .lock_ignoring_poison()
@@ -170,9 +171,10 @@ impl MockSandbox {
 
     /// Return this sandbox's recorded write-file calls.
     ///
-    /// The returned vector is a cloned snapshot in recorded order. When this
-    /// sandbox was built with shared overrides, write-file calls are also
-    /// recorded in [`MockSandboxOverrides::write_file_calls`].
+    /// The returned vector is a cloned snapshot in recorded order. Calls are
+    /// recorded before mock guest-path validation. When this sandbox was built
+    /// with shared overrides, write-file calls are also recorded in
+    /// [`MockSandboxOverrides::write_file_calls`].
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
     }
@@ -182,14 +184,16 @@ impl MockSandbox {
     /// Batch entries are also expanded into [`Self::write_file_calls`] so tests
     /// that only need path/content assertions can use one observation surface.
     /// That expansion is only for call recording: queued write results are
-    /// consumed, and the write lifecycle gate is entered, per write operation
-    /// rather than per expanded file entry.
+    /// consumed, and the write lifecycle gate is entered, per non-empty write
+    /// operation rather than per expanded file entry. Invalid and empty batches
+    /// remain recorded, but empty batches expand to no write-file calls and do
+    /// not consume a result or enter the gate.
     pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
         self.write_files_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a write_private_file result. Results are consumed in FIFO order.
-    /// When the queue is empty, write_private_file returns `Ok(())`.
+    /// When the queue is empty, a valid write_private_file returns `Ok(())`.
     pub fn push_private_write_file_result(&self, result: Result<()>) {
         self.private_write_file_results
             .lock_ignoring_poison()
@@ -198,9 +202,10 @@ impl MockSandbox {
 
     /// Return this sandbox's recorded private write-file calls.
     ///
-    /// The returned vector is a cloned snapshot in recorded order. When this
-    /// sandbox was built with shared overrides, private write-file calls are
-    /// also recorded in [`MockSandboxOverrides::private_write_file_calls`].
+    /// The returned vector is a cloned snapshot in recorded order. Calls are
+    /// recorded before mock guest-path validation. When this sandbox was built
+    /// with shared overrides, private write-file calls are also recorded in
+    /// [`MockSandboxOverrides::private_write_file_calls`].
     pub fn private_write_file_calls(&self) -> Vec<WriteFileCall> {
         self.private_write_file_calls.lock_ignoring_poison().clone()
     }
@@ -210,7 +215,8 @@ impl MockSandbox {
     /// Calls are recorded before they enter the gate, so tests can assert that a
     /// write was attempted while keeping the mock response pending. Both
     /// [`write_file`](Sandbox::write_file) and [`write_files`](Sandbox::write_files)
-    /// enter this gate; `write_files` enters it once for the whole batch.
+    /// enter this gate; non-empty `write_files` calls enter it once for the
+    /// whole batch. Empty batches are recorded but do not enter the gate.
     pub fn set_write_file_lifecycle_gate(&self, gate: MockLifecycleGate) {
         *self.write_file_gate.lock_ignoring_poison() = Some(gate);
     }
@@ -512,6 +518,7 @@ impl Sandbox for MockSandbox {
                 .lock_ignoring_poison()
                 .push(call);
         }
+        validate_mock_guest_file_path(SandboxOperation::WriteFile, "write_file", path)?;
         let gate = self.write_file_gate.lock_ignoring_poison().clone();
         if let Some(gate) = gate {
             gate.enter_and_wait().await;
@@ -551,6 +558,12 @@ impl Sandbox for MockSandbox {
                 .lock_ignoring_poison()
                 .extend(calls);
         }
+        if files.is_empty() {
+            return Ok(());
+        }
+        for file in files {
+            validate_mock_guest_file_path(SandboxOperation::WriteFile, "write_files", file.path)?;
+        }
         let gate = self.write_file_gate.lock_ignoring_poison().clone();
         if let Some(gate) = gate {
             gate.enter_and_wait().await;
@@ -576,6 +589,7 @@ impl Sandbox for MockSandbox {
                 .lock_ignoring_poison()
                 .push(call);
         }
+        validate_mock_guest_file_path(SandboxOperation::WriteFile, "write_private_file", path)?;
         if let Some(result) = self
             .private_write_file_results
             .lock_ignoring_poison()

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -384,6 +384,57 @@ async fn sandbox_write_file_queued_error() {
 }
 
 #[tokio::test]
+async fn sandbox_write_file_rejects_invalid_paths_before_gate_or_result() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let sandbox = MockSandbox::with_overrides("test-1", Arc::clone(&overrides));
+    let gate = MockLifecycleGate::new();
+    sandbox.set_write_file_lifecycle_gate(gate.clone());
+    sandbox.push_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "queued write failed".into(),
+    }));
+
+    for (path, expected_message) in [
+        ("", "guest file path must not be empty"),
+        ("/tmp/bad\0path.txt", "guest file path contains NUL bytes"),
+    ] {
+        let error =
+            tokio::time::timeout(test_timeout(), sandbox.write_file(path, b"invalid content"))
+                .await
+                .expect("invalid write_file must not wait on the lifecycle gate")
+                .unwrap_err();
+        assert_operation_error(
+            error,
+            SandboxOperation::WriteFile,
+            SandboxOperationReason::Other,
+            expected_message,
+        );
+    }
+
+    assert_eq!(gate.entered_count(), 0);
+    sandbox.clear_write_file_lifecycle_gate();
+
+    let queued_error = sandbox
+        .write_file("/tmp/valid.txt", b"valid content")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        queued_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "queued write failed",
+    );
+
+    let calls = sandbox.write_file_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].path, "");
+    assert_eq!(calls[1].path, "/tmp/bad\0path.txt");
+    assert_eq!(calls[2].path, "/tmp/valid.txt");
+    assert_eq!(overrides.write_file_calls(), calls);
+}
+
+#[tokio::test]
 async fn sandbox_write_files_records_batch_and_consumes_one_result() {
     let sandbox = MockSandbox::new("test-1");
     sandbox.push_write_file_result(Err(SandboxError::Operation {
@@ -420,6 +471,83 @@ async fn sandbox_write_files_records_batch_and_consumes_one_result() {
 }
 
 #[tokio::test]
+async fn sandbox_write_files_rejects_invalid_paths_and_treats_empty_batch_as_noop() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let sandbox = MockSandbox::with_overrides("test-1", Arc::clone(&overrides));
+    let gate = MockLifecycleGate::new();
+    sandbox.set_write_file_lifecycle_gate(gate.clone());
+    sandbox.push_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "queued batch failed".into(),
+    }));
+
+    for (path, expected_message) in [
+        ("", "guest file path must not be empty"),
+        ("/tmp/bad\0path.txt", "guest file path contains NUL bytes"),
+    ] {
+        let files = [
+            WriteFileEntry {
+                path: "/tmp/valid-before-invalid.txt",
+                content: b"valid",
+            },
+            WriteFileEntry {
+                path,
+                content: b"invalid",
+            },
+        ];
+        let error = tokio::time::timeout(test_timeout(), sandbox.write_files(&files))
+            .await
+            .expect("invalid write_files must not wait on the lifecycle gate")
+            .unwrap_err();
+        assert_operation_error(
+            error,
+            SandboxOperation::WriteFile,
+            SandboxOperationReason::Other,
+            expected_message,
+        );
+    }
+
+    tokio::time::timeout(test_timeout(), sandbox.write_files(&[]))
+        .await
+        .expect("empty write_files must not wait on the lifecycle gate")
+        .unwrap();
+    assert_eq!(gate.entered_count(), 0);
+    sandbox.clear_write_file_lifecycle_gate();
+
+    let valid_files = [WriteFileEntry {
+        path: "/tmp/valid.txt",
+        content: b"valid",
+    }];
+    let queued_error = sandbox.write_files(&valid_files).await.unwrap_err();
+    assert_operation_error(
+        queued_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "queued batch failed",
+    );
+
+    let batch_calls = sandbox.write_files_calls();
+    assert_eq!(batch_calls.len(), 4);
+    assert_eq!(batch_calls[0].files.len(), 2);
+    assert_eq!(
+        batch_calls[0].files[0].path,
+        "/tmp/valid-before-invalid.txt"
+    );
+    assert_eq!(batch_calls[0].files[1].path, "");
+    assert_eq!(batch_calls[1].files.len(), 2);
+    assert_eq!(batch_calls[1].files[1].path, "/tmp/bad\0path.txt");
+    assert!(batch_calls[2].files.is_empty());
+    assert_eq!(batch_calls[3].files.len(), 1);
+    assert_eq!(batch_calls[3].files[0].path, "/tmp/valid.txt");
+    assert_eq!(overrides.write_files_calls(), batch_calls);
+
+    let write_calls = sandbox.write_file_calls();
+    assert_eq!(write_calls.len(), 5);
+    assert_eq!(overrides.write_file_calls(), write_calls);
+}
+
+#[tokio::test]
 async fn sandbox_write_private_file_queued_error_and_records_calls() {
     let sandbox = MockSandbox::new("test-1");
     sandbox.push_private_write_file_result(Err(SandboxError::Operation {
@@ -442,6 +570,71 @@ async fn sandbox_write_private_file_queued_error_and_records_calls() {
     assert_eq!(calls.len(), 2);
     assert_eq!(calls[0].path, "/tmp/private.env");
     assert_eq!(calls[0].content, b"secret");
+}
+
+#[tokio::test]
+async fn sandbox_write_private_file_rejects_invalid_paths_before_local_or_shared_results() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "shared private write failed".into(),
+    }));
+    let sandbox = MockSandbox::with_overrides("test-1", Arc::clone(&overrides));
+    sandbox.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "local private write failed".into(),
+    }));
+
+    for (path, expected_message) in [
+        ("", "guest file path must not be empty"),
+        (
+            "/tmp/bad\0private.env",
+            "guest file path contains NUL bytes",
+        ),
+    ] {
+        let error = sandbox
+            .write_private_file(path, b"invalid private content")
+            .await
+            .unwrap_err();
+        assert_operation_error(
+            error,
+            SandboxOperation::WriteFile,
+            SandboxOperationReason::Other,
+            expected_message,
+        );
+    }
+
+    let local_error = sandbox
+        .write_private_file("/tmp/local-private.env", b"local")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        local_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "local private write failed",
+    );
+
+    let shared_error = sandbox
+        .write_private_file("/tmp/shared-private.env", b"shared")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        shared_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "shared private write failed",
+    );
+
+    let calls = sandbox.private_write_file_calls();
+    assert_eq!(calls.len(), 4);
+    assert_eq!(calls[0].path, "");
+    assert_eq!(calls[1].path, "/tmp/bad\0private.env");
+    assert_eq!(calls[2].path, "/tmp/local-private.env");
+    assert_eq!(calls[3].path, "/tmp/shared-private.env");
+    assert_eq!(overrides.private_write_file_calls(), calls);
 }
 
 #[tokio::test]

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -213,6 +213,8 @@ pub trait Sandbox: Send + Sync + Any {
     /// Write `content` to `path` inside the guest, creating parent
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
+    ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
 
     /// Write multiple ordinary files inside the guest.
@@ -220,6 +222,8 @@ pub trait Sandbox: Send + Sync + Any {
     /// Each entry has the same semantics as [`write_file`](Self::write_file):
     /// create parent directories, create or truncate the target file, and write
     /// the provided content without sudo or private runtime-file semantics.
+    /// Every guest path must be non-empty and must not contain NUL bytes. An
+    /// empty batch is accepted as a no-op.
     /// Callers are responsible for bounding the number of files and total
     /// content size. The default implementation preserves compatibility by
     /// writing entries sequentially with [`write_file`](Self::write_file).
@@ -236,6 +240,8 @@ pub trait Sandbox: Send + Sync + Any {
     /// parent directories are private, reject symlinked parent components, and
     /// write the file with private permissions. Generic workspace file writes
     /// should continue to use [`write_file`](Self::write_file).
+    ///
+    /// The guest path must be non-empty and must not contain NUL bytes.
     async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()>;
 
     /// Start `request.cmd` in the guest and return a handle for later


### PR DESCRIPTION
## Summary

- validate `MockSandbox` paths for `write_file`, `write_files`, and `write_private_file` using the existing mock guest-path contract
- preserve attempted-call recording while rejecting invalid paths before lifecycle gates or queued results are consumed
- make empty `write_files` batches observable no-ops, matching the sandbox trait and Firecracker implementation
- document write path and empty-batch semantics on the public `Sandbox` trait

## Compatibility

- keeps existing local/shared call recording and queued-result ordering
- does not change Firecracker error mapping, protocols, schemas, persisted data, or rollout behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock write`

Closes #21612
