### PR TITLE
test(guest-agent): tolerate procfs esrch during cleanup

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -1168,7 +1168,7 @@ fn linux_process_identity(pid: u32) -> Result<Option<LinuxProcessIdentity>, Stri
     let stat_path = format!("/proc/{pid}/stat");
     let stat = match std::fs::read_to_string(&stat_path) {
         Ok(stat) => stat,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if linux_proc_task_disappeared(&error) => return Ok(None),
         Err(error) => return Err(format!("read {stat_path}: {error}")),
     };
 
@@ -1222,7 +1222,7 @@ fn linux_process_group_has_no_live_members(pgid: i32) -> Result<bool, String> {
         let stat_path = entry.path().join("stat");
         let stat = match std::fs::read_to_string(&stat_path) {
             Ok(stat) => stat,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) if linux_proc_task_disappeared(&error) => continue,
             Err(error) => return Err(format!("read {}: {error}", stat_path.display())),
         };
         let process_stat = parse_linux_process_stat(&stat)
@@ -1233,6 +1233,11 @@ fn linux_process_group_has_no_live_members(pgid: i32) -> Result<bool, String> {
     }
 
     Ok(true)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_proc_task_disappeared(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::NotFound || error.raw_os_error() == Some(libc::ESRCH)
 }
 
 #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
## Summary

- Treat `ESRCH` from `/proc/<pid>/stat` as a process that disappeared during app-server cleanup checks.
- Apply the same race handling to process identity reads and process-group enumeration.
- Keep surfacing all other procfs I/O errors so real cleanup failures remain visible.

## Scope

- Test-only change; production process cleanup behavior is unchanged.
- No API, schema, protocol, or persisted-data changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo test -p guest-agent --test codex_app_server_client` (10 consecutive runs)
