### PR TITLE
perf(api): consolidate run admission reads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -32,7 +32,11 @@ import {
   seedOrgMetadata,
   seedUsagePricingRows,
 } from "../../../test-fixtures/system-config-seeds";
-import { readOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import {
+  deleteOrgPlanEntitlementFixture,
+  readOrgPlanEntitlementFixture,
+  upsertOrgPlanEntitlementFixture,
+} from "../../../test-fixtures/org-plan-entitlement";
 import {
   createBddApi,
   expectApiError,
@@ -80,6 +84,7 @@ import {
  */
 
 const context = testContext();
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_MESSAGE_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
@@ -147,6 +152,7 @@ const RUNNER_CLAIM_POLL_TIMING_ACTION_TYPES = [
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
   "api_dispatch_check_org_tier",
+  "api_dispatch_check_run_admission",
   "api_dispatch_prepare_run_context",
   "api_dispatch_prepare_context_feature_switches",
   "api_dispatch_prepare_context_resolve_compose",
@@ -1097,6 +1103,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       timingEvents,
       API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES,
       "nested",
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_check_run_admission"],
+      "top_level",
     );
     expectApiDispatchActions(timingEvents, [
       "api_dispatch_resolve_compose_by_compose_id",
@@ -3860,6 +3871,53 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
   });
 
+  it("uses staff entitlement capabilities for run admission", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const actor = bdd.user({ orgId: STAFF_ORG_ID });
+    onTestFinished(async () => {
+      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+    });
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    api.configureRunnerGroup();
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId: STAFF_ORG_ID,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    await bdd.setupOnboarding(actor, {
+      displayName: "BDD staff entitlement admission",
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: STAFF_ORG_ID,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    await api.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD staff entitlement admission agent",
+      visibility: "private",
+    });
+    await seedOrgMetadata({
+      orgId: STAFF_ORG_ID,
+      tier: "limited-free-1",
+      credits: 20_000,
+    });
+
+    const run = await api.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "staff entitlement BYOK run",
+      modelProvider: "anthropic-api-key",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
   it("defaults limited-free runs to Luna, allows Terra, and rejects Sol", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
@@ -3949,6 +4007,17 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       prompt: "vm0 built-in model provider",
       modelProvider: "vm0",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_check_run_admission"],
+      "top_level",
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_check_vm0_credits"],
+      "nested",
+    );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -183,6 +183,8 @@ import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 import {
   checkOrgModelRunAdmission,
   checkOrgCreditsForRunAdmission,
+  checkResolvedOrgCreditsForRunAdmission,
+  resolveOrgCreditAvailability,
 } from "./zero-run-admission.service";
 import { activateUsageAllowanceWindowsForRun } from "./usage-allowance.service";
 import {
@@ -3932,17 +3934,48 @@ async function checkRunConcurrencyLimit(
   return activeCount >= limit ? concurrentRunLimit() : null;
 }
 
-async function checkVm0Credits(
+async function checkFinalRunAdmission(
   db: Db,
-  args: { readonly orgId: string; readonly selectedModel?: string | null },
+  args: {
+    readonly orgId: string;
+    readonly modelProviderType: string | null | undefined;
+    readonly selectedModel: string | null | undefined;
+    readonly enforceVm0Credits: boolean;
+    readonly signal: AbortSignal;
+    readonly timing: ApiDispatchTimingCollector;
+  },
 ): Promise<CreateRunErrorResult | null> {
+  if (args.enforceVm0Credits) {
+    return await args.timing.measure(
+      "api_dispatch_check_vm0_credits",
+      "nested",
+      async () => {
+        const availability = await resolveOrgCreditAvailability({
+          db,
+          orgId: args.orgId,
+        });
+        args.signal.throwIfAborted();
+        return (
+          (await checkResolvedOrgCreditsForRunAdmission({
+            db,
+            orgId: args.orgId,
+            modelProviderType: args.modelProviderType,
+            selectedModel: args.selectedModel,
+            availability,
+          })) ?? null
+        );
+      },
+    );
+  }
+
+  const capabilities = await loadOrgPlanCapabilities(db, args.orgId);
+  args.signal.throwIfAborted();
   return (
-    (await checkOrgCreditsForRunAdmission({
-      db,
-      orgId: args.orgId,
-      modelProviderType: "vm0",
+    checkOrgModelRunAdmission({
+      capabilities,
+      modelProviderType: args.modelProviderType,
       selectedModel: args.selectedModel,
-    })) ?? null
+    }) ?? null
   );
 }
 
@@ -6026,10 +6059,13 @@ async function resolveRunModelProvider(
   }
 
   if (args.enforceVm0Credits && args.modelProviderType === "vm0") {
-    const creditGate = await checkVm0Credits(db, {
-      orgId: args.orgId,
-      selectedModel: args.selectedModelOverride,
-    });
+    const creditGate =
+      (await checkOrgCreditsForRunAdmission({
+        db,
+        orgId: args.orgId,
+        modelProviderType: "vm0",
+        selectedModel: args.selectedModelOverride,
+      })) ?? null;
     options.signal.throwIfAborted();
     if (creditGate) {
       return creditGate;
@@ -7383,35 +7419,29 @@ export const completeAgentRun$ = command(
     );
     signal.throwIfAborted();
 
-    const modelTierGate = await checkOrgModelRunAdmission({
-      db,
-      orgId: args.orgId,
-      modelProviderType: context.modelProvider?.type ?? args.modelProviderType,
-      selectedModel:
-        context.modelProvider?.selectedModel ?? args.selectedModelOverride,
-    });
+    const modelProviderType =
+      context.modelProvider?.type ?? args.modelProviderType;
+    const selectedModel =
+      context.modelProvider?.selectedModel ?? args.selectedModelOverride;
+    const admissionGate = await timing.measure(
+      "api_dispatch_check_run_admission",
+      "top_level",
+      async () => {
+        return await checkFinalRunAdmission(db, {
+          orgId: args.orgId,
+          modelProviderType,
+          selectedModel,
+          enforceVm0Credits:
+            args.enforceVm0Credits === true &&
+            context.modelProvider?.type === "vm0",
+          signal,
+          timing,
+        });
+      },
+    );
     signal.throwIfAborted();
-    if (modelTierGate) {
-      return modelTierGate;
-    }
-
-    if (args.enforceVm0Credits && context.modelProvider?.type === "vm0") {
-      const creditGate = await timing.measure(
-        "api_dispatch_check_vm0_credits",
-        "top_level",
-        async () => {
-          return await checkVm0Credits(db, {
-            orgId: args.orgId,
-            selectedModel:
-              context.modelProvider?.selectedModel ??
-              args.selectedModelOverride,
-          });
-        },
-      );
-      signal.throwIfAborted();
-      if (creditGate) {
-        return creditGate;
-      }
+    if (admissionGate) {
+      return admissionGate;
     }
 
     if (args.beforeDispatch) {

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -98,6 +98,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_workflow_event_build_run_input"
   | "api_dispatch_pre_create_zero_workflow_event_handoff_run"
   | "api_dispatch_check_org_tier"
+  | "api_dispatch_check_run_admission"
   | "api_dispatch_prepare_run_context"
   | "api_dispatch_prepare_context_feature_switches"
   | "api_dispatch_prepare_context_resolve_compose"

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -94,12 +94,13 @@ export async function checkResolvedOrgCreditsForRunAdmission(params: {
   if (!availability) {
     return insufficientCredits();
   }
-  if (
-    (!availability.supportByok && params.modelProviderType !== "vm0") ||
-    (availability.restrictedVm0Models &&
-      isLimitedFree1RestrictedRunModel(params.selectedModel))
-  ) {
-    return insufficientCredits();
+  const modelAdmission = checkOrgModelRunAdmission({
+    capabilities: availability,
+    modelProviderType: params.modelProviderType,
+    selectedModel: params.selectedModel,
+  });
+  if (modelAdmission) {
+    return modelAdmission;
   }
   if (availability.status !== "active") {
     return insufficientCredits();

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -3,7 +3,10 @@ import { isLimitedFree1RestrictedRunModel } from "@vm0/api-contracts/contracts/m
 
 import { insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
-import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
+import {
+  loadOrgPlanCapabilities,
+  type OrgPlanCapabilities,
+} from "./org-plan-entitlement-read.service";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 
 type CreditDb = Pick<Db, "execute" | "select">;
@@ -14,11 +17,16 @@ interface CreditCheckRow extends Record<string, unknown> {
 }
 
 interface OrgCreditAvailability {
-  readonly status: string;
+  readonly status: OrgPlanCapabilities["status"];
   readonly supportByok: boolean;
   readonly restrictedVm0Models: boolean;
   readonly spendableCredits: number;
 }
+
+type OrgModelAdmissionCapabilities = Pick<
+  OrgPlanCapabilities,
+  "supportByok" | "restrictedVm0Models"
+>;
 
 export async function resolveOrgCreditAvailability(params: {
   readonly db: CreditDb;
@@ -69,6 +77,20 @@ export async function checkOrgCreditsForRunAdmission(params: {
   readonly selectedModel?: string | null;
 }): Promise<ReturnType<typeof insufficientCredits> | undefined> {
   const availability = await resolveOrgCreditAvailability(params);
+  return await checkResolvedOrgCreditsForRunAdmission({
+    ...params,
+    availability,
+  });
+}
+
+export async function checkResolvedOrgCreditsForRunAdmission(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly modelProviderType: string | null | undefined;
+  readonly selectedModel?: string | null;
+  readonly availability: OrgCreditAvailability | null;
+}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+  const { availability } = params;
   if (!availability) {
     return insufficientCredits();
   }
@@ -100,18 +122,17 @@ export async function checkOrgCreditsForRunAdmission(params: {
     : insufficientCredits();
 }
 
-export async function checkOrgModelRunAdmission(params: {
-  readonly db: Db;
-  readonly orgId: string;
+export function checkOrgModelRunAdmission(params: {
+  readonly capabilities: OrgModelAdmissionCapabilities | null;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel: string | null | undefined;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
-  const availability = await resolveOrgCreditAvailability(params);
-  if (!availability) {
+}): ReturnType<typeof insufficientCredits> | undefined {
+  const { capabilities } = params;
+  if (!capabilities) {
     return undefined;
   }
-  return (!availability.supportByok && params.modelProviderType !== "vm0") ||
-    (availability.restrictedVm0Models &&
+  return (!capabilities.supportByok && params.modelProviderType !== "vm0") ||
+    (capabilities.restrictedVm0Models &&
       isLimitedFree1RestrictedRunModel(params.selectedModel))
     ? insufficientCredits()
     : undefined;

--- a/turbo/apps/api/src/test-fixtures/org-plan-entitlement.ts
+++ b/turbo/apps/api/src/test-fixtures/org-plan-entitlement.ts
@@ -39,6 +39,8 @@ export async function upsertOrgPlanEntitlementFixture(values: {
   readonly orgId: string;
   readonly status?: string;
   readonly baseConcurrencyLimit?: number;
+  readonly supportByok?: boolean;
+  readonly restrictedVm0Models?: boolean;
 }): Promise<void> {
   const row = {
     orgId: values.orgId,
@@ -47,6 +49,8 @@ export async function upsertOrgPlanEntitlementFixture(values: {
     source: "test_fixture",
     status: values.status ?? "active",
     baseConcurrencyLimit: values.baseConcurrencyLimit ?? 0,
+    supportByok: values.supportByok,
+    restrictedVm0Models: values.restrictedVm0Models,
   };
   await createStore()
     .set(writeDb$)
@@ -60,6 +64,12 @@ export async function upsertOrgPlanEntitlementFixture(values: {
         source: row.source,
         status: row.status,
         baseConcurrencyLimit: row.baseConcurrencyLimit,
+        ...(row.supportByok === undefined
+          ? {}
+          : { supportByok: row.supportByok }),
+        ...(row.restrictedVm0Models === undefined
+          ? {}
+          : { restrictedVm0Models: row.restrictedVm0Models }),
       },
     });
 }


### PR DESCRIPTION
## Summary

- consolidate final run admission around one fresh organization-policy snapshot
- skip credit-balance and expired-grant reads for paths that only need model policy
- reuse one full availability result for enforced VM0 model, status, credit, and allowance decisions
- add all-run admission timing plus nested VM0 timing and staff-entitlement route coverage

## Query impact

- non-credit final admission now performs one plan-capabilities query
- enforced VM0 final admission now performs one credit CTE and one plan-capabilities query instead of resolving full availability twice
- at the production volume recorded in #21621, this removes at least 262 SQL statements per two hours (approximately 3,144 per day); this is a query-load estimate, not a claimed latency result

## Compatibility

- keep the early plan-status read and transactional concurrency read independent
- preserve existing model restrictions, suspended-state handling, credits, expired grants, and allowance fallback
- leave model-selection, billable-operation, and firewall-auth availability callers self-contained
- no schema, persisted-data, public API, queue payload, runner protocol, or frontend changes

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/zero-run-admission.service.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/api-dispatch-timing.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/test-fixtures/org-plan-entitlement.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/zero-chat-threads-model-selection.test.ts` (109 tests)
- `pnpm knip --workspace api`
- pre-commit hooks, including repository-wide Turbo type checking and cached Knip

Closes #21621

Parent objective: #18746
