### PR TITLE
test: stabilize failed chat auto-send context coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3026,6 +3026,7 @@ describe("CHAT-02: failed chat callbacks", () => {
 describe("CHAT-02: auto-send after failures", () => {
   it("auto-sends the queued message after a failure, carrying attachments, incomplete-round context, and the continued session", async () => {
     const { actor, agentId, runnerGroup, storage } = await entitledChatActor();
+    await enableChatMessageQueue(actor);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await startChatRun(actor, {
@@ -3036,6 +3037,11 @@ describe("CHAT-02: auto-send after failures", () => {
     const firstHeaders = await claimChatRun(runnerGroup, first.runId);
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(first.runId, firstHeaders);
+    // This journey verifies failed-run auto-send context, not overlap with the
+    // successful anchor's detached terminal materialization. Drain the tracked
+    // waitUntil work so later lifecycle/follow-up rows cannot move its boundary
+    // after the failed run starts; callback ordering has dedicated gate coverage.
+    await flushWaitUntilForTest();
 
     const completedFirst = await api.readRun(actor, first.runId);
     expect(completedFirst.result?.agentSessionId).toMatch(/[0-9a-f-]{36}/);


### PR DESCRIPTION
## Summary

- explicitly enable the chat message queue in the failed auto-send BDD now that the feature defaults off
- drain tracked `waitUntil` work after the successful anchor run so optional terminal side effects cannot accidentally shift the fixture boundary
- preserve the existing assertions for queued auto-send, failed-run prompt truncation, attachments, failure status, and session continuation

## Impact

This keeps the failed auto-send journey deterministic without weakening its product contract. Callback ordering remains covered by the dedicated deferred-side-effect gate test. This PR does not change production incomplete-context boundary semantics; it is related to #21585 but does not close it.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "auto-sends the queued message after a failure, carrying attachments, incomplete-round context, and the continued session" --reporter=dot`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "auto-sends the queued message before completed-run LLM side effects finish" --reporter=dot`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `git diff --check`
