### PR TITLE
docs(mitm-addon): correct request capture test comment

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -332,10 +332,10 @@ class TestAddCaptureFields:
         assert entry["response_body_encoding"] == "binary"  # marked as binary
 
     def test_request_decompression_error_marks_body_binary(self, real_flow):
-        # Content-Encoding: gzip + non-gzip bytes on the REQUEST side makes
-        # flow.request.content raise ValueError.  add_capture_fields must
-        # catch it and mark request_body_encoding as binary, mirroring the
-        # response-side behaviour (#10792).
+        # Request capture decodes the captured stream buffer or raw_content with the
+        # bounded helper. Malformed gzip returns None, so add_capture_fields marks the
+        # body binary without accessing flow.request.content, unlike the response
+        # fallback above.
         flow = real_flow(
             method="POST",
             host="api.example.com",


### PR DESCRIPTION
## Summary

- correct the stale request decompression test explanation to describe bounded decoding from captured stream or raw bytes
- clarify that malformed request decoding returns `None` and is marked binary without accessing `flow.request.content`
- preserve the intentional difference from the response fallback, with no runtime or assertion changes

## Validation

- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python -m pytest tests/ -v` (`3984 passed`)
- `git diff --check`

Closes #21634
