### PR TITLE
docs(nbd-cow): document detailed destroy runtime contract

### DIFF
--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -252,7 +252,12 @@ impl PooledNbdCowDevice {
     /// Destroy the device and distinguish NBD shutdown failures from COW file
     /// cleanup failures.
     ///
-    /// Finalization starts immediately. When this returns an error with
+    /// Finalization starts when this method is called, before the returned
+    /// future is polled. Dropping the returned future does not cancel cleanup;
+    /// it continues in the background and logs its result. Must be called from
+    /// a Tokio runtime.
+    ///
+    /// When this returns an error with
     /// [`PooledDestroyError::backing_files_safe_to_delete`] set, the NBD device
     /// was released and callers may safely delete the containing workspace or
     /// snapshot attempt directory.


### PR DESCRIPTION
## Summary

- Clarify that detailed pooled COW destruction starts when the method is called, before its returned future is polled.
- Document that dropping the returned future does not cancel cleanup and that the method requires an entered Tokio runtime.
- Preserve the existing detailed backing-file safety contract and all runtime behavior.

Closes #21640

## Scope

- Rustdoc-only change in `nbd-cow`.
- No finalizer timing, error mapping, public type, downstream call site, data, protocol, migration, feature switch, or rollout change.
- No new tests: existing finalizer tests already cover eager start and cleanup continuation after the observer future is dropped.

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`, `check-file-size`, `ensure-generated-connector-firewalls-untracked`, `commitlint`
