### PR TITLE
docs(runner): clarify systemd enablement semantics

### DIFF
--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -394,7 +394,11 @@ fn cleanup_unit_active_state_from_output(
     )
 }
 
-/// Check whether a systemd unit is enabled for boot.
+/// Check whether systemd reports a unit file as enabled.
+///
+/// Returns `true` for both the persistent `enabled` state and the transient
+/// `enabled-runtime` state. This does not indicate whether the unit is active
+/// or whether it will remain enabled after a reboot.
 pub(crate) async fn is_unit_enabled(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
     let svc = unit.service_name();
     let output = tokio::process::Command::new("systemctl")
@@ -405,6 +409,11 @@ pub(crate) async fn is_unit_enabled(unit: &RunnerServiceUnit) -> RunnerResult<bo
     unit_enabled_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
 }
 
+/// Check whether systemd reports a unit file as enabled.
+///
+/// Returns `true` for both the persistent `enabled` state and the transient
+/// `enabled-runtime` state. This does not indicate whether the unit is active
+/// or whether it will remain enabled after a reboot.
 pub(super) async fn is_unit_enabled_bounded(
     unit: &RunnerServiceUnit,
     duration: Duration,


### PR DESCRIPTION
## Summary

- document that both persistent `enabled` and transient `enabled-runtime` states return `true`
- distinguish unit-file enablement from active/running state and next-boot persistence
- give the bounded and unbounded helpers the same self-contained contract

## Explicit exclusions

- no changes to the systemd state classifier, helper APIs, callers, or runtime behavior
- no new tests because existing regression coverage already pins both accepted states

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features`

Closes #21638
