### PR TITLE
docs(runner): document active service states

### DIFF
--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -235,7 +235,15 @@ async fn kill_and_reap_child(program: &str, child: &mut tokio::process::Child) -
     }
 }
 
-/// Check whether a systemd unit is active (running or activating).
+/// Check whether a systemd unit is active for normal health checks.
+///
+/// Returns `true` for the `ActiveState` values `active`, `activating`,
+/// `reloading`, and `refreshing`. `deactivating` intentionally returns `false`
+/// because a unit that has begun shutdown is no longer runnable.
+///
+/// Cleanup callers must use `cleanup_unit_active_state_bounded`, which treats
+/// `deactivating` as active-like so cleanup can wait or escalate instead of
+/// reporting success before the unit is fully inactive.
 pub(crate) async fn is_unit_active(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
     let svc = unit.service_name();
     let properties = ["LoadState", "ActiveState"];


### PR DESCRIPTION
## Summary

- document every systemd `ActiveState` treated as active by normal service health checks
- clarify why `deactivating` is intentionally false and direct cleanup callers to the active-like cleanup helper

## Scope

- documentation only; no runtime behavior, API, protocol, schema, persisted data, dependency, or rollout changes
- no new tests because the existing state-classification tests already cover every documented state

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`

Closes #21639
