### PR TITLE
test(mitm-addon): cover active shared-base connector intent

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -221,6 +221,38 @@ async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_befor
     assert proxy_log_entry["ownership_hint_status"] == "used"
 
 
+async def test_shared_base_active_connector_intent_keeps_active_auth_path(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    _write_shared_base_diagnostic_catalog(tmp_path)
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        method="POST",
+        path="/graphql/v2",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "active-shared"),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "active-shared"
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
 async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):


### PR DESCRIPTION
## Summary

- cover a valid active connector intent on a base-only shared connector endpoint through the real mitmproxy request hook
- verify the request continues through active auth injection without installing a local connector diagnostic
- verify the private connector-intent header is stripped and no diagnostic failure metadata is recorded

This is a test-only change. It does not modify runtime behavior, schemas, persisted data, APIs,
protocols, or generated catalogs.

Closes #21637

## Verification

- `.venv/bin/python -m pytest -q tests/test_request_handler_connector_diagnostics.py::test_shared_base_active_connector_intent_keeps_active_auth_path` (`1 passed`)
- `.venv/bin/python -m pytest -q tests/test_request_handler_connector_diagnostics.py` (`17 passed`)
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m basedpyright -p .` (`0 errors, 0 warnings, 0 notes`)
- `.venv/bin/python -m pytest -q` (`3985 passed`)
- `lefthook run pre-commit --file crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py --no-tty`
