### PR TITLE
fix(runner): reject firewall auth redirects

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import urllib.error
-import urllib.request
 from dataclasses import dataclass, field
 from typing import Protocol
 
@@ -19,6 +18,7 @@ _STRUCTURED_FIREWALL_AUTH_ERROR_CODES = frozenset(
     }
 )
 _FIREWALL_AUTH_FAILURE_REASONS = frozenset({"upstream_provider", "reconnect_required"})
+_opener = platform_api.build_api_opener()
 
 
 class ConnectorNotConfiguredError(Exception):
@@ -302,7 +302,7 @@ def _fetch_firewall_headers_sync(
     req = platform_api.make_api_request(url, data, request.sandbox_token)
     try:
         # nosemgrep: dynamic-urllib-use-detected
-        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        with _opener.open(req, timeout=10) as resp:
             decoded: object = json.loads(_read_firewall_auth_response_body(resp))
             return _parse_firewall_auth_success(decoded, request)
     except urllib.error.HTTPError as e:

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -1,4 +1,4 @@
-"""Shared platform API request helpers for the mitmproxy addon."""
+"""Shared platform API request and redirect-policy helpers for the mitmproxy addon."""
 
 import os
 import urllib.parse
@@ -17,6 +17,26 @@ CLIENT_TYPE_MITM_ADDON = "MitmAddon"
 _CLIENT_HEADERS = ("", "")
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Reject redirects from credential-bearing platform API requests."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def build_api_opener() -> urllib.request.OpenerDirector:
+    """Build an opener that returns redirects as HTTP errors."""
+    return urllib.request.build_opener(_NoRedirect)
+
+
 def configure_client_headers(*, client_session_id: str, client_version: str) -> None:
     """Snapshot runner-provided client header values for worker-thread requests."""
     global _CLIENT_HEADERS
@@ -32,7 +52,9 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     """Build a Request with standard platform API headers.
 
     Centralises User-Agent, Authorization, Content-Type, and the optional
-    Vercel bypass header so that callers cannot accidentally omit them.
+    Vercel bypass header so that callers cannot accidentally omit them. The
+    credentials are unredirected as defense in depth; callers must still use
+    :func:`build_api_opener` so redirects fail before contacting another URL.
     """
     parsed_url = urllib.parse.urlsplit(url)
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
@@ -47,7 +69,6 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
         data=data,
         headers={
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {sandbox_token}",
             "User-Agent": "vm0-mitm-addon/1.0",
             CLIENT_VERSION_HEADER: client_version,
             CLIENT_TYPE_HEADER: CLIENT_TYPE_MITM_ADDON,
@@ -55,6 +76,7 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
             CLIENT_REQUEST_ID_HEADER: str(uuid.uuid4()),
         },
     )
+    req.add_unredirected_header("Authorization", f"Bearer {sandbox_token}")
     if VERCEL_BYPASS:
-        req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)
+        req.add_unredirected_header("x-vercel-protection-bypass", VERCEL_BYPASS)
     return req

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -12,14 +12,13 @@ import threading
 import time
 import urllib.error
 import urllib.parse
-import urllib.request
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Literal
 
 import network_log_sanitization
 from logging_utils import log_proxy_entry
-from platform_api import make_api_request
+from platform_api import build_api_opener, make_api_request
 
 from .counters import PendingReportLease, admit_pending_report
 
@@ -33,22 +32,7 @@ _RETRYABLE_HTTP_STATUS_CODES = {408, 429}
 _WEBHOOK_RETRY_DELAY_SECONDS = 0.5
 
 
-class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    """Disable automatic redirect following for webhook delivery."""
-
-    def redirect_request(
-        self,
-        req: urllib.request.Request,
-        fp: object,
-        code: int,
-        msg: str,
-        headers: object,
-        newurl: str,
-    ) -> None:
-        return None
-
-
-_opener = urllib.request.build_opener(_NoRedirect)
+_opener = build_api_opener()
 
 
 def _payload_log_summary(payload: dict) -> dict:

--- a/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_endpoint_helpers.py
@@ -34,8 +34,8 @@ class AuthEndpointResponse:
 class FakeAuthEndpoint:
     """Threaded local auth endpoint for mitm-addon auth-related tests.
 
-    The endpoint is live only inside ``run()``. It only implements POST
-    handling, records method, path, raw body, and lower-cased headers, and
+    The endpoint is live only inside ``run()``. It implements GET and POST,
+    records method, path, raw body, and lower-cased headers, and
     serves queued responses in FIFO order. Requests without a queued response
     receive a synthetic HTTP 500 response so accidental extra auth calls fail
     visibly.
@@ -129,6 +129,9 @@ class FakeAuthEndpoint:
         endpoint = self
 
         class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                endpoint._handle_request(self)
+
             def do_POST(self) -> None:
                 endpoint._handle_request(self)
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1206,7 +1206,7 @@ class TestHandleFirewallRequest:
         ],
         ids=["url-error", "socket-timeout", "connection-reset"],
     )
-    async def test_urlopen_transport_failure_returns_502(
+    async def test_auth_endpoint_transport_failure_returns_502(
         self,
         network_error: Exception,
         expected_message: str,
@@ -1220,7 +1220,7 @@ class TestHandleFirewallRequest:
         allow = _allow(api_entry)
 
         with (
-            patch("firewall_auth_client.urllib.request.urlopen", side_effect=network_error),
+            patch("firewall_auth_client._opener.open", side_effect=network_error),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1258,7 +1258,7 @@ class TestHandleFirewallRequest:
         mock_resp.read.return_value = b"not-json"
 
         with (
-            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1302,7 +1302,7 @@ class TestHandleFirewallRequest:
         )
 
         with (
-            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             result = await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1341,7 +1341,7 @@ class TestHandleFirewallRequest:
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
                 len(response_body) - 1,
             ),
-            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1380,7 +1380,7 @@ class TestHandleFirewallRequest:
         mock_resp = _json_response({"headers": []})
 
         with (
-            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            patch("firewall_auth_client._opener.open", return_value=mock_resp),
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1777,6 +1777,26 @@ class TestMakeApiRequest:
         assert normalized_headers["x-client-type"] == "MitmAddon"
         assert normalized_headers["x-client-session-id"] == "runner-session-direct"
         uuid.UUID(normalized_headers["x-client-request-id"])
+
+    def test_marks_credentials_as_unredirected(self, mitm_ctx):
+        with (
+            mitm_ctx(),
+            patch.object(platform_api, "VERCEL_BYPASS", "secret-bypass-value"),
+        ):
+            req = platform_api.make_api_request(
+                "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
+                b"{}",
+                "tok-xyz",
+            )
+
+        redirected_headers = {name.lower(): value for name, value in req.headers.items()}
+        unredirected_headers = {
+            name.lower(): value for name, value in req.unredirected_hdrs.items()
+        }
+        assert "authorization" not in redirected_headers
+        assert "x-vercel-protection-bypass" not in redirected_headers
+        assert unredirected_headers["authorization"] == "Bearer tok-xyz"
+        assert unredirected_headers["x-vercel-protection-bypass"] == "secret-bypass-value"
 
     @pytest.mark.parametrize(
         "url",
@@ -2285,15 +2305,45 @@ class TestFetchFirewallHeaders:
 
         assert endpoint.requests[0].headers["x-vercel-protection-bypass"] == "secret-bypass-value"
 
-    async def test_invalid_api_url_raises_before_urlopen(self):
+    @pytest.mark.parametrize("status", [301, 302, 303])
+    async def test_rejects_cross_origin_redirect_without_forwarding_credentials(
+        self,
+        status: int,
+        mitm_ctx,
+    ):
+        source = FakeAuthEndpoint()
+        target = FakeAuthEndpoint()
+
+        with target.run():
+            source.queue_response(
+                status,
+                headers=(("Location", f"{target.api_url}/redirected"),),
+            )
+            with (
+                source.run(),
+                mitm_ctx(api_url=source.api_url),
+                patch.object(platform_api, "VERCEL_BYPASS", "secret-bypass-value"),
+                pytest.raises(urllib.error.HTTPError) as exc_info,
+            ):
+                await auth_client.fetch_firewall_headers(_firewall_auth_request())
+
+        assert exc_info.value.code == status
+        assert source.request_count == 1
+        request = source.requests[0]
+        assert request.method == "POST"
+        assert request.headers["authorization"] == "Bearer tok-xyz"
+        assert request.headers["x-vercel-protection-bypass"] == "secret-bypass-value"
+        assert target.requests == ()
+
+    async def test_invalid_api_url_raises_before_open(self):
         with (
             patch.object(platform_api, "get_api_url", return_value="file:///etc/passwd"),
-            patch("firewall_auth_client.urllib.request.urlopen") as mock_urlopen,
+            patch("firewall_auth_client._opener.open") as mock_open,
             pytest.raises(ValueError, match="absolute http"),
         ):
             await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
-        mock_urlopen.assert_not_called()
+        mock_open.assert_not_called()
 
     async def test_424_connector_not_configured_raises_custom_error(self, mitm_ctx):
         """Auth endpoint 424 CONNECTOR_NOT_CONFIGURED raises ConnectorNotConfiguredError."""
@@ -2639,7 +2689,7 @@ class TestFirewallAuthResponseBodyReader:
 
 class TestFetchFirewallHeadersResourceBoundary:
     def test_closes_response_on_success(self, mitm_ctx):
-        """Success path must close the urlopen response — FD leak guard (#10475)."""
+        """Success path must close the HTTP response — FD leak guard (#10475)."""
         mock_resp = MagicMock()
         mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
@@ -2647,7 +2697,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         with (
             mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            patch("firewall_auth_client._opener.open", return_value=mock_resp),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
@@ -2667,7 +2717,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         with (
             mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
+            patch("firewall_auth_client._opener.open", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
@@ -2688,7 +2738,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         with (
             mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
+            patch("firewall_auth_client._opener.open", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
@@ -2723,7 +2773,7 @@ class TestFetchFirewallHeadersResourceBoundary:
                 len(error_body) - 1,
             ),
             patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
+            patch("firewall_auth_client._opener.open", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(
                 auth_client.FirewallAuthResponseTooLargeError,
@@ -2769,7 +2819,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         with (
             mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
-            patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
+            patch("firewall_auth_client._opener.open", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(expected_exception),
         ):

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -184,6 +184,9 @@ class UsageWebhookServer:
         server_ref = self
 
         class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                server_ref._handle_request(self)
+
             def do_POST(self) -> None:
                 server_ref._handle_request(self)
 


### PR DESCRIPTION
## Summary

- reject redirects for credential-bearing platform API requests through a shared no-redirect opener policy
- mark sandbox authorization and Vercel bypass credentials as unredirected defense in depth
- strengthen live HTTP fixtures and verify 301, 302, and 303 responses never reach a cross-origin target

## Scope

- runner mitm-addon only
- no API, database schema, persisted-state, queue-payload, or protocol changes
- redirects are intentionally unsupported; deployments must configure the canonical platform API origin

## Validation

- `python3 -m ruff format .`
- `python3 -m ruff check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/test_firewall_auth.py tests/test_webhook_http_delivery.py tests/test_addon_configuration.py -q` (176 passed)
- `python3 -m pytest tests/ -q` (3,988 passed)

Closes #21636
