### PR TITLE
docs(guest-agent): document active-input payload schema

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -440,8 +440,15 @@ impl ActiveInputController {
 
     /// Validates and queues one process-control active-input payload.
     ///
-    /// `message_id` is the control-plane id used to reject duplicate requests.
-    /// `payload` must decode to an active-input request with non-empty text.
+    /// `message_id` is the non-empty control-plane id used to reject duplicate
+    /// requests. It is passed separately and is not part of `payload`.
+    ///
+    /// `payload` must be a JSON object with the required string fields `type`
+    /// and `text`. `type` must equal `active-input`, and `text` must be non-empty:
+    ///
+    /// ```json
+    /// {"type":"active-input","text":"follow-up prompt"}
+    /// ```
     ///
     /// The method returns [`ActiveInputControlOutcome::Accepted`] only after the
     /// follow-up frame has been queued for the paired writer. Unsupported,


### PR DESCRIPTION
## Summary

- Document that active-input control message ids are non-empty and passed separately from the payload.
- Specify the required `type` and `text` JSON fields, discriminator value, and non-empty text requirement.
- Include a directly constructible JSON payload example in the public rustdoc.

This is documentation-only: it does not change runtime behavior, public type visibility, the wire format, tests, manifests, or release configuration.

Closes #21641

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets --all-features`
- `cd crates && cargo doc -p guest-agent --all-features --no-deps`
- `cd crates && cargo test -p guest-agent`
- `git diff --check`
- pre-commit: workspace Rust formatting, Clippy, cargo-doc, and commitlint
