### PR TITLE
test(vsock-host): cover malformed frames after handle drop

### DIFF
--- a/crates/vsock-host/src/tests/exec_operation/malformed.rs
+++ b/crates/vsock-host/src/tests/exec_operation/malformed.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
-use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START};
+use vsock_proto::{
+    ExecTermination, MSG_ERROR, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
+};
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, exec_capture_default, normal_operation_readiness,
-    operation_count, read_guest_message, send_exec_result, setup_host_and_guest,
-    wait_for_operation_count,
+    assert_connection_accepts_exec_operation, exec_capture_default, is_connected,
+    normal_operation_readiness, operation_count, read_guest_message, send_exec_result,
+    setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::{ExecOwnedCapturedOutput, operation_tracker::NormalOperationReadiness};
@@ -92,18 +94,49 @@ async fn malformed_exec_output_after_result_is_ignored() {
 async fn malformed_exec_frames_after_handle_drop_are_ignored() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
-    let handle = start_capture_operation(&host, "abandoned").await;
-    let msg = read_guest_message(&mut guest).await;
-    assert_eq!(msg.msg_type, MSG_EXEC_START);
-    assert_eq!(operation_count(&host), 1);
+    let abandoned_handle = start_capture_operation(&host, "abandoned").await;
+    let abandoned_msg = read_guest_message(&mut guest).await;
+    assert_eq!(abandoned_msg.msg_type, MSG_EXEC_START);
 
-    drop(handle);
-    wait_for_operation_count(&host, 0).await;
+    let survivor_handle = start_capture_operation(&host, "survivor").await;
+    let survivor_msg = read_guest_message(&mut guest).await;
+    assert_eq!(survivor_msg.msg_type, MSG_EXEC_START);
+    assert_ne!(abandoned_msg.seq, survivor_msg.seq);
+    assert_eq!(operation_count(&host), 2);
+
+    drop(abandoned_handle);
+    wait_for_operation_count(&host, 1).await;
 
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
     );
+
+    for msg_type in [MSG_EXEC_STARTED, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT] {
+        let frame = vsock_proto::encode(msg_type, abandoned_msg.seq, &[0]).unwrap();
+        guest.write_all(&frame).await.unwrap();
+    }
+
+    send_exec_result(
+        &mut guest,
+        survivor_msg.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"survived",
+        b"",
+    )
+    .await;
+    let result = survivor_handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(
+        result.stdout,
+        ExecOwnedCapturedOutput::Captured {
+            bytes: b"survived".to_vec(),
+            truncated: false,
+        }
+    );
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+
     let err = exec_capture_default(&host, "after-drop", 5000, &[], false)
         .await
         .unwrap_err();


### PR DESCRIPTION
## Summary

- start a second exec operation before abandoning a one-shot handle
- send malformed `MSG_EXEC_STARTED`, `MSG_EXEC_OUTPUT`, and `MSG_EXEC_RESULT` frames for the abandoned sequence
- verify the existing in-flight operation still completes, the connection remains open, and later normal operations remain unavailable

## Scope

- test-only change in `vsock-host`
- no runtime dispatcher, wire protocol, API, schema, persistence, or rollout changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::exec_operation::malformed::malformed_exec_frames_after_handle_drop_are_ignored -- --exact`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::exec_operation::malformed`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `lefthook run pre-commit --files crates/vsock-host/src/tests/exec_operation/malformed.rs`

Closes #21644
