### PR TITLE
test(runner): verify bounded systemctl child reaping

### DIFF
--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -776,6 +776,8 @@ fn systemctl_show_status_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use crate::process::read_process_stat;
 
     fn systemctl_show_output(status: ExitStatus, stdout: &[u8], stderr: &[u8]) -> Output {
         Output {
@@ -816,7 +818,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_command_bounded_times_out_and_reaps_child() {
+    async fn run_command_bounded_times_out() {
         let outcome = run_command_bounded("sleep", &["60"], Duration::from_millis(1))
             .await
             .unwrap();
@@ -825,12 +827,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_command_output_bounded_times_out_and_reaps_child() {
+    async fn run_command_output_bounded_times_out() {
         let err = run_command_output_bounded("sleep", &["60"], Duration::from_millis(1))
             .await
             .unwrap_err();
 
         assert!(err.to_string().contains("timed out"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn kill_and_reap_child_reaps_running_child() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        let starttime = read_process_stat(pid)
+            .await
+            .unwrap_or_else(|| panic!("read initial process stat for pid {pid}"))
+            .starttime;
+
+        kill_and_reap_child("sleep", &mut child).await.unwrap();
+
+        let observed = read_process_stat(pid).await;
+        assert!(
+            !matches!(&observed, Some(stat) if stat.starttime == starttime),
+            "killed child pid {pid} was not reaped: {observed:?}"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

- rename the two bounded command timeout tests so their names match their outcome/error assertions
- add Linux real-process coverage that verifies `kill_and_reap_child` removes the original PID/start-time identity before the retained child handle is dropped
- avoid PID publication races, artificial delays, mocks, and production abstractions added solely for test visibility

## Scope

- test-only change in `crates/runner/src/cmd/service/systemctl.rs`
- no production behavior, API, protocol, schema, persisted-data, dependency, or deployment compatibility change

## Validation

- `cargo test -p runner kill_and_reap_child_reaps_running_child -- --nocapture`
- temporary local kill-only mutation: the targeted test failed as intended with the original process in `state: 'Z'`; the mutation was then restored and the test passed
- `cargo test -p runner cmd::service::systemctl::tests::run_command_ -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2695 passed, 0 failed, 9 existing ignored; guest inventory passed)
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc, file-size and generated-firewall checks
- commitlint

Closes #21646
