### PR TITLE
test(runner): assert exec target and policy forwarding

### DIFF
--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -184,7 +184,7 @@ fn write_remote_exec_warning(stderr: &mut impl Write, line_open: &mut bool, mess
 #[cfg(test)]
 mod tests {
     use sandbox::SandboxControlError;
-    use sandbox_mock::MockSandboxControl;
+    use sandbox_mock::{MockSandboxControl, RemoteExecCall};
 
     use super::*;
 
@@ -206,6 +206,12 @@ mod tests {
             sudo: false,
             command: command.into_iter().map(String::from).collect(),
         }
+    }
+
+    fn assert_recorded_command(control: &MockSandboxControl, expected: &str) {
+        let calls = control.recorded_exec_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].command, expected);
     }
 
     #[tokio::test]
@@ -233,6 +239,31 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result, ExitCode::SUCCESS);
+    }
+
+    #[tokio::test]
+    async fn forwards_direct_sandbox_target_and_exec_policy() {
+        let control = MockSandboxControl::new("/tmp");
+        let args = ExecArgs {
+            run: None,
+            sandbox: Some("direct-sandbox".into()),
+            timeout: 47,
+            sudo: true,
+            command: vec!["echo".into(), "hello world".into()],
+        };
+
+        let result = run_exec(args, &control).await.unwrap();
+
+        assert_eq!(result, ExitCode::SUCCESS);
+        assert_eq!(
+            control.recorded_exec_calls(),
+            vec![RemoteExecCall {
+                sandbox_id: "direct-sandbox".to_string(),
+                command: "'echo' 'hello world'".to_string(),
+                timeout: Duration::from_secs(47),
+                sudo: true,
+            }],
+        );
     }
 
     #[tokio::test]
@@ -449,10 +480,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'ls' '-la' '/var/log'".to_string()],
-        );
+        assert_recorded_command(&control, "'ls' '-la' '/var/log'");
     }
 
     #[tokio::test]
@@ -465,10 +493,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'cat' '/var/log/some file.log'".to_string()],
-        );
+        assert_recorded_command(&control, "'cat' '/var/log/some file.log'");
     }
 
     #[tokio::test]
@@ -478,10 +503,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'echo' 'it'\\''s'".to_string()],
-        );
+        assert_recorded_command(&control, "'echo' 'it'\\''s'");
     }
 
     #[tokio::test]
@@ -494,10 +516,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'bash' '-c' 'echo a | tr a b'".to_string()],
-        );
+        assert_recorded_command(&control, "'bash' '-c' 'echo a | tr a b'");
     }
 
     #[tokio::test]
@@ -508,10 +527,7 @@ mod tests {
             .unwrap();
 
         // `$` must be quoted so the guest shell does not expand it.
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'echo' '$HOME'".to_string()],
-        );
+        assert_recorded_command(&control, "'echo' '$HOME'");
     }
 
     #[tokio::test]
@@ -521,10 +537,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'echo' 'ok; uname -a'".to_string()],
-        );
+        assert_recorded_command(&control, "'echo' 'ok; uname -a'");
     }
 
     #[tokio::test]
@@ -537,10 +550,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'printf' '$(id)' '`id`' '*' 'x > out'".to_string()],
-        );
+        assert_recorded_command(&control, "'printf' '$(id)' '`id`' '*' 'x > out'");
     }
 
     #[tokio::test]
@@ -550,7 +560,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(control.recorded_commands(), vec!["'echo' ''".to_string()],);
+        assert_recorded_command(&control, "'echo' ''");
     }
 
     #[tokio::test]
@@ -562,10 +572,7 @@ mod tests {
 
         // `FOO=bar` must be quoted so the guest shell treats it as a command
         // name instead of a variable assignment.
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'FOO=bar' 'env'".to_string()],
-        );
+        assert_recorded_command(&control, "'FOO=bar' 'env'");
     }
 
     #[tokio::test]
@@ -573,6 +580,6 @@ mod tests {
         let control = MockSandboxControl::new("/tmp");
         run_exec(make_args_vec(vec!["if"]), &control).await.unwrap();
 
-        assert_eq!(control.recorded_commands(), vec!["'if'".to_string()]);
+        assert_recorded_command(&control, "'if'");
     }
 }

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -19,6 +19,19 @@ pub struct ExecMatcher {
     pub stderr: Vec<u8>,
 }
 
+/// Captured `exec_remote` call fields recorded for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteExecCall {
+    /// Sandbox identifier passed to `SandboxControl::exec_remote`.
+    pub sandbox_id: String,
+    /// Command string passed to `SandboxControl::exec_remote`.
+    pub command: String,
+    /// Timeout passed to `SandboxControl::exec_remote`.
+    pub timeout: Duration,
+    /// Whether the remote command requested sudo privileges.
+    pub sudo: bool,
+}
+
 /// Captured `exec` request fields recorded for test assertions.
 ///
 /// The record intentionally keeps environment variable names but not their

--- a/crates/sandbox-mock/src/control.rs
+++ b/crates/sandbox-mock/src/control.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use ::sandbox::*;
 use async_trait::async_trait;
 
+use crate::call_records::RemoteExecCall;
 use crate::support::LockIgnoringPoison;
 
 /// A mock [`SandboxControl`] for testing exec/kill commands.
@@ -17,12 +18,12 @@ pub struct MockSandboxControl {
     base_dir: PathBuf,
     exec_results: Mutex<VecDeque<std::result::Result<RemoteExecResult, SandboxControlError>>>,
     kill_results: Mutex<VecDeque<std::result::Result<RemoteKillResult, SandboxControlError>>>,
-    recorded_commands: Mutex<Vec<String>>,
+    recorded_exec_calls: Mutex<Vec<RemoteExecCall>>,
     recorded_kill_ids: Mutex<Vec<String>>,
 }
 
 impl MockSandboxControl {
-    /// Create a control mock that records remote exec commands and kill ids.
+    /// Create a control mock that records remote exec calls and kill ids.
     ///
     /// The `base_dir` is used as the remote exec working directory. Result
     /// queues start empty, so remote exec succeeds with ordinary exit code 0
@@ -32,7 +33,7 @@ impl MockSandboxControl {
             base_dir: base_dir.into(),
             exec_results: Mutex::new(VecDeque::new()),
             kill_results: Mutex::new(VecDeque::new()),
-            recorded_commands: Mutex::new(Vec::new()),
+            recorded_exec_calls: Mutex::new(Vec::new()),
             recorded_kill_ids: Mutex::new(Vec::new()),
         }
     }
@@ -45,9 +46,18 @@ impl MockSandboxControl {
         self.exec_results.lock_ignoring_poison().push_back(result);
     }
 
+    /// Return every call made to `exec_remote`, in call order.
+    pub fn recorded_exec_calls(&self) -> Vec<RemoteExecCall> {
+        self.recorded_exec_calls.lock_ignoring_poison().clone()
+    }
+
     /// Return every command string passed to `exec_remote`, in call order.
     pub fn recorded_commands(&self) -> Vec<String> {
-        self.recorded_commands.lock_ignoring_poison().clone()
+        self.recorded_exec_calls
+            .lock_ignoring_poison()
+            .iter()
+            .map(|call| call.command.clone())
+            .collect()
     }
 
     /// Queue a kill remote result. Results are consumed in FIFO order.
@@ -68,14 +78,19 @@ impl MockSandboxControl {
 impl SandboxControl for MockSandboxControl {
     async fn exec_remote(
         &self,
-        _sandbox_id: &str,
+        sandbox_id: &str,
         command: &str,
-        _timeout: Duration,
-        _sudo: bool,
+        timeout: Duration,
+        sudo: bool,
     ) -> std::result::Result<RemoteExecResult, SandboxControlError> {
-        self.recorded_commands
+        self.recorded_exec_calls
             .lock_ignoring_poison()
-            .push(command.to_string());
+            .push(RemoteExecCall {
+                sandbox_id: sandbox_id.to_string(),
+                command: command.to_string(),
+                timeout,
+                sudo,
+            });
         self.exec_results
             .lock_ignoring_poison()
             .pop_front()

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -31,7 +31,7 @@ mod support;
 
 pub use call_records::{
     CopyFileCall, ExecCall, ExecMatcher, ProcessCancelCall, ProcessControlCall, ReadFileCall,
-    StartProcessCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
+    RemoteExecCall, StartProcessCall, WaitProcessCall, WriteFileCall, WriteFilesCall,
 };
 pub use control::MockSandboxControl;
 pub use factory_runtime::{MockRuntimeProvider, MockSandboxFactory, MockSandboxRuntime};

--- a/crates/sandbox-mock/src/tests/control.rs
+++ b/crates/sandbox-mock/src/tests/control.rs
@@ -19,17 +19,34 @@ async fn sandbox_control_default_succeeds() {
 }
 
 #[tokio::test]
-async fn sandbox_control_records_commands() {
+async fn sandbox_control_records_exec_calls() {
     let control = MockSandboxControl::new("/tmp/test");
     control
         .exec_remote("sandbox-1", "echo one", Duration::from_secs(5), false)
         .await
         .unwrap();
     control
-        .exec_remote("sandbox-1", "echo two", Duration::from_secs(5), true)
+        .exec_remote("sandbox-2", "echo two", Duration::from_secs(7), true)
         .await
         .unwrap();
 
+    assert_eq!(
+        control.recorded_exec_calls(),
+        vec![
+            RemoteExecCall {
+                sandbox_id: "sandbox-1".to_string(),
+                command: "echo one".to_string(),
+                timeout: Duration::from_secs(5),
+                sudo: false,
+            },
+            RemoteExecCall {
+                sandbox_id: "sandbox-2".to_string(),
+                command: "echo two".to_string(),
+                timeout: Duration::from_secs(7),
+                sudo: true,
+            },
+        ],
+    );
     assert_eq!(
         control.recorded_commands(),
         vec!["echo one".to_string(), "echo two".to_string()],


### PR DESCRIPTION
## Summary

- record complete `SandboxControl::exec_remote` calls in `MockSandboxControl`, keeping sandbox id, command, timeout, and sudo associated in call order
- preserve `recorded_commands()` as a compatibility projection while exposing structured `RemoteExecCall` records
- assert direct sandbox targeting and non-default timeout/sudo forwarding at the `run_exec` entry point
- keep all existing shell-quoting cases focused on the command field of the richer call record

## Scope

This changes Rust test infrastructure and tests only. It does not change the production `SandboxControl` trait, Firecracker behavior, wire protocols, APIs, schemas, persisted state, deployment compatibility, or production runtime performance.

## Validation

- `cd crates && cargo fmt --all`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p sandbox-mock` (77 passed)
- `cd crates && cargo test -p runner --bin runner cmd::exec::tests` (25 passed)
- `cd crates && cargo test -p runner --bin runner` (2695 passed, 9 pre-existing ignored)
- `cd crates && cargo clippy -p sandbox-mock -p runner --all-targets --all-features`
- `cd crates && cargo doc -p sandbox-mock -p runner --all-features --no-deps`
- pre-commit formatting, workspace Rust documentation, Clippy, file-size, generated-file, and commit-message hooks

Closes #21648
