### PR TITLE
docs(guest-init): correct waitpid architecture description

### DIFF
--- a/crates/guest-init/src/main.rs
+++ b/crates/guest-init/src/main.rs
@@ -7,11 +7,16 @@
 //! PID 1 then enters a reap loop, waiting for the child to exit while also
 //! reaping orphaned zombie processes.
 //!
-//! This architecture cleanly separates concerns:
-//! - PID 1 only calls `waitpid(-1)`, which reaps any zombie (orphans + the child)
-//! - PID 2 (vsock-guest) calls `waitpid(pid)` for the commands it spawns
-//! - Since PID 2's children are not visible to PID 1's `waitpid(-1)` (they are
-//!   PID 2's children, not PID 1's), there is no ECHILD race condition.
+//! This architecture separates wait domains and supervision phases:
+//! - During normal supervision, PID 1 calls `waitpid(-1, WNOHANG)` to reap PID 2
+//!   and orphaned processes reparented to PID 1.
+//! - After escalating shutdown to SIGKILL, PID 1 switches to blocking
+//!   `waitpid(child_pid, 0)` to reap PID 2.
+//! - PID 2 (vsock-guest) calls `waitpid(pid)` for the commands it spawns. While
+//!   PID 2 owns those children, PID 1 cannot reap them, so the processes do not
+//!   race and PID 2 does not see `ECHILD` from PID 1's reaper.
+//! - PID 1's generic and targeted waits run sequentially in the same thread, so
+//!   they cannot race with each other.
 //!
 //! Startup sequence:
 //! 1. Initialize filesystem (mount /proc, /sys, set env vars)


### PR DESCRIPTION
## Summary

- correct the guest-init PID 1 architecture description to distinguish normal `waitpid(-1, WNOHANG)` reaping from the post-SIGKILL `waitpid(child_pid, 0)` wait
- clarify that PID 1 and PID 2 avoid `ECHILD` races through child ownership, while PID 1's two wait forms are safe because they run sequentially
- account for orphaned processes that may be reparented to PID 1

## Scope

- documentation only; no runtime process-supervision behavior changes
- no API, protocol, persistence, migration, or deployment compatibility changes

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-init --all-targets --all-features`
- `cd crates && cargo doc -p guest-init --bin guest-init --all-features --no-deps`
- `cd crates && cargo test -p guest-init`
- `git diff --check`
- lefthook pre-commit Rust formatting, Clippy, documentation, file checks, and commitlint

Closes #21664
