### PR TITLE
docs(python): clarify usage flush semantics

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -167,7 +167,19 @@ def buffer_source_model_usage_observations(
 
 
 def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
-    """Flush the singleton, log the trigger, and return the webhook batch count."""
+    """Attempt to admit buffered webhook batches from the singleton.
+
+    ``runner`` and ``shutdown`` wait for flush ownership. ``timer``,
+    ``threshold``, and ``test`` defer when another invocation owns the flush;
+    when timers are enabled, the buffered work remains eligible for a later
+    timer.
+
+    Return the number of webhook batches admitted by this invocation. Zero
+    does not prove that the buffer is empty. Admission does not wait for final
+    delivery or retained-retry completion. Non-shutdown triggers schedule
+    retained work for a later timer when timers are enabled; shutdown does not
+    schedule another timer.
+    """
     return _usage_event_buffer.flush_usage_events(trigger=trigger)
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -149,7 +149,19 @@ class UsageEventBuffer:
         return accepted_count
 
     def flush_usage_events(self, *, trigger: UsageFlushTrigger) -> int:
-        """Flush all buffered usage events now."""
+        """Attempt to admit buffered webhook batches for ``trigger``.
+
+        ``runner`` and ``shutdown`` wait for flush ownership. ``timer``,
+        ``threshold``, and ``test`` defer when another invocation owns the
+        flush; when timers are enabled, the buffered work remains eligible for
+        a later timer.
+
+        Return the number of webhook batches admitted by this invocation. Zero
+        does not prove that the buffer is empty. Admission does not wait for
+        final delivery or retained-retry completion. Non-shutdown triggers
+        schedule retained work for a later timer when timers are enabled;
+        shutdown does not schedule another timer.
+        """
         return self._flush_usage_events(trigger=trigger)
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

- document which usage flush triggers wait for ownership and which can defer
- clarify that the return value counts batches admitted by the current invocation and that `0` does not prove the buffer is empty
- distinguish executor admission from final webhook delivery and retained-retry completion, including the shutdown timer boundary

## Scope

- keeps runtime behavior and public signatures unchanged
- does not change schemas, persisted data, protocols, deployment compatibility, feature switches, or performance

## Testing

- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd crates/runner/mitm-addon && pytest` (3989 passed)

Closes #21665
