### PR TITLE
perf(guest-download): stop retrying malformed urls

### DIFF
--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -51,7 +51,7 @@ fn classify_http_error(error: &ureq::Error) -> (bool, String) {
         ureq::Error::StatusCode(code) => {
             (*code >= 500 || *code == 429, format!("HTTP status {code}"))
         }
-        ureq::Error::HostNotFound => request_error("dns"),
+        ureq::Error::HostNotFound => (true, request_error_message("dns")),
         ureq::Error::Timeout(timeout) => (
             true,
             format!(
@@ -59,7 +59,7 @@ fn classify_http_error(error: &ureq::Error) -> (bool, String) {
                 timeout_phase(*timeout)
             ),
         ),
-        ureq::Error::ConnectionFailed => request_error("connection"),
+        ureq::Error::ConnectionFailed => (true, request_error_message("connection")),
         ureq::Error::Io(error) => (
             true,
             format!("HTTP request error (kind=io io_kind={:?})", error.kind()),
@@ -67,25 +67,27 @@ fn classify_http_error(error: &ureq::Error) -> (bool, String) {
         ureq::Error::Tls(_)
         | ureq::Error::Pem(_)
         | ureq::Error::Rustls(_)
-        | ureq::Error::TlsRequired => request_error("tls"),
-        ureq::Error::InvalidProxyUrl | ureq::Error::ConnectProxyFailed(_) => request_error("proxy"),
+        | ureq::Error::TlsRequired => (true, request_error_message("tls")),
+        ureq::Error::InvalidProxyUrl | ureq::Error::ConnectProxyFailed(_) => {
+            (true, request_error_message("proxy"))
+        }
         ureq::Error::Protocol(_)
         | ureq::Error::RedirectFailed
         | ureq::Error::BodyExceedsLimit(_)
         | ureq::Error::TooManyRedirects
         | ureq::Error::LargeResponseHeader(_, _)
         | ureq::Error::Decompress(_, _)
-        | ureq::Error::BodyStalled => request_error("protocol"),
+        | ureq::Error::BodyStalled => (true, request_error_message("protocol")),
         ureq::Error::Http(_) | ureq::Error::BadUri(_) | ureq::Error::RequireHttpsOnly(_) => {
-            request_error("invalid_request")
+            (false, request_error_message("invalid_request"))
         }
-        ureq::Error::Other(_) => request_error("unknown"),
-        _ => request_error("unknown"),
+        ureq::Error::Other(_) => (true, request_error_message("unknown")),
+        _ => (true, request_error_message("unknown")),
     }
 }
 
-fn request_error(kind: &'static str) -> (bool, String) {
-    (true, format!("HTTP request error (kind={kind})"))
+fn request_error_message(kind: &'static str) -> String {
+    format!("HTTP request error (kind={kind})")
 }
 
 fn timeout_phase(timeout: ureq::Timeout) -> &'static str {

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -36,14 +36,19 @@ fn validate_attempt_warning(
     Ok(())
 }
 
-fn validate_retry_warnings(log_name: &str, log: &str, expected_error: &str) -> Result<(), String> {
+fn validate_attempt_warnings(
+    log_name: &str,
+    log: &str,
+    expected_attempts: usize,
+    expected_error: &str,
+) -> Result<(), String> {
     let warning_count = log.lines().filter(|line| line.contains("Attempt ")).count();
-    if warning_count != EXPECTED_RETRY_ATTEMPTS {
+    if warning_count != expected_attempts {
         return Err(format!(
             "unexpected attempt warning count in {log_name}: {log}"
         ));
     }
-    for attempt in 1..=EXPECTED_RETRY_ATTEMPTS {
+    for attempt in 1..=expected_attempts {
         validate_attempt_warning(log_name, log, attempt, expected_error)?;
     }
     Ok(())
@@ -213,8 +218,8 @@ fn binary_classifies_malformed_http_url_without_logging_it() {
     assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
 
     let expected_error = "HTTP request error (kind=invalid_request)";
-    validate_retry_warnings("stderr", &stderr, expected_error).unwrap();
-    validate_retry_warnings("system log", &system_log_content, expected_error).unwrap();
+    validate_attempt_warnings("stderr", &stderr, 1, expected_error).unwrap();
+    validate_attempt_warnings("system log", &system_log_content, 1, expected_error).unwrap();
 
     let ops = fixture.ops_entries().unwrap();
     assert!(
@@ -263,8 +268,14 @@ fn binary_classifies_connection_drop_without_logging_url() {
     assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
 
     let expected_error = "HTTP request error (kind=io io_kind=UnexpectedEof)";
-    validate_retry_warnings("stderr", &stderr, expected_error).unwrap();
-    validate_retry_warnings("system log", &system_log_content, expected_error).unwrap();
+    validate_attempt_warnings("stderr", &stderr, EXPECTED_RETRY_ATTEMPTS, expected_error).unwrap();
+    validate_attempt_warnings(
+        "system log",
+        &system_log_content,
+        EXPECTED_RETRY_ATTEMPTS,
+        expected_error,
+    )
+    .unwrap();
 
     let ops = fixture.ops_entries().unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- classify ureq's deterministic `Http`, `BadUri`, and `RequireHttpsOnly` request failures as non-retriable
- keep retry eligibility explicit in the HTTP error classifier while preserving bounded credential-safe diagnostics
- verify malformed URLs fail after one attempt and transient connection drops still use all three attempts

## Scope

- does not add a second URL parser or pre-validation layer
- does not change retry behavior for DNS, timeout, connection, I/O, TLS, proxy, protocol, HTTP 429, HTTP 5xx, or unknown failures
- does not change APIs, schemas, protocols, persisted state, dependencies, or public Rust interfaces

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p guest-download --test integration binary_classifies_malformed_http_url_without_logging_it -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- staged-file lefthook pre-commit checks

Closes #21666
