### PR TITLE
test(sandbox-fc): assert process cleanup before network release

### DIFF
--- a/crates/sandbox-fc/src/snapshot/attempt/cleanup.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/cleanup.rs
@@ -12,7 +12,7 @@ use super::super::cow::{
 };
 use super::super::output::cleanup_workspace_image_file_sync;
 use super::super::publish::SnapshotPublishAttempt;
-use super::process::SnapshotProcess;
+use super::process::{SnapshotProcess, SnapshotProcessCleanupReport};
 
 async fn release_snapshot_netns(
     netns_pool: &mut NetnsPool,
@@ -326,15 +326,8 @@ pub(super) struct SnapshotCleanupFinalizer {
 
 impl SnapshotCleanupFinalizer {
     pub(super) async fn run(mut self) {
-        let process = self.resources.process.finalize_after_cancellation().await;
-
-        let network_released = self
-            .resources
-            .release_network(
-                "failed to release netns during snapshot cancellation cleanup",
-                "snapshot cancellation cleanup missing netns pool while releasing netns",
-            )
-            .await;
+        let process = self.finalize_process().await;
+        let network_released = self.release_network().await;
         let workspace_image_cleaned = self.cleanup_workspace_image();
         let publish_cleaned = self.cleanup_publish_attempt().await;
         let cow_destroyed = self.resources.destroy_cow_during_cancellation().await;
@@ -375,6 +368,30 @@ impl SnapshotCleanupFinalizer {
         if let Some(tx) = self.cleanup_complete_tx.take() {
             let _ = tx.send(report);
         }
+    }
+
+    async fn finalize_process(&mut self) -> SnapshotProcessCleanupReport {
+        #[cfg(test)]
+        let had_child = self.resources.process.presence().has_child;
+        let report = self.resources.process.finalize_after_cancellation().await;
+        #[cfg(test)]
+        if had_child && report.child_reaped {
+            self.cleanup_events.push("child_reaped");
+        }
+        report
+    }
+
+    async fn release_network(&mut self) -> bool {
+        #[cfg(test)]
+        if self.resources.network.is_some() {
+            self.cleanup_events.push("network_release_started");
+        }
+        self.resources
+            .release_network(
+                "failed to release netns during snapshot cancellation cleanup",
+                "snapshot cancellation cleanup missing netns pool while releasing netns",
+            )
+            .await
     }
 
     async fn cleanup_publish_attempt(&mut self) -> bool {

--- a/crates/sandbox-fc/src/snapshot/attempt/tests.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/tests.rs
@@ -481,7 +481,7 @@ async fn snapshot_attempt_drop_handoff_releases_netns_without_unlocked_sock_clea
 }
 
 #[tokio::test]
-async fn snapshot_attempt_drop_handoff_kills_child_before_netns_release() {
+async fn snapshot_attempt_drop_handoff_reaps_child_before_netns_release() {
     let dir = tempfile::tempdir().expect("tempdir");
     let (mut attempt, sock_dir) = snapshot_attempt_for_test(&dir);
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -499,6 +499,11 @@ async fn snapshot_attempt_drop_handoff_kills_child_before_netns_release() {
 
     assert!(report.child_reaped);
     assert!(report.network_released);
+    assert_eq!(
+        report.cleanup_events,
+        vec!["child_reaped", "network_release_started"],
+        "child reaping must finish before network release starts"
+    );
     assert!(
         tokio::fs::try_exists(&sock_dir).await.unwrap(),
         "detached cleanup must not remove the stable snapshot socket directory without the outer snapshot lock"


### PR DESCRIPTION
## Summary

- record successful snapshot child reaping and network-release start in the existing test-only cleanup trace
- bind those events to finalizer operation helpers so call reordering changes the observed sequence
- assert the exact reap-before-release order through the real Drop-handoff child-process test

## Behavior and scope

This protects the existing bounded process-cleanup-before-network-release invariant. It does not change production cleanup ordering, child wait timeouts, fallback behavior, public APIs, persistence, or deployment contracts.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot_attempt_drop_handoff_reaps_child_before_netns_release`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::attempt`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`
- `git diff --check`
- pre-commit workspace Rustfmt, Clippy, documentation, file checks, and commitlint

Mutation proof: temporarily reversing process cleanup and network release made the targeted test fail with the reversed event trace; the correct order was restored before validation and commit.

Closes #21669
