### PR TITLE
chore: configure model proxy token

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -86,8 +86,8 @@ OPENAI_API_KEY=op://Development/openai/OPENAI_API_KEY
 # Optional: OpenRouter lightweight model calls
 OPENROUTER_API_KEY=op://Development/openrouter/Section_ak7dvythmldarvk4dodjs4ecyq/OPENROUTER_API_KEY
 
-# Optional: VM0 Auto Responses proxy authentication
-VM0_AUTO_PROXY_TOKEN=op://Development/vm0/VM0_AUTO_PROXY_TOKEN
+# Optional: VM0 Model proxy authentication (required to run vm0-model)
+VM0_MODEL_PROXY_TOKEN=op://Development/vm0/VM0_MODEL_PROXY_TOKEN
 
 # Required: OpenAI Webhook signing secret (for built-in generations webhook)
 OPENAI_WEBHOOK_SECRET=op://Development/openai/OPENAI_WEBHOOK_SECRET


### PR DESCRIPTION
## Summary

- replace the obsolete `VM0_AUTO_PROXY_TOKEN` local template entry
- load `VM0_MODEL_PROXY_TOKEN` from the shared Development vault item

## Testing

- `op inject -i turbo/apps/api/.env.local.tpl`
- `git diff --check`