### PR TITLE
fix(runner): reject invalid parameterized firewall authorities

### DIFF
--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -1504,7 +1504,11 @@ mod tests {
                 "https://bad,.{tenant}.example.com".to_string(),
             ),
             (
-                "materialized DNS label above 63 bytes",
+                "literal DNS label above 63 bytes",
+                format!("https://{}.{{tenant}}.example.com", "a".repeat(64)),
+            ),
+            (
+                "mixed materialized DNS label above 63 bytes",
                 format!("https://{}{{tenant}}.example.com", "a".repeat(63)),
             ),
             (

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -1011,27 +1011,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_catalog_cache_accepts_valid_parameterized_base() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
-        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
-        let mut valid = catalog("github");
-        valid
-            .firewalls
-            .get_mut("github")
-            .expect("catalog should contain github")
-            .apis[0]
-            .base = "https://github.com/{owner}/{repo}.git".to_string();
+    async fn write_catalog_cache_accepts_valid_parameterized_authorities() {
+        let valid_bases = vec![
+            "https://{tenant}.example.com:0".to_string(),
+            "https://{tenant}.example.com:65535".to_string(),
+            "https://{tenant}.example.com/items/{item}".to_string(),
+            "https://api-{tenant}.example.com".to_string(),
+            "https://{tenant*}.example.com".to_string(),
+            format!("https://{}{{tenant}}.example.com", "a".repeat(62)),
+        ];
 
-        write_catalog_cache(&cache_path, &lock_path, valid)
-            .await
-            .unwrap();
+        for base in valid_bases {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
 
-        let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
-        assert_eq!(
-            cache.firewalls["github"].apis[0].base,
-            "https://github.com/{owner}/{repo}.git"
-        );
+            write_catalog_cache(&cache_path, &lock_path, catalog_with_base(&base))
+                .await
+                .unwrap_or_else(|error| panic!("valid base {base:?} was rejected: {error}"));
+
+            let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
+            assert_eq!(cache.firewalls["github"].apis[0].base, base);
+        }
     }
 
     #[tokio::test]
@@ -1472,33 +1473,79 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_parameterized_base_port_does_not_overwrite_existing_cache() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
-        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+    async fn invalid_parameterized_authorities_do_not_publish_or_replace_cache() {
+        let invalid_bases = vec![
+            (
+                "non-numeric port",
+                "https://{tenant}.example.com:abc".to_string(),
+            ),
+            (
+                "non-ASCII decimal port",
+                "https://{tenant}.example.com:\u{ff19}\u{ff19}".to_string(),
+            ),
+            (
+                "port immediately above the valid range",
+                "https://{tenant}.example.com:65536".to_string(),
+            ),
+            (
+                "shared-contract out-of-range port",
+                "https://{tenant}.example.com:99999".to_string(),
+            ),
+            (
+                "excessively long decimal port",
+                format!("https://{{tenant}}.example.com:{}", "9".repeat(100)),
+            ),
+            (
+                "raw wildcard literal",
+                "https://*.{tenant}.example.com".to_string(),
+            ),
+            (
+                "literal comma",
+                "https://bad,.{tenant}.example.com".to_string(),
+            ),
+            (
+                "materialized DNS label above 63 bytes",
+                format!("https://{}{{tenant}}.example.com", "a".repeat(63)),
+            ),
+            (
+                "URL-forbidden literal",
+                "https://a<b.{tenant}.example.com".to_string(),
+            ),
+            (
+                "extra authority colon",
+                "https://{tenant}.example.com:80:90".to_string(),
+            ),
+        ];
 
-        write_catalog_cache(&cache_path, &lock_path, catalog("github"))
-            .await
-            .unwrap();
-        let before = tokio::fs::read_to_string(&cache_path).await.unwrap();
+        for (name, base) in invalid_bases {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
 
-        let mut invalid = catalog("github");
-        invalid
-            .firewalls
-            .get_mut("github")
-            .expect("catalog should contain github")
-            .apis[0]
-            .base = "https://{tenant}.example.com:abc".to_string();
-        let error = write_catalog_cache(&cache_path, &lock_path, invalid)
-            .await
-            .unwrap_err();
+            let initial_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(&base))
+                    .await
+                    .unwrap_err();
+            assert!(
+                !cache_path.exists(),
+                "{name} unexpectedly published an initial cache after {initial_error}"
+            );
 
-        assert!(
-            error.to_string().contains("invalid port"),
-            "unexpected error: {error}"
-        );
-        let after = tokio::fs::read_to_string(&cache_path).await.unwrap();
-        assert_eq!(after, before);
+            write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+                .await
+                .unwrap();
+            let before = tokio::fs::read(&cache_path).await.unwrap();
+
+            let refresh_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(&base))
+                    .await
+                    .unwrap_err();
+            let after = tokio::fs::read(&cache_path).await.unwrap();
+            assert_eq!(
+                after, before,
+                "{name} replaced the valid cache after {refresh_error}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -278,8 +278,11 @@ const VALID_FIREWALL_RULE_METHODS: &[&str] = &[
 struct FirewallRuleSegmentParam<'a> {
     name: &'a str,
     greedy: bool,
-    mixed_with_literal: bool,
+    prefix: &'a str,
+    suffix: &'a str,
 }
+
+const DNS_LABEL_MAX_LENGTH: usize = 63;
 
 fn validate_firewall_permission_rule(rule: &str) -> Result<(), String> {
     let Some((method, path)) = rule.split_once(' ') else {
@@ -323,7 +326,7 @@ fn validate_firewall_permission_rule(rule: &str) -> Result<(), String> {
                 param.name
             ));
         }
-        if param.greedy && param.mixed_with_literal {
+        if param.greedy && (!param.prefix.is_empty() || !param.suffix.is_empty()) {
             return Err(format!(
                 "greedy parameter {:?} cannot be combined with a literal prefix or suffix",
                 param.name
@@ -395,7 +398,8 @@ fn parse_firewall_rule_segment(
     Ok(Some(FirewallRuleSegmentParam {
         name,
         greedy,
-        mixed_with_literal: !prefix.is_empty() || !suffix.is_empty(),
+        prefix,
+        suffix,
     }))
 }
 
@@ -536,14 +540,15 @@ fn validate_parameterized_firewall_base_for_cache(base: &str) -> Result<(), Stri
         return Err("base URL must not contain userinfo".to_string());
     }
 
-    let host = parameterized_base_host(authority)?;
+    let (host, port_suffix) = parameterized_base_authority(authority)?;
     let mut param_names = HashSet::new();
-    validate_parameterized_firewall_base_host(host, &mut param_names)?;
+    let materialized_host = validate_parameterized_firewall_base_host(host, &mut param_names)?;
+    validate_parameterized_firewall_base_authority(scheme, &materialized_host, port_suffix)?;
     validate_parameterized_firewall_base_path(path, &mut param_names)?;
     Ok(())
 }
 
-fn parameterized_base_host(authority: &str) -> Result<&str, String> {
+fn parameterized_base_authority(authority: &str) -> Result<(&str, &str), String> {
     if authority.ends_with(':') {
         return Err("base URL authority must not include an empty port".to_string());
     }
@@ -556,7 +561,7 @@ fn parameterized_base_host(authority: &str) -> Result<&str, String> {
         );
     }
     let Some((host, port)) = authority.rsplit_once(':') else {
-        return Ok(authority);
+        return Ok((authority, ""));
     };
     if !port.chars().all(|ch| ch.is_ascii_digit()) {
         return Err("base URL authority has invalid port".to_string());
@@ -564,48 +569,86 @@ fn parameterized_base_host(authority: &str) -> Result<&str, String> {
     if host.is_empty() {
         return Err("base URL must include a host".to_string());
     }
-    Ok(host)
+    Ok((host, &authority[host.len()..]))
 }
 
 fn validate_parameterized_firewall_base_host(
     host: &str,
     param_names: &mut HashSet<String>,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let segments: Vec<&str> = host.split('.').collect();
     if segments.len() < 2 {
         return Err("base URL host must have at least two segments".to_string());
     }
 
     let mut has_static_segment = false;
+    let mut materialized_host = String::with_capacity(host.len());
     for (index, segment) in segments.iter().enumerate() {
         if segment.is_empty() {
             return Err("base URL host segments must be non-empty".to_string());
         }
-        let Some(param) = parse_firewall_rule_segment(segment)? else {
+        if index > 0 {
+            materialized_host.push('.');
+        }
+        if let Some(param) = parse_firewall_rule_segment(segment)? {
+            if !param_names.insert(param.name.to_string()) {
+                return Err(format!(
+                    "duplicate parameter name {:?} in base URL host",
+                    param.name
+                ));
+            }
+            if param.greedy && index != 0 {
+                return Err(format!(
+                    "greedy parameter {:?} must be the first host segment",
+                    param.name
+                ));
+            }
+            if param.greedy && (!param.prefix.is_empty() || !param.suffix.is_empty()) {
+                return Err(format!(
+                    "greedy parameter {:?} cannot be combined with a literal prefix or suffix in base URL host",
+                    param.name
+                ));
+            }
+            validate_parameterized_firewall_base_host_literal(param.prefix)?;
+            validate_parameterized_firewall_base_host_literal(param.suffix)?;
+            materialized_host.push_str(param.prefix);
+            materialized_host.push('x');
+            materialized_host.push_str(param.suffix);
+        } else {
+            validate_parameterized_firewall_base_host_literal(segment)?;
             has_static_segment = true;
-            continue;
-        };
-        if !param_names.insert(param.name.to_string()) {
-            return Err(format!(
-                "duplicate parameter name {:?} in base URL host",
-                param.name
-            ));
-        }
-        if param.greedy && index != 0 {
-            return Err(format!(
-                "greedy parameter {:?} must be the first host segment",
-                param.name
-            ));
-        }
-        if param.greedy && param.mixed_with_literal {
-            return Err(format!(
-                "greedy parameter {:?} cannot be combined with a literal prefix or suffix in base URL host",
-                param.name
-            ));
+            materialized_host.push_str(segment);
         }
     }
     if !has_static_segment {
         return Err("base URL host must have at least one static segment".to_string());
+    }
+    Ok(materialized_host)
+}
+
+fn validate_parameterized_firewall_base_host_literal(literal: &str) -> Result<(), String> {
+    if literal.contains('*') || literal.contains(',') {
+        return Err("parameterized base URL host contains invalid literal syntax".to_string());
+    }
+    Ok(())
+}
+
+fn validate_parameterized_firewall_base_authority(
+    scheme: &str,
+    materialized_host: &str,
+    port_suffix: &str,
+) -> Result<(), String> {
+    let syntax_target = format!("{scheme}://{materialized_host}{port_suffix}");
+    let parsed = url::Url::parse(&syntax_target)
+        .map_err(|_| "parameterized base URL authority is invalid".to_string())?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "parameterized base URL authority must include a host".to_string())?;
+    if host
+        .split('.')
+        .any(|label| label.len() > DNS_LABEL_MAX_LENGTH)
+    {
+        return Err("parameterized base URL host label is too long".to_string());
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- materialize validated firewall host parameters before checking parameterized authorities with `url::Url`
- reject out-of-range ports, malformed authority syntax, raw wildcard/comma literals, and overlong DNS labels before cache publication
- cover valid boundary forms plus invalid initial publication and byte-identical last-good cache preservation

## Compatibility

- preserves the original catalog value instead of persisting URL parser canonical output
- does not change the API payload, cache schema, generated catalog, TypeScript producer, or Python proxy behavior
- keeps existing parameter, template, path, and greedy-host forms supported

## Validation

- `cargo test -p runner builtin_firewall_catalog::tests:: -- --nocapture` (32 passed)
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts` (16 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2695 passed, 9 ignored; guest inventory passed)
- `lefthook run pre-commit`
- `git diff --check`

Closes #21670
