### PR TITLE
perf(api): reuse memory candidate rows during final ranking

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
@@ -1003,21 +1003,16 @@ async function loadExpansionCandidates(
   return [...candidates.values()];
 }
 
-async function rankCandidates(
-  db: ReadonlyDb,
-  args: SearchParams & {
-    readonly normalizedQuery: string;
-    readonly candidates: readonly CandidateScore[];
-  },
-): Promise<readonly MemoryProfileRow[]> {
-  const candidateIds = args.candidates.map((candidate) => {
-    return candidate.id;
-  });
-  const rowsById = await loadRowsByIds(db, args, candidateIds);
+function rankCandidates(args: {
+  readonly normalizedQuery: string;
+  readonly candidates: readonly CandidateScore[];
+  readonly rowsById: ReadonlyMap<string, MemoryProfileRow>;
+  readonly limit: number;
+}): readonly MemoryProfileRow[] {
   const queryTokens = tokenize(args.normalizedQuery);
   const ranked = args.candidates
     .map((candidate) => {
-      const row = rowsById.get(candidate.id);
+      const row = args.rowsById.get(candidate.id);
       if (!row) {
         return null;
       }
@@ -1113,15 +1108,27 @@ async function loadSearchResults(
     }
   }
 
+  const initialCandidates = [...candidates.values()];
+  const rowsById = new Map<string, MemoryProfileRow>();
   const seedRows = await measureMemoryList(
     args.timing,
     "profile_search_seed_rank",
     "memory_profile_seed_ranked_count_bucket",
     async () => {
-      return await rankCandidates(db, {
-        ...args,
+      const initialRowsById = await loadRowsByIds(
+        db,
+        args,
+        initialCandidates.map((candidate) => {
+          return candidate.id;
+        }),
+      );
+      for (const [id, row] of initialRowsById) {
+        rowsById.set(id, row);
+      }
+      return rankCandidates({
         normalizedQuery,
-        candidates: [...candidates.values()],
+        candidates: initialCandidates,
+        rowsById,
         limit: Math.max(args.limit, Math.min(args.limit * 2, 20)),
       });
     },
@@ -1140,16 +1147,32 @@ async function loadSearchResults(
   for (const candidate of expansionCandidates) {
     mergeCandidate(candidates, candidate);
   }
+  const unseenExpansionIds = expansionCandidates
+    .filter((candidate) => {
+      return !rowsById.has(candidate.id);
+    })
+    .map((candidate) => {
+      return candidate.id;
+    });
 
   const rankedRows = await measureMemoryList(
     args.timing,
     "profile_search_final_rank",
     "memory_profile_final_ranked_count_bucket",
     async () => {
-      return await rankCandidates(db, {
-        ...args,
+      const expansionRowsById = await loadRowsByIds(
+        db,
+        args,
+        unseenExpansionIds,
+      );
+      for (const [id, row] of expansionRowsById) {
+        rowsById.set(id, row);
+      }
+      return rankCandidates({
         normalizedQuery,
         candidates: [...candidates.values()],
+        rowsById,
+        limit: args.limit,
       });
     },
   );


### PR DESCRIPTION
## Summary

- separate memory candidate row loading from the ranking calculation
- retain initial exact/semantic candidate rows in a request-local map across seed and final ranking
- load full rows during final ranking only for graph-expansion candidates missing from that map
- preserve existing scoring, ordering, limits, graph behavior, hydration, failure behavior, and timing stages

## Semantics and scope

Initial candidate rows now form a bounded snapshot for one memory-profile search. Newly discovered graph candidates still pass the existing active, organization, and user filters when loaded.

This does not add a process-global cache, transaction, schema, migration, persisted state, API field, queue payload, runner change, frontend change, or ranking-policy change. The independent tie-ordering issue in #21044 remains out of scope.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-memory-recall.test.ts` — 16 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` — 107 passed
- `pnpm -F api exec vitest run --maxWorkers=1 --silent=passed-only` against a migrated and seeded temporary clean database — 163 files and 2,216 tests passed
- pre-commit hook: repository Knip and TypeScript checks passed

## Rollout

Use production SQL spans to confirm that candidate-bearing searches no longer repeat the initial full-row hydration query and that final ranking loads only genuinely unseen graph rows. Compare existing final-rank, memory-profile, pre-create, and `api_to_spawn` timing stages without summing their independent percentiles.

Closes #21684

Parent delivery issue: #21674
