### PR TITLE
perf(api): attribute postgres new-connection phases

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -17,11 +17,33 @@ import {
   it,
 } from "vitest";
 
-import { instrumentPgPool } from "../db-instrumentation";
+import {
+  createInstrumentedPgStream,
+  instrumentPgPool,
+} from "../db-instrumentation";
 import { env } from "../env";
 
 const ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
 const ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
+const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
+  "vm0.db.connection.lookup.duration_ms";
+const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
+  "vm0.db.connection.socket_connect.duration_ms";
+const CONNECTION_ATTEMPT_COUNT_ATTRIBUTE = "vm0.db.connection.attempt_count";
+const CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE =
+  "vm0.db.connection.attempt_failed_count";
+const CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE =
+  "vm0.db.connection.attempt_timeout_count";
+const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
+
+const CONNECTION_ATTRIBUTE_NAMES = [
+  CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
+  CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
+  CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
+  CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
+  CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE,
+  CONNECTION_ADDRESS_FAMILY_ATTRIBUTE,
+] as const;
 
 type AcquirePath = "idle" | "new" | "queued";
 
@@ -33,6 +55,76 @@ function expectAcquisition(span: ReadableSpan, path: AcquirePath): void {
     throw new Error("Acquisition duration is not numeric");
   }
   expect(duration).toBeGreaterThanOrEqual(0);
+}
+
+function numericAttribute(
+  span: ReadableSpan,
+  name: string,
+): number | undefined {
+  const value = span.attributes[name];
+  if (value === undefined) {
+    return undefined;
+  }
+  expect(typeof value).toBe("number");
+  if (typeof value !== "number") {
+    throw new Error(`${name} is not numeric`);
+  }
+  return value;
+}
+
+function expectConnectionAcquisition(span: ReadableSpan): void {
+  const socketConnectDuration = numericAttribute(
+    span,
+    CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
+  );
+  expect(socketConnectDuration).toBeDefined();
+  if (socketConnectDuration === undefined) {
+    throw new Error("Socket connect duration is missing");
+  }
+  expect(socketConnectDuration).toBeGreaterThanOrEqual(0);
+
+  expect(span.attributes[CONNECTION_ADDRESS_FAMILY_ATTRIBUTE]).toMatch(
+    /^ipv[46]$/,
+  );
+
+  const lookupDuration = numericAttribute(
+    span,
+    CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
+  );
+  if (lookupDuration !== undefined) {
+    expect(lookupDuration).toBeGreaterThanOrEqual(0);
+    expect(lookupDuration).toBeLessThanOrEqual(socketConnectDuration);
+  }
+
+  const attemptCount = numericAttribute(
+    span,
+    CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
+  );
+  if (attemptCount !== undefined) {
+    expect(Number.isInteger(attemptCount)).toBeTruthy();
+    expect(attemptCount).toBeGreaterThan(0);
+  }
+
+  for (const name of [
+    CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
+    CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE,
+  ]) {
+    const count = numericAttribute(span, name);
+    if (count !== undefined) {
+      expect(Number.isInteger(count)).toBeTruthy();
+      expect(count).toBeGreaterThan(0);
+      expect(attemptCount).toBeDefined();
+      if (attemptCount !== undefined) {
+        expect(count).toBeLessThanOrEqual(attemptCount);
+      }
+    }
+  }
+}
+
+function expectNoConnectionAcquisition(span: ReadableSpan): void {
+  for (const name of CONNECTION_ATTRIBUTE_NAMES) {
+    expect(span.attributes[name]).toBeUndefined();
+  }
 }
 
 function captureRejection(promise: Promise<unknown>): Promise<unknown> {
@@ -60,6 +152,7 @@ describe("instrumentPgPool", () => {
         idleTimeoutMillis: 0,
         max: 1,
         ...config,
+        stream: createInstrumentedPgStream,
       }),
       tracer,
     );
@@ -144,9 +237,15 @@ describe("instrumentPgPool", () => {
     expect(newResult.rowCount).toBe(1);
     expect(idleResult.rowCount).toBe(1);
     expect(queuedResult.rowCount).toBe(1);
-    expectAcquisition(findSpan(newStatement), "new");
-    expectAcquisition(findSpan(idleStatement), "idle");
-    expectAcquisition(findSpan(queuedStatement), "queued");
+    const newSpan = findSpan(newStatement);
+    const idleSpan = findSpan(idleStatement);
+    const queuedSpan = findSpan(queuedStatement);
+    expectAcquisition(newSpan, "new");
+    expectAcquisition(idleSpan, "idle");
+    expectAcquisition(queuedSpan, "queued");
+    expectConnectionAcquisition(newSpan);
+    expectNoConnectionAcquisition(idleSpan);
+    expectNoConnectionAcquisition(queuedSpan);
   });
 
   it("reserves idle and new capacity for earlier synchronous queries", async () => {

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -1,3 +1,4 @@
+import { Socket } from "node:net";
 import { performance } from "node:perf_hooks";
 
 import {
@@ -15,6 +16,16 @@ import { deriveSqlSpanName } from "./sql-span-name";
 const POOL_QUERY_SPAN_KEY = createContextKey("vm0.pg.pool-query-span");
 const POOL_ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
 const POOL_ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
+const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
+  "vm0.db.connection.lookup.duration_ms";
+const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
+  "vm0.db.connection.socket_connect.duration_ms";
+const CONNECTION_ATTEMPT_COUNT_ATTRIBUTE = "vm0.db.connection.attempt_count";
+const CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE =
+  "vm0.db.connection.attempt_failed_count";
+const CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE =
+  "vm0.db.connection.attempt_timeout_count";
+const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
 
 type AnyArgs = readonly unknown[];
 type PgQuery = (...args: AnyArgs) => unknown;
@@ -28,6 +39,99 @@ type PoolConnectCallback = (
 
 class PoolQuerySpan {
   constructor(readonly span: Span) {}
+}
+
+function normalizeAddressFamily(
+  family: string | undefined,
+): "ipv4" | "ipv6" | undefined {
+  if (family === "IPv4") {
+    return "ipv4";
+  }
+  if (family === "IPv6") {
+    return "ipv6";
+  }
+  return undefined;
+}
+
+export function createInstrumentedPgStream(): Socket {
+  const socket = new Socket();
+  const markedSpan = context.active().getValue(POOL_QUERY_SPAN_KEY);
+  if (
+    !(markedSpan instanceof PoolQuerySpan) ||
+    !markedSpan.span.isRecording()
+  ) {
+    return socket;
+  }
+
+  const querySpan = markedSpan.span;
+  const startedAt = performance.now();
+  let attemptCount = 0;
+  let failedAttemptCount = 0;
+  let timedOutAttemptCount = 0;
+
+  function onLookup(): void {
+    querySpan.setAttribute(
+      CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
+      performance.now() - startedAt,
+    );
+  }
+
+  function onConnectionAttempt(): void {
+    attemptCount += 1;
+    querySpan.setAttribute(CONNECTION_ATTEMPT_COUNT_ATTRIBUTE, attemptCount);
+  }
+
+  function onConnectionAttemptFailed(): void {
+    failedAttemptCount += 1;
+    querySpan.setAttribute(
+      CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
+      failedAttemptCount,
+    );
+  }
+
+  function onConnectionAttemptTimeout(): void {
+    timedOutAttemptCount += 1;
+    querySpan.setAttribute(
+      CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE,
+      timedOutAttemptCount,
+    );
+  }
+
+  function removePhaseListeners(): void {
+    socket.removeListener("lookup", onLookup);
+    socket.removeListener("connectionAttempt", onConnectionAttempt);
+    socket.removeListener("connectionAttemptFailed", onConnectionAttemptFailed);
+    socket.removeListener(
+      "connectionAttemptTimeout",
+      onConnectionAttemptTimeout,
+    );
+    socket.removeListener("connect", onConnect);
+    socket.removeListener("close", removePhaseListeners);
+  }
+
+  function onConnect(): void {
+    querySpan.setAttribute(
+      CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
+      performance.now() - startedAt,
+    );
+    const addressFamily = normalizeAddressFamily(socket.remoteFamily);
+    if (addressFamily) {
+      querySpan.setAttribute(
+        CONNECTION_ADDRESS_FAMILY_ATTRIBUTE,
+        addressFamily,
+      );
+    }
+    removePhaseListeners();
+  }
+
+  socket.once("lookup", onLookup);
+  socket.on("connectionAttempt", onConnectionAttempt);
+  socket.on("connectionAttemptFailed", onConnectionAttemptFailed);
+  socket.on("connectionAttemptTimeout", onConnectionAttemptTimeout);
+  socket.once("connect", onConnect);
+  socket.once("close", removePhaseListeners);
+
+  return socket;
 }
 
 function extractSql(args: AnyArgs): string {

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -4,7 +4,10 @@ import { attachDatabasePool } from "@vercel/functions";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
-import { instrumentPgPool } from "./db-instrumentation";
+import {
+  createInstrumentedPgStream,
+  instrumentPgPool,
+} from "./db-instrumentation";
 import { env } from "./env";
 import { logger } from "./log";
 import { singleton } from "./singleton";
@@ -33,6 +36,7 @@ const pool = singleton((): Pool => {
       max: env("DB_POOL_MAX"),
       idleTimeoutMillis: env("DB_POOL_IDLE_TIMEOUT_MS"),
       connectionTimeoutMillis: env("DB_POOL_CONNECT_TIMEOUT_MS"),
+      stream: createInstrumentedPgStream,
     }),
     trace.getTracer("vm0-api/pg"),
   );


### PR DESCRIPTION
## Summary

- instrument new PostgreSQL sockets with elapsed time to DNS lookup completion and raw socket connection, observed connection-attempt counters, and normalized address family on the originating query span
- define socket-connect elapsed time cumulatively from stream creation, intentionally including lookup, while preserving existing pool, TLS, timeout, DNS, retry, and lifecycle behavior
- cover new connections versus idle and queued pool paths with a real PostgreSQL integration test

## Scope

- telemetry only; no connection-pool sizing, timeout, DNS, retry, or TLS behavior changes
- no schema, persisted-data, public API, queue payload, or runner protocol changes
- post-TCP time remains a residual rather than being labeled as TLS, proxy admission, authentication, or PostgreSQL startup

## Rollout analysis

After deployment, select a fixed cohort from the instrumented API revision and compare both burst and standalone slow `new` acquisitions, including `api_to_spawn` traces:

- classify lookup delay when lookup elapsed time owns most of socket-connect and total acquisition time
- classify address-selection or TCP delay when lookup is short but socket-connect is long, using attempt counters as supporting evidence
- classify post-TCP residual when socket-connect is short but total acquisition is long

Record that evidence on #21674 before proposing a separate causal mitigation.

## Validation

- `pnpm -F api exec vitest run src/lib/__tests__/db-instrumentation.test.ts` (6 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` against a fresh migrated temporary database (2,261 passed)

Closes #21705

Parent: #21674
