### PR TITLE
refactor: reduce fallback slop in connector identities

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/quickbooks.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/quickbooks.test.ts
@@ -144,6 +144,35 @@ describe("connector/providers/quickbooks", () => {
         ),
       ).rejects.toThrow("No access token in QuickBooks response");
     });
+
+    it("throws when user info has no stable identity", async () => {
+      const tokenHandler = http.post(
+        "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+        () => {
+          return HttpResponse.json({
+            access_token: "quickbooks-test-token",
+          });
+        },
+      );
+      const userInfoHandler = http.get(
+        "https://accounts.platform.intuit.com/v1/openid_connect/userinfo",
+        () => {
+          return HttpResponse.json({});
+        },
+      );
+      server.use(tokenHandler, userInfoHandler);
+
+      await expect(
+        exchangeQuickBooksCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+          JSON.stringify({ realmId: "1234567890" }),
+        ),
+      ).rejects.toThrow("No user id in QuickBooks user info response");
+    });
   });
 
   describe("refreshQuickBooksToken", () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts
@@ -102,7 +102,7 @@ export async function exchangeCloseCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(" ") : authCodeGrant.scopes,
     userInfo: {
-      id: userInfo.id ?? data.user_id ?? "unknown",
+      id: userInfo.id,
       email: userInfo.email,
       organizationId: data.organization_id ?? null,
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts
@@ -210,9 +210,13 @@ async function fetchQuickBooksUserInfo(
   const givenName = data.givenName ?? data.given_name;
   const familyName = data.familyName ?? data.family_name;
   const username = [givenName, familyName].filter(Boolean).join(" ").trim();
+  const id = data.sub ?? data.email;
+  if (!id) {
+    throw new Error("No user id in QuickBooks user info response");
+  }
 
   return {
-    id: data.sub ?? data.email ?? "",
+    id,
     username: username || (data.email ?? null),
     email: data.email ?? null,
   };


### PR DESCRIPTION
## Summary

- removes an unreachable Close connector identity fallback after the user-info schema has already required `id`
- makes QuickBooks reject user-info responses without a stable `sub` or email instead of persisting an empty external identity
- adds regression coverage for the missing QuickBooks identity boundary

## Scan

- Timestamp: `2026-07-15T20:01:14.301Z`
- Base commit: `5edaafcdf15ab37c2c96b3584c70f9b145ace20e`
- Tracked files scanned: `4,291`
- `actionable_total`: `237` high-confidence production candidates reported by the scanner
- `edit_budget`: `12` (`ceil(237 * 0.05)`)
- Candidates changed: `2`

Total matches by category:

- `nullish`: 6,121
- `nullish-chain`: 136
- `field-fallback-chain`: 111
- `optional-prop`: 6,324
- `zod-optional`: 2,341
- `zod-loose-optional`: 2
- `loose-record`: 1,211
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 34
- `empty-fallback`: 711
- `string-fallback`: 764
- `null-undefined-fallback`: 1,665
- `empty-catch`: 3
- `promise-catch-swallow`: 14
- `rust-unwrap-or`: 636
- `rust-ok-discard`: 142

## Safety

- `turbo/packages/connectors/src/auth-providers/connectors/close/oauth.ts`: the fetched Close user-info schema already requires a string `id`, so the token-response and `"unknown"` fallbacks were unreachable and masked the actual runtime contract.
- `turbo/packages/connectors/src/auth-providers/connectors/quickbooks/oauth.ts`: vm0 stores this value as the connector's external identity; an empty string is not a valid stable identity, so the boundary now fails clearly when both supported identity fields are absent.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/quickbooks.test.ts`: covers rejection of an identity-less user-info response.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped` — 12/12 tasks passed
- `pnpm check-types` — 12 packages passed before the API process reached the default 2 GB heap limit
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm run check-types` in `apps/api` — passed
- `pnpm exec vitest run src/auth-providers/connectors/__tests__/quickbooks.test.ts` — 8/8 tests passed
- `git diff --check`
- Post-change scanner confirmed both selected fallback expressions are gone; the scanner's high-confidence production count decreased from 237 to 233 because each expression matched two overlapping categories.

This workflow intentionally leaves the remaining candidates for later daily runs.
