### PR TITLE
test(api): enforce external behavior test boundary

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -98,24 +98,36 @@ const productionRouteTestImportMessage =
   "Production route composition must not import test-only routes. Mount required test fixture routes explicitly from tests.";
 
 const apiTestDirectDbImportPatterns = [
+  "./lib/db",
+  "./lib/db.ts",
   "./external/db",
   "./external/db.ts",
+  "../lib/db",
+  "../lib/db.ts",
   "../external/db",
   "../external/db.ts",
   "../signals/external/db",
   "../signals/external/db.ts",
+  "../../lib/db",
+  "../../lib/db.ts",
   "../../external/db",
   "../../external/db.ts",
   "../../signals/external/db",
   "../../signals/external/db.ts",
+  "../../../lib/db",
+  "../../../lib/db.ts",
   "../../../external/db",
   "../../../external/db.ts",
   "../../../signals/external/db",
   "../../../signals/external/db.ts",
+  "../../../../lib/db",
+  "../../../../lib/db.ts",
   "../../../../external/db",
   "../../../../external/db.ts",
   "../../../../signals/external/db",
   "../../../../signals/external/db.ts",
+  "src/lib/db",
+  "src/lib/db.ts",
   "src/signals/external/db",
   "src/signals/external/db.ts",
 ];
@@ -245,6 +257,11 @@ export default [
   },
   {
     files: ["src/**/__tests__/**/*.ts", "src/**/*.test.ts"],
+    ignores: [
+      // Central test lifecycle owns connection-pool teardown; it does not
+      // construct or assert API behavior.
+      "src/__tests__/test-context.ts",
+    ],
     rules: {
       "no-restricted-imports": [
         "error",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { sql } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
@@ -26,7 +25,6 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { z } from "zod";
 
 import { createApp } from "../../../app-factory";
-import { db } from "../../../lib/db";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -52,6 +50,7 @@ import { createDeferredPromise } from "../../utils";
 import {
   deleteBddVm0ApiKeys,
   hasVm0ApiKeyLabel,
+  holdOrgAdmissionLockFixture,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
 
@@ -3609,20 +3608,9 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
     // Hold the real org admission lock after the inline send has persisted its
     // queue-first row. This lets both the inline path and terminal callback
     // drain reach run insertion before either can claim the message.
-    const lockHolderStarted = createDeferredPromise<number>(context.signal);
-    const releaseAdmissionLock = createDeferredPromise<void>(context.signal);
-    const admissionLock = db().transaction(async (tx) => {
-      const result = await tx.execute<{ readonly pid: number }>(sql`
-        SELECT
-          pg_backend_pid() AS "pid",
-          pg_advisory_xact_lock(hashtext(${actor.orgId}))
-      `);
-      const holderPid = result.rows[0]?.pid;
-      if (!holderPid) {
-        throw new Error("Expected the admission lock holder pid");
-      }
-      lockHolderStarted.resolve(holderPid);
-      await releaseAdmissionLock.promise;
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: actor.orgId,
+      signal: context.signal,
     });
 
     const callbackQueryStarted = createDeferredPromise<void>(context.signal);
@@ -3631,29 +3619,9 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
       if (!releaseCallbackQuery.settled()) {
         releaseCallbackQuery.resolve(undefined);
       }
-      if (!releaseAdmissionLock.settled()) {
-        releaseAdmissionLock.resolve(undefined);
-      }
-      await admissionLock;
+      admissionLock.release();
+      await admissionLock.done;
     });
-
-    const holderPid = await lockHolderStarted.promise;
-    const admissionWaiterCount = async (): Promise<number> => {
-      const result = await db().execute<{ readonly waiterCount: number }>(sql`
-        SELECT count(*)::int AS "waiterCount"
-        FROM pg_locks AS waiting
-        WHERE waiting.locktype = 'advisory'
-          AND NOT waiting.granted
-          AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
-            SELECT held.classid, held.objid, held.objsubid
-            FROM pg_locks AS held
-            WHERE held.locktype = 'advisory'
-              AND held.pid = ${holderPid}
-              AND held.granted
-          )
-      `);
-      return result.rows[0]?.waiterCount ?? 0;
-    };
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
@@ -3675,7 +3643,7 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
     // Completing the anchor also starts the org run-queue drain. Pin that
     // known waiter first so the next two waiters identify the inline send and
     // the terminal callback's chat-message drain respectively.
-    await expect.poll(admissionWaiterCount).toBe(1);
+    await expect.poll(admissionLock.waiterCount).toBe(1);
 
     const prompt = "terminal drain and inline send share one claim";
     const messageId = randomUUID();
@@ -3697,14 +3665,14 @@ describe("CHAT-02: queue-first sends (ChatMessageQueue switch)", () => {
         });
       })
       .toBe(true);
-    await expect.poll(admissionWaiterCount).toBe(2);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
 
     releaseCallbackQuery.resolve(undefined);
-    await expect.poll(admissionWaiterCount).toBe(3);
-    releaseAdmissionLock.resolve(undefined);
+    await expect.poll(admissionLock.waiterCount).toBe(3);
+    admissionLock.release();
 
     const sent = await send;
-    await admissionLock;
+    await admissionLock.done;
     await flushWaitUntilForTest();
     if (sent.status !== 201 || sent.body.runId === null) {
       throw new Error("Expected one race winner to own the queued message");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -8,12 +8,14 @@ import {
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
-import { sql } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { db } from "../../../lib/db";
 import { now } from "../../../lib/time";
+import {
+  deleteUnsupportedHistoricalConnectors,
+  seedUnsupportedHistoricalConnectors,
+} from "../../../test-fixtures/historical-connectors";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
   deleteOrgMembership$,
@@ -35,7 +37,6 @@ const bdd = createBddApi(context);
 const connectorsApi = createConnectorBddApi(context);
 const authDevice = createAuthDeviceApiActions(context);
 const store = createStore();
-const REMOVED_CONNECTOR_TYPE = "removed-connector";
 const REMOVED_AUTH_CONNECTOR_TYPE = "github";
 const MISMATCHED_AUTH_CONNECTOR_TYPE = "gitlab";
 
@@ -171,16 +172,7 @@ describe("GET /api/zero/connector-catalog", () => {
     while (historicalConnectorFixtures.length > 0) {
       const fixture = historicalConnectorFixtures.pop();
       if (fixture) {
-        await db().execute(sql`
-          DELETE FROM connectors
-          WHERE org_id = ${fixture.orgId}
-            AND user_id = ${fixture.userId}
-            AND type IN (
-              ${REMOVED_CONNECTOR_TYPE},
-              ${REMOVED_AUTH_CONNECTOR_TYPE},
-              ${MISMATCHED_AUTH_CONNECTOR_TYPE}
-            )
-        `);
+        await deleteUnsupportedHistoricalConnectors(fixture);
       }
     }
   });
@@ -648,15 +640,10 @@ describe("GET /api/zero/connector-catalog", () => {
       apiKey: "sk-public-status",
     });
 
-    // These rows model identities accepted by an older registry. The current
-    // production API cannot construct these historical states.
-    await db().execute(sql`
-      INSERT INTO connectors (type, auth_method, user_id, org_id)
-      VALUES
-        (${REMOVED_CONNECTOR_TYPE}, 'api-token', ${actor.userId}, ${actor.orgId}),
-        (${REMOVED_AUTH_CONNECTOR_TYPE}, 'removed-auth-method', ${actor.userId}, ${actor.orgId}),
-        (${MISMATCHED_AUTH_CONNECTOR_TYPE}, 'oauth', ${actor.userId}, ${actor.orgId})
-    `);
+    await seedUnsupportedHistoricalConnectors({
+      orgId: actor.orgId,
+      userId: actor.userId,
+    });
     historicalConnectorFixtures.push({
       orgId: actor.orgId,
       userId: actor.userId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -1,11 +1,10 @@
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
-import { sql } from "drizzle-orm";
 
-import { db } from "../../../lib/db";
 import { mockOptionalEnv } from "../../../lib/env";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { seedInvalidLegacyGoalMessages } from "../../../test-fixtures/legacy-goals";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../external/time";
 import { createBddApi } from "./helpers/api-bdd";
@@ -355,48 +354,7 @@ describe("zero goals", () => {
     const chat = createChatFilesBddApi(context);
     await createGoal(fixture, "ship goals");
 
-    // This bad persisted shape cannot be produced through the public API, but
-    // older or manually repaired jsonb rows can still be read by the messages
-    // endpoint.
-    const updated = await db().execute(sql`
-      UPDATE chat_messages
-      SET
-        goal_event = '{"type":"state","status":"active","objectiveBrief":123}'::jsonb,
-        goal_snapshot = '{"objectiveBrief":{"bad":true}}'::jsonb
-      WHERE chat_thread_id = ${fixture.threadId}
-        AND goal_event IS NOT NULL
-    `);
-    expect(updated.rowCount).toBe(1);
-    const inserted = await db().execute(sql`
-      INSERT INTO chat_messages (
-        chat_thread_id,
-        role,
-        goal_event,
-        goal_snapshot
-      )
-      VALUES (
-        ${fixture.threadId},
-        'assistant',
-        '{"type":"state","status":"unknown","objectiveBrief":"bad"}'::jsonb,
-        '{"objectiveBrief":{"bad":true}}'::jsonb
-      )
-    `);
-    expect(inserted.rowCount).toBe(1);
-    const insertedMissingSnapshotBrief = await db().execute(sql`
-      INSERT INTO chat_messages (
-        chat_thread_id,
-        role,
-        content,
-        goal_snapshot
-      )
-      VALUES (
-        ${fixture.threadId},
-        'user',
-        'legacy snapshot without objective brief',
-        '{"bad":true}'::jsonb
-      )
-    `);
-    expect(insertedMissingSnapshotBrief.rowCount).toBe(1);
+    await seedInvalidLegacyGoalMessages(fixture.threadId);
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const messages = await chat.listThreadMessages(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -6,13 +6,15 @@ import type {
   TestSlackStateResponse,
 } from "@vm0/api-contracts/contracts/test-slack-state";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
-import { sql } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
-import { db } from "../../../lib/db";
 import { server } from "../../../mocks/server";
+import {
+  deleteUnsupportedHistoricalConnectors,
+  seedUnsupportedHistoricalConnectors,
+} from "../../../test-fixtures/historical-connectors";
 import { now } from "../../external/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { ROUTES } from "../../route";
@@ -33,9 +35,6 @@ import {
 const context = testContext();
 const store = createStore();
 const SLACK_STATE_ROUTE = "/api/test/slack-state";
-const REMOVED_CONNECTOR_TYPE = "removed-connector";
-const REMOVED_AUTH_CONNECTOR_TYPE = "github";
-const MISMATCHED_AUTH_CONNECTOR_TYPE = "gitlab";
 
 interface SlackFixture {
   readonly userId: string;
@@ -149,16 +148,7 @@ describe("GET /api/zero/integrations/slack", () => {
     while (historicalConnectorFixtures.length > 0) {
       const historicalFixture = historicalConnectorFixtures.pop();
       if (historicalFixture) {
-        await db().execute(sql`
-          DELETE FROM connectors
-          WHERE org_id = ${historicalFixture.orgId}
-            AND user_id = ${historicalFixture.userId}
-            AND type IN (
-              ${REMOVED_CONNECTOR_TYPE},
-              ${REMOVED_AUTH_CONNECTOR_TYPE},
-              ${MISMATCHED_AUTH_CONNECTOR_TYPE}
-            )
-        `);
+        await deleteUnsupportedHistoricalConnectors(historicalFixture);
       }
     }
     await cleanupSlackFixture(fixture);
@@ -370,15 +360,7 @@ describe("GET /api/zero/integrations/slack", () => {
     it("ignores unsupported historical connectors when loading environment", async () => {
       await seedEnvironmentVersion();
 
-      // These rows model identities accepted by an older registry. The current
-      // production API cannot construct these historical states.
-      await db().execute(sql`
-        INSERT INTO connectors (type, auth_method, user_id, org_id)
-        VALUES
-          (${REMOVED_CONNECTOR_TYPE}, 'api-token', ${fixture.userId}, ${fixture.orgId}),
-          (${REMOVED_AUTH_CONNECTOR_TYPE}, 'removed-auth-method', ${fixture.userId}, ${fixture.orgId}),
-          (${MISMATCHED_AUTH_CONNECTOR_TYPE}, 'oauth', ${fixture.userId}, ${fixture.orgId})
-      `);
+      await seedUnsupportedHistoricalConnectors(fixture);
       historicalConnectorFixtures.push(fixture);
 
       mockAdminAuth();

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,7 +1,8 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
-import { and, eq, like, or } from "drizzle-orm";
+import { and, eq, like, or, sql } from "drizzle-orm";
 
 import { db } from "../lib/db";
+import { createDeferredPromise } from "../signals/utils";
 
 /**
  * BDD-scoped vm0 managed key prefixes. Fixture writes below only ever touch
@@ -105,4 +106,60 @@ export async function hasVm0ApiKeyLabel(args: {
     )
     .limit(1);
   return rows.length === 1;
+}
+
+/**
+ * Holds the production org admission advisory lock and reports its waiter
+ * count. No product API exposes database lock timing, so this fixture is the
+ * narrow boundary exception for the queue-drain concurrency test.
+ */
+export async function holdOrgAdmissionLockFixture(args: {
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly waiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const result = await tx.execute<{ readonly pid: number }>(sql`
+      SELECT
+        pg_backend_pid() AS "pid",
+        pg_advisory_xact_lock(hashtext(${args.orgId}))
+    `);
+    const holderPid = result.rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the admission lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    waiterCount: async () => {
+      const result = await db().execute<{ readonly waiterCount: number }>(sql`
+        SELECT count(*)::int AS "waiterCount"
+        FROM pg_locks AS waiting
+        WHERE waiting.locktype = 'advisory'
+          AND NOT waiting.granted
+          AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
+            SELECT held.classid, held.objid, held.objsubid
+            FROM pg_locks AS held
+            WHERE held.locktype = 'advisory'
+              AND held.pid = ${holderPid}
+              AND held.granted
+          )
+      `);
+      return result.rows[0]?.waiterCount ?? 0;
+    },
+  };
 }

--- a/turbo/apps/api/src/test-fixtures/historical-connectors.ts
+++ b/turbo/apps/api/src/test-fixtures/historical-connectors.ts
@@ -1,0 +1,62 @@
+import { connectors } from "@vm0/db/schema/connector";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+const UNSUPPORTED_CONNECTOR_TYPES = [
+  "removed-connector",
+  "github",
+  "gitlab",
+] as const;
+
+interface HistoricalConnectorFixture {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+/**
+ * Seeds connector identities accepted by older registries but rejected by the
+ * current product API. This is the narrow test-boundary exception for testing
+ * reads of persisted connector identities that production APIs cannot create.
+ */
+export async function seedUnsupportedHistoricalConnectors(
+  fixture: HistoricalConnectorFixture,
+): Promise<void> {
+  await db()
+    .insert(connectors)
+    .values([
+      {
+        type: "removed-connector",
+        authMethod: "api-token",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+      },
+      {
+        type: "github",
+        authMethod: "removed-auth-method",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+      },
+      {
+        type: "gitlab",
+        authMethod: "oauth",
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+      },
+    ]);
+}
+
+/** Deletes only the unsupported connector identities seeded above. */
+export async function deleteUnsupportedHistoricalConnectors(
+  fixture: HistoricalConnectorFixture,
+): Promise<void> {
+  await db()
+    .delete(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, fixture.orgId),
+        eq(connectors.userId, fixture.userId),
+        inArray(connectors.type, UNSUPPORTED_CONNECTOR_TYPES),
+      ),
+    );
+}

--- a/turbo/apps/api/src/test-fixtures/legacy-goals.ts
+++ b/turbo/apps/api/src/test-fixtures/legacy-goals.ts
@@ -1,0 +1,59 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+/**
+ * Seeds malformed goal JSON left by legacy or manual database writes. The
+ * current product API validates these shapes, so it cannot construct them.
+ */
+export async function seedInvalidLegacyGoalMessages(
+  threadId: string,
+): Promise<void> {
+  const updated = await db().execute(sql`
+    UPDATE chat_messages
+    SET
+      goal_event = '{"type":"state","status":"active","objectiveBrief":123}'::jsonb,
+      goal_snapshot = '{"objectiveBrief":{"bad":true}}'::jsonb
+    WHERE chat_thread_id = ${threadId}
+      AND goal_event IS NOT NULL
+  `);
+  if (updated.rowCount !== 1) {
+    throw new Error("Expected one current goal marker fixture");
+  }
+
+  const inserted = await db().execute(sql`
+    INSERT INTO chat_messages (
+      chat_thread_id,
+      role,
+      goal_event,
+      goal_snapshot
+    )
+    VALUES (
+      ${threadId},
+      'assistant',
+      '{"type":"state","status":"unknown","objectiveBrief":"bad"}'::jsonb,
+      '{"objectiveBrief":{"bad":true}}'::jsonb
+    )
+  `);
+  if (inserted.rowCount !== 1) {
+    throw new Error("Expected one legacy goal marker fixture");
+  }
+
+  const insertedMissingSnapshotBrief = await db().execute(sql`
+    INSERT INTO chat_messages (
+      chat_thread_id,
+      role,
+      content,
+      goal_snapshot
+    )
+    VALUES (
+      ${threadId},
+      'user',
+      'legacy snapshot without objective brief',
+      '{"bad":true}'::jsonb
+    )
+  `);
+  if (insertedMissingSnapshotBrief.rowCount !== 1) {
+    throw new Error("Expected one legacy goal snapshot fixture");
+  }
+}


### PR DESCRIPTION
## Scan

- Timestamp: 2026-07-16T05:19:54+08:00
- Base commit: `5edaafcdf15ab37c2c96b3584c70f9b145ace20e`
- Primary API ESLint scan: 0 errors, 0 warnings, and 0 `no-restricted-imports` findings
- Prescribed secondary scan: 250 broad `.update()` / `.delete()` matches, all classified as production API client calls, crypto builders, or in-memory collection operations
- Supplemental current-DB-handle scan: 4 route-test files directly imported `lib/db` and contained 9 SQL/transaction call sites

## Violations found and fixed

- `chat-messages.bdd.test.ts` directly opened a transaction, held the production org advisory lock, and queried `pg_locks` to coordinate a queue-drain race. The route test now delegates only that production-unreachable timing seam to a documented fixture and continues asserting messages and runs through production APIs.
- `zero-connector-catalog.test.ts` and `zero-integrations-slack.test.ts` directly inserted and deleted connector identities accepted by historical registries but rejected by the current API. Both now share a narrow documented historical-connector fixture; their assertions remain production connector-catalog, connector-read, and Slack-status API responses.
- `zero-goals.test.ts` directly updated and inserted malformed legacy goal JSON. That production-unreachable setup now lives in a documented legacy-goal fixture, while normalization remains asserted through the production messages API.
- API lint now rejects imports of the current `lib/db` handle from test files, preventing this boundary regression.

## Files changed

- `turbo/apps/api/eslint.config.mjs`: extends the direct-DB import guard to `lib/db`; the central pool-teardown harness remains an explicit non-behavior exception.
- `turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts`: removes direct transaction and lock-state queries.
- `turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts`: removes historical connector SQL setup and teardown.
- `turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts`: removes historical connector SQL setup and teardown.
- `turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts`: removes malformed goal-row SQL setup and row-count assertions.
- `turbo/apps/api/src/test-fixtures/chat-messages.ts`: contains the narrow advisory-lock timing fixture.
- `turbo/apps/api/src/test-fixtures/historical-connectors.ts`: contains exact historical connector setup and scoped teardown.
- `turbo/apps/api/src/test-fixtures/legacy-goals.ts`: contains exact malformed legacy goal setup.

## Intentional exceptions

- Historical connector identities cannot be created through production APIs because the current connector registry rejects the removed connector/auth-method combinations.
- Malformed legacy goal JSON cannot be created through production APIs because request contracts validate the persisted shape.
- PostgreSQL advisory-lock timing and waiter visibility have no production API surface; only that timing control remains in the fixture, while the race result is observed through production message and run APIs.

No test-only endpoints were added.

## Verification

- Prettier on all changed files
- `git diff --check`
- Primary API ESLint scan: 0 errors and 0 warnings
- Post-change restricted-import scan: no DB schema, service, DB read/write, or route-test `lib/db` imports; only central `test-context.ts` pool teardown remains
- Direct-DB lint probe: rejected `../../../lib/db` with `no-restricted-imports`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types`
- PostgreSQL 18 test database migrated successfully with pgvector 0.8.5
- Historical connector and legacy goal cases: 3 passed, 63 skipped
- The changed chat concurrency case was attempted twice. Both runs stopped before the modified lock fixture was reached: the initial `claimChatRun` returned `404 NOT_FOUND` (`Job not found in queue`).
