### PR TITLE
fix: route chat thread navigation through page setup

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -497,21 +497,19 @@ export const setChatKeyboardScrollRoot$ = onRef(
       if (!targetId) {
         return;
       }
-      const promise =
-        pane === "main"
-          ? set(loadLeftThread$, targetId, signal)
-          : set(loadRightThread$, targetId, signal);
-      await Promise.all([
-        promise,
-        set(
-          scrollToThread$,
-          {
-            threadId: targetId,
-            align: direction === "next" ? "bottom" : "top",
-          },
-          get(rootSignal$),
-        ),
-      ]);
+      if (pane === "main") {
+        set(loadLeftThread$, targetId);
+      } else {
+        set(loadRightThread$, targetId);
+      }
+      await set(
+        scrollToThread$,
+        {
+          threadId: targetId,
+          align: direction === "next" ? "bottom" : "top",
+        },
+        get(rootSignal$),
+      );
     };
     const navigateFocusedThread = (direction: "prev" | "next") => {
       const pane = paneForThread(

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -8,8 +8,8 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { searchParams$ } from "../route.ts";
 import {
   SIDEBAR_PARAM,
-  loadLeftThread$,
-  loadRightThread$,
+  setupLeftThread$,
+  setupRightThread$,
   unloadRightThread$,
 } from "./chat-thread-panes.ts";
 import {
@@ -34,17 +34,13 @@ const internalSetupChatPage$ = command(
     const shouldLoadRight = sidebarThreadId && sidebarThreadId !== threadId;
 
     await Promise.all([
-      set(loadLeftThread$, threadId, signal),
+      set(setupLeftThread$, threadId, signal),
       set(scrollToThread$, threadId, signal),
       shouldLoadRight
-        ? set(loadRightThread$, sidebarThreadId, signal)
-        : Promise.resolve(),
+        ? set(setupRightThread$, sidebarThreadId, signal)
+        : set(unloadRightThread$),
     ]);
     signal.throwIfAborted();
-
-    if (sidebarThreadId && !shouldLoadRight) {
-      set(unloadRightThread$);
-    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -2,10 +2,11 @@ import { command, computed, state, type Command } from "ccstate";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { logger } from "../log.ts";
 import {
-  pushPathSilently$,
+  detachedNavigateTo$,
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
 import { resetSignal } from "../utils.ts";
 import { createRestoredAttachment } from "../zero-page/chat-draft.ts";
 import { clearArtifactPreview$ } from "../zero-page/zero-artifact-sidebar.ts";
@@ -144,29 +145,12 @@ const setupPaneThread$ = command(
   },
 );
 
-export const loadLeftThread$ = command(
+export const setupLeftThread$ = command(
   async (
-    { get, set },
+    { set },
     threadId: string,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    if (get(internalRightThread$)?.threadId === threadId) {
-      set(unloadRightThread$);
-    }
-
-    const currentLeftThread = get(internalLeftThread$);
-    if (currentLeftThread && currentLeftThread.threadId !== threadId) {
-      set(currentLeftThread.resetRenderedChatGroupsIfAtBottom$);
-    }
-
-    if (get(currentChatThreadId$) !== threadId) {
-      // Drop right sidebar state before switching threads — open artifact
-      // and automation panels are anchored to the previous thread's messages.
-      set(clearArtifactPreview$);
-      set(closeHeaderAutomationSidebar$);
-      set(pushPathSilently$, "/chats/:threadId", { threadId });
-    }
-
     await Promise.all([
       set(syncPrimaryThread$, threadId, parentSignal),
       set(
@@ -182,13 +166,50 @@ export const loadLeftThread$ = command(
   },
 );
 
-export const loadRightThread$ = command(
+export const setupRightThread$ = command(
   async (
-    { get, set },
+    { set },
     threadId: string,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    if (get(internalLeftThread$)?.threadId === threadId) {
+    await set(
+      setupPaneThread$,
+      {
+        setPaneThread$: setRightThread$,
+        resetSetupSignal$: resetRightSetupSignal$,
+      },
+      threadId,
+      parentSignal,
+    );
+  },
+);
+
+export const loadLeftThread$ = command(
+  ({ get, set }, threadId: string): void => {
+    if (get(currentChatThreadId$) === threadId) {
+      return;
+    }
+
+    // Drop right sidebar state before switching threads — open artifact
+    // and automation panels are anchored to the previous thread's messages.
+    set(clearArtifactPreview$);
+    set(closeHeaderAutomationSidebar$);
+
+    const next = new URLSearchParams(get(searchParams$));
+    if (next.get(SIDEBAR_PARAM) === threadId) {
+      next.delete(SIDEBAR_PARAM);
+    }
+    set(detachedNavigateTo$, ROUTES.chat, {
+      pathParams: { threadId },
+      searchParams: next,
+    });
+  },
+);
+
+export const loadRightThread$ = command(
+  ({ get, set }, threadId: string): void => {
+    const mainThreadId = get(currentChatThreadId$);
+    if (!mainThreadId || mainThreadId === threadId) {
       return;
     }
 
@@ -205,19 +226,10 @@ export const loadRightThread$ = command(
     set(closeHeaderAutomationSidebar$);
 
     const next = new URLSearchParams(get(searchParams$));
-    if (next.get(SIDEBAR_PARAM) !== threadId) {
-      next.set(SIDEBAR_PARAM, threadId);
-      set(updateSearchParams$, next);
-    }
-
-    await set(
-      setupPaneThread$,
-      {
-        setPaneThread$: setRightThread$,
-        resetSetupSignal$: resetRightSetupSignal$,
-      },
-      threadId,
-      parentSignal,
-    );
+    next.set(SIDEBAR_PARAM, threadId);
+    set(detachedNavigateTo$, ROUTES.chat, {
+      pathParams: { threadId: mainThreadId },
+      searchParams: next,
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -231,15 +231,11 @@ const routeMainChatThread$ = command(
 );
 
 const routeSidebarChatThread$ = command(
-  async (
-    { get, set },
-    threadId: string,
-    signal: AbortSignal,
-  ): Promise<void> => {
+  ({ get, set }, threadId: string): void => {
     if (!get(currentChatThreadId$)) {
       return;
     }
-    await set(loadRightThread$, threadId, signal);
+    set(loadRightThread$, threadId);
   },
 );
 
@@ -265,7 +261,7 @@ const routeChatThread$ = command(
         ...(searchParams ? { searchParams } : {}),
       });
     } else {
-      await set(routeSidebarChatThread$, threadId, signal);
+      await set(routeSidebarChatThread$, threadId);
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -47,6 +47,7 @@ import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { CHAT_THREAD_VIRTUAL_ROW_HEIGHT } from "../../../signals/zero-page/zero-sidebar-state.ts";
+import { pathname$ } from "../../../signals/route.ts";
 import {
   click,
   detachedSetupPage as baseDetachedSetupPage,
@@ -3569,6 +3570,9 @@ describe("chat lifecycle", () => {
         screen.getByText("Previous thread launch note"),
       ).toBeInTheDocument();
     });
+    expect(context.store.get(pathname$)).toBe(
+      `/chats/${KEYBOARD_PREV_THREAD_ID}`,
+    );
 
     const previousThreadRegion = screen.getByLabelText("Chat thread");
     previousThreadRegion.focus();
@@ -3583,6 +3587,9 @@ describe("chat lifecycle", () => {
         screen.getByText("Current thread launch note"),
       ).toBeInTheDocument();
     });
+    expect(context.store.get(pathname$)).toBe(
+      `/chats/${KEYBOARD_CURRENT_THREAD_ID}`,
+    );
 
     const restoredScrollContainer = chatScrollContainer();
     setScrollMetrics(restoredScrollContainer, {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -231,17 +231,15 @@ function handleChatThreadClick(
     loadLeftThread,
     loadRightThread,
     onChatPage,
-    pageSignal,
     threadId,
     unloadRightThread,
   }: {
     closeSidebarOnSelect: () => void;
     currentLeftId: string | null;
     currentRightId: string | null;
-    loadLeftThread: (threadId: string, signal: AbortSignal) => Promise<void>;
-    loadRightThread: (threadId: string, signal: AbortSignal) => Promise<void>;
+    loadLeftThread: (threadId: string) => void;
+    loadRightThread: (threadId: string) => void;
     onChatPage: boolean;
-    pageSignal: AbortSignal;
     threadId: string;
     unloadRightThread: () => void;
   },
@@ -271,22 +269,14 @@ function handleChatThreadClick(
       // Same thread already in right → toggle close.
       unloadRightThread();
     } else {
-      detach(
-        loadRightThread(threadId, pageSignal),
-        Reason.DomCallback,
-        "loadRightThread",
-      );
+      loadRightThread(threadId);
     }
   } else {
     // Plain click → drive the left pane.
     if (threadId === currentLeftId) {
       return;
     }
-    detach(
-      loadLeftThread(threadId, pageSignal),
-      Reason.DomCallback,
-      "loadLeftThread",
-    );
+    loadLeftThread(threadId);
   }
 
   closeSidebarOnSelect();
@@ -564,7 +554,6 @@ function ChatThreadItemLink({
           loadLeftThread: state.loadLeftThread,
           loadRightThread: state.loadRightThread,
           onChatPage: state.onChatPage,
-          pageSignal: state.pageSignal,
           threadId: session.id,
           unloadRightThread: state.unloadRightThread,
         });


### PR DESCRIPTION
## Summary
- route left and right chat-thread navigation through full URL navigation and a fresh route/page signal
- keep pane initialization in route-owned setup commands instead of navigation commands
- update keyboard and sidebar lifecycle coverage to assert route changes

## Validation
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --silent=passed-only` (131 passed)
- Prettier check passed

## Known baseline issue
The pre-commit Knip check reports the pre-existing unused export `normalizePresentationElementOffset` in `apps/platform/src/views/zero-page/presentation-html-element-offsets.ts`; that file is not part of this change.