### PR TITLE
feat: enable chat model family session continuity for all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3337,10 +3337,18 @@ describe("CHAT-02: auto-send after failures", () => {
 });
 
 describe("CHAT-02: auto-send across a model switch", () => {
-  it("starts a fresh session with prior web context when the queued model differs, without regenerating an existing title", async () => {
+  it("starts a fresh session with prior web context when family continuity is disabled, without regenerating an existing title", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled actor to belong to an org");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.ChatModelFamilySessionContinuity]: false },
+    );
     await chatCallbacks.updateOrgModelPolicies(actor, [
       {
         model: "claude-sonnet-4-6",
@@ -3478,18 +3486,10 @@ describe("CHAT-02: auto-send across a model switch", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("resumes the CLI session when the queued model stays within the same family", async () => {
+  it("resumes the CLI session by default when the queued model stays within the same family", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled actor to belong to an org");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ChatModelFamilySessionContinuity]: true },
-    );
     await chatCallbacks.updateOrgModelPolicies(actor, [
       {
         model: "claude-opus-4-6",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2147,7 +2147,7 @@ describe("CHAT-02: model-first provider policies", () => {
 });
 
 describe("CHAT-02: run-level model overrides", () => {
-  it("uses send model overrides for the run without mutating the thread model", async () => {
+  it("uses send model overrides without mutating the thread model while preserving same-family sessions", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -2196,8 +2196,8 @@ describe("CHAT-02: run-level model overrides", () => {
       (await api.readRun(actor, first.runId)).result?.agentSessionId,
     ).toMatch(/[0-9a-f-]{36}/);
 
-    // A run-level override of another model starts a fresh session that carries
-    // the prior web round as context instead of resuming the CLI session.
+    // A run-level override of another model in the same family resumes the CLI
+    // session while carrying the prior web round as context.
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
@@ -2212,7 +2212,9 @@ describe("CHAT-02: run-level model overrides", () => {
     expect(appended).toContain(`User: ${firstPrompt}`);
     expect(appended).toContain("Assistant: opus answer");
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
-    expect(secondClaim.claim.resumeSession).toBeNull();
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
     expect(claimEnvironment(secondClaim.claim).ANTHROPIC_MODEL).toBe(
       "claude-sonnet-4-6",
     );
@@ -2225,15 +2227,17 @@ describe("CHAT-02: run-level model overrides", () => {
     await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
 
     // Follow-ups without a send model override go back to the thread's stored
-    // model. Because the latest run used a different run-level override, this
-    // starts a fresh session instead of resuming the previous CLI session.
+    // model. Both models remain in the Claude family, so session continuity is
+    // preserved.
     const third = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
       prompt: "continue on the thread model",
     });
     const thirdClaim = await claimChatRun(runnerGroup, third.runId);
-    expect(thirdClaim.claim.resumeSession).toBeNull();
+    expect(thirdClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${second.runId}`,
+    );
     expect(claimEnvironment(thirdClaim.claim).ANTHROPIC_MODEL).toBe(
       "claude-opus-4-6",
     );

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,6 +12,9 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ChatModelFamilySessionContinuity, {}),
+    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -32,9 +35,6 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.HtmlArtifactCommentEditing, {}),
     ).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.WebsiteTemplates, {})).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.ChatModelFamilySessionContinuity, {}),
-    ).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.AgentDetailWorkflowsTab, {})).toBe(
       false,
     );
@@ -189,7 +189,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
     expect(
       otherOrgStates[FeatureSwitchKey.ChatModelFamilySessionContinuity],
-    ).toBe(false);
+    ).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -315,7 +315,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Reuse Claude Code or Codex chat sessions when switching models within the same model family.",
-    enabled: false,
+    enabled: true,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.RealAgentInPreview]: {


### PR DESCRIPTION
## Summary

- enable `chatModelFamilySessionContinuity` globally so every organization preserves Claude Code or Codex sessions when switching models within the same model family
- update the core feature-switch regression coverage for global and non-staff organization contexts

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests passed)

Full monorepo lint was also attempted. Ten tasks passed, but the API type-aware linter process was terminated with `SIGKILL` by the local environment; the scoped core lint completed with zero warnings and zero errors.
