### PR TITLE
ci: preserve chromium failure diagnostics

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -273,9 +273,15 @@ echo "--- Test: HTTPS through proxy ---"
 TLS_URL="https://www.vm0.ai"
 tls_check() {
   local label=$1 cmd=$2 t=${3:-15}
-  OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "timeout $t $cmd" 2>&1) \
-    || fail "HTTPS $label: $OUTPUT"
-  echo "  HTTPS $label: ok"
+  local output status
+
+  if output=$(sudo "$BIN_DIR/runner" exec --timeout "$((t + 10))" \
+    --sandbox "$SANDBOX_ID" -- sh -c "timeout --kill-after=5s $t $cmd" 2>&1); then
+    echo "  HTTPS $label: ok"
+  else
+    status=$?
+    fail "HTTPS $label failed with exit code $status: ${output:-no output}"
+  fi
 }
 tls_check "curl"      "curl -sf --max-time 10 $TLS_URL"
 tls_check "wget"      "wget -qO /dev/null --timeout=10 $TLS_URL"
@@ -285,7 +291,7 @@ tls_check "node"      "node -e \"require('https').get('$TLS_URL',r=>{r.resume();
 tls_check "ruby"      "ruby -e \"require 'net/http'; Net::HTTP.get(URI('$TLS_URL'))\""
 tls_check "php"       "php -r \"file_get_contents('$TLS_URL');\""
 tls_check "cargo"     "env CARGO_HOME=/tmp/cargo-test cargo search --limit 1 serde" 30
-tls_check "chromium"  "chromium --headless --disable-gpu --no-sandbox --dump-dom $TLS_URL 2>/dev/null | head -1" 30
+tls_check "chromium"  "chromium --headless --disable-gpu --no-sandbox --dump-dom $TLS_URL >/dev/null" 30
 
 # Java and Go need multi-line scripts — write temp files then run
 sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "printf '%s\n' 'import java.net.*;import java.net.http.*;' 'var c=HttpClient.newHttpClient();' 'var r=HttpRequest.newBuilder(URI.create(\"$TLS_URL\")).build();' 'c.send(r,HttpResponse.BodyHandlers.discarding());' '/exit' | timeout 30 jshell -" \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -275,6 +275,8 @@ tls_check() {
   local label=$1 cmd=$2 t=${3:-15}
   local output status
 
+  # Let the guest timeout finish its TERM/KILL cycle and return stderr before
+  # runner exec's timeout can replace the result with a synthetic Timeout.
   if output=$(sudo "$BIN_DIR/runner" exec --timeout "$((t + 10))" \
     --sandbox "$SANDBOX_ID" -- sh -c "timeout --kill-after=5s $t $cmd" 2>&1); then
     echo "  HTTPS $label: ok"


### PR DESCRIPTION
## Summary

- preserve Chromium stderr while keeping successful DOM output quiet
- give the guest timeout time to terminate Chromium before the runner timeout fires
- include the command exit code and captured output in HTTPS test failures

## Context

The intermittent Chromium failure in [runner behavior lane B](https://github.com/vm0-ai/vm0/actions/runs/29429907858/job/87402920948) only reported a synthetic `Timeout`. The test discarded Chromium stderr and used the same 30-second deadline for both the guest command and `runner exec`.

## Not included

- no retry or relaxation of the 30-second Chromium test threshold
- no claim that the underlying intermittent Chromium hang is fixed
- no runner runtime behavior changes

## Validation

- `bash -n` for all GitHub workflow scripts
- ShellCheck 0.11.0 for all runner behavior scripts
- all scripts under `.github/scripts/tests`
- `git diff --check`
