### PR TITLE
refactor: remove chat model family session continuity switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3337,18 +3337,10 @@ describe("CHAT-02: auto-send after failures", () => {
 });
 
 describe("CHAT-02: auto-send across a model switch", () => {
-  it("starts a fresh session with prior web context when family continuity is disabled, without regenerating an existing title", async () => {
+  it("preserves the CLI session across same-family queued model switches without regenerating an existing title", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled actor to belong to an org");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ChatModelFamilySessionContinuity]: false },
-    );
     await chatCallbacks.updateOrgModelPolicies(actor, [
       {
         model: "claude-sonnet-4-6",
@@ -3440,18 +3432,9 @@ describe("CHAT-02: auto-send across a model switch", () => {
 
     const autoContext = await waitForRunContext(actor, claimed.runId);
     const appended = autoContext.body.appendSystemPrompt ?? "";
-    expect(appended).toContain("# Web Chat Run Context");
-    expect(appended).toContain(`- RUN_ID: ${second.runId}`);
-    expect(appended).toContain(
-      `- LOG_COMMAND: zero logs ${second.runId} --all`,
-    );
-    expect(appended).toContain("User: And stringify?");
-    expect(appended).toContain("Assistant: Use JSON.stringify(value).");
-    expect(appended).toContain("...[truncated]");
+    expect(appended).not.toContain("# Web Chat Run Context");
     expect(appended).not.toContain("# Incomplete Rounds Context");
-    // Fresh session: the queued model pin differs from the completed run's
-    // model, so the auto-send run resumes no CLI session.
-    expect(autoContext.body.sessionId).toBeNull();
+    expect(autoContext.body.sessionId).toBe(`bdd-cli-${second.runId}`);
     expect(Object.keys(autoContext.body.environment)).toContain(
       "ANTHROPIC_API_KEY",
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2244,18 +2244,10 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, third.runId);
   }, 90_000);
 
-  it("resumes the CLI session across same-family model switches when enabled", async () => {
+  it("resumes the CLI session across same-family model switches", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled actor to belong to an org");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ChatModelFamilySessionContinuity]: true },
-    );
     await chatCallbacks.updateOrgModelPolicies(actor, [
       {
         model: "claude-opus-4-6",

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -231,7 +231,6 @@ function shouldTouchThreadSortFromNormalSend(
 interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
   readonly websiteTemplatesEnabled: boolean;
-  readonly chatModelFamilySessionContinuityEnabled: boolean;
 }
 
 interface ResolvedComputerUseHostGrant {
@@ -1120,10 +1119,6 @@ async function resolveNormalSendFeatureSwitches(
       FeatureSwitchKey.WebsiteTemplates,
       context,
     ),
-    chatModelFamilySessionContinuityEnabled: isFeatureEnabled(
-      FeatureSwitchKey.ChatModelFamilySessionContinuity,
-      context,
-    ),
   };
 }
 
@@ -1478,7 +1473,6 @@ async function resolveThread(params: {
   readonly initialPin: ThreadModelPin;
   readonly codexServiceTier: CodexServiceTier | null;
   readonly modelSelection: IncomingModelSelection;
-  readonly chatModelFamilySessionContinuityEnabled: boolean;
 }): Promise<ResolvedThread | ReturnType<typeof notFound>> {
   if (!params.existingThreadId) {
     const thread = await createChatThread(params.db, {
@@ -1533,7 +1527,6 @@ async function resolveThread(params: {
       modelSelection: params.modelSelection,
       threadSelectedModel: thread.selectedModel,
     }),
-    preserveModelFamilySession: params.chatModelFamilySessionContinuityEnabled,
   });
   return {
     threadId: thread.id,
@@ -2219,7 +2212,6 @@ function resolveTimedThread(
   args: NormalSendArgs,
   db: Db,
   initialPin: ThreadModelPin,
-  chatModelFamilySessionContinuityEnabled: boolean,
 ): ReturnType<typeof resolveThread> {
   return measureApiDispatchTiming(
     args.timing,
@@ -2237,7 +2229,6 @@ function resolveTimedThread(
         initialPin,
         codexServiceTier: args.body.runOptions?.codexServiceTier ?? null,
         modelSelection: args.body.modelSelection,
-        chatModelFamilySessionContinuityEnabled,
       });
     },
   );
@@ -2369,12 +2360,7 @@ const prepareNormalSend$ = command(
       return initialPin;
     }
 
-    const thread = await resolveTimedThread(
-      args,
-      db,
-      initialPin,
-      featureSwitches.chatModelFamilySessionContinuityEnabled,
-    );
+    const thread = await resolveTimedThread(args, db, initialPin);
     signal.throwIfAborted();
     if ("status" in thread) {
       return thread;

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -19,7 +19,6 @@ function chatSessionModelFamily(model: string): string {
 export function shouldStartNewChatSession(args: {
   readonly latestModel: string | null | undefined;
   readonly nextModel: string | null;
-  readonly preserveModelFamilySession: boolean;
 }): boolean {
   if (
     args.latestModel === undefined ||
@@ -27,10 +26,6 @@ export function shouldStartNewChatSession(args: {
     args.nextModel === null
   ) {
     return false;
-  }
-
-  if (!args.preserveModelFamilySession) {
-    return args.latestModel !== args.nextModel;
   }
 
   return (

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -3,8 +3,6 @@ import { randomBytes } from "node:crypto";
 import { command } from "ccstate";
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
@@ -84,7 +82,6 @@ import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
-import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { shouldStartNewChatSession } from "./chat-session-continuity.service";
 
 const log = logger("callback:chat");
@@ -114,7 +111,6 @@ type ChatCallbackPreCreateTimingActionType =
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_model_pin"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prior_context"
-  | "api_dispatch_pre_create_zero_chat_callback_auto_send_load_feature_switch_context"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_computer_use_host"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_generation_template"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prompt"
@@ -1543,12 +1539,10 @@ async function latestSessionForThreadFromDb(
 function shouldStartNewSessionForQueuedMessage(params: {
   readonly latestSession: LatestThreadSession | null;
   readonly queuedMessage: QueuedUserMessage;
-  readonly chatModelFamilySessionContinuityEnabled: boolean;
 }): boolean {
   return shouldStartNewChatSession({
     latestModel: params.latestSession?.selectedModel,
     nextModel: params.queuedMessage.selectedModel,
-    preserveModelFamilySession: params.chatModelFamilySessionContinuityEnabled,
   });
 }
 
@@ -1751,27 +1745,9 @@ async function buildCreateQueuedChatRunInput(args: {
         ]);
       },
     );
-  const chatModelFamilySessionContinuityEnabled =
-    await measureChatCallbackPreCreateTiming(
-      args.timing,
-      "api_dispatch_pre_create_zero_chat_callback_auto_send_load_feature_switch_context",
-      "nested",
-      async () => {
-        const context = await loadUserFeatureSwitchContext(
-          args.db,
-          args.agent.orgId,
-          args.userId,
-        );
-        return isFeatureEnabled(
-          FeatureSwitchKey.ChatModelFamilySessionContinuity,
-          context,
-        );
-      },
-    );
   const startNewSession = shouldStartNewSessionForQueuedMessage({
     latestSession,
     queuedMessage: resolvedQueuedMessage,
-    chatModelFamilySessionContinuityEnabled,
   });
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,7 +54,6 @@ export enum FeatureSwitchKey {
   CodexFrameworkForMinimax = "codexFrameworkForMinimax",
   CodexFastMode = "codexFastMode",
   Vm0Model = "vm0Model",
-  ChatModelFamilySessionContinuity = "chatModelFamilySessionContinuity",
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,9 +12,6 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.ChatModelFamilySessionContinuity, {}),
-    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -147,9 +144,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
-    expect(
-      staffOrgStates[FeatureSwitchKey.ChatModelFamilySessionContinuity],
-    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationElementDragging]).toBe(
@@ -187,9 +181,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
-    expect(
-      otherOrgStates[FeatureSwitchKey.ChatModelFamilySessionContinuity],
-    ).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -311,13 +311,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Show VM0 Model in the workspace Add model selector.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatModelFamilySessionContinuity]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Reuse Claude Code or Codex chat sessions when switching models within the same model family.",
-    enabled: true,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.RealAgentInPreview]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove `ChatModelFamilySessionContinuity` from the feature-switch key and registry.
- Keep same-model-family session reuse as unconditional behavior for normal sends and queued auto-sends.
- Delete the obsolete feature-switch plumbing, timing action, conditional branch, and rollout-only test setup.

## Verification

- `pnpm dlx --package=prettier@3.8.1 prettier --check` passed for all changed files after formatting.
- `git diff --check` passed.
- Local lint, type-check, and BDD tests were not run because `pnpm install --frozen-lockfile` exhausted the runtime filesystem (`ENOSPC`); CI should run the full required checks.
