### PR TITLE
docs(mitm-addon): clarify force-refresh cooldown start

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -81,10 +81,12 @@ def _get_auth_state(cache_key: FirewallAuthCacheKey) -> _FirewallAuthState:
 def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
     """Request a forced token refresh on the next /firewall/auth fetch.
 
-    No-op if a forced refresh already completed within
-    ``_FORCE_REFRESH_COOLDOWN_SECS`` — rate limiter for the case where the
-    token is actually fine but the endpoint rejects for another reason
-    (scope, resource-level permission). See #9860.
+    No-op if a forced-refresh marker was consumed within
+    ``_FORCE_REFRESH_COOLDOWN_SECS``. The cooldown starts when the marker is
+    consumed, before the forced fetch completes, so the same window covers
+    requests made while that fetch is in flight or after it fails. This
+    rate-limits the case where the token is actually fine but the endpoint
+    rejects for another reason (scope, resource-level permission). See #9860.
 
     Design notes for future changes:
 

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -81,7 +81,7 @@ def _get_auth_state(cache_key: FirewallAuthCacheKey) -> _FirewallAuthState:
 def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
     """Request a forced token refresh on the next /firewall/auth fetch.
 
-    No-op if a forced-refresh marker was consumed within
+    No-op if a force-refresh marker was consumed within
     ``_FORCE_REFRESH_COOLDOWN_SECS``. The cooldown starts when the marker is
     consumed, before the forced fetch completes, so the same window covers
     requests made while that fetch is in flight or after it fails. This


### PR DESCRIPTION
## Summary

- clarify that the force-refresh cooldown starts when the pending marker is consumed, before the fetch completes
- explicitly document that the same cooldown covers in-flight and failed forced fetches
- preserve the established runtime behavior and existing focused test coverage

## Scope

Documentation only. This PR does not change cooldown state, retry behavior, APIs, persisted data, or deployment compatibility.

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/ -q` — 4002 passed

Closes #21701
