### PR TITLE
docs(guest-agent): correct heartbeat failure threshold wording

### DIFF
--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -16,7 +16,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Run the heartbeat loop. Returns when:
 /// - The first heartbeat fails (returns `Err`)
-/// - Consecutive heartbeat failures exceed `MAX_CONSECUTIVE_HEARTBEAT_FAILURES` (returns `Err`)
+/// - Consecutive heartbeat failures reach `MAX_CONSECUTIVE_HEARTBEAT_FAILURES` (returns `Err`)
 /// - The shutdown token is cancelled (returns `Ok(())`)
 ///
 /// The caller should race this against CLI execution so that a network


### PR DESCRIPTION
## Summary

- correct the public heartbeat loop rustdoc to say termination occurs when consecutive failures reach the configured maximum
- keep the established `>=` comparison, threshold value, logging, and integration coverage unchanged

## Exclusions

- no runtime behavior change
- no schema, migration, persisted-data, API, protocol, or deployment-order change
- no new test that duplicates source prose; the existing integration test already verifies termination after exactly three consecutive failures

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets --all-features`
- `cd crates && cargo doc -p guest-agent --all-features --no-deps`
- `cd crates && cargo test -p guest-agent --all-features`
- pre-commit hook: workspace Rust formatting, Clippy, and documentation checks

Closes #21700
