### PR TITLE
test(runner): isolate orphan cleanup test paths

### DIFF
--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -1732,17 +1732,20 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_orphan_succeeds_when_dirs_missing() {
-        let control = MockSandboxControl::new("/tmp/nonexistent-base");
-        let results = cleanup_orphan(
-            "sbox-456",
-            std::path::Path::new("/tmp/no-such-dir"),
-            &control,
-        )
-        .await;
+        let workspace_base = tempfile::tempdir().unwrap();
+        let sock_base = tempfile::tempdir().unwrap();
+        let control = MockSandboxControl::new(sock_base.path());
+        let workspace = workspace_base.path().join("workspaces").join("sbox-456");
+        let sock_dir = control.runtime_dir("sbox-456");
+
+        assert!(!workspace.exists(), "workspace should start missing");
+        assert!(!sock_dir.exists(), "socket directory should start missing");
+
+        let results = cleanup_orphan("sbox-456", workspace_base.path(), &control).await;
 
         // Both should "succeed" — NotFound is treated as success
         assert_eq!(results.len(), 2);
-        assert!(results[0].1);
-        assert!(results[1].1);
+        assert!(results[0].1, "workspace cleanup should succeed");
+        assert!(results[1].1, "socket cleanup should succeed");
     }
 }


### PR DESCRIPTION
## Summary

- replace fixed global orphan-cleanup test paths with separate test-owned temporary roots
- derive and assert both workspace and socket cleanup targets are absent before cleanup
- retain coverage that both missing-directory cleanup attempts succeed

## Scope

- test-only change in `crates/runner/src/cmd/kill.rs`
- no production cleanup behavior, dependency, API, protocol, persistence, or documentation changes
- unrelated timing-sensitive runner tests are intentionally not changed

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cleanup_orphan_succeeds_when_dirs_missing`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet -- --test-threads=4` (2,699 passed; 9 existing ignored)
- repository pre-commit hooks (workspace Rust formatting, documentation, and Clippy)

Two default 12-thread local suite attempts each exposed a different unrelated timing-sensitive test failure; both failing tests passed immediately when rerun in isolation. The complete suite passed with four test threads, without skipping tests or changing timeouts. CI remains the independent default-pipeline verification.

Closes #21698
