### PR TITLE
test(runner): isolate touch mtime missing-path test

### DIFF
--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -846,7 +846,11 @@ mod tests {
 
     #[test]
     fn touch_mtime_nonexistent_dir_does_not_panic() {
-        touch_mtime(Path::new("/nonexistent/dir"));
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_dir = temp_dir.path().join("missing");
+        assert!(!missing_dir.exists());
+
+        touch_mtime(&missing_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the fixed `/nonexistent/dir` test path with a test-owned temporary root
- assert that the derived child path is missing before exercising `touch_mtime`
- preserve the existing non-panicking best-effort behavior coverage without touching host-owned filesystem state

## Exclusions

- no production logic, API, schema, dependency, documentation, or runner protocol changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner touch_mtime_nonexistent_dir_does_not_panic`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (`2698 passed`, `9 ignored`)
- pre-commit workspace Rust formatting, Clippy, and documentation checks

Closes #21699
