### PR TITLE
fix(runner): hide token values from help

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -45,7 +45,7 @@ pub struct ConfigArgs {
     #[arg(long, env = "VM0_API_BACKEND_URL")]
     api_url: String,
     /// Runner authentication token
-    #[arg(long, env = "VM0_RUNNER_TOKEN")]
+    #[arg(long, env = "VM0_RUNNER_TOKEN", hide_env_values = true)]
     token: String,
 }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -166,7 +166,7 @@ pub struct StartArgs {
     #[arg(long, env = "VM0_API_BACKEND_URL")]
     api_url: Option<String>,
     /// Runner authentication token (overrides config)
-    #[arg(long, env = "VM0_RUNNER_TOKEN")]
+    #[arg(long, env = "VM0_RUNNER_TOKEN", hide_env_values = true)]
     token: Option<String>,
     /// Use local file queue provider instead of API (for testing)
     #[arg(long)]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -307,7 +307,14 @@ async fn main() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+    const HELP_TOKEN_CHILD_SCENARIO_ENV: &str = "VM0_RUNNER_HELP_TOKEN_CHILD_SCENARIO";
+    const HELP_TOKEN_CHILD_TEST: &str = "tests::runner_help_hides_token_environment_values_child";
+    const HELP_TOKEN_SENTINEL: &str = "sentinel-runner-token";
 
     #[test]
     fn sanitize_name_passthrough() {
@@ -339,6 +346,53 @@ mod tests {
         assert_eq!(
             runner_name_from_config(Path::new("/nonexistent.yaml")),
             "default"
+        );
+    }
+
+    #[tokio::test]
+    async fn runner_help_hides_token_environment_values() {
+        for subcommand in ["config", "start"] {
+            run_ignored_child_test(
+                HELP_TOKEN_CHILD_TEST,
+                (HELP_TOKEN_CHILD_SCENARIO_ENV, subcommand),
+                &[("VM0_RUNNER_TOKEN", Some(HELP_TOKEN_SENTINEL))],
+                Duration::from_secs(5),
+            )
+            .await;
+        }
+    }
+
+    #[test]
+    #[ignore = "spawned by runner_help_hides_token_environment_values"]
+    fn runner_help_hides_token_environment_values_child() {
+        let Ok(subcommand) = std::env::var(HELP_TOKEN_CHILD_SCENARIO_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((HELP_TOKEN_CHILD_SCENARIO_ENV, &subcommand)) {
+            return;
+        }
+        let subcommand = match subcommand.as_str() {
+            "config" => "config",
+            "start" => "start",
+            unexpected => panic!("unexpected runner help token scenario: {unexpected}"),
+        };
+
+        let error = Cli::try_parse_from(["runner", subcommand, "--help"])
+            .err()
+            .expect("runner subcommand help should exit through clap");
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::DisplayHelp,
+            "{subcommand} --help should produce clap help"
+        );
+        let help = error.to_string();
+        assert!(
+            help.contains("VM0_RUNNER_TOKEN"),
+            "{subcommand} help should identify the token environment variable"
+        );
+        assert!(
+            !help.contains(HELP_TOKEN_SENTINEL),
+            "{subcommand} help should hide the token environment value"
         );
     }
 


### PR DESCRIPTION
## Summary

- hide captured `VM0_RUNNER_TOKEN` values from `runner config --help` and `runner start --help`
- keep the environment variable name visible and preserve environment-based token resolution
- cover both real clap help paths with isolated child-process regression scenarios using the existing runner test fixture

## Scope

This changes only clap help rendering for the two runner token arguments. It does not change token precedence, root gating, APIs, protocols, schemas, persisted configuration, or deployment compatibility.

## Validation

- mutation proof: the focused test failed before the argument change because `config --help` contained the synthetic sentinel
- `cargo test -p runner --bin runner tests::runner_help_hides_token_environment_values -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (2699 unit tests and 1 integration test passed)
- pre-commit workspace Rust format, documentation, and Clippy checks

Closes #21702
