### PR TITLE
refactor(mitm-addon): unify connector usage registration

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -162,8 +162,7 @@ Model-provider usage
 Connector usage and parser state
 --------------------------------
 - ``X_NDJSON_STATE``: ``dict`` owned by the X connector NDJSON parser. Written
-  when a streaming X response parser is registered, read by X billing, and
-  also read by ``error()`` to report partial stream usage.
+  when a streaming X response parser is registered and read by X billing.
 - ``X_JSON_STATE``: ``dict`` owned by the X connector JSON parser. Written by
   connector parser finalization before normal response billing, then read by X
   billing instead of the capped stream-buffer fallback.

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1366,14 +1366,10 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     response_streaming.finalize_model_sse_usage(flow)
     terminal_usage.report_model_provider_usage_once(flow, run_id)
 
-    # Billable connector usage for X NDJSON streams that crash mid-flight
-    # (issue #9534): the incremental parser populated x_ndjson_state during
-    # chunks; log what was observed so partial streams aren't silently
-    # dropped from billing.  Do not run the generic connector fallback for
-    # non-streaming JSON errors: partial bodies could otherwise be treated
-    # as unparseable successes and billed from request-side hints.
-    if flow.metadata.get(metadata_keys.X_NDJSON_STATE) is not None:
-        response_streaming.finalize_connector_response_state(flow)
+    # Connector parsers opt into interrupted reporting only when accumulated
+    # partial observations are independently billable. Ordinary JSON parsers do
+    # not opt in because incomplete responses could reach request-side hints.
+    if response_streaming.finalize_interrupted_connector_response_state(flow):
         usage.report_connector_usage(flow, run_id)
 
     safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -8,7 +8,8 @@ Lifecycle:
   terminal server-side usage frames on model-provider WebSocket upgrades.
 - ``mitm_addon.response()`` finalizes HTTP model and connector usage before
   reporting it.
-- ``mitm_addon.error()`` may finalize partial SSE usage before terminal cleanup.
+- ``mitm_addon.error()`` may finalize partial SSE or opted-in connector usage
+  before terminal cleanup.
 - ``mitm_addon.websocket_end()`` is terminal for model-provider WebSocket
   upgrades. HTTP 101 responses defer tracked usage release until that hook.
 - hook cleanup paths call ``release_response_stream_state()`` to remove parser
@@ -41,6 +42,7 @@ _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
+_CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION = "connector_response_report_on_interruption"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 _HTTP_OWS_CHARS = " \t"
 
@@ -265,6 +267,8 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         decode_session = _make_response_decode_session(connector_parser.feed, response.headers)
         if decode_session is None:
             raise RuntimeError("stream-decodable connector response did not create a decoder")
+        if connector_parser.report_on_interruption:
+            flow.metadata[_CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION] = True
         if connector_parser.finish is not None or connector_parser.finish_decode_error is not None:
 
             def finish_connector_response() -> None:
@@ -500,18 +504,36 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
 
-def finalize_connector_response_state(flow: http.HTTPFlow) -> None:
-    """Finalize connector response parser state before connector usage reporting.
-
-    Called from ``response()`` before ``usage.report_connector_usage()`` and
-    from selected connector error paths that explicitly keep partial streamed
-    usage. Pops ``_CONNECTOR_RESPONSE_FINISH``, so repeated calls after the
-    first are no-ops. Connector-specific parser state is owned by the
-    registered finish callback, for example X JSON or NDJSON usage metadata.
-    """
+def _finish_connector_response_state(flow: http.HTTPFlow) -> None:
     finish = flow.metadata.pop(_CONNECTOR_RESPONSE_FINISH, None)
     if finish is not None:
         finish()
+
+
+def finalize_connector_response_state(flow: http.HTTPFlow) -> None:
+    """Finalize connector response parser state before connector usage reporting.
+
+    Called from ``response()`` before ``usage.report_connector_usage()``. Clears
+    the interrupted-report opt-in and pops ``_CONNECTOR_RESPONSE_FINISH``, so
+    repeated calls after the first are no-ops. Connector-specific parser state
+    is owned by the registered finish callback, for example X JSON or NDJSON
+    usage metadata.
+    """
+    flow.metadata.pop(_CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION, None)
+    _finish_connector_response_state(flow)
+
+
+def finalize_interrupted_connector_response_state(flow: http.HTTPFlow) -> bool:
+    """Finalize state when the active parser opted into interruption reporting.
+
+    Returns whether the caller should run connector usage reporting. The parser
+    finalizer handles decoder completion first, so an incomplete compressed body
+    can invalidate best-effort state before the reporter observes it.
+    """
+    if not flow.metadata.pop(_CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION, False):
+        return False
+    _finish_connector_response_state(flow)
+    return True
 
 
 def release_response_stream_state(flow: http.HTTPFlow) -> None:
@@ -533,5 +555,6 @@ def release_response_stream_state(flow: http.HTTPFlow) -> None:
     flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)
     flow.metadata.pop(_MODEL_SSE_USAGE_FINISH, None)
     flow.metadata.pop(_CONNECTOR_RESPONSE_FINISH, None)
+    flow.metadata.pop(_CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION, None)
     if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
         flow.response.stream = False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -10,13 +10,14 @@ delegates to the matching per-connector ``report_usage`` function.
 The TypeScript billable connector manifest lives in
 ``turbo/packages/firewalls-generator/src/connector-firewall-manifest.ts`` as
 ``BILLABLE_FIREWALL_CONNECTOR_TYPES``. Adding a new billable connector means
-marking it billable there, adding a connector module here, and registering it
-in :data:`_HANDLERS`. Connectors that need incremental response-body usage
-extraction also register a parser factory in :data:`_RESPONSE_PARSER_FACTORIES`.
-The dispatcher already enforces the cross-connector invariants.
+marking it billable there, adding a connector module here, and registering its
+reporter plus optional response-inspection capability in :data:`_REGISTRATIONS`.
+Response inspection owns both parser creation and buffered-fallback selection,
+so those decisions cannot drift across independent registries.
 """
 
 from collections.abc import Callable
+from typing import NamedTuple
 
 from mitmproxy import http
 
@@ -30,26 +31,30 @@ _ConnectorUsageHandler = Callable[[http.HTTPFlow, str, str], None]
 _ResponseParserFactory = Callable[[http.HTTPFlow, str], ConnectorResponseParser | None]
 _ResponseBufferFallbackPredicate = Callable[[http.HTTPFlow], bool]
 
-# Map firewall_name → per-connector report_usage handler. A handler is only
-# invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True. That
-# flag comes from the runner claim's ``billableFirewalls`` list, generated from
-# ``BILLABLE_FIREWALL_CONNECTOR_TYPES`` in the TypeScript firewall manifest.
-# This table controls which billable flows the addon knows how to parse. Desync
-# manifests as a dropped billing record plus a missing handler in test coverage.
-_HANDLERS: dict[str, _ConnectorUsageHandler] = {
-    "x": x.report_usage,
-}
 
-# Response parser factories are consulted at response-header time for registered
-# connector firewall flows that may need streamed response-body state before
-# final usage reporting. A factory returns None when the specific flow needs no
-# parser.
-_RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
-    "x": x.create_response_parser,
-}
+class _ConnectorResponseInspection(NamedTuple):
+    create_parser: _ResponseParserFactory
+    needs_buffered_fallback: _ResponseBufferFallbackPredicate
 
-_RESPONSE_BUFFER_FALLBACK_PREDICATES: dict[str, _ResponseBufferFallbackPredicate] = {
-    "x": x.needs_response_buffer_fallback,
+
+class _ConnectorUsageRegistration(NamedTuple):
+    report_usage: _ConnectorUsageHandler
+    response_inspection: _ConnectorResponseInspection | None = None
+
+
+# Map firewall_name → one coherent connector usage registration. A reporter is
+# only invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True.
+# That flag comes from the runner claim's ``billableFirewalls`` list, generated
+# from ``BILLABLE_FIREWALL_CONNECTOR_TYPES`` in the TypeScript firewall manifest.
+# Deployment desync manifests as a dropped billing record plus the warning below.
+_REGISTRATIONS: dict[str, _ConnectorUsageRegistration] = {
+    "x": _ConnectorUsageRegistration(
+        report_usage=x.report_usage,
+        response_inspection=_ConnectorResponseInspection(
+            create_parser=x.create_response_parser,
+            needs_buffered_fallback=x.needs_response_buffer_fallback,
+        ),
+    ),
 }
 
 # One-shot guard: first time we see a billable firewall_name with no
@@ -65,6 +70,11 @@ def _require_original_url(flow: http.HTTPFlow) -> str:
     if not original_url:
         raise ValueError("registered billable connector flow is missing original_url")
     return original_url
+
+
+def _response_inspection(firewall_name: str) -> _ConnectorResponseInspection | None:
+    registration = _REGISTRATIONS.get(firewall_name)
+    return registration.response_inspection if registration is not None else None
 
 
 def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
@@ -89,27 +99,27 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     firewall_name = flow_metadata.firewall_name(flow.metadata)
     if firewall_name.startswith("model-provider:"):
         return
-    handler = _HANDLERS.get(firewall_name)
-    if handler is None:
+    registration = _REGISTRATIONS.get(firewall_name)
+    if registration is None:
         if firewall_name and firewall_name not in _unregistered_handler_warned:
             _unregistered_handler_warned.add(firewall_name)
             log_usage_underbilling(
                 flow_metadata.proxy_log_path(flow.metadata),
                 f"Billable firewall {firewall_name!r} has no registered handler — "
                 "billing records for this firewall will be dropped.  Check that "
-                "BILLABLE_FIREWALL_CONNECTOR_TYPES and _HANDLERS here are in sync.",
+                "BILLABLE_FIREWALL_CONNECTOR_TYPES and _REGISTRATIONS here are in sync.",
                 "unregistered_billable_handler",
                 "confirmed",
                 firewall_name=firewall_name,
             )
         return
     original_url = _require_original_url(flow)
-    handler(flow, run_id, original_url)
+    registration.report_usage(flow, run_id, original_url)
 
 
 def has_connector_response_parser(firewall_name: str) -> bool:
     """Return whether a connector has response-body parser capability."""
-    return firewall_name in _RESPONSE_PARSER_FACTORIES
+    return _response_inspection(firewall_name) is not None
 
 
 def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
@@ -122,11 +132,11 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
     if not flow_metadata.is_firewall_billable(flow.metadata):
         return None
     firewall_name = flow_metadata.firewall_name(flow.metadata)
-    factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
-    if factory is None:
+    inspection = _response_inspection(firewall_name)
+    if inspection is None:
         return None
     original_url = _require_original_url(flow)
-    return factory(flow, original_url)
+    return inspection.create_parser(flow, original_url)
 
 
 def needs_connector_response_buffer_fallback(flow: http.HTTPFlow) -> bool:
@@ -134,5 +144,5 @@ def needs_connector_response_buffer_fallback(flow: http.HTTPFlow) -> bool:
     if not flow_metadata.is_firewall_billable(flow.metadata):
         return False
     firewall_name = flow_metadata.firewall_name(flow.metadata)
-    predicate = _RESPONSE_BUFFER_FALLBACK_PREDICATES.get(firewall_name)
-    return predicate(flow) if predicate is not None else False
+    inspection = _response_inspection(firewall_name)
+    return inspection.needs_buffered_fallback(flow) if inspection is not None else False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 class ConnectorResponseParser(NamedTuple):
     """Incremental parser hooks for connector response-body usage extraction.
 
-    Connector parser factories registered in ``_RESPONSE_PARSER_FACTORIES``
+    Connector response-inspection capabilities registered in ``_REGISTRATIONS``
     return this value when a connector flow needs response-body parsing for
     connector usage extraction. The response streaming layer wires ``feed`` into
     the stream callback for that flow.
@@ -21,21 +21,27 @@ class ConnectorResponseParser(NamedTuple):
     no-op: incremental decompressors may produce no output for a source chunk,
     and decompression failures intentionally suppress later parser input.
 
+    ``report_on_interruption`` explicitly declares whether state accumulated by
+    this parser may be finalized and reported after a connection error. Use it
+    only when partial observations are independently billable; ordinary JSON
+    parsers must leave it false so an incomplete body cannot reach request-side
+    billing fallbacks.
+
     ``finish`` is optional. When provided, normal completed-response
     finalization calls it once after streaming has fed all chunks and before
-    ``report_connector_usage`` consumes connector metadata. It should publish
-    final parser state to connector-owned ``flow.metadata`` keys through the
-    closure created by the connector parser factory. Cleanup and connection
-    error paths can release unfinished parser state without finalizing it, so
-    parser correctness must not rely on ``finish`` running for every interrupted
-    response.
+    ``report_connector_usage`` consumes connector metadata. An interrupted
+    response also calls it when ``report_on_interruption`` is true. It should
+    publish final parser state to connector-owned ``flow.metadata`` keys through
+    the closure created by the connector parser factory.
 
     ``finish_decode_error`` is optional. When provided, response streaming calls
     it instead of ``finish`` if the transport decoder cannot prove a compressed
     response body completed. It should publish connector-owned unparsed state so
-    later fallback parsing does not trust best-effort decoded bytes.
+    later fallback parsing does not trust best-effort decoded bytes. This runs
+    before an opted-in interrupted response is reported.
     """
 
     feed: Callable[[bytes], None]
+    report_on_interruption: bool
     finish: Callable[[], None] | None = None
     finish_decode_error: Callable[[str], None] | None = None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -488,6 +488,7 @@ def create_response_parser(
 
             return ConnectorResponseParser(
                 feed=extractor.feed,
+                report_on_interruption=True,
                 finish=extractor.finish,
                 finish_decode_error=finish_ndjson_decode_error,
             )
@@ -512,6 +513,7 @@ def create_response_parser(
 
     return ConnectorResponseParser(
         feed=extractor.feed,
+        report_on_interruption=False,
         finish=finish_json_state,
         finish_decode_error=finish_json_decode_error,
     )

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -54,7 +54,7 @@ class TestConnectorUsageDispatcher:
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model-provider flows go through report_model_provider_usage instead.
-        The dispatcher has no ``model-provider:*`` entry in ``_HANDLERS``, so
+        The dispatcher has no ``model-provider:*`` entry in ``_REGISTRATIONS``, so
         it early-returns and never reaches the X parser even when
         firewall_billable=True."""
         flow = self._make_x_flow(real_flow, tmp_path)
@@ -85,7 +85,7 @@ class TestConnectorUsageDispatcher:
         the TypeScript firewall billable metadata) must NOT reach the X parser.
         The dispatcher drops when the firewall_name has no registered handler,
         which prevents bogus billing records if someone marks a connector
-        billable without also registering a handler in ``_HANDLERS``."""
+        billable without also adding it to ``_REGISTRATIONS``."""
         flow = self._make_x_flow(real_flow, tmp_path)
         flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
         assert self._call_and_get_billing(flow) == []

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -1113,7 +1113,14 @@ class TestReleaseResponseStreamState:
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     @pytest.mark.parametrize(
-        ("host", "path", "response_content_type", "metadata", "finish_key"),
+        (
+            "host",
+            "path",
+            "response_content_type",
+            "metadata",
+            "finish_key",
+            "reports_on_interruption",
+        ),
         [
             pytest.param(
                 "api.anthropic.com",
@@ -1125,6 +1132,7 @@ class TestReleaseResponseStreamState:
                     metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
                 },
                 "model_json_usage_finish",
+                False,
                 id="model-json",
             ),
             pytest.param(
@@ -1138,6 +1146,7 @@ class TestReleaseResponseStreamState:
                     metadata_keys.MODEL_USAGE_PROVIDER: "gpt-5.5",
                 },
                 "model_sse_usage_finish",
+                False,
                 id="model-sse",
             ),
             pytest.param(
@@ -1150,6 +1159,7 @@ class TestReleaseResponseStreamState:
                     metadata_keys.ORIGINAL_URL: "https://api.x.com/2/tweets",
                 },
                 "connector_response_finish",
+                False,
                 id="x-json",
             ),
             pytest.param(
@@ -1162,6 +1172,7 @@ class TestReleaseResponseStreamState:
                     metadata_keys.ORIGINAL_URL: "https://api.x.com/2/tweets/search/stream",
                 },
                 "connector_response_finish",
+                True,
                 id="x-ndjson",
             ),
         ],
@@ -1174,6 +1185,7 @@ class TestReleaseResponseStreamState:
         response_content_type,
         metadata,
         finish_key,
+        reports_on_interruption,
     ):
         flow = real_flow(with_response=False, host=host, path=path)
         flow.metadata.update(metadata)
@@ -1184,10 +1196,14 @@ class TestReleaseResponseStreamState:
 
         mitm_addon.responseheaders(flow)
         assert finish_key in flow.metadata
+        assert (
+            "connector_response_report_on_interruption" in flow.metadata
+        ) is reports_on_interruption
 
         response_streaming.release_response_stream_state(flow)
 
         assert finish_key not in flow.metadata
+        assert "connector_response_report_on_interruption" not in flow.metadata
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -16,7 +16,6 @@ import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
-from tests.stream_buffer_helpers import set_response_stream_buffer
 from tests.x_flow_helpers import (
     json_body_that_exceeds_decoder_recursion,
     json_body_that_exceeds_integer_digit_limit,
@@ -527,29 +526,24 @@ class TestXConnectorErrorPipeline:
     def _sync_executor(self, sync_usage_executor):
         """Run delivery inline for error-pipeline behavior tests."""
 
-    def test_error_logs_connector_usage_for_x_stream(
+    def test_full_pipeline_json_error_does_not_bill_request_hints(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
-        """Mid-flight stream crash: partial counts still reported (issue #9534)."""
-        flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
-        flow.metadata[metadata_keys.X_NDJSON_STATE] = {
-            "data_count": 23,
-            "includes": {"users": 5},
-            "lines_parsed": 23,
-            "lines_failed": 0,
-        }
-        set_response_stream_buffer(flow, b"")
+        """Interrupted ordinary JSON cannot bill from request-side hints."""
+        flow = make_x_pipeline_flow(real_flow, tmp_path, query="ids=1,2,3")
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(b'{"data":[')
         flow.error = Error("connection reset by peer")
 
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
 
-        assert webhook.request_count > 0
-        payloads = webhook.usage_events()
-        by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat["posts.read"] == 23
-        assert by_cat["user.read"] == 5
+        assert webhook.usage_events() == []
+        assert metadata_keys.X_JSON_STATE not in flow.metadata
+        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_report_on_interruption" not in flow.metadata
 
     def test_full_pipeline_stream_error_midflight(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
@@ -584,6 +578,7 @@ class TestXConnectorErrorPipeline:
         by_cat = {p["category"]: p["quantity"] for p in payloads}
         assert by_cat["posts.read"] == 2  # not 3; partial trailing dropped
         assert by_cat["user.read"] == 1
+        assert "connector_response_report_on_interruption" not in flow.metadata
 
     def test_full_pipeline_stream_error_counts_complete_final_line_without_newline(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api


### PR DESCRIPTION
## Summary

- consolidate connector usage reporting and response inspection into one typed registration per connector
- let response parsers explicitly opt into interrupted usage reporting, preserving partial X NDJSON billing without connector-specific checks in the central error hook
- keep interrupted ordinary X JSON responses away from request-side billing fallbacks and clean up the generic lifecycle state on every terminal path

## Compatibility

- no API, schema, persisted-state, runner protocol, pricing, or feature-switch changes
- existing connector usage entry points and completed-response behavior remain unchanged

## Validation

- `python3 -m ruff format .`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest -q tests/test_connector_usage_dispatcher.py tests/test_response_streaming.py tests/test_x_connector_pipeline.py` (119 passed)
- `python3 -m pytest -q` (4002 passed)

Closes #21703
