### PR TITLE
fix(platform): clarify presentation speaker notes and close flow

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -387,11 +387,13 @@ export const openPresentationEditor$ = command(({ get, set }, url: string) => {
 export const closePresentationEditor$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
   set(internalPresentationEditorCloseDialogOpen$, false);
-  if (!params.has(PRESENTATION_EDITOR_QUERY_PARAM)) {
+  const presentationUrl = params.get(PRESENTATION_EDITOR_QUERY_PARAM);
+  if (presentationUrl === null) {
     return;
   }
   params.delete(PRESENTATION_EDITOR_QUERY_PARAM);
   params.delete(ARTIFACT_FULLSCREEN_PARAM);
+  params.set(ARTIFACT_QUERY_PARAM, presentationUrl);
   set(replaceSearchParams$, params);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -67,6 +67,7 @@ export type ArtifactInboxSection = "all" | "media" | "docs" | "sites";
 const internalArtifactInboxSection$ = state<ArtifactInboxSection>("all");
 const internalArtifactInboxQuery$ = state("");
 const internalArtifactInboxSearchOpen$ = state(false);
+const internalPresentationEditorCloseDialogOpen$ = state(false);
 const internalHtmlDomEditPendingUrl$ = state<string | null>(null);
 const internalHtmlDomEditPublishingUrl$ = state<string | null>(null);
 const internalHtmlDomEditPreviewHtmlByUrl$ = state<
@@ -304,6 +305,16 @@ export const currentPresentationEditorUrl$ = computed((get) => {
   return get(searchParams$).get(PRESENTATION_EDITOR_QUERY_PARAM);
 });
 
+export const presentationEditorCloseDialogOpen$ = computed((get) => {
+  return get(internalPresentationEditorCloseDialogOpen$);
+});
+
+export const setPresentationEditorCloseDialogOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalPresentationEditorCloseDialogOpen$, open);
+  },
+);
+
 function setArtifactPreviewParams(
   params: URLSearchParams,
   args: {
@@ -363,6 +374,7 @@ export const openArtifactSidebarHtmlEdit$ = command(
 
 export const openPresentationEditor$ = command(({ get, set }, url: string) => {
   const params = new URLSearchParams(get(searchParams$));
+  set(internalPresentationEditorCloseDialogOpen$, false);
   params.set(PRESENTATION_EDITOR_QUERY_PARAM, url);
   params.set(ARTIFACT_FULLSCREEN_PARAM, "1");
   params.delete(ARTIFACT_QUERY_PARAM);
@@ -374,6 +386,7 @@ export const openPresentationEditor$ = command(({ get, set }, url: string) => {
 
 export const closePresentationEditor$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
+  set(internalPresentationEditorCloseDialogOpen$, false);
   if (!params.has(PRESENTATION_EDITOR_QUERY_PARAM)) {
     return;
   }

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -211,6 +211,55 @@ body {
   }
 }
 
+.speaker-notes-dot-1 {
+  animation: speaker-notes-dot-1 1.2s steps(1, end) infinite;
+}
+
+.speaker-notes-dot-2 {
+  animation: speaker-notes-dot-2 1.2s steps(1, end) infinite;
+}
+
+.speaker-notes-dot-3 {
+  animation: speaker-notes-dot-3 1.2s steps(1, end) infinite;
+}
+
+@keyframes speaker-notes-dot-1 {
+  0%,
+  74% {
+    opacity: 1;
+  }
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes speaker-notes-dot-2 {
+  0%,
+  24%,
+  75%,
+  100% {
+    opacity: 0;
+  }
+  25%,
+  74% {
+    opacity: 1;
+  }
+}
+
+@keyframes speaker-notes-dot-3 {
+  0%,
+  49%,
+  75%,
+  100% {
+    opacity: 0;
+  }
+  50%,
+  74% {
+    opacity: 1;
+  }
+}
+
 /* Landing tagline carousel: smooth vertical fade-in */
 @keyframes zero-tagline-in {
   from {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -362,10 +362,16 @@ describe("previewPresentationHtml", () => {
       .join("\n");
 
     expect(injectedCss).toMatch(
+      /\[data-vm0-editor-edit-id\]\s*{[^}]*outline:\s*4px solid transparent\s*!important;/,
+    );
+    expect(injectedCss).toMatch(
       /\[data-vm0-editor-edit-id\]:hover\s*{\s*outline-color:\s*#0f82ff\s*!important;/,
     );
     expect(injectedCss).toMatch(
       /\[data-vm0-editor-edit-id\]:focus\s*{\s*outline-color:\s*hsl\(var\(--ring, 15 80% 66%\)\)\s*!important;/,
+    );
+    expect(injectedCss).toMatch(
+      /\[data-vm0-editor-edit-id\]:focus\s*{[^}]*filter:\s*none\s*!important;/,
     );
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -3275,12 +3275,15 @@ ${openFencedHostedSiteUrl}`,
     click(screen.getByLabelText("Close presentation editor"));
 
     await waitFor(() => {
-      expect(screen.getByText("Save changes?")).toBeInTheDocument();
-      expect(screen.getByText("Presentation editor")).toBeInTheDocument();
+      expect(
+        screen.getByText("Do you want to save your changes?", {
+          selector: "h2",
+        }),
+      ).toBeInTheDocument();
     });
     expect(redeployedHtml).toBeNull();
 
-    click(screen.getByRole("button", { name: "Save" }));
+    click(screen.getByText("Save"));
 
     await waitFor(() => {
       expect(screen.getByText("Presentation updated")).toBeInTheDocument();
@@ -3335,11 +3338,15 @@ ${openFencedHostedSiteUrl}`,
 
     click(screen.getByLabelText("Close presentation editor"));
     await waitFor(() => {
-      expect(screen.getByText("Save changes?")).toBeInTheDocument();
+      expect(
+        screen.getByText("Do you want to save your changes?", {
+          selector: "h2",
+        }),
+      ).toBeInTheDocument();
     });
     expect(redeployCount).toBe(0);
 
-    click(screen.getByRole("button", { name: "Exit" }));
+    click(screen.getByText("Discard"));
     await waitFor(() => {
       expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
     });
@@ -3356,7 +3363,11 @@ ${openFencedHostedSiteUrl}`,
     await waitFor(() => {
       expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
     });
-    expect(screen.queryByText("Save changes?")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Do you want to save your changes?", {
+        selector: "h2",
+      }),
+    ).not.toBeInTheDocument();
     expect(redeployCount).toBe(0);
   });
 
@@ -3364,6 +3375,7 @@ ${openFencedHostedSiteUrl}`,
     const thumbnailObserver = mockIntersectionObserver();
     const presentationUrl = "https://deck.sites.vm7.io/quarterly-roadmap.html";
     const downloads = captureDownloads(context.signal);
+    const speakerNotesResponse = Promise.withResolvers<void>();
     let generatedSlides: { slideId: string; speakerNotes: string }[] = [
       {
         slideId: "slide-plan",
@@ -3384,7 +3396,8 @@ ${openFencedHostedSiteUrl}`,
     );
     context.mocks.api(
       zeroHostContract.generatePresentationSpeakerNotes,
-      ({ respond }) => {
+      async ({ respond }) => {
+        await speakerNotesResponse.promise;
         return respond(200, {
           kind: "presentation-speaker-notes-patch",
           version: 1,
@@ -3471,6 +3484,15 @@ ${openFencedHostedSiteUrl}`,
 
     await fill(screen.getByLabelText("Speaker notes"), " ");
     click(screen.getByLabelText("Generate speaker notes"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Generating speaker notes")).toHaveAttribute(
+        "data-generating",
+        "true",
+      );
+      expect(screen.getByText("Generating")).toBeInTheDocument();
+    });
+    speakerNotesResponse.resolve();
 
     await waitFor(() => {
       expect(
@@ -3601,9 +3623,13 @@ ${openFencedHostedSiteUrl}`,
     click(screen.getByLabelText("Close presentation editor"));
 
     await waitFor(() => {
-      expect(screen.getByText("Save changes?")).toBeInTheDocument();
+      expect(
+        screen.getByText("Do you want to save your changes?", {
+          selector: "h2",
+        }),
+      ).toBeInTheDocument();
     });
-    click(screen.getByRole("button", { name: "Save" }));
+    click(screen.getByText("Save"));
 
     await waitFor(() => {
       expect(screen.getByText("Presentation updated")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -3275,6 +3275,14 @@ ${openFencedHostedSiteUrl}`,
     click(screen.getByLabelText("Close presentation editor"));
 
     await waitFor(() => {
+      expect(screen.getByText("Save changes?")).toBeInTheDocument();
+      expect(screen.getByText("Presentation editor")).toBeInTheDocument();
+    });
+    expect(redeployedHtml).toBeNull();
+
+    click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
       expect(screen.getByText("Presentation updated")).toBeInTheDocument();
       expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
     });
@@ -3288,6 +3296,68 @@ ${openFencedHostedSiteUrl}`,
         screen.queryByText("Presentation updated"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("exits the presentation editor without publishing draft changes", async () => {
+    const presentationUrl =
+      "https://deck.sites.vm7.io/exit-without-saving.html";
+    let redeployCount = 0;
+
+    context.mocks.api(
+      zeroHostContract.redeployPresentationHtml,
+      ({ respond }) => {
+        redeployCount += 1;
+        return respond(200, {
+          siteId: "44444444-4444-4444-8444-444444444444",
+          deploymentId: "55555555-5555-4555-8555-555555555555",
+          publicSlug: "exit-without-saving",
+          url: presentationUrl,
+          status: "ready",
+        });
+      },
+    );
+    setupPresentationArtifactThread(presentationUrl);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Edit presentation")).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Edit presentation"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Speaker notes")).toHaveValue(
+        "Open with launch metrics.",
+      );
+    });
+    await fill(
+      screen.getByLabelText("Speaker notes"),
+      "Discard this local draft.",
+    );
+
+    click(screen.getByLabelText("Close presentation editor"));
+    await waitFor(() => {
+      expect(screen.getByText("Save changes?")).toBeInTheDocument();
+    });
+    expect(redeployCount).toBe(0);
+
+    click(screen.getByRole("button", { name: "Exit" }));
+    await waitFor(() => {
+      expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
+    });
+    expect(redeployCount).toBe(0);
+
+    click(screen.getByLabelText("Edit presentation"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Speaker notes")).toHaveValue(
+        "Open with launch metrics.",
+      );
+    });
+
+    click(screen.getByLabelText("Close presentation editor"));
+    await waitFor(() => {
+      expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("Save changes?")).not.toBeInTheDocument();
+    expect(redeployCount).toBe(0);
   });
 
   it("edits and downloads a presentation artifact from the editor", async () => {
@@ -3400,7 +3470,7 @@ ${openFencedHostedSiteUrl}`,
     });
 
     await fill(screen.getByLabelText("Speaker notes"), " ");
-    click(screen.getByLabelText("Generate PPT script"));
+    click(screen.getByLabelText("Generate speaker notes"));
 
     await waitFor(() => {
       expect(
@@ -3417,7 +3487,7 @@ ${openFencedHostedSiteUrl}`,
       ).not.toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Generate PPT script"));
+    click(screen.getByLabelText("Generate speaker notes"));
 
     await waitFor(() => {
       expect(
@@ -3438,7 +3508,7 @@ ${openFencedHostedSiteUrl}`,
       },
     ];
     await fill(screen.getByLabelText("Speaker notes"), " ");
-    click(screen.getByLabelText("Generate PPT script"));
+    click(screen.getByLabelText("Generate speaker notes"));
 
     await waitFor(() => {
       expect(
@@ -3529,6 +3599,11 @@ ${openFencedHostedSiteUrl}`,
     });
 
     click(screen.getByLabelText("Close presentation editor"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Save changes?")).toBeInTheDocument();
+    });
+    click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(screen.getByText("Presentation updated")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -894,7 +894,7 @@ function presentationPreviewInteractionStyle(
     return `
       [data-vm0-editor-edit-id] {
         cursor: text !important;
-        outline: 2px solid transparent !important;
+        outline: 4px solid transparent !important;
         outline-offset: 4px !important;
         z-index: 2 !important;
         pointer-events: auto !important;
@@ -905,16 +905,18 @@ function presentationPreviewInteractionStyle(
       }
       [data-vm0-editor-edit-id]:hover {
         outline-color: #0f82ff !important;
+        filter: none !important;
       }
       [data-vm0-editor-edit-id]:focus {
         outline-color: hsl(var(--ring, 15 80% 66%)) !important;
+        filter: none !important;
       }
     `;
   }
   return `
     [data-vm0-editor-move-id] {
       cursor: move !important;
-      outline: 2px solid transparent !important;
+      outline: 4px solid transparent !important;
       outline-offset: 4px !important;
       z-index: 2 !important;
       pointer-events: auto !important;
@@ -923,6 +925,7 @@ function presentationPreviewInteractionStyle(
     }
     [data-vm0-editor-selected="true"] {
       outline-color: #0f82ff !important;
+      filter: none !important;
     }
     [data-vm0-editor-edit-id][contenteditable="true"] {
       cursor: text !important;
@@ -933,6 +936,7 @@ function presentationPreviewInteractionStyle(
     }
     [data-vm0-editor-edit-id][contenteditable="true"]:focus {
       outline-color: hsl(var(--ring, 15 80% 66%)) !important;
+      filter: none !important;
     }
   `;
 }

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -6,7 +6,15 @@ import {
   IconSparkles,
   IconX,
 } from "@tabler/icons-react";
-import { cn } from "@vm0/ui";
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { useGet, useLoadable, useSet } from "ccstate-react";
@@ -18,6 +26,10 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { refreshPresentationHtmlPreviews$ } from "../../signals/zero-page/presentation-html-cache-bust.ts";
 import { createPresentationDraftByUrlFactory } from "../../signals/zero-page/presentation-html-editor-draft.ts";
+import {
+  presentationEditorCloseDialogOpen$,
+  setPresentationEditorCloseDialogOpen$,
+} from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import { detach, Reason, tapError } from "../../signals/utils.ts";
 import { downloadPresentationHtmlStringPptx } from "./presentation-html-pptx-download.ts";
 import {
@@ -276,14 +288,14 @@ function PresentationEditorHeader({
       <button
         type="button"
         data-presentation-editor-action="true"
-        aria-label="Generate PPT script"
-        title="Generate PPT script"
+        aria-label="Generate speaker notes"
+        title="Generate speaker notes"
         disabled={!onGenerateSpeakerNotes}
         onClick={onGenerateSpeakerNotes}
         className="inline-flex h-8 w-8 items-center justify-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:w-auto sm:px-2"
       >
         <IconSparkles size={16} stroke={1.5} />
-        <span className="hidden sm:inline">Script</span>
+        <span className="hidden sm:inline">Speaker notes</span>
       </button>
       <button
         type="button"
@@ -1027,12 +1039,11 @@ function createPresentationEditorController(params: {
       publishingRef: params.publishingRef,
     });
   };
+  const hasUnsavedChanges = () => {
+    return currentSignature() !== params.publishedSignatureRef.current;
+  };
   const markDirty = () => {
-    setStatus(
-      currentSignature() !== params.publishedSignatureRef.current
-        ? "Unsaved changes"
-        : "Presentation editor",
-    );
+    setStatus(hasUnsavedChanges() ? "Unsaved changes" : "Presentation editor");
   };
   const queueSlideThumbnailUpdate = (slideId: string) => {
     params.pendingThumbnailSlideIdRef.current = slideId;
@@ -1104,12 +1115,88 @@ function createPresentationEditorController(params: {
     buildEditedHtml,
     ensureRedeployed,
     fillEmptySpeakerNotes,
+    hasUnsavedChanges,
     markDirty,
     previewHtml,
     queueSlideThumbnailUpdate,
     showSlide,
     slides,
   };
+}
+
+function createPresentationEditorCloseActions(params: {
+  readonly controller: ReturnType<typeof createPresentationEditorController>;
+  readonly draft: EditorDraft;
+  readonly onClose: () => void;
+  readonly publishingRef: MutableValue<boolean>;
+  readonly setCloseDialogOpen: (open: boolean) => void;
+  readonly sourceUrl: string;
+}) {
+  const requestClose = () => {
+    if (!params.controller.hasUnsavedChanges()) {
+      params.onClose();
+      return;
+    }
+    params.setCloseDialogOpen(true);
+  };
+  const exitWithoutSaving = () => {
+    presentationDraftByUrl.invalidate(params.sourceUrl);
+    presentationDraftByUrl.invalidate(params.draft.publicUrl);
+    params.setCloseDialogOpen(false);
+    params.onClose();
+  };
+  const saveAndClose = () => {
+    params.setCloseDialogOpen(false);
+    runEditorTaskIfIdle({
+      publishingRef: params.publishingRef,
+      reason: "presentation html editor close",
+      task: async () => {
+        if (await params.controller.ensureRedeployed()) {
+          params.onClose();
+        }
+      },
+    });
+  };
+  return { exitWithoutSaving, requestClose, saveAndClose };
+}
+
+function PresentationEditorCloseDialog({
+  onExit,
+  onOpenChange,
+  onSave,
+  open,
+}: {
+  readonly onExit: () => void;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onSave: () => void;
+  readonly open: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="zero-app !z-[10000] gap-5 sm:max-w-xs"
+        overlayClassName="!z-[10000]"
+      >
+        <DialogHeader>
+          <DialogTitle>Save changes?</DialogTitle>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={onExit}
+          >
+            Exit
+          </Button>
+          <Button type="button" size="sm" onClick={onSave}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function PresentationEditorReady({
@@ -1127,6 +1214,8 @@ function PresentationEditorReady({
 }) {
   const pageSignal = useGet(pageSignal$);
   const createClient = useGet(zeroClient$);
+  const closeDialogOpen = useGet(presentationEditorCloseDialogOpen$);
+  const setCloseDialogOpen = useSet(setPresentationEditorCloseDialogOpen$);
   const refreshPresentationHtmlPreviews = useSet(
     refreshPresentationHtmlPreviews$,
   );
@@ -1160,17 +1249,14 @@ function PresentationEditorReady({
     thumbnailUpdateFrameRef,
   });
 
-  const closeAfterPublish = () => {
-    runEditorTaskIfIdle({
-      publishingRef,
-      reason: "presentation html editor close",
-      task: async () => {
-        if (await controller.ensureRedeployed()) {
-          onClose();
-        }
-      },
-    });
-  };
+  const closeActions = createPresentationEditorCloseActions({
+    controller,
+    draft,
+    onClose,
+    publishingRef,
+    setCloseDialogOpen,
+    sourceUrl,
+  });
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background">
@@ -1178,7 +1264,7 @@ function PresentationEditorReady({
         busyRef={(node) => {
           busyRef.current = node;
         }}
-        onClose={closeAfterPublish}
+        onClose={closeActions.requestClose}
         onDownloadPptx={() => {
           runEditorTaskIfIdle({
             publishingRef,
@@ -1220,6 +1306,12 @@ function PresentationEditorReady({
         showSlide={controller.showSlide}
         slidesRef={slidesRef}
         slides={controller.slides}
+      />
+      <PresentationEditorCloseDialog
+        open={closeDialogOpen}
+        onExit={closeActions.exitWithoutSaving}
+        onOpenChange={setCloseDialogOpen}
+        onSave={closeActions.saveAndClose}
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -288,14 +288,25 @@ function PresentationEditorHeader({
       <button
         type="button"
         data-presentation-editor-action="true"
+        data-presentation-speaker-notes-action="true"
         aria-label="Generate speaker notes"
         title="Generate speaker notes"
         disabled={!onGenerateSpeakerNotes}
         onClick={onGenerateSpeakerNotes}
-        className="inline-flex h-8 w-8 items-center justify-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:w-auto sm:px-2"
+        className="inline-flex h-8 w-8 items-center justify-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[generating=true]:bg-violet-500/10 data-[generating=true]:text-violet-600 data-[generating=true]:disabled:opacity-100 dark:data-[generating=true]:text-violet-400 sm:w-auto sm:px-2"
       >
         <IconSparkles size={16} stroke={1.5} />
-        <span className="hidden sm:inline">Speaker notes</span>
+        <span data-speaker-notes-idle className="hidden sm:inline">
+          Speaker notes
+        </span>
+        <span data-speaker-notes-generating className="hidden">
+          Generating
+          <span aria-hidden="true" className="inline-flex">
+            <span className="speaker-notes-dot-1">.</span>
+            <span className="speaker-notes-dot-2">.</span>
+            <span className="speaker-notes-dot-3">.</span>
+          </span>
+        </span>
       </button>
       <button
         type="button"
@@ -692,6 +703,29 @@ function setEditorActionsDisabled(disabled: boolean) {
   }
 }
 
+function setSpeakerNotesGenerating(generating: boolean) {
+  const action = document.querySelector<HTMLButtonElement>(
+    '[data-presentation-speaker-notes-action="true"]',
+  );
+  if (!action) {
+    return;
+  }
+  const idleLabel = action.querySelector<HTMLElement>(
+    "[data-speaker-notes-idle]",
+  );
+  const generatingLabel = action.querySelector<HTMLElement>(
+    "[data-speaker-notes-generating]",
+  );
+  action.dataset.generating = generating ? "true" : "false";
+  const label = generating
+    ? "Generating speaker notes"
+    : "Generate speaker notes";
+  action.setAttribute("aria-label", label);
+  action.title = label;
+  idleLabel?.classList.toggle("sm:inline", !generating);
+  generatingLabel?.classList.toggle("sm:inline-flex", generating);
+}
+
 function setEditorPublishing(params: {
   readonly busyRef: MutableValue<SVGSVGElement | null>;
   readonly publishing: boolean;
@@ -948,6 +982,7 @@ async function runFillEmptySpeakerNotes(ctx: {
   }
 
   ctx.setPublishing(true);
+  setSpeakerNotesGenerating(true);
   ctx.setStatus("Generating speaker notes");
   const generated = await tapError(
     generatePresentationSpeakerNotes({
@@ -955,6 +990,7 @@ async function runFillEmptySpeakerNotes(ctx: {
       html: ctx.buildEditedHtml(),
       signal: params.pageSignal,
     }).finally(() => {
+      setSpeakerNotesGenerating(false);
       ctx.setPublishing(false);
     }),
     (error) => {
@@ -1174,23 +1210,25 @@ function PresentationEditorCloseDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="zero-app !z-[10000] gap-5 sm:max-w-xs"
+        className="zero-app !z-[10000] gap-5 sm:max-w-md"
         overlayClassName="!z-[10000]"
       >
         <DialogHeader>
-          <DialogTitle>Save changes?</DialogTitle>
+          <DialogTitle className="whitespace-nowrap">
+            Do you want to save your changes?
+          </DialogTitle>
         </DialogHeader>
         <DialogFooter>
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="text-destructive hover:text-destructive"
+            className="h-9 px-4 text-destructive hover:text-destructive"
             onClick={onExit}
           >
-            Exit
+            Discard
           </Button>
-          <Button type="button" size="sm" onClick={onSave}>
+          <Button type="button" size="sm" className="h-9 px-4" onClick={onSave}>
             Save
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary

Closes #21714

- rename the presentation editor action from `Script` to `Speaker notes`, including its tooltip and accessible label
- keep clean closes immediate, but ask users with unsaved changes whether to `Exit` or `Save`
- discard the cached local draft on `Exit` without redeploying, while preserving the existing redeploy-and-close behavior on `Save`
- cover saving, exiting without publishing, draft cleanup, clean close, and the updated speaker-notes action in the page-level test

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `pnpm knip --workspace @vm0/app`

The local dev server was not started, following the vm0 PR verification policy.
