### PR TITLE
test(mitm-addon): cover failed request stream decoding

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -119,6 +119,35 @@ class TestBodyCaptureStreamBuffer:
         assert entry["request_body_encoding"] == "binary"
         assert entry["request_body_truncated"] is True
 
+    @pytest.mark.parametrize(
+        ("complete", "truncated", "expected_truncated"),
+        [
+            pytest.param(True, True, True, id="truncated-buffer"),
+            pytest.param(False, False, True, id="incomplete-stream"),
+            pytest.param(True, False, False, id="complete-malformed-body"),
+        ],
+    )
+    def test_failed_request_stream_decode_preserves_capture_completeness(
+        self, real_flow, complete, truncated, expected_truncated
+    ):
+        body = gzip.compress(b"streamed request body")[:-1]
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            request_encoding="gzip",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, body, complete=complete, truncated=truncated)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+        if expected_truncated:
+            assert entry["request_body_truncated"] is True
+        else:
+            assert "request_body_truncated" not in entry
+
     def test_non_empty_request_stream_buffer_requires_state(self, real_flow):
         body = b'{"ok": true}'
         flow = real_flow(


### PR DESCRIPTION
## Summary

- cover failed gzip decoding on the request stream-buffer path
- verify binary classification for truncated, incomplete, and complete malformed streams
- preserve the distinction between decode failure and capture truncation

## Scope

- test-only change; no runner or mitm-addon runtime behavior changes
- no API, schema, migration, dependency, or deployment compatibility changes

## Validation

- `.venv/bin/python -m pytest tests/test_body_capture_stream_buffer.py -q` — 33 passed
- `.venv/bin/ruff format src scripts tests` — 236 files unchanged
- `.venv/bin/ruff check src scripts tests` — passed
- `.venv/bin/basedpyright` — 0 errors, 0 warnings, 0 notes
- `.venv/bin/python -m pytest -q` — 4005 passed
- pre-commit and commit-message hooks — passed

Closes #21704
