### PR TITLE
ci: reduce rust coverage disk pressure

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -338,6 +338,17 @@ jobs:
           shared-key: coverage
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Report coverage disk usage after cache restore
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          for path in crates/target crates/target/llvm-cov-target; do
+            if [ -e "$path" ]; then
+              du -sh "$path"
+            else
+              echo "$path: not present"
+            fi
+          done
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
@@ -345,6 +356,18 @@ jobs:
         run: |
           cd crates
           cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info
+
+      - name: Report final coverage disk usage
+        if: success() || failure()
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          for path in crates/target crates/target/llvm-cov-target; do
+            if [ -e "$path" ]; then
+              du -sh "$path"
+            else
+              echo "$path: not present"
+            fi
+          done
 
       - name: Upload coverage to Codecov
         if: success() || failure()

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -325,6 +325,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
@@ -335,7 +337,7 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: crates -> target
-          shared-key: coverage
+          shared-key: coverage-line-tables-only
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Report coverage disk usage after cache restore


### PR DESCRIPTION
## Summary

- compile the Rust coverage test profile with line-table-only debug information to reduce artifact size
- isolate the coverage cache key so full-debug artifacts cannot be restored into the optimized job
- report filesystem and Rust target sizes after cache restoration and after coverage completes or fails

The coverage test command, feature and target selection, timeout, Codecov upload, and CI gate are unchanged.

## Measurements

| Head | Cache | After restore | After coverage | Available space |
| --- | --- | --- | --- | --- |
| [`44545960ce`](https://github.com/vm0-ai/vm0/actions/runs/29467686779/job/87524310959) (baseline) | hit, 782 MiB compressed | 2.8 GiB target | 13 GiB target | 83 GiB → 74 GiB |
| [`f2ce98c6fd`](https://github.com/vm0-ai/vm0/actions/runs/29468019655/job/87525329725) (optimized) | cold, isolated namespace | target absent | 5.8 GiB target | 86 GiB → 80 GiB |

The optimized profile reduced the final target directory by approximately 7.2 GiB (55%). It also consumed approximately 6 GiB of runner disk from a cold start, compared with 9 GiB after the warm baseline cache restore. Both heads completed the unchanged full coverage command and uploaded `lcov.info` to Codecov successfully.

The optimized head intentionally uses a new cache namespace, so runtime is not used for the comparison.

## Validation

- `git diff --check`
- parsed `.github/workflows/crates.yml` with PyYAML
- `actionlint .github/workflows/crates.yml`
- executed both diagnostic steps with POSIX `sh`
- `CARGO_PROFILE_TEST_DEBUG=line-tables-only cargo test -p shell-quote --no-run`
- baseline and optimized Crates coverage jobs passed all targets and features and uploaded `lcov.info` to Codecov

Closes #21725
