### PR TITLE
docs(mitm-addon): clarify bounded jsonl shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -119,12 +119,12 @@ def flush_all_logs() -> None:
 def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) -> bool:
     """Stop accepting entries and wait for the writer to process accepted entries.
 
-    The default wait is ``SHUTDOWN_JOIN_TIMEOUT_SECONDS`` (one second), while
-    ``timeout=None`` waits without a deadline. Return ``False`` only when a
-    writer other than the calling thread remains alive after the deadline. In
-    that case, accepted entries may still be pending, and the worker and queued
-    stop marker remain registered so a later call can wait for the same
-    shutdown. Return ``True`` otherwise.
+    When another thread owns the writer, the default wait is
+    ``SHUTDOWN_JOIN_TIMEOUT_SECONDS`` (one second), while ``timeout=None`` waits
+    without a deadline. Return ``False`` only when that writer remains alive
+    after the deadline. In that case, accepted entries may still be pending,
+    and the worker and stop-signal state remain registered so a later call can
+    wait for the same shutdown. Return ``True`` otherwise.
     """
     global _worker, _shutdown, _stop_enqueued
 

--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -117,7 +117,15 @@ def flush_all_logs() -> None:
 
 
 def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) -> bool:
-    """Drain accepted writes and stop the background writer."""
+    """Stop accepting entries and wait for the writer to process accepted entries.
+
+    The default wait is ``SHUTDOWN_JOIN_TIMEOUT_SECONDS`` (one second), while
+    ``timeout=None`` waits without a deadline. Return ``False`` only when a
+    writer other than the calling thread remains alive after the deadline. In
+    that case, accepted entries may still be pending, and the worker and queued
+    stop marker remain registered so a later call can wait for the same
+    shutdown. Return ``True`` otherwise.
+    """
     global _worker, _shutdown, _stop_enqueued
 
     with _condition:

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -57,7 +57,11 @@ def flush_all_logs() -> None:
 
 
 def shutdown_log_writer() -> None:
-    """Drain and stop the JSONL writer."""
+    """Request the default bounded JSONL writer shutdown.
+
+    If the writer times out, it logs a warning and can leave accepted entries
+    pending; this wrapper does not report completion.
+    """
     jsonl_writer.shutdown_writer()
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1399,7 +1399,9 @@ def done():
     usage executor and JSONL writer. Auth.base forwarding does not need to
     finish running work during shutdown, so its worker shutdown stops new
     forwards and best-effort closes active upstream sockets without waiting for
-    slow upstream responses.
+    slow upstream responses. JSONL writer shutdown is also bounded and
+    best-effort; if it times out, process shutdown continues with accepted log
+    entries possibly still pending.
     """
     try:
         runner_flush_lifecycle.drain_and_close()


### PR DESCRIPTION
## Summary

- document the JSONL writer's default one-second shutdown wait, unbounded `timeout=None` behavior, boolean result, and retained state after timeout
- clarify that the logging wrapper and mitmproxy `done()` hook perform bounded, best-effort shutdown rather than guaranteeing a full drain
- preserve the existing timeout, warning, state transitions, function signatures, and cleanup control flow

## Scope

This PR changes docstrings only. It does not change runtime behavior, schemas, persisted data, APIs, runner protocols, queue payloads, or deployment compatibility.

## Validation

- `.venv/bin/ruff format --check src/jsonl_writer.py src/logging_utils.py src/mitm_addon.py`
- `.venv/bin/ruff check src/jsonl_writer.py src/logging_utils.py src/mitm_addon.py`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/pytest tests/test_jsonl_writer.py tests/test_logging_utils.py tests/test_done_hook.py` (56 passed)

Closes #21730
