### PR TITLE
docs(mitm-addon): align request hook classification contract

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -808,8 +808,9 @@ async def request(flow: http.HTTPFlow) -> None:
     `request_classification.classification_for_request()` reuses an intentionally
     cached header-phase classification when present; otherwise it delegates to
     `request_classification.classify_request()`, which owns the canonical decision
-    order. This hook dispatches that result and revalidates firewall allows against
-    the current `publicDestination` before policy allow or credential injection.
+    order. This hook dispatches the result. For firewall allows, it revalidates any
+    `publicDestination` constraint against the current runtime destination before
+    allowing traffic or injecting credentials.
     """
     connector_intent.capture_and_strip(flow)
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -803,13 +803,13 @@ def _unhandled_request_classification(classification: NoReturn) -> NoReturn:
 
 
 async def request(flow: http.HTTPFlow) -> None:
-    """
-    Intercept request: inject firewall auth headers for configured firewall rules.
+    """Dispatch a request-phase classification and apply its outcome.
 
-    Order:
-    1. Registry gate (block unavailable or invalid registered VM state)
-    2. VM0 API auto-allow (agent must always reach the platform)
-    3. Firewall match (inject auth headers for allowed requests)
+    `request_classification.classification_for_request()` reuses an intentionally
+    cached header-phase classification when present; otherwise it delegates to
+    `request_classification.classify_request()`, which owns the canonical decision
+    order. This hook dispatches that result and revalidates firewall allows against
+    the current `publicDestination` before policy allow or credential injection.
     """
     connector_intent.capture_and_strip(flow)
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -124,11 +124,10 @@ async def test_vm0_api_test_paths_skip_auto_allow(
 ):
     """`/api/test/*` routes exist to exercise the firewall pipeline itself.
 
-    If they fell into Step 2's auto-allow fast path, the test-oauth E2E
-    test would never get proxy-injected Authorization headers and the
-    pipeline it's supposed to exercise would be silently bypassed. The
-    carve-out drops these paths into Step 3 so the registered firewall
-    runs `handle_firewall_request`.
+    If they entered the platform API auto-allow fast path, the test-oauth E2E test
+    would never get proxy-injected Authorization headers and the pipeline it's
+    supposed to exercise would be silently bypassed. The carve-out instead lets
+    the registered firewall match and run `handle_firewall_request`.
     """
     reg_path = _write_registry(
         tmp_path,

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -126,8 +126,8 @@ async def test_vm0_api_test_paths_skip_auto_allow(
 
     If they entered the platform API auto-allow fast path, the test-oauth E2E test
     would never get proxy-injected Authorization headers and the pipeline it's
-    supposed to exercise would be silently bypassed. The carve-out instead lets
-    the registered firewall match and run `handle_firewall_request`.
+    supposed to exercise would be silently bypassed. The carve-out instead lets the
+    registered firewall match these paths and run `handle_firewall_request`.
     """
     reg_path = _write_registry(
         tmp_path,


### PR DESCRIPTION
## Summary

- delegate request-decision precedence to the canonical `classify_request()` contract
- document cached header-phase reuse, request dispatch, and `publicDestination` revalidation in the request hook
- replace stale numbered-order references in the `/api/test/*` integration-test explanation

## Scope

- documentation only; no classifier, dispatcher, test behavior, API, data, or deployment contract changes

## Tests

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/ -q` (4002 passed)

Closes #21729
