### PR TITLE
test(nbd-cow): avoid pid 1 ownership assumption

### DIFF
--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -856,12 +856,9 @@ mod tests {
         handle.join().unwrap();
     }
 
-    /// Verify is_our_thread rejects a TID that doesn't belong to our process.
+    /// Verify is_our_thread rejects a TID that cannot exist.
     #[test]
-    fn is_our_thread_foreign_tid() {
-        // PID 1 (init) is never one of our threads.
-        assert!(!is_our_thread(1));
-        // A very large TID that doesn't exist.
+    fn is_our_thread_nonexistent_tid() {
         assert!(!is_our_thread(u32::MAX));
     }
 }


### PR DESCRIPTION
## Summary

- remove the namespace-dependent assertion that PID 1 is always foreign
- retain the impossible-TID negative lookup and rename the test to match that fixture
- leave `is_our_thread` and all production behavior unchanged

## Scope

This changes one inline `nbd-cow` test. It does not change runtime code, public APIs, dependencies, persisted data, schemas, protocols, CI configuration, or deployment behavior.

## Validation

- `cargo test -p nbd-cow device::connection::tests::is_our_thread_nonexistent_tid -- --exact --nocapture`
- `unshare --user --map-root-user --pid --fork --mount-proc target/debug/deps/nbd_cow-aebc41816ab86eb8 device::connection::tests::is_our_thread_nonexistent_tid --exact --nocapture`
- `cargo test -p nbd-cow` (215 passed; 11 existing privileged integration tests ignored by the default harness)
- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --all-targets --all-features`
- `cargo doc -p nbd-cow --all-features --no-deps`
- pre-commit Rust workspace formatting, Clippy, and documentation hooks

Closes #21731
