### PR TITLE
perf(api): move queue-first invalidation off dispatch path

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3526,6 +3526,159 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, runId);
   }, 90_000);
 
+  it("dispatches an idle send while thread-list publication is pending", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const publicationStarted = createDeferredPromise<void>(context.signal);
+    const releasePublication = createDeferredPromise<void>(context.signal);
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "threadListChanged") {
+        if (!publicationStarted.settled()) {
+          publicationStarted.resolve(undefined);
+        }
+        return releasePublication.promise;
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const prompt = "dispatch while thread list publication is pending";
+    const send = chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        prompt,
+        clientMessageId: randomUUID(),
+      },
+      [201],
+    );
+    const sendOutcome = send.then(
+      (value) => {
+        return { ok: true as const, value };
+      },
+      (error: unknown) => {
+        return { ok: false as const, error };
+      },
+    );
+    onTestFinished(async () => {
+      if (!releasePublication.settled()) {
+        releasePublication.resolve(undefined);
+      }
+      await sendOutcome;
+    });
+
+    await publicationStarted.promise;
+    await expect
+      .poll(async () => {
+        const runList = await api.listAgentRuns(actor, {
+          status: "queued,pending,running,completed,failed,timeout,cancelled",
+          limit: 100,
+        });
+        return runList.runs.some((run) => {
+          return run.prompt === prompt;
+        });
+      })
+      .toBe(true);
+    expect(releasePublication.settled()).toBeFalsy();
+
+    releasePublication.resolve(undefined);
+    const outcome = await sendOutcome;
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    const sent = outcome.value;
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected the pending publication not to gate dispatch");
+    }
+    await waitForRunUserMessage(
+      actor,
+      sent.body.threadId,
+      sent.body.runId,
+      prompt,
+    );
+
+    const threadListPublishes = context.mocks.ably.publish.mock.calls.filter(
+      ([topic]) => {
+        return topic === "threadListChanged";
+      },
+    );
+    expect(threadListPublishes).toHaveLength(1);
+    await cancelChatRun(actor, sent.body.runId);
+  }, 90_000);
+
+  it("keeps a queued send drainable when thread-list publication fails", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "thread list publication failure anchor",
+    });
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some(([topic]) => {
+          return topic === "threadListChanged";
+        });
+      })
+      .toBe(true);
+    context.mocks.ably.publish.mockClear();
+
+    let failedThreadListPublish = false;
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "threadListChanged" && !failedThreadListPublish) {
+        failedThreadListPublish = true;
+        return Promise.reject(new Error("thread list publication failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const queuedMessageId = randomUUID();
+    const queuedBody = {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "queued send survives thread list publication failure",
+      clientMessageId: queuedMessageId,
+    };
+    const queued = await chat.requestSendMessage(actor, queuedBody, [201]);
+    expect(queued.body).toMatchObject({
+      runId: null,
+      threadId: anchor.threadId,
+    });
+    expect(failedThreadListPublish).toBeTruthy();
+
+    const retried = await chat.requestSendMessage(actor, queuedBody, [201]);
+    expect(retried.body).toMatchObject({
+      runId: null,
+      threadId: anchor.threadId,
+    });
+    const threadListPublishes = context.mocks.ably.publish.mock.calls.filter(
+      ([topic]) => {
+        return topic === "threadListChanged";
+      },
+    );
+    expect(threadListPublishes).toHaveLength(1);
+
+    await cancelChatRun(actor, anchor.runId);
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.id === queuedMessageId && typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const promoted = userMessages(messages.messages).find((message) => {
+      return message.id === queuedMessageId;
+    });
+    if (!promoted?.runId) {
+      throw new Error("Expected the queued message to remain drainable");
+    }
+    await cancelChatRun(actor, promoted.runId);
+  }, 90_000);
+
   it("serializes a terminal drain against an idle queue-first send", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3552,11 +3552,14 @@ describe("CHAT-02: shared user message queue", () => {
       },
       [201],
     );
+    let sendSettled = false;
     const sendOutcome = send.then(
       (value) => {
+        sendSettled = true;
         return { ok: true as const, value };
       },
       (error: unknown) => {
+        sendSettled = true;
         return { ok: false as const, error };
       },
     );
@@ -3569,19 +3572,11 @@ describe("CHAT-02: shared user message queue", () => {
 
     await publicationStarted.promise;
     await expect
-      .poll(async () => {
-        const runList = await api.listAgentRuns(actor, {
-          status: "queued,pending,running,completed,failed,timeout,cancelled",
-          limit: 100,
-        });
-        return runList.runs.some((run) => {
-          return run.prompt === prompt;
-        });
+      .poll(() => {
+        return sendSettled;
       })
-      .toBe(true);
+      .toBeTruthy();
     expect(releasePublication.settled()).toBeFalsy();
-
-    releasePublication.resolve(undefined);
     const outcome = await sendOutcome;
     if (!outcome.ok) {
       throw outcome.error;
@@ -3597,12 +3592,25 @@ describe("CHAT-02: shared user message queue", () => {
       prompt,
     );
 
+    await expect
+      .poll(async () => {
+        const runList = await api.listAgentRuns(actor, {
+          status: "queued,pending,running,completed,failed,timeout,cancelled",
+          limit: 100,
+        });
+        return runList.runs.some((run) => {
+          return run.prompt === prompt;
+        });
+      })
+      .toBe(true);
+
     const threadListPublishes = context.mocks.ably.publish.mock.calls.filter(
       ([topic]) => {
         return topic === "threadListChanged";
       },
     );
     expect(threadListPublishes).toHaveLength(1);
+    releasePublication.resolve(undefined);
     await cancelChatRun(actor, sent.body.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -57,6 +57,7 @@ import {
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
+import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
 import {
   createZeroRun$,
@@ -106,12 +107,14 @@ import {
 import { appendChatThreadEvent } from "../services/zero-chat-thread-event.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { shouldStartNewChatSession } from "../services/chat-session-continuity.service";
-import { bestEffort } from "../utils";
+import { bestEffort, tapError } from "../utils";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { RouteEntry } from "../route-entry";
 import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
 import { resolveThreadGenerationTemplatePrompt } from "./thread-generation-template";
+
+const L = logger("ZeroChatMessages");
 
 type SendBody = z.infer<typeof chatMessagesContract.send.body>;
 
@@ -2426,7 +2429,15 @@ async function queueUnassociatedNormalMessage(params: {
     orgId: params.orgId,
   });
   if (message.kind === "queued" && message.inserted) {
-    await publishThreadListChanged(params.userId);
+    waitUntil(
+      tapError(publishThreadListChanged(params.userId), (error) => {
+        L.warn("Failed to publish queue-first thread list changed signal", {
+          userId: params.userId,
+          chatThreadId: params.prepared.thread.threadId,
+          error,
+        });
+      }),
+    );
   }
   const response = clientMessageIdResolutionResponse(
     message,


### PR DESCRIPTION
## Summary

- schedule queue-first thread-list invalidation with API `waitUntil` after the durable enqueue commits
- log and settle Ably publication failures so they cannot block queue arbitration or run creation
- cover delayed and failed publication through the public chat route

## Compatibility

- no schema, migration, persisted-data, API, queue-payload, runner, or frontend contract changes
- other thread-list mutation routes keep their existing synchronous publication semantics

## Validation

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "thread-list publication" --maxWorkers=1 --silent=passed-only` (2 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts --maxWorkers=1 --silent=passed-only` (37 passed)
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (164 files, 2271 tests passed)
- pre-commit repository formatting, Knip, and type checks

Closes #21721

Parent: #21674
