### PR TITLE
fix(runner): fail closed on incomplete image gc scans

### DIFF
--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -7,7 +7,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
 use super::lock_file::{LockProbe, probe_lock};
 use super::report::{GcReport, human_bytes};
 
@@ -42,7 +42,7 @@ pub(super) async fn gc_debootstrap(
     };
 
     let mut files: Vec<DeBootstrapCacheFile> = Vec::new();
-    while let Some(entry) = next_entry_warn(&mut entries, "gc_debootstrap", &dir).await {
+    while let Some(entry) = next_entry_warn_or_stop(&mut entries, "gc_debootstrap", &dir).await {
         let path = entry.path();
         let meta = match tokio::fs::metadata(&path).await {
             Ok(m) => m,

--- a/crates/runner/src/cmd/gc/filesystem.rs
+++ b/crates/runner/src/cmd/gc/filesystem.rs
@@ -6,22 +6,73 @@ use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
 
-/// Like `next_entry()`, but logs a warning and returns `None` on I/O error
-/// instead of propagating — suitable for best-effort scans like GC.
-///
-/// Returning `None` terminates a `while let Some(entry)` loop, so an error
-/// stops iteration for the current directory (remaining entries are skipped).
+fn warn_next_entry_error(label: &str, dir: &Path, error: &std::io::Error) {
+    warn!("{label}: read entry in {}: {error}", dir.display());
+}
+
+/// Like `next_entry()`, but logs an I/O error before returning it.
 pub(super) async fn next_entry_warn(
     entries: &mut tokio::fs::ReadDir,
     label: &str,
     dir: &Path,
-) -> Option<tokio::fs::DirEntry> {
+) -> std::io::Result<Option<tokio::fs::DirEntry>> {
     match entries.next_entry().await {
-        Ok(entry) => entry,
-        Err(e) => {
-            warn!("{label}: read entry in {}: {e}", dir.display());
-            None
+        Ok(entry) => Ok(entry),
+        Err(error) => {
+            warn_next_entry_error(label, dir, &error);
+            Err(error)
         }
+    }
+}
+
+/// Stop a best-effort directory scan after logging an I/O error.
+pub(super) async fn next_entry_warn_or_stop(
+    entries: &mut tokio::fs::ReadDir,
+    label: &str,
+    dir: &Path,
+) -> Option<tokio::fs::DirEntry> {
+    next_entry_warn(entries, label, dir).await.ok().flatten()
+}
+
+/// Stateful directory reader for GC scans whose completeness authorizes deletion.
+pub(super) struct GcDirEntryReader {
+    #[cfg(test)]
+    entries_before_error: Option<usize>,
+}
+
+impl GcDirEntryReader {
+    pub(super) const fn new() -> Self {
+        Self {
+            #[cfg(test)]
+            entries_before_error: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) const fn failing_after(successful_entries: usize) -> Self {
+        Self {
+            entries_before_error: Some(successful_entries),
+        }
+    }
+
+    pub(super) async fn next_entry_warn(
+        &mut self,
+        entries: &mut tokio::fs::ReadDir,
+        label: &str,
+        dir: &Path,
+    ) -> std::io::Result<Option<tokio::fs::DirEntry>> {
+        #[cfg(test)]
+        if let Some(remaining) = &mut self.entries_before_error {
+            if *remaining == 0 {
+                self.entries_before_error = None;
+                let error = std::io::Error::other("injected directory iteration failure");
+                warn_next_entry_error(label, dir, &error);
+                return Err(error);
+            }
+            *remaining -= 1;
+        }
+
+        next_entry_warn(entries, label, dir).await
     }
 }
 
@@ -93,7 +144,7 @@ pub(super) async fn dir_stats(dir: &Path) -> (u64, SystemTime) {
                 continue;
             }
         };
-        while let Some(entry) = next_entry_warn(&mut entries, "dir_stats", &current).await {
+        while let Some(entry) = next_entry_warn_or_stop(&mut entries, "dir_stats", &current).await {
             let path = entry.path();
             let Ok(meta) = tokio::fs::symlink_metadata(&path).await else {
                 tracing::debug!("dir_stats: cannot stat {}", entry.path().display());

--- a/crates/runner/src/cmd/gc/image_refs.rs
+++ b/crates/runner/src/cmd/gc/image_refs.rs
@@ -8,10 +8,44 @@ use crate::config;
 use crate::image_hash;
 use crate::paths::HomePaths;
 
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{GcDirEntryReader, read_dir_or_missing};
 use super::versions::VersionGcAnalysis;
 
-pub(super) type ProtectedImageRefs = HashMap<String, HashSet<String>>;
+type ProtectedImageRefMap = HashMap<String, HashSet<String>>;
+
+pub(super) enum ProtectedImageRefs {
+    Complete(ProtectedImageRefMap),
+    Incomplete,
+}
+
+impl ProtectedImageRefs {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) const fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete(_))
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        match self {
+            Self::Complete(refs) => refs.is_empty(),
+            Self::Incomplete => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) const fn incomplete() -> Self {
+        Self::Incomplete
+    }
+}
+
+impl Default for ProtectedImageRefs {
+    fn default() -> Self {
+        Self::Complete(HashMap::new())
+    }
+}
 
 #[derive(serde::Deserialize)]
 struct ConfigImageRefs {
@@ -29,10 +63,9 @@ fn insert_protected_image_ref(
     rootfs_hash: String,
     snapshot_hash: String,
 ) {
-    protected_image_refs
-        .entry(rootfs_hash)
-        .or_default()
-        .insert(snapshot_hash);
+    if let ProtectedImageRefs::Complete(refs) = protected_image_refs {
+        refs.entry(rootfs_hash).or_default().insert(snapshot_hash);
+    }
 }
 
 pub(super) fn is_protected_image_ref(
@@ -40,18 +73,30 @@ pub(super) fn is_protected_image_ref(
     rootfs_hash: &str,
     snapshot_hash: &str,
 ) -> bool {
-    protected_image_refs
-        .get(rootfs_hash)
-        .is_some_and(|snapshot_hashes| snapshot_hashes.contains(snapshot_hash))
+    match protected_image_refs {
+        ProtectedImageRefs::Complete(refs) => refs
+            .get(rootfs_hash)
+            .is_some_and(|snapshot_hashes| snapshot_hashes.contains(snapshot_hash)),
+        // Preserve fail-closed behavior if a future caller checks a pair
+        // without first rejecting the incomplete inventory.
+        ProtectedImageRefs::Incomplete => true,
+    }
 }
 
 pub(super) async fn protected_image_refs_for_gc(
     home: &HomePaths,
     version_analysis: &VersionGcAnalysis,
 ) -> ProtectedImageRefs {
+    if !version_analysis.directory_scan_complete() {
+        warn!("runner image refs: version directory scan incomplete, skipping image GC");
+        return ProtectedImageRefs::Incomplete;
+    }
+
     let mut refs = ProtectedImageRefs::new();
     collect_retained_version_image_refs(home, version_analysis, &mut refs).await;
-    collect_enabled_service_image_refs(&mut refs).await;
+    if !collect_enabled_service_image_refs(&mut refs).await {
+        return ProtectedImageRefs::Incomplete;
+    }
     refs
 }
 
@@ -66,13 +111,28 @@ async fn collect_retained_version_image_refs(
     }
 }
 
-async fn collect_enabled_service_image_refs(refs: &mut ProtectedImageRefs) {
-    for config_path in enabled_runner_service_config_paths(Path::new("/etc/systemd/system")).await {
+async fn collect_enabled_service_image_refs(refs: &mut ProtectedImageRefs) -> bool {
+    let scan = enabled_runner_service_config_paths(Path::new("/etc/systemd/system")).await;
+    for config_path in scan.paths {
         collect_config_image_refs(&config_path, "enabled service", refs).await;
     }
+    scan.directory_scan_complete
 }
 
-async fn enabled_runner_service_config_paths(system_dir: &Path) -> Vec<PathBuf> {
+struct EnabledRunnerServiceConfigPaths {
+    paths: Vec<PathBuf>,
+    directory_scan_complete: bool,
+}
+
+async fn enabled_runner_service_config_paths(system_dir: &Path) -> EnabledRunnerServiceConfigPaths {
+    let mut entry_reader = GcDirEntryReader::new();
+    enabled_runner_service_config_paths_with_reader(system_dir, &mut entry_reader).await
+}
+
+async fn enabled_runner_service_config_paths_with_reader(
+    system_dir: &Path,
+    entry_reader: &mut GcDirEntryReader,
+) -> EnabledRunnerServiceConfigPaths {
     let Some(mut entries) = (match read_dir_or_missing(system_dir).await {
         Ok(entries) => entries,
         Err(e) => {
@@ -80,16 +140,32 @@ async fn enabled_runner_service_config_paths(system_dir: &Path) -> Vec<PathBuf> 
                 "runner service image refs: cannot read {} ({e}), skipping service-derived refs",
                 system_dir.display()
             );
-            return Vec::new();
+            return EnabledRunnerServiceConfigPaths {
+                paths: Vec::new(),
+                directory_scan_complete: false,
+            };
         }
     }) else {
-        return Vec::new();
+        return EnabledRunnerServiceConfigPaths {
+            paths: Vec::new(),
+            directory_scan_complete: true,
+        };
     };
 
     let mut paths = Vec::new();
-    while let Some(entry) =
-        next_entry_warn(&mut entries, "runner_service_config_refs", system_dir).await
-    {
+    let mut directory_scan_complete = true;
+    loop {
+        let entry = match entry_reader
+            .next_entry_warn(&mut entries, "runner_service_config_refs", system_dir)
+            .await
+        {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(_) => {
+                directory_scan_complete = false;
+                break;
+            }
+        };
         let file_name = entry.file_name();
         let Some(file_name) = file_name.to_str() else {
             continue;
@@ -117,7 +193,10 @@ async fn enabled_runner_service_config_paths(system_dir: &Path) -> Vec<PathBuf> 
         };
         paths.push(config_path);
     }
-    paths
+    EnabledRunnerServiceConfigPaths {
+        paths,
+        directory_scan_complete,
+    }
 }
 
 fn runner_service_unit_from_file_name(file_name: &str) -> Option<service::RunnerServiceUnit> {

--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::cmd::gc::GC_MIN_AGE;
 use crate::cmd::gc::images::gc_nested_images_with_protected_refs;
 use crate::cmd::gc::test_support::{old_gc_time, set_mtime, test_home};
-use crate::cmd::gc::versions::analyze_version_gc;
+use crate::cmd::gc::versions::{analyze_version_gc, analyze_version_gc_with_injected_scan_error};
 
 fn age_version_past_gc_min_age(home: &HomePaths, name: &str) {
     let old_time = SystemTime::now() - Duration::from_secs(GC_MIN_AGE.as_secs() + 60);
@@ -312,4 +312,56 @@ fn runner_service_unit_from_file_name_accepts_only_runner_services() {
     assert!(runner_service_unit_from_file_name("other-v1.0.0.service").is_none());
     assert!(runner_service_unit_from_file_name("vm0-runner-v1.0.0.timer").is_none());
     assert!(runner_service_unit_from_file_name("vm0-runner-.service").is_none());
+}
+
+#[tokio::test]
+async fn enabled_service_directory_scan_reports_iteration_error() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("unrelated-a.service"), "").unwrap();
+    std::fs::write(dir.path().join("unrelated-b.service"), "").unwrap();
+    let mut entry_reader = GcDirEntryReader::failing_after(1);
+
+    let scan = enabled_runner_service_config_paths_with_reader(dir.path(), &mut entry_reader).await;
+
+    assert!(!scan.directory_scan_complete);
+    assert!(scan.paths.is_empty());
+}
+
+#[tokio::test]
+async fn incomplete_version_scan_makes_protection_inventory_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    for version in ["v1.0.0", "v2.0.0"] {
+        std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+    }
+    let analysis = analyze_version_gc_with_injected_scan_error(&home, None, None, 1)
+        .await
+        .unwrap();
+
+    let refs = protected_image_refs_for_gc(&home, &analysis).await;
+
+    assert!(!refs.is_complete());
+}
+
+#[tokio::test]
+async fn incomplete_protection_inventory_skips_image_gc() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let rootfs_hash = test_hash('a');
+    let snapshot_hash = test_hash('b');
+    let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+
+    let report = gc_nested_images_with_protected_refs(
+        &home,
+        Some(0),
+        false,
+        &ProtectedImageRefs::incomplete(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.freed_bytes, 0);
+    assert_eq!(report.activity_count, 0);
+    assert!(snapshot_dir.exists());
+    assert!(home.images_dir().join(rootfs_hash).exists());
 }

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -9,8 +9,8 @@ use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
 use super::filesystem::{
-    GcDirStatus, dir_stats, gc_entry_is_real_dir, gc_path_dir_status, next_entry_warn,
-    read_dir_or_missing,
+    GcDirEntryReader, GcDirStatus, dir_stats, gc_entry_is_real_dir, gc_path_dir_status,
+    next_entry_warn_or_stop, read_dir_or_missing,
 };
 use super::image_refs::{ProtectedImageRefs, is_protected_image_ref};
 use super::lock_file::{LockProbe, probe_lock};
@@ -211,6 +211,29 @@ pub(super) async fn gc_nested_images_with_protected_refs(
     dry_run: bool,
     protected_image_refs: &ProtectedImageRefs,
 ) -> RunnerResult<GcReport> {
+    let mut snapshot_entry_reader = GcDirEntryReader::new();
+    gc_nested_images_with_protected_refs_and_reader(
+        home,
+        keep_latest,
+        dry_run,
+        protected_image_refs,
+        &mut snapshot_entry_reader,
+    )
+    .await
+}
+
+async fn gc_nested_images_with_protected_refs_and_reader(
+    home: &HomePaths,
+    keep_latest: Option<usize>,
+    dry_run: bool,
+    protected_image_refs: &ProtectedImageRefs,
+    snapshot_entry_reader: &mut GcDirEntryReader,
+) -> RunnerResult<GcReport> {
+    if !protected_image_refs.is_complete() {
+        warn!("image protection inventory incomplete, skipping image GC");
+        return Ok(GcReport::default());
+    }
+
     let images_dir = home.images_dir();
     let Some(mut rootfs_entries) = read_dir_or_missing(&images_dir).await? else {
         return Ok(GcReport::default());
@@ -221,7 +244,8 @@ pub(super) async fn gc_nested_images_with_protected_refs(
     let mut candidates: Vec<GcCandidate> = Vec::new();
 
     // Phase 1: walk all rootfs, collect candidates across the entire images tree.
-    while let Some(rootfs_entry) = next_entry_warn(&mut rootfs_entries, "images", &images_dir).await
+    while let Some(rootfs_entry) =
+        next_entry_warn_or_stop(&mut rootfs_entries, "images", &images_dir).await
     {
         let rootfs_path = rootfs_entry.path();
         let Some(rootfs_hash) = rootfs_path
@@ -305,9 +329,20 @@ pub(super) async fn gc_nested_images_with_protected_refs(
             any_snapshot_survives: false,
         });
 
-        while let Some(snap_entry) =
-            next_entry_warn(&mut snapshot_entries, "snapshots", &snapshots_dir).await
-        {
+        let candidate_checkpoint = candidates.len();
+        loop {
+            let snap_entry = match snapshot_entry_reader
+                .next_entry_warn(&mut snapshot_entries, "snapshots", &snapshots_dir)
+                .await
+            {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(_) => {
+                    candidates.truncate(candidate_checkpoint);
+                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
+                    break;
+                }
+            };
             let snap_path = snap_entry.path();
             let Some(snap_hash) = snap_path
                 .file_name()
@@ -456,6 +491,25 @@ pub(super) async fn gc_nested_images_with_protected_refs(
     }
 
     Ok(report)
+}
+
+#[cfg(test)]
+async fn gc_nested_images_with_injected_snapshot_scan_error(
+    home: &HomePaths,
+    keep_latest: Option<usize>,
+    dry_run: bool,
+    protected_image_refs: &ProtectedImageRefs,
+    successful_entries: usize,
+) -> RunnerResult<GcReport> {
+    let mut snapshot_entry_reader = GcDirEntryReader::failing_after(successful_entries);
+    gc_nested_images_with_protected_refs_and_reader(
+        home,
+        keep_latest,
+        dry_run,
+        protected_image_refs,
+        &mut snapshot_entry_reader,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -6,6 +6,58 @@ use super::*;
 use crate::cmd::gc::test_support::{assert_is_symlink, old_gc_time, set_mtime, test_home};
 use crate::lock;
 
+async fn assert_incomplete_snapshot_scan_keeps_rootfs(dry_run: bool) {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let rootfs_dir = home.images_dir().join("rootfs_incomplete_scan");
+    let snapshots_dir = rootfs_dir.join("snapshots");
+    let snapshot_dirs = [
+        snapshots_dir.join("snapshot_a"),
+        snapshots_dir.join("snapshot_b"),
+    ];
+    for snapshot_dir in &snapshot_dirs {
+        std::fs::create_dir_all(snapshot_dir).unwrap();
+        std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+        set_mtime(snapshot_dir, old_gc_time());
+    }
+    std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+    set_mtime(&rootfs_dir, old_gc_time());
+
+    let report = gc_nested_images_with_injected_snapshot_scan_error(
+        &home,
+        Some(0),
+        dry_run,
+        &ProtectedImageRefs::new(),
+        1,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report, GcReport::default());
+    assert!(
+        rootfs_dir.exists(),
+        "an incompletely scanned rootfs must survive"
+    );
+    for snapshot_dir in snapshot_dirs {
+        assert!(
+            snapshot_dir.exists(),
+            "all snapshots must survive an incomplete directory scan"
+        );
+    }
+}
+
+#[tokio::test]
+async fn gc_nested_images_fails_closed_after_snapshot_scan_error() {
+    assert_incomplete_snapshot_scan_keeps_rootfs(false).await;
+}
+
+#[tokio::test]
+async fn gc_nested_images_dry_run_ignores_incomplete_snapshot_scan() {
+    assert_incomplete_snapshot_scan_keeps_rootfs(true).await;
+}
+
 #[tokio::test]
 async fn gc_nested_images_empty_dir_returns_zero() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/cmd/gc/job_logs.rs
+++ b/crates/runner/src/cmd/gc/job_logs.rs
@@ -6,7 +6,7 @@ use tracing::{info, warn};
 use crate::error::RunnerResult;
 use crate::paths::{HomePaths, LogPaths};
 
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
 use super::report::{GcReport, human_bytes};
 
 /// Per-job log files older than this are eligible for GC.
@@ -27,7 +27,7 @@ pub(super) async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult
     let mut removed = 0u64;
     let mut freed = 0u64;
 
-    while let Some(entry) = next_entry_warn(&mut entries, "gc_job_logs", &logs_dir).await {
+    while let Some(entry) = next_entry_warn_or_stop(&mut entries, "gc_job_logs", &logs_dir).await {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
 

--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -1,7 +1,7 @@
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
 use super::lock_file::{LockProbe, probe_lock, remove_unused_lock_after_probe};
 use super::report::GcReport;
 use super::workspaces::is_base_dir_lock_name;
@@ -22,7 +22,9 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
 
     let mut removed = 0u64;
 
-    while let Some(entry) = next_entry_warn(&mut entries, "gc_orphaned_locks", &locks_dir).await {
+    while let Some(entry) =
+        next_entry_warn_or_stop(&mut entries, "gc_orphaned_locks", &locks_dir).await
+    {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
         if !name.ends_with(".lock") {

--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -10,7 +10,7 @@ use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
 use super::filesystem::{
-    GcDirStatus, dir_stats, gc_entry_is_real_dir, gc_path_dir_status, next_entry_warn,
+    GcDirStatus, dir_stats, gc_entry_is_real_dir, gc_path_dir_status, next_entry_warn_or_stop,
     read_dir_or_missing,
 };
 use super::lock_file::{LockProbe, probe_lock};
@@ -124,7 +124,7 @@ async fn gc_storage_cache_with_limits_report(
     let mut evicted_entries: u64 = 0;
 
     while let Some(name_entry) =
-        next_entry_warn(&mut name_entries, "gc_storage_cache", &storages_dir).await
+        next_entry_warn_or_stop(&mut name_entries, "gc_storage_cache", &storages_dir).await
     {
         let name_path = name_entry.path();
         let Some(name_str) = name_path.file_name().and_then(|n| n.to_str()) else {
@@ -148,7 +148,7 @@ async fn gc_storage_cache_with_limits_report(
         };
 
         while let Some(version_entry) =
-            next_entry_warn(&mut version_entries, "gc_storage_cache", &name_path).await
+            next_entry_warn_or_stop(&mut version_entries, "gc_storage_cache", &name_path).await
         {
             let version_path = version_entry.path();
             let Some(version_str) = version_path.file_name().and_then(|n| n.to_str()) else {

--- a/crates/runner/src/cmd/gc/version_service_locks.rs
+++ b/crates/runner/src/cmd/gc/version_service_locks.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
 use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_lock_after_probe};
 use super::report::GcReport;
 use super::versions::parse_semver;
@@ -39,7 +39,7 @@ pub(super) async fn gc_orphaned_version_service_locks(
     let mut removed = 0u64;
     let bin_dir = home.bin_dir();
 
-    while let Some(entry) = next_entry_warn(
+    while let Some(entry) = next_entry_warn_or_stop(
         &mut entries,
         "gc_orphaned_version_service_locks",
         &locks_dir,

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -176,6 +176,7 @@ async fn analyze_version_gc_with_reader(
         let file_type = match entry.file_type().await {
             Ok(file_type) => file_type,
             Err(e) => {
+                directory_scan_complete = false;
                 warn!(
                     "version entry {}: cannot read file type ({e}), skipping",
                     entry.path().display()

--- a/crates/runner/src/cmd/gc/versions.rs
+++ b/crates/runner/src/cmd/gc/versions.rs
@@ -15,7 +15,7 @@ use crate::lock;
 use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
-use super::filesystem::{next_entry_warn, read_dir_or_missing};
+use super::filesystem::{GcDirEntryReader, read_dir_or_missing};
 use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_lock_after_probe};
 use super::report::GcReport;
 
@@ -117,6 +117,7 @@ struct VersionGcEntry {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) struct VersionGcAnalysis {
     entries: Vec<VersionGcEntry>,
+    directory_scan_complete: bool,
 }
 
 impl VersionGcAnalysis {
@@ -126,6 +127,10 @@ impl VersionGcAnalysis {
             .filter(|entry| entry.retained.is_some())
             .map(|entry| entry.name.as_str())
     }
+
+    pub(super) const fn directory_scan_complete(&self) -> bool {
+        self.directory_scan_complete
+    }
 }
 
 pub(super) async fn analyze_version_gc(
@@ -133,10 +138,21 @@ pub(super) async fn analyze_version_gc(
     protect: Option<&str>,
     keep_latest: Option<usize>,
 ) -> RunnerResult<VersionGcAnalysis> {
+    let mut entry_reader = GcDirEntryReader::new();
+    analyze_version_gc_with_reader(home, protect, keep_latest, &mut entry_reader).await
+}
+
+async fn analyze_version_gc_with_reader(
+    home: &HomePaths,
+    protect: Option<&str>,
+    keep_latest: Option<usize>,
+    entry_reader: &mut GcDirEntryReader,
+) -> RunnerResult<VersionGcAnalysis> {
     let bin_dir = home.bin_dir();
     let Some(mut entries) = read_dir_or_missing(&bin_dir).await? else {
         return Ok(VersionGcAnalysis {
             entries: Vec::new(),
+            directory_scan_complete: true,
         });
     };
 
@@ -144,7 +160,19 @@ pub(super) async fn analyze_version_gc(
     // pick the top `keep_latest` by version, so we can't decide-and-delete
     // in one pass.
     let mut semver_dirs: Vec<(String, (u32, u32, u32))> = Vec::new();
-    while let Some(entry) = next_entry_warn(&mut entries, "gc_versions", &bin_dir).await {
+    let mut directory_scan_complete = true;
+    loop {
+        let entry = match entry_reader
+            .next_entry_warn(&mut entries, "gc_versions", &bin_dir)
+            .await
+        {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(_) => {
+                directory_scan_complete = false;
+                break;
+            }
+        };
         let file_type = match entry.file_type().await {
             Ok(file_type) => file_type,
             Err(e) => {
@@ -190,7 +218,21 @@ pub(super) async fn analyze_version_gc(
         });
     }
 
-    Ok(VersionGcAnalysis { entries })
+    Ok(VersionGcAnalysis {
+        entries,
+        directory_scan_complete,
+    })
+}
+
+#[cfg(test)]
+pub(super) async fn analyze_version_gc_with_injected_scan_error(
+    home: &HomePaths,
+    protect: Option<&str>,
+    keep_latest: Option<usize>,
+    successful_entries: usize,
+) -> RunnerResult<VersionGcAnalysis> {
+    let mut entry_reader = GcDirEntryReader::failing_after(successful_entries);
+    analyze_version_gc_with_reader(home, protect, keep_latest, &mut entry_reader).await
 }
 
 async fn version_retention_reason(

--- a/crates/runner/src/cmd/gc/versions/tests.rs
+++ b/crates/runner/src/cmd/gc/versions/tests.rs
@@ -60,6 +60,42 @@ fn parse_semver_orders_numerically() {
 }
 
 #[tokio::test]
+async fn analyze_version_gc_marks_partial_directory_scan_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    let versions = ["v1.0.0", "v2.0.0", "v3.0.0"];
+    for version in versions {
+        std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+    }
+    age_versions_past_gc_min_age(&home, &versions);
+
+    let analysis = analyze_version_gc_with_injected_scan_error(&home, None, None, 1)
+        .await
+        .unwrap();
+
+    assert!(!analysis.directory_scan_complete());
+    assert_eq!(analysis.entries.len(), 1);
+
+    let removed = gc_versions_with_analysis_and_uninstall(
+        &home,
+        false,
+        analysis,
+        successful_fake_uninstall_service_unit,
+    )
+    .await
+    .unwrap();
+    assert_eq!(removed.len(), 1);
+    assert_eq!(
+        versions
+            .into_iter()
+            .filter(|version| home.bin_dir().join(version).exists())
+            .count(),
+        2,
+        "versions omitted by the interrupted scan must remain untouched"
+    );
+}
+
+#[tokio::test]
 async fn gc_versions_removes_inactive_semver_dirs() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());


### PR DESCRIPTION
## Summary

- preserve directory iteration errors so safety-critical GC inventories can distinguish failure from EOF
- discard snapshot deletion candidates for a rootfs when its snapshot scan is incomplete
- skip image GC when retained-version or enabled-service protection inventories are incomplete
- keep explicitly best-effort GC scans unchanged and add deterministic scan-failure coverage

## Scope

- preserves existing handling for individual invalid service states, configs, and image hashes
- version cleanup may continue for entries discovered before an interrupted version scan; unvisited versions remain untouched
- no API, protocol, schema, migration, dependency, or deployment compatibility changes

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy -p runner --all-targets --all-features` — passed
- `cargo doc -p runner --all-features --no-deps` — passed
- `cargo test -p runner cmd::gc` — 173 passed, 1 ignored
- `cargo test -p runner --quiet` — 2705 passed, 10 ignored; integration test passed
- pre-commit and commit-message hooks — passed

Closes #21732
