### PR TITLE
fix(mitm-addon): validate empty zlib tails at decode limit

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -389,22 +389,22 @@ def _decompress_zlib_json_usage_body(
     out = bytearray()
 
     while remaining_data:
-        if len(out) >= max_output:
-            return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
-
+        remaining_output = max_output - len(out)
+        # One probe byte distinguishes exact completion from real overflow.
         obj = zlib.decompressobj(wbits)
         try:
-            decoded = obj.decompress(remaining_data, max_length=max_output - len(out))
+            decoded = obj.decompress(remaining_data, max_length=remaining_output + 1)
         except zlib.error as exc:
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
             return b"", INVALID_COMPRESSED_BODY
 
+        if len(decoded) > remaining_output:
+            out.extend(decoded[:remaining_output])
+            return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
         out.extend(decoded)
         if not obj.eof:
-            if len(out) >= max_output:
-                return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
             return bytes(out), INCOMPLETE_COMPRESSED_BODY
         if not obj.unused_data:
             return bytes(out), None

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -483,6 +483,68 @@ class TestDecodeRequestBodyForNetworkLogCapture:
 class TestDecompressJsonUsageBody:
     """Direct tests for strict JSON usage decompression."""
 
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_exact_limit_accepts_empty_trailing_members(self, headers, encoding):
+        body = b"A" * 32
+        compressed = (
+            _compress_one_shot_body(encoding, body)
+            + _compress_one_shot_body(encoding, b"")
+            + _compress_one_shot_body(encoding, b"")
+        )
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=len(body))
+
+        assert decoded == body
+        assert error is None
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_exact_limit_rejects_nonempty_trailing_member(self, headers, encoding):
+        body = b"A" * 32
+        compressed = (
+            _compress_one_shot_body(encoding, body)
+            + _compress_one_shot_body(encoding, b"")
+            + _compress_one_shot_body(encoding, b"B")
+        )
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=len(body))
+
+        assert decoded == body
+        assert error == "decoded body limit exceeded"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_exact_limit_classifies_invalid_trailing_data(self, headers, encoding):
+        body = b"A" * 32
+        compressed = _compress_one_shot_body(encoding, body) + b"not compressed"
+        hdrs = headers(("Content-Encoding", encoding))
+
+        _decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=len(body))
+
+        assert error == "invalid compressed body"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_exact_limit_classifies_incomplete_trailing_member(self, headers, encoding):
+        body = b"A" * 32
+        trailing_member = _compress_one_shot_body(encoding, b"")
+        compressed = _compress_one_shot_body(encoding, body) + trailing_member[:-1]
+        hdrs = headers(("Content-Encoding", encoding))
+
+        _decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=len(body))
+
+        assert error == "incomplete compressed body"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_single_member_exceeding_limit_returns_error(self, headers, encoding):
+        body = b"A" * 33
+        compressed = _compress_one_shot_body(encoding, body)
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=32)
+
+        assert decoded == body[:32]
+        assert error == "decoded body limit exceeded"
+
     def test_zstd_valid_single_frame_returns_decoded_body(self, headers):
         body = b'{"usage":{"input_tokens":1}}'
         compressed = zstandard.ZstdCompressor().compress(body)


### PR DESCRIPTION
## Summary

- validate concatenated gzip and deflate members after decoded output reaches the exact limit
- use one bounded probe byte to distinguish exact completion from real overflow
- preserve invalid and incomplete trailing-member classifications
- cover empty, non-empty, invalid, incomplete, and same-member limit boundaries for both codecs

## Behavior

Strict JSON usage decoding now accepts an exact-limit body when every remaining gzip/deflate member is complete and empty. Any additional decoded byte still returns `decoded body limit exceeded`. Invalid and incomplete zero-output tails retain their existing errors.

Returned and accumulated decoded output remain bounded by `max_output`; each zlib call may produce at most one temporary probe byte beyond the remaining returned-output budget.

## Exclusions

- no streaming decoder or best-effort capture changes
- no schema, persisted data, API, protocol, migration, or rollout changes

## Testing

- `.venv/bin/python -m pytest tests/test_body_decoding.py` (81 passed)
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/` (4015 passed)
- `git diff --check`

Closes #21734
