### PR TITLE
fix(api): redirect invitation magic links to app url

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -472,11 +472,21 @@ describe("ORG-01 and ORG-02", () => {
     expect(members.pendingInvitations?.[0]?.id).toBe(inviteId);
     expect(members.membershipRequests?.[0]?.id).toBe(requestId);
 
+    const inviteeEmail = `new-member-${shortId()}@example.test`;
     const invite = await api.inviteMember(admin, {
-      email: `new-member-${shortId()}@example.test`,
+      email: inviteeEmail,
       role: "member",
     });
     expect(invite.message).toContain("Invitation sent");
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledWith({
+      organizationId: admin.orgId,
+      emailAddress: inviteeEmail,
+      inviterUserId: admin.userId,
+      role: "org:member",
+      redirectUrl: "http://localhost:3002",
+    });
 
     api.mockClerkOrg(member, {
       slug: nextSlug,

--- a/turbo/apps/api/src/signals/routes/zero-org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-invite.ts
@@ -1,10 +1,11 @@
 import { command } from "ccstate";
 import { zeroOrgInviteContract } from "@vm0/api-contracts/contracts/zero-org-members";
 
+import { env } from "../../lib/env";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { clerk$ } from "../external/clerk";
 import { bodyResultOf } from "../context/request";
+import { clerk$ } from "../external/clerk";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -38,6 +39,7 @@ const inviteInner$ = command(async ({ get }, signal: AbortSignal) => {
     emailAddress: body.data.email,
     inviterUserId: auth.userId,
     role: body.data.role === "admin" ? "org:admin" : "org:member",
+    redirectUrl: env("APP_URL"),
   });
   signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary

- pass the configured APP_URL to Clerk organization invitations so magic links return to the application instead of the marketing site
- cover the redirect URL in the existing organization API integration flow

## Issue

Addresses the magic-link redirect portion of #21694. The Gmail Promotions classification investigation remains open.

## Test plan

- pnpm exec prettier --write on the two changed files
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- pnpm -F api exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts -t "ORG-01 and ORG-02"