### PR TITLE
fix(runner): close workspace gc ownership race

### DIFF
--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -83,8 +83,8 @@ fn parse_base_dir_lock_content(
     Some(base_dir)
 }
 
-/// Find base-dir lock paths written by `runner start`.
-fn discover_dead_runner_base_dir_lock_candidates(
+/// Find base-dir lock paths that are free before ownership discovery.
+fn discover_initially_free_base_dir_lock_candidates(
     locks_dir: &Path,
 ) -> Vec<DeadRunnerBaseDirLockCandidate> {
     let entries = match std::fs::read_dir(locks_dir) {
@@ -109,10 +109,23 @@ fn discover_dead_runner_base_dir_lock_candidates(
         if !is_base_dir_lock_name(name) {
             continue;
         }
-        candidates.push(DeadRunnerBaseDirLockCandidate {
+        let candidate = DeadRunnerBaseDirLockCandidate {
             lock_path: entry.path(),
             lock_name: name.to_string(),
-        });
+        };
+        match probe_existing_lock(&candidate.lock_path) {
+            ExistingLockProbe::Free(lock_guard) => {
+                drop(lock_guard);
+                candidates.push(candidate);
+            }
+            ExistingLockProbe::Held | ExistingLockProbe::Missing => {}
+            ExistingLockProbe::Error(e) => {
+                warn!(
+                    "workspace gc: cannot probe base-dir lock {} during candidate discovery: {e}",
+                    candidate.lock_path.display()
+                );
+            }
+        }
     }
     candidates
 }
@@ -206,9 +219,27 @@ pub(super) async fn gc_workspace_orphans(
     home: &HomePaths,
     dry_run: bool,
 ) -> RunnerResult<WorkspaceGcSummary> {
-    // 1. Discover active workspaces from any running Firecracker process.
-    //    This protects orphaned FCs whose parent runner already died but
-    //    whose VM is still running.
+    // The initial free-lock observation, later ownership snapshots, fixed age
+    // boundary, and final held lease form one safety invariant. Keep this
+    // ordering: a runner holding a base-dir lock here must be excluded for the
+    // entire pass, while a runner entering later can only create workspaces
+    // newer than this age reference.
+    let workspace_age_reference = SystemTime::now();
+    let locks_dir = home.locks_dir();
+    let candidates = tokio::task::spawn_blocking(move || {
+        discover_initially_free_base_dir_lock_candidates(&locks_dir)
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("discover base-dir locks task failed: {e}")))?;
+
+    if candidates.is_empty() {
+        tracing::debug!("workspace gc: no initially-free base-dir locks discovered");
+        return Ok(WorkspaceGcSummary::default());
+    }
+
+    // Discover active workspaces after initial candidate selection. This
+    // protects orphaned Firecrackers whose parent runner already died but
+    // whose VM is still running.
     let discovered = crate::process::discover_all_with_status().await;
     if !discovered.proc_scan_complete {
         warn!(
@@ -239,26 +270,12 @@ pub(super) async fn gc_workspace_orphans(
         return Ok(WorkspaceGcSummary::default());
     }
 
-    // 2. Enumerate base-dir lock candidates without holding their fds. Each
-    //    candidate is leased separately while it is processed, so a large
-    //    backlog of old lock files cannot exhaust the process fd limit.
-    let locks_dir = home.locks_dir();
-    let candidates = tokio::task::spawn_blocking(move || {
-        discover_dead_runner_base_dir_lock_candidates(&locks_dir)
-    })
-    .await
-    .map_err(|e| RunnerError::Internal(format!("discover base-dir locks task failed: {e}")))?;
-
-    if candidates.is_empty() {
-        tracing::debug!("workspace gc: no dead-runner base_dirs discovered");
-        return Ok(WorkspaceGcSummary::default());
-    }
-
     gc_workspace_orphans_with_candidates(
         candidates,
         &discovered.firecrackers,
         &live_runner_base_dirs,
         false,
+        workspace_age_reference,
         dry_run,
     )
     .await
@@ -269,6 +286,7 @@ async fn gc_workspace_orphans_with_candidates(
     firecrackers: &[crate::process::FirecrackerProcessInfo],
     live_runner_base_dirs: &HashSet<PathBuf>,
     process_discovery_uncertain: bool,
+    workspace_age_reference: SystemTime,
     dry_run: bool,
 ) -> RunnerResult<WorkspaceGcSummary> {
     if process_discovery_uncertain {
@@ -277,8 +295,6 @@ async fn gc_workspace_orphans_with_candidates(
     }
 
     let active = active_workspace_paths(firecrackers);
-    // 3. Scan each base_dir/workspaces/ for orphans.
-    let now = SystemTime::now();
     let mut summary = WorkspaceGcSummary::default();
     let candidate_count = candidates.len();
 
@@ -316,7 +332,8 @@ async fn gc_workspace_orphans_with_candidates(
         }
 
         let (cleaned, freed, lock_decision) =
-            gc_workspace_orphans_in_base_dir(base_dir, &active, now, dry_run).await;
+            gc_workspace_orphans_in_base_dir(base_dir, &active, workspace_age_reference, dry_run)
+                .await;
         summary.workspaces_cleaned += cleaned;
         summary.bytes_freed += freed;
 
@@ -352,7 +369,7 @@ async fn gc_workspace_orphans_with_candidates(
 async fn gc_workspace_orphans_in_base_dir(
     base_dir: &Path,
     active: &HashSet<PathBuf>,
-    now: SystemTime,
+    workspace_age_reference: SystemTime,
     dry_run: bool,
 ) -> (u32, u64, BaseDirLockDecision) {
     match gc_path_dir_status(base_dir).await {
@@ -443,7 +460,7 @@ async fn gc_workspace_orphans_in_base_dir(
         let age = meta
             .modified()
             .ok()
-            .and_then(|mtime| now.duration_since(mtime).ok())
+            .and_then(|mtime| workspace_age_reference.duration_since(mtime).ok())
             .unwrap_or_default();
         if age < GC_MIN_AGE {
             tracing::debug!(

--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -13,14 +13,14 @@ fn discovered_base_dirs(leases: &[DeadRunnerBaseDirLease]) -> Vec<PathBuf> {
 }
 
 fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLease> {
-    discover_dead_runner_base_dir_lock_candidates(locks_dir)
+    discover_initially_free_base_dir_lock_candidates(locks_dir)
         .into_iter()
         .filter_map(acquire_dead_runner_base_dir_lease)
         .collect()
 }
 
 fn discover_base_dir_lock_candidates(home: &HomePaths) -> Vec<DeadRunnerBaseDirLockCandidate> {
-    discover_dead_runner_base_dir_lock_candidates(&home.locks_dir())
+    discover_initially_free_base_dir_lock_candidates(&home.locks_dir())
 }
 
 fn write_base_dir_lock(home: &HomePaths, base_dir: &Path) -> PathBuf {
@@ -144,7 +144,7 @@ fn discover_dead_runner_base_dirs_keeps_lock_guard_alive() {
 }
 
 #[test]
-fn discover_base_dir_lock_candidates_does_not_hold_locks() {
+fn discover_initially_free_base_dir_lock_candidates_drops_probe_guards() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
     let locks_dir = home.locks_dir();
@@ -155,9 +155,100 @@ fn discover_base_dir_lock_candidates_does_not_hold_locks() {
     let candidates = discover_base_dir_lock_candidates(&home);
     assert_eq!(candidates.len(), 1);
     match probe_existing_lock(&lock_path) {
-        ExistingLockProbe::Free(_) => {}
-        _ => panic!("candidate discovery must not hold base-dir locks"),
+        ExistingLockProbe::Free(lock_guard) => drop(lock_guard),
+        _ => panic!("initial candidate discovery must drop free probe guards"),
     }
+}
+
+#[tokio::test]
+async fn gc_workspace_orphans_excludes_candidate_held_during_initial_discovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let base_dir = dir.path().join("runner-data");
+    let workspace = base_dir.join("workspaces").join("run-old");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+    set_mtime(&workspace, old_gc_time());
+
+    let lock_path = write_base_dir_lock(&home, &base_dir);
+    let lock_file = std::fs::File::options()
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap();
+    let held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+    let candidates = discover_base_dir_lock_candidates(&home);
+    assert!(
+        candidates.is_empty(),
+        "a base dir held at initial discovery must be excluded for the pass"
+    );
+
+    drop(held_lock);
+    match probe_existing_lock(&lock_path) {
+        ExistingLockProbe::Free(lock_guard) => drop(lock_guard),
+        _ => panic!("the simulated runner lock should now be free"),
+    }
+
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.workspaces_cleaned, 0);
+    assert_eq!(summary.base_dir_locks_removed, 0);
+    assert!(workspace.exists(), "the old workspace must remain");
+    assert!(lock_path.exists(), "the retry lock must remain");
+}
+
+#[tokio::test]
+async fn gc_workspace_orphans_preserves_workspace_created_after_pass_reference() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let workspace_age_reference = old_gc_time();
+    let base_dir = dir.path().join("runner-data");
+    let lock_path = write_base_dir_lock(&home, &base_dir);
+
+    let candidates = discover_base_dir_lock_candidates(&home);
+    assert_eq!(candidates.len(), 1);
+    match probe_existing_lock(&lock_path) {
+        ExistingLockProbe::Free(lock_guard) => drop(lock_guard),
+        _ => panic!("initial candidate discovery must not retain the lock"),
+    }
+
+    let workspace = base_dir.join("workspaces").join("run-new");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+    set_mtime(&workspace, workspace_age_reference + Duration::from_secs(1));
+
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        false,
+        workspace_age_reference,
+        false,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.workspaces_cleaned, 0);
+    assert_eq!(summary.base_dir_locks_removed, 0);
+    assert!(
+        workspace.exists(),
+        "the post-boundary workspace must remain"
+    );
+    assert!(lock_path.exists(), "the retry lock must remain");
 }
 
 #[tokio::test]
@@ -173,10 +264,16 @@ async fn gc_workspace_orphans_does_not_recreate_missing_candidate_lock() {
     assert_eq!(candidates.len(), 1);
     std::fs::remove_file(&lock_path).unwrap();
 
-    let summary =
-        gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, true)
-            .await
-            .unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        true,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 0);
@@ -297,6 +394,7 @@ async fn gc_workspace_orphans_skips_when_incomplete_firecracker_unattributed() {
         &firecrackers,
         &HashSet::new(),
         true,
+        SystemTime::now(),
         false,
     )
     .await
@@ -326,10 +424,16 @@ async fn gc_workspace_orphans_skips_when_process_discovery_incomplete() {
     let lock_path = write_base_dir_lock(&home, &base_dir);
 
     let candidates = discover_base_dir_lock_candidates(&home);
-    let summary =
-        gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), true, false)
-            .await
-            .unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        true,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 0);
@@ -361,6 +465,7 @@ async fn gc_workspace_orphans_cleans_when_incomplete_firecracker_is_live_runner_
         &firecrackers,
         &HashSet::new(),
         false,
+        SystemTime::now(),
         false,
     )
     .await
@@ -400,6 +505,7 @@ async fn gc_workspace_orphans_preserves_known_live_firecracker_workspace() {
         &firecrackers,
         &HashSet::new(),
         false,
+        SystemTime::now(),
         false,
     )
     .await
@@ -433,10 +539,16 @@ async fn gc_workspace_orphans_preserves_live_runner_base_dir_candidate() {
 
     let candidates = discover_base_dir_lock_candidates(&home);
     let live_runner_base_dirs = HashSet::from([base_dir.clone()]);
-    let summary =
-        gc_workspace_orphans_with_candidates(candidates, &[], &live_runner_base_dirs, false, false)
-            .await
-            .unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &live_runner_base_dirs,
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 0);
@@ -471,10 +583,16 @@ async fn base_dir_lock_cleanup_removes_missing_or_empty_base_dir_lock() {
     std::fs::write(&relative_content_lock, "relative-runner-data").unwrap();
 
     let candidates = discover_base_dir_lock_candidates(&home);
-    let summary =
-        gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, false)
-            .await
-            .unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 4);
@@ -510,10 +628,16 @@ async fn base_dir_lock_cleanup_preserves_recent_workspace_retry_metadata() {
     let lock_path = write_base_dir_lock(&home, &base_dir);
 
     let candidates = discover_base_dir_lock_candidates(&home);
-    let summary =
-        gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, false)
-            .await
-            .unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        candidates,
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 0);


### PR DESCRIPTION
## Summary

- capture the workspace age boundary and initially-free base-dir lock candidates before Firecracker and live-runner discovery
- reacquire and hold each candidate lease through cleanup, preserving the existing fail-closed process, path, and retry-lock behavior
- add real-filesystem and real-`flock` regression coverage for held-to-free candidates and workspaces created after the pass boundary

## Compatibility

- no API, schema, migration, persisted-state, runner protocol, or lock-file format changes
- initial probe guards are dropped immediately, so candidate discovery does not retain file descriptors or block runner starts
- `/proc` and live-runner discovery remain once per workspace GC pass

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner gc_workspace_orphans`
- `cargo test --manifest-path crates/Cargo.toml -p runner discover_dead_runner_base_dir`
- `cargo test --manifest-path crates/Cargo.toml -p runner discover_initially_free_base_dir_lock_candidates`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `git diff --check`

Closes #21733
