### PR TITLE
refactor: remove dead selected-indicator branch from model picker row

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -6,7 +6,7 @@ import {
   useLoadable,
   useSet,
 } from "ccstate-react";
-import { IconBolt, IconCheck, IconCpu } from "@tabler/icons-react";
+import { IconBolt, IconCpu } from "@tabler/icons-react";
 import {
   Select,
   SelectContent,
@@ -414,13 +414,9 @@ function modelFirstSelectionFromRaw(
 function ModelFirstPolicyRowContent({
   policy,
   limitedFree1,
-  selected = false,
-  showSelectedIndicator = false,
 }: {
   policy: OrgModelPolicy;
   limitedFree1: boolean;
-  selected?: boolean;
-  showSelectedIndicator?: boolean;
 }) {
   const iconType = getModelFirstIconType(policy.model);
   const builtInPriceTier =
@@ -440,11 +436,6 @@ function ModelFirstPolicyRowContent({
         <ByokBadge />
       )}
       {restricted && <ProBadge />}
-      {showSelectedIndicator && (
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-foreground">
-          {selected && <IconCheck size={15} stroke={1.8} />}
-        </span>
-      )}
     </span>
   );
 }


### PR DESCRIPTION
## What

Removes dead code from `ModelFirstPolicyRowContent` in `model-provider-picker.tsx`.

The function accepted `selected` and `showSelectedIndicator` props whose only use was an inline `IconCheck` (`size={15} stroke={1.8}`). Neither prop is ever passed `true` anywhere in the repository — the sole caller, `ModelFirstPolicyRow`, omits both — so the branch never rendered.

## Why

- **Dead code / YAGNI.** The unused props and branch violate the project's aggressive-delete-unused-code principle. Lint/Knip don't flag it because the props *are* referenced inside the (unreachable) branch, so it silently survives CI.
- **Divergent check style.** The selected checkmark actually shown in the model dropdown list is rendered by `SelectItem`'s built-in `ItemIndicator` (`IconCheck h-4 w-4` → 16px, global tabler stroke 1.5). The dead branch carried a *different* check (15px, stroke 1.8) that could drift from the real indicator if ever re-enabled.

## Change

- Drop `selected` / `showSelectedIndicator` props (and their type members) from `ModelFirstPolicyRowContent`.
- Remove the unreachable `showSelectedIndicator && (...)` JSX branch.
- Remove the now-unused `IconCheck` import (`IconBolt` / `IconCpu` remain in use).

Net: `1 insertion(+), 10 deletions(-)`, no behavior change — the list check keeps rendering via `SelectItem`'s `ItemIndicator`.

## Verification

- Grepped the whole repo: no remaining references to `showSelectedIndicator`, the removed `selected` prop, or `IconCheck` in this file.
- No runtime behavior change; relying on the PR pipeline for lint / type-check / tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)