### PR TITLE
fix(runner): protect sidecar staging from cache gc

### DIFF
--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -70,6 +70,12 @@ pub(crate) struct WorkspaceImagePromotionContext {
     restored_session_identity: Option<crate::restored_session_identity::RestoredSessionIdentity>,
 }
 
+pub(crate) struct WorkspaceSessionHistorySidecarEntryGuard<'a> {
+    promotion: &'a WorkspaceImagePromotionContext,
+    restored_session_identity: &'a crate::restored_session_identity::RestoredSessionIdentity,
+    _late_entry_lock: Option<Flock<std::fs::File>>,
+}
+
 pub(crate) struct WorkspaceImagePromotionIdentityFailure {
     pub(crate) promotion: WorkspaceImagePromotionContext,
     pub(crate) mismatch: WorkspaceImagePromotionIdentityMismatch,
@@ -1120,34 +1126,6 @@ impl WorkspaceImagePromotionContext {
         self.restored_session_identity.as_ref()
     }
 
-    pub(crate) fn session_history_sidecar_tmp_path(&self) -> PathBuf {
-        self.cache
-            .session_workspace_cache_tmp_sidecar(&self.cache_key, self.run_id)
-    }
-
-    pub(crate) fn session_history_sidecar_source(
-        &self,
-        tmp_path: PathBuf,
-        representation: super::types::WorkspaceSessionHistorySidecarRepresentation,
-        encoded_size: u64,
-    ) -> Option<WorkspaceSessionHistorySidecarPromotionSource> {
-        Some(WorkspaceSessionHistorySidecarPromotionSource {
-            tmp_path,
-            representation,
-            encoded_size,
-            restored_session_identity: self.restored_session_identity.clone()?,
-        })
-    }
-
-    pub(crate) async fn discard_session_history_sidecar_source(
-        &self,
-        source: &WorkspaceSessionHistorySidecarPromotionSource,
-    ) {
-        self.cache
-            .discard_session_history_sidecar_source(source)
-            .await;
-    }
-
     pub(crate) fn validate_identity(
         &self,
         expected: &WorkspaceImagePromotionIdentity,
@@ -1194,12 +1172,39 @@ impl WorkspaceImagePromotionContext {
 
     #[cfg(test)]
     pub(crate) async fn promote(&self) -> RunnerResult<WorkspaceImagePromotionOutcome> {
-        self.promote_with_session_history_sidecar(None).await
+        self.promote_without_session_history_sidecar().await
     }
 
-    pub(crate) async fn promote_with_session_history_sidecar(
+    pub(crate) async fn try_acquire_session_history_sidecar_entry_guard(
         &self,
-        session_history_sidecar: Option<&WorkspaceSessionHistorySidecarPromotionSource>,
+    ) -> Option<WorkspaceSessionHistorySidecarEntryGuard<'_>> {
+        let restored_session_identity = self.restored_session_identity.as_ref()?;
+        let late_entry_lock = match self.entry_lock.as_ref() {
+            Some(_) => None,
+            None => {
+                match crate::lock::try_acquire(self.cache.entry_lock_path(&self.cache_key)).await {
+                    Ok(lock) => Some(lock),
+                    Err(e) => {
+                        info!(
+                            run_id = %self.run_id,
+                            cache_key = self.cache_key,
+                            error = %e,
+                            "workspace image cache sidecar staging skipped: late entry lock unavailable"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
+        Some(WorkspaceSessionHistorySidecarEntryGuard {
+            promotion: self,
+            restored_session_identity,
+            _late_entry_lock: late_entry_lock,
+        })
+    }
+
+    pub(crate) async fn promote_without_session_history_sidecar(
+        &self,
     ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         let _late_entry_lock_guard = match self.entry_lock.as_ref() {
             Some(_) => None,
@@ -1219,6 +1224,13 @@ impl WorkspaceImagePromotionContext {
             }
         };
 
+        self.promote_locked(None).await
+    }
+
+    async fn promote_locked(
+        &self,
+        session_history_sidecar: Option<&WorkspaceSessionHistorySidecarPromotionSource>,
+    ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         self.cache
             .promote_locked(WorkspaceImagePromotionInput {
                 run_id: self.run_id,
@@ -1371,6 +1383,45 @@ impl WorkspaceImagePromotionContext {
                 result: WorkspaceCacheCheckoutResult::Miss,
             },
         )
+    }
+}
+
+impl WorkspaceSessionHistorySidecarEntryGuard<'_> {
+    pub(crate) fn session_history_sidecar_tmp_path(&self) -> PathBuf {
+        self.promotion
+            .cache
+            .session_workspace_cache_tmp_sidecar(&self.promotion.cache_key, self.promotion.run_id)
+    }
+
+    pub(crate) fn session_history_sidecar_source(
+        &self,
+        tmp_path: PathBuf,
+        representation: super::types::WorkspaceSessionHistorySidecarRepresentation,
+        encoded_size: u64,
+    ) -> WorkspaceSessionHistorySidecarPromotionSource {
+        WorkspaceSessionHistorySidecarPromotionSource {
+            tmp_path,
+            representation,
+            encoded_size,
+            restored_session_identity: self.restored_session_identity.clone(),
+        }
+    }
+
+    pub(crate) async fn discard_session_history_sidecar_source(
+        &self,
+        source: &WorkspaceSessionHistorySidecarPromotionSource,
+    ) {
+        self.promotion
+            .cache
+            .discard_session_history_sidecar_source(source)
+            .await;
+    }
+
+    pub(crate) async fn promote_with_session_history_sidecar(
+        &self,
+        source: &WorkspaceSessionHistorySidecarPromotionSource,
+    ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
+        self.promotion.promote_locked(Some(source)).await
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -16,6 +16,9 @@
 //!   shared root.
 //! - Entry locks protect one cache key. Capacity lock protects budget-sensitive
 //!   promotion and GC work across the shared cache root.
+//! - Session-history sidecar staging inside a cache entry holds that entry's
+//!   lock from the first managed temporary-path operation through publication
+//!   or discard, so GC cannot classify active staging as orphaned state.
 //! - GC takes the capacity lock and then uses non-blocking entry lock attempts.
 //!   Promotion already holds or reacquires an entry lock and then uses a
 //!   non-blocking capacity lock attempt. Do not turn either side into blocking
@@ -47,7 +50,7 @@ mod tests;
 
 pub(crate) use lifecycle::{
     WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityFailure,
-    WorkspaceImagePromotionOutcome,
+    WorkspaceImagePromotionOutcome, WorkspaceSessionHistorySidecarEntryGuard,
 };
 pub(crate) use types::{
     CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -32,7 +32,6 @@ enum WorkspacePromotionAction {
 struct SessionHistorySidecarSourceGuard<'a> {
     entry_guard: WorkspaceSessionHistorySidecarEntryGuard<'a>,
     source: WorkspaceSessionHistorySidecarPromotionSource,
-    remove_on_drop: bool,
 }
 
 impl<'a> SessionHistorySidecarSourceGuard<'a> {
@@ -43,7 +42,6 @@ impl<'a> SessionHistorySidecarSourceGuard<'a> {
         Self {
             entry_guard,
             source,
-            remove_on_drop: true,
         }
     }
 
@@ -51,11 +49,10 @@ impl<'a> SessionHistorySidecarSourceGuard<'a> {
         &self.source.tmp_path
     }
 
-    async fn discard(mut self) {
+    async fn discard(self) {
         self.entry_guard
             .discard_session_history_sidecar_source(&self.source)
             .await;
-        self.remove_on_drop = false;
     }
 
     async fn promote(&self) -> crate::error::RunnerResult<WorkspaceImagePromotionOutcome> {
@@ -67,9 +64,7 @@ impl<'a> SessionHistorySidecarSourceGuard<'a> {
 
 impl Drop for SessionHistorySidecarSourceGuard<'_> {
     fn drop(&mut self) {
-        if self.remove_on_drop {
-            let _ = std::fs::remove_file(&self.source.tmp_path);
-        }
+        let _ = std::fs::remove_file(&self.source.tmp_path);
     }
 }
 

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -15,7 +15,7 @@ use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::guest;
 use crate::workspace_image_cache::{
     WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
-    WorkspaceSessionHistorySidecarPromotionSource,
+    WorkspaceSessionHistorySidecarEntryGuard, WorkspaceSessionHistorySidecarPromotionSource,
 };
 use crate::workspace_mount::flush_and_unmount_workspace_drive;
 
@@ -29,33 +29,46 @@ enum WorkspacePromotionAction {
     AbandonUnpublished,
 }
 
-struct SessionHistorySidecarSourceGuard {
-    source: Option<WorkspaceSessionHistorySidecarPromotionSource>,
+struct SessionHistorySidecarSourceGuard<'a> {
+    entry_guard: WorkspaceSessionHistorySidecarEntryGuard<'a>,
+    source: WorkspaceSessionHistorySidecarPromotionSource,
+    remove_on_drop: bool,
 }
 
-impl SessionHistorySidecarSourceGuard {
-    fn new(source: Option<WorkspaceSessionHistorySidecarPromotionSource>) -> Self {
-        Self { source }
-    }
-
-    fn as_ref(&self) -> Option<&WorkspaceSessionHistorySidecarPromotionSource> {
-        self.source.as_ref()
-    }
-
-    async fn discard(&mut self, promotion: &WorkspaceImagePromotionContext) {
-        if let Some(source) = self.source.as_ref() {
-            promotion
-                .discard_session_history_sidecar_source(source)
-                .await;
+impl<'a> SessionHistorySidecarSourceGuard<'a> {
+    fn new(
+        entry_guard: WorkspaceSessionHistorySidecarEntryGuard<'a>,
+        source: WorkspaceSessionHistorySidecarPromotionSource,
+    ) -> Self {
+        Self {
+            entry_guard,
+            source,
+            remove_on_drop: true,
         }
-        self.source = None;
+    }
+
+    fn tmp_path(&self) -> &std::path::Path {
+        &self.source.tmp_path
+    }
+
+    async fn discard(mut self) {
+        self.entry_guard
+            .discard_session_history_sidecar_source(&self.source)
+            .await;
+        self.remove_on_drop = false;
+    }
+
+    async fn promote(&self) -> crate::error::RunnerResult<WorkspaceImagePromotionOutcome> {
+        self.entry_guard
+            .promote_with_session_history_sidecar(&self.source)
+            .await
     }
 }
 
-impl Drop for SessionHistorySidecarSourceGuard {
+impl Drop for SessionHistorySidecarSourceGuard<'_> {
     fn drop(&mut self) {
-        if let Some(source) = self.source.take() {
-            let _ = std::fs::remove_file(source.tmp_path);
+        if self.remove_on_drop {
+            let _ = std::fs::remove_file(&self.source.tmp_path);
         }
     }
 }
@@ -101,13 +114,13 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     promotion: &WorkspaceImagePromotionContext,
     reason: &'static str,
 ) -> WorkspacePromotionAction {
-    let mut sidecar_source = SessionHistorySidecarSourceGuard::new(
-        export_session_history_sidecar(sandbox, promotion, reason).await,
-    );
+    let mut sidecar_source = export_session_history_sidecar(sandbox, promotion, reason).await;
     match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
         Ok(()) => {}
         Err(e) => {
-            sidecar_source.discard(promotion).await;
+            if let Some(source) = sidecar_source.take() {
+                source.discard().await;
+            }
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
@@ -121,11 +134,14 @@ async fn promote_workspace_image_from_active_sandbox_inner(
         }
     }
 
-    let outcome = promotion
-        .promote_with_session_history_sidecar(sidecar_source.as_ref())
-        .await;
-    if !matches!(outcome, Ok(WorkspaceImagePromotionOutcome::Promoted)) {
-        sidecar_source.discard(promotion).await;
+    let outcome = match sidecar_source.as_ref() {
+        Some(source) => source.promote().await,
+        None => promotion.promote_without_session_history_sidecar().await,
+    };
+    if !matches!(outcome, Ok(WorkspaceImagePromotionOutcome::Promoted))
+        && let Some(source) = sidecar_source.take()
+    {
+        source.discard().await;
     }
     match outcome {
         Ok(WorkspaceImagePromotionOutcome::Promoted) => WorkspacePromotionAction::Promoted,
@@ -150,11 +166,11 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     }
 }
 
-async fn export_session_history_sidecar(
+async fn export_session_history_sidecar<'a>(
     sandbox: &dyn Sandbox,
-    promotion: &WorkspaceImagePromotionContext,
+    promotion: &'a WorkspaceImagePromotionContext,
     reason: &'static str,
-) -> Option<WorkspaceSessionHistorySidecarPromotionSource> {
+) -> Option<SessionHistorySidecarSourceGuard<'a>> {
     let verification = promotion
         .restored_session_identity()?
         .final_metadata_verification()?;
@@ -238,12 +254,26 @@ async fn export_session_history_sidecar(
             return None;
         }
     };
-    let tmp_path = promotion.session_history_sidecar_tmp_path();
-    let _ = fs::remove_file(&tmp_path).await;
+    let Some(entry_guard) = promotion
+        .try_acquire_session_history_sidecar_entry_guard()
+        .await
+    else {
+        cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
+            .await;
+        return None;
+    };
+    let tmp_path = entry_guard.session_history_sidecar_tmp_path();
+    let source = entry_guard.session_history_sidecar_source(
+        tmp_path,
+        metadata.representation,
+        metadata.encoded_size,
+    );
+    let sidecar_source = SessionHistorySidecarSourceGuard::new(entry_guard, source);
+    let _ = fs::remove_file(sidecar_source.tmp_path()).await;
     let copied = match sandbox
         .copy_file(
             &export_path,
-            &tmp_path,
+            sidecar_source.tmp_path(),
             CopyFileOptions {
                 max_bytes: SESSION_HISTORY_SIDECAR_MAX_BYTES,
                 timeout: SESSION_HISTORY_SIDECAR_COPY_TIMEOUT,
@@ -256,7 +286,7 @@ async fn export_session_history_sidecar(
         Err(e) => {
             cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
                 .await;
-            let _ = fs::remove_file(&tmp_path).await;
+            sidecar_source.discard().await;
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
@@ -271,7 +301,7 @@ async fn export_session_history_sidecar(
     };
     cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason).await;
     if copied.bytes_copied != metadata.encoded_size {
-        let _ = fs::remove_file(&tmp_path).await;
+        sidecar_source.discard().await;
         warn!(
             run_id = %promotion.run_id(),
             sandbox_id = %promotion.sandbox_id(),
@@ -284,11 +314,7 @@ async fn export_session_history_sidecar(
         );
         return None;
     }
-    promotion.session_history_sidecar_source(
-        tmp_path,
-        metadata.representation,
-        metadata.encoded_size,
-    )
+    Some(sidecar_source)
 }
 
 async fn cleanup_guest_session_history_sidecar_export(

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -32,6 +32,22 @@ impl WorkspacePromotionFixture {
         session_id: &str,
         restored_session_identity: Option<&RestoredSessionIdentity>,
     ) -> Self {
+        Self::new_with_lease_session_id(session_id, Some(session_id), restored_session_identity)
+            .await
+    }
+
+    pub(crate) async fn new_late_session_with_restored_session_identity(
+        session_id: &str,
+        restored_session_identity: &RestoredSessionIdentity,
+    ) -> Self {
+        Self::new_with_lease_session_id(session_id, None, Some(restored_session_identity)).await
+    }
+
+    async fn new_with_lease_session_id(
+        session_id: &str,
+        lease_session_id: Option<&str>,
+        restored_session_identity: Option<&RestoredSessionIdentity>,
+    ) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -44,7 +60,7 @@ impl WorkspacePromotionFixture {
                     run_id,
                     sandbox_id,
                     profile_name: "vm0/default",
-                    cli_agent_session_id: Some(session_id),
+                    cli_agent_session_id: lease_session_id,
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
                 },

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -407,6 +407,70 @@ async fn late_session_sidecar_staging_is_protected_from_gc() {
 }
 
 #[tokio::test]
+async fn late_session_sidecar_staging_cleans_source_and_unlocks_when_cancelled() {
+    let session_id = "sess-late-sidecar-cancelled";
+    let history = br#"{"type":"message","content":"cancelled"}"#;
+    let restored_identity = test_restored_session_identity(session_id, history);
+    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
+        session_id,
+        &restored_identity,
+    )
+    .await;
+    let cache = fixture.cache.clone();
+    let sandbox = Arc::new(PostCopyGateSandbox::new(fixture.sandbox_id.to_string()));
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+    sandbox.inner.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    sandbox.inner.push_copy_file_result(Ok(history.to_vec()));
+    let promotion = fixture.promotion;
+    let promotion_sandbox = Arc::clone(&sandbox);
+    let promotion_task = tokio::spawn(async move {
+        promote_workspace_image_from_active_sandbox(
+            promotion_sandbox.as_ref(),
+            Some(promotion),
+            "test",
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), sandbox.wait_for_copy())
+        .await
+        .expect("sidecar host copy must complete before cancellation");
+    let copy_calls = sandbox.inner.copy_file_calls();
+    assert_eq!(copy_calls.len(), 1);
+    let tmp_path = copy_calls[0].host_path.clone();
+    assert!(tmp_path.is_file());
+
+    promotion_task.abort();
+    let join_error = promotion_task
+        .await
+        .expect_err("cancelled promotion task must not complete normally");
+
+    assert!(join_error.is_cancelled());
+    assert!(!tmp_path.exists());
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+}
+
+#[tokio::test]
 async fn late_session_sidecar_staging_skips_copy_when_entry_lock_is_busy() {
     let session_id = "sess-late-sidecar-lock-busy";
     let history = br#"{"type":"message","content":"busy"}"#;

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -14,7 +14,7 @@ use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
     Sandbox, SandboxFactory, SandboxId, StartProcessRequest,
 };
-use sandbox_mock::{ExecMatcher, MockSandboxFactory, MockSandboxOverrides};
+use sandbox_mock::{ExecMatcher, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 use sha2::{Digest, Sha256};
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -42,6 +42,122 @@ async fn mock_sandbox_with_overrides(
         })
         .await
         .expect("create sandbox")
+}
+
+fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
+    let metadata = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        format!("/home/user/.claude/projects/-home-user-workspace/{session_id}.jsonl"),
+    )
+    .unwrap();
+    RestoredSessionIdentity::from_final_metadata(
+        metadata,
+        "/home/user/.vm0/guest-agent/runs/run-1/final-session-history-identity.json",
+        "/home/user/.vm0/guest-agent/runs/run-1",
+    )
+    .unwrap()
+}
+
+struct PostCopyGateSandbox {
+    inner: MockSandbox,
+    copy_completed: Arc<tokio::sync::Barrier>,
+    copy_release: Arc<tokio::sync::Notify>,
+}
+
+impl PostCopyGateSandbox {
+    fn new(id: impl Into<String>) -> Self {
+        Self {
+            inner: MockSandbox::new(id),
+            copy_completed: Arc::new(tokio::sync::Barrier::new(2)),
+            copy_release: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    async fn wait_for_copy(&self) {
+        self.copy_completed.wait().await;
+    }
+
+    fn release_copy(&self) {
+        self.copy_release.notify_one();
+    }
+}
+
+#[async_trait]
+impl Sandbox for PostCopyGateSandbox {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn source_ip(&self) -> &str {
+        self.inner.source_ip()
+    }
+
+    async fn start(&mut self) -> sandbox::Result<()> {
+        self.inner.start().await
+    }
+
+    async fn stop(&mut self) -> sandbox::Result<()> {
+        self.inner.stop().await
+    }
+
+    async fn kill(&mut self) -> sandbox::Result<()> {
+        self.inner.kill().await
+    }
+
+    async fn park(&mut self) -> sandbox::Result<()> {
+        self.inner.park().await
+    }
+
+    async fn unpark(&mut self) -> sandbox::Result<()> {
+        self.inner.unpark().await
+    }
+
+    async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        self.inner.exec(request).await
+    }
+
+    async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
+        self.inner.read_file(path, max_bytes).await
+    }
+
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &std::path::Path,
+        options: CopyFileOptions,
+    ) -> sandbox::Result<CopyFileResult> {
+        let result = self.inner.copy_file(path, host_path, options).await;
+        self.copy_completed.wait().await;
+        self.copy_release.notified().await;
+        result
+    }
+
+    async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_file(path, content).await
+    }
+
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_private_file(path, content).await
+    }
+
+    async fn start_process(
+        &self,
+        request: &StartProcessRequest<'_>,
+    ) -> sandbox::Result<GuestProcessHandle> {
+        self.inner.start_process(request).await
+    }
+
+    async fn wait_process(
+        &self,
+        handle: GuestProcessHandle,
+        timeout: Duration,
+    ) -> sandbox::Result<ProcessExit> {
+        self.inner.wait_process(handle, timeout).await
+    }
 }
 
 struct PanicExecSandbox {
@@ -153,21 +269,7 @@ async fn parked_workspace_promotion_unparks_unmounts_and_promotes_cache_entry() 
 async fn active_workspace_promotion_exports_session_history_sidecar() {
     let session_id = "sess-active-sidecar-promote";
     let history = br#"{"type":"message","content":"cached"}"#;
-    let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
-        hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
-        hex::encode(Sha256::digest(history)),
-        history.len() as u64,
-        format!("/home/user/.claude/projects/-home-user-workspace/{session_id}.jsonl"),
-    )
-    .unwrap();
-    let restored_identity = RestoredSessionIdentity::from_final_metadata(
-        metadata,
-        "/home/user/.vm0/guest-agent/runs/run-1/final-session-history-identity.json",
-        "/home/user/.vm0/guest-agent/runs/run-1",
-    )
-    .unwrap();
+    let restored_identity = test_restored_session_identity(session_id, history);
     let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
         session_id,
         Some(&restored_identity),
@@ -233,6 +335,185 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
         .await
         .unwrap();
     assert_eq!(tokio::fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn late_session_sidecar_staging_is_protected_from_gc() {
+    let session_id = "sess-late-sidecar-gc";
+    let history = br#"{"type":"message","content":"late cached"}"#;
+    let restored_identity = test_restored_session_identity(session_id, history);
+    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
+        session_id,
+        &restored_identity,
+    )
+    .await;
+    let cache = fixture.cache.clone();
+    let sandbox = PostCopyGateSandbox::new(fixture.sandbox_id.to_string());
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+    sandbox.inner.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    sandbox.inner.push_copy_file_result(Ok(history.to_vec()));
+
+    let (promoted, ()) = tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::join!(
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(fixture.promotion), "test",),
+            async {
+                sandbox.wait_for_copy().await;
+                let copy_calls = sandbox.inner.copy_file_calls();
+                assert_eq!(copy_calls.len(), 1);
+                let tmp_path = &copy_calls[0].host_path;
+                let entry_dir = tmp_path.parent().unwrap();
+                assert!(tmp_path.is_file());
+                assert!(entry_dir.is_dir());
+
+                let freed = cache.gc(false).await.unwrap();
+
+                assert_eq!(freed, 0);
+                assert!(tmp_path.is_file());
+                assert!(entry_dir.is_dir());
+                sandbox.release_copy();
+            },
+        )
+    })
+    .await
+    .expect("sidecar promotion and GC interleaving must complete");
+
+    assert!(promoted);
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+    let sidecar = lease
+        .probe_session_history_sidecar(&restored_identity)
+        .await
+        .unwrap();
+    assert_eq!(tokio::fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn late_session_sidecar_staging_skips_copy_when_entry_lock_is_busy() {
+    let session_id = "sess-late-sidecar-lock-busy";
+    let history = br#"{"type":"message","content":"busy"}"#;
+    let restored_identity = test_restored_session_identity(session_id, history);
+    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
+        session_id,
+        &restored_identity,
+    )
+    .await;
+    let held_lease = fixture
+        .cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(held_lease.result(), WorkspaceCacheCheckoutResult::Miss);
+    let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+
+    let promoted = tokio::time::timeout(
+        Duration::from_secs(1),
+        promote_workspace_image_from_active_sandbox(&sandbox, Some(fixture.promotion), "test"),
+    )
+    .await
+    .expect("late sidecar lock contention must not block");
+
+    assert!(!promoted);
+    assert!(sandbox.copy_file_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 3);
+    assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
+    assert!(exec_calls[1].cmd.contains("rm -f --"));
+    assert!(exec_calls[1].cmd.contains("/session-history-sidecar"));
+    assert!(exec_calls[2].sudo);
+    drop(held_lease);
+    assert!(fixture.cache.held_session_states().await.is_empty());
+}
+
+#[tokio::test]
+async fn late_session_sidecar_staging_cleans_source_and_unlocks_after_unmount_failure() {
+    let session_id = "sess-late-sidecar-unmount-failure";
+    let history = br#"{"type":"message","content":"unmount"}"#;
+    let restored_identity = test_restored_session_identity(session_id, history);
+    let fixture = WorkspacePromotionFixture::new_late_session_with_restored_session_identity(
+        session_id,
+        &restored_identity,
+    )
+    .await;
+    let cache = fixture.cache.clone();
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.add_exec_matcher(ExecMatcher {
+        pattern: "umount -- \"$workspace_dir\"".into(),
+        exit_code: 64,
+        stdout: Vec::new(),
+        stderr: b"not mounted".to_vec(),
+    });
+    let sandbox =
+        MockSandbox::with_overrides(fixture.sandbox_id.to_string(), Arc::clone(&overrides));
+    let export_metadata = SessionHistorySidecarExportMetadata {
+        representation: SessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+    };
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&export_metadata).unwrap(),
+        Vec::new(),
+    )));
+    sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    let promoted =
+        promote_workspace_image_from_active_sandbox(&sandbox, Some(fixture.promotion), "test")
+            .await;
+
+    assert!(!promoted);
+    let copy_calls = sandbox.copy_file_calls();
+    assert_eq!(copy_calls.len(), 1);
+    assert!(!copy_calls[0].host_path.exists());
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- hold the workspace cache entry lock across managed session-history sidecar staging and publication
- preserve the non-blocking late-session fallback without changing cache abandonment ownership
- add deterministic coverage for GC interleaving, same-key lock contention, unmount cleanup, and task cancellation
- retain final drop cleanup when best-effort async discard cannot remove the temporary source

## Scope

- runner-only; no guest helper protocol or cache format changes
- oversized sidecar failure classification remains tracked by #21756

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner workspace_promotion::tests`
- `cargo test -p runner workspace_image_cache::tests`
- `cargo test -p runner --quiet`

Closes #21755

Parent: #21737
