### PR TITLE
perf(api): hedge slow postgres dns lookups

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -1,3 +1,6 @@
+import { lookup as dnsLookup } from "node:dns";
+import type { LookupFunction } from "node:net";
+
 import { context, SpanStatusCode, type Tracer } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import {
@@ -17,6 +20,7 @@ import {
   it,
 } from "vitest";
 
+import { createDeferredPromise } from "../../signals/utils";
 import {
   createInstrumentedPgStream,
   instrumentPgPool,
@@ -27,6 +31,8 @@ const ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
 const ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
 const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
   "vm0.db.connection.lookup.duration_ms";
+const CONNECTION_LOOKUP_HEDGED_ATTRIBUTE = "vm0.db.connection.lookup.hedged";
+const CONNECTION_LOOKUP_SOURCE_ATTRIBUTE = "vm0.db.connection.lookup.source";
 const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
   "vm0.db.connection.socket_connect.duration_ms";
 const CONNECTION_ATTEMPT_COUNT_ATTRIBUTE = "vm0.db.connection.attempt_count";
@@ -38,6 +44,8 @@ const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
 
 const CONNECTION_ATTRIBUTE_NAMES = [
   CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
+  CONNECTION_LOOKUP_HEDGED_ATTRIBUTE,
+  CONNECTION_LOOKUP_SOURCE_ATTRIBUTE,
   CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
   CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
   CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
@@ -46,6 +54,72 @@ const CONNECTION_ATTRIBUTE_NAMES = [
 ] as const;
 
 type AcquirePath = "idle" | "new" | "queued";
+type PgStreamFactory = NonNullable<PoolConfig["stream"]>;
+
+interface ControlledLookupInvocation {
+  complete(): Promise<void>;
+  fail(error: NodeJS.ErrnoException): void;
+}
+
+interface ControlledLookup {
+  readonly callCount: number;
+  readonly lookup: LookupFunction;
+  next(): Promise<ControlledLookupInvocation>;
+}
+
+const systemLookup: LookupFunction = dnsLookup;
+
+function createControlledLookup(signal: AbortSignal): ControlledLookup {
+  const invocations: ControlledLookupInvocation[] = [];
+  const waiters: ((invocation: ControlledLookupInvocation) => void)[] = [];
+  let callCount = 0;
+
+  const lookup: LookupFunction = (hostname, options, callback): void => {
+    callCount += 1;
+    const invocation: ControlledLookupInvocation = {
+      complete(): Promise<void> {
+        const completion = createDeferredPromise<void>(signal);
+        systemLookup(hostname, options, (error, address, family) => {
+          callback(error, address, family);
+          completion.resolve();
+        });
+        return completion.promise;
+      },
+      fail(error: NodeJS.ErrnoException): void {
+        callback(error, "", 0);
+      },
+    };
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter(invocation);
+    } else {
+      invocations.push(invocation);
+    }
+  };
+
+  return {
+    get callCount(): number {
+      return callCount;
+    },
+    lookup,
+    next(): Promise<ControlledLookupInvocation> {
+      const invocation = invocations.shift();
+      if (invocation) {
+        return Promise.resolve(invocation);
+      }
+      const nextInvocation =
+        createDeferredPromise<ControlledLookupInvocation>(signal);
+      waiters.push(nextInvocation.resolve);
+      return nextInvocation.promise;
+    },
+  };
+}
+
+function createLookupError(message: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(message);
+  error.code = "ENOTFOUND";
+  return error;
+}
 
 function expectAcquisition(span: ReadableSpan, path: AcquirePath): void {
   expect(span.attributes[ACQUIRE_PATH_ATTRIBUTE]).toBe(path);
@@ -143,8 +217,14 @@ describe("instrumentPgPool", () => {
   let provider: BasicTracerProvider;
   let tracer: Tracer;
   let pools: Pool[];
+  let testAbortController: AbortController;
 
-  function createPool(config: PoolConfig = {}): Pool {
+  function createPool(
+    config: PoolConfig = {},
+    stream: PgStreamFactory = () => {
+      return createInstrumentedPgStream();
+    },
+  ): Pool {
     const pool = instrumentPgPool(
       new Pool({
         allowExitOnIdle: true,
@@ -152,7 +232,7 @@ describe("instrumentPgPool", () => {
         idleTimeoutMillis: 0,
         max: 1,
         ...config,
-        stream: createInstrumentedPgStream,
+        stream,
       }),
       tracer,
     );
@@ -203,9 +283,11 @@ describe("instrumentPgPool", () => {
     });
     tracer = provider.getTracer("db-instrumentation-test");
     pools = [];
+    testAbortController = new AbortController();
   });
 
   afterEach(async () => {
+    testAbortController.abort();
     await Promise.all(
       pools.map((pool) => {
         return pool.end();
@@ -246,6 +328,178 @@ describe("instrumentPgPool", () => {
     expectConnectionAcquisition(newSpan);
     expectNoConnectionAcquisition(idleSpan);
     expectNoConnectionAcquisition(queuedSpan);
+  });
+
+  it("keeps a fast lookup on the single primary path", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const pool = createPool({}, () => {
+      return createInstrumentedPgStream({
+        lookup: controlledLookup.lookup,
+        lookupHedgeDelayMs: 60_000,
+      });
+    });
+    const statement = "SELECT 111 AS primary_lookup";
+    const query = pool.query(statement);
+
+    const primary = await controlledLookup.next();
+    await primary.complete();
+    const result = await query;
+
+    expect(result.rowCount).toBe(1);
+    expect(controlledLookup.callCount).toBe(1);
+    expect(pool.totalCount).toBe(1);
+    const span = findSpan(statement);
+    expectConnectionAcquisition(span);
+    expect(span.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE]).toBeUndefined();
+    expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBeUndefined();
+  });
+
+  it("uses a successful secondary lookup for one real database client", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const pool = createPool({}, () => {
+      return createInstrumentedPgStream({
+        lookup: controlledLookup.lookup,
+        lookupHedgeDelayMs: 0,
+      });
+    });
+    let connectedClientCount = 0;
+    pool.on("connect", () => {
+      connectedClientCount += 1;
+    });
+    const statement = "SELECT 112 AS secondary_lookup";
+    const query = pool.query(statement);
+
+    const primary = await controlledLookup.next();
+    const secondary = await controlledLookup.next();
+    await secondary.complete();
+    const result = await query;
+    await primary.complete();
+
+    expect(result.rowCount).toBe(1);
+    expect(controlledLookup.callCount).toBe(2);
+    expect(connectedClientCount).toBe(1);
+    expect(pool.totalCount).toBe(1);
+    const span = findSpan(statement);
+    expectConnectionAcquisition(span);
+    expect(span.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE]).toBeTruthy();
+    expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe(
+      "secondary",
+    );
+    expect(span.attributes[CONNECTION_ATTEMPT_COUNT_ATTRIBUTE]).toBe(1);
+  });
+
+  it("allows only one unresolved secondary lookup across connections", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const pool = createPool({ max: 2 }, () => {
+      return createInstrumentedPgStream({
+        lookup: controlledLookup.lookup,
+        lookupHedgeDelayMs: 0,
+      });
+    });
+    let connectedClientCount = 0;
+    pool.on("connect", () => {
+      connectedClientCount += 1;
+    });
+    const statementA = "SELECT 113 AS hedged_connection";
+    const statementB = "SELECT 114 AS primary_only_connection";
+    const queryA = pool.query(statementA);
+    const queryB = pool.query(statementB);
+
+    const primaryA = await controlledLookup.next();
+    const primaryB = await controlledLookup.next();
+    const secondaryA = await controlledLookup.next();
+    await secondaryA.complete();
+    const resultA = await queryA;
+
+    expect(controlledLookup.callCount).toBe(3);
+
+    await primaryB.complete();
+    const resultB = await queryB;
+    await primaryA.complete();
+
+    expect(resultA.rowCount).toBe(1);
+    expect(resultB.rowCount).toBe(1);
+    expect(connectedClientCount).toBe(2);
+    expect(pool.totalCount).toBe(2);
+    expect(
+      findSpan(statementA).attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE],
+    ).toBe("secondary");
+    expect(
+      findSpan(statementB).attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE],
+    ).toBeUndefined();
+  });
+
+  it("keeps primary errors authoritative after a secondary starts", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const pool = createPool({}, () => {
+      return createInstrumentedPgStream({
+        lookup: controlledLookup.lookup,
+        lookupHedgeDelayMs: 0,
+      });
+    });
+    const statement = "SELECT 115 AS primary_lookup_error";
+    const queryError = captureRejection(pool.query(statement));
+
+    const primary = await controlledLookup.next();
+    const secondary = await controlledLookup.next();
+    const expectedError = createLookupError("primary lookup failed");
+    primary.fail(expectedError);
+    const actualError = await queryError;
+    await secondary.complete();
+
+    expect(actualError).toBe(expectedError);
+    expect(controlledLookup.callCount).toBe(2);
+    const span = findSpan(statement);
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE]).toBeTruthy();
+    expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe("primary");
+  });
+
+  it("waits for the primary after a secondary lookup error", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const pool = createPool({}, () => {
+      return createInstrumentedPgStream({
+        lookup: controlledLookup.lookup,
+        lookupHedgeDelayMs: 0,
+      });
+    });
+    const statement = "SELECT 116 AS secondary_lookup_error";
+    const query = pool.query(statement);
+
+    const primary = await controlledLookup.next();
+    const secondary = await controlledLookup.next();
+    secondary.fail(createLookupError("secondary lookup failed"));
+    expect(pool.totalCount).toBe(1);
+    await primary.complete();
+    const result = await query;
+
+    expect(result.rowCount).toBe(1);
+    expect(controlledLookup.callCount).toBe(2);
+    expect(pool.totalCount).toBe(1);
+    const span = findSpan(statement);
+    expect(span.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE]).toBeTruthy();
+    expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe("primary");
+  });
+
+  it("cancels a pending secondary when the socket is destroyed", async () => {
+    const controlledLookup = createControlledLookup(testAbortController.signal);
+    const databaseUrl = new URL(env("DATABASE_URL"));
+    const socket = createInstrumentedPgStream({
+      lookup: controlledLookup.lookup,
+      lookupHedgeDelayMs: 0,
+    });
+    const closed = createDeferredPromise<void>(testAbortController.signal);
+    socket.once("close", () => {
+      closed.resolve();
+    });
+
+    socket.connect(Number(databaseUrl.port || "5432"), databaseUrl.hostname);
+    const primary = await controlledLookup.next();
+    socket.destroy();
+    await closed.promise;
+    await primary.complete();
+
+    expect(controlledLookup.callCount).toBe(1);
   });
 
   it("reserves idle and new capacity for earlier synchronous queries", async () => {

--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -388,14 +388,15 @@ describe("instrumentPgPool", () => {
     expect(span.attributes[CONNECTION_ATTEMPT_COUNT_ATTRIBUTE]).toBe(1);
   });
 
-  it("allows only one unresolved secondary lookup across connections", async () => {
+  it("bounds and releases secondary lookup capacity across connections", async () => {
     const controlledLookup = createControlledLookup(testAbortController.signal);
-    const pool = createPool({ max: 2 }, () => {
+    const stream: PgStreamFactory = () => {
       return createInstrumentedPgStream({
         lookup: controlledLookup.lookup,
         lookupHedgeDelayMs: 0,
       });
-    });
+    };
+    const pool = createPool({ max: 2 }, stream);
     let connectedClientCount = 0;
     pool.on("connect", () => {
       connectedClientCount += 1;
@@ -427,6 +428,22 @@ describe("instrumentPgPool", () => {
     expect(
       findSpan(statementB).attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE],
     ).toBeUndefined();
+
+    const laterPool = createPool({}, stream);
+    const laterStatement = "SELECT 117 AS hedge_after_release";
+    const laterQuery = laterPool.query(laterStatement);
+    const laterPrimary = await controlledLookup.next();
+    const laterSecondary = await controlledLookup.next();
+    await laterSecondary.complete();
+    const laterResult = await laterQuery;
+    await laterPrimary.complete();
+
+    expect(laterResult.rowCount).toBe(1);
+    expect(controlledLookup.callCount).toBe(5);
+    expect(laterPool.totalCount).toBe(1);
+    expect(
+      findSpan(laterStatement).attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE],
+    ).toBe("secondary");
   });
 
   it("keeps primary errors authoritative after a secondary starts", async () => {

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -1,4 +1,5 @@
-import { Socket } from "node:net";
+import { lookup as dnsLookup, type LookupAddress } from "node:dns";
+import { Socket, type LookupFunction, type SocketConnectOpts } from "node:net";
 import { performance } from "node:perf_hooks";
 
 import {
@@ -9,6 +10,7 @@ import {
   type Span,
   type Tracer,
 } from "@opentelemetry/api";
+import { createStore, state } from "ccstate";
 import type { Pool, PoolClient } from "pg";
 
 import { deriveSqlSpanName } from "./sql-span-name";
@@ -18,6 +20,8 @@ const POOL_ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
 const POOL_ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
 const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
   "vm0.db.connection.lookup.duration_ms";
+const CONNECTION_LOOKUP_HEDGED_ATTRIBUTE = "vm0.db.connection.lookup.hedged";
+const CONNECTION_LOOKUP_SOURCE_ATTRIBUTE = "vm0.db.connection.lookup.source";
 const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
   "vm0.db.connection.socket_connect.duration_ms";
 const CONNECTION_ATTEMPT_COUNT_ATTRIBUTE = "vm0.db.connection.attempt_count";
@@ -26,6 +30,7 @@ const CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE =
 const CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE =
   "vm0.db.connection.attempt_timeout_count";
 const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
+const LOOKUP_HEDGE_DELAY_MS = 250;
 
 type AnyArgs = readonly unknown[];
 type PgQuery = (...args: AnyArgs) => unknown;
@@ -36,9 +41,206 @@ type PoolConnectCallback = (
   client?: PoolClient,
   release?: PoolRelease,
 ) => void;
+type LookupSource = "primary" | "secondary";
+
+interface InstrumentedPgStreamOptions {
+  lookup?: LookupFunction;
+  lookupHedgeDelayMs?: number;
+}
+
+const systemLookup: LookupFunction = dnsLookup;
+const secondaryLookupInFlight$ = state(false);
+const lookupHedgeStore = createStore();
 
 class PoolQuerySpan {
   constructor(readonly span: Span) {}
+}
+
+function claimSecondaryLookup(): boolean {
+  if (lookupHedgeStore.get(secondaryLookupInFlight$)) {
+    return false;
+  }
+  lookupHedgeStore.set(secondaryLookupInFlight$, true);
+  return true;
+}
+
+function releaseSecondaryLookup(): void {
+  lookupHedgeStore.set(secondaryLookupInFlight$, false);
+}
+
+function createHedgedLookup(
+  socket: Socket,
+  lookup: LookupFunction,
+  hedgeDelayMs: number,
+  querySpan: Span | undefined,
+): LookupFunction {
+  return function hedgedLookup(hostname, options, callback): void {
+    let delivered = false;
+    let primarySettled = false;
+    let secondaryStarted = false;
+    let secondarySettled = false;
+    let holdsHedgeBudget = false;
+    let hedgeDelayController: AbortController | undefined;
+
+    function removePendingHedgeListeners(): void {
+      socket.removeListener("close", cancelPendingHedge);
+      socket.removeListener("timeout", cancelPendingHedge);
+    }
+
+    function cancelPendingHedge(): void {
+      hedgeDelayController?.abort();
+      hedgeDelayController = undefined;
+      removePendingHedgeListeners();
+    }
+
+    function releaseHedgeBudget(): void {
+      if (holdsHedgeBudget && primarySettled && secondarySettled) {
+        holdsHedgeBudget = false;
+        releaseSecondaryLookup();
+      }
+    }
+
+    function deliver(
+      source: LookupSource,
+      error: NodeJS.ErrnoException | null,
+      address: string | LookupAddress[],
+      family?: number,
+    ): void {
+      if (delivered) {
+        return;
+      }
+      delivered = true;
+      cancelPendingHedge();
+      if (secondaryStarted) {
+        querySpan?.setAttribute(CONNECTION_LOOKUP_SOURCE_ATTRIBUTE, source);
+      }
+      callback(error, address, family);
+    }
+
+    function onPrimaryLookup(
+      error: NodeJS.ErrnoException | null,
+      address: string | LookupAddress[],
+      family?: number,
+    ): void {
+      primarySettled = true;
+      releaseHedgeBudget();
+      deliver("primary", error, address, family);
+    }
+
+    function onSecondaryLookup(
+      error: NodeJS.ErrnoException | null,
+      address: string | LookupAddress[],
+      family?: number,
+    ): void {
+      secondarySettled = true;
+      releaseHedgeBudget();
+      if (error === null) {
+        deliver("secondary", error, address, family);
+      }
+    }
+
+    function startSecondaryLookup(): void {
+      hedgeDelayController = undefined;
+      removePendingHedgeListeners();
+      if (
+        primarySettled ||
+        socket.destroyed ||
+        !socket.connecting ||
+        !claimSecondaryLookup()
+      ) {
+        return;
+      }
+
+      holdsHedgeBudget = true;
+      secondaryStarted = true;
+      querySpan?.setAttribute(CONNECTION_LOOKUP_HEDGED_ATTRIBUTE, true);
+      lookup(hostname, options, onSecondaryLookup);
+    }
+
+    lookup(hostname, options, onPrimaryLookup);
+    if (primarySettled || socket.destroyed || !socket.connecting) {
+      return;
+    }
+
+    socket.once("close", cancelPendingHedge);
+    socket.once("timeout", cancelPendingHedge);
+    const delayController = new AbortController();
+    hedgeDelayController = delayController;
+    const delaySignal = AbortSignal.any([
+      delayController.signal,
+      AbortSignal.timeout(hedgeDelayMs),
+    ]);
+    delaySignal.addEventListener(
+      "abort",
+      () => {
+        if (!delayController.signal.aborted) {
+          startSecondaryLookup();
+        }
+      },
+      { once: true },
+    );
+  };
+}
+
+class InstrumentedPgSocket extends Socket {
+  constructor(
+    private readonly lookup: LookupFunction,
+    private readonly lookupHedgeDelayMs: number,
+    private readonly querySpan: Span | undefined,
+  ) {
+    super();
+  }
+
+  override connect(
+    options: SocketConnectOpts,
+    connectionListener?: () => void,
+  ): this;
+  override connect(
+    port: number,
+    host: string,
+    connectionListener?: () => void,
+  ): this;
+  override connect(port: number, connectionListener?: () => void): this;
+  override connect(path: string, connectionListener?: () => void): this;
+  override connect(
+    optionsOrPortOrPath: SocketConnectOpts | number | string,
+    hostOrListener?: string | (() => void),
+    connectionListener?: () => void,
+  ): this {
+    if (typeof optionsOrPortOrPath === "number") {
+      if (typeof hostOrListener === "string") {
+        return super.connect(
+          {
+            port: optionsOrPortOrPath,
+            host: hostOrListener,
+            lookup: createHedgedLookup(
+              this,
+              this.lookup,
+              this.lookupHedgeDelayMs,
+              this.querySpan,
+            ),
+          },
+          connectionListener,
+        );
+      }
+      if (hostOrListener) {
+        return super.connect(optionsOrPortOrPath, hostOrListener);
+      }
+      return super.connect(optionsOrPortOrPath);
+    }
+
+    if (typeof optionsOrPortOrPath === "string") {
+      if (typeof hostOrListener === "function") {
+        return super.connect(optionsOrPortOrPath, hostOrListener);
+      }
+      return super.connect(optionsOrPortOrPath);
+    }
+
+    if (typeof hostOrListener === "function") {
+      return super.connect(optionsOrPortOrPath, hostOrListener);
+    }
+    return super.connect(optionsOrPortOrPath);
+  }
 }
 
 function normalizeAddressFamily(
@@ -53,24 +255,31 @@ function normalizeAddressFamily(
   return undefined;
 }
 
-export function createInstrumentedPgStream(): Socket {
-  const socket = new Socket();
+export function createInstrumentedPgStream(
+  options: InstrumentedPgStreamOptions = {},
+): Socket {
   const markedSpan = context.active().getValue(POOL_QUERY_SPAN_KEY);
-  if (
-    !(markedSpan instanceof PoolQuerySpan) ||
-    !markedSpan.span.isRecording()
-  ) {
+  const querySpan =
+    markedSpan instanceof PoolQuerySpan && markedSpan.span.isRecording()
+      ? markedSpan.span
+      : undefined;
+  const socket = new InstrumentedPgSocket(
+    options.lookup ?? systemLookup,
+    options.lookupHedgeDelayMs ?? LOOKUP_HEDGE_DELAY_MS,
+    querySpan,
+  );
+  if (!querySpan) {
     return socket;
   }
+  const recordingSpan = querySpan;
 
-  const querySpan = markedSpan.span;
   const startedAt = performance.now();
   let attemptCount = 0;
   let failedAttemptCount = 0;
   let timedOutAttemptCount = 0;
 
   function onLookup(): void {
-    querySpan.setAttribute(
+    recordingSpan.setAttribute(
       CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
       performance.now() - startedAt,
     );
@@ -78,12 +287,15 @@ export function createInstrumentedPgStream(): Socket {
 
   function onConnectionAttempt(): void {
     attemptCount += 1;
-    querySpan.setAttribute(CONNECTION_ATTEMPT_COUNT_ATTRIBUTE, attemptCount);
+    recordingSpan.setAttribute(
+      CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
+      attemptCount,
+    );
   }
 
   function onConnectionAttemptFailed(): void {
     failedAttemptCount += 1;
-    querySpan.setAttribute(
+    recordingSpan.setAttribute(
       CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
       failedAttemptCount,
     );
@@ -91,7 +303,7 @@ export function createInstrumentedPgStream(): Socket {
 
   function onConnectionAttemptTimeout(): void {
     timedOutAttemptCount += 1;
-    querySpan.setAttribute(
+    recordingSpan.setAttribute(
       CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE,
       timedOutAttemptCount,
     );
@@ -110,13 +322,13 @@ export function createInstrumentedPgStream(): Socket {
   }
 
   function onConnect(): void {
-    querySpan.setAttribute(
+    recordingSpan.setAttribute(
       CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
       performance.now() - startedAt,
     );
     const addressFamily = normalizeAddressFamily(socket.remoteFamily);
     if (addressFamily) {
-      querySpan.setAttribute(
+      recordingSpan.setAttribute(
         CONNECTION_ADDRESS_FAMILY_ATTRIBUTE,
         addressFamily,
       );

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -36,7 +36,9 @@ const pool = singleton((): Pool => {
       max: env("DB_POOL_MAX"),
       idleTimeoutMillis: env("DB_POOL_IDLE_TIMEOUT_MS"),
       connectionTimeoutMillis: env("DB_POOL_CONNECT_TIMEOUT_MS"),
-      stream: createInstrumentedPgStream,
+      stream: () => {
+        return createInstrumentedPgStream();
+      },
     }),
     trace.getTracer("vm0-api/pg"),
   );


### PR DESCRIPTION
## Summary

- keep the ordinary OS `dns.lookup()` as the immediate PostgreSQL hostname lookup
- after 250 ms, allow one identical secondary lookup per connection and at most one unresolved secondary per API process
- let a successful secondary supply the existing socket callback without creating another socket, TCP connection, PostgreSQL client, query, or write
- record fixed low-cardinality hedge/source attributes on the existing database query span

## Safety and compatibility

- hold the process-wide hedge budget until both uncancelable lookup callbacks settle
- cancel delayed hedge startup when the primary completes or the socket closes, times out, or is destroyed
- preserve Node's lookup options/callback shape and `pg`'s original hostname for TLS SNI
- do not cache or pin addresses and do not change pool sizing, connection timeouts, schema, persisted data, public APIs, queue payloads, runner protocols, dependencies, or environment variables
- mixed API revisions remain compatible; rollback is a code revert with no data action

## Validation

- `pnpm exec prettier --write apps/api/src/lib/db-instrumentation.ts apps/api/src/lib/db.ts apps/api/src/lib/__tests__/db-instrumentation.test.ts`
- `pnpm -F api exec vitest run src/lib/__tests__/db-instrumentation.test.ts` (12 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F @vm0/db db:reset`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (2,277 passed)
- pre-commit repository Knip and TypeScript checks

Closes #21751

Parent context: #21674
