### PR TITLE
fix(runner): contain supervised run descendants

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -173,7 +173,7 @@ HEALTHY_CREATE_US=$(sed -n 's/.*create_us=\([0-9][0-9]*\).*/\1/p' <<<"$HEALTHY_L
 [ -n "$HEALTHY_CREATE_US" ] || fail "missing healthy creation latency"
 [ "$LEAK_CLEANUP_MS" -le 2000 ] \
   || fail "leaked cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
-[ "$HEALTHY_CLEANUP_MS" -le 500 ] \
+[ "$HEALTHY_CLEANUP_MS" -lt 500 ] \
   || fail "healthy cleanup unexpectedly entered a wait: ${HEALTHY_CLEANUP_MS}ms"
 
 echo "PASS: detached user/root descendants were reclaimed"

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE="${METAL_USER}@${HOST}"
+SVC="${JOB_REF}-process-containment"
+GROUP="vm0/process-containment-${JOB_REF}"
+RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+GROUP_DIR="/var/lib/vm0-runner/groups/vm0/process-containment-${JOB_REF}"
+
+echo "=== Cleaning stale process-containment runner state ==="
+ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+BIN_DIR=$1; SVC=$2; GROUP_DIR=$3; RUNNER_DIR=$4
+UNIT="vm0-runner-${SVC}.service"
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+for _ in $(seq 1 30); do
+  if ! sudo systemctl is-active --quiet "$UNIT"; then
+    break
+  fi
+  sleep 1
+done
+if sudo systemctl is-active --quiet "$UNIT"; then
+  echo "FAIL: ${UNIT} is still active after cleanup stop" >&2
+  exit 1
+fi
+sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+REMOTE_SCRIPT
+
+echo "=== Generating config ==="
+# shellcheck disable=SC2029
+ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
+  --profile vm0/default \
+  --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+  --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
+  --name ${SVC} \
+  --group ${GROUP} \
+  --runner-dirname ${SVC} \
+  --max-concurrent 1 \
+  --api-url https://not-a-real-server.test \
+  --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+echo "=== Running process-containment test ==="
+ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GROUP_DIR}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
+UNIT="vm0-runner-${SVC}.service"
+SESSION_ID="e2e-process-containment-session"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+wait_for_unit_inactive() {
+  for _ in $(seq 1 30); do
+    if ! sudo systemctl is-active --quiet "$UNIT"; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail "$UNIT is still active after stop"
+}
+
+cleanup() {
+  echo "--- Cleanup ---"
+  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+  wait_for_unit_inactive
+  sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+}
+trap cleanup EXIT
+
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+wait_for_unit_inactive
+sudo rm -rf "$GROUP_DIR"
+
+echo "--- Starting runner ---"
+sudo "$BIN_DIR/runner" service start --name "$SVC" \
+  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+
+for _ in $(seq 1 30); do
+  INVOCATION_ID=$(sudo systemctl show "$UNIT" --property=InvocationID --value 2>/dev/null) || true
+  [ -n "$INVOCATION_ID" ] && break
+  sleep 1
+done
+[ -n "${INVOCATION_ID:-}" ] || fail "runner invocation ID unavailable"
+
+LEAK_PROMPT=$(cat <<'PROMPT'
+set -eu
+marker=/tmp/vm0-process-containment
+rm -rf "$marker"
+mkdir -p "$marker"
+touch "$marker/vm-reuse-marker"
+
+setsid python3 -c 'import os, pathlib, signal, time; p=pathlib.Path("/tmp/vm0-process-containment/user.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); p.write_text(f"{os.getpid()} {fields[19]}\n"); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)' </dev/null >/dev/null 2>&1 &
+setsid sudo -n python3 -c 'import os, pathlib, time; p=pathlib.Path("/tmp/vm0-process-containment/root.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >/dev/null 2>&1 &
+
+for _ in $(seq 1 100); do
+  [ -s "$marker/user.identity" ] && [ -s "$marker/root.identity" ] && break
+  sleep 0.01
+done
+test -s "$marker/user.identity"
+test -s "$marker/root.identity"
+echo containment-turn-1
+PROMPT
+)
+
+echo "--- Turn 1: leave detached user/root descendants ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt "$LEAK_PROMPT" \
+  || fail "Turn 1 failed"
+
+VERIFY_PROMPT=$(cat <<'PROMPT'
+set -eu
+marker=/tmp/vm0-process-containment
+base=/sys/fs/cgroup/vm0-supervised
+test -f "$marker/vm-reuse-marker"
+
+for identity in "$marker/user.identity" "$marker/root.identity"; do
+  read -r pid start_time < "$identity"
+  if [ -r "/proc/$pid/stat" ]; then
+    current_start=$(awk '{print $22}' "/proc/$pid/stat")
+    [ "$current_start" != "$start_time" ] || {
+      echo "recorded descendant is still alive: $identity pid=$pid" >&2
+      exit 1
+    }
+  fi
+done
+
+relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
+own_group=${relative##*/}
+test -n "$own_group"
+test -d "$base/$own_group"
+test -z "$(find "$base" -mindepth 1 -maxdepth 1 -type d ! -name "$own_group" -print -quit)"
+grep -q '^populated 1$' "$base/cgroup.events"
+test -z "$(cat "$base/cgroup.subtree_control")"
+echo containment-turn-2
+PROMPT
+)
+
+echo "--- Turn 2: prove descendants are gone and only this turn is owned ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt "$VERIFY_PROMPT" \
+  || fail "Turn 2 failed; VM was not safely reused"
+
+echo "--- Turn 3: prove healthy Turn 2 cleanup was also reusable ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --session-id "$SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'test -f /tmp/vm0-process-containment/vm-reuse-marker' \
+  || fail "Turn 3 failed; healthy cleanup did not re-enter reuse"
+
+LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+  || fail "failed to read runner logs"
+LEAK_LINE=$(printf '%s\n' "$LOGS" \
+  | grep -F 'supervised process containment cleaned' \
+  | grep -F 'descendants_observed=true' \
+  | grep -F 'cgroup_kill_used=true' \
+  | head -1) \
+  || fail "missing populated cleanup that used cgroup.kill"
+HEALTHY_LINE=$(printf '%s\n' "$LOGS" \
+  | grep -F 'supervised process containment cleaned' \
+  | grep -F 'descendants_observed=false' \
+  | grep -F 'cgroup_kill_used=false' \
+  | head -1) \
+  || fail "missing healthy cleanup that skipped grace and kill"
+
+LEAK_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$LEAK_LINE")
+HEALTHY_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$HEALTHY_LINE")
+HEALTHY_CREATE_US=$(sed -n 's/.*create_us=\([0-9][0-9]*\).*/\1/p' <<<"$HEALTHY_LINE")
+[ -n "$LEAK_CLEANUP_MS" ] || fail "missing leaked cleanup latency"
+[ -n "$HEALTHY_CLEANUP_MS" ] || fail "missing healthy cleanup latency"
+[ -n "$HEALTHY_CREATE_US" ] || fail "missing healthy creation latency"
+[ "$LEAK_CLEANUP_MS" -le 2000 ] \
+  || fail "leaked cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
+[ "$HEALTHY_CLEANUP_MS" -le 500 ] \
+  || fail "healthy cleanup unexpectedly entered a wait: ${HEALTHY_CLEANUP_MS}ms"
+
+echo "PASS: detached user/root descendants were reclaimed"
+echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy create ${HEALTHY_CREATE_US}us; healthy cleanup ${HEALTHY_CLEANUP_MS}ms"
+
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+wait_for_unit_inactive
+sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+trap - EXIT
+
+echo "=== Process-containment test passed ==="
+REMOTE_SCRIPT

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -715,6 +715,14 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-cancel.sh
 
+      - name: Test supervised process containment
+        id: process_containment
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-process-containment.sh
+
       - name: Test runner exec
         id: exec
         timeout-minutes: 5
@@ -727,6 +735,7 @@ jobs:
         env:
           DRAIN_RESUME_RESULT: ${{ steps.drain_resume.outcome }}
           CANCEL_RESULT: ${{ steps.cancel.outcome }}
+          PROCESS_CONTAINMENT_RESULT: ${{ steps.process_containment.outcome }}
           EXEC_RESULT: ${{ steps.exec.outcome }}
         run: |
           FAILED=0
@@ -744,6 +753,7 @@ jobs:
           echo "::group::Runner Behavior Lane B Results"
           check_result "drain-resume" "$DRAIN_RESUME_RESULT"
           check_result "cancel" "$CANCEL_RESULT"
+          check_result "process-containment" "$PROCESS_CONTAINMENT_RESULT"
           check_result "exec" "$EXEC_RESULT"
           echo "::endgroup::"
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1333,8 +1333,10 @@ dependencies = [
 name = "guest-init"
 version = "0.16.113"
 dependencies = [
+ "guest-contracts",
  "libc",
  "nix",
+ "tempfile",
  "vsock-guest",
 ]
 
@@ -3728,6 +3730,7 @@ dependencies = [
  "libc",
  "process-control-ipc",
  "shell-quote",
+ "tempfile",
  "vsock-proto",
 ]
 

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -5,9 +5,7 @@ use std::io::{self, Read};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
-use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, ProcessContainmentEvidence, SUPERVISED_CGROUP_BASE_PATH,
-};
+use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, SUPERVISED_CGROUP_BASE_PATH};
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
@@ -107,8 +105,7 @@ fn prepare(
         .map(Path::new)
         .map(|path| split_retained_runtime_path(path, &runtime_parent))
         .transpose()?;
-    let process_containment =
-        verify_process_containment().map_err(ReusePreparationError::Containment)?;
+    verify_process_containment().map_err(ReusePreparationError::Containment)?;
 
     let parent = Dir::open_absolute(&runtime_parent).map_err(ReusePreparationError::Cleanup)?;
     let parent_identity = parent.identity().map_err(ReusePreparationError::Cleanup)?;
@@ -167,7 +164,6 @@ fn prepare(
         before,
         after,
         removed_entries,
-        process_containment: Some(process_containment),
     })
 }
 
@@ -177,7 +173,7 @@ struct ProcessContainmentPaths {
     require_cgroup2_filesystem: bool,
 }
 
-fn verify_process_containment() -> io::Result<ProcessContainmentEvidence> {
+fn verify_process_containment() -> io::Result<()> {
     let paths = process_containment_paths();
     if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.mount)? {
         return Err(io::Error::new(
@@ -232,7 +228,7 @@ fn verify_process_containment() -> io::Result<ProcessContainmentEvidence> {
 
     let events = std::fs::read_to_string(paths.base.join(CGROUP_EVENTS_FILE))?;
     match parse_populated(&events) {
-        Some(false) => Ok(ProcessContainmentEvidence::CgroupV2),
+        Some(false) => Ok(()),
         Some(true) => Err(io::Error::other("supervised cgroup remains populated")),
         None => Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -1,18 +1,29 @@
 //! Safe reclamation of runner-owned runtime state before idle reuse.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::{CString, OsStr, OsString};
 use std::io::{self, Read};
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
+use guest_contracts::process_containment::{
+    CGROUP_V2_MOUNT_PATH, ProcessContainmentEvidence, SUPERVISED_CGROUP_BASE_PATH,
+};
 use guest_contracts::reuse_preparation::{
-    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
-    REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
-    RootFilesystemCapacity,
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
+    REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+    ReusePreparationReport, ReusePreparationRequest, RootFilesystemCapacity,
 };
 
 use crate::nofollow_fs::{Dir, FileIdentity};
 
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
+const CGROUP2_SUPER_MAGIC: i64 = 0x6367_7270;
+const CGROUP_EVENTS_FILE: &str = "cgroup.events";
+const CGROUP_KILL_FILE: &str = "cgroup.kill";
+const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
+#[cfg(debug_assertions)]
+const TEST_CONTAINMENT_ROOT_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_ROOT";
 
 /// Failure returned by the reuse-preparation helper.
 #[derive(Debug)]
@@ -23,6 +34,8 @@ pub enum ReusePreparationError {
     Inspection(io::Error),
     /// Stale runtime entries could not be safely removed.
     Cleanup(io::Error),
+    /// Supervised process containment could not be proven healthy and empty.
+    Containment(io::Error),
 }
 
 impl ReusePreparationError {
@@ -33,6 +46,7 @@ impl ReusePreparationError {
             Self::InvalidRequest(_) => REUSE_PREPARATION_EXIT_INVALID_REQUEST,
             Self::Inspection(_) => REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
             Self::Cleanup(_) => REUSE_PREPARATION_EXIT_CLEANUP_FAILED,
+            Self::Containment(_) => REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
         }
     }
 }
@@ -43,6 +57,7 @@ impl std::fmt::Display for ReusePreparationError {
             Self::InvalidRequest(error) => write!(f, "invalid reuse-preparation request: {error}"),
             Self::Inspection(error) => write!(f, "rootfs capacity inspection failed: {error}"),
             Self::Cleanup(error) => write!(f, "runtime cleanup failed: {error}"),
+            Self::Containment(error) => write!(f, "process containment check failed: {error}"),
         }
     }
 }
@@ -50,9 +65,10 @@ impl std::fmt::Display for ReusePreparationError {
 impl std::error::Error for ReusePreparationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::InvalidRequest(error) | Self::Inspection(error) | Self::Cleanup(error) => {
-                Some(error)
-            }
+            Self::InvalidRequest(error)
+            | Self::Inspection(error)
+            | Self::Cleanup(error)
+            | Self::Containment(error) => Some(error),
         }
     }
 }
@@ -92,6 +108,8 @@ fn prepare(
         .map(Path::new)
         .map(|path| split_retained_runtime_path(path, &runtime_parent))
         .transpose()?;
+    let process_containment =
+        verify_process_containment().map_err(ReusePreparationError::Containment)?;
 
     let parent = Dir::open_absolute(&runtime_parent).map_err(ReusePreparationError::Cleanup)?;
     let parent_identity = parent.identity().map_err(ReusePreparationError::Cleanup)?;
@@ -150,6 +168,123 @@ fn prepare(
         before,
         after,
         removed_entries,
+        process_containment: Some(process_containment),
+    })
+}
+
+struct ProcessContainmentPaths {
+    mount: PathBuf,
+    base: PathBuf,
+    require_cgroup2_filesystem: bool,
+}
+
+fn verify_process_containment() -> io::Result<ProcessContainmentEvidence> {
+    let paths = process_containment_paths();
+    if paths.require_cgroup2_filesystem && filesystem_type(&paths.mount)? != CGROUP2_SUPER_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "canonical cgroup mount is not cgroup v2",
+        ));
+    }
+
+    let base_metadata = std::fs::symlink_metadata(&paths.base)?;
+    if !base_metadata.is_dir() || base_metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "supervised cgroup base is not a directory",
+        ));
+    }
+    if paths.require_cgroup2_filesystem && filesystem_type(&paths.base)? != CGROUP2_SUPER_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "supervised cgroup base is not on cgroup v2",
+        ));
+    }
+    for filename in [
+        CGROUP_PROCS_FILE,
+        CGROUP_EVENTS_FILE,
+        CGROUP_KILL_FILE,
+        CGROUP_SUBTREE_CONTROL_FILE,
+    ] {
+        if !std::fs::metadata(paths.base.join(filename))?.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("supervised cgroup core file is invalid: {filename}"),
+            ));
+        }
+    }
+
+    let subtree_control = std::fs::read_to_string(paths.base.join(CGROUP_SUBTREE_CONTROL_FILE))?;
+    if !subtree_control.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "resource controllers are enabled for the supervised cgroup",
+        ));
+    }
+
+    for entry in std::fs::read_dir(&paths.base)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            return Err(io::Error::other(
+                "stale supervised operation cgroup remains",
+            ));
+        }
+    }
+
+    let events = std::fs::read_to_string(paths.base.join(CGROUP_EVENTS_FILE))?;
+    match parse_populated(&events) {
+        Some(false) => Ok(ProcessContainmentEvidence::CgroupV2),
+        Some(true) => Err(io::Error::other("supervised cgroup remains populated")),
+        None => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "cgroup.events is missing valid populated state",
+        )),
+    }
+}
+
+fn process_containment_paths() -> ProcessContainmentPaths {
+    #[cfg(debug_assertions)]
+    if let Some(root) = std::env::var_os(TEST_CONTAINMENT_ROOT_ENV) {
+        let mount = PathBuf::from(root);
+        let base = mount.join("vm0-supervised");
+        return ProcessContainmentPaths {
+            mount,
+            base,
+            require_cgroup2_filesystem: false,
+        };
+    }
+
+    ProcessContainmentPaths {
+        mount: PathBuf::from(CGROUP_V2_MOUNT_PATH),
+        base: PathBuf::from(SUPERVISED_CGROUP_BASE_PATH),
+        require_cgroup2_filesystem: true,
+    }
+}
+
+fn filesystem_type(path: &Path) -> io::Result<i64> {
+    let path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL byte"))?;
+    let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    // SAFETY: `path` is NUL-terminated and `stats` points to writable memory.
+    let result = unsafe { libc::statfs(path.as_ptr(), stats.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful statfs initialized the structure.
+    Ok(unsafe { stats.assume_init() }.f_type)
+}
+
+fn parse_populated(content: &str) -> Option<bool> {
+    content.lines().find_map(|line| {
+        let (key, value) = line.split_once(' ')?;
+        if key != "populated" {
+            return None;
+        }
+        match value {
+            "0" => Some(false),
+            "1" => Some(true),
+            _ => None,
+        }
     })
 }
 

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -17,7 +17,6 @@ use guest_contracts::reuse_preparation::{
 use crate::nofollow_fs::{Dir, FileIdentity};
 
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
-const CGROUP2_SUPER_MAGIC: i64 = 0x6367_7270;
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
@@ -180,7 +179,7 @@ struct ProcessContainmentPaths {
 
 fn verify_process_containment() -> io::Result<ProcessContainmentEvidence> {
     let paths = process_containment_paths();
-    if paths.require_cgroup2_filesystem && filesystem_type(&paths.mount)? != CGROUP2_SUPER_MAGIC {
+    if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.mount)? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "canonical cgroup mount is not cgroup v2",
@@ -194,7 +193,7 @@ fn verify_process_containment() -> io::Result<ProcessContainmentEvidence> {
             "supervised cgroup base is not a directory",
         ));
     }
-    if paths.require_cgroup2_filesystem && filesystem_type(&paths.base)? != CGROUP2_SUPER_MAGIC {
+    if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.base)? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "supervised cgroup base is not on cgroup v2",
@@ -261,7 +260,7 @@ fn process_containment_paths() -> ProcessContainmentPaths {
     }
 }
 
-fn filesystem_type(path: &Path) -> io::Result<i64> {
+fn is_cgroup2_filesystem(path: &Path) -> io::Result<bool> {
     let path = CString::new(path.as_os_str().as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL byte"))?;
     let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
@@ -271,7 +270,7 @@ fn filesystem_type(path: &Path) -> io::Result<i64> {
         return Err(io::Error::last_os_error());
     }
     // SAFETY: successful statfs initialized the structure.
-    Ok(unsafe { stats.assume_init() }.f_type)
+    Ok(unsafe { stats.assume_init() }.f_type == 0x6367_7270)
 }
 
 fn parse_populated(content: &str) -> Option<bool> {

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -8,7 +8,6 @@ use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-use guest_contracts::process_containment::ProcessContainmentEvidence;
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
@@ -54,10 +53,6 @@ fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
     );
     let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
     assert_eq!(report.removed_entries, 3);
-    assert_eq!(
-        report.process_containment,
-        Some(ProcessContainmentEvidence::CgroupV2)
-    );
     assert!(report.before.available_bytes > 0);
     assert!(report.after.available_bytes > 0);
     assert_eq!(

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -8,9 +8,10 @@ use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
+use guest_contracts::process_containment::ProcessContainmentEvidence;
 use guest_contracts::reuse_preparation::{
-    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
-    ReusePreparationReport, ReusePreparationRequest,
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
+    REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
 };
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
@@ -53,6 +54,10 @@ fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
     );
     let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
     assert_eq!(report.removed_entries, 3);
+    assert_eq!(
+        report.process_containment,
+        Some(ProcessContainmentEvidence::CgroupV2)
+    );
     assert!(report.before.available_bytes > 0);
     assert!(report.after.available_bytes > 0);
     assert_eq!(
@@ -198,9 +203,122 @@ fn prepare_for_reuse_rejects_same_filesystem_bind_mount() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn prepare_for_reuse_rejects_missing_containment_capability() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::remove_file(containment.base.join("cgroup.kill"))?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_stale_operation_cgroup() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::create_dir(containment.base.join("exec-stale"))?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_populated_supervised_cgroup() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(containment.base.join("cgroup.events"), b"populated 1\n")?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_enabled_controllers() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(
+        containment.base.join("cgroup.subtree_control"),
+        b"+memory\n",
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+struct ContainmentFixture {
+    _directory: tempfile::TempDir,
+    root: PathBuf,
+    base: PathBuf,
+}
+
+impl ContainmentFixture {
+    fn new() -> TestResult<Self> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path().join("cgroup");
+        let base = root.join("vm0-supervised");
+        std::fs::create_dir_all(&base)?;
+        for (filename, content) in [
+            ("cgroup.procs", ""),
+            ("cgroup.events", "populated 0\nfrozen 0\n"),
+            ("cgroup.kill", ""),
+            ("cgroup.subtree_control", ""),
+        ] {
+            std::fs::write(base.join(filename), content)?;
+        }
+        Ok(Self {
+            _directory: directory,
+            root,
+            base,
+        })
+    }
+}
+
+fn reusable_request() -> TestResult<(ReusePreparationRequest, tempfile::TempDir)> {
+    let runtime = tempfile::tempdir()?;
+    let current = runtime.path().join("runs/current");
+    std::fs::create_dir_all(&current)?;
+    Ok((
+        ReusePreparationRequest {
+            current_runtime_dir: path_string(&current),
+            retained_runtime_dir: None,
+        },
+        runtime,
+    ))
+}
+
 fn run_helper(request: &ReusePreparationRequest) -> Result<Output, Box<dyn std::error::Error>> {
+    let containment = ContainmentFixture::new()?;
+    run_helper_with_containment(request, &containment)
+}
+
+fn run_helper_with_containment(
+    request: &ReusePreparationRequest,
+    containment: &ContainmentFixture,
+) -> Result<Output, Box<dyn std::error::Error>> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
         .env_clear()
+        .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
         .arg("prepare-for-reuse")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -219,8 +337,10 @@ fn run_helper_with_bind_mount(
     mount_source: &Path,
     mount_target: &Path,
 ) -> Result<Output, Box<dyn std::error::Error>> {
+    let containment = ContainmentFixture::new()?;
     let mut child = Command::new("/usr/bin/unshare")
         .env_clear()
+        .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
         .env("VM0_MOUNT_SOURCE", mount_source)
         .env("VM0_MOUNT_TARGET", mount_target)
         .env("VM0_HELPER", env!("CARGO_BIN_EXE_guest-agent"))

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -9,6 +9,7 @@ pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;
 pub mod exec_limits;
+pub mod process_containment;
 pub mod reuse_preparation;
 pub mod runtime_paths;
 pub mod session_history_identity;

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -1,17 +1,7 @@
-//! Shared guest process-containment paths and evidence.
-
-use serde::{Deserialize, Serialize};
+//! Shared guest process-containment paths.
 
 /// Canonical cgroup v2 mount inside the guest.
 pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
 
 /// Cgroup containing all active supervised-operation child cgroups.
 pub const SUPERVISED_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-supervised";
-
-/// Proof emitted only after the supervised cgroup hierarchy is verified empty.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum ProcessContainmentEvidence {
-    /// Cgroup v2 is available and the supervised subtree is empty.
-    CgroupV2,
-}

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -1,0 +1,17 @@
+//! Shared guest process-containment paths and evidence.
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical cgroup v2 mount inside the guest.
+pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
+
+/// Cgroup containing all active supervised-operation child cgroups.
+pub const SUPERVISED_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-supervised";
+
+/// Proof emitted only after the supervised cgroup hierarchy is verified empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProcessContainmentEvidence {
+    /// Cgroup v2 is available and the supervised subtree is empty.
+    CgroupV2,
+}

--- a/crates/guest-contracts/src/reuse_preparation.rs
+++ b/crates/guest-contracts/src/reuse_preparation.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::process_containment::ProcessContainmentEvidence;
+
 /// Helper completed successfully and emitted a reuse-preparation report.
 pub const REUSE_PREPARATION_EXIT_SUCCESS: i32 = 0;
 /// The helper request was missing or invalid.
@@ -10,6 +12,8 @@ pub const REUSE_PREPARATION_EXIT_INVALID_REQUEST: i32 = 2;
 pub const REUSE_PREPARATION_EXIT_INSPECTION_FAILED: i32 = 3;
 /// Stale runner-owned runtime state could not be safely removed.
 pub const REUSE_PREPARATION_EXIT_CLEANUP_FAILED: i32 = 4;
+/// Supervised process containment could not be proven healthy and empty.
+pub const REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED: i32 = 5;
 
 /// Runtime directories that must remain available after reuse preparation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,4 +46,67 @@ pub struct ReusePreparationReport {
     pub after: RootFilesystemCapacity,
     /// Number of unprotected entries removed directly below the runtime parent.
     pub removed_entries: u64,
+    /// Proof that completed supervised work cannot survive into idle reuse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_containment: Option<ProcessContainmentEvidence>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process_containment::ProcessContainmentEvidence;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LegacyReusePreparationReport {
+        before: RootFilesystemCapacity,
+        after: RootFilesystemCapacity,
+        removed_entries: u64,
+    }
+
+    fn report(process_containment: Option<ProcessContainmentEvidence>) -> ReusePreparationReport {
+        ReusePreparationReport {
+            before: RootFilesystemCapacity {
+                available_bytes: 10,
+                available_inodes: 20,
+            },
+            after: RootFilesystemCapacity {
+                available_bytes: 30,
+                available_inodes: 40,
+            },
+            removed_entries: 2,
+            process_containment,
+        }
+    }
+
+    #[test]
+    fn old_report_decodes_without_containment_evidence() {
+        let decoded: ReusePreparationReport = serde_json::from_value(serde_json::json!({
+            "before": { "availableBytes": 10, "availableInodes": 20 },
+            "after": { "availableBytes": 30, "availableInodes": 40 },
+            "removedEntries": 2
+        }))
+        .unwrap();
+
+        assert_eq!(decoded, report(None));
+    }
+
+    #[test]
+    fn legacy_reader_ignores_new_containment_evidence() {
+        let encoded =
+            serde_json::to_value(report(Some(ProcessContainmentEvidence::CgroupV2))).unwrap();
+        let decoded: LegacyReusePreparationReport = serde_json::from_value(encoded).unwrap();
+
+        assert_eq!(decoded.before.available_bytes, 10);
+        assert_eq!(decoded.after.available_inodes, 40);
+        assert_eq!(decoded.removed_entries, 2);
+    }
+
+    #[test]
+    fn containment_evidence_has_stable_json_spelling() {
+        let encoded =
+            serde_json::to_value(report(Some(ProcessContainmentEvidence::CgroupV2))).unwrap();
+
+        assert_eq!(encoded["processContainment"], "cgroupV2");
+    }
 }

--- a/crates/guest-contracts/src/reuse_preparation.rs
+++ b/crates/guest-contracts/src/reuse_preparation.rs
@@ -2,8 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::process_containment::ProcessContainmentEvidence;
-
 /// Helper completed successfully and emitted a reuse-preparation report.
 pub const REUSE_PREPARATION_EXIT_SUCCESS: i32 = 0;
 /// The helper request was missing or invalid.
@@ -46,67 +44,4 @@ pub struct ReusePreparationReport {
     pub after: RootFilesystemCapacity,
     /// Number of unprotected entries removed directly below the runtime parent.
     pub removed_entries: u64,
-    /// Proof that completed supervised work cannot survive into idle reuse.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_containment: Option<ProcessContainmentEvidence>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::process_containment::ProcessContainmentEvidence;
-
-    #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct LegacyReusePreparationReport {
-        before: RootFilesystemCapacity,
-        after: RootFilesystemCapacity,
-        removed_entries: u64,
-    }
-
-    fn report(process_containment: Option<ProcessContainmentEvidence>) -> ReusePreparationReport {
-        ReusePreparationReport {
-            before: RootFilesystemCapacity {
-                available_bytes: 10,
-                available_inodes: 20,
-            },
-            after: RootFilesystemCapacity {
-                available_bytes: 30,
-                available_inodes: 40,
-            },
-            removed_entries: 2,
-            process_containment,
-        }
-    }
-
-    #[test]
-    fn old_report_decodes_without_containment_evidence() {
-        let decoded: ReusePreparationReport = serde_json::from_value(serde_json::json!({
-            "before": { "availableBytes": 10, "availableInodes": 20 },
-            "after": { "availableBytes": 30, "availableInodes": 40 },
-            "removedEntries": 2
-        }))
-        .unwrap();
-
-        assert_eq!(decoded, report(None));
-    }
-
-    #[test]
-    fn legacy_reader_ignores_new_containment_evidence() {
-        let encoded =
-            serde_json::to_value(report(Some(ProcessContainmentEvidence::CgroupV2))).unwrap();
-        let decoded: LegacyReusePreparationReport = serde_json::from_value(encoded).unwrap();
-
-        assert_eq!(decoded.before.available_bytes, 10);
-        assert_eq!(decoded.after.available_inodes, 40);
-        assert_eq!(decoded.removed_entries, 2);
-    }
-
-    #[test]
-    fn containment_evidence_has_stable_json_spelling() {
-        let encoded =
-            serde_json::to_value(report(Some(ProcessContainmentEvidence::CgroupV2))).unwrap();
-
-        assert_eq!(encoded["processContainment"], "cgroupV2");
-    }
 }

--- a/crates/guest-init/Cargo.toml
+++ b/crates/guest-init/Cargo.toml
@@ -5,9 +5,13 @@ edition.workspace = true
 description = "Guest init process for Firecracker - filesystem setup, PID 1, and vsock-guest"
 
 [dependencies]
+guest-contracts.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["mount"] }
 vsock-guest.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -9,6 +9,15 @@
 
 use nix::mount::{MsFlags, mount};
 use std::fs;
+use std::io;
+use std::path::Path;
+
+use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, SUPERVISED_CGROUP_BASE_PATH};
+
+const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const CGROUP_EVENTS_FILE: &str = "cgroup.events";
+const CGROUP_KILL_FILE: &str = "cgroup.kill";
+const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
 
 /// Initialize virtual filesystems and environment.
 ///
@@ -56,6 +65,8 @@ pub fn init_filesystem() -> Result<(), InitError> {
         source: e,
     })?;
 
+    initialize_process_containment()?;
+
     // Mount tmpfs on /dev/shm — required by Chromium for shared memory.
     // devtmpfs (CONFIG_DEVTMPFS_MOUNT=y) doesn't create /dev/shm.
     let _ = fs::create_dir_all("/dev/shm");
@@ -100,7 +111,16 @@ pub fn init_filesystem() -> Result<(), InitError> {
 /// Errors that can occur during filesystem initialization
 #[derive(Debug)]
 pub enum InitError {
-    Mount { target: String, source: nix::Error },
+    Mount {
+        target: String,
+        source: nix::Error,
+    },
+    Filesystem {
+        operation: &'static str,
+        path: String,
+        source: io::Error,
+    },
+    InvalidProcessContainment(String),
 }
 
 impl std::fmt::Display for InitError {
@@ -109,11 +129,84 @@ impl std::fmt::Display for InitError {
             InitError::Mount { target, source } => {
                 write!(f, "Failed to mount {}: {}", target, source)
             }
+            InitError::Filesystem {
+                operation,
+                path,
+                source,
+            } => write!(f, "Failed to {operation} {path}: {source}"),
+            InitError::InvalidProcessContainment(message) => {
+                write!(f, "Invalid process containment: {message}")
+            }
         }
     }
 }
 
 impl std::error::Error for InitError {}
+
+fn initialize_process_containment() -> Result<(), InitError> {
+    create_dir_all(Path::new(CGROUP_V2_MOUNT_PATH))?;
+    mount(
+        Some("cgroup2"),
+        CGROUP_V2_MOUNT_PATH,
+        Some("cgroup2"),
+        MsFlags::MS_NODEV | MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID,
+        None::<&str>,
+    )
+    .map_err(|source| InitError::Mount {
+        target: CGROUP_V2_MOUNT_PATH.into(),
+        source,
+    })?;
+
+    let base = Path::new(SUPERVISED_CGROUP_BASE_PATH);
+    create_dir_all(base)?;
+    verify_process_containment_base(base)?;
+    eprintln!("[guest-init] Supervised process containment initialized");
+    Ok(())
+}
+
+fn create_dir_all(path: &Path) -> Result<(), InitError> {
+    fs::create_dir_all(path).map_err(|source| InitError::Filesystem {
+        operation: "create directory",
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
+    for filename in [
+        CGROUP_PROCS_FILE,
+        CGROUP_EVENTS_FILE,
+        CGROUP_KILL_FILE,
+        CGROUP_SUBTREE_CONTROL_FILE,
+    ] {
+        let path = base.join(filename);
+        let metadata = fs::metadata(&path).map_err(|source| InitError::Filesystem {
+            operation: "inspect",
+            path: path.display().to_string(),
+            source,
+        })?;
+        if !metadata.is_file() {
+            return Err(InitError::InvalidProcessContainment(format!(
+                "{} is not a file",
+                path.display()
+            )));
+        }
+    }
+
+    let subtree_control_path = base.join(CGROUP_SUBTREE_CONTROL_FILE);
+    let subtree_control =
+        fs::read_to_string(&subtree_control_path).map_err(|source| InitError::Filesystem {
+            operation: "read",
+            path: subtree_control_path.display().to_string(),
+            source,
+        })?;
+    if !subtree_control.trim().is_empty() {
+        return Err(InitError::InvalidProcessContainment(
+            "resource controllers are enabled for the supervised subtree".into(),
+        ));
+    }
+    Ok(())
+}
 
 /// Parse environment file content into key-value pairs.
 ///
@@ -156,6 +249,18 @@ unsafe fn load_etc_environment() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_cgroup_core_files(base: &Path, subtree_control: &str) {
+        fs::create_dir_all(base).unwrap();
+        for (filename, content) in [
+            (CGROUP_PROCS_FILE, ""),
+            (CGROUP_EVENTS_FILE, "populated 0\nfrozen 0\n"),
+            (CGROUP_KILL_FILE, ""),
+            (CGROUP_SUBTREE_CONTROL_FILE, subtree_control),
+        ] {
+            fs::write(base.join(filename), content).unwrap();
+        }
+    }
 
     #[test]
     fn parse_env_basic() {
@@ -226,5 +331,34 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("/proc"));
         assert!(msg.contains("EACCES"));
+    }
+
+    #[test]
+    fn process_containment_base_requires_core_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cgroup_core_files(dir.path(), "");
+        fs::remove_file(dir.path().join(CGROUP_KILL_FILE)).unwrap();
+
+        let error = verify_process_containment_base(dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains(CGROUP_KILL_FILE));
+    }
+
+    #[test]
+    fn process_containment_base_rejects_enabled_controllers() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cgroup_core_files(dir.path(), "+memory\n");
+
+        let error = verify_process_containment_base(dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("resource controllers"));
+    }
+
+    #[test]
+    fn process_containment_base_accepts_controller_free_core_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cgroup_core_files(dir.path(), "\n");
+
+        verify_process_containment_base(dir.path()).unwrap();
     }
 }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -635,6 +635,7 @@ mod tests {
         constants::runners::paths::CANONICAL_WORKING_DIR,
         types::runners::storage::{ArtifactEntry, StorageEntry, StorageManifest},
     };
+    use guest_contracts::process_containment::ProcessContainmentEvidence;
     use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -914,6 +915,7 @@ mod tests {
                     available_inodes: 4096,
                 },
                 removed_entries: 0,
+                process_containment: Some(ProcessContainmentEvidence::CgroupV2),
             })
             .unwrap(),
             stderr: Vec::new(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -635,7 +635,6 @@ mod tests {
         constants::runners::paths::CANONICAL_WORKING_DIR,
         types::runners::storage::{ArtifactEntry, StorageEntry, StorageManifest},
     };
-    use guest_contracts::process_containment::ProcessContainmentEvidence;
     use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -915,7 +914,6 @@ mod tests {
                     available_inodes: 4096,
                 },
                 removed_entries: 0,
-                process_containment: Some(ProcessContainmentEvidence::CgroupV2),
             })
             .unwrap(),
             stderr: Vec::new(),

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
-use guest_contracts::process_containment::ProcessContainmentEvidence;
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
@@ -30,7 +29,6 @@ enum ReuseRejectionReason {
     ContainmentFailed,
     HelperFailed,
     InvalidReport,
-    MissingContainmentEvidence,
     LowBytes,
     LowInodes,
     LowBytesAndInodes,
@@ -45,7 +43,6 @@ impl ReuseRejectionReason {
             Self::ContainmentFailed => "containment_failed",
             Self::HelperFailed => "helper_failed",
             Self::InvalidReport => "invalid_report",
-            Self::MissingContainmentEvidence => "missing_containment_evidence",
             Self::LowBytes => "low_bytes",
             Self::LowInodes => "low_inodes",
             Self::LowBytesAndInodes => "low_bytes_and_inodes",
@@ -139,15 +136,6 @@ pub(crate) async fn prepare_sandbox_for_idle_reuse(
                 format!("reuse preparation returned an invalid report: {error}"),
             )
         })?;
-    if report.process_containment != Some(ProcessContainmentEvidence::CgroupV2) {
-        return Err(reject_with_result(
-            sandbox,
-            run_id,
-            ReuseRejectionReason::MissingContainmentEvidence,
-            &result,
-            "reuse preparation did not prove supervised process containment".into(),
-        ));
-    }
     let low_bytes = report.after.available_bytes < MIN_REUSE_ROOTFS_AVAILABLE_BYTES;
     let low_inodes = report.after.available_inodes < MIN_REUSE_ROOTFS_AVAILABLE_INODES;
     if low_bytes || low_inodes {
@@ -185,7 +173,6 @@ pub(crate) fn healthy_reuse_preparation_report() -> ReusePreparationReport {
             available_inodes: 2048,
         },
         removed_entries: 0,
-        process_containment: Some(ProcessContainmentEvidence::CgroupV2),
     }
 }
 
@@ -346,7 +333,6 @@ mod tests {
                 available_inodes: after_inodes,
             },
             removed_entries: 3,
-            process_containment: Some(ProcessContainmentEvidence::CgroupV2),
         }
     }
 
@@ -504,29 +490,6 @@ mod tests {
                 Some(expected_reason)
             );
         }
-    }
-
-    #[tokio::test]
-    async fn preparation_rejects_old_guest_report_without_containment_evidence() {
-        let sandbox = MockSandbox::new("missing-containment-evidence");
-        let mut report = healthy_reuse_preparation_report();
-        report.process_containment = None;
-        sandbox.push_exec_result(Ok(ExecResult::new(
-            0,
-            serde_json::to_vec(&report).unwrap(),
-            Vec::new(),
-        )));
-
-        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
-
-        assert!(result.is_err());
-        assert_eq!(
-            captured_event(&events, "sandbox rejected from idle reuse")
-                .fields
-                .get("reason")
-                .map(String::as_str),
-            Some("missing_containment_evidence")
-        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -3,9 +3,11 @@
 use std::time::Duration;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
+use guest_contracts::process_containment::ProcessContainmentEvidence;
 use guest_contracts::reuse_preparation::{
-    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
-    REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
+    REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
+    ReusePreparationReport, ReusePreparationRequest,
 };
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecResult, ExecTermination, Sandbox};
 use tracing::{info, warn};
@@ -25,8 +27,10 @@ enum ReuseRejectionReason {
     InvalidRequest,
     InspectionFailed,
     CleanupFailed,
+    ContainmentFailed,
     HelperFailed,
     InvalidReport,
+    MissingContainmentEvidence,
     LowBytes,
     LowInodes,
     LowBytesAndInodes,
@@ -38,8 +42,10 @@ impl ReuseRejectionReason {
             Self::InvalidRequest => "invalid_request",
             Self::InspectionFailed => "inspection_failed",
             Self::CleanupFailed => "cleanup_failed",
+            Self::ContainmentFailed => "containment_failed",
             Self::HelperFailed => "helper_failed",
             Self::InvalidReport => "invalid_report",
+            Self::MissingContainmentEvidence => "missing_containment_evidence",
             Self::LowBytes => "low_bytes",
             Self::LowInodes => "low_inodes",
             Self::LowBytesAndInodes => "low_bytes_and_inodes",
@@ -133,6 +139,15 @@ pub(crate) async fn prepare_sandbox_for_idle_reuse(
                 format!("reuse preparation returned an invalid report: {error}"),
             )
         })?;
+    if report.process_containment != Some(ProcessContainmentEvidence::CgroupV2) {
+        return Err(reject_with_result(
+            sandbox,
+            run_id,
+            ReuseRejectionReason::MissingContainmentEvidence,
+            &result,
+            "reuse preparation did not prove supervised process containment".into(),
+        ));
+    }
     let low_bytes = report.after.available_bytes < MIN_REUSE_ROOTFS_AVAILABLE_BYTES;
     let low_inodes = report.after.available_inodes < MIN_REUSE_ROOTFS_AVAILABLE_INODES;
     if low_bytes || low_inodes {
@@ -170,6 +185,7 @@ pub(crate) fn healthy_reuse_preparation_report() -> ReusePreparationReport {
             available_inodes: 2048,
         },
         removed_entries: 0,
+        process_containment: Some(ProcessContainmentEvidence::CgroupV2),
     }
 }
 
@@ -205,6 +221,9 @@ fn helper_failure_reason(result: &ExecResult) -> ReuseRejectionReason {
         ExecTermination::Exited {
             exit_code: REUSE_PREPARATION_EXIT_CLEANUP_FAILED,
         } => ReuseRejectionReason::CleanupFailed,
+        ExecTermination::Exited {
+            exit_code: REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
+        } => ReuseRejectionReason::ContainmentFailed,
         ExecTermination::Exited { .. }
         | ExecTermination::TimedOut
         | ExecTermination::Cancelled
@@ -327,6 +346,7 @@ mod tests {
                 available_inodes: after_inodes,
             },
             removed_entries: 3,
+            process_containment: Some(ProcessContainmentEvidence::CgroupV2),
         }
     }
 
@@ -456,13 +476,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn preparation_distinguishes_helper_inspection_and_cleanup_failures() {
+    async fn preparation_distinguishes_typed_helper_failures() {
         for (exit_code, expected_reason) in [
             (
                 REUSE_PREPARATION_EXIT_INSPECTION_FAILED,
                 "inspection_failed",
             ),
             (REUSE_PREPARATION_EXIT_CLEANUP_FAILED, "cleanup_failed"),
+            (
+                REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
+                "containment_failed",
+            ),
         ] {
             let sandbox = MockSandbox::new(expected_reason);
             sandbox.push_exec_result(Ok(ExecResult::new(
@@ -480,6 +504,29 @@ mod tests {
                 Some(expected_reason)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn preparation_rejects_old_guest_report_without_containment_evidence() {
+        let sandbox = MockSandbox::new("missing-containment-evidence");
+        let mut report = healthy_reuse_preparation_report();
+        report.process_containment = None;
+        sandbox.push_exec_result(Ok(ExecResult::new(
+            0,
+            serde_json::to_vec(&report).unwrap(),
+            Vec::new(),
+        )));
+
+        let (result, events) = capture_preparation(&sandbox, RunId::new_v4()).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            captured_event(&events, "sandbox rejected from idle reuse")
+                .fields
+                .get("reason")
+                .map(String::as_str),
+            Some("missing_containment_evidence")
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -13,6 +13,13 @@ pub(crate) struct LocalDiscoveredJob {
     pub(crate) run_id: RunId,
     pub(crate) profile_name: String,
     pub(crate) job_path: PathBuf,
+    pub(crate) cli_agent_session_id: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct LocalDiscoveryMetadata {
+    #[serde(default)]
+    session_id: Option<String>,
 }
 
 pub(crate) enum LocalClaimResult {
@@ -181,10 +188,18 @@ impl LocalQueue {
                 if self.discovery_candidate_ineligible(&candidate, snapshot.as_ref()) {
                     continue;
                 }
+                let cli_agent_session_id =
+                    super::read_private_file(&candidate.path, "local job discovery metadata")
+                        .ok()
+                        .and_then(|bytes| {
+                            serde_json::from_slice::<LocalDiscoveryMetadata>(&bytes).ok()
+                        })
+                        .and_then(|metadata| metadata.session_id);
                 return Some(LocalDiscoveredJob {
                     run_id: candidate.run_id,
                     profile_name: profile.clone(),
                     job_path: candidate.path,
+                    cli_agent_session_id,
                 });
             }
         }

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -113,6 +113,7 @@ fn job_candidate_from_discovered(discovered: LocalDiscoveredJob) -> JobCandidate
         discovered.profile_name,
         discovered.job_path,
     )
+    .with_affinity_metadata(discovered.cli_agent_session_id, None)
 }
 
 #[async_trait::async_trait]

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -35,6 +35,24 @@ async fn discover_claim_complete() {
 }
 
 #[tokio::test]
+async fn discover_exposes_session_affinity_before_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let job_id = RunId::new_v4();
+
+    write_job_with_session(dir.path(), job_id, "continue", "session-123");
+
+    let candidate = provider.discover().await.unwrap();
+    assert_eq!(candidate.cli_agent_session_id(), Some("session-123"));
+
+    let claimed = provider.claim(candidate).await.unwrap();
+    assert_eq!(
+        claimed.context().cli_agent_session_id(),
+        Some("session-123")
+    );
+}
+
+#[tokio::test]
 async fn shutdown_returns_none() {
     let dir = tempfile::tempdir().unwrap();
     let cancel = CancellationToken::new();

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -98,13 +98,31 @@ pub(super) fn write_job_with_profile(
 }
 
 pub(super) fn write_job_with_active_input(dir: &std::path::Path, job_id: RunId, prompt: &str) {
-    write_job_in_partition_with_active_input(
+    write_job_in_partition_with_options(
         dir,
         crate::profile::DEFAULT_PROFILE,
         job_id,
         prompt,
         Some(crate::profile::DEFAULT_PROFILE),
+        None,
         Some(true),
+    );
+}
+
+pub(super) fn write_job_with_session(
+    dir: &std::path::Path,
+    job_id: RunId,
+    prompt: &str,
+    session_id: &str,
+) {
+    write_job_in_partition_with_options(
+        dir,
+        crate::profile::DEFAULT_PROFILE,
+        job_id,
+        prompt,
+        Some(crate::profile::DEFAULT_PROFILE),
+        Some(session_id),
+        None,
     );
 }
 
@@ -115,22 +133,24 @@ pub(super) fn write_job_in_partition(
     prompt: &str,
     json_profile: Option<&str>,
 ) {
-    write_job_in_partition_with_active_input(
+    write_job_in_partition_with_options(
         dir,
         partition_profile,
         job_id,
         prompt,
         json_profile,
         None,
+        None,
     );
 }
 
-fn write_job_in_partition_with_active_input(
+fn write_job_in_partition_with_options(
     dir: &std::path::Path,
     partition_profile: &str,
     job_id: RunId,
     prompt: &str,
     json_profile: Option<&str>,
+    session_id: Option<&str>,
     active_input: Option<bool>,
 ) {
     let req = JobRequest {
@@ -142,7 +162,7 @@ fn write_job_in_partition_with_active_input(
         secret_environment: None,
         user_timezone: None,
         profile: json_profile.map(String::from),
-        session_id: None,
+        session_id: session_id.map(String::from),
         feature_flags: None,
         active_input,
     };

--- a/crates/vsock-guest/Cargo.toml
+++ b/crates/vsock-guest/Cargo.toml
@@ -14,5 +14,8 @@ vsock-proto.workspace = true
 # Enables local integration-test hooks. Do not enable for production guest binaries.
 test-support = []
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -22,6 +22,7 @@ use crate::process::{
     ProcessTreeKillTarget, extract_exit_code, kill_and_reap_child_with_target,
     process_tree_kill_target, refresh_process_tree_kill_target,
 };
+use crate::process_containment::SupervisedProcessContainment;
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
     SpawnedShellCommand, format_env_diagnostics, spawn_shell_command_with_pipes,
@@ -395,6 +396,7 @@ impl ExecCompletion<'_> {
 struct ExecSetup {
     child: Child,
     kill_target: ProcessTreeKillTarget,
+    process_containment: Option<SupervisedProcessContainment>,
     stdin_writer: Option<StdinWriter>,
     drain_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
@@ -402,13 +404,14 @@ struct ExecSetup {
 }
 
 impl ExecSetup {
-    fn new(child: Child) -> Self {
+    fn new(child: Child, process_containment: Option<SupervisedProcessContainment>) -> Self {
         let kill_target = process_tree_kill_target(child.id());
         let drain_cancel = Arc::new(AtomicBool::new(false));
         let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
         Self {
             child,
             kill_target,
+            process_containment,
             stdin_writer: None,
             drain_cancel,
             drain_done_tx,
@@ -461,6 +464,7 @@ impl ExecSetup {
         let ExecSetup {
             child,
             kill_target,
+            process_containment,
             stdin_writer,
             drain_cancel,
             drain_done_tx: _,
@@ -469,6 +473,7 @@ impl ExecSetup {
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
         kill_and_reap_child_with_target(child, kill_target);
+        cleanup_process_containment(process_containment);
         join_stdin_writer_after_kill(stdin_writer);
         completion.wait_failed(diagnostic);
     }
@@ -478,12 +483,14 @@ impl ExecSetup {
         let ExecSetup {
             child,
             kill_target,
+            process_containment,
             stdin_writer: _,
             drain_cancel: _,
             drain_done_tx: _,
             drain_done_rx: _,
         } = self;
         kill_and_reap_child_with_target(child, kill_target);
+        cleanup_process_containment(process_containment);
         completion.release_without_result();
     }
 }
@@ -517,6 +524,7 @@ impl ExecSetupWithStdout {
         let ExecSetup {
             child,
             kill_target,
+            process_containment,
             stdin_writer,
             drain_cancel,
             drain_done_tx: _,
@@ -525,6 +533,7 @@ impl ExecSetupWithStdout {
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
         kill_and_reap_child_with_target(child, kill_target);
+        cleanup_process_containment(process_containment);
         join_stdin_writer_after_kill(stdin_writer);
         let _ = stdout_handle.join();
         completion.wait_failed(diagnostic);
@@ -543,6 +552,7 @@ impl ExecSetupWithStdout {
         let ExecSetup {
             child,
             kill_target,
+            process_containment,
             stdin_writer,
             drain_cancel,
             drain_done_tx,
@@ -553,6 +563,7 @@ impl ExecSetupWithStdout {
         RunningExec {
             child,
             kill_target,
+            process_containment,
             stdin_writer,
             stdout_handle,
             stdout_result_rx,
@@ -567,6 +578,7 @@ impl ExecSetupWithStdout {
 struct RunningExec {
     child: Child,
     kill_target: ProcessTreeKillTarget,
+    process_containment: Option<SupervisedProcessContainment>,
     stdin_writer: Option<StdinWriter>,
     stdout_handle: JoinHandle<()>,
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
@@ -587,6 +599,7 @@ impl RunningExec {
         let RunningExec {
             child,
             mut kill_target,
+            process_containment,
             stdin_writer,
             stdout_handle,
             stdout_result_rx,
@@ -617,9 +630,11 @@ impl RunningExec {
             prepare_stdin_writer_for_pre_reap,
         );
         join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
+        let containment_clean = cleanup_process_containment(process_containment);
         if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
             || connection_cancel.load(Ordering::Acquire)
             || exec_cancel.load(Ordering::Acquire)
+            || !containment_clean
         {
             exec_cancel.store(true, Ordering::Release);
             drain_cancel.store(true, Ordering::Release);
@@ -673,6 +688,13 @@ impl RunningExec {
             &diagnostic,
         );
     }
+}
+
+fn cleanup_process_containment(process_containment: Option<SupervisedProcessContainment>) -> bool {
+    process_containment
+        .map(SupervisedProcessContainment::cleanup)
+        .transpose()
+        .is_ok()
 }
 
 pub(crate) fn start_exec_operation(
@@ -809,11 +831,25 @@ fn run_exec_operation_worker<S>(
     } else {
         env_refs.as_slice()
     };
+    let process_containment = if request.lifecycle == ExecOperationLifecycle::Supervised {
+        match SupervisedProcessContainment::create(request.seq) {
+            Ok(process_containment) => Some(process_containment),
+            Err(error) => {
+                completion.start_failed(&format!(
+                    "Failed to initialize supervised process containment: {error}"
+                ));
+                return;
+            }
+        }
+    } else {
+        None
+    };
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
         effective_env,
         request.sudo,
         pipe_stdin,
+        process_containment.as_ref(),
     ) {
         Ok(spawned) => spawned,
         Err(e) => {
@@ -828,7 +864,7 @@ fn run_exec_operation_worker<S>(
 
     let SpawnedShellCommand { child, env_script } = spawned;
     let _env_script = env_script;
-    let mut setup = ExecSetup::new(child);
+    let mut setup = ExecSetup::new(child, process_containment);
 
     if request.lifecycle == ExecOperationLifecycle::Supervised
         && let Err(e) = send_exec_started(request.seq, setup.child.id(), &writer)

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -15,6 +15,7 @@ mod file_write_worker;
 mod handlers;
 mod log;
 mod process;
+mod process_containment;
 mod quiesce;
 mod shell_command;
 mod shutdown;

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -1,0 +1,417 @@
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use guest_contracts::process_containment::SUPERVISED_CGROUP_BASE_PATH;
+
+use crate::log::log;
+
+const CGROUP_EVENTS_FILE: &str = "cgroup.events";
+const CGROUP_KILL_FILE: &str = "cgroup.kill";
+const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const TERM_GRACE: Duration = Duration::from_millis(500);
+const KILL_EMPTY_TIMEOUT: Duration = Duration::from_secs(1);
+const REMOVE_TIMEOUT: Duration = Duration::from_millis(250);
+
+static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) struct SupervisedProcessContainment {
+    backend: ContainmentBackend,
+}
+
+enum ContainmentBackend {
+    Cgroup(CgroupGuard),
+    TestNoop,
+}
+
+struct CgroupGuard {
+    group_name: String,
+    group_path: PathBuf,
+    placement: OwnedFd,
+    create_elapsed: Duration,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProcessContainmentError {
+    stage: &'static str,
+    source: io::Error,
+}
+
+impl std::fmt::Display for ProcessContainmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.stage, self.source)
+    }
+}
+
+impl std::error::Error for ProcessContainmentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl ProcessContainmentError {
+    fn new(stage: &'static str, source: io::Error) -> Self {
+        Self { stage, source }
+    }
+}
+
+impl SupervisedProcessContainment {
+    pub(crate) fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
+        if cfg!(debug_assertions) || cfg!(feature = "test-support") {
+            return Ok(Self {
+                backend: ContainmentBackend::TestNoop,
+            });
+        }
+
+        CgroupGuard::create(sequence).map(|guard| Self {
+            backend: ContainmentBackend::Cgroup(guard),
+        })
+    }
+
+    pub(crate) fn configure_command(
+        &self,
+        command: &mut Command,
+    ) -> Result<(), ProcessContainmentError> {
+        match &self.backend {
+            ContainmentBackend::Cgroup(guard) => guard.configure_command(command),
+            ContainmentBackend::TestNoop => Ok(()),
+        }
+    }
+
+    pub(crate) fn cleanup(self) -> Result<(), ProcessContainmentError> {
+        match self.backend {
+            ContainmentBackend::Cgroup(guard) => guard.cleanup(),
+            ContainmentBackend::TestNoop => Ok(()),
+        }
+    }
+}
+
+impl CgroupGuard {
+    fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
+        let started = Instant::now();
+        let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
+        let group_name = format!("exec-{}-{sequence}-{id}", std::process::id());
+        let group_path = Path::new(SUPERVISED_CGROUP_BASE_PATH).join(&group_name);
+        fs::create_dir(&group_path)
+            .map_err(|error| ProcessContainmentError::new("create cgroup", error))?;
+        let placement = OpenOptions::new()
+            .write(true)
+            .open(group_path.join(CGROUP_PROCS_FILE))
+            .map_err(|error| ProcessContainmentError::new("open cgroup.procs", error))?;
+
+        Ok(Self {
+            group_name,
+            group_path,
+            placement: placement.into(),
+            create_elapsed: started.elapsed(),
+        })
+    }
+
+    fn configure_command(&self, command: &mut Command) -> Result<(), ProcessContainmentError> {
+        let placement = self
+            .placement
+            .try_clone()
+            .map_err(|error| ProcessContainmentError::new("clone cgroup.procs", error))?;
+        install_child_placement(command, placement);
+        Ok(())
+    }
+
+    fn cleanup(self) -> Result<(), ProcessContainmentError> {
+        let started = Instant::now();
+        let CgroupGuard {
+            group_name,
+            group_path,
+            placement,
+            create_elapsed,
+        } = self;
+        drop(placement);
+
+        let result = cleanup_cgroup(&group_path);
+        match result {
+            Ok(report) => {
+                log(
+                    "INFO",
+                    &format!(
+                        "supervised process containment cleaned group={group_name} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
+                        report.descendants_observed,
+                        report.cgroup_kill_used,
+                        report.initial_members,
+                        report.graceful_errors,
+                        create_elapsed.as_micros(),
+                        started.elapsed().as_millis()
+                    ),
+                );
+                Ok(())
+            }
+            Err(error) => {
+                log(
+                    "ERROR",
+                    &format!(
+                        "supervised process containment cleanup failed group={group_name} stage={} error={}",
+                        error.stage, error.source
+                    ),
+                );
+                Err(error)
+            }
+        }
+    }
+}
+
+struct CleanupReport {
+    descendants_observed: bool,
+    cgroup_kill_used: bool,
+    initial_members: usize,
+    graceful_errors: usize,
+}
+
+fn cleanup_cgroup(group_path: &Path) -> Result<CleanupReport, ProcessContainmentError> {
+    let descendants_observed = read_populated(group_path)?;
+    let mut cgroup_kill_used = false;
+    let mut initial_members = 0;
+    let mut graceful_errors = 0;
+
+    if descendants_observed {
+        match read_member_pids(group_path) {
+            Ok(pids) => {
+                initial_members = pids.len();
+                graceful_errors = signal_term(&pids);
+            }
+            Err(error) => {
+                graceful_errors = 1;
+                log(
+                    "WARN",
+                    &format!(
+                        "supervised process containment graceful enumeration failed error={error}"
+                    ),
+                );
+            }
+        }
+
+        if !wait_until_empty(group_path, TERM_GRACE)? {
+            fs::write(group_path.join(CGROUP_KILL_FILE), b"1")
+                .map_err(|error| ProcessContainmentError::new("write cgroup.kill", error))?;
+            cgroup_kill_used = true;
+            if !wait_until_empty(group_path, KILL_EMPTY_TIMEOUT)? {
+                return Err(ProcessContainmentError::new(
+                    "wait for cgroup.kill",
+                    io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "cgroup remained populated after cgroup.kill",
+                    ),
+                ));
+            }
+        }
+    }
+
+    remove_empty_cgroup(group_path)?;
+    Ok(CleanupReport {
+        descendants_observed,
+        cgroup_kill_used,
+        initial_members,
+        graceful_errors,
+    })
+}
+
+fn install_child_placement(command: &mut Command, placement: OwnedFd) {
+    // SAFETY: the closure performs only a raw write to an already-open file
+    // descriptor. `write` and reading errno are async-signal-safe between
+    // `fork` and `exec`.
+    unsafe {
+        command.pre_exec(move || write_self_to_cgroup(placement.as_raw_fd()));
+    }
+}
+
+fn write_self_to_cgroup(fd: RawFd) -> io::Result<()> {
+    loop {
+        // SAFETY: `fd` is open for writing and the one-byte buffer is valid for
+        // the duration of the call.
+        let written = unsafe { libc::write(fd, b"0".as_ptr().cast(), 1) };
+        if written == 1 {
+            return Ok(());
+        }
+        if written < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        return Err(io::Error::from_raw_os_error(libc::EIO));
+    }
+}
+
+fn read_populated(group_path: &Path) -> Result<bool, ProcessContainmentError> {
+    let content = fs::read_to_string(group_path.join(CGROUP_EVENTS_FILE))
+        .map_err(|error| ProcessContainmentError::new("read cgroup.events", error))?;
+    parse_populated(&content).ok_or_else(|| {
+        ProcessContainmentError::new(
+            "parse cgroup.events",
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cgroup.events is missing populated state",
+            ),
+        )
+    })
+}
+
+fn parse_populated(content: &str) -> Option<bool> {
+    content.lines().find_map(|line| {
+        let (key, value) = line.split_once(' ')?;
+        if key != "populated" {
+            return None;
+        }
+        match value {
+            "0" => Some(false),
+            "1" => Some(true),
+            _ => None,
+        }
+    })
+}
+
+fn read_member_pids(group_path: &Path) -> io::Result<Vec<libc::pid_t>> {
+    let content = fs::read_to_string(group_path.join(CGROUP_PROCS_FILE))?;
+    content
+        .lines()
+        .map(|line| {
+            let pid = line
+                .parse::<libc::pid_t>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if pid <= 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "cgroup.procs contains a non-positive pid",
+                ));
+            }
+            Ok(pid)
+        })
+        .collect()
+}
+
+fn signal_term(pids: &[libc::pid_t]) -> usize {
+    let mut errors = 0;
+    for &pid in pids {
+        let pidfd = match open_pidfd(pid) {
+            Ok(Some(pidfd)) => pidfd,
+            Ok(None) => continue,
+            Err(_) => {
+                errors += 1;
+                continue;
+            }
+        };
+        if let Err(error) = signal_pidfd(&pidfd, libc::SIGTERM)
+            && error.raw_os_error() != Some(libc::ESRCH)
+        {
+            errors += 1;
+        }
+    }
+    errors
+}
+
+fn open_pidfd(pid: libc::pid_t) -> io::Result<Option<OwnedFd>> {
+    // SAFETY: `pidfd_open` does not dereference user pointers and the PID came
+    // from the kernel-owned cgroup.procs file.
+    let result = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(None);
+        }
+        return Err(error);
+    }
+    let fd = RawFd::try_from(result)
+        .map_err(|_| io::Error::other("pidfd_open returned an invalid file descriptor"))?;
+    // SAFETY: `fd` is a new descriptor returned by pidfd_open.
+    Ok(Some(unsafe { OwnedFd::from_raw_fd(fd) }))
+}
+
+fn signal_pidfd(pidfd: &OwnedFd, signal: libc::c_int) -> io::Result<()> {
+    // SAFETY: `pidfd` is valid, signal is a standard signal number, and a null
+    // siginfo pointer requests ordinary signal semantics.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_pidfd_send_signal,
+            pidfd.as_raw_fd(),
+            signal,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn wait_until_empty(group_path: &Path, timeout: Duration) -> Result<bool, ProcessContainmentError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !read_populated(group_path)? {
+            return Ok(true);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        thread::sleep(remaining.min(POLL_INTERVAL));
+    }
+}
+
+fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError> {
+    let deadline = Instant::now() + REMOVE_TIMEOUT;
+    loop {
+        match fs::remove_dir(group_path) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(libc::EBUSY) | Some(libc::ENOTEMPTY)
+                ) && Instant::now() < deadline =>
+            {
+                thread::sleep(POLL_INTERVAL);
+            }
+            Err(error) => {
+                return Err(ProcessContainmentError::new("remove cgroup", error));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek, SeekFrom};
+    use std::process::Stdio;
+
+    #[test]
+    fn parses_recursive_populated_state() {
+        assert_eq!(parse_populated("populated 0\nfrozen 0\n"), Some(false));
+        assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));
+        assert_eq!(parse_populated("frozen 0\n"), None);
+        assert_eq!(parse_populated("populated 2\n"), None);
+    }
+
+    #[test]
+    fn pre_exec_writes_child_into_open_placement_file() {
+        let mut placement = tempfile::tempfile().unwrap();
+        let child_fd: OwnedFd = placement.try_clone().unwrap().into();
+        let mut command = Command::new("/bin/true");
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        install_child_placement(&mut command, child_fd);
+
+        let status = command.status().unwrap();
+
+        assert!(status.success());
+        placement.seek(SeekFrom::Start(0)).unwrap();
+        let mut content = String::new();
+        placement.read_to_string(&mut content).unwrap();
+        assert_eq!(content, "0");
+    }
+}

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -65,7 +65,12 @@ impl ProcessContainmentError {
 
 impl SupervisedProcessContainment {
     pub(crate) fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
-        if cfg!(debug_assertions) || cfg!(feature = "test-support") {
+        // Host-side debug integration tests have no guest cgroup hierarchy.
+        // A real guest, including a debug build, gets the hierarchy from
+        // guest-init before vsock-guest starts and therefore uses cgroups.
+        if cfg!(feature = "test-support")
+            || (cfg!(debug_assertions) && !Path::new(SUPERVISED_CGROUP_BASE_PATH).is_dir())
+        {
             return Ok(Self {
                 backend: ContainmentBackend::TestNoop,
             });

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
@@ -181,7 +182,7 @@ fn cleanup_cgroup(group_path: &Path) -> Result<CleanupReport, ProcessContainment
         match read_member_pids(group_path) {
             Ok(pids) => {
                 initial_members = pids.len();
-                graceful_errors = signal_term(&pids);
+                graceful_errors = signal_term(group_path, &pids);
             }
             Err(error) => {
                 graceful_errors = 1;
@@ -294,8 +295,9 @@ fn read_member_pids(group_path: &Path) -> io::Result<Vec<libc::pid_t>> {
         .collect()
 }
 
-fn signal_term(pids: &[libc::pid_t]) -> usize {
+fn signal_term(group_path: &Path, pids: &[libc::pid_t]) -> usize {
     let mut errors = 0;
+    let mut candidates = Vec::with_capacity(pids.len());
     for &pid in pids {
         let pidfd = match open_pidfd(pid) {
             Ok(Some(pidfd)) => pidfd,
@@ -305,6 +307,23 @@ fn signal_term(pids: &[libc::pid_t]) -> usize {
                 continue;
             }
         };
+        candidates.push((pid, pidfd));
+    }
+    if candidates.is_empty() {
+        return errors;
+    }
+
+    // Opening a pidfd stabilizes identity only from that point onward. Recheck
+    // membership so a PID recycled after the first enumeration is never
+    // signalled through a pidfd opened for an unrelated process.
+    let current_members = match read_member_pids(group_path) {
+        Ok(pids) => pids.into_iter().collect::<HashSet<_>>(),
+        Err(_) => return errors + 1,
+    };
+    for (pid, pidfd) in candidates {
+        if !current_members.contains(&pid) {
+            continue;
+        }
         if let Err(error) = signal_pidfd(&pidfd, libc::SIGTERM)
             && error.raw_os_error() != Some(libc::ESRCH)
         {
@@ -387,8 +406,17 @@ fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Read, Seek, SeekFrom};
-    use std::process::Stdio;
+    use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+    use std::process::{Child, Stdio};
+
+    struct ChildGuard(Child);
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
 
     #[test]
     fn parses_recursive_populated_state() {
@@ -413,5 +441,38 @@ mod tests {
         let mut content = String::new();
         placement.read_to_string(&mut content).unwrap();
         assert_eq!(content, "0");
+    }
+
+    #[test]
+    fn graceful_signal_rechecks_membership_after_opening_pidfd() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join(CGROUP_PROCS_FILE), "").unwrap();
+        let mut child = ChildGuard(
+            Command::new("/bin/sh")
+                .arg("-c")
+                .arg(
+                    "trap 'printf \"term\\n\"; exit 42' TERM; \
+                     printf 'ready\\n'; \
+                     while IFS= read -r line; do printf '%s\\n' \"$line\"; done",
+                )
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
+        let enumerated_pid = libc::pid_t::try_from(child.0.id()).unwrap();
+        let mut stdout = BufReader::new(child.0.stdout.take().unwrap());
+        let mut response = String::new();
+        stdout.read_line(&mut response).unwrap();
+        assert_eq!(response, "ready\n");
+
+        let errors = signal_term(directory.path(), &[enumerated_pid]);
+        writeln!(child.0.stdin.as_mut().unwrap(), "probe").unwrap();
+        response.clear();
+        stdout.read_line(&mut response).unwrap();
+
+        assert_eq!(errors, 0);
+        assert_eq!(response, "probe\n");
     }
 }

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -44,6 +44,8 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 use shell_quote::quote_shell_arg;
 
+use crate::process_containment::SupervisedProcessContainment;
+
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
 const ENV_SCRIPT_PREFIX: &str = "vm0-env-";
@@ -551,6 +553,7 @@ pub(crate) fn spawn_shell_command_with_pipes(
     env: &[(&str, &str)],
     sudo: bool,
     pipe_stdin: bool,
+    process_containment: Option<&SupervisedProcessContainment>,
 ) -> io::Result<SpawnedShellCommand> {
     let PreparedShellCommand {
         mut command,
@@ -559,6 +562,13 @@ pub(crate) fn spawn_shell_command_with_pipes(
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     if pipe_stdin {
         command.stdin(Stdio::piped());
+    }
+    if let Some(process_containment) = process_containment {
+        process_containment
+            .configure_command(&mut command)
+            .map_err(|error| {
+                io::Error::other(format!("process containment setup failed: {error}"))
+            })?;
     }
     let child = crate::process::spawn_in_own_process_group(&mut command)?;
     Ok(SpawnedShellCommand { child, env_script })


### PR DESCRIPTION
## Summary

- Mount a controller-free cgroup v2 hierarchy during guest initialization and place every supervised exec into a unique operation cgroup before `exec`.
- Reclaim escaped descendants with a bounded SIGTERM grace followed by recursive `cgroup.kill`, removing the operation cgroup before reporting completion.
- Verify the supervised cgroup hierarchy is healthy and empty before idle reuse; containment failures preserve the completed run result but reject and destroy the sandbox.
- Preserve local queue session affinity before claim so an immediate same-session follow-up reserves the just-parked VM instead of evicting it.
- Add a Firecracker metal scenario covering detached user, root, and SIGTERM-ignoring descendants, same-VM reuse, and healthy-path latency bounds.

## Compatibility and scope

- Runner and guest binaries ship in the same runner artifact, so the reuse-preparation report remains an internal contract and carries no cross-version capability field.
- Local queue JSON, atomic claim, and the authoritative post-claim request parse are unchanged; discovery only exposes the existing optional session ID for admission.
- No database schema, persisted-data, API, queue payload, cache format, or vsock protocol migration is required.
- No feature switch is added; containment enforces the existing rule that completed runs cannot leave background workload processes alive.
- Severe balloon-retention admission remains follow-up work in #21770.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo test -p guest-contracts -p guest-init -p vsock-guest -p guest-agent -p runner`
  - runner: 2713 passed, 10 ignored
  - vsock-guest: 149 unit and 66 connection tests passed
  - all selected package and doc tests passed with 0 failures
- Compatibility-layer removal revalidated with:
  - `cargo test -p guest-contracts`
  - `cargo test -p guest-agent --test reuse_preparation_helper`
  - `cargo test -p runner idle_reuse_preparation`
  - targeted Clippy and documentation checks for `guest-contracts`, `guest-agent`, and `runner`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `shellcheck .github/scripts/runner-behavior-process-containment.sh`
- `actionlint .github/workflows/crates.yml`
- x86_64 and aarch64 musl target checks
- Real Firecracker stress: three immediate three-turn cycles (9/9 runs successful); each follow-up reused its pre-claim reserved same-session VM, reclaimed detached user/root descendants, and produced no admission eviction.
- `git diff --check`

Closes #21769

Delivery parent: #21740
