### PR TITLE
fix: use app tenant for teams bot replies

### DIFF
--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -3,8 +3,6 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { safeJsonParse, safeUrlParse, settle } from "../utils";
 
-const BOT_FRAMEWORK_TOKEN_URL =
-  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
 const MICROSOFT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
 const DEFAULT_MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
@@ -268,13 +266,17 @@ function e2eTeamsMockHeaders(): Record<string, string> {
   };
 }
 
-function botTokenUrl(): string {
+function botTokenUrl(): string | undefined {
   const configured = optionalEnv("MICROSOFT_TEAMS_BOT_TOKEN_URL");
   if (configured) {
     return configured;
   }
   const mockBaseUrl = e2eTeamsMockBaseUrl();
-  return mockBaseUrl ? `${mockBaseUrl}/token` : BOT_FRAMEWORK_TOKEN_URL;
+  if (mockBaseUrl) {
+    return `${mockBaseUrl}/token`;
+  }
+  const appTenantId = env("MICROSOFT_TEAMS_APP_TENANT_ID");
+  return appTenantId ? tenantTokenUrl(appTenantId) : undefined;
 }
 
 function graphTokenUrl(tenantId: string): string {
@@ -369,8 +371,14 @@ function fetchTeamsBotAccessToken(
 ): Promise<
   { readonly kind: "ok"; readonly accessToken: string } | TeamsApiErrorResult
 > {
+  const tokenUrl = botTokenUrl();
+  if (!tokenUrl) {
+    return Promise.resolve(
+      teamsApiError(502, "Microsoft Teams bot app tenant is not configured"),
+    );
+  }
   return fetchClientCredentialsAccessToken({
-    tokenUrl: botTokenUrl(),
+    tokenUrl,
     scope: BOT_FRAMEWORK_SCOPE,
     signal,
   });

--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { safeJsonParse, safeUrlParse, settle } from "../utils";
 
+const BOT_FRAMEWORK_TOKEN_URL =
+  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
 const MICROSOFT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
 const DEFAULT_MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
@@ -266,13 +268,13 @@ function e2eTeamsMockHeaders(): Record<string, string> {
   };
 }
 
-function botTokenUrl(tenantId: string): string {
+function botTokenUrl(): string {
   const configured = optionalEnv("MICROSOFT_TEAMS_BOT_TOKEN_URL");
   if (configured) {
     return configured;
   }
   const mockBaseUrl = e2eTeamsMockBaseUrl();
-  return mockBaseUrl ? `${mockBaseUrl}/token` : tenantTokenUrl(tenantId);
+  return mockBaseUrl ? `${mockBaseUrl}/token` : BOT_FRAMEWORK_TOKEN_URL;
 }
 
 function graphTokenUrl(tenantId: string): string {
@@ -362,16 +364,15 @@ async function fetchClientCredentialsAccessToken(args: {
   return { kind: "ok", accessToken: parsed.data.access_token };
 }
 
-function fetchTeamsBotAccessToken(args: {
-  readonly tenantId: string;
-  readonly signal: AbortSignal;
-}): Promise<
+function fetchTeamsBotAccessToken(
+  signal: AbortSignal,
+): Promise<
   { readonly kind: "ok"; readonly accessToken: string } | TeamsApiErrorResult
 > {
   return fetchClientCredentialsAccessToken({
-    tokenUrl: botTokenUrl(args.tenantId),
+    tokenUrl: botTokenUrl(),
     scope: BOT_FRAMEWORK_SCOPE,
-    signal: args.signal,
+    signal,
   });
 }
 
@@ -533,10 +534,7 @@ export async function fetchTeamsFile(args: {
   };
 
   if (shouldAuthorizeTeamsFileDownload(args.url)) {
-    const accessToken = await fetchTeamsBotAccessToken({
-      tenantId: args.tenantId,
-      signal: args.signal,
-    });
+    const accessToken = await fetchTeamsBotAccessToken(args.signal);
     if (accessToken.kind === "teams-error") {
       return accessToken;
     }
@@ -630,10 +628,7 @@ async function postTeamsActivity(args: {
   readonly activity: TeamsActivityBody;
   readonly signal: AbortSignal;
 }): Promise<SendTeamsActivityResult> {
-  const accessToken = await fetchTeamsBotAccessToken({
-    tenantId: args.tenantId,
-    signal: args.signal,
-  });
+  const accessToken = await fetchTeamsBotAccessToken(args.signal);
   if (accessToken.kind === "teams-error") {
     return accessToken;
   }
@@ -696,10 +691,7 @@ export async function createTeamsPersonalConversation(args: {
   readonly teamsUserDisplayName?: string | null;
   readonly signal: AbortSignal;
 }): Promise<CreateTeamsConversationResult> {
-  const accessToken = await fetchTeamsBotAccessToken({
-    tenantId: args.tenantId,
-    signal: args.signal,
-  });
+  const accessToken = await fetchTeamsBotAccessToken(args.signal);
   if (accessToken.kind === "teams-error") {
     return accessToken;
   }
@@ -774,10 +766,7 @@ async function requestTeamsReaction(args: {
   readonly reactionType: string;
   readonly signal: AbortSignal;
 }): Promise<SendTeamsReactionResult> {
-  const accessToken = await fetchTeamsBotAccessToken({
-    tenantId: args.tenantId,
-    signal: args.signal,
-  });
+  const accessToken = await fetchTeamsBotAccessToken(args.signal);
   if (accessToken.kind === "teams-error") {
     return accessToken;
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -53,7 +53,9 @@ const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
 const MICROSOFT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
-const MICROSOFT_TOKEN_URL =
+const BOT_FRAMEWORK_TOKEN_URL =
+  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const MICROSOFT_GRAPH_TOKEN_URL =
   "https://login.microsoftonline.com/:tenantId/oauth2/v2.0/token";
 
 interface TeamsPostedActivity {
@@ -113,19 +115,19 @@ function teamsApiMocks(args: {
   const serviceBaseUrl = teamsServiceBaseUrl(args.serviceUrl);
 
   server.use(
-    http.post(MICROSOFT_TOKEN_URL, async ({ request }) => {
+    http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
       const form = new URLSearchParams(await request.text());
-      const scope = form.get("scope");
-      if (scope === BOT_FRAMEWORK_SCOPE) {
-        tokenRequests.push(form);
-        return HttpResponse.json({
-          access_token: "teams-access-token",
-          token_type: "Bearer",
-          expires_in: 3600,
-        });
-      }
-
-      expect(scope).toBe(MICROSOFT_GRAPH_SCOPE);
+      expect(form.get("scope")).toBe(BOT_FRAMEWORK_SCOPE);
+      tokenRequests.push(form);
+      return HttpResponse.json({
+        access_token: "teams-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    }),
+    http.post(MICROSOFT_GRAPH_TOKEN_URL, async ({ request }) => {
+      const form = new URLSearchParams(await request.text());
+      expect(form.get("scope")).toBe(MICROSOFT_GRAPH_SCOPE);
       return HttpResponse.json({
         access_token: "teams-graph-token",
         token_type: "Bearer",

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -51,10 +51,10 @@ const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
 const APP_URL = "https://app.vm0.test";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
+const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
 const MICROSOFT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
-const BOT_FRAMEWORK_TOKEN_URL =
-  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const BOT_FRAMEWORK_TOKEN_URL = `https://login.microsoftonline.com/${TEAMS_APP_TENANT_ID}/oauth2/v2.0/token`;
 const MICROSOFT_GRAPH_TOKEN_URL =
   "https://login.microsoftonline.com/:tenantId/oauth2/v2.0/token";
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
@@ -28,8 +28,8 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
-const BOT_FRAMEWORK_TOKEN_URL =
-  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
+const BOT_FRAMEWORK_TOKEN_URL = `https://login.microsoftonline.com/${TEAMS_APP_TENANT_ID}/oauth2/v2.0/token`;
 
 interface CapturedTeamsActivity {
   conversationBody?: Record<string, unknown>;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
@@ -28,6 +28,8 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
+const BOT_FRAMEWORK_TOKEN_URL =
+  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 
 interface CapturedTeamsActivity {
   conversationBody?: Record<string, unknown>;
@@ -68,14 +70,11 @@ function teamsFixture(): TeamsConnectFixture {
 
 function mockOutgoingTeams(captured: CapturedTeamsActivity): void {
   server.use(
-    http.post(
-      "https://login.microsoftonline.com/:tenant/oauth2/v2.0/token",
-      async ({ request }) => {
-        const form = await request.formData();
-        expect(form.get("scope")).toBe("https://api.botframework.com/.default");
-        return HttpResponse.json({ access_token: "bot-framework-token" });
-      },
-    ),
+    http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
+      const form = await request.formData();
+      expect(form.get("scope")).toBe("https://api.botframework.com/.default");
+      return HttpResponse.json({ access_token: "bot-framework-token" });
+    }),
     http.post(
       "https://smba.trafficmanager.net/amer/v3/conversations",
       async ({ request }) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -70,6 +70,8 @@ const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
 const BOT_FRAMEWORK_KEYS_URL =
   "https://login.botframework.com/v1/.well-known/keys";
+const BOT_FRAMEWORK_TOKEN_URL =
+  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 
 const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const publicJwk = keyPair.publicKey.export({ format: "jwk" });
@@ -148,17 +150,14 @@ type TeamsOutboundRequests = TeamsOutboundRequest[] & {
   readonly reactions: TeamsReactionRequest[];
 };
 
-function teamsOutboundHandlers(
-  serviceUrl: string,
-  tenantId = "tenant-1",
-): TeamsOutboundRequests {
+function teamsOutboundHandlers(serviceUrl: string): TeamsOutboundRequests {
   const serviceBaseUrl = teamsServiceBaseUrl(serviceUrl);
   const requests: TeamsOutboundRequests = Object.assign(
     [] as TeamsOutboundRequest[],
     { reactions: [] as TeamsReactionRequest[] },
   );
   server.use(
-    http.post(graphTokenUrl(tenantId), async ({ request }) => {
+    http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
       const form = await request.formData();
       expect(form.get("client_id")).toBe(BOT_APP_ID);
       expect(form.get("client_secret")).toBe(BOT_APP_PASSWORD);
@@ -328,15 +327,7 @@ function teamsGraphHistoryHandlers(args: {
       const form = await request.formData();
       expect(form.get("client_id")).toBe(BOT_APP_ID);
       expect(form.get("client_secret")).toBe(BOT_APP_PASSWORD);
-      const scope = form.get("scope");
-      if (scope === "https://api.botframework.com/.default") {
-        return HttpResponse.json({
-          access_token: "teams-access-token",
-          token_type: "Bearer",
-          expires_in: 3600,
-        });
-      }
-      expect(scope).toBe("https://graph.microsoft.com/.default");
+      expect(form.get("scope")).toBe("https://graph.microsoft.com/.default");
       requests.push("graph-token");
       return HttpResponse.json({
         access_token: "teams-graph-token",
@@ -727,10 +718,7 @@ async function setupConnectedTeamsBotActor(): Promise<{
   await runsApi.grantProEntitlement(actor);
   await runsApi.ensureOrgModelProvider(actor);
   botFrameworkHandlers();
-  const outboundRequests = teamsOutboundHandlers(
-    fixture.serviceUrl,
-    fixture.teamsTenantId,
-  );
+  const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
 
   const installResponse = await postTeamsActivity({
     activity: teamsMessageActivity(fixture),
@@ -753,7 +741,7 @@ describe("POST /api/zero/teams/bot", () => {
     mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.test");
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     context.mocks.axiom.query.mockResolvedValue([]);
-    teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    teamsOutboundHandlers(SERVICE_URL);
   });
 
   afterEach(async () => {
@@ -796,7 +784,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("normalizes a valid Teams message activity", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(),
@@ -956,7 +944,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("sends a welcome message when Teams adds the bot in team scope", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: teamsBotInstalledActivity(),
@@ -996,7 +984,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("sends a personal welcome message when Teams adds the bot in personal scope", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: {
@@ -1036,7 +1024,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("responds to Teams validation help and greeting messages without a mention", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const helpResponse = await postTeamsActivity({
       activity: teamsMessageActivity(botFixture(), {
@@ -1116,7 +1104,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("responds to Teams greeting messages with a mention", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(botFixture(), {
@@ -1148,7 +1136,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("does not run other Teams commands without a mention in channel scope", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(botFixture(), {
@@ -1175,7 +1163,7 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("handles Teams personal messages without requiring a bot mention", async () => {
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(SERVICE_URL, "tenant-1");
+    const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(botFixture(), {
@@ -1270,7 +1258,7 @@ describe("POST /api/zero/teams/bot", () => {
     await connectTeamsFixture(fixture);
     clearTeamsBotAuthCacheForTest();
     botFrameworkHandlers();
-    teamsOutboundHandlers(fixture.serviceUrl, fixture.teamsTenantId);
+    teamsOutboundHandlers(fixture.serviceUrl);
 
     const downloadUrl = "https://contoso.sharepoint.com/sites/docs/spec.png";
     const response = await postTeamsActivity({
@@ -1803,10 +1791,7 @@ describe("POST /api/zero/teams/bot", () => {
       },
     );
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(
-      fixture.serviceUrl,
-      fixture.teamsTenantId,
-    );
+    const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
 
     const installResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture),
@@ -1890,10 +1875,7 @@ describe("POST /api/zero/teams/bot", () => {
     await runsApi.grantProEntitlement(actor);
     await runsApi.ensureOrgModelProvider(actor);
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(
-      fixture.serviceUrl,
-      fixture.teamsTenantId,
-    );
+    const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
 
     const installResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture),
@@ -2247,10 +2229,7 @@ describe("POST /api/zero/teams/bot", () => {
       Promise.resolve(teamsConnectFixture()),
     );
     botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(
-      fixture.serviceUrl,
-      fixture.teamsTenantId,
-    );
+    const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
 
     const installResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -70,8 +70,7 @@ const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
 const BOT_FRAMEWORK_KEYS_URL =
   "https://login.botframework.com/v1/.well-known/keys";
-const BOT_FRAMEWORK_TOKEN_URL =
-  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const BOT_FRAMEWORK_TOKEN_URL = `https://login.microsoftonline.com/${TEAMS_APP_TENANT_ID}/oauth2/v2.0/token`;
 
 const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const publicJwk = keyPair.publicKey.export({ format: "jwk" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -25,8 +25,8 @@ const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
-const MICROSOFT_TOKEN_URL =
-  "https://login.microsoftonline.com/:tenantId/oauth2/v2.0/token";
+const BOT_FRAMEWORK_TOKEN_URL =
+  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 
 interface TeamsWelcomeRequest {
   readonly kind: "conversation" | "activity";
@@ -86,7 +86,7 @@ function teamsWelcomeHandlers(
   const serviceBaseUrl = teamsServiceBaseUrl(fixture.serviceUrl);
 
   server.use(
-    http.post(MICROSOFT_TOKEN_URL, async ({ request }) => {
+    http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
       const form = new URLSearchParams(await request.text());
       expect(form.get("client_id")).toBe(BOT_APP_ID);
       expect(form.get("client_secret")).toBe(BOT_APP_PASSWORD);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -25,8 +25,7 @@ const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
-const BOT_FRAMEWORK_TOKEN_URL =
-  "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+const BOT_FRAMEWORK_TOKEN_URL = `https://login.microsoftonline.com/${TEAMS_APP_TENANT_ID}/oauth2/v2.0/token`;
 
 interface TeamsWelcomeRequest {
   readonly kind: "conversation" | "activity";


### PR DESCRIPTION
## Summary

- request Bot Framework reply tokens from the configured bot app tenant instead of the incoming customer tenant, matching the Teams-managed single-tenant registration
- keep Microsoft Graph token acquisition scoped to the destination tenant
- preserve explicit token URL and E2E mock overrides
- update Teams route integration mocks to enforce the app-tenant reply-token authority

## Portal updates

- remove `groupChat` from the live Okou and Okou-test manifests while retaining `personal` and `team` scopes
- publish validated manifest versions Okou 1.0.10 and Okou-test 1.0.21

## Validation

- API lint and TypeScript checks
- API-scoped and repository Knip checks
- 17 Teams connect/integration route tests
- 4 focused welcome, help, and Hi bot tests
- Teams callback E2E mock-override test
- pre-commit formatting, repository Knip, and full TypeScript checks
- all GitHub CI checks passed