### PR TITLE
feat(guest-download): attribute remote archive download phases

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -19,7 +19,7 @@ type TaskRunner = fn(DownloadTask) -> bool;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DownloadTask {
     label: String,
-    op_name: &'static str,
+    archive_kind: ArchiveKind,
     url: String,
     mount_path: String,
     kind: DownloadTaskKind,
@@ -29,23 +29,29 @@ impl DownloadTask {
     #[cfg(test)]
     pub(crate) fn new(
         label: String,
-        op_name: &'static str,
+        archive_kind: ArchiveKind,
         url: String,
         mount_path: String,
     ) -> Self {
-        Self::new_with_kind(label, op_name, url, mount_path, DownloadTaskKind::Other)
+        Self::new_with_kind(
+            label,
+            archive_kind,
+            url,
+            mount_path,
+            DownloadTaskKind::Other,
+        )
     }
 
     pub(crate) fn new_with_kind(
         label: String,
-        op_name: &'static str,
+        archive_kind: ArchiveKind,
         url: String,
         mount_path: String,
         kind: DownloadTaskKind,
     ) -> Self {
         Self {
             label,
-            op_name,
+            archive_kind,
             url,
             mount_path,
             kind,
@@ -71,6 +77,165 @@ impl DownloadTask {
 
     fn failure_detail(&self, error: &DownloadError) -> String {
         format!("{} download failed: {}", self.label, error)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ArchiveKind {
+    Storage,
+    Artifact,
+}
+
+impl ArchiveKind {
+    fn total_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download",
+            Self::Artifact => "artifact_download",
+        }
+    }
+
+    fn request_to_response_headers_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download_remote_request_to_response_headers",
+            Self::Artifact => "artifact_download_remote_request_to_response_headers",
+        }
+    }
+
+    fn body_read_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download_remote_body_read",
+            Self::Artifact => "artifact_download_remote_body_read",
+        }
+    }
+
+    fn extract_outside_body_read_action(self) -> &'static str {
+        match self {
+            Self::Storage => "storage_download_remote_extract_outside_body_read",
+            Self::Artifact => "artifact_download_remote_extract_outside_body_read",
+        }
+    }
+
+    fn compressed_bytes_consumed_action(self, bytes: u64) -> &'static str {
+        match (self, CompressedBytesBucket::from_bytes(bytes)) {
+            (Self::Storage, CompressedBytesBucket::Zero) => {
+                "storage_download_remote_compressed_bytes_consumed_zero"
+            }
+            (Self::Storage, CompressedBytesBucket::Under64Kib) => {
+                "storage_download_remote_compressed_bytes_consumed_lt_64_kib"
+            }
+            (Self::Storage, CompressedBytesBucket::Kib64To256) => {
+                "storage_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
+            }
+            (Self::Storage, CompressedBytesBucket::Kib256To1Mib) => {
+                "storage_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib1To4) => {
+                "storage_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib4To16) => {
+                "storage_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib16To64) => {
+                "storage_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
+            }
+            (Self::Storage, CompressedBytesBucket::Mib64Plus) => {
+                "storage_download_remote_compressed_bytes_consumed_64_mib_plus"
+            }
+            (Self::Artifact, CompressedBytesBucket::Zero) => {
+                "artifact_download_remote_compressed_bytes_consumed_zero"
+            }
+            (Self::Artifact, CompressedBytesBucket::Under64Kib) => {
+                "artifact_download_remote_compressed_bytes_consumed_lt_64_kib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Kib64To256) => {
+                "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Kib256To1Mib) => {
+                "artifact_download_remote_compressed_bytes_consumed_256_kib_to_1_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib1To4) => {
+                "artifact_download_remote_compressed_bytes_consumed_1_mib_to_4_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib4To16) => {
+                "artifact_download_remote_compressed_bytes_consumed_4_mib_to_16_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib16To64) => {
+                "artifact_download_remote_compressed_bytes_consumed_16_mib_to_64_mib"
+            }
+            (Self::Artifact, CompressedBytesBucket::Mib64Plus) => {
+                "artifact_download_remote_compressed_bytes_consumed_64_mib_plus"
+            }
+        }
+    }
+
+    fn attempt_count_action(self, attempts: u32) -> &'static str {
+        match (self, attempts) {
+            (Self::Storage, 1) => "storage_download_remote_attempt_count_1",
+            (Self::Storage, 2) => "storage_download_remote_attempt_count_2",
+            (Self::Storage, _) => "storage_download_remote_attempt_count_3",
+            (Self::Artifact, 1) => "artifact_download_remote_attempt_count_1",
+            (Self::Artifact, 2) => "artifact_download_remote_attempt_count_2",
+            (Self::Artifact, _) => "artifact_download_remote_attempt_count_3",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CompressedBytesBucket {
+    Zero,
+    Under64Kib,
+    Kib64To256,
+    Kib256To1Mib,
+    Mib1To4,
+    Mib4To16,
+    Mib16To64,
+    Mib64Plus,
+}
+
+impl CompressedBytesBucket {
+    fn from_bytes(bytes: u64) -> Self {
+        match bytes {
+            0 => Self::Zero,
+            1..65_536 => Self::Under64Kib,
+            65_536..262_144 => Self::Kib64To256,
+            262_144..1_048_576 => Self::Kib256To1Mib,
+            1_048_576..4_194_304 => Self::Mib1To4,
+            4_194_304..16_777_216 => Self::Mib4To16,
+            16_777_216..67_108_864 => Self::Mib16To64,
+            _ => Self::Mib64Plus,
+        }
+    }
+}
+
+#[derive(Default)]
+struct RemoteArchiveTaskMetrics {
+    request_to_response_headers: Duration,
+    body_read: Duration,
+    extract_outside_body_read: Duration,
+    compressed_bytes_consumed: u64,
+    attempts: u32,
+}
+
+impl RemoteArchiveTaskMetrics {
+    fn begin_attempt(&mut self) {
+        self.attempts = self.attempts.saturating_add(1);
+    }
+
+    fn record_attempt(
+        &mut self,
+        metrics: source::RemoteArchiveAttemptSnapshot,
+        extract_wall: Duration,
+    ) {
+        self.request_to_response_headers = self
+            .request_to_response_headers
+            .saturating_add(metrics.request_to_response_headers);
+        self.body_read = self.body_read.saturating_add(metrics.body_read);
+        self.extract_outside_body_read = self
+            .extract_outside_body_read
+            .saturating_add(extract_wall.saturating_sub(metrics.body_read));
+        self.compressed_bytes_consumed = self
+            .compressed_bytes_consumed
+            .saturating_add(metrics.compressed_bytes_consumed);
     }
 }
 
@@ -639,11 +804,15 @@ fn panic_message(payload: &(dyn Any + Send)) -> String {
 fn run_download_task(task: DownloadTask) -> bool {
     let start = Instant::now();
     log_info!(LOG_TAG, "Downloading {} to {}", task.label, task.mount_path);
+    let mut remote_metrics = task.is_remote_url().then(RemoteArchiveTaskMetrics::default);
 
-    match download_with_retry(&task.url, &task.mount_path) {
+    match download_with_retry(&task.url, &task.mount_path, remote_metrics.as_mut()) {
         Ok(()) => {
             let elapsed = start.elapsed();
-            record_sandbox_op(task.op_name, elapsed, true, None);
+            record_sandbox_op(task.archive_kind.total_action(), elapsed, true, None);
+            if let Some(metrics) = &remote_metrics {
+                record_remote_archive_attribution(task.archive_kind, metrics, true);
+            }
             log_info!(
                 LOG_TAG,
                 "{} downloaded in {}ms",
@@ -654,19 +823,71 @@ fn run_download_task(task: DownloadTask) -> bool {
         }
         Err(e) => {
             let failure_detail = task.failure_detail(&e);
-            record_sandbox_op(task.op_name, start.elapsed(), false, Some(&failure_detail));
+            record_sandbox_op(
+                task.archive_kind.total_action(),
+                start.elapsed(),
+                false,
+                Some(&failure_detail),
+            );
+            if let Some(metrics) = &remote_metrics {
+                record_remote_archive_attribution(task.archive_kind, metrics, false);
+            }
             log_error!(LOG_TAG, "{failure_detail}");
             false
         }
     }
 }
 
-fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError> {
+fn record_remote_archive_attribution(
+    archive_kind: ArchiveKind,
+    metrics: &RemoteArchiveTaskMetrics,
+    success: bool,
+) {
+    record_sandbox_op(
+        archive_kind.request_to_response_headers_action(),
+        metrics.request_to_response_headers,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.body_read_action(),
+        metrics.body_read,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.extract_outside_body_read_action(),
+        metrics.extract_outside_body_read,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.compressed_bytes_consumed_action(metrics.compressed_bytes_consumed),
+        Duration::ZERO,
+        success,
+        None,
+    );
+    record_sandbox_op(
+        archive_kind.attempt_count_action(metrics.attempts),
+        Duration::ZERO,
+        success,
+        None,
+    );
+}
+
+fn download_with_retry(
+    url: &str,
+    target_path: &str,
+    mut remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
+) -> Result<(), DownloadError> {
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRIES {
+        if let Some(metrics) = remote_metrics.as_deref_mut() {
+            metrics.begin_attempt();
+        }
         let attempt_start = Instant::now();
-        match download_and_extract(url, target_path) {
+        match download_and_extract(url, target_path, remote_metrics.as_deref_mut()) {
             Ok(()) => return Ok(()),
             Err(e) => {
                 log_warn!(
@@ -689,13 +910,34 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError
     Err(last_error.unwrap_or_else(|| DownloadError::fatal("download failed with no error")))
 }
 
-fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadError> {
+fn download_and_extract(
+    url: &str,
+    target_path: &str,
+    remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
+) -> Result<(), DownloadError> {
     fs::create_dir_all(target_path).map_err(|e| {
         DownloadError::fatal(format!("Failed to create directory {target_path}: {e}"))
     })?;
 
-    let reader = source::open_archive(url)?;
-    archive::extract_tar_gz(reader, target_path)
+    let attempt_metrics = remote_metrics
+        .is_some()
+        .then(source::RemoteArchiveAttemptMetrics::default);
+    let reader = match source::open_archive(url, attempt_metrics.as_ref()) {
+        Ok(reader) => reader,
+        Err(error) => {
+            if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
+                metrics.record_attempt(attempt_metrics.snapshot(), Duration::ZERO);
+            }
+            return Err(error);
+        }
+    };
+    let extract_start = Instant::now();
+    let result = archive::extract_tar_gz(reader, target_path);
+    let extract_wall = extract_start.elapsed();
+    if let (Some(metrics), Some(attempt_metrics)) = (remote_metrics, &attempt_metrics) {
+        metrics.record_attempt(attempt_metrics.snapshot(), extract_wall);
+    }
+    result
 }
 
 #[cfg(test)]
@@ -729,7 +971,7 @@ mod tests {
     fn task_at(path: &str, kind: DownloadTaskKind) -> DownloadTask {
         DownloadTask::new_with_kind(
             format!("task {path}"),
-            "storage_download",
+            ArchiveKind::Storage,
             "file:///tmp/archive.tar.gz".to_owned(),
             path.to_owned(),
             kind,
@@ -916,13 +1158,13 @@ mod tests {
                 vec![
                     DownloadTask::new(
                         "panic".to_owned(),
-                        "storage_download",
+                        ArchiveKind::Storage,
                         "panic".to_owned(),
                         "/tmp/panic".to_owned(),
                     ),
                     DownloadTask::new(
                         "success".to_owned(),
-                        "storage_download",
+                        ArchiveKind::Storage,
                         "success".to_owned(),
                         "/tmp/success".to_owned(),
                     ),
@@ -939,13 +1181,13 @@ mod tests {
         let pending = VecDeque::from(vec![
             DownloadTask::new(
                 "blocked child".to_owned(),
-                "storage_download",
+                ArchiveKind::Storage,
                 "file:///tmp/archive.tar.gz".to_owned(),
                 "/tmp/mount/child".to_owned(),
             ),
             DownloadTask::new(
                 "independent".to_owned(),
-                "artifact_download",
+                ArchiveKind::Artifact,
                 "https://example.com/archive.tar.gz".to_owned(),
                 "/tmp/other".to_owned(),
             ),
@@ -1101,7 +1343,7 @@ mod tests {
         let task = DownloadTask::new(
             "storage 1 mountPath=/workspace vasStorageName=repo vasVersionId=v1 urlScheme=file cached=false"
                 .into(),
-            "storage_download",
+            ArchiveKind::Storage,
             "file:///tmp/archive.tar.gz".into(),
             "/workspace".into(),
         );

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::download::{DownloadTask, classify_download_task_kind};
+use crate::download::{ArchiveKind, DownloadTask, classify_download_task_kind};
 use crate::instructions::{InstructionCleanup, InstructionNormalization};
 use crate::manifest::{ArtifactEntry, Manifest, StorageEntry};
 use std::path::Path;
@@ -65,10 +65,10 @@ impl ManifestEntryKind {
         }
     }
 
-    fn op_name(self) -> &'static str {
+    fn archive_kind(self) -> ArchiveKind {
         match self {
-            Self::Storage => "storage_download",
-            Self::Artifact => "artifact_download",
+            Self::Storage => ArchiveKind::Storage,
+            Self::Artifact => ArchiveKind::Artifact,
         }
     }
 
@@ -191,7 +191,7 @@ fn append_storage_download_tasks(tasks: &mut Vec<DownloadTask>, entries: &[Stora
                 idx + 1,
                 EntryLabel::storage(entry, url),
             ),
-            ManifestEntryKind::Storage.op_name(),
+            ManifestEntryKind::Storage.archive_kind(),
             url.clone(),
             download_mount_path.to_string(),
             task_kind,
@@ -217,7 +217,7 @@ fn append_artifact_download_tasks(tasks: &mut Vec<DownloadTask>, entries: &[Arti
                 idx + 1,
                 EntryLabel::artifact(entry, url),
             ),
-            ManifestEntryKind::Artifact.op_name(),
+            ManifestEntryKind::Artifact.archive_kind(),
             url.clone(),
             entry.mount_path.clone(),
             task_kind,
@@ -332,7 +332,7 @@ mod tests {
             plan.download_tasks[0],
             DownloadTask::new(
                 "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
-                "storage_download",
+                ArchiveKind::Storage,
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
             )
@@ -341,7 +341,7 @@ mod tests {
             plan.download_tasks[1],
             DownloadTask::new(
                 "artifact 1 mountPath=/workspace/a vasStorageName=workspace-a vasVersionId=artifact-v1 urlScheme=https cached=false missingRootPolicy=preserveParentVersion".into(),
-                "artifact_download",
+                ArchiveKind::Artifact,
                 "https://s3/a.tar.gz".into(),
                 "/workspace/a".into(),
             )
@@ -350,7 +350,7 @@ mod tests {
             plan.download_tasks[2],
             DownloadTask::new(
                 "artifact 2 mountPath=/workspace/b vasStorageName=workspace-b vasVersionId=artifact-v2 urlScheme=file cached=false missingRootPolicy=fail".into(),
-                "artifact_download",
+                ArchiveKind::Artifact,
                 "file:///tmp/vm0-storage-cache/b.tar.gz".into(),
                 "/workspace/b".into(),
             )
@@ -405,7 +405,7 @@ mod tests {
             plan.download_tasks,
             [DownloadTask::new(
                 "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
-                "storage_download",
+                ArchiveKind::Storage,
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
             )]
@@ -474,7 +474,7 @@ mod tests {
             plan.download_tasks[0],
             DownloadTask::new_with_kind(
                 "storage 1 mountPath=/home/user/.codex vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
-                "storage_download",
+                ArchiveKind::Storage,
                 "https://s3/instructions.tar.gz".into(),
                 "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
                 crate::download::DownloadTaskKind::FrameworkHomeInstructions,
@@ -501,7 +501,7 @@ mod tests {
             plan.download_tasks[0],
             DownloadTask::new_with_kind(
                 "storage 1 mountPath=/data vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
-                "storage_download",
+                ArchiveKind::Storage,
                 "https://s3/data.tar.gz".into(),
                 "/data".into(),
                 crate::download::DownloadTaskKind::Other,
@@ -527,7 +527,7 @@ mod tests {
             plan.download_tasks[0],
             DownloadTask::new_with_kind(
                 "artifact 1 mountPath=/workspace vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false missingRootPolicy=fail".into(),
-                "artifact_download",
+                ArchiveKind::Artifact,
                 "https://s3/workspace.tar.gz".into(),
                 "/workspace".into(),
                 crate::download::DownloadTaskKind::Other,
@@ -668,7 +668,7 @@ mod tests {
                 format!(
                     "storage 1 mountPath={mount_path} vasStorageName=storage vasVersionId=storage-v1 urlScheme=https cached=true"
                 ),
-                "storage_download",
+                ArchiveKind::Storage,
                 "https://s3/storage.tar.gz".into(),
                 mount_path,
             )],
@@ -708,7 +708,7 @@ mod tests {
                 format!(
                     "artifact 1 mountPath={mount_path} vasStorageName=artifact vasVersionId=artifact-v1 urlScheme=https cached=true missingRootPolicy=fail"
                 ),
-                "artifact_download",
+                ArchiveKind::Artifact,
                 "https://s3/artifact.tar.gz".into(),
                 mount_path,
             )],

--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::io::Read;
 use std::rc::Rc;
 use std::sync::LazyLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -29,7 +29,10 @@ static HTTP_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
 /// Open the archive byte stream. HTTP/HTTPS URLs use the direct remote-fetch
 /// path; `file://` URLs are the runner storage-cache path for guest-local
 /// tarballs staged over vsock.
-pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
+pub(crate) fn open_archive(
+    url: &str,
+    metrics: Option<&RemoteArchiveAttemptMetrics>,
+) -> Result<ArchiveSource, DownloadError> {
     if let Some(path) = url.strip_prefix("file://") {
         log_info!(LOG_TAG, "Reading local archive");
         let file = std::fs::File::open(path)
@@ -37,11 +40,18 @@ pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
         return Ok(ArchiveSource::local(file));
     }
 
-    let response = HTTP_AGENT.get(url).call().map_err(|e| {
+    let metrics = metrics.cloned().unwrap_or_default();
+    let request_start = Instant::now();
+    let response = HTTP_AGENT.get(url).call();
+    metrics.record_request_to_response_headers(request_start.elapsed());
+    let response = response.map_err(|e| {
         let (retriable, message) = classify_http_error(&e);
         DownloadError::transport(message, retriable)
     })?;
-    Ok(ArchiveSource::http(response.into_body().into_reader()))
+    Ok(ArchiveSource::http(
+        response.into_body().into_reader(),
+        metrics,
+    ))
 }
 
 fn classify_http_error(error: &ureq::Error) -> (bool, String) {
@@ -118,12 +128,13 @@ impl ArchiveSource {
         }
     }
 
-    fn http(reader: impl Read + 'static) -> Self {
+    fn http(reader: impl Read + 'static, metrics: RemoteArchiveAttemptMetrics) -> Self {
         let http_body_read_failure = HttpBodyReadFailure::enabled();
         Self {
             reader: Box::new(HttpBodyReader {
                 reader,
                 failure: http_body_read_failure.clone(),
+                metrics,
             }),
             http_body_read_failure,
         }
@@ -131,6 +142,57 @@ impl ArchiveSource {
 
     pub(crate) fn into_parts(self) -> (Box<dyn Read>, HttpBodyReadFailure) {
         (self.reader, self.http_body_read_failure)
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct RemoteArchiveAttemptMetrics {
+    state: Rc<RemoteArchiveAttemptMetricsState>,
+}
+
+#[derive(Default)]
+struct RemoteArchiveAttemptMetricsState {
+    request_to_response_headers: Cell<Duration>,
+    body_read: Cell<Duration>,
+    compressed_bytes_consumed: Cell<u64>,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RemoteArchiveAttemptSnapshot {
+    pub(crate) request_to_response_headers: Duration,
+    pub(crate) body_read: Duration,
+    pub(crate) compressed_bytes_consumed: u64,
+}
+
+impl RemoteArchiveAttemptMetrics {
+    fn record_request_to_response_headers(&self, duration: Duration) {
+        self.state.request_to_response_headers.set(
+            self.state
+                .request_to_response_headers
+                .get()
+                .saturating_add(duration),
+        );
+    }
+
+    fn record_body_read(&self, duration: Duration, bytes_read: usize) {
+        let bytes_read = u64::try_from(bytes_read).unwrap_or(u64::MAX);
+        self.state
+            .body_read
+            .set(self.state.body_read.get().saturating_add(duration));
+        self.state.compressed_bytes_consumed.set(
+            self.state
+                .compressed_bytes_consumed
+                .get()
+                .saturating_add(bytes_read),
+        );
+    }
+
+    pub(crate) fn snapshot(&self) -> RemoteArchiveAttemptSnapshot {
+        RemoteArchiveAttemptSnapshot {
+            request_to_response_headers: self.state.request_to_response_headers.get(),
+            body_read: self.state.body_read.get(),
+            compressed_bytes_consumed: self.state.compressed_bytes_consumed.get(),
+        }
     }
 }
 
@@ -164,13 +226,21 @@ impl HttpBodyReadFailure {
 struct HttpBodyReader<R> {
     reader: R,
     failure: HttpBodyReadFailure,
+    metrics: RemoteArchiveAttemptMetrics,
 }
 
 impl<R: Read> Read for HttpBodyReader<R> {
     fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        match self.reader.read(buffer) {
-            Ok(bytes_read) => Ok(bytes_read),
+        let start = Instant::now();
+        let result = self.reader.read(buffer);
+        let duration = start.elapsed();
+        match result {
+            Ok(bytes_read) => {
+                self.metrics.record_body_read(duration, bytes_read);
+                Ok(bytes_read)
+            }
             Err(e) => {
+                self.metrics.record_body_read(duration, 0);
                 self.failure.mark_failed();
                 Err(e)
             }

--- a/crates/guest-download/tests/integration/binary_logging/attribution.rs
+++ b/crates/guest-download/tests/integration/binary_logging/attribution.rs
@@ -1,6 +1,54 @@
 use super::{BinaryLoggingFixture, assert_action_types_present};
-use crate::support::{create_tar_gz, write_manifest};
+use crate::support::{create_tar_gz, read_http_request_path, write_manifest};
 use httpmock::prelude::*;
+use httpmock::{HttpMockRequest, HttpMockResponse};
+use serde_json::Value;
+use std::io::Write as _;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+const STORAGE_REMOTE_PREFIX: &str = "storage_download_remote_";
+const ARTIFACT_REMOTE_PREFIX: &str = "artifact_download_remote_";
+
+fn operation<'a>(ops: &'a [Value], action: &str) -> Option<&'a Value> {
+    ops.iter().find(|entry| entry["action_type"] == action)
+}
+
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_u32;
+    (0..len)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            state.to_be_bytes().into_iter().next().unwrap_or_default()
+        })
+        .collect()
+}
+
+fn start_delayed_archive_server(
+    archive: Vec<u8>,
+    header_delay: Duration,
+    body_delay: Duration,
+) -> std::io::Result<(String, thread::JoinHandle<std::io::Result<()>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let url = format!("http://{}/archive.tar.gz", listener.local_addr()?);
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept()?;
+        assert_eq!(read_http_request_path(&mut stream)?, "/archive.tar.gz");
+        thread::sleep(header_delay);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/gzip\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            archive.len()
+        )?;
+        stream.flush()?;
+        thread::sleep(body_delay);
+        stream.write_all(&archive)?;
+        stream.flush()
+    });
+    Ok((url, handle))
+}
 
 #[test]
 fn binary_records_download_scheduler_attribution() {
@@ -60,9 +108,20 @@ fn binary_records_download_scheduler_attribution() {
             "guest_download_exact_path_conflict_deferral_count_0",
             "guest_download_other_parent_child_conflict_deferral_count_1",
             "storage_download",
+            "storage_download_remote_request_to_response_headers",
+            "storage_download_remote_body_read",
+            "storage_download_remote_extract_outside_body_read",
+            "storage_download_remote_compressed_bytes_consumed_lt_64_kib",
+            "storage_download_remote_attempt_count_1",
             "artifact_download",
             "download_total",
         ],
+    );
+    assert!(
+        !actions
+            .iter()
+            .any(|action| action.starts_with(ARTIFACT_REMOTE_PREFIX)),
+        "local artifact emitted remote attribution: {actions:?}"
     );
 }
 
@@ -120,4 +179,168 @@ fn binary_records_scheduler_attribution_for_failed_download() {
         .find(|entry| entry["action_type"] == "download_total")
         .unwrap_or_else(|| panic!("missing download_total in {ops:?}"));
     assert_eq!(total["success"], false);
+
+    let remote_ops: Vec<&Value> = ops
+        .iter()
+        .filter(|entry| {
+            entry["action_type"]
+                .as_str()
+                .is_some_and(|action| action.starts_with(STORAGE_REMOTE_PREFIX))
+        })
+        .collect();
+    assert_eq!(remote_ops.len(), 5, "unexpected remote operations: {ops:?}");
+    assert!(remote_ops.iter().all(|entry| entry["success"] == false));
+    assert!(remote_ops.iter().all(|entry| entry.get("error").is_none()));
+    assert_eq!(
+        operation(&ops, "storage_download_remote_attempt_count_1").unwrap()["duration_ms"],
+        0
+    );
+    assert_eq!(
+        operation(
+            &ops,
+            "storage_download_remote_compressed_bytes_consumed_zero"
+        )
+        .unwrap()["duration_ms"],
+        0
+    );
+}
+
+#[test]
+fn binary_records_remote_artifact_attribution_and_compressed_byte_bucket() {
+    let server = MockServer::start();
+    let content = deterministic_bytes(100_000);
+    let archive = create_tar_gz(&[("artifact.bin", &content)]).unwrap();
+    assert!(archive.len() >= 65_536, "archive compressed too small");
+    assert!(archive.len() < 262_144, "archive compressed too large");
+    let archive_mock = server.mock(|when, then| {
+        when.method(GET).path("/artifact.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&archive);
+    });
+
+    let fixture = BinaryLoggingFixture::new("artifact-remote-attribution").unwrap();
+    let mount = fixture.dir.path().join("artifact");
+    let url = server.url("/artifact.tar.gz");
+    let manifest = write_manifest(
+        &fixture.dir,
+        &[],
+        Some((mount.to_str().unwrap(), Some(&url))),
+    )
+    .unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    archive_mock.assert_calls(1);
+    assert_eq!(std::fs::read(mount.join("artifact.bin")).unwrap(), content);
+
+    let actions = fixture.action_types().unwrap();
+    assert_action_types_present(
+        &actions,
+        &[
+            "artifact_download",
+            "artifact_download_remote_request_to_response_headers",
+            "artifact_download_remote_body_read",
+            "artifact_download_remote_extract_outside_body_read",
+            "artifact_download_remote_compressed_bytes_consumed_64_kib_to_256_kib",
+            "artifact_download_remote_attempt_count_1",
+        ],
+    );
+    assert!(
+        !actions
+            .iter()
+            .any(|action| action.starts_with(STORAGE_REMOTE_PREFIX)),
+        "artifact emitted storage attribution: {actions:?}"
+    );
+}
+
+#[test]
+fn binary_aggregates_remote_attribution_across_retries() {
+    let server = MockServer::start();
+    let archive = create_tar_gz(&[("recovered.txt", b"recovered")]).unwrap();
+    let calls = AtomicUsize::new(0);
+    let archive_mock = server.mock(move |when, then| {
+        when.method(GET).path("/retry.tar.gz");
+        then.delay(Duration::from_millis(60))
+            .respond_with(move |_request: &HttpMockRequest| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    HttpMockResponse::builder().status(500).build()
+                } else {
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/gzip")
+                        .body(archive.clone())
+                        .build()
+                }
+            });
+    });
+
+    let fixture = BinaryLoggingFixture::new("remote-attribution-retry").unwrap();
+    let mount = fixture.dir.path().join("storage");
+    let url = server.url("/retry.tar.gz");
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    archive_mock.assert_calls(2);
+    let ops = fixture.ops_entries().unwrap();
+    let attempt = operation(&ops, "storage_download_remote_attempt_count_2").unwrap();
+    assert_eq!(attempt["success"], true);
+    assert!(attempt.get("error").is_none());
+    assert_eq!(
+        operation(&ops, "storage_download_remote_request_to_response_headers").unwrap()["success"],
+        true
+    );
+    let request_wait = operation(&ops, "storage_download_remote_request_to_response_headers")
+        .unwrap()["duration_ms"]
+        .as_u64()
+        .unwrap();
+    assert!(
+        request_wait >= 100,
+        "request wait did not include both attempts: {ops:?}"
+    );
+}
+
+#[test]
+fn binary_separates_response_header_and_body_read_wait() {
+    let archive = create_tar_gz(&[("delayed.txt", b"delayed")]).unwrap();
+    let delay = Duration::from_millis(80);
+    let (url, server) = start_delayed_archive_server(archive, delay, delay).unwrap();
+    let fixture = BinaryLoggingFixture::new("remote-attribution-delays").unwrap();
+    let mount = fixture.dir.path().join("storage");
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+    server.join().unwrap().unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let ops = fixture.ops_entries().unwrap();
+    let header_wait = operation(&ops, "storage_download_remote_request_to_response_headers")
+        .unwrap()["duration_ms"]
+        .as_u64()
+        .unwrap();
+    let body_wait = operation(&ops, "storage_download_remote_body_read").unwrap()["duration_ms"]
+        .as_u64()
+        .unwrap();
+    assert!(
+        header_wait >= 50,
+        "header wait was {header_wait}ms: {ops:?}"
+    );
+    assert!(body_wait >= 50, "body wait was {body_wait}ms: {ops:?}");
 }


### PR DESCRIPTION
## Summary

- emit fixed-cardinality sandbox operation rows for remote archive request-to-headers, body reads, and extraction outside body reads
- aggregate phase durations, compressed bytes, and attempt counts across retries for both storage and artifact downloads
- keep existing task totals and error behavior intact, and emit no remote attribution rows or metrics allocations for `file://` cache downloads

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-download --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-download --all-features --no-deps`
- `cargo test -p guest-download` (93 lib, 9 binary, 54 integration tests)
- pre-commit hook workspace Rust Clippy and rustdoc checks
- controlled ARM64 metal comparison and causal controls: https://github.com/vm0-ai/vm0/issues/21760#issuecomment-4988657296
  - final-commit treatment records: 160/160 successful
  - delayed headers, delayed body delivery, throttled delivery, extraction-heavy input, and retry aggregation moved only the expected attribution rows
  - final treatment serial versus two-job concurrent task p50/p95: `114/123 ms` versus `114/128 ms`; no production host-overlap state is justified
- controlled-metal host resource addendum: https://github.com/vm0-ai/vm0/issues/21760#issuecomment-4988783822
  - 15 serial jobs and 15 two-job rounds all succeeded
  - CPU, memory, PSI, NVMe, and NBD signals showed no host-resource saturation

No API, schema, persisted-state, cache-policy, scheduler, or retry-policy changes.

Relates to #21760
