### PR TITLE
docs(sandbox-fc): document snapshot socket id constraints

### DIFF
--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -248,9 +248,10 @@ impl SnapshotOutputPaths {
     ///
     /// `sock_id` identifies the socket directory under `/run/vm0/sock/` —
     /// typically the config hash so each snapshot gets a unique path. It must
-    /// be a single, non-empty ASCII path segment containing only letters,
-    /// digits, `.`, `-`, or `_`. Nested or composite IDs such as
-    /// `<rootfs>/<snapshot>` are invalid. The complete generated
+    /// be a single, non-empty normal path segment containing only ASCII
+    /// letters, digits, `.`, `-`, or `_`. The special `.` and `..` components,
+    /// as well as nested or composite IDs such as `<rootfs>/<snapshot>`, are
+    /// invalid. The complete generated
     /// `/run/vm0/sock/<sock_id>/vsock/vsock.sock` path must be at most 107
     /// bytes.
     ///

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -247,7 +247,16 @@ impl SnapshotOutputPaths {
     /// the work directory paths recorded during snapshot creation.
     ///
     /// `sock_id` identifies the socket directory under `/run/vm0/sock/` —
-    /// typically the config hash so each snapshot gets a unique path.
+    /// typically the config hash so each snapshot gets a unique path. It must
+    /// be a single, non-empty ASCII path segment containing only letters,
+    /// digits, `.`, `-`, or `_`. Nested or composite IDs such as
+    /// `<rootfs>/<snapshot>` are invalid. The complete generated
+    /// `/run/vm0/sock/<sock_id>/vsock/vsock.sock` path must be at most 107
+    /// bytes.
+    ///
+    /// This helper only constructs paths; it does not validate `sock_id`.
+    /// Callers must ensure these requirements are met before using the returned
+    /// config.
     pub fn snapshot_config(&self, sock_id: &str) -> SnapshotConfig {
         let work = SandboxPaths::new(self.work_dir());
         let runtime = RuntimePaths::new();


### PR DESCRIPTION
## Summary

- document the exact single-segment ASCII grammar for `SnapshotOutputPaths::snapshot_config` socket IDs
- document the complete generated vsock path and its 107-byte maximum
- clarify that nested or composite IDs are invalid and that the helper performs unchecked path construction

## Scope

Documentation only. This PR does not change the public signature, runtime validation, behavior, tests, or deployment compatibility.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox-fc --all-targets --all-features`
- `cd crates && cargo doc -p sandbox-fc --all-features --no-deps`
- `cd crates && cargo test -p sandbox-fc` (710 passed; doc-tests passed)
- pre-commit hook, including workspace Rustdoc generation

Closes #21777
