### PR TITLE
fix(core): disable zero mail for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -125,6 +125,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ZeroWebSearch]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ZeroMail]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       false,
     );
@@ -160,6 +161,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroScrape]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ZeroWebSearch]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ZeroMail]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -498,7 +498,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable persistent Gmail and Outlook draft cards created through the Zero Mail CLI.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary

- remove the staff organization allowlist from the Zero Mail feature switch
- keep Zero Mail disabled by default for both staff and non-staff organizations
- cover both rollout states in the core feature-switch integration test

## Test plan

- `pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm knip --workspace @vm0/core`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- pre-commit hook (full Knip and Turbo type checks)