### PR TITLE
test(runner): cover active stop panic reconciliation

### DIFF
--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -1,8 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config_with_overrides, push_job, shutdown,
-    test_profiles, wait_cancel_token, wait_cancel_token_removed, wait_idle_pool_len,
-    wait_status_idle_sessions_and_active_runs,
+    test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
+    wait_idle_pool_len, wait_status_idle_sessions_and_active_runs,
 };
 use super::support::assert_no_completion_for_run;
 
@@ -85,6 +85,63 @@ async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
         &env,
         run_id,
         "outer job panic must not synthesize provider completion",
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn outer_job_panic_after_active_stop_panic_preserves_status_for_reconciliation() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_stop_panic("simulated active stop panic");
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+
+    let (mut config, env) =
+        mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, Arc::clone(&overrides));
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
+    config.orphan_reap.process_discovery = Some(OrphanReapProcessDiscovery {
+        firecrackers: Arc::new(Vec::new()),
+        incomplete_for_current_runner: false,
+    });
+    let budget = Arc::clone(&config.capacity.budget);
+    let cancel_tokens = Arc::clone(&config.provider.cancel_tokens);
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    assert_eq!(
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect("active destroy should still run after stop panic"),
+        1
+    );
+    let _token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    destroy_gate.release_one();
+
+    wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.destroy_call_count(), 1);
+    wait_status_idle_sessions_and_active_runs(
+        &status_path,
+        &[],
+        &[run_id.to_string()],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_no_completion_for_run(
+        &env,
+        run_id,
+        "outer job panic must not synthesize provider completion",
+    );
+
+    shutdown(&env, run_handle).await;
+    wait_status_idle_sessions_and_active_runs(&status_path, &[], &[], Duration::from_secs(5)).await;
+    assert_no_completion_for_run(
+        &env,
+        run_id,
+        "orphan reconciliation must not synthesize provider completion",
     );
 }
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -97,6 +97,7 @@ async fn outer_job_panic_after_active_stop_panic_preserves_status_for_reconcilia
 
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, Arc::clone(&overrides));
+    // This hook runs after destroy bookkeeping for completed and uncertain outcomes.
     config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::DestroyCompleted);
     config.orphan_reap.process_discovery = Some(OrphanReapProcessDiscovery {
         firecrackers: Arc::new(Vec::new()),


### PR DESCRIPTION
## Summary

- add runner-start failure-recovery coverage for an active sandbox stop panic followed by an outer-job panic
- verify factory destruction is still attempted while uncertain ownership keeps the active run visible
- verify cancel-token and budget cleanup, deterministic orphan reconciliation, and the absence of synthetic provider completion

## Scope

- test-only change in the Runner outer-panic integration suite
- no runtime behavior, API, protocol, persisted-state, schema, dependency, migration, or rollout changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner outer_job_panic_after_active_stop_panic_preserves_status_for_reconciliation`
- `cargo test --manifest-path crates/Cargo.toml -p runner outer_job_panic`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2706 passed, 10 ignored; guest inventory passed)
- `git diff --check`
- pre-commit and commit-message hooks

Closes #21778
