### PR TITLE
fix(platform): gate artifact favorites behind feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -10,10 +10,6 @@ import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
 import { localStorageSignals } from "./local-storage.ts";
 
 export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v2";
-export const LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY = "artifactFavorites";
-
-type FeatureSwitchStates = Record<FeatureSwitchKey, boolean> &
-  Partial<Record<typeof LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY, boolean>>;
 
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
@@ -33,7 +29,7 @@ const apiFeatureSwitchClient$ = computed((get) => {
 });
 
 function applySwitches(
-  result: FeatureSwitchStates,
+  result: Record<FeatureSwitchKey, boolean>,
   overrides: Partial<Record<string, boolean>> | undefined,
   effectiveSwitches: Partial<Record<string, boolean>> | undefined,
 ) {
@@ -54,25 +50,16 @@ function applySwitches(
       notionWorkflowAutomations,
     );
   }
-
-  // Keep the retired key only for the cross-version window where a new
-  // frontend can still receive an explicit disabled state from an old API.
-  // Remove this compatibility path after the previous API version has drained.
-  const artifactFavorites =
-    effectiveSwitches?.[LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY];
-  if (artifactFavorites !== undefined) {
-    result[LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY] = Boolean(artifactFavorites);
-  }
 }
 
-export const featureSwitch$ = computed((get): FeatureSwitchStates => {
+export const featureSwitch$ = computed((get) => {
   const raw = get(featureSwitchCache$);
   if (!raw) {
     // First-ever load: identity-gated switches start disabled until
     // `reloadFeatureSwitch$` populates the cache.
     return getAllFeatureStates({});
   }
-  return JSON.parse(raw) as FeatureSwitchStates;
+  return JSON.parse(raw) as Record<FeatureSwitchKey, boolean>;
 });
 
 export const codexFastModeEnabled$ = computed((get): boolean => {

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -5,7 +5,6 @@ import {
   type ArtifactItem,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroAgentDraftContract } from "@vm0/api-contracts/contracts/zero-agents";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it, vi } from "vitest";
@@ -20,10 +19,6 @@ import { pathname } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { openChatIdb } from "../../../signals/external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../../../signals/external/idb-artifact-item-store.ts";
-import {
-  LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY,
-  reloadFeatureSwitch$,
-} from "../../../signals/external/feature-switch.ts";
 
 const artifactIdbMock = vi.hoisted(() => {
   interface StoredObjectStore {
@@ -419,11 +414,13 @@ function mockScrollViewport(
 function setupArtifactsPage({
   scope,
   enabled = true,
+  artifactFavoritesEnabled = false,
   htmlArtifactCommentEditingEnabled = false,
   imageEditingEnabled = false,
 }: {
   readonly scope: TestAuthScope;
   readonly enabled?: boolean;
+  readonly artifactFavoritesEnabled?: boolean;
   readonly htmlArtifactCommentEditingEnabled?: boolean;
   readonly imageEditingEnabled?: boolean;
 }): void {
@@ -440,6 +437,7 @@ function setupArtifactsPage({
     },
     featureSwitches: {
       [FeatureSwitchKey.Artifacts]: enabled,
+      [FeatureSwitchKey.ArtifactFavorites]: artifactFavoritesEnabled,
       [FeatureSwitchKey.HtmlArtifactCommentEditing]:
         htmlArtifactCommentEditingEnabled,
       [FeatureSwitchKey.ImageEditing]: imageEditingEnabled,
@@ -1191,31 +1189,20 @@ describe("artifacts page", () => {
     expect(listCalls).toBe(1);
   });
 
-  it("hides favorite controls when the previous API effectively disables artifact favorites", async () => {
+  it("hides favorite controls when artifact favorites are disabled", async () => {
     setupTeam();
-    const scope = testAuthScope("legacy-favorites-disabled");
+    const scope = testAuthScope("favorites-disabled");
     mockArtifacts([createArtifact()]);
 
     setupArtifactsPage({ scope });
-    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
-      return respond(200, {
-        switches: {},
-        effectiveSwitches: {
-          [LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY]: false,
-        },
-      });
-    });
-    await context.store.set(reloadFeatureSwitch$, context.signal);
 
     await screen.findByText("launch-plan.html");
-    await waitFor(() => {
-      expect(
-        screen.queryByLabelText("Show favorite artifacts"),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByLabelText("Add launch-plan.html to favorites"),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      screen.queryByLabelText("Show favorite artifacts"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Add launch-plan.html to favorites"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows interaction feedback on artifact card actions", async () => {
@@ -1223,7 +1210,7 @@ describe("artifacts page", () => {
     const scope = testAuthScope("card-action-feedback");
     mockArtifacts([createArtifact()]);
 
-    setupArtifactsPage({ scope });
+    setupArtifactsPage({ scope, artifactFavoritesEnabled: true });
 
     await screen.findByText("launch-plan.html");
     expect(buttonByLabel("Add launch-plan.html to favorites")).toHaveClass(
@@ -1278,7 +1265,7 @@ describe("artifacts page", () => {
       return respond(204);
     });
 
-    setupArtifactsPage({ scope });
+    setupArtifactsPage({ scope, artifactFavoritesEnabled: true });
 
     await screen.findByText("launch-plan.html");
     await screen.findByText("favorite-brief.html");

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -21,6 +21,7 @@ import {
   IconVideo,
   IconWorld,
 } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { r2ImageTransformUrl } from "@vm0/core";
 import {
   useGet,
@@ -84,10 +85,7 @@ import {
   classifyChatAttachment,
   type BodyPreviewKind,
 } from "../../signals/chat-page/parse-body-blocks.ts";
-import {
-  featureSwitch$,
-  LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY,
-} from "../../signals/external/feature-switch.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   lightboxUrl$,
@@ -1201,7 +1199,7 @@ export function ArtifactsPage() {
   const agents = useLastResolved(agents$) ?? [];
   const features = useLastResolved(featureSwitch$);
   const artifactFavoritesEnabled =
-    features?.[LEGACY_ARTIFACT_FAVORITES_SWITCH_KEY] !== false;
+    features?.[FeatureSwitchKey.ArtifactFavorites] ?? false;
   const remoteData =
     remoteLoadable.state === "hasData" ? remoteLoadable.data : null;
   const cachedData =

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -75,6 +75,7 @@ export enum FeatureSwitchKey {
   PresentationGoogleSlidesUpload = "presentationGoogleSlidesUpload",
   PresentationElementDragging = "presentationElementDragging",
   Artifacts = "artifacts",
+  ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
   WorkflowTemplateCatalog = "workflowTemplateCatalog",
   WebsiteTemplates = "websiteTemplates",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -143,6 +143,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
@@ -180,6 +181,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -449,6 +449,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ArtifactFavorites]: {
+    maintainer: "bingjie@vm0.ai",
+    description: "Enable favoriting artifacts on the Artifacts page.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ArtifactPreviewImage]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Restore the `artifactFavorites` feature switch with its previous staff-org rollout configuration.
- Show the favorites-only filter and per-artifact favorite action only when the switch is enabled.
- Remove the retired-key frontend compatibility path now that `artifactFavorites` is a current switch again.
- Keep favorite and unfavorite API behavior unchanged; this PR gates only the frontend controls.

## User impact

Users outside the switch no longer see or use artifact favorite controls in the UI. Users inside the switch retain the existing favorite, unfavorite, and favorites-filter experience.

## Verification

- Targeted Prettier formatting for all changed TypeScript files
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests)
- `pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx` (26 tests)
- `pnpm knip --workspace @vm0/app --workspace @vm0/core --workspace @vm0/connectors`

Browser verification was not run because the vm0 PR workflow avoids starting a local dev server unless explicitly requested.