### PR TITLE
ci: split runner behavior tests into three lanes

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -612,9 +612,9 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
-  # Cap these runner behavior scenarios at two concurrent metal-host users.
-  # Run balloon first in lane A and exec last in lane B to stagger the two
-  # heaviest scenarios during normal runs.
+  # Cap these runner behavior scenarios at three concurrent metal-host users.
+  # Run balloon first in lane A, exec last in lane B, and upgrade last in lane C
+  # to stagger the three heaviest scenarios during normal runs.
   runner-behavior-lane-a:
     runs-on: ubuntu-latest
     needs: [runner-build]
@@ -644,15 +644,6 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-balloon.sh
 
-      - name: Test local active input with real Claude Code
-        id: local_claude_active_input_smoke
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
-        run: .github/scripts/runner-behavior-local-claude-active-input-smoke.sh
-
       - name: Test local active input with real Codex
         id: local_codex_active_input_smoke
         timeout-minutes: 8
@@ -662,20 +653,10 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: .github/scripts/runner-behavior-local-codex-active-input-smoke.sh
 
-      - name: Run benchmark
-        id: benchmark
-        timeout-minutes: 8
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-benchmark.sh
-
       - name: Summarize runner behavior lane A results
         env:
           BALLOON_RESULT: ${{ steps.balloon.outcome }}
-          LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT: ${{ steps.local_claude_active_input_smoke.outcome }}
           LOCAL_CODEX_ACTIVE_INPUT_SMOKE_RESULT: ${{ steps.local_codex_active_input_smoke.outcome }}
-          BENCHMARK_RESULT: ${{ steps.benchmark.outcome }}
         run: |
           FAILED=0
 
@@ -691,9 +672,7 @@ jobs:
 
           echo "::group::Runner Behavior Lane A Results"
           check_result "balloon" "$BALLOON_RESULT"
-          check_result "local-claude-active-input-smoke" "$LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT"
           check_result "local-codex-active-input-smoke" "$LOCAL_CODEX_ACTIVE_INPUT_SMOKE_RESULT"
-          check_result "benchmark" "$BENCHMARK_RESULT"
           echo "::endgroup::"
 
           exit "$FAILED"
@@ -719,22 +698,6 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
-      - name: Test runner local cancel
-        id: cancel
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-cancel.sh
-
-      - name: Test VM keep-alive across conversation turns
-        id: keep_alive
-        timeout-minutes: 5
-        continue-on-error: true
-        env:
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-keep-alive.sh
-
       - name: Test runner service drain + resume
         id: drain_resume
         timeout-minutes: 5
@@ -743,13 +706,13 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-drain-resume.sh
 
-      - name: Run upgrade test
-        id: upgrade_local
+      - name: Test runner local cancel
+        id: cancel
         timeout-minutes: 5
         continue-on-error: true
         env:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-        run: .github/scripts/runner-behavior-upgrade-local.sh
+        run: .github/scripts/runner-behavior-cancel.sh
 
       - name: Test runner exec
         id: exec
@@ -761,10 +724,8 @@ jobs:
 
       - name: Summarize runner behavior lane B results
         env:
-          CANCEL_RESULT: ${{ steps.cancel.outcome }}
-          KEEP_ALIVE_RESULT: ${{ steps.keep_alive.outcome }}
           DRAIN_RESUME_RESULT: ${{ steps.drain_resume.outcome }}
-          UPGRADE_LOCAL_RESULT: ${{ steps.upgrade_local.outcome }}
+          CANCEL_RESULT: ${{ steps.cancel.outcome }}
           EXEC_RESULT: ${{ steps.exec.outcome }}
         run: |
           FAILED=0
@@ -780,11 +741,91 @@ jobs:
           }
 
           echo "::group::Runner Behavior Lane B Results"
-          check_result "cancel" "$CANCEL_RESULT"
-          check_result "keep-alive" "$KEEP_ALIVE_RESULT"
           check_result "drain-resume" "$DRAIN_RESUME_RESULT"
-          check_result "upgrade-local" "$UPGRADE_LOCAL_RESULT"
+          check_result "cancel" "$CANCEL_RESULT"
           check_result "exec" "$EXEC_RESULT"
+          echo "::endgroup::"
+
+          exit "$FAILED"
+
+  runner-behavior-lane-c:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 35
+    env:
+      METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+      HOST: ${{ needs.runner-build.outputs.host }}
+      JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+      BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
+      DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+      DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Run benchmark
+        id: benchmark
+        timeout-minutes: 8
+        continue-on-error: true
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-benchmark.sh
+
+      - name: Test local active input with real Claude Code
+        id: local_claude_active_input_smoke
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+        run: .github/scripts/runner-behavior-local-claude-active-input-smoke.sh
+
+      - name: Test VM keep-alive across conversation turns
+        id: keep_alive
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-keep-alive.sh
+
+      - name: Run upgrade test
+        id: upgrade_local
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+        run: .github/scripts/runner-behavior-upgrade-local.sh
+
+      - name: Summarize runner behavior lane C results
+        env:
+          BENCHMARK_RESULT: ${{ steps.benchmark.outcome }}
+          LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT: ${{ steps.local_claude_active_input_smoke.outcome }}
+          KEEP_ALIVE_RESULT: ${{ steps.keep_alive.outcome }}
+          UPGRADE_LOCAL_RESULT: ${{ steps.upgrade_local.outcome }}
+        run: |
+          FAILED=0
+
+          check_result() {
+            local name=$1 result=$2
+            if [ "$result" = "success" ]; then
+              echo "✅ $name: $result"
+            else
+              echo "::error::$name: expected success, got ${result:-missing}"
+              FAILED=1
+            fi
+          }
+
+          echo "::group::Runner Behavior Lane C Results"
+          check_result "benchmark" "$BENCHMARK_RESULT"
+          check_result "local-claude-active-input-smoke" "$LOCAL_CLAUDE_ACTIVE_INPUT_SMOKE_RESULT"
+          check_result "keep-alive" "$KEEP_ALIVE_RESULT"
+          check_result "upgrade-local" "$UPGRADE_LOCAL_RESULT"
           echo "::endgroup::"
 
           exit "$FAILED"
@@ -804,6 +845,7 @@ jobs:
       - runner-image-architecture-manifest
       - runner-behavior-lane-a
       - runner-behavior-lane-b
+      - runner-behavior-lane-c
       - nbd-cow-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
@@ -851,6 +893,7 @@ jobs:
           check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"
           check_result "runner-behavior-lane-a" "${{ needs.runner-behavior-lane-a.result }}" "true"
           check_result "runner-behavior-lane-b" "${{ needs.runner-behavior-lane-b.result }}" "true"
+          check_result "runner-behavior-lane-c" "${{ needs.runner-behavior-lane-c.result }}" "true"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
 
           echo "::endgroup::"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -612,7 +612,8 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
-  # Cap these runner behavior scenarios at three concurrent metal-host users.
+  # Balance these scenarios by recent CI timings across three concurrent
+  # metal-host users.
   # Run balloon first in lane A, exec last in lane B, and upgrade last in lane C
   # to stagger the three heaviest scenarios during normal runs.
   runner-behavior-lane-a:


### PR DESCRIPTION
## Summary

- rebalance the nine runner behavior scenarios from two serial lanes into three
- use five recent successful CI runs to target median lane durations of 118s, 116s, and 124s
- stagger balloon, exec, and upgrade so the three heaviest scenarios do not all start together
- require all three lanes in the Crates CI gate while preserving per-scenario timeouts and secret scope

## Validation

- `pnpm prettier --write --ignore-unknown ../.github/workflows/crates.yml`
- `codex-work/tmp/actionlint/actionlint .github/workflows/crates.yml`
- static contract check for lane membership, one invocation per scenario, and CI gate wiring
- real Crates runner coverage on [run 29478376564](https://github.com/vm0-ai/vm0/actions/runs/29478376564) for current head `f4199350b9c6794cd86862db242108f0026dc57e`

## CI result

All three runner behavior lanes passed on the current head:

- lane A: 2m19s
- lane B: 2m11s
- lane C: 2m09s

The post-build runner behavior critical path fell from 4m23s in a recent successful two-lane run to 2m19s, a 47% reduction.
