### PR TITLE
fix(runner): isolate heartbeat requests from reactor

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
+use futures_util::future::BoxFuture;
 use tracing::{debug, info};
 
 use super::active_sessions::{ActiveCliAgentSessions, active_cli_agent_session_ids};
@@ -20,6 +21,7 @@ pub(super) const HEARTBEAT_PERIOD: Duration = Duration::from_secs(10);
 /// References needed to collect and send a heartbeat.
 ///
 /// Avoids passing 8+ arguments through `send_heartbeat`.
+#[derive(Clone)]
 pub(super) struct HeartbeatContext<'a> {
     idle_pool: &'a Arc<tokio::sync::Mutex<IdlePool>>,
     runner_id: &'a str,
@@ -60,6 +62,95 @@ impl<'a> HeartbeatContext<'a> {
             active_cli_agent_sessions: init.active_cli_agent_sessions,
             held_session_snapshot: init.held_session_snapshot,
         }
+    }
+}
+
+/// Single-flight heartbeat work polled alongside the main reactor.
+///
+/// Trigger handlers only call [`request`](Self::request). The active future is
+/// kept outside `tokio::select!`, so other ready branches neither await nor
+/// cancel it. Any number of triggers during one send collapse into one
+/// follow-up built from live state when that send starts.
+pub(super) struct HeartbeatController<'a> {
+    context: HeartbeatContext<'a>,
+    in_flight: Option<BoxFuture<'a, ()>>,
+    pending: bool,
+}
+
+impl<'a> HeartbeatController<'a> {
+    pub(super) fn new(context: HeartbeatContext<'a>) -> Self {
+        Self {
+            context,
+            in_flight: None,
+            pending: false,
+        }
+    }
+
+    pub(super) fn request(&mut self, mode: RunnerMode) {
+        if self.in_flight.is_some() {
+            self.pending = true;
+        } else {
+            self.start(mode);
+        }
+    }
+
+    pub(super) fn is_sending(&self) -> bool {
+        self.in_flight.is_some()
+    }
+
+    /// Wait for the stored future from an enabled `tokio::select!` branch.
+    pub(super) async fn wait_for_send(&mut self) {
+        debug_assert!(self.in_flight.is_some());
+        match &mut self.in_flight {
+            Some(send) => send.await,
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Clear a completed send and start one live-state follow-up when dirty.
+    pub(super) fn finish_send(&mut self, live_mode: RunnerMode) {
+        debug_assert!(self.in_flight.is_some());
+        self.in_flight = None;
+        if std::mem::take(&mut self.pending) {
+            self.start(live_mode);
+        }
+    }
+
+    /// Finish current work and emit one lifecycle-critical snapshot.
+    ///
+    /// Natural stopping uses this to replace all ordinary pending work with a
+    /// single `Stopping` heartbeat before teardown.
+    pub(super) async fn flush(&mut self, mode: RunnerMode) {
+        self.request(mode);
+        loop {
+            self.wait_for_send().await;
+            self.in_flight = None;
+            if std::mem::take(&mut self.pending) {
+                self.start(mode);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Finish only the active send and discard ordinary coalesced work.
+    ///
+    /// Hard stopping calls this before provider shutdown. Awaiting the bounded
+    /// request preserves local ordering without assuming that dropping a
+    /// client future retracts a request already queued remotely.
+    pub(super) async fn drain(&mut self) {
+        if let Some(send) = self.in_flight.take() {
+            send.await;
+        }
+        self.pending = false;
+    }
+
+    fn start(&mut self, mode: RunnerMode) {
+        debug_assert!(self.in_flight.is_none());
+        let context = self.context.clone();
+        self.in_flight = Some(Box::pin(async move {
+            send_heartbeat(&context, mode).await;
+        }));
     }
 }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -7,6 +7,7 @@ use tracing::{debug, info};
 
 use super::active_sessions::{ActiveCliAgentSessions, active_cli_agent_session_ids};
 use crate::config::ProfileConfig;
+use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::IdlePool;
 use crate::provider::JobProvider;
 use crate::resource_budget::ResourceBudget;
@@ -99,12 +100,12 @@ impl<'a> HeartbeatController<'a> {
     }
 
     /// Wait for the stored future from an enabled `tokio::select!` branch.
-    pub(super) async fn wait_for_send(&mut self) {
-        debug_assert!(self.in_flight.is_some());
-        match &mut self.in_flight {
-            Some(send) => send.await,
-            None => std::future::pending().await,
-        }
+    pub(super) async fn wait_for_send(&mut self) -> RunnerResult<()> {
+        let send = self.in_flight.as_mut().ok_or_else(|| {
+            RunnerError::Internal("heartbeat wait requires an active send".to_string())
+        })?;
+        send.await;
+        Ok(())
     }
 
     /// Clear a completed send and start one live-state follow-up when dirty.
@@ -120,10 +121,10 @@ impl<'a> HeartbeatController<'a> {
     ///
     /// Natural stopping uses this to replace all ordinary pending work with a
     /// single `Stopping` heartbeat before teardown.
-    pub(super) async fn flush(&mut self, mode: RunnerMode) {
+    pub(super) async fn flush(&mut self, mode: RunnerMode) -> RunnerResult<()> {
         self.request(mode);
         loop {
-            self.wait_for_send().await;
+            self.wait_for_send().await?;
             self.in_flight = None;
             if std::mem::take(&mut self.pending) {
                 self.start(mode);
@@ -131,6 +132,7 @@ impl<'a> HeartbeatController<'a> {
                 break;
             }
         }
+        Ok(())
     }
 
     /// Finish only the active send and discard ordinary coalesced work.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -24,8 +24,11 @@
 //! - lifecycle signals are registered before slow startup work;
 //! - discovery is pinned across `select!` ticks so heartbeat and cleanup
 //!   branches do not restart polling;
+//! - heartbeat work is pinned and single-flight so its I/O does not stall the
+//!   main reactor or overlap a newer snapshot;
 //! - the first heartbeat and idle-cleanup ticks are deferred;
-//! - teardown drops discovery before provider shutdown.
+//! - teardown drains heartbeat work and drops discovery before provider
+//!   shutdown.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
@@ -85,8 +88,9 @@ mod signals;
 use active_sessions::new_active_cli_agent_sessions;
 use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_factories};
 use heartbeat::{
-    HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeldSessionStateSnapshot,
-    collect_heartbeat_state, refresh_workspace_cache_held_session_snapshot, send_heartbeat,
+    HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeartbeatController,
+    HeldSessionStateSnapshot, collect_heartbeat_state,
+    refresh_workspace_cache_held_session_snapshot,
 };
 use identity::load_or_generate_runner_id;
 use idle_lifecycle::{
@@ -1359,6 +1363,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     )
     .await;
     debug_assert!(held_session_snapshot.workspace_cache_loaded());
+    let mut heartbeat = HeartbeatController::new(hb_ctx);
 
     // Pin the discover future so it survives cancellation by other select!
     // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
@@ -1418,7 +1423,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     if transitioned {
                         // Live observability: fire an immediate "stopping"
                         // heartbeat before teardown removes the runner.
-                        send_heartbeat(&hb_ctx, RunnerMode::Stopping).await;
+                        heartbeat.flush(RunnerMode::Stopping).await;
                     }
                     continue;
                 }
@@ -1459,6 +1464,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         if matches!(mode, RunnerMode::Running) && !can_discover {
             test_hooks.test_observer.notify_budget_exhausted_reactor();
         }
+        let heartbeat_sending = heartbeat.is_sending();
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup
@@ -1525,8 +1531,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         drained_ready_candidates,
                         "session affinity state triggered immediate heartbeat"
                     );
-                    send_heartbeat(&hb_ctx, live_mode).await;
+                    heartbeat.request(live_mode);
                 }
+            }
+            // The active heartbeat future is pinned in the controller so
+            // network and state-refresh waits yield to every other reactor
+            // branch instead of being awaited by a trigger handler.
+            _ = heartbeat.wait_for_send(), if heartbeat_sending => {
+                let live_mode = *mode_rx.borrow();
+                heartbeat.finish_send(live_mode);
             }
             // Mode changes (signals)
             _ = mode_rx.changed() => {}
@@ -1616,7 +1629,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
-                send_heartbeat(&hb_ctx, live_mode).await;
+                heartbeat.request(live_mode);
             }
             // Immediate heartbeat after session affinity state changes —
             // eliminates the up-to-10s blind spot for affinity routing.
@@ -1632,7 +1645,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 };
                 if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {
                     info!(source, "session affinity state triggered immediate heartbeat");
-                    send_heartbeat(&hb_ctx, live_mode).await;
+                    heartbeat.request(live_mode);
                 }
             }
         }
@@ -1644,6 +1657,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
+
+    let phase = teardown.phase_start("heartbeat_drain");
+    heartbeat.drain().await;
+    drop(heartbeat);
+    teardown.phase_complete("heartbeat_drain", phase);
 
     // Drop the pinned discover future before provider shutdown so any
     // provider-local discovery resources are released first. This also keeps

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1423,7 +1423,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     if transitioned {
                         // Live observability: fire an immediate "stopping"
                         // heartbeat before teardown removes the runner.
-                        heartbeat.flush(RunnerMode::Stopping).await;
+                        heartbeat.flush(RunnerMode::Stopping).await?;
                     }
                     continue;
                 }
@@ -1537,7 +1537,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // The active heartbeat future is pinned in the controller so
             // network and state-refresh waits yield to every other reactor
             // branch instead of being awaited by a trigger handler.
-            _ = heartbeat.wait_for_send(), if heartbeat_sending => {
+            result = heartbeat.wait_for_send(), if heartbeat_sending => {
+                result?;
                 let live_mode = *mode_rx.borrow();
                 heartbeat.finish_send(live_mode);
             }

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -1,10 +1,28 @@
 use super::super::super::*;
 use super::super::support::{
-    assert_run_exits_within, minimal_context, mock_run_config, mock_run_config_with_delay,
-    mock_run_config_with_overrides, push_job, shutdown, test_profiles, wait_budget_count,
-    wait_budget_exhausted_reactor, wait_cancel_token, wait_discover_entered, wait_status_mode,
+    MockRunEnv, assert_run_exits_within, minimal_context, mock_run_config,
+    mock_run_config_with_delay, mock_run_config_with_overrides, push_job, shutdown, test_profiles,
+    wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_token, wait_cancel_token_removed,
+    wait_discover_entered, wait_status_mode,
 };
 use std::sync::Arc;
+
+async fn wait_for_blocked_routine_heartbeat(env: &MockRunEnv) {
+    wait_discover_entered(env, Duration::from_secs(2)).await;
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    assert!(
+        env.handle
+            .wait_heartbeat_past(0, Duration::from_secs(5))
+            .await,
+        "first routine heartbeat should enter the provider",
+    );
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(5))
+            .await,
+        "first routine heartbeat should remain blocked",
+    );
+}
 
 // -----------------------------------------------------------------------
 // Test 2: Discover survives heartbeat ticks (regression #8783)
@@ -69,6 +87,207 @@ async fn discover_survives_heartbeat_ticks() {
     );
 
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocked_heartbeat_does_not_block_job_discovery_or_reaping() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+    wait_for_blocked_routine_heartbeat(&env).await;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    assert!(
+        env.handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "job should complete while heartbeat I/O is blocked",
+    );
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    assert_eq!(env.handle.heartbeat_in_flight(), 1);
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
+    env.handle.unblock_heartbeats();
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(0, Duration::from_secs(5))
+            .await,
+        "blocked heartbeat should finish after release",
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&gate),
+    ));
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    assert!(
+        env.handle
+            .wait_heartbeat_past(0, Duration::from_secs(5))
+            .await,
+        "first routine heartbeat should enter the provider",
+    );
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(5))
+            .await,
+        "first routine heartbeat should remain blocked",
+    );
+
+    // Change mode without notifying the reactor. The next routine tick must
+    // both wake the reactor and coalesce a current-mode follow-up.
+    env.mode_tx.send_if_modified(|mode| {
+        *mode = RunnerMode::Draining;
+        false
+    });
+    let status_path = env._temp_dir.path().join("status.json");
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+
+    // A further tick while the first request is blocked must collapse into
+    // the same dirty follow-up rather than overlap or queue another payload.
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
+    assert_eq!(env.handle.heartbeat_count(), 1);
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
+
+    env.handle.unblock_heartbeats();
+    assert!(
+        env.handle
+            .wait_heartbeat_past(1, Duration::from_secs(5))
+            .await,
+        "coalesced trigger should produce one follow-up",
+    );
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(0, Duration::from_secs(5))
+            .await,
+        "follow-up heartbeat should finish",
+    );
+
+    {
+        let heartbeats = env
+            .handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(heartbeats.len(), 2);
+        assert_eq!(heartbeats[0].mode, "running");
+        assert_eq!(heartbeats[1].mode, "draining");
+        assert_eq!(heartbeats[1].running_count, 1);
+    }
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
+
+    gate.notify_one();
+    assert!(
+        env.handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .is_some(),
+        "gated job should complete after release",
+    );
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn hard_shutdown_drains_current_heartbeat_and_discards_pending_work() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let status_path = env._temp_dir.path().join("status.json");
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+    wait_for_blocked_routine_heartbeat(&env).await;
+
+    // Add an ordinary pending trigger, then enter Stopping. The reactor must
+    // observe the mode while provider I/O is still blocked, but teardown must
+    // wait for the current send rather than assuming drop cancels it remotely.
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
+    env.mode_tx.send(RunnerMode::Stopping).unwrap();
+    wait_status_mode(&status_path, "stopping", Duration::from_secs(5)).await;
+
+    assert!(!run_handle.is_finished());
+    assert_eq!(env.handle.heartbeat_count(), 1);
+    assert_eq!(env.handle.heartbeat_in_flight(), 1);
+
+    env.handle.unblock_heartbeats();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should finish after the current heartbeat is released",
+    )
+    .await;
+
+    let modes: Vec<String> = env
+        .handle
+        .heartbeats
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .iter()
+        .map(|heartbeat| heartbeat.mode.clone())
+        .collect();
+    assert_eq!(modes, ["running", "stopping"]);
+    assert_eq!(env.handle.heartbeat_in_flight(), 0);
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn natural_shutdown_flushes_stopping_after_current_heartbeat() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    env.handle.block_heartbeats();
+    let run_handle = tokio::spawn(run(config));
+    wait_for_blocked_routine_heartbeat(&env).await;
+
+    let mut mode_rx = env.mode_tx.subscribe();
+    env.drain();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if *mode_rx.borrow_and_update() == RunnerMode::Stopping {
+                break;
+            }
+            mode_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("natural drain should commit Stopping while heartbeat is blocked");
+
+    assert!(!run_handle.is_finished());
+    assert_eq!(env.handle.heartbeat_count(), 1);
+    assert_eq!(env.handle.heartbeat_in_flight(), 1);
+
+    env.handle.unblock_heartbeats();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "natural shutdown should finish after the current heartbeat is released",
+    )
+    .await;
+
+    let modes: Vec<String> = env
+        .handle
+        .heartbeats
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .iter()
+        .map(|heartbeat| heartbeat.mode.clone())
+        .collect();
+    assert_eq!(modes, ["running", "stopping", "stopping"]);
+    assert_eq!(env.handle.heartbeat_in_flight(), 0);
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
 }
 
 /// Invariant: heartbeat ticks must fire while the unified reactor is

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -166,6 +166,14 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
     assert_eq!(env.handle.heartbeat_count(), 1);
     assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
 
+    // Flip again without notifying or adding another trigger. The follow-up
+    // must sample mode when the active send completes, not retain the mode
+    // observed by the trigger that marked it dirty.
+    env.mode_tx.send_if_modified(|mode| {
+        *mode = RunnerMode::Running;
+        false
+    });
+
     env.handle.unblock_heartbeats();
     assert!(
         env.handle
@@ -188,7 +196,7 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
             .unwrap_or_else(|error| error.into_inner());
         assert_eq!(heartbeats.len(), 2);
         assert_eq!(heartbeats[0].mode, "running");
-        assert_eq!(heartbeats[1].mode, "draining");
+        assert_eq!(heartbeats[1].mode, "running");
         assert_eq!(heartbeats[1].running_count, 1);
     }
     assert_eq!(env.handle.max_heartbeat_in_flight(), 1);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -644,8 +644,8 @@ impl ApiClient {
         })
     }
 
-    /// Send a heartbeat with runner state. Uses a short timeout (3s) to
-    /// avoid blocking the main loop.
+    /// Send a heartbeat with runner state. The short timeout (3s) bounds this
+    /// best-effort request and any lifecycle drain waiting for it.
     async fn heartbeat(&self, state: &HeartbeatState) -> RunnerResult<()> {
         let resp = send_api(
             self.http

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -7,6 +7,8 @@
 //!   can wait on that resource, preserving the shutdown regression shape.
 //! - `discover()` has an optional pre-channel delay simulating the API provider's
 //!   poll timer that restarts from scratch when the future is cancelled.
+//! - `heartbeat()` can be blocked at the provider boundary while tests observe
+//!   request entry, release, and maximum concurrency.
 //!
 //! This lets integration tests catch:
 //! - **#8783**: heartbeat cancelling and recreating `discover()` each tick —
@@ -87,6 +89,7 @@ pub struct MockJobProvider {
     /// `wait_heartbeat_past` uses the same subscribe-then-check pattern as
     /// `wait_completion` so a heartbeat that lands mid-check is still observed.
     heartbeat_notify: Arc<Notify>,
+    heartbeat_control: Arc<MockHeartbeatControl>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -107,6 +110,7 @@ pub struct MockProviderHandle {
     discover_started_count: Arc<AtomicUsize>,
     /// See [`MockJobProvider::heartbeat_notify`].
     heartbeat_notify: Arc<Notify>,
+    heartbeat_control: Arc<MockHeartbeatControl>,
 }
 
 #[derive(Clone)]
@@ -122,6 +126,44 @@ struct MockStartupReadiness {
     release: Notify,
     released: AtomicBool,
     calls: AtomicUsize,
+}
+
+#[derive(Default)]
+struct MockHeartbeatControl {
+    blocked: AtomicBool,
+    in_flight: AtomicUsize,
+    max_in_flight: AtomicUsize,
+    release: Notify,
+    state_changed: Notify,
+}
+
+impl MockHeartbeatControl {
+    fn enter(&self) -> MockHeartbeatInFlight<'_> {
+        let in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight.fetch_max(in_flight, Ordering::SeqCst);
+        self.state_changed.notify_waiters();
+        MockHeartbeatInFlight { control: self }
+    }
+
+    fn block(&self) {
+        self.blocked.store(true, Ordering::SeqCst);
+    }
+
+    fn unblock(&self) {
+        self.blocked.store(false, Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+}
+
+struct MockHeartbeatInFlight<'a> {
+    control: &'a MockHeartbeatControl,
+}
+
+impl Drop for MockHeartbeatInFlight<'_> {
+    fn drop(&mut self) {
+        self.control.in_flight.fetch_sub(1, Ordering::SeqCst);
+        self.control.state_changed.notify_waiters();
+    }
 }
 
 impl Default for MockStartupReadiness {
@@ -215,6 +257,7 @@ impl MockJobProvider {
         let discover_poll_started = Arc::new(Notify::new());
         let discover_started_count = Arc::new(AtomicUsize::new(0));
         let heartbeat_notify = Arc::new(Notify::new());
+        let heartbeat_control = Arc::new(MockHeartbeatControl::default());
         let provider = Arc::new(Self {
             startup_readiness: Arc::clone(&startup_readiness),
             discovery: Mutex::new(rx),
@@ -231,6 +274,7 @@ impl MockJobProvider {
             discover_poll_started: Arc::clone(&discover_poll_started),
             discover_started_count: Arc::clone(&discover_started_count),
             heartbeat_notify: Arc::clone(&heartbeat_notify),
+            heartbeat_control: Arc::clone(&heartbeat_control),
         });
         let handle = MockProviderHandle {
             startup_readiness,
@@ -245,6 +289,7 @@ impl MockJobProvider {
             discover_poll_started,
             discover_started_count,
             heartbeat_notify,
+            heartbeat_control,
         };
         (provider, handle)
     }
@@ -353,6 +398,45 @@ impl MockProviderHandle {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .len()
+    }
+
+    /// Block heartbeat calls after recording their submitted state.
+    pub fn block_heartbeats(&self) {
+        self.heartbeat_control.block();
+    }
+
+    /// Release all currently blocked heartbeat calls and allow later calls.
+    pub fn unblock_heartbeats(&self) {
+        self.heartbeat_control.unblock();
+    }
+
+    pub fn heartbeat_in_flight(&self) -> usize {
+        self.heartbeat_control.in_flight.load(Ordering::SeqCst)
+    }
+
+    pub fn max_heartbeat_in_flight(&self) -> usize {
+        self.heartbeat_control.max_in_flight.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_heartbeat_in_flight(&self, expected: usize, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let changed = self.heartbeat_control.state_changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+
+            if self.heartbeat_in_flight() == expected {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, changed).await.is_err() {
+                return false;
+            }
+        }
     }
 
     pub fn claim_candidates(&self) -> Vec<JobCandidate> {
@@ -495,11 +579,18 @@ impl JobProvider for MockJobProvider {
     }
 
     async fn heartbeat(&self, state: &HeartbeatState) {
+        let release = self.heartbeat_control.release.notified();
+        tokio::pin!(release);
+        release.as_mut().enable();
+        let _in_flight = self.heartbeat_control.enter();
         self.heartbeats
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push(state.clone());
         self.heartbeat_notify.notify_waiters();
+        if self.heartbeat_control.blocked.load(Ordering::SeqCst) {
+            release.await;
+        }
     }
 
     async fn defer_poll_after(&self, delay: Duration) {

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -609,8 +609,10 @@ pub trait JobProvider: Send + Sync {
         completion_auth: CompletionAuth,
     );
 
-    /// Report runner state to the server. Fire-and-forget — failures are
-    /// logged but do not affect runner operation.
+    /// Report runner state to the server as a best-effort operation.
+    ///
+    /// Delivery failures do not affect runner operation, but callers retain
+    /// the future to enforce single-flight and lifecycle ordering.
     async fn heartbeat(&self, state: &HeartbeatState);
 
     /// Delay the next API-backed poll until a protected same-session job can


### PR DESCRIPTION
## Summary

- poll heartbeat delivery as a pinned, single-flight future alongside the runner reactor instead of awaiting network I/O in live trigger branches
- coalesce triggers that arrive during an in-flight request into one follow-up heartbeat built from the latest live runner state
- drain the active request during shutdown, discard obsolete live work on hard stop, and preserve the explicit final `Stopping` heartbeat ordering
- add deterministic main-loop integration coverage for blocked I/O, coalescing, single-flight delivery, and natural/hard shutdown

## Scope

- no heartbeat payload, API, persistence, dependency, timeout, or retry changes
- no claim that a timed-out remote request cannot complete late; server-side epoch fencing remains separate unless that failure is observed

## Testing

- `cargo check -p runner --tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (2,715 passed, 10 existing ignored)

Closes #21752
