### PR TITLE
fix: hide connectors filter on mobile layouts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -912,6 +912,7 @@ describe("connectors page", () => {
     await expectConnectorCardsVisible({ github: true, asana: true });
 
     const filterTrigger = screen.getByLabelText("Filter connectors");
+    expect(filterTrigger).toHaveClass("hidden", "sm:inline-flex");
     click(filterTrigger);
     click(menuItemByText("Connected"));
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -328,7 +328,7 @@ function ConnectorFilterDropdown({
           variant="outline"
           size="sm"
           aria-label="Filter connectors"
-          className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
+          className="zero-btn-morandi hidden h-9 shrink-0 gap-1.5 rounded-lg border sm:inline-flex"
         >
           <IconFilter
             size={14}


### PR DESCRIPTION
## Summary

- Hide the grouped connectors filter trigger below the `sm` breakpoint so the `/connectors` toolbar fits within mobile viewports without horizontal scrolling.
- Preserve the existing filter behavior and presentation on tablet and desktop layouts.
- Add regression coverage for the responsive visibility classes.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types` (12 workspaces passed; the API workspace hit the default Node heap limit and passed when rerun with `NODE_OPTIONS=--max-old-space-size=4096`)
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (47 tests passed)

Browser verification is deferred to the PR preview; no local dev server was started per repository preference.