### PR TITLE
test(runner): stabilize deferred network log shutdown test

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -79,10 +79,15 @@ handle_flush_request() {
 }
 mkfifo "$fifo"
 exec 3<>"$fifo"
-trap handle_flush_request USR1
+# Match the addon lifecycle: the signal handler only wakes the worker, which
+# performs file I/O outside the trap and coalesces repeated requests naturally.
+trap 'printf "\n" >&3' USR1
 trap 'exit 0' TERM
 echo ready
-while true; do read -r _ <&3 || true; done
+while true; do
+  read -r _ <&3 || true
+  handle_flush_request
+done
 "#,
     )
     .unwrap();

--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -79,8 +79,8 @@ handle_flush_request() {
 }
 mkfifo "$fifo"
 exec 3<>"$fifo"
-# Match the addon lifecycle: the signal handler only wakes the worker, which
-# performs file I/O outside the trap and coalesces repeated requests naturally.
+# Match the addon lifecycle: the signal handler only wakes the worker. File I/O
+# runs outside the trap, and every queued wake reads the latest request markers.
 trap 'printf "\n" >&3' USR1
 trap 'exit 0' TERM
 echo ready


### PR DESCRIPTION
## Summary

- Keep the fake addon's `SIGUSR1` trap limited to waking its FIFO.
- Process usage and JSONL flush requests in the child loop, matching the production addon's worker lifecycle.
- Preserve the existing graceful-shutdown drain timing and JSONL acknowledgement assertions.

## Problem

The test child performed `sed`, `date`, and state-file writes directly inside a Bash signal trap. Under concurrent CI load and repeated flush signals, the child could fail to produce `jsonl-flush-state`, causing an intermittent `NotFound` panic even though the deferred network-log upload completed.

## Scope

This is a test-only synchronization change. It does not change runner or addon production behavior, flush timeouts, retry behavior, or test assertions.

## Validation

- Target test passed 50 consecutive runs.
- `taskset -c 0 cargo test --manifest-path crates/Cargo.toml -p runner --bin runner -- --quiet` (2,711 passed, 10 ignored)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
