### PR TITLE
fix(runner): block managed credentials on trace requests

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -188,6 +188,10 @@ def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) ->
     )
 
 
+def _request_method_forbids_managed_credentials(method: str) -> bool:
+    return method.upper() == "TRACE"
+
+
 def _firewall_auth_context_needs_resolution(context: _FirewallAuthContext) -> bool:
     return context.auth_request.firewall_billable or _firewall_auth_context_injects_credentials(
         context
@@ -555,8 +559,29 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
+    injects_credentials = _firewall_auth_context_injects_credentials(context)
+    request_method = flow.request.method.upper()
+    if _request_method_forbids_managed_credentials(request_method) and injects_credentials:
+        log_proxy_entry(
+            context.proxy_log_path,
+            "warn",
+            "Refusing to inject firewall credentials into TRACE request",
+            type="firewall",
+            firewall_base=context.firewall_base,
+            request_method=request_method,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=403,
+            action="BLOCK",
+            error_code="unsafe_auth_method",
+            message="Firewall credentials cannot be injected into TRACE requests",
+            permission=context.allow.name,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
     request_scheme = flow.request.scheme.lower()
-    if request_scheme != "https" and _firewall_auth_context_injects_credentials(context):
+    if request_scheme != "https" and injects_credentials:
         log_proxy_entry(
             context.proxy_log_path,
             "warn",
@@ -1001,6 +1026,9 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
     injects_credentials = auth_config_injects_credentials(auth_config)
+    if injects_credentials and _request_method_forbids_managed_credentials(flow.request.method):
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
     needs_auth_resolution = injects_credentials or is_billable_firewall(allow.name, vm_info)
     request_scheme = flow.request.scheme.lower()
     if request_scheme != "https" and injects_credentials:

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -13,6 +13,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
     _shared_route_vm,
@@ -1010,6 +1011,137 @@ async def test_http_firewall_without_managed_credentials_still_matches(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "http://api.github.com"
     assert "Authorization" not in flow.request.headers
+
+
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+        {"query": {"api_key": "${{ secrets.API_TOKEN }}"}},
+        {
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            }
+        },
+        {"base": "${{ secrets.WEBHOOK_URL }}"},
+    ],
+    ids=["headers", "query", "aws-sigv4", "auth-base"],
+)
+async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    auth_config,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": auth_config,
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="trace",
+        path="/diagnostic?client=visible",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("X-Client-Header", "visible"),
+        ),
+    )
+    original_headers = tuple(flow.request.headers.fields)
+    original_path = flow.request.path
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+        fake_forwarder_upstream(body=b"Authorization: Bearer reflected-by-trace") as upstream,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert upstream.getaddrinfo_calls == []
+    assert upstream.create_connection_calls == []
+    assert upstream.sockets == []
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_auth_method"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.path == original_path
+    body = json.loads(flow.response.content)
+    assert body == {
+        "error": "unsafe_auth_method",
+        "message": "Firewall credentials cannot be injected into TRACE requests",
+        "permission": "github",
+        "base": "https://api.github.com",
+    }
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["level"] == "warn"
+    assert proxy_log_entry["type"] == "firewall"
+    assert proxy_log_entry["firewall_base"] == "https://api.github.com"
+    assert proxy_log_entry["request_method"] == "TRACE"
+
+
+async def test_trace_firewall_without_managed_credentials_still_matches(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            include_encrypted_secrets=False,
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="TRACE",
+        path="/diagnostic",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata.get(metadata_keys.FIREWALL_ERROR) is None
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -1016,7 +1016,6 @@ async def test_capture_enabled_trace_with_managed_auth_defers_to_request_block(
         request_headers=headers(
             ("Host", "api.github.com"),
             ("X-Client-Header", "visible"),
-            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
     original_headers = tuple(flow.request.headers.fields)

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -973,6 +973,78 @@ async def test_capture_enabled_firewall_allow_header_auth_installs_request_strea
     assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
 
 
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+        {"query": {"api_key": "${{ secrets.API_TOKEN }}"}},
+    ],
+    ids=["headers", "query"],
+)
+async def test_capture_enabled_trace_with_managed_auth_defers_to_request_block(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    auth_config,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": auth_config,
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="trace",
+        path="/diagnostic?client=visible",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("X-Client-Header", "visible"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    original_headers = tuple(flow.request.headers.fields)
+    original_path = flow.request.path
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+
+        auth_fetch.assert_not_called()
+        _assert_no_request_stream(flow)
+        assert tuple(flow.request.headers.fields) == original_headers
+        assert flow.request.path == original_path
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_auth_method"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.path == original_path
+
+
 async def test_firewall_allow_header_auth_requestheaders_strips_connector_intent(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):


### PR DESCRIPTION
## Summary

- reject credentialed firewall TRACE requests locally before auth resolution or mutation
- defer request-header early auth so the normal request hook owns the stable 403 response
- cover header, query, SigV4, and auth.base credentials while preserving credential-free TRACE

## Scope

- keeps `ANY` permission matching unchanged
- does not globally reject TRACE or add TRACE to the explicit rule grammar
- preserves existing auth.base body-framing error precedence

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_request_headers_handler.py -v` (119 passed)
- `.venv/bin/python -m pytest tests/ -v` (4022 passed)
- self-review head: `.venv/bin/python -m pytest tests/test_request_headers_handler.py -v` (54 passed)

Closes #21767
