### PR TITLE
test(api): stabilize failed chat callback synchronization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2773,11 +2773,18 @@ describe("CHAT-02: failed chat callbacks", () => {
         .toBe(true);
       context.mocks.ably.publish.mockClear();
       await failChatRun(run.runId, sandboxHeaders, round.error);
-      expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-        `chatThreadRunCreated:${threadId}`,
+      // The complete webhook acknowledges before terminal callback work
+      // finishes. Drain its tracked waitUntil work so both realtime assertions
+      // cover the complete failed-run callback instead of a one-second window.
+      await flushWaitUntilForTest();
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        `chatThreadMessageCreated:${run.threadId}`,
         null,
       );
-      await waitForChatThreadMessageCreatedPublish(run.threadId);
+      expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+        `chatThreadRunCreated:${run.threadId}`,
+        null,
+      );
     }
     const reportRunId = runIds[2];
     if (!threadId || !reportRunId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2761,16 +2761,12 @@ describe("CHAT-02: failed chat callbacks", () => {
       threadId = run.threadId;
       runIds.push(run.runId);
       const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
-      await expect
-        .poll(() => {
-          return context.mocks.ably.publish.mock.calls.some((call) => {
-            return (
-              call[0] === `chatThreadRunCreated:${run.threadId}` &&
-              call[1] === null
-            );
-          });
-        })
-        .toBe(true);
+      // Isolate failed-callback notifications from send-side background work.
+      await flushWaitUntilForTest();
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        `chatThreadRunCreated:${run.threadId}`,
+        null,
+      );
       context.mocks.ably.publish.mockClear();
       await failChatRun(run.runId, sandboxHeaders, round.error);
       // The complete webhook acknowledges before terminal callback work
@@ -2828,11 +2824,7 @@ describe("CHAT-02: failed chat callbacks", () => {
       })?.content,
     ).toBe(usageLimitError);
 
-    await expect
-      .poll(() => {
-        return context.mocks.webpush.sendNotification.mock.calls.length;
-      })
-      .toBe(4);
+    expect(context.mocks.webpush.sendNotification).toHaveBeenCalledTimes(4);
     expect(
       pushPayload(context.mocks.webpush.sendNotification.mock.calls[1]),
     ).toMatchObject({


### PR DESCRIPTION
## Summary

- drain tracked send-side `waitUntil` work before clearing realtime mocks, isolating failed-callback notifications from user-message and initial-thinking notifications
- drain the failed terminal callback before asserting that a message notification was published and no new run was auto-sent
- replace the journey's one-second realtime and push polling windows with deterministic assertions after the owned background work completes

## Scope

- test-only synchronization change; production callback behavior is unchanged

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'formats failed-run errors with escalation and notifies, without auto-sending' --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=1`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks, including repository-wide Turbo type checking and Knip
