### PR TITLE
fix(runner): bound image gc lock descriptors

### DIFF
--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use nix::fcntl::Flock;
 use tracing::{info, warn};
 
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
@@ -18,45 +18,31 @@ use super::report::{GcReport, human_bytes};
 
 const TEMPLATE_WARM_DIR_PREFIX: &str = "template-warm-";
 
-/// An unused artifact directory whose exclusive lock is held to prevent races.
+/// Scan-time metadata for an unused snapshot eligible for global top-N.
 struct GcCandidate {
-    path: PathBuf,
     hash: String,
     size: u64,
     mtime: SystemTime,
-    /// Index into the enclosing `Vec<RootfsState>` so we can mark the parent
-    /// rootfs as "has a surviving snapshot" when this candidate is kept.
+    /// Index into the enclosing `Vec<RootfsState>`.
     rootfs_idx: usize,
-    /// Exclusive lock held until the candidate is deleted or explicitly kept.
-    /// Prevents a `runner start` from acquiring a shared lock between probe and delete.
-    _lock: Flock<std::fs::File>,
 }
 
-/// Per-rootfs state carried through the two-phase global GC for rootfs
-/// directories whose exclusive lock we hold: first we walk snapshots and record
-/// whether any locked / recent snapshot already forces the rootfs to survive;
-/// then we prune snapshots globally and, for each rootfs with no surviving
-/// snapshot, try to delete the rootfs dir itself.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum SnapshotDisposition {
+    Keep,
+    Delete,
+}
+
+/// Metadata for one rootfs whose initial snapshot inventory completed.
 struct RootfsState {
     path: PathBuf,
     hash: String,
-    /// Exclusive rootfs lock held until this GC pass finishes.
-    _rootfs_lock: Flock<std::fs::File>,
-    /// True once any snapshot under this rootfs is known to survive GC
-    /// (in-use, too recent, kept by top-N, or a deletion failure). Blocks
-    /// rootfs-dir deletion in the final pass.
-    any_snapshot_survives: bool,
+    snapshot_dispositions: HashMap<String, SnapshotDisposition>,
 }
 
-/// Set `any_snapshot_survives = true` on the rootfs at `idx`. `idx` is
-/// either a freshly-minted `rootfs_states.len()` at push time or a
-/// `GcCandidate.rootfs_idx` stamped at push time, so the `Some` branch is
-/// the only reachable one in practice; the no-op `None` is a belt-and-
-/// braces guard to satisfy panic-free indexing.
-fn mark_rootfs_survives(states: &mut [RootfsState], idx: usize) {
-    if let Some(state) = states.get_mut(idx) {
-        state.any_snapshot_survives = true;
-    }
+struct SnapshotDeletion {
+    path: PathBuf,
+    hash: String,
 }
 
 /// Try to delete an orphaned rootfs directory (no surviving snapshots).
@@ -174,19 +160,224 @@ async fn gc_template_warm_dir(
     Some(size)
 }
 
+/// Apply the global snapshot decisions for one rootfs under a fresh rootfs lock.
+///
+/// The current snapshot directory is fully enumerated before deletion starts.
+/// Each planned deletion then acquires and validates its snapshot lock while the
+/// rootfs lock remains held, preserving the global rootfs-before-snapshot order.
+async fn gc_rootfs_action(
+    home: &HomePaths,
+    state: &RootfsState,
+    dry_run: bool,
+    snapshot_entry_reader: &mut GcDirEntryReader,
+) -> GcReport {
+    let rootfs_lock_path = home.rootfs_lock(&state.hash);
+    let _rootfs_lock = match probe_lock(&rootfs_lock_path) {
+        LockProbe::Free(lock) => lock,
+        LockProbe::Held => {
+            info!("images/{}: rootfs in use, skipping", state.hash);
+            return GcReport::default();
+        }
+        LockProbe::Error(e) => {
+            info!("images/{}: lock probe failed ({e}), skipping", state.hash);
+            return GcReport::default();
+        }
+    };
+
+    match gc_path_dir_status(&state.path).await {
+        Ok(GcDirStatus::RealDir(_)) => {}
+        Ok(GcDirStatus::Missing) => return GcReport::default(),
+        Ok(GcDirStatus::NotDirectory) => {
+            info!("images/{}: not a real directory, skipping", state.hash);
+            return GcReport::default();
+        }
+        Err(e) => {
+            warn!("images/{}: stat failed ({e}), skipping", state.hash);
+            return GcReport::default();
+        }
+    }
+
+    let snapshots_dir = state.path.join("snapshots");
+    match gc_path_dir_status(&snapshots_dir).await {
+        Ok(GcDirStatus::RealDir(_)) => {}
+        Ok(GcDirStatus::Missing) => {
+            return try_delete_orphan_rootfs(&state.path, &state.hash, dry_run)
+                .await
+                .map_or_else(GcReport::default, |freed_bytes| {
+                    GcReport::cleanup(1, freed_bytes)
+                });
+        }
+        Ok(GcDirStatus::NotDirectory) => {
+            info!(
+                "images/{}/snapshots: not a real directory, skipping",
+                state.hash
+            );
+            return GcReport::default();
+        }
+        Err(e) => {
+            warn!(
+                "images/{}/snapshots: stat failed ({e}), skipping",
+                state.hash
+            );
+            return GcReport::default();
+        }
+    }
+
+    let mut snapshot_entries = match tokio::fs::read_dir(&snapshots_dir).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!(
+                "images/{}/snapshots: read failed ({e}), skipping",
+                state.hash
+            );
+            return GcReport::default();
+        }
+    };
+
+    let mut any_snapshot_survives = false;
+    let mut deletions = Vec::new();
+    loop {
+        let snap_entry = match snapshot_entry_reader
+            .next_entry_warn(&mut snapshot_entries, "snapshots", &snapshots_dir)
+            .await
+        {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(_) => return GcReport::default(),
+        };
+        let snap_path = snap_entry.path();
+        let Some(snap_hash) = snap_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(String::from)
+        else {
+            any_snapshot_survives = true;
+            continue;
+        };
+
+        match state.snapshot_dispositions.get(&snap_hash).copied() {
+            Some(SnapshotDisposition::Delete) => deletions.push(SnapshotDeletion {
+                path: snap_path,
+                hash: snap_hash,
+            }),
+            Some(SnapshotDisposition::Keep) | None => any_snapshot_survives = true,
+        }
+    }
+
+    let mut report = GcReport::default();
+    let mut dry_run_snapshot_bytes = 0u64;
+    for deletion in deletions {
+        let lock_path = home.snapshot_lock(&deletion.hash);
+        let _snapshot_lock = match probe_lock(&lock_path) {
+            LockProbe::Free(lock) => lock,
+            LockProbe::Held => {
+                any_snapshot_survives = true;
+                info!(
+                    "images/{}/snapshots/{}: in use, skipping",
+                    state.hash, deletion.hash
+                );
+                continue;
+            }
+            LockProbe::Error(e) => {
+                any_snapshot_survives = true;
+                info!(
+                    "images/{}/snapshots/{}: lock probe failed ({e}), skipping",
+                    state.hash, deletion.hash
+                );
+                continue;
+            }
+        };
+
+        match gc_path_dir_status(&deletion.path).await {
+            Ok(GcDirStatus::RealDir(_)) => {}
+            Ok(GcDirStatus::Missing) => continue,
+            Ok(GcDirStatus::NotDirectory) => {
+                any_snapshot_survives = true;
+                info!(
+                    "images/{}/snapshots/{}: not a real directory, skipping",
+                    state.hash, deletion.hash
+                );
+                continue;
+            }
+            Err(e) => {
+                any_snapshot_survives = true;
+                warn!(
+                    "images/{}/snapshots/{}: stat failed ({e}), skipping",
+                    state.hash, deletion.hash
+                );
+                continue;
+            }
+        }
+
+        let (size, mtime) = dir_stats(&deletion.path).await;
+        let age = SystemTime::now().duration_since(mtime).unwrap_or_default();
+        if age < GC_MIN_AGE {
+            any_snapshot_survives = true;
+            info!(
+                "images/{}/snapshots/{}: too recent ({}s), keeping",
+                state.hash,
+                deletion.hash,
+                age.as_secs()
+            );
+            continue;
+        }
+
+        if dry_run {
+            info!(
+                "[dry-run] would delete images/{}/snapshots/{} ({})",
+                state.hash,
+                deletion.hash,
+                human_bytes(size)
+            );
+            dry_run_snapshot_bytes = dry_run_snapshot_bytes.saturating_add(size);
+        } else {
+            match tokio::fs::remove_dir_all(&deletion.path).await {
+                Ok(()) => {
+                    info!(
+                        "deleted images/{}/snapshots/{} ({})",
+                        state.hash,
+                        deletion.hash,
+                        human_bytes(size)
+                    );
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    any_snapshot_survives = true;
+                    warn!(
+                        "failed to remove images/{}/snapshots/{}: {e}",
+                        state.hash, deletion.hash
+                    );
+                    continue;
+                }
+            }
+        }
+        report += GcReport::cleanup(1, size);
+    }
+
+    if !any_snapshot_survives
+        && let Some(rootfs_bytes) =
+            try_delete_orphan_rootfs(&state.path, &state.hash, dry_run).await
+    {
+        let overlap = if dry_run { dry_run_snapshot_bytes } else { 0 };
+        report += GcReport::cleanup(1, rootfs_bytes.saturating_sub(overlap));
+    }
+
+    report
+}
+
 /// GC for the nested image layout: `<images>/<rootfs>/snapshots/<snapshot>/`.
 ///
 /// Three phases, with **global** top-N semantics across all rootfs:
 ///
-/// 1. Walk every rootfs. Probe locks and filter out snapshots that must
-///    survive (in-use, too recent, malformed); collect the remaining
-///    eligible snapshots into one flat candidate list. Rootfs dirs with
-///    no `snapshots/` subdir are orphan-deleted inline when we hold the
-///    rootfs lock.
-/// 2. Global top-N: sort the candidate list by mtime (newest first), keep
-///    the first `keep_latest`, delete the rest.
-/// 3. Orphan rootfs sweep: any rootfs whose lock we hold AND where no
-///    snapshot survived is deleted.
+/// 1. Inventory every rootfs with short-lived lock probes. Filter out
+///    snapshots that must survive (in-use, too recent, malformed) and collect
+///    the remaining eligible metadata into one flat candidate list. Rootfs
+///    dirs with no `snapshots/` subdir are orphan-deleted inline.
+/// 2. Global top-N: sort the candidate list by mtime (newest first) and record
+///    keep/delete decisions per rootfs.
+/// 3. Reacquire one rootfs lock at a time, complete a current snapshot scan,
+///    then lock and revalidate each planned deletion. Delete the rootfs under
+///    the same lock only when no snapshot survives.
 ///
 /// Global (cross-rootfs) rather than per-rootfs so a host that has
 /// accumulated many distinct rootfs hashes (e.g. per-PR builds) can be
@@ -211,23 +402,26 @@ pub(super) async fn gc_nested_images_with_protected_refs(
     dry_run: bool,
     protected_image_refs: &ProtectedImageRefs,
 ) -> RunnerResult<GcReport> {
-    let mut snapshot_entry_reader = GcDirEntryReader::new();
-    gc_nested_images_with_protected_refs_and_reader(
+    let mut inventory_entry_reader = GcDirEntryReader::new();
+    let mut action_entry_reader = GcDirEntryReader::new();
+    gc_nested_images_with_protected_refs_and_readers(
         home,
         keep_latest,
         dry_run,
         protected_image_refs,
-        &mut snapshot_entry_reader,
+        &mut inventory_entry_reader,
+        &mut action_entry_reader,
     )
     .await
 }
 
-async fn gc_nested_images_with_protected_refs_and_reader(
+async fn gc_nested_images_with_protected_refs_and_readers(
     home: &HomePaths,
     keep_latest: Option<usize>,
     dry_run: bool,
     protected_image_refs: &ProtectedImageRefs,
-    snapshot_entry_reader: &mut GcDirEntryReader,
+    inventory_entry_reader: &mut GcDirEntryReader,
+    action_entry_reader: &mut GcDirEntryReader,
 ) -> RunnerResult<GcReport> {
     if !protected_image_refs.is_complete() {
         warn!("image protection inventory incomplete, skipping image GC");
@@ -322,25 +516,17 @@ async fn gc_nested_images_with_protected_refs_and_reader(
         };
 
         let rootfs_idx = rootfs_states.len();
-        rootfs_states.push(RootfsState {
-            path: rootfs_path.clone(),
-            hash: rootfs_hash.clone(),
-            _rootfs_lock: rootfs_lock,
-            any_snapshot_survives: false,
-        });
-
         let candidate_checkpoint = candidates.len();
-        loop {
-            let snap_entry = match snapshot_entry_reader
+        let scan_complete = loop {
+            let snap_entry = match inventory_entry_reader
                 .next_entry_warn(&mut snapshot_entries, "snapshots", &snapshots_dir)
                 .await
             {
                 Ok(Some(entry)) => entry,
-                Ok(None) => break,
+                Ok(None) => break true,
                 Err(_) => {
                     candidates.truncate(candidate_checkpoint);
-                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
-                    break;
+                    break false;
                 }
             };
             let snap_path = snap_entry.path();
@@ -349,17 +535,12 @@ async fn gc_nested_images_with_protected_refs_and_reader(
                 .and_then(|n| n.to_str())
                 .map(String::from)
             else {
-                mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                 continue;
             };
             match gc_entry_is_real_dir(&snap_entry).await {
                 Ok(true) => {}
-                Ok(false) => {
-                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
-                    continue;
-                }
+                Ok(false) => continue,
                 Err(e) => {
-                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                     warn!(
                         "images/{rootfs_hash}/snapshots/{snap_hash}: cannot read file type ({e}), skipping"
                     );
@@ -368,7 +549,6 @@ async fn gc_nested_images_with_protected_refs_and_reader(
             }
 
             if is_protected_image_ref(protected_image_refs, &rootfs_hash, &snap_hash) {
-                mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                 info!(
                     "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner or service config, keeping"
                 );
@@ -380,114 +560,74 @@ async fn gc_nested_images_with_protected_refs_and_reader(
                 LockProbe::Free(lock) => {
                     let (size, mtime) = dir_stats(&snap_path).await;
                     let age = SystemTime::now().duration_since(mtime).unwrap_or_default();
+                    drop(lock);
                     if age < GC_MIN_AGE {
                         // Too recent to be safely deleted (races with
-                        // `runner build` releasing its lock). Drop our
-                        // exclusive lock so the next caller can pick it
-                        // up; mark the rootfs as preserved.
-                        mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
+                        // `runner build` releasing its lock).
                         info!(
                             "images/{rootfs_hash}/snapshots/{snap_hash}: too recent ({}s), keeping",
                             age.as_secs()
                         );
                     } else {
                         candidates.push(GcCandidate {
-                            path: snap_path,
                             hash: snap_hash,
                             size,
                             mtime,
                             rootfs_idx,
-                            _lock: lock,
                         });
                     }
                 }
                 LockProbe::Held => {
-                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                     info!("images/{rootfs_hash}/snapshots/{snap_hash}: in use, skipping");
                 }
                 LockProbe::Error(e) => {
-                    mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                     info!(
                         "images/{rootfs_hash}/snapshots/{snap_hash}: lock probe failed ({e}), skipping"
                     );
                 }
             }
+        };
+
+        drop(rootfs_lock);
+        if scan_complete {
+            rootfs_states.push(RootfsState {
+                path: rootfs_path,
+                hash: rootfs_hash,
+                snapshot_dispositions: HashMap::new(),
+            });
         }
     }
+    drop(rootfs_entries);
 
-    // Phase 2a: global sort by mtime descending, keep the top N across all rootfs.
+    // Phase 2: global sort by mtime descending and record each top-N decision.
     candidates.sort_by_key(|c| std::cmp::Reverse(c.mtime));
     let keep_count = keep_latest.unwrap_or(0);
-    for c in candidates.iter().take(keep_count) {
-        if let Some(state) = rootfs_states.get_mut(c.rootfs_idx) {
-            state.any_snapshot_survives = true;
+    for (rank, candidate) in candidates.into_iter().enumerate() {
+        let state = rootfs_states.get_mut(candidate.rootfs_idx).ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "image GC candidate {} references missing rootfs state {}",
+                candidate.hash, candidate.rootfs_idx
+            ))
+        })?;
+        let disposition = if rank < keep_count {
             info!(
                 "images/{}/snapshots/{}: keeping (global top-{keep_count}, {})",
                 state.hash,
-                c.hash,
-                human_bytes(c.size)
+                candidate.hash,
+                human_bytes(candidate.size)
             );
-        }
-    }
-
-    // Phase 2b: delete everything past the top-N cutoff. Track per-rootfs
-    // deleted-snapshot bytes so the dry-run orphan accounting can subtract
-    // the overlap (see orphan-rootfs note below). Skip the allocation in
-    // real-mode — nothing reads or writes it there.
-    let mut dry_run_snapshot_bytes: Vec<u64> = if dry_run {
-        vec![0; rootfs_states.len()]
-    } else {
-        Vec::new()
-    };
-    for c in candidates.iter().skip(keep_count) {
-        // Clone `hash` so the immutable borrow on `rootfs_states` is
-        // released before the error branch mutates it below.
-        let Some(rootfs_hash) = rootfs_states.get(c.rootfs_idx).map(|s| s.hash.clone()) else {
-            continue;
-        };
-        if dry_run {
-            info!(
-                "[dry-run] would delete images/{rootfs_hash}/snapshots/{} ({})",
-                c.hash,
-                human_bytes(c.size)
-            );
-            if let Some(slot) = dry_run_snapshot_bytes.get_mut(c.rootfs_idx) {
-                *slot += c.size;
-            }
-        } else if let Err(e) = tokio::fs::remove_dir_all(&c.path).await {
-            warn!(
-                "failed to remove images/{rootfs_hash}/snapshots/{}: {e}",
-                c.hash
-            );
-            mark_rootfs_survives(&mut rootfs_states, c.rootfs_idx);
-            continue;
+            SnapshotDisposition::Keep
         } else {
-            info!(
-                "deleted images/{rootfs_hash}/snapshots/{} ({})",
-                c.hash,
-                human_bytes(c.size)
-            );
-        }
-        report += GcReport::cleanup(1, c.size);
+            SnapshotDisposition::Delete
+        };
+        let _ = state
+            .snapshot_dispositions
+            .insert(candidate.hash, disposition);
     }
 
-    // Phase 3: any rootfs whose lock we hold AND where no snapshot survives
-    // is orphan — delete the rootfs directory itself. In dry-run mode
-    // `try_delete_orphan_rootfs` stats the rootfs *including* the snapshot
-    // subdirs we already counted (dry-run leaves them on disk), so subtract
-    // that overlap to match the real-mode total.
-    for (idx, state) in rootfs_states.iter().enumerate() {
-        if !state.any_snapshot_survives
-            && let Some(rootfs_bytes) =
-                try_delete_orphan_rootfs(&state.path, &state.hash, dry_run).await
-        {
-            let overlap = if dry_run {
-                dry_run_snapshot_bytes.get(idx).copied().unwrap_or(0)
-            } else {
-                0
-            };
-            report += GcReport::cleanup(1, rootfs_bytes.saturating_sub(overlap));
-        }
+    // Phase 3: lock, rescan, and act on one rootfs at a time.
+    for state in &rootfs_states {
+        report += gc_rootfs_action(home, state, dry_run, action_entry_reader).await;
     }
 
     Ok(report)
@@ -501,13 +641,36 @@ async fn gc_nested_images_with_injected_snapshot_scan_error(
     protected_image_refs: &ProtectedImageRefs,
     successful_entries: usize,
 ) -> RunnerResult<GcReport> {
-    let mut snapshot_entry_reader = GcDirEntryReader::failing_after(successful_entries);
-    gc_nested_images_with_protected_refs_and_reader(
+    let mut inventory_entry_reader = GcDirEntryReader::failing_after(successful_entries);
+    let mut action_entry_reader = GcDirEntryReader::new();
+    gc_nested_images_with_protected_refs_and_readers(
         home,
         keep_latest,
         dry_run,
         protected_image_refs,
-        &mut snapshot_entry_reader,
+        &mut inventory_entry_reader,
+        &mut action_entry_reader,
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn gc_nested_images_with_injected_action_scan_error(
+    home: &HomePaths,
+    keep_latest: Option<usize>,
+    dry_run: bool,
+    protected_image_refs: &ProtectedImageRefs,
+    successful_entries: usize,
+) -> RunnerResult<GcReport> {
+    let mut inventory_entry_reader = GcDirEntryReader::new();
+    let mut action_entry_reader = GcDirEntryReader::failing_after(successful_entries);
+    gc_nested_images_with_protected_refs_and_readers(
+        home,
+        keep_latest,
+        dry_run,
+        protected_image_refs,
+        &mut inventory_entry_reader,
+        &mut action_entry_reader,
     )
     .await
 }

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -27,7 +27,7 @@ struct GcCandidate {
     rootfs_idx: usize,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 enum SnapshotDisposition {
     Keep,
     Delete,

--- a/crates/runner/src/cmd/gc/images/tests.rs
+++ b/crates/runner/src/cmd/gc/images/tests.rs
@@ -1,10 +1,29 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
-use nix::fcntl::FlockArg;
+use nix::fcntl::{Flock, FlockArg};
 
 use super::*;
-use crate::cmd::gc::test_support::{assert_is_symlink, old_gc_time, set_mtime, test_home};
+use crate::cmd::gc::test_support::{
+    assert_is_symlink, old_gc_time, set_mtime, set_soft_nofile_limit_for_child, test_home,
+};
 use crate::lock;
+use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+fn rootfs_state_with_deletion(
+    rootfs_path: PathBuf,
+    rootfs_hash: &str,
+    snapshot_hash: &str,
+) -> RootfsState {
+    RootfsState {
+        path: rootfs_path,
+        hash: rootfs_hash.to_owned(),
+        snapshot_dispositions: HashMap::from([(
+            snapshot_hash.to_owned(),
+            SnapshotDisposition::Delete,
+        )]),
+    }
+}
 
 async fn assert_incomplete_snapshot_scan_keeps_rootfs(dry_run: bool) {
     let dir = tempfile::tempdir().unwrap();
@@ -48,6 +67,48 @@ async fn assert_incomplete_snapshot_scan_keeps_rootfs(dry_run: bool) {
     }
 }
 
+async fn assert_incomplete_action_scan_keeps_rootfs(dry_run: bool) {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let rootfs_dir = home.images_dir().join("rootfs_incomplete_action_scan");
+    let snapshots_dir = rootfs_dir.join("snapshots");
+    let snapshot_dirs = [
+        snapshots_dir.join("snapshot_a"),
+        snapshots_dir.join("snapshot_b"),
+    ];
+    for snapshot_dir in &snapshot_dirs {
+        std::fs::create_dir_all(snapshot_dir).unwrap();
+        std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+        set_mtime(snapshot_dir, old_gc_time());
+    }
+    std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+    set_mtime(&rootfs_dir, old_gc_time());
+
+    let report = gc_nested_images_with_injected_action_scan_error(
+        &home,
+        Some(0),
+        dry_run,
+        &ProtectedImageRefs::new(),
+        1,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report, GcReport::default());
+    assert!(
+        rootfs_dir.exists(),
+        "a rootfs with an incomplete action scan must survive"
+    );
+    for snapshot_dir in snapshot_dirs {
+        assert!(
+            snapshot_dir.exists(),
+            "action must not start before the current snapshot scan completes"
+        );
+    }
+}
+
 #[tokio::test]
 async fn gc_nested_images_fails_closed_after_snapshot_scan_error() {
     assert_incomplete_snapshot_scan_keeps_rootfs(false).await;
@@ -56,6 +117,16 @@ async fn gc_nested_images_fails_closed_after_snapshot_scan_error() {
 #[tokio::test]
 async fn gc_nested_images_dry_run_ignores_incomplete_snapshot_scan() {
     assert_incomplete_snapshot_scan_keeps_rootfs(true).await;
+}
+
+#[tokio::test]
+async fn gc_nested_images_fails_closed_after_action_scan_error() {
+    assert_incomplete_action_scan_keeps_rootfs(false).await;
+}
+
+#[tokio::test]
+async fn gc_nested_images_dry_run_ignores_incomplete_action_scan() {
+    assert_incomplete_action_scan_keeps_rootfs(true).await;
 }
 
 #[tokio::test]
@@ -914,6 +985,67 @@ async fn gc_nested_images_skips_locked_snapshot() {
     assert_eq!(freed, 0);
 }
 
+#[tokio::test]
+async fn gc_rootfs_action_keeps_candidate_locked_after_inventory() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let rootfs_hash = "rootfs_action_lock";
+    let snapshot_hash = "snapshot_action_lock";
+    let rootfs_dir = home.images_dir().join(rootfs_hash);
+    let snapshot_dir = rootfs_dir.join("snapshots").join(snapshot_hash);
+    std::fs::create_dir_all(&snapshot_dir).unwrap();
+    std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+    std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+    set_mtime(&snapshot_dir, old_gc_time());
+    set_mtime(&rootfs_dir, old_gc_time());
+
+    let state = rootfs_state_with_deletion(rootfs_dir.clone(), rootfs_hash, snapshot_hash);
+    let snapshot_lock_file = lock::open_lock_file(&home.snapshot_lock(snapshot_hash)).unwrap();
+    let _snapshot_lock = Flock::lock(snapshot_lock_file, FlockArg::LockShared).unwrap();
+    let mut action_entry_reader = GcDirEntryReader::new();
+
+    let report = gc_rootfs_action(&home, &state, false, &mut action_entry_reader).await;
+
+    assert_eq!(report, GcReport::default());
+    assert!(
+        snapshot_dir.exists(),
+        "a candidate locked after inventory must survive action"
+    );
+    assert!(rootfs_dir.exists(), "the candidate's rootfs must survive");
+}
+
+#[tokio::test]
+async fn gc_rootfs_action_keeps_candidate_that_became_recent() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let rootfs_hash = "rootfs_action_recent";
+    let snapshot_hash = "snapshot_action_recent";
+    let rootfs_dir = home.images_dir().join(rootfs_hash);
+    let snapshot_dir = rootfs_dir.join("snapshots").join(snapshot_hash);
+    std::fs::create_dir_all(&snapshot_dir).unwrap();
+    std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+    std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+    set_mtime(&snapshot_dir, old_gc_time());
+    set_mtime(&rootfs_dir, old_gc_time());
+
+    let state = rootfs_state_with_deletion(rootfs_dir.clone(), rootfs_hash, snapshot_hash);
+    set_mtime(&snapshot_dir, SystemTime::now());
+    let mut action_entry_reader = GcDirEntryReader::new();
+
+    let report = gc_rootfs_action(&home, &state, false, &mut action_entry_reader).await;
+
+    assert_eq!(report, GcReport::default());
+    assert!(
+        snapshot_dir.exists(),
+        "a candidate that became recent after inventory must survive action"
+    );
+    assert!(rootfs_dir.exists(), "the candidate's rootfs must survive");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn gc_nested_images_skips_symlink_rootfs_entry() {
@@ -1010,4 +1142,70 @@ async fn gc_nested_images_symlink_snapshot_entry_preserves_rootfs() {
         outside_snapshot.exists(),
         "GC must not delete a symlinked snapshot target"
     );
+}
+
+const LOW_FD_IMAGE_GC_CHILD_ENV: &str = "VM0_RUNNER_LOW_FD_IMAGE_GC_CHILD";
+
+#[tokio::test]
+async fn gc_nested_images_many_candidates_does_not_exhaust_lock_fds() {
+    run_ignored_child_test(
+        "cmd::gc::images::tests::gc_nested_images_many_candidates_low_fd_child",
+        (LOW_FD_IMAGE_GC_CHILD_ENV, "1"),
+        &[],
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "spawned by gc_nested_images_many_candidates_does_not_exhaust_lock_fds"]
+async fn gc_nested_images_many_candidates_low_fd_child() {
+    if !ignored_child_test_env_guard_enabled((LOW_FD_IMAGE_GC_CHILD_ENV, "1")) {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let entry_count = 220usize;
+    let keep_count = 20usize;
+    for index in 0..entry_count {
+        let rootfs_hash = format!("rootfs-low-fd-{index:03}");
+        let snapshot_hash = format!("snapshot-low-fd-{index:03}");
+        let rootfs_dir = home.images_dir().join(&rootfs_hash);
+        let snapshot_dir = rootfs_dir.join("snapshots").join(snapshot_hash);
+        std::fs::create_dir_all(&snapshot_dir).unwrap();
+        std::fs::write(snapshot_dir.join("snapshot.bin"), [0u8; 4096]).unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), [0u8; 4096]).unwrap();
+        set_mtime(&snapshot_dir, old_gc_time());
+        set_mtime(&rootfs_dir, old_gc_time());
+    }
+
+    let _nofile_limit = set_soft_nofile_limit_for_child(128);
+    let freed = gc_nested_images(&home, Some(keep_count), false)
+        .await
+        .unwrap();
+
+    let mut remaining_rootfs = 0usize;
+    let mut remaining_snapshots = 0usize;
+    for rootfs_entry in std::fs::read_dir(home.images_dir()).unwrap() {
+        let rootfs_entry = rootfs_entry.unwrap();
+        if !rootfs_entry.file_type().unwrap().is_dir() {
+            continue;
+        }
+        remaining_rootfs += 1;
+        for snapshot_entry in std::fs::read_dir(rootfs_entry.path().join("snapshots")).unwrap() {
+            if snapshot_entry.unwrap().file_type().unwrap().is_dir() {
+                remaining_snapshots += 1;
+            }
+        }
+    }
+
+    assert_eq!(
+        remaining_rootfs, keep_count,
+        "image GC left {remaining_rootfs} rootfs directories for keep count {keep_count}; freed {freed}"
+    );
+    assert_eq!(remaining_snapshots, keep_count);
+    assert!(freed > 0, "low-FD image GC must remove old artifacts");
 }

--- a/crates/runner/src/cmd/gc/storage/tests.rs
+++ b/crates/runner/src/cmd/gc/storage/tests.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 use nix::fcntl::FlockArg;
 
 use super::*;
-use crate::cmd::gc::test_support::{assert_is_symlink, old_gc_time, test_home};
+use crate::cmd::gc::test_support::{
+    assert_is_symlink, old_gc_time, set_soft_nofile_limit_for_child, test_home,
+};
 use crate::lock;
 use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
 
@@ -854,59 +856,4 @@ async fn gc_storage_cache_many_candidates_low_fd_child() {
         "storage GC left {remaining} versions with cap for {keep_count}; freed {freed}"
     );
     assert_eq!(freed, expected_freed);
-}
-
-struct SoftNofileLimitGuard {
-    original: nix::libc::rlimit,
-}
-
-impl Drop for SoftNofileLimitGuard {
-    fn drop(&mut self) {
-        unsafe {
-            let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &self.original);
-            if rc != 0 {
-                let message = format!(
-                    "restore RLIMIT_NOFILE failed: {}",
-                    std::io::Error::last_os_error()
-                );
-                if std::thread::panicking() {
-                    eprintln!("{message}");
-                } else {
-                    panic!("{message}");
-                }
-            }
-        }
-    }
-}
-
-fn set_soft_nofile_limit_for_child(limit: u64) -> SoftNofileLimitGuard {
-    unsafe {
-        let mut current = std::mem::MaybeUninit::<nix::libc::rlimit>::uninit();
-        let rc = nix::libc::getrlimit(nix::libc::RLIMIT_NOFILE, current.as_mut_ptr());
-        assert_eq!(
-            rc,
-            0,
-            "getrlimit(RLIMIT_NOFILE) failed: {}",
-            std::io::Error::last_os_error()
-        );
-        let current = current.assume_init();
-        let target = std::cmp::min(limit as nix::libc::rlim_t, current.rlim_max);
-        assert!(
-            target >= 64,
-            "RLIMIT_NOFILE hard limit {target} is too low for this regression test"
-        );
-
-        let next = nix::libc::rlimit {
-            rlim_cur: target,
-            rlim_max: current.rlim_max,
-        };
-        let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &next);
-        assert_eq!(
-            rc,
-            0,
-            "setrlimit(RLIMIT_NOFILE) failed: {}",
-            std::io::Error::last_os_error()
-        );
-        SoftNofileLimitGuard { original: current }
-    }
 }

--- a/crates/runner/src/cmd/gc/test_support.rs
+++ b/crates/runner/src/cmd/gc/test_support.rs
@@ -18,6 +18,61 @@ pub(super) fn set_mtime(path: &Path, mtime: SystemTime) {
         .unwrap();
 }
 
+pub(super) struct SoftNofileLimitGuard {
+    original: nix::libc::rlimit,
+}
+
+impl Drop for SoftNofileLimitGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &self.original);
+            if rc != 0 {
+                let message = format!(
+                    "restore RLIMIT_NOFILE failed: {}",
+                    std::io::Error::last_os_error()
+                );
+                if std::thread::panicking() {
+                    eprintln!("{message}");
+                } else {
+                    panic!("{message}");
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn set_soft_nofile_limit_for_child(limit: u64) -> SoftNofileLimitGuard {
+    unsafe {
+        let mut current = std::mem::MaybeUninit::<nix::libc::rlimit>::uninit();
+        let rc = nix::libc::getrlimit(nix::libc::RLIMIT_NOFILE, current.as_mut_ptr());
+        assert_eq!(
+            rc,
+            0,
+            "getrlimit(RLIMIT_NOFILE) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        let current = current.assume_init();
+        let target = std::cmp::min(limit as nix::libc::rlim_t, current.rlim_max);
+        assert!(
+            target >= 64,
+            "RLIMIT_NOFILE hard limit {target} is too low for this regression test"
+        );
+
+        let next = nix::libc::rlimit {
+            rlim_cur: target,
+            rlim_max: current.rlim_max,
+        };
+        let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &next);
+        assert_eq!(
+            rc,
+            0,
+            "setrlimit(RLIMIT_NOFILE) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        SoftNofileLimitGuard { original: current }
+    }
+}
+
 #[cfg(unix)]
 pub(super) fn assert_is_symlink(path: &Path, message: &str) {
     assert!(


### PR DESCRIPTION
## Summary

- inventory image GC candidates with short-lived lock probes, then keep only metadata for the global top-N decision
- reacquire one rootfs lock at a time, complete a current snapshot scan, and lock/revalidate each planned deletion immediately before acting
- add low-`RLIMIT_NOFILE` coverage for hundreds of image candidates and share the existing child-process limit helper with storage GC tests

This bounds image GC lock file descriptors independently of the number of rootfs and snapshot candidates while preserving global top-N, dry-run accounting, lock ordering, and fail-closed behavior when either scan is incomplete.

## Compatibility

- no database schema or persisted-data changes
- no API, runner protocol, queue payload, configuration, or migration changes

## Validation

- `cargo test -p runner --all-features cmd::gc::images::tests`
- `cargo test -p runner --all-features gc_storage_cache_many_candidates_does_not_exhaust_lock_fds`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`
- `git diff --check`

Closes #21775
