### PR TITLE
fix(rust): sync sandbox-fc lockfile version

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox-fc"
-version = "0.37.123"
+version = "0.37.124"
 dependencies = [
  "async-trait",
  "base64",


### PR DESCRIPTION
## Summary

Restore the `sandbox-fc` workspace package version in `Cargo.lock` to `0.37.124`, matching its manifest. A dependency refresh had accidentally moved the lockfile entry back to `0.37.123`.

## Changes

- Align the `sandbox-fc` lockfile entry with `sandbox-fc/Cargo.toml`.

## Exclusions

- No Rust source code or dependency versions are changed.
- No runtime behavior is changed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features --locked -- -D warnings`
- `cargo doc -p sandbox-fc --all-features --no-deps --locked`
- `cargo test -p sandbox-fc --all-features --locked` (710 tests passed)
