### PR TITLE
fix(platform): resolve relative assets in presentation editor

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -3190,6 +3190,103 @@ ${openFencedHostedSiteUrl}`,
     });
   });
 
+  it("resolves relative presentation assets from the hosted deck while editing", async () => {
+    const thumbnailObserver = mockIntersectionObserver();
+    const presentationUrl = "https://relative-assets.sites.vm7.io/index.html";
+    const expectedImageUrl =
+      "https://relative-assets.sites.vm7.io/assets/user-upload.png";
+    const browser = context.mocks.browser.blobDownload();
+    const html = `<!doctype html>
+<html>
+  <head><title>Relative assets</title></head>
+  <body>
+    <section data-vm0-slide data-slide-id="slide-intro">
+      <h1 data-vm0-editable="text" data-vm0-edit-id="intro">Intro</h1>
+    </section>
+    <section data-vm0-slide data-slide-id="slide-workflows">
+      <h2 data-vm0-editable="text" data-vm0-edit-id="workflows">Workflows</h2>
+      <img src="./assets/user-upload.png" alt="User upload" />
+    </section>
+  </body>
+</html>`;
+    setupPresentationArtifactThread(presentationUrl, html);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Edit presentation")).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Edit presentation"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Open slide 2")).toBeInTheDocument();
+    });
+    thumbnailObserver.triggerAll();
+
+    const thumbnailFrame = document.querySelector(
+      'iframe[data-slide-thumbnail-frame="slide-workflows"]',
+    );
+    if (!(thumbnailFrame instanceof HTMLIFrameElement)) {
+      throw new Error("Presentation thumbnail frame not found");
+    }
+    const resolvedImageUrl = async (frame: HTMLIFrameElement) => {
+      const previewHtml = await generatedPresentationPreviewHtml(
+        frame,
+        browser.blobForUrl,
+      );
+      const previewDocument = new DOMParser().parseFromString(
+        previewHtml,
+        "text/html",
+      );
+      const baseHref = previewDocument
+        .querySelector("base[href]")
+        ?.getAttribute("href");
+      const imageSrc = previewDocument
+        .querySelector('img[alt="User upload"]')
+        ?.getAttribute("src");
+      if (!baseHref || !imageSrc) {
+        throw new Error("Relative presentation asset base not found");
+      }
+      return new URL(imageSrc, baseHref).href;
+    };
+    await expect(resolvedImageUrl(thumbnailFrame)).resolves.toBe(
+      expectedImageUrl,
+    );
+
+    click(screen.getByLabelText("Open slide 2"));
+    const previewFrame = await waitFor(() => {
+      const frame = document.querySelector(
+        'iframe[title="Presentation preview"]',
+      );
+      expect(frame).toBeInstanceOf(HTMLIFrameElement);
+      return frame as HTMLIFrameElement;
+    });
+    await expect(resolvedImageUrl(previewFrame)).resolves.toBe(
+      expectedImageUrl,
+    );
+
+    const previewDocument = await installGeneratedPresentationPreviewDocument(
+      previewFrame,
+      browser.blobForUrl,
+    );
+    fireEvent.load(previewFrame);
+    const title = previewDocument.querySelector(
+      '[data-vm0-editor-edit-id="workflows"]',
+    );
+    if (!(title instanceof HTMLElement)) {
+      throw new Error("Presentation workflow title not found");
+    }
+    const initialThumbnailUrl = thumbnailFrame.src;
+    title.textContent = "Reusable workflows";
+    fireEvent.input(title);
+    fireEvent.blur(title);
+
+    await waitFor(() => {
+      expect(thumbnailFrame.src).not.toBe(initialThumbnailUrl);
+    });
+    await expect(resolvedImageUrl(thumbnailFrame)).resolves.toBe(
+      expectedImageUrl,
+    );
+  });
+
   it("downloads an asset-backed presentation without speaker notes", async () => {
     const presentationUrl = "https://deck.sites.vm7.io/asset-backed-deck.html";
     const assetUrl = "https://assets.test/roadmap-cover.png";

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -464,6 +464,29 @@ function sanitizePreviewDocument(doc: Document): void {
   appendPresentationElementOffsetPreviewRuntime(doc);
 }
 
+function applyPresentationPreviewBase(
+  doc: Document,
+  sourceUrl: string | undefined,
+): void {
+  if (!sourceUrl) {
+    return;
+  }
+  const authoredBase = doc.head.querySelector<HTMLBaseElement>("base[href]");
+  if (authoredBase) {
+    const authoredHref = authoredBase.getAttribute("href") ?? "";
+    authoredBase.setAttribute(
+      "href",
+      URL.canParse(authoredHref, sourceUrl)
+        ? new URL(authoredHref, sourceUrl).href
+        : sourceUrl,
+    );
+    return;
+  }
+  const base = doc.createElement("base");
+  base.setAttribute("href", sourceUrl);
+  doc.head.prepend(base);
+}
+
 function extractVariableObjectText(
   scriptText: string,
   variableName: string,
@@ -1083,6 +1106,7 @@ export function previewPresentationHtml(params: {
   readonly additionalHeadStyle?: string;
   readonly html: string;
   readonly movementEditingEnabled?: boolean;
+  readonly sourceUrl?: string;
 }): string {
   const doc = new DOMParser().parseFromString(params.html, "text/html");
   const movementEditingEnabled =
@@ -1096,6 +1120,7 @@ export function previewPresentationHtml(params: {
   for (const node of Array.from(doc.head.childNodes)) {
     previewDoc.head.append(node.cloneNode(true));
   }
+  applyPresentationPreviewBase(previewDoc, params.sourceUrl);
   const stage = previewDoc.createElement("div");
   previewDoc.body.append(stage);
   let activeSlideClone: Element | null = null;

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -1486,6 +1486,7 @@ function showPresentationSlide(params: {
   readonly movementEnabled: boolean;
   readonly previewFrameRef: MutableValue<HTMLIFrameElement | null>;
   readonly slideId: string;
+  readonly sourceUrl: string;
 }) {
   for (const button of document.querySelectorAll<HTMLElement>(
     "[data-slide-id]",
@@ -1508,6 +1509,7 @@ function showPresentationSlide(params: {
         activeSlideId: params.slideId,
         html: params.buildEditedHtml(),
         movementEditingEnabled: params.movementEnabled,
+        sourceUrl: params.sourceUrl,
       }),
     );
   }
@@ -1516,6 +1518,7 @@ function showPresentationSlide(params: {
 function updateSlideThumbnail(params: {
   readonly buildEditedHtml: () => string;
   readonly slideId: string;
+  readonly sourceUrl: string;
 }) {
   const thumbnailFrame = Array.from(
     document.querySelectorAll<HTMLIFrameElement>(
@@ -1530,6 +1533,7 @@ function updateSlideThumbnail(params: {
       previewPresentationHtml({
         activeSlideId: params.slideId,
         html: params.buildEditedHtml(),
+        sourceUrl: params.sourceUrl,
       }),
     );
   }
@@ -1621,6 +1625,7 @@ function PresentationEditorWorkspace({
   showSlide,
   slidesRef,
   slides,
+  sourceUrl,
 }: {
   activeSlide: PresentationSlideDraft | undefined;
   activeSlideId: string;
@@ -1635,6 +1640,7 @@ function PresentationEditorWorkspace({
   showSlide: (slideId: string) => void;
   slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
   slides: readonly PresentationSlideDraft[];
+  sourceUrl: string;
 }) {
   if (slides.length === 0 || !activeSlide) {
     return <UnsupportedPresentation />;
@@ -1643,6 +1649,7 @@ function PresentationEditorWorkspace({
     return previewPresentationHtml({
       activeSlideId: slideId,
       html: buildEditedHtml(),
+      sourceUrl,
     });
   };
 
@@ -1808,12 +1815,14 @@ function buildActiveSlidePreviewHtml(
   activeSlideId: string,
   buildEditedHtml: () => string,
   movementEnabled: boolean,
+  sourceUrl: string,
 ): string | null {
   return activeSlideId.length > 0
     ? previewPresentationHtml({
         activeSlideId,
         html: buildEditedHtml(),
         movementEditingEnabled: movementEnabled,
+        sourceUrl,
       })
     : null;
 }
@@ -1888,7 +1897,11 @@ function createPresentationEditorController(
         const pendingSlideId = params.pendingThumbnailSlideIdRef.current;
         params.pendingThumbnailSlideIdRef.current = null;
         if (pendingSlideId) {
-          updateSlideThumbnail({ buildEditedHtml, slideId: pendingSlideId });
+          updateSlideThumbnail({
+            buildEditedHtml,
+            slideId: pendingSlideId,
+            sourceUrl: params.draft.publicUrl,
+          });
         }
       },
     );
@@ -1932,12 +1945,14 @@ function createPresentationEditorController(
       movementEnabled: params.movementEnabled,
       previewFrameRef: params.previewFrameRef,
       slideId,
+      sourceUrl: params.draft.publicUrl,
     });
   };
   const previewHtml = buildActiveSlidePreviewHtml(
     activeSlideId,
     buildEditedHtml,
     params.movementEnabled,
+    params.draft.publicUrl,
   );
 
   return {
@@ -2149,6 +2164,7 @@ function PresentationEditorReady({
         showSlide={controller.showSlide}
         slidesRef={slidesRef}
         slides={controller.slides}
+        sourceUrl={draft.publicUrl}
       />
       <PresentationEditorCloseDialog
         open={closeDialogOpen}


### PR DESCRIPTION
## Summary

- preserve the hosted presentation URL as the base for editor Blob previews
- resolve existing authored base URLs against the hosted document URL
- cover switched slides, initial thumbnails, and refreshed thumbnails with a page-level regression test

## Test plan

- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx (50 passed)

## Full-suite note

The broader app suite was also attempted. The affected tests pass, while unrelated slash-workflow UI tests in an unchanged file failed nondeterministically under the full run; the set of failures changed between attempts and the targeted failure passed in isolation.

Fixes #21758