### PR TITLE
feat: fade workflow template cards under the persona pill row

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5328,22 +5328,27 @@ function TemplatePickerCategoryContent({
             onSelect={onWorkflowCategoryChange}
           />
         )}
-        <div
-          data-workflow-template-grid-scroll=""
-          className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4"
-        >
-          {workflowCatalog.items.length > 0 ? (
-            <WorkflowTemplateGrid
-              items={workflowCatalog.items}
-              value={value}
-              onSelect={onSelectWorkflow}
-            />
-          ) : (
-            <TemplateEmptyPanel
-              title="No matches"
-              description="Try a different search."
-            />
-          )}
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            data-workflow-template-grid-scroll=""
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4"
+          >
+            {workflowCatalog.items.length > 0 ? (
+              <WorkflowTemplateGrid
+                items={workflowCatalog.items}
+                value={value}
+                onSelect={onSelectWorkflow}
+              />
+            ) : (
+              <TemplateEmptyPanel
+                title="No matches"
+                description="Try a different search."
+              />
+            )}
+          </div>
+          {/* Soften the hard clip where cards scroll up under the pill row,
+              mirroring the chat-to-composer top fade. */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-card to-transparent" />
         </div>
       </div>
     );


### PR DESCRIPTION
## What

In the Workflow template picker, the scrollable card grid ended at a hard clip line directly beneath the category (persona) pill row — when you scrolled up, card tops were cut off abruptly, which looked harsh.

This adds a soft top gradient so cards **dissolve** under the pill row as they scroll, matching the existing **chat → composer** top fade.

## How

- Wrapped the workflow grid's scroll container in a `relative` box.
- Added a `pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-card to-transparent` overlay pinned to the top of the scroll region.
- Fades to `card` (the dialog surface color), same technique as the composer fade in `zero-chat-thread-page.tsx` (`bg-gradient-to-t from-[hsl(var(--background))] to-transparent`).

Scoped to the workflow tab only (the tab that has the pill row and the reported harshness). No behavior/logic change — presentational overlay, non-interactive.

## Verification

- Rendered the exact markup (pill row + card grid + fade, on the `card` surface) in an isolated browser and confirmed the top card edges fade softly under the pills when the grid is scrolled.
- Relying on the PR pipeline for lint/type-check/tests per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)