### PR TITLE
fix(platform): mute artifact action menu icons to match dropdown spec

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -675,7 +675,12 @@ function ArtifactCardActions({
               onStartChat(item);
             }}
           >
-            <IconMessagePlus size={14} stroke={1.7} aria-hidden />
+            <IconMessagePlus
+              size={14}
+              stroke={1.7}
+              className="text-muted-foreground"
+              aria-hidden
+            />
             Ask about it
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -683,7 +688,12 @@ function ArtifactCardActions({
               onOpenChat(item.threadId);
             }}
           >
-            <IconHistory size={14} stroke={1.7} aria-hidden />
+            <IconHistory
+              size={14}
+              stroke={1.7}
+              className="text-muted-foreground"
+              aria-hidden
+            />
             View creation chat
           </DropdownMenuItem>
           {isZipArtifact(item) ? (
@@ -696,7 +706,12 @@ function ArtifactCardActions({
                 );
               }}
             >
-              <IconDownload size={14} stroke={1.7} aria-hidden />
+              <IconDownload
+                size={14}
+                stroke={1.7}
+                className="text-muted-foreground"
+                aria-hidden
+              />
               Download
             </DropdownMenuItem>
           ) : (
@@ -707,7 +722,12 @@ function ArtifactCardActions({
                 rel="noreferrer"
                 aria-label={`Open preview for ${item.filename}`}
               >
-                <IconExternalLink size={14} stroke={1.7} aria-hidden />
+                <IconExternalLink
+                  size={14}
+                  stroke={1.7}
+                  className="text-muted-foreground"
+                  aria-hidden
+                />
                 Open a new tab
               </a>
             </DropdownMenuItem>

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -662,7 +662,7 @@ function ArtifactCardActions({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
-          className="w-48"
+          className="w-48 [&_svg]:text-muted-foreground"
           onClick={(event) => {
             event.stopPropagation();
           }}
@@ -675,12 +675,7 @@ function ArtifactCardActions({
               onStartChat(item);
             }}
           >
-            <IconMessagePlus
-              size={14}
-              stroke={1.7}
-              className="text-muted-foreground"
-              aria-hidden
-            />
+            <IconMessagePlus size={14} stroke={1.7} aria-hidden />
             Ask about it
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -688,12 +683,7 @@ function ArtifactCardActions({
               onOpenChat(item.threadId);
             }}
           >
-            <IconHistory
-              size={14}
-              stroke={1.7}
-              className="text-muted-foreground"
-              aria-hidden
-            />
+            <IconHistory size={14} stroke={1.7} aria-hidden />
             View creation chat
           </DropdownMenuItem>
           {isZipArtifact(item) ? (
@@ -706,12 +696,7 @@ function ArtifactCardActions({
                 );
               }}
             >
-              <IconDownload
-                size={14}
-                stroke={1.7}
-                className="text-muted-foreground"
-                aria-hidden
-              />
+              <IconDownload size={14} stroke={1.7} aria-hidden />
               Download
             </DropdownMenuItem>
           ) : (
@@ -722,12 +707,7 @@ function ArtifactCardActions({
                 rel="noreferrer"
                 aria-label={`Open preview for ${item.filename}`}
               >
-                <IconExternalLink
-                  size={14}
-                  stroke={1.7}
-                  className="text-muted-foreground"
-                  aria-hidden
-                />
+                <IconExternalLink size={14} stroke={1.7} aria-hidden />
                 Open a new tab
               </a>
             </DropdownMenuItem>


### PR DESCRIPTION
## What

On the artifacts page, the action menu on each artifact card (the `…` overflow menu) rendered its item icons darker than the rest of the app's dropdown menus. The icons inherited the menu item's default dark `text-foreground`, while every other `DropdownMenu` in the platform (e.g. `zero-sidebar-account`) mutes menu-item icons with `text-muted-foreground`.

## Change

Single-line change: add `[&_svg]:text-muted-foreground` to the menu's `DropdownMenuContent` className (`w-48` → `w-48 [&_svg]:text-muted-foreground`). This mutes every icon in the menu at once — Ask about it, View creation chat, Open a new tab, and the Download alternate — with no new JSX lines.

> Note: an earlier revision added `className="text-muted-foreground"` to each of the four icons individually. Because that forced Prettier to wrap each icon onto multiple lines, `ArtifactCardActions` exceeded the 128-line eslint limit. The content-wrapper approach achieves the identical visual result in one line and keeps the function under the limit.

The `…` trigger button lives in `DropdownMenuTrigger` (outside the content) and is intentionally unchanged.

## User-visible impact

Artifact action-menu icons now read as light gray instead of near-black, consistent with the design spec and the other dropdown menus in the app. Labels stay at `text-foreground`.

## Verification

- CI green on the latest commit: `lint-eslint`, `lint-format`, `lint-types`, `lint-types-apps`, `test-app` all pass.
- Browser walkthrough on the PR preview was attempted but **blocked**: `pr-21824-api.vm6.ai` enforces a Vercel automation-bypass secret (`VERCEL_AUTOMATION_BYPASS_SECRET`), so every authenticated `/api/zero/*` request returns 403 and the app never bootstraps far enough to render the artifacts grid. Reaching it requires a preview URL carrying `?x-vercel-protection-bypass=<secret>`, unavailable in this environment. The change is CSS-only and data-independent, so CI + code review cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)