### PR TITLE
fix(runner): require exclusive factory ownership before shutdown

### DIFF
--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -320,17 +320,15 @@ mod tests {
             profile: "vm0/second".into(),
             shutdowns: Arc::clone(&factory_shutdowns),
         }));
-        let other_retained_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
+        let weakly_referenced_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
             profile: "vm0/third".into(),
             shutdowns: Arc::clone(&factory_shutdowns),
         }));
+        let retained_weak_factory = Arc::downgrade(&weakly_referenced_factory);
         let mut factories = BTreeMap::new();
         factories.insert("vm0/first".into(), (unique_factory, false));
         factories.insert("vm0/second".into(), (Arc::clone(&retained_factory), false));
-        factories.insert(
-            "vm0/third".into(),
-            (Arc::clone(&other_retained_factory), false),
-        );
+        factories.insert("vm0/third".into(), (weakly_referenced_factory, false));
 
         let error = shutdown_factory_instances(&mut factories, None)
             .await
@@ -344,7 +342,7 @@ mod tests {
             "got: {message}"
         );
         assert!(
-            message.contains("vm0/third (strong=2, weak=0)"),
+            message.contains("vm0/third (strong=1, weak=1)"),
             "got: {message}"
         );
         assert_eq!(factories.len(), 3);
@@ -352,7 +350,7 @@ mod tests {
         assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
 
         drop(retained_factory);
-        drop(other_retained_factory);
+        drop(retained_weak_factory);
 
         shutdown_factory_instances(&mut factories, None)
             .await

--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -6,18 +6,18 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use sandbox::{SandboxFactory, SandboxRuntime};
-use tracing::{info, warn};
+use tracing::{error, info};
 
 use super::TeardownTimer;
 use crate::config::{self, ProfileConfig};
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 /// A sandbox factory shared across concurrent job executors.
 ///
-/// Uses `Arc<Box<...>>` instead of `Arc<dyn ...>` because `Arc::try_unwrap`
-/// requires a sized type -- `dyn SandboxFactory` is unsized, but `Box<dyn
-/// SandboxFactory>` is sized, allowing `try_unwrap` at shutdown.
+/// The runner retains one owner while live jobs and idle sandboxes clone the
+/// `Arc`. Shutdown begins only after the runner recovers exclusive mutable
+/// access to every factory.
 pub(super) type SharedFactory = Arc<Box<dyn SandboxFactory>>;
 
 /// Build one sandbox factory per configured profile.
@@ -32,7 +32,7 @@ pub(super) async fn start_factories(
     home: &HomePaths,
     runtime: &mut dyn SandboxRuntime,
 ) -> RunnerResult<BTreeMap<String, (SharedFactory, bool)>> {
-    let mut factories: BTreeMap<String, (SharedFactory, bool)> = BTreeMap::new();
+    let mut factories: BTreeMap<String, (Box<dyn SandboxFactory>, bool)> = BTreeMap::new();
     for (profile_name, profile_config) in profiles {
         let factory_config = config::RunnerConfig::build_factory_config(
             firecracker,
@@ -46,51 +46,87 @@ pub(super) async fn start_factories(
         let factory = match factory_result {
             Ok(factory) => factory,
             Err(e) => {
-                shutdown_factory_instances(&mut factories, None).await;
+                for (name, (mut factory, _)) in factories {
+                    shutdown_factory_instance(&name, factory.as_mut(), None).await;
+                }
                 return Err(e.into());
             }
         };
-        factories.insert(
-            profile_name.clone(),
-            (Arc::new(factory), restore_guest_state),
-        );
+        factories.insert(profile_name.clone(), (factory, restore_guest_state));
         info!(profile = %profile_name, "factory started");
     }
-    Ok(factories)
+    Ok(factories
+        .into_iter()
+        .map(|(name, (factory, restore_guest_state))| {
+            (name, (Arc::new(factory), restore_guest_state))
+        })
+        .collect())
 }
 
-/// Shut down all factory-owned sandboxes while retaining shared runtime resources.
+async fn shutdown_factory_instance(
+    name: &str,
+    factory: &mut dyn SandboxFactory,
+    teardown: Option<&TeardownTimer>,
+) {
+    let phase = teardown.map(|timer| {
+        let phase_start = Instant::now();
+        info!(
+            phase = "factory_shutdown",
+            profile = %name,
+            elapsed_ms = timer.elapsed_ms(),
+            "teardown phase started"
+        );
+        phase_start
+    });
+    factory.shutdown().await;
+    if let (Some(timer), Some(phase)) = (teardown, phase) {
+        info!(
+            phase = "factory_shutdown",
+            profile = %name,
+            phase_ms = TeardownTimer::duration_ms(phase.elapsed()),
+            elapsed_ms = timer.elapsed_ms(),
+            "teardown phase complete"
+        );
+    }
+}
+
+/// Shut down all factories while retaining shared runtime resources.
+///
+/// Every factory must be exclusively mutable before any shutdown begins. On
+/// failure, the complete map remains intact and no factory has been stopped.
 pub(super) async fn shutdown_factory_instances(
     factories: &mut BTreeMap<String, (SharedFactory, bool)>,
     teardown: Option<&TeardownTimer>,
-) {
-    for (name, (factory, _)) in std::mem::take(factories) {
-        match Arc::try_unwrap(factory) {
-            Ok(mut f) => {
-                let phase = teardown.map(|timer| {
-                    let phase_start = Instant::now();
-                    info!(
-                        phase = "factory_shutdown",
-                        profile = %name,
-                        elapsed_ms = timer.elapsed_ms(),
-                        "teardown phase started"
-                    );
-                    phase_start
-                });
-                f.shutdown().await;
-                if let (Some(timer), Some(phase)) = (teardown, phase) {
-                    info!(
-                        phase = "factory_shutdown",
-                        profile = %name,
-                        phase_ms = TeardownTimer::duration_ms(phase.elapsed()),
-                        elapsed_ms = timer.elapsed_ms(),
-                        "teardown phase complete"
-                    );
-                }
+) -> RunnerResult<()> {
+    let mut exclusive_factories = Vec::with_capacity(factories.len());
+    let mut retained_profiles = Vec::new();
+    for (name, (factory, _)) in factories.iter_mut() {
+        let strong_count = Arc::strong_count(factory);
+        let weak_count = Arc::weak_count(factory);
+        match Arc::get_mut(factory) {
+            Some(factory) => exclusive_factories.push((name.as_str(), factory.as_mut())),
+            None => {
+                retained_profiles.push(format!("{name} (strong={strong_count}, weak={weak_count})"))
             }
-            Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
         }
     }
+
+    if !retained_profiles.is_empty() {
+        let retained_profiles = retained_profiles.join(", ");
+        error!(
+            retained_profiles = %retained_profiles,
+            "factory shutdown requires exclusive ownership"
+        );
+        return Err(RunnerError::Internal(format!(
+            "factory shutdown requires exclusive ownership: {retained_profiles}"
+        )));
+    }
+
+    for (name, factory) in exclusive_factories {
+        shutdown_factory_instance(name, factory, teardown).await;
+    }
+    factories.clear();
+    Ok(())
 }
 
 /// Release runtime-owned shared resources after their dependent services stop.
@@ -117,7 +153,7 @@ mod tests {
 
     struct RecordingRuntime {
         create_calls: AtomicUsize,
-        factory_shutdowns: Arc<AtomicUsize>,
+        factory_shutdowns: Arc<Mutex<Vec<String>>>,
         factory_configs: Mutex<Vec<sandbox::FactoryConfig>>,
         runtime_shutdowns: AtomicUsize,
         fail_at: usize,
@@ -127,11 +163,18 @@ mod tests {
         fn new(fail_at: usize) -> Self {
             Self {
                 create_calls: AtomicUsize::new(0),
-                factory_shutdowns: Arc::new(AtomicUsize::new(0)),
+                factory_shutdowns: Arc::new(Mutex::new(Vec::new())),
                 factory_configs: Mutex::new(Vec::new()),
                 runtime_shutdowns: AtomicUsize::new(0),
                 fail_at,
             }
+        }
+
+        fn factory_shutdowns(&self) -> Vec<String> {
+            self.factory_shutdowns
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
         }
     }
 
@@ -148,11 +191,13 @@ mod tests {
                     message: "factory failed".into(),
                 });
             }
+            let profile = config.profile.clone();
             self.factory_configs
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .push(config);
             Ok(Box::new(RecordingFactory {
+                profile,
                 shutdowns: Arc::clone(&self.factory_shutdowns),
             }))
         }
@@ -163,13 +208,14 @@ mod tests {
     }
 
     struct RecordingFactory {
-        shutdowns: Arc<AtomicUsize>,
+        profile: String,
+        shutdowns: Arc<Mutex<Vec<String>>>,
     }
 
     #[async_trait]
     impl SandboxFactory for RecordingFactory {
         fn name(&self) -> &str {
-            "recording"
+            &self.profile
         }
 
         fn config_hash(&self) -> String {
@@ -186,7 +232,10 @@ mod tests {
         async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {}
 
         async fn shutdown(&mut self) {
-            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+            self.shutdowns
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(self.profile.clone());
         }
     }
 
@@ -217,9 +266,16 @@ mod tests {
 
         let result = start_factories(&profiles, &firecracker, &base_dir, &home, &mut runtime).await;
 
-        assert!(result.is_err());
+        match result {
+            Err(RunnerError::Sandbox(SandboxError::Initialization { phase, message })) => {
+                assert_eq!(phase, SandboxInitializationPhase::Factory);
+                assert_eq!(message, "factory failed");
+            }
+            Err(other) => panic!("expected factory creation error, got {other:?}"),
+            Ok(_) => panic!("expected factory creation error"),
+        }
         assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 2);
-        assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.factory_shutdowns(), vec!["vm0/first"]);
         assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
     }
 
@@ -239,28 +295,78 @@ mod tests {
 
         let result = start_factories(&profiles, &firecracker, &base_dir, &home, &mut runtime).await;
 
-        assert!(result.is_err());
+        match result {
+            Err(RunnerError::Sandbox(SandboxError::Initialization { phase, message })) => {
+                assert_eq!(phase, SandboxInitializationPhase::Factory);
+                assert_eq!(message, "factory failed");
+            }
+            Err(other) => panic!("expected factory creation error, got {other:?}"),
+            Ok(_) => panic!("expected factory creation error"),
+        }
         assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(runtime.factory_shutdowns.load(Ordering::SeqCst), 0);
+        assert!(runtime.factory_shutdowns().is_empty());
         assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
-    async fn split_shutdown_skips_referenced_factories_and_releases_runtime() {
+    async fn split_shutdown_preserves_all_factories_until_every_reference_is_released() {
         let mut runtime = RecordingRuntime::new(usize::MAX);
         let factory_shutdowns = Arc::clone(&runtime.factory_shutdowns);
+        let unique_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
+            profile: "vm0/first".into(),
+            shutdowns: Arc::clone(&factory_shutdowns),
+        }));
         let retained_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
+            profile: "vm0/second".into(),
+            shutdowns: Arc::clone(&factory_shutdowns),
+        }));
+        let other_retained_factory: SharedFactory = Arc::new(Box::new(RecordingFactory {
+            profile: "vm0/third".into(),
             shutdowns: Arc::clone(&factory_shutdowns),
         }));
         let mut factories = BTreeMap::new();
-        factories.insert("vm0/first".into(), (Arc::clone(&retained_factory), false));
+        factories.insert("vm0/first".into(), (unique_factory, false));
+        factories.insert("vm0/second".into(), (Arc::clone(&retained_factory), false));
+        factories.insert(
+            "vm0/third".into(),
+            (Arc::clone(&other_retained_factory), false),
+        );
 
-        shutdown_factory_instances(&mut factories, None).await;
-        shutdown_runtime(&mut runtime, None).await;
+        let error = shutdown_factory_instances(&mut factories, None)
+            .await
+            .unwrap_err();
+
+        let RunnerError::Internal(message) = error else {
+            panic!("expected internal ownership error, got {error:?}");
+        };
+        assert!(
+            message.contains("vm0/second (strong=2, weak=0)"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("vm0/third (strong=2, weak=0)"),
+            "got: {message}"
+        );
+        assert_eq!(factories.len(), 3);
+        assert!(runtime.factory_shutdowns().is_empty());
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
+
+        drop(retained_factory);
+        drop(other_retained_factory);
+
+        shutdown_factory_instances(&mut factories, None)
+            .await
+            .unwrap();
 
         assert!(factories.is_empty());
-        assert_eq!(factory_shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            runtime.factory_shutdowns(),
+            vec!["vm0/first", "vm0/second", "vm0/third"]
+        );
+        assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 0);
+
+        shutdown_runtime(&mut runtime, None).await;
+
         assert_eq!(runtime.runtime_shutdowns.load(Ordering::SeqCst), 1);
-        drop(retained_factory);
     }
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1264,8 +1264,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     let mut jobs: JoinSet<Option<RunId>> = JoinSet::new();
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
-    // destroys at shutdown, preventing factory Arc leaks that cause
-    // "factory still referenced" warnings from Arc::try_unwrap.
+    // destroys at shutdown so their factory Arcs are released before the
+    // exclusive ownership preflight.
     let mut destroy_tasks: JoinSet<bool> = JoinSet::new();
 
     if startup_mode == RunnerMode::Running {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1766,7 +1766,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     info!("shutting down factories");
     let phase = teardown.phase_start("shutdown_factory_instances");
-    shutdown_factory_instances(&mut factories, Some(&teardown)).await;
+    shutdown_factory_instances(&mut factories, Some(&teardown)).await?;
     teardown.phase_complete("shutdown_factory_instances", phase);
 
     // Keep the pool-scoped INPUT filters installed until dnsmasq is gone.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1744,8 +1744,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         teardown.phase_complete("orphan_reap_shutdown_final", phase);
     }
     // Wait for any in-flight destroy tasks (from cleanup tick, profile
-    // mismatch eviction, etc.) so their factory Arcs are dropped before
-    // shutdown_factories calls Arc::try_unwrap.
+    // mismatch eviction, etc.) so their factory Arcs are dropped before the
+    // factory shutdown ownership preflight.
     let phase = teardown.phase_start("destroy_tasks_drain");
     while let Some(result) = destroy_tasks.join_next().await {
         match result {


### PR DESCRIPTION
## Summary

- retain exclusive factory ownership until every configured profile has started, while preserving cleanup on partial startup failure
- preflight ownership for every factory before teardown so a retained reference fails the shutdown explicitly without partially stopping other profiles or discarding the factory map
- stop runner teardown before DNS and runtime shutdown when factory ownership has not fully drained

## Exclusions

- no polling, timeout, or retry policy is added for retained references
- no change to the sandbox factory trait, runner protocol, or persisted state

## Validation

- `cargo check --manifest-path crates/Cargo.toml -p runner --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner factory_lifecycle`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-features`

Closes #21764
