### PR TITLE
fix: clarify artifact card menu item wording

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -844,7 +844,7 @@ describe("artifacts page", () => {
       expect(
         downloadItem?.querySelector(".tabler-icon-download"),
       ).not.toBeNull();
-      expect(screen.queryByText("Open a new tab")).not.toBeInTheDocument();
+      expect(screen.queryByText("Open in new tab")).not.toBeInTheDocument();
 
       click(screen.getByText("Download"));
       await waitFor(() => {
@@ -1313,7 +1313,7 @@ describe("artifacts page", () => {
 
     await screen.findByText("launch-plan.html");
     click(buttonByLabel("More actions for launch-plan.html"));
-    click(screen.getByText("Ask about it"));
+    click(screen.getByText("Ask about this"));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${ZERO_AGENT_ID}/chat`);
@@ -1369,7 +1369,7 @@ describe("artifacts page", () => {
 
     await screen.findByText("same-name.png");
     click(buttonByLabel("More actions for same-name.png"));
-    click(screen.getByText("Ask about it"));
+    click(screen.getByText("Ask about this"));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/agents/${ZERO_AGENT_ID}/chat`);
@@ -1414,7 +1414,7 @@ describe("artifacts page", () => {
       screen.queryByLabelText("Open source chat for launch-plan.html"),
     ).toBeNull();
     click(buttonByLabel("More actions for launch-plan.html"));
-    click(screen.getByText("View creation chat"));
+    click(screen.getByText("View original chat"));
 
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${SOURCE_THREAD_ID}`);

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -676,7 +676,7 @@ function ArtifactCardActions({
             }}
           >
             <IconMessagePlus size={14} stroke={1.7} aria-hidden />
-            Ask about it
+            Ask about this
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
@@ -684,7 +684,7 @@ function ArtifactCardActions({
             }}
           >
             <IconHistory size={14} stroke={1.7} aria-hidden />
-            View creation chat
+            View original chat
           </DropdownMenuItem>
           {isZipArtifact(item) ? (
             <DropdownMenuItem
@@ -708,7 +708,7 @@ function ArtifactCardActions({
                 aria-label={`Open preview for ${item.filename}`}
               >
                 <IconExternalLink size={14} stroke={1.7} aria-hidden />
-                Open a new tab
+                Open in new tab
               </a>
             </DropdownMenuItem>
           )}


### PR DESCRIPTION
## What

Reword the three items in the artifact card context menu (`artifacts-page.tsx`) so they read as natural, native English:

| Before | After |
| --- | --- |
| Ask about it | **Ask about this** |
| View creation chat | **View original chat** |
| Open a new tab | **Open in new tab** |

## Why

- **"Ask about it" → "Ask about this"** — "this" reads more naturally than "it" for a menu acting on the specific artifact.
- **"View creation chat" → "View original chat"** — the action calls `onOpenChat(item.threadId)`, i.e. it opens the conversation that produced the artifact. "creation chat" is literal/awkward; "original chat" is clearer.
- **"Open a new tab" → "Open in new tab"** — the item opens the preview URL *in* a new tab; "Open in new tab" is the standard idiomatic phrasing.

## User-visible impact

Copy-only change to the artifact card `...` (more actions) dropdown. No behavior change.

## Verification

Updated the corresponding assertions in `artifacts-page.test.tsx`; grep confirms no stale strings remain. Relying on the PR pipeline for lint/tests.