### PR TITLE
fix(platform): align template picker category nav with app sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -3473,9 +3473,11 @@ describe("chat composer templates", () => {
     expect(screen.queryByText("Website")).not.toBeInTheDocument();
     expect(document.activeElement).not.toBe(tabByText("Presentation"));
     expect(tabByText("Presentation")).toHaveAttribute("aria-selected", "true");
-    expect(tabByText("Presentation")).toHaveClass("bg-card");
-    expect(tabByText("Presentation")).toHaveClass("text-foreground");
-    expect(tabByText("Illustration")).toHaveClass("text-muted-foreground");
+    expect(tabByText("Presentation")).toHaveClass("bg-gray-200");
+    expect(tabByText("Presentation")).toHaveClass("font-medium");
+    expect(tabByText("Presentation")).toHaveClass("text-sidebar-foreground");
+    expect(tabByText("Illustration")).toHaveClass("text-sidebar-foreground");
+    expect(tabByText("Illustration")).not.toHaveClass("bg-gray-200");
     const categorySelect = screen.getByRole("combobox", {
       name: "Template category",
     });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4671,10 +4671,7 @@ function TemplatePickerCategoryNav({
                   : "text-sidebar-foreground hover:bg-sidebar-accent focus-visible:bg-sidebar-accent",
               )}
             >
-              <Icon
-                className="h-4 w-4 shrink-0 text-gray-700"
-                stroke={1.8}
-              />
+              <Icon className="h-4 w-4 shrink-0 text-gray-700" stroke={1.8} />
               <span className="truncate">{label}</span>
             </button>
           );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4665,17 +4665,14 @@ function TemplatePickerCategoryNav({
                 onChange(categoryOptions[nextIndex]?.value ?? value);
               }}
               className={cn(
-                "flex h-9 w-full items-center gap-2 rounded-lg border px-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                "flex h-8 w-full items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                 selected
-                  ? "border-border bg-card font-medium text-foreground"
-                  : "border-transparent text-muted-foreground hover:bg-card hover:text-foreground focus-visible:bg-card focus-visible:text-foreground",
+                  ? "bg-gray-200 font-medium text-sidebar-foreground"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent focus-visible:bg-sidebar-accent",
               )}
             >
               <Icon
-                className={cn(
-                  "h-4 w-4 shrink-0",
-                  selected ? "text-primary" : "text-muted-foreground",
-                )}
+                className="h-4 w-4 shrink-0 text-gray-700"
                 stroke={1.8}
               />
               <span className="truncate">{label}</span>


### PR DESCRIPTION
## What

The Template gallery modal's left category nav (Presentation / Website / Illustration / Video / Workflow) visually diverged from the app's outer sidebar — it read like a separate product. This aligns it to the sidebar nav-item so the whole app shares one navigation language.

Reported by Ming: "左侧交互导航和外面的 side bar 不一致".

## User-visible change

Before → after for each category item in `TemplatePickerCategoryNav`:

- **Active state**: bordered white card (`bg-card` + `border-border`) → flat `bg-gray-200` fill, **no border** (matches sidebar active pill)
- **Active icon**: brand-colored `text-primary` → constant light `text-gray-700` (icon no longer recolors or darkens on select)
- **Text color**: `text-muted-foreground` → `text-sidebar-foreground` in **both** states; selection is signaled by the gray fill + `font-medium` only, exactly like the sidebar
- **Metrics**: item height `h-9`→`h-8`, padding `px-2`→`p-2`, added `leading-5` to match the sidebar nav-item box

Unchanged: the nav container (`bg-gray-50` surface + right divider), `rounded-lg` radius, `gap`, keyboard `role=tab` arrow-key navigation and its focus-visible ring, and the mobile `<Select>` fallback.

## Why this shape

Direction was reviewed with Ming over three mock iterations. Final call: copy the sidebar (`zero-sidebar.tsx`) nav-item rules rather than invent a parallel style — text always `sidebar-foreground`, selection via fill + weight, icons kept light.

## Scope

Single component, `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx` (4 insertions, 7 deletions). No behavior/logic change — className only.

## Verification

Relying on the PR pipeline for lint/type/test. Visual reviewed against faithful token-accurate mocks of both the modal nav and the sidebar.