### PR TITLE
test(mitm-addon): verify truncated compressed capture output

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -9,9 +9,12 @@ import pytest
 import zstandard
 from mitmproxy import http
 
+import flow_metadata_keys as metadata_keys
+import mitm_addon
 from body_capture import add_capture_fields
-from body_limits import BODY_CAPTURE_LIMIT
+from body_limits import BODY_CAPTURE_LIMIT, STREAM_BUFFER_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
+from tests.flow_helpers import response_stream
 from tests.stream_buffer_helpers import set_response_stream_buffer
 
 
@@ -222,27 +225,37 @@ class TestDecompression:
         assert entry["response_body_truncated"] is True
         assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
-    def test_truncated_brotli_falls_back(self, real_flow):
-        """Truncated brotli data should fall back gracefully."""
-        original = b"hello world " * 1000
-        compressed = brotli.compress(original)
-        truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(
-            real_flow, truncated, "br", "text/plain", truncated=True
+    @pytest.mark.parametrize("encoding", ["br", "zstd"])
+    def test_truncated_compressed_stream_captures_plaintext_prefix(self, real_flow, encoding):
+        # Moderate entropy keeps the wire body over the cap while allowing both
+        # decoders to emit a useful prefix from the retained bytes.
+        original = bytes(
+            ord("a") + value % 8 for value in pseudo_random_ascii(STREAM_BUFFER_LIMIT * 4)
         )
-        entry = {}
-        add_capture_fields(flow, entry)
-        # Should not crash; body is either partial decompressed or original
-        assert entry.get("response_body_truncated") is True or "response_body" not in entry
+        compressed = (
+            brotli.compress(original)
+            if encoding == "br"
+            else zstandard.ZstdCompressor().compress(original)
+        )
+        assert len(compressed) > STREAM_BUFFER_LIMIT
 
-    def test_truncated_zstd_falls_back(self, real_flow):
-        """Truncated zstd data should fall back gracefully."""
-        original = b"hello world " * 1000
-        compressed = zstandard.ZstdCompressor().compress(original)
-        truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(
-            real_flow, truncated, "zstd", "text/plain", truncated=True
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="text/plain",
+            response_encoding=encoding,
         )
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(compressed) == compressed
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+
         entry = {}
         add_capture_fields(flow, entry)
-        assert entry.get("response_body_truncated") is True or "response_body" not in entry
+        expected_body = original[:BODY_CAPTURE_LIMIT].decode("ascii")
+        assert expected_body
+        assert entry["response_body"] == expected_body
+        assert entry["response_body_encoding"] == "utf-8"
+        assert entry["response_body_truncated"] is True


### PR DESCRIPTION
## Summary

- replace permissive Brotli and Zstandard truncation tests with a production-shaped streamed response
- verify the 64 KiB wire cap, truncation metadata, UTF-8 encoding, and exact captured plaintext prefix

## Scope

This changes test coverage only. It does not change production behavior, APIs, schemas, or persisted data.

## Validation

- `python3 -m pytest tests/test_body_capture_decompression.py -q`
- `python3 -m pytest tests/ -qq`
- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`

Closes #21786
