### PR TITLE
feat: match artifacts agent filter to connector agent dropdown

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -521,6 +521,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function menuItemByText(text: string): HTMLElement {
+  const menuItem = queryAllByRoleFast("menuitem").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!menuItem) {
+    throw new Error(`${text} menu item not found`);
+  }
+  return menuItem;
+}
+
 function focusedArtifactIndex(): string | null {
   return (
     document.activeElement?.closest<HTMLElement>("[data-artifact-index]")
@@ -1176,7 +1186,11 @@ describe("artifacts page", () => {
 
     await fill(screen.getByLabelText("Search artifacts"), "");
     click(screen.getByLabelText("Agent filter"));
-    click(await screen.findByRole("menuitem", { name: "Research Agent" }));
+    click(
+      await waitFor(() => {
+        return menuItemByText("Research Agent");
+      }),
+    );
     await waitFor(() => {
       expect(screen.getByText("research-brief.html")).toBeInTheDocument();
       expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -608,9 +608,9 @@ describe("artifacts page", () => {
 
     const agentFilter = await screen.findByLabelText("Agent filter");
     expect(agentFilter).toHaveClass(
-      "focus:border-primary",
-      "focus:ring-[3px]",
-      "focus:ring-primary/10",
+      "focus-visible:ring-2",
+      "focus-visible:ring-ring",
+      "focus-visible:ring-offset-2",
     );
   });
 
@@ -1176,7 +1176,7 @@ describe("artifacts page", () => {
 
     await fill(screen.getByLabelText("Search artifacts"), "");
     click(screen.getByLabelText("Agent filter"));
-    click(await screen.findByRole("option", { name: "Research Agent" }));
+    click(await screen.findByRole("menuitem", { name: "Research Agent" }));
     await waitFor(() => {
       expect(screen.getByText("research-brief.html")).toBeInTheDocument();
       expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -9,9 +9,12 @@ import {
   IconAlertTriangle,
   IconCarambola,
   IconCarambolaFilled,
+  IconCheck,
+  IconChevronDown,
   IconDownload,
   IconDots,
   IconExternalLink,
+  IconFilter,
   IconHistory,
   IconMessagePlus,
   IconPhoto,
@@ -33,13 +36,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -48,6 +47,7 @@ import {
 } from "@vm0/ui";
 
 import { agents$ } from "../../signals/agent.ts";
+import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import {
   applyArtifactFavoriteOverrides,
   artifactFavoriteOverrides$,
@@ -288,6 +288,133 @@ function useOpenArtifactPreview(): (item: ArtifactItem) => void {
   };
 }
 
+function artifactsAgentName(agent: TeamComposeItem): string {
+  return agent.displayName ?? "Zero";
+}
+
+function ArtifactsAgentFilterSectionLabel({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return (
+    <div className="px-2 pb-1 pt-1.5 text-xs font-medium text-muted-foreground/80">
+      {children}
+    </div>
+  );
+}
+
+function ArtifactsAgentFilterOption({
+  active,
+  onSelect,
+  children,
+}: {
+  readonly active: boolean;
+  readonly onSelect: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <DropdownMenuItem className="justify-between gap-2" onClick={onSelect}>
+      <span className="flex min-w-0 items-center gap-2">{children}</span>
+      {active && (
+        <IconCheck size={15} stroke={2} className="shrink-0 text-foreground" />
+      )}
+    </DropdownMenuItem>
+  );
+}
+
+function ArtifactsAgentFilter({
+  agents,
+  selectedAgentId,
+  onAgentChange,
+}: {
+  readonly agents: readonly TeamComposeItem[];
+  readonly selectedAgentId: string | null;
+  readonly onAgentChange: (value: string | null) => void;
+}) {
+  const activeAgent =
+    selectedAgentId === null
+      ? undefined
+      : agents.find((agent) => {
+          return agent.id === selectedAgentId;
+        });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Agent filter"
+          className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
+        >
+          <IconFilter
+            size={14}
+            stroke={1.5}
+            className="text-muted-foreground"
+          />
+          {activeAgent && (
+            <AvatarFromUrl
+              avatarUrl={activeAgent.avatarUrl}
+              alt={artifactsAgentName(activeAgent)}
+              size={16}
+              className="h-4 w-4 rounded-full object-cover"
+            />
+          )}
+          <span className="max-w-[140px] truncate">
+            {activeAgent ? artifactsAgentName(activeAgent) : "All agents"}
+          </span>
+          <IconChevronDown
+            size={14}
+            stroke={1.5}
+            className="text-muted-foreground"
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="max-h-[min(420px,var(--radix-dropdown-menu-content-available-height))] w-56 overflow-y-auto"
+      >
+        <ArtifactsAgentFilterOption
+          active={selectedAgentId === null}
+          onSelect={() => {
+            onAgentChange(null);
+          }}
+        >
+          All agents
+        </ArtifactsAgentFilterOption>
+        {agents.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <ArtifactsAgentFilterSectionLabel>
+              Agents
+            </ArtifactsAgentFilterSectionLabel>
+            {agents.map((agent) => {
+              return (
+                <ArtifactsAgentFilterOption
+                  key={agent.id}
+                  active={selectedAgentId === agent.id}
+                  onSelect={() => {
+                    onAgentChange(agent.id);
+                  }}
+                >
+                  <AvatarFromUrl
+                    avatarUrl={agent.avatarUrl}
+                    alt={artifactsAgentName(agent)}
+                    size={16}
+                    className="h-4 w-4 rounded-full object-cover"
+                  />
+                  <span className="truncate">{artifactsAgentName(agent)}</span>
+                </ArtifactsAgentFilterOption>
+              );
+            })}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function ArtifactsToolbar({
   search,
   selectedAgentId,
@@ -356,29 +483,11 @@ function ArtifactsToolbar({
             </button>
           )}
         </div>
-        <Select
-          value={selectedAgentId ?? "all"}
-          onValueChange={(value) => {
-            onAgentChange(value === "all" ? null : value);
-          }}
-        >
-          <SelectTrigger
-            aria-label="Agent filter"
-            className="w-full transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 sm:w-52"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All agents</SelectItem>
-            {agents.map((agent) => {
-              return (
-                <SelectItem key={agent.id} value={agent.id}>
-                  {agent.displayName ?? "Zero"}
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
+        <ArtifactsAgentFilter
+          agents={agents}
+          selectedAgentId={selectedAgentId}
+          onAgentChange={onAgentChange}
+        />
       </div>
       <div
         className="flex flex-wrap items-center gap-1.5"


### PR DESCRIPTION
## What & why

The **Artifacts** page agent filter (the highlighted "All agents" control) used a plain shadcn `Select` showing text-only agent names, while the **Connectors** page uses a richer `DropdownMenu` agent filter (`ConnectorFilterDropdown`) with a filter icon, per-agent avatars, and a check on the active item. This unifies the two so the artifacts filter looks and behaves the same as the connector agent dropdown.

Per the request, this filter is **agent-only** — the connector dropdown's **Connected / Not connected** status section is intentionally omitted.

## User-visible impact

- The artifacts "All agents" control is now a morandi outline button (`zero-btn-morandi`) with a filter icon, the selected agent's avatar, its name, and a chevron — matching the connectors toolbar.
- Opening it shows an **All agents** option, a separator, an **Agents** section header, and each agent rendered with its avatar + name, with a check mark on the active selection.
- No status (Connected / Not connected) rows, since artifacts filtering is by agent only.

## Implementation

- `artifacts-page.tsx`: replaced the `Select`/`SelectItem` block with a new `ArtifactsAgentFilter` component (plus `ArtifactsAgentFilterOption` / `ArtifactsAgentFilterSectionLabel` helpers) built on `DropdownMenu`, reusing `AvatarFromUrl` from `zero-sidebar-shared.tsx`. Trigger markup mirrors `ConnectorFilterDropdown`; the `aria-label="Agent filter"` is preserved.
- Removed the now-unused `Select*` imports; added `IconCheck`, `IconChevronDown`, `IconFilter`, `DropdownMenuSeparator`, and the `AvatarFromUrl` import.
- Updated `artifacts-page.test.tsx`: the agent-filter option is now a `menuitem` (was `option`), and the focus-feedback assertion now checks the Button's built-in `focus-visible:ring-*` classes instead of the old Select's focus ring.

## Verification

Relying on the PR CI pipeline for lint / type-check / tests (local `node_modules` not installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)