### PR TITLE
refactor: pass explicit connector auth contracts to provider execution

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -16,6 +16,7 @@ import {
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodRuntimeConfig,
   type ConnectorAuthMethodId,
   type ConnectorAuthMethodIds,
   type ConnectorAuthCodeGrantAuthMethodId,
@@ -87,11 +88,16 @@ import {
 import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   buildConnectorAuthCodeAuthorizationUrl,
+  buildConnectorAuthCodeAuthorizationUrlWithMethod,
+  buildConnectorOpenIdAuthAuthorizationUrlWithMethod,
   getConnectorAuthProviderRegistryCapabilities,
   pollConnectorDeviceAuthorization,
   refreshConnectorAuthProviderAccessToken,
+  refreshConnectorAuthProviderAccessTokenWithMethod,
   revokeConnectorAuthMethodAccessToken,
+  revokeConnectorAuthMethodAccessTokenWithMethod,
   startConnectorDeviceAuthorization,
+  startConnectorDeviceAuthorizationWithMethod,
   type ConnectorAuthProviderRegistryCapability,
 } from "../auth-providers/connector-auth";
 import type { ConnectorAuthProviderRefreshArgs } from "../auth-providers/types";
@@ -939,6 +945,235 @@ describe("connector selected auth method capability checks", () => {
     for (const [ref, capability] of expectedCapabilities) {
       expect(actualCapabilities.get(ref)).toStrictEqual(capability);
     }
+  });
+
+  it("passes supplied grant scopes through the explicit provider path", async () => {
+    const method = getConnectorAuthMethod("test-oauth", "api");
+    const selectedMethod = {
+      ...method,
+      grant: {
+        ...method.grant,
+        scopes: ["catalog.read", "catalog.write"],
+      },
+    } satisfies ConnectorAuthMethodRuntimeConfig;
+    const authClient = resolveConnectorAuthClientForMethod(
+      "test-oauth",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    if (!authClient) {
+      throw new Error("Expected test-oauth API auth client");
+    }
+
+    const result = await buildConnectorAuthCodeAuthorizationUrlWithMethod({
+      connectorRef: "test-oauth",
+      authMethodId: "api",
+      method: selectedMethod,
+      authClient,
+      redirectUri: "https://app.test/callback",
+      state: "catalog-state",
+    });
+    const url = new URL(typeof result === "string" ? result : result.url);
+
+    expect(url.searchParams.get("scope")).toBe("catalog.read catalog.write");
+  });
+
+  it("passes supplied device option defaults through the explicit provider path", async () => {
+    server.use(
+      http.post(
+        /\/api\/test\/oauth-provider\/device\/code$/,
+        async ({ request }) => {
+          const body = new URLSearchParams(await request.text());
+          expect(body.get("mode")).toBe("live");
+          return HttpResponse.json({
+            device_code: "catalog-device-code",
+            user_code: "CATALOG-DEVICE",
+            verification_uri: "https://oauth-device.test/device",
+            expires_in: 600,
+            interval: 0,
+          });
+        },
+      ),
+    );
+    const method = getConnectorAuthMethod("test-oauth-device", "api");
+    const selectedMethod = {
+      ...method,
+      grant: {
+        ...method.grant,
+        startOptions: {
+          ...method.grant.startOptions,
+          mode: {
+            ...method.grant.startOptions.mode,
+            defaultValue: "live",
+          },
+        },
+      },
+    } satisfies ConnectorAuthMethodRuntimeConfig;
+    const authClient = resolveConnectorAuthClientForMethod(
+      "test-oauth-device",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    if (!authClient) {
+      throw new Error("Expected test-oauth-device API auth client");
+    }
+
+    await expect(
+      startConnectorDeviceAuthorizationWithMethod({
+        connectorRef: "test-oauth-device",
+        authMethodId: "api",
+        method: selectedMethod,
+        authClient,
+        options: {},
+      }),
+    ).resolves.toMatchObject({ deviceCode: "catalog-device-code" });
+  });
+
+  it("rejects unknown identities and wrong operation handlers", async () => {
+    const method = getConnectorAuthMethod("test-oauth", "api");
+    const authClient = resolveConnectorAuthClientForMethod(
+      "test-oauth",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    if (!authClient) {
+      throw new Error("Expected test-oauth API auth client");
+    }
+
+    await expect(
+      buildConnectorAuthCodeAuthorizationUrlWithMethod({
+        connectorRef: "catalog-only-connector",
+        authMethodId: "api",
+        method,
+        authClient,
+        redirectUri: "https://app.test/callback",
+        state: "catalog-state",
+      }),
+    ).rejects.toThrow(
+      "Missing auth provider registration for catalog-only-connector:api",
+    );
+    await expect(
+      buildConnectorOpenIdAuthAuthorizationUrlWithMethod({
+        connectorRef: "test-oauth",
+        authMethodId: "api",
+        method,
+        returnTo: "https://app.test/callback",
+        realm: "https://app.test",
+        state: "catalog-state",
+      }),
+    ).rejects.toThrow("Missing openid-auth grant provider for test-oauth:api");
+  });
+
+  it("rejects grant, access, and revoke contract mismatches before side effects", async () => {
+    const authCodeMethod = getConnectorAuthMethod("test-oauth", "api");
+    const authClient = resolveConnectorAuthClientForMethod(
+      "test-oauth",
+      "api",
+      () => {
+        return undefined;
+      },
+    );
+    if (!authClient) {
+      throw new Error("Expected test-oauth API auth client");
+    }
+    const grantMismatch = {
+      ...authCodeMethod,
+      grant: {
+        ...authCodeMethod.grant,
+        outputs: {
+          ...authCodeMethod.grant.outputs,
+          unexpectedToken: "$secrets.UNEXPECTED_TOKEN",
+        },
+      },
+    } satisfies ConnectorAuthMethodRuntimeConfig;
+    await expect(
+      buildConnectorAuthCodeAuthorizationUrlWithMethod({
+        connectorRef: "test-oauth",
+        authMethodId: "api",
+        method: grantMismatch,
+        authClient,
+        redirectUri: "https://app.test/callback",
+        state: "catalog-state",
+      }),
+    ).rejects.toThrow("Auth provider contract mismatch for test-oauth:api");
+
+    const refreshMethod = getConnectorAuthMethod("test-oauth", "api-token");
+    const accessMismatch = {
+      ...refreshMethod,
+      access: {
+        ...refreshMethod.access,
+        outputs: {
+          ...refreshMethod.access.outputs,
+          unexpectedToken: "$secrets.UNEXPECTED_TOKEN",
+        },
+      },
+    } satisfies ConnectorAuthMethodRuntimeConfig;
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod({
+        connectorRef: "test-oauth",
+        authMethodId: "api-token",
+        method: accessMismatch,
+        inputs: {
+          inputSecret: "secret-input",
+          inputVariable: "variable-input",
+        },
+        signal: testRefreshSignal(),
+      }),
+    ).rejects.toThrow(
+      "Auth provider contract mismatch for test-oauth:api-token",
+    );
+
+    const revokeMethod = getConnectorAuthMethod("github", "oauth");
+    const revokeMismatch = {
+      ...revokeMethod,
+      revoke: {
+        ...revokeMethod.revoke,
+        inputs: {
+          ...revokeMethod.revoke.inputs,
+          unexpectedToken: "$secrets.UNEXPECTED_TOKEN",
+        },
+      },
+    } satisfies ConnectorAuthMethodRuntimeConfig;
+    let loadedInputs = false;
+    await expect(
+      revokeConnectorAuthMethodAccessTokenWithMethod({
+        connectorRef: "github",
+        authMethodId: "oauth",
+        method: revokeMismatch,
+        readEnv: () => {
+          return "configured";
+        },
+        signal: testRefreshSignal(),
+        loadInputs: () => {
+          loadedInputs = true;
+          return { accessToken: "github-token" };
+        },
+      }),
+    ).rejects.toThrow("Auth provider contract mismatch for github:oauth");
+    expect(loadedInputs).toBe(false);
+  });
+
+  it("rejects undeclared provider outputs", async () => {
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod({
+        connectorRef: "test-oauth",
+        authMethodId: "api-token",
+        method: getConnectorAuthMethod("test-oauth", "api-token"),
+        inputs: {
+          inputSecret: "undeclared-output",
+          inputVariable: "variable-input",
+        },
+        signal: testRefreshSignal(),
+      }),
+    ).rejects.toThrow(
+      "test-oauth connector auth method api-token returned undeclared refresh output unexpectedToken",
+    );
   });
 
   it("matches exactly the auth methods that declare refresh-token access", () => {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -739,105 +739,92 @@ function assertConnectorAuthProviderMethodContract(
   }
 }
 
-function connectorAuthCodeGrantProviderFor(
+function connectorAuthProviderRegistrationFor(
   selection: ConnectorAuthProviderMethodSelection,
-): RuntimeAuthCodeGrantProvider {
+): PreparedRuntimeAuthProviderRegistration {
   const registration = getRuntimeAuthProviderRegistration(
     selection.connectorRef,
     selection.authMethodId,
   );
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return registration;
+}
+
+function connectorAuthCodeGrantProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeAuthCodeGrantProvider {
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { grant } = registration.entry;
   if (grant?.kind !== "auth-code") {
     throw new Error(
       `Missing auth-code grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return grant;
 }
 
 function connectorDeviceAuthGrantProviderFor(
   selection: ConnectorAuthProviderMethodSelection,
 ): RuntimeDeviceAuthGrantProvider {
-  const registration = getRuntimeAuthProviderRegistration(
-    selection.connectorRef,
-    selection.authMethodId,
-  );
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { grant } = registration.entry;
   if (grant?.kind !== "device-auth") {
     throw new Error(
       `Missing device-auth grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return grant;
 }
 
 function connectorOpenIdAuthGrantProviderFor(
   selection: ConnectorAuthProviderMethodSelection,
 ): RuntimeOpenIdAuthGrantProvider {
-  const registration = getRuntimeAuthProviderRegistration(
-    selection.connectorRef,
-    selection.authMethodId,
-  );
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { grant } = registration.entry;
   if (grant?.kind !== "openid-auth") {
     throw new Error(
       `Missing openid-auth grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return grant;
 }
 
 function connectorExternalCodeGrantProviderFor(
   selection: ConnectorAuthProviderMethodSelection,
 ): RuntimeExternalCodeGrantProvider {
-  const registration = getRuntimeAuthProviderRegistration(
-    selection.connectorRef,
-    selection.authMethodId,
-  );
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { grant } = registration.entry;
   if (grant?.kind !== "external-code") {
     throw new Error(
       `Missing external-code grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return grant;
 }
 
 function connectorRefreshTokenAccessProviderFor(
   selection: ConnectorAuthProviderMethodSelection,
 ): RuntimeRefreshTokenAccessProvider {
-  const registration = getRuntimeAuthProviderRegistration(
-    selection.connectorRef,
-    selection.authMethodId,
-  );
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { access } = registration.entry;
   if (access?.kind !== "refresh-token") {
     throw new Error(
       `Missing refresh-token access provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return access;
 }
 
 function connectorTokenRevokeProviderFor(
   selection: ConnectorAuthProviderMethodSelection,
 ): RuntimeTokenRevokeProvider {
-  const registration = getRuntimeAuthProviderRegistration(
-    selection.connectorRef,
-    selection.authMethodId,
-  );
+  const registration = connectorAuthProviderRegistrationFor(selection);
   const { revoke } = registration.entry;
   if (revoke?.kind !== "token-revoke") {
     throw new Error(
       `Missing token-revoke provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  assertConnectorAuthProviderMethodContract(selection, registration);
   return revoke;
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,8 +1,8 @@
 import {
   type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
-  connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
+  type ConnectorAuthMethodRuntimeConfig,
   type ConnectorType,
   type ConnectorDeviceAuthGrantAuthMethodId,
   type ConnectorExternalCodeGrantAuthMethodId,
@@ -14,27 +14,27 @@ import {
   type OpenIdAuthGrantConnectorType,
   type ConnectorAuthMethodIdsByAccessKind,
   type ConnectorAuthMethodIdsByRevokeKind,
-  type ConnectorAuthMethodConfig,
+  type ConnectorAuthCodeGrantConfig,
+  type ConnectorExternalCodeGrantConfig,
+  type ConnectorOpenIdAuthGrantConfig,
   type ConnectorRefreshInputValues,
-  type ConnectorRevokeInputValues,
   type RefreshTokenAccessConnectorType,
   type TokenRevokeConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  connectorAuthClientIdentityForMethod,
-  connectorAuthMethodRefHasRevokeKind,
+  connectorAuthClientIdentity,
+  connectorAuthMethodAccessMetadata,
+  connectorGrantScopes,
   getConnectorAuthMethod,
-  getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodAuthCodeGrantConfig,
-  getConnectorAuthMethodOpenIdAuthGrantConfig,
-  getConnectorAuthMethodExternalCodeGrantConfig,
-  getConnectorAuthMethodGrantScopes,
   isStaticConnectorAuthClient,
-  parseConnectorDeviceAuthStartOptions,
-  resolveConnectorAuthClientForMethod,
+  parseConnectorDeviceAuthStartOptionsConfig,
+  resolveConnectorAuthClient,
+  type ConnectorAuthClient,
+  type ConnectorAuthClientIdentity,
   type ConnectorAuthClientForMethod,
   type ConnectorResolvedAuthMethodClientByGrantKind,
   type ConnectorEnvReader,
+  type StaticConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import type {
   AuthCodeConnectorAuthProvider,
@@ -156,30 +156,6 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "revoked" }
   | { readonly status: "unsupported" };
 
-type ConnectorAuthCodeGrantProvider<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> =
-    ConnectorAuthCodeGrantAuthMethodId<Type>,
-> = AuthCodeConnectorAuthProvider<Type, Method>["grant"];
-
-type ConnectorDeviceAuthGrantProvider<
-  Type extends DeviceAuthGrantConnectorType,
-  Method extends ConnectorDeviceAuthGrantAuthMethodId<Type> =
-    ConnectorDeviceAuthGrantAuthMethodId<Type>,
-> = DeviceAuthConnectorAuthProvider<Type, Method>["grant"];
-
-type ConnectorOpenIdAuthGrantProvider<
-  Type extends OpenIdAuthGrantConnectorType,
-  Method extends ConnectorOpenIdAuthGrantAuthMethodId<Type> =
-    ConnectorOpenIdAuthGrantAuthMethodId<Type>,
-> = OpenIdAuthConnectorAuthProvider<Type, Method>["grant"];
-
-type ConnectorExternalCodeGrantProvider<
-  Type extends ExternalCodeGrantConnectorType,
-  Method extends ConnectorExternalCodeGrantAuthMethodId<Type> =
-    ConnectorExternalCodeGrantAuthMethodId<Type>,
-> = ExternalCodeConnectorAuthProvider<Type, Method>["grant"];
-
 type ConnectorAuthMethodIdsWithoutProviderGrant<Type extends ConnectorType> =
   Exclude<
     ConnectorAuthMethodId,
@@ -283,20 +259,14 @@ type RuntimeAuthProviderRegistration<
   readonly entry: RuntimeAuthProviderEntry;
 };
 
-type RuntimeAuthProviderRegistry = Readonly<
-  Partial<
-    Record<
-      ConnectorType,
-      Readonly<Partial<Record<ConnectorAuthMethodId, RuntimeAuthProviderEntry>>>
-    >
-  >
->;
+type PreparedRuntimeAuthProviderRegistration =
+  RuntimeAuthProviderRegistration & {
+    readonly capability: ConnectorAuthProviderRegistrationCapability;
+  };
 
-type MutableRuntimeAuthProviderRegistry = Partial<
-  Record<
-    ConnectorType,
-    Partial<Record<ConnectorAuthMethodId, RuntimeAuthProviderEntry>>
-  >
+type RuntimeAuthProviderRegistry = ReadonlyMap<
+  string,
+  PreparedRuntimeAuthProviderRegistration
 >;
 
 export type ConnectorAuthProviderRegistryCapability = {
@@ -342,19 +312,19 @@ export type ConnectorAuthProviderClientContract =
 export interface ConnectorAuthProviderMethodContract {
   readonly client: ConnectorAuthProviderClientContract;
   readonly grant: {
-    readonly kind: ConnectorAuthMethodConfig["grant"]["kind"];
+    readonly kind: ConnectorAuthMethodRuntimeConfig["grant"]["kind"];
     readonly callbackOrigin: "web" | "api" | null;
     readonly outputNames: readonly string[];
     readonly startOptionNames: readonly string[];
   };
   readonly access: {
-    readonly kind: ConnectorAuthMethodConfig["access"]["kind"];
+    readonly kind: ConnectorAuthMethodRuntimeConfig["access"]["kind"];
     readonly inputNames: readonly string[];
     readonly outputNames: readonly string[];
     readonly platformSecrets: readonly string[];
   };
   readonly revoke: {
-    readonly kind: ConnectorAuthMethodConfig["revoke"]["kind"];
+    readonly kind: ConnectorAuthMethodRuntimeConfig["revoke"]["kind"];
     readonly inputNames: readonly string[];
   };
 }
@@ -372,7 +342,7 @@ function compareCapabilityStrings(left: string, right: string): number {
 }
 
 function connectorAuthProviderClientContract(
-  method: ConnectorAuthMethodConfig,
+  method: ConnectorAuthMethodRuntimeConfig,
 ): ConnectorAuthProviderClientContract {
   const client = method.client;
   if (client === undefined) {
@@ -396,7 +366,7 @@ function connectorAuthProviderClientContract(
 }
 
 function connectorAuthProviderMethodContract(
-  method: ConnectorAuthMethodConfig,
+  method: ConnectorAuthMethodRuntimeConfig,
 ): ConnectorAuthProviderMethodContract {
   const callbackOrigin =
     method.grant.kind === "auth-code"
@@ -457,7 +427,7 @@ function connectorAuthProviderMethodContract(
 }
 
 function connectorAuthProviderRequiredConfigurationNames(
-  method: ConnectorAuthMethodConfig,
+  method: ConnectorAuthMethodRuntimeConfig,
 ): readonly string[] {
   const names = new Set<string>();
   const client = method.client;
@@ -475,6 +445,38 @@ function connectorAuthProviderRequiredConfigurationNames(
   return [...names].sort(compareCapabilityStrings);
 }
 
+function connectorAuthProviderRegistryCapability(
+  entry: RuntimeAuthProviderEntry,
+): ConnectorAuthProviderRegistryCapability {
+  return {
+    ...(entry.grant === undefined ? {} : { grant: entry.grant.kind }),
+    ...(entry.access === undefined ? {} : { access: entry.access.kind }),
+    ...(entry.revoke === undefined ? {} : { revoke: entry.revoke.kind }),
+  };
+}
+
+function connectorAuthProviderRegistrationCapability(
+  registration: RuntimeAuthProviderRegistration,
+): ConnectorAuthProviderRegistrationCapability {
+  const method = getConnectorAuthMethod(
+    registration.type,
+    registration.authMethod,
+  );
+  if (method === undefined) {
+    throw new Error(
+      `Missing auth method configuration for ${registration.type}:${registration.authMethod}`,
+    );
+  }
+  return {
+    connectorRef: registration.type,
+    authMethodId: registration.authMethod,
+    handlers: connectorAuthProviderRegistryCapability(registration.entry),
+    contract: connectorAuthProviderMethodContract(method),
+    requiredConfigurationNames:
+      connectorAuthProviderRequiredConfigurationNames(method),
+  };
+}
+
 type MutableConnectorAuthProviderRegistryCapabilities = Partial<
   Record<
     ConnectorType,
@@ -483,14 +485,6 @@ type MutableConnectorAuthProviderRegistryCapabilities = Partial<
     >
   >
 >;
-
-type TokenRevokeAuthMethodRef = {
-  readonly type: TokenRevokeConnectorType;
-  readonly authMethod: ConnectorAuthMethodIdsByRevokeKind<
-    TokenRevokeConnectorType,
-    "token-revoke"
-  >;
-};
 
 function connectorAuthProviderRegistryEntry<
   Type extends ConnectorType,
@@ -506,31 +500,45 @@ function connectorAuthProviderRegistryEntry<
 function buildRuntimeProviderRegistry(
   registrations: readonly RuntimeAuthProviderRegistration[],
 ): RuntimeAuthProviderRegistry {
-  const registry: MutableRuntimeAuthProviderRegistry = {};
+  const registry = new Map<string, PreparedRuntimeAuthProviderRegistration>();
   for (const registration of registrations) {
-    const methodEntries = registry[registration.type] ?? {};
-    if (methodEntries[registration.authMethod] !== undefined) {
+    const key = connectorAuthProviderRegistrationKey(
+      registration.type,
+      registration.authMethod,
+    );
+    if (registry.has(key)) {
       throw new Error(
         `Duplicate auth provider registration for ${registration.type}:${registration.authMethod}`,
       );
     }
-    methodEntries[registration.authMethod] = registration.entry;
-    registry[registration.type] = methodEntries;
+    registry.set(key, {
+      ...registration,
+      capability: connectorAuthProviderRegistrationCapability(registration),
+    });
   }
   return registry;
 }
 
-function getRuntimeAuthProviderEntry(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): RuntimeAuthProviderEntry {
-  const entry = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY[type]?.[authMethod];
-  if (entry === undefined) {
+function connectorAuthProviderRegistrationKey(
+  connectorRef: string,
+  authMethodId: string,
+): string {
+  return `${connectorRef}\0${authMethodId}`;
+}
+
+function getRuntimeAuthProviderRegistration(
+  connectorRef: string,
+  authMethodId: string,
+): PreparedRuntimeAuthProviderRegistration {
+  const registration = CONNECTOR_AUTH_METHOD_PROVIDER_REGISTRY.get(
+    connectorAuthProviderRegistrationKey(connectorRef, authMethodId),
+  );
+  if (registration === undefined) {
     throw new Error(
-      `Missing auth provider registration for ${type}:${authMethod}`,
+      `Missing auth provider registration for ${connectorRef}:${authMethodId}`,
     );
   }
-  return entry;
+  return registration;
 }
 
 function authCodeProviderEntry<
@@ -711,111 +719,216 @@ function refreshProviderEntry<
   });
 }
 
-function connectorRefreshTokenAccessProviderFor<
-  T extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<T, "refresh-token">,
->(type: T, authMethod: Method): RefreshTokenAccessProvider<T, Method> {
-  const { access } = getRuntimeAuthProviderEntry(type, authMethod);
-  if (access?.kind !== "refresh-token") {
-    throw new Error(
-      `Missing refresh-token access provider for ${type}:${authMethod}`,
-    );
-  }
-  return access as RefreshTokenAccessProvider<T, Method>;
+export interface ConnectorAuthProviderMethodSelection {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
 }
 
-function connectorAuthCodeGrantProviderFor<
-  T extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
->(type: T, authMethod: Method): ConnectorAuthCodeGrantProvider<T, Method> {
-  const { grant } = getRuntimeAuthProviderEntry(type, authMethod);
+function assertConnectorAuthProviderMethodContract(
+  selection: ConnectorAuthProviderMethodSelection,
+  registration: PreparedRuntimeAuthProviderRegistration,
+): void {
+  if (
+    JSON.stringify(connectorAuthProviderMethodContract(selection.method)) !==
+    JSON.stringify(registration.capability.contract)
+  ) {
+    throw new Error(
+      `Auth provider contract mismatch for ${selection.connectorRef}:${selection.authMethodId}`,
+    );
+  }
+}
+
+function connectorAuthCodeGrantProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeAuthCodeGrantProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
+  );
+  const { grant } = registration.entry;
   if (grant?.kind !== "auth-code") {
     throw new Error(
-      `Missing auth-code grant provider for ${type}:${authMethod}`,
+      `Missing auth-code grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  return grant as ConnectorAuthCodeGrantProvider<T, Method>;
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return grant;
 }
 
-function connectorDeviceAuthGrantProviderFor<
-  T extends DeviceAuthGrantConnectorType,
-  Method extends ConnectorDeviceAuthGrantAuthMethodId<T>,
->(type: T, authMethod: Method): ConnectorDeviceAuthGrantProvider<T, Method> {
-  const { grant } = getRuntimeAuthProviderEntry(type, authMethod);
+function connectorDeviceAuthGrantProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeDeviceAuthGrantProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
+  );
+  const { grant } = registration.entry;
   if (grant?.kind !== "device-auth") {
     throw new Error(
-      `Missing device-auth grant provider for ${type}:${authMethod}`,
+      `Missing device-auth grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  return grant as ConnectorDeviceAuthGrantProvider<T, Method>;
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return grant;
 }
 
-function connectorOpenIdAuthGrantProviderFor<
-  T extends OpenIdAuthGrantConnectorType,
-  Method extends ConnectorOpenIdAuthGrantAuthMethodId<T>,
->(type: T, authMethod: Method): ConnectorOpenIdAuthGrantProvider<T, Method> {
-  const { grant } = getRuntimeAuthProviderEntry(type, authMethod);
+function connectorOpenIdAuthGrantProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeOpenIdAuthGrantProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
+  );
+  const { grant } = registration.entry;
   if (grant?.kind !== "openid-auth") {
     throw new Error(
-      `Missing openid-auth grant provider for ${type}:${authMethod}`,
+      `Missing openid-auth grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  return grant as ConnectorOpenIdAuthGrantProvider<T, Method>;
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return grant;
 }
 
-function connectorExternalCodeGrantProviderFor<
-  T extends ExternalCodeGrantConnectorType,
-  Method extends ConnectorExternalCodeGrantAuthMethodId<T>,
->(type: T, authMethod: Method): ConnectorExternalCodeGrantProvider<T, Method> {
-  const { grant } = getRuntimeAuthProviderEntry(type, authMethod);
+function connectorExternalCodeGrantProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeExternalCodeGrantProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
+  );
+  const { grant } = registration.entry;
   if (grant?.kind !== "external-code") {
     throw new Error(
-      `Missing external-code grant provider for ${type}:${authMethod}`,
+      `Missing external-code grant provider for ${selection.connectorRef}:${selection.authMethodId}`,
     );
   }
-  return grant as ConnectorExternalCodeGrantProvider<T, Method>;
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return grant;
 }
 
-async function revokeTokenRevokeConnectorAccessToken<
-  T extends TokenRevokeConnectorType,
-  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
->(args: {
-  readonly type: T;
-  readonly authMethod: Method;
-  readonly readEnv: ConnectorEnvReader;
-  readonly signal: AbortSignal;
-  readonly loadInputs: () =>
-    | ConnectorRevokeInputValues<T, Method>
-    | Promise<ConnectorRevokeInputValues<T, Method>>;
-}): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
-  const revoke = connectorTokenRevokeProviderFor(args.type, args.authMethod);
-
-  const authClient = resolveConnectorAuthClientForMethod(
-    args.type,
-    args.authMethod,
-    args.readEnv,
+function connectorRefreshTokenAccessProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeRefreshTokenAccessProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
   );
-  if (!authClient || !isStaticConnectorAuthClient(authClient)) {
-    return { status: "unsupported" };
+  const { access } = registration.entry;
+  if (access?.kind !== "refresh-token") {
+    throw new Error(
+      `Missing refresh-token access provider for ${selection.connectorRef}:${selection.authMethodId}`,
+    );
   }
-
-  await revoke.revokeToken({
-    authClient,
-    inputs: await args.loadInputs(),
-    signal: args.signal,
-  });
-  return { status: "revoked" };
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return access;
 }
 
-function connectorTokenRevokeProviderFor<
-  T extends TokenRevokeConnectorType,
-  Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
->(type: T, authMethod: Method): TokenRevokeProvider<T, Method> {
-  const { revoke } = getRuntimeAuthProviderEntry(type, authMethod);
+function connectorTokenRevokeProviderFor(
+  selection: ConnectorAuthProviderMethodSelection,
+): RuntimeTokenRevokeProvider {
+  const registration = getRuntimeAuthProviderRegistration(
+    selection.connectorRef,
+    selection.authMethodId,
+  );
+  const { revoke } = registration.entry;
   if (revoke?.kind !== "token-revoke") {
-    throw new Error(`Missing token-revoke provider for ${type}:${authMethod}`);
+    throw new Error(
+      `Missing token-revoke provider for ${selection.connectorRef}:${selection.authMethodId}`,
+    );
   }
-  return revoke as TokenRevokeProvider<T, Method>;
+  assertConnectorAuthProviderMethodContract(selection, registration);
+  return revoke;
+}
+
+function invokeRuntimeProvider<Args, Result>(
+  handler: (args: never) => Result,
+  args: Args,
+): Result {
+  // Typed registry builders establish the handler/method relation. Exact
+  // runtime contract validation restores it after the open-key lookup.
+  return (handler as (input: Args) => Result)(args);
+}
+
+function assertConnectorAuthClientMatchesMethod(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly authClient: ConnectorAuthClient;
+}): void {
+  const client = args.selection.method.client;
+  if (client === undefined) {
+    throw new Error(
+      `Missing auth client configuration for ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+  if (
+    client.clientRegistration !== args.authClient.clientRegistration ||
+    client.clientType !== args.authClient.clientType
+  ) {
+    throw new Error(
+      `Auth client does not match ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+  if (
+    client.clientRegistration === "static" &&
+    "clientId" in client &&
+    (args.authClient.clientRegistration !== "static" ||
+      client.clientId !== args.authClient.clientId)
+  ) {
+    throw new Error(
+      `Auth client does not match ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+  if (
+    client.clientRegistration === "static" &&
+    client.clientType === "confidential" &&
+    "clientSecret" in client &&
+    (args.authClient.clientRegistration !== "static" ||
+      args.authClient.clientType !== "confidential" ||
+      client.clientSecret !== args.authClient.clientSecret)
+  ) {
+    throw new Error(
+      `Auth client does not match ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+}
+
+function assertDeclaredProviderOutputs(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly operation: "grant" | "refresh";
+  readonly declaredOutputNames: readonly string[];
+  readonly outputs: Readonly<Record<string, string | null | undefined>>;
+}): void {
+  const declaredOutputs = new Set(args.declaredOutputNames);
+  for (const outputName of Object.keys(args.outputs)) {
+    if (!declaredOutputs.has(outputName)) {
+      throw new Error(
+        `${args.selection.connectorRef} connector auth method ${args.selection.authMethodId} returned undeclared ${args.operation} output ${outputName}`,
+      );
+    }
+  }
+}
+
+function assertDeclaredProviderInputs(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly operation: "refresh" | "revoke";
+  readonly declaredInputNames: readonly string[];
+  readonly inputs: Readonly<Record<string, string>>;
+}): void {
+  const declaredInputs = new Set(args.declaredInputNames);
+  for (const inputName of Object.keys(args.inputs)) {
+    if (!declaredInputs.has(inputName)) {
+      throw new Error(
+        `${args.selection.connectorRef} connector auth method ${args.selection.authMethodId} received undeclared ${args.operation} input ${inputName}`,
+      );
+    }
+  }
+  for (const inputName of declaredInputs) {
+    if (!Object.hasOwn(args.inputs, inputName)) {
+      throw new Error(
+        `${args.selection.connectorRef} connector auth method ${args.selection.authMethodId} is missing ${args.operation} input ${inputName}`,
+      );
+    }
+  }
 }
 
 const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
@@ -950,17 +1063,8 @@ export function getConnectorAuthProviderRegistryCapabilities(): ConnectorAuthPro
   const capabilities: MutableConnectorAuthProviderRegistryCapabilities = {};
   for (const registration of CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES) {
     const methodCapabilities = capabilities[registration.type] ?? {};
-    methodCapabilities[registration.authMethod] = {
-      ...(registration.entry.grant === undefined
-        ? {}
-        : { grant: registration.entry.grant.kind }),
-      ...(registration.entry.access === undefined
-        ? {}
-        : { access: registration.entry.access.kind }),
-      ...(registration.entry.revoke === undefined
-        ? {}
-        : { revoke: registration.entry.revoke.kind }),
-    };
+    methodCapabilities[registration.authMethod] =
+      connectorAuthProviderRegistryCapability(registration.entry);
     capabilities[registration.type] = methodCapabilities;
   }
   return capabilities;
@@ -968,33 +1072,12 @@ export function getConnectorAuthProviderRegistryCapabilities(): ConnectorAuthPro
 
 export function getConnectorAuthProviderRegistrationCapabilities(): readonly ConnectorAuthProviderRegistrationCapability[] {
   return CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES.map((registration) => {
-    const method = getConnectorAuthMethod(
-      registration.type,
-      registration.authMethod,
+    return structuredClone(
+      getRuntimeAuthProviderRegistration(
+        registration.type,
+        registration.authMethod,
+      ).capability,
     );
-    if (method === undefined) {
-      throw new Error(
-        `Missing auth method configuration for ${registration.type}:${registration.authMethod}`,
-      );
-    }
-    return {
-      connectorRef: registration.type,
-      authMethodId: registration.authMethod,
-      handlers: {
-        ...(registration.entry.grant === undefined
-          ? {}
-          : { grant: registration.entry.grant.kind }),
-        ...(registration.entry.access === undefined
-          ? {}
-          : { access: registration.entry.access.kind }),
-        ...(registration.entry.revoke === undefined
-          ? {}
-          : { revoke: registration.entry.revoke.kind }),
-      },
-      contract: connectorAuthProviderMethodContract(method),
-      requiredConfigurationNames:
-        connectorAuthProviderRequiredConfigurationNames(method),
-    };
   }).sort((left, right) => {
     return (
       compareCapabilityStrings(left.connectorRef, right.connectorRef) ||
@@ -1111,6 +1194,448 @@ type ConnectorRefreshTokenAccessDynamicCallArgs = {
   }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
 }[RefreshTokenAccessConnectorType];
 
+interface RuntimeAuthCodeAuthorizeArgs {
+  readonly authClient: ConnectorAuthClientIdentity;
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  readonly redirectUri: string;
+  readonly state: string;
+}
+
+interface RuntimeAuthCodeExchangeArgs {
+  readonly authClient: ConnectorAuthClient;
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+}
+
+interface RuntimeOpenIdAuthorizeArgs {
+  readonly openIdAuthGrant: ConnectorOpenIdAuthGrantConfig;
+  readonly returnTo: string;
+  readonly realm: string;
+  readonly state: string;
+}
+
+interface RuntimeOpenIdVerifyArgs {
+  readonly openIdAuthGrant: ConnectorOpenIdAuthGrantConfig;
+  readonly callbackParams: Readonly<Record<string, string>>;
+  readonly expectedReturnTo: string;
+  readonly expectedRealm: string;
+  readonly signal: AbortSignal;
+}
+
+interface RuntimeExternalCodeStartArgs {
+  readonly authClient: ConnectorAuthClientIdentity;
+  readonly externalCodeGrant: ConnectorExternalCodeGrantConfig;
+}
+
+interface RuntimeExternalCodeCompleteArgs {
+  readonly authClient: ConnectorAuthClient;
+  readonly externalCodeGrant: ConnectorExternalCodeGrantConfig;
+  readonly code: string;
+  readonly providerState: string;
+  readonly signal: AbortSignal;
+}
+
+interface RuntimeDeviceAuthorizationStartArgs {
+  readonly authClient: ConnectorAuthClientIdentity;
+  readonly scopes: readonly string[];
+  readonly options: ConnectorDeviceAuthStartOptions;
+}
+
+interface RuntimeDeviceAuthorizationPollArgs {
+  readonly authClient: ConnectorAuthClient;
+  readonly deviceCode: string;
+  readonly pollState?: string;
+}
+
+interface RuntimeRefreshTokenAccessArgs {
+  readonly authClient?: ConnectorAuthClient;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly signal: AbortSignal;
+}
+
+interface RuntimeTokenRevokeArgs {
+  readonly authClient: StaticConnectorAuthClient;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly signal: AbortSignal;
+}
+
+function getStaticConnectorAuthProviderMethod(
+  type: ConnectorType,
+  authMethod: string,
+): ConnectorAuthMethodRuntimeConfig {
+  const method = getConnectorAuthMethod(type, authMethod);
+  if (method === undefined) {
+    throw new Error(
+      `Missing auth method configuration for ${type}:${authMethod}`,
+    );
+  }
+  return method;
+}
+
+function assertGrantOutputs(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly result: ConnectorAuthProviderGrantResult;
+}): void {
+  const { grant } = args.selection.method;
+  if (
+    grant.kind !== "auth-code" &&
+    grant.kind !== "openid-auth" &&
+    grant.kind !== "external-code" &&
+    grant.kind !== "device-auth"
+  ) {
+    throw new Error(
+      `Provider-backed grant required for ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+  assertDeclaredProviderOutputs({
+    selection: args.selection,
+    operation: "grant",
+    declaredOutputNames: Object.keys(grant.outputs),
+    outputs: args.result.outputs,
+  });
+}
+
+function assertOptionalConnectorAuthClientMatchesMethod(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly authClient: ConnectorAuthClient | undefined;
+}): void {
+  if (args.selection.method.client === undefined) {
+    if (args.authClient !== undefined) {
+      throw new Error(
+        `Unexpected auth client for ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+      );
+    }
+    return;
+  }
+  if (args.authClient === undefined) {
+    throw new Error(
+      `Missing auth client for ${args.selection.connectorRef}:${args.selection.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args.selection,
+    authClient: args.authClient,
+  });
+}
+
+export async function buildConnectorAuthCodeAuthorizationUrlWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly redirectUri: string;
+    readonly state: string;
+  },
+): Promise<string | AuthUrlResult> {
+  const provider = connectorAuthCodeGrantProviderFor(args);
+  if (args.method.grant.kind !== "auth-code") {
+    throw new Error(
+      `Auth-code grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  return await invokeRuntimeProvider<
+    RuntimeAuthCodeAuthorizeArgs,
+    string | AuthUrlResult | Promise<string | AuthUrlResult>
+  >(provider.buildAuthUrl, {
+    authClient: connectorAuthClientIdentity(args.authClient),
+    authCodeGrant: args.method.grant,
+    redirectUri: args.redirectUri,
+    state: args.state,
+  });
+}
+
+export async function buildConnectorOpenIdAuthAuthorizationUrlWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly returnTo: string;
+    readonly realm: string;
+    readonly state: string;
+  },
+): Promise<string | AuthUrlResult> {
+  const provider = connectorOpenIdAuthGrantProviderFor(args);
+  if (args.method.grant.kind !== "openid-auth") {
+    throw new Error(
+      `OpenID grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  return await invokeRuntimeProvider<
+    RuntimeOpenIdAuthorizeArgs,
+    string | AuthUrlResult | Promise<string | AuthUrlResult>
+  >(provider.buildAuthUrl, {
+    openIdAuthGrant: args.method.grant,
+    returnTo: args.returnTo,
+    realm: args.realm,
+    state: args.state,
+  });
+}
+
+export async function exchangeConnectorAuthCodeWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly code: string;
+    readonly redirectUri: string;
+    readonly state: string | undefined;
+    readonly codeVerifier: string | undefined;
+    readonly oauthContext: string | undefined;
+  },
+): Promise<ConnectorAuthProviderGrantResult> {
+  const provider = connectorAuthCodeGrantProviderFor(args);
+  if (args.method.grant.kind !== "auth-code") {
+    throw new Error(
+      `Auth-code grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  const result = await invokeRuntimeProvider<
+    RuntimeAuthCodeExchangeArgs,
+    Promise<ConnectorAuthProviderGrantResult>
+  >(provider.exchangeCode, {
+    authClient: args.authClient,
+    authCodeGrant: args.method.grant,
+    code: args.code,
+    redirectUri: args.redirectUri,
+    state: args.state,
+    codeVerifier: args.codeVerifier,
+    oauthContext: args.oauthContext,
+  });
+  assertGrantOutputs({ selection: args, result });
+  return result;
+}
+
+export async function verifyConnectorOpenIdAuthCallbackWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly callbackParams: Readonly<Record<string, string>>;
+    readonly expectedReturnTo: string;
+    readonly expectedRealm: string;
+    readonly signal: AbortSignal;
+  },
+): Promise<ConnectorAuthProviderGrantResult> {
+  const provider = connectorOpenIdAuthGrantProviderFor(args);
+  if (args.method.grant.kind !== "openid-auth") {
+    throw new Error(
+      `OpenID grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  const result = await invokeRuntimeProvider<
+    RuntimeOpenIdVerifyArgs,
+    Promise<ConnectorAuthProviderGrantResult>
+  >(provider.verifyCallback, {
+    openIdAuthGrant: args.method.grant,
+    callbackParams: args.callbackParams,
+    expectedReturnTo: args.expectedReturnTo,
+    expectedRealm: args.expectedRealm,
+    signal: args.signal,
+  });
+  assertGrantOutputs({ selection: args, result });
+  return result;
+}
+
+export async function startConnectorExternalCodeAuthorizationWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+  },
+): Promise<ExternalCodeAuthorizationStartResult> {
+  const provider = connectorExternalCodeGrantProviderFor(args);
+  if (args.method.grant.kind !== "external-code") {
+    throw new Error(
+      `External-code grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  return await invokeRuntimeProvider<
+    RuntimeExternalCodeStartArgs,
+    Promise<ExternalCodeAuthorizationStartResult>
+  >(provider.startExternalCodeAuthorization, {
+    authClient: connectorAuthClientIdentity(args.authClient),
+    externalCodeGrant: args.method.grant,
+  });
+}
+
+export async function completeConnectorExternalCodeAuthorizationWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly code: string;
+    readonly providerState: string;
+    readonly signal: AbortSignal;
+  },
+): Promise<ConnectorAuthProviderGrantResult> {
+  const provider = connectorExternalCodeGrantProviderFor(args);
+  if (args.method.grant.kind !== "external-code") {
+    throw new Error(
+      `External-code grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  const result = await invokeRuntimeProvider<
+    RuntimeExternalCodeCompleteArgs,
+    Promise<ConnectorAuthProviderGrantResult>
+  >(provider.completeExternalCodeAuthorization, {
+    authClient: args.authClient,
+    externalCodeGrant: args.method.grant,
+    code: args.code,
+    providerState: args.providerState,
+    signal: args.signal,
+  });
+  assertGrantOutputs({ selection: args, result });
+  return result;
+}
+
+export async function startConnectorDeviceAuthorizationWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly options: ConnectorDeviceAuthStartOptions;
+  },
+): Promise<OAuthDeviceAuthStartResult> {
+  const provider = connectorDeviceAuthGrantProviderFor(args);
+  if (args.method.grant.kind !== "device-auth") {
+    throw new Error(
+      `Device-auth grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  const startOptionsResult = parseConnectorDeviceAuthStartOptionsConfig({
+    connectorRef: args.connectorRef,
+    authMethodId: args.authMethodId,
+    startOptions: args.method.grant.startOptions,
+    options: args.options,
+  });
+  if (!startOptionsResult.success) {
+    throw new Error(startOptionsResult.message);
+  }
+  return await invokeRuntimeProvider<
+    RuntimeDeviceAuthorizationStartArgs,
+    Promise<OAuthDeviceAuthStartResult>
+  >(provider.startDeviceAuth, {
+    authClient: connectorAuthClientIdentity(args.authClient),
+    scopes: connectorGrantScopes(args.method.grant),
+    options: startOptionsResult.options,
+  });
+}
+
+export async function pollConnectorDeviceAuthorizationWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly deviceCode: string;
+    readonly pollState?: string;
+  },
+): Promise<OAuthDeviceAuthPollResultBase> {
+  const provider = connectorDeviceAuthGrantProviderFor(args);
+  if (args.method.grant.kind !== "device-auth") {
+    throw new Error(
+      `Device-auth grant required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  const result = await invokeRuntimeProvider<
+    RuntimeDeviceAuthorizationPollArgs,
+    Promise<OAuthDeviceAuthPollResultBase>
+  >(provider.pollDeviceAuth, {
+    authClient: args.authClient,
+    deviceCode: args.deviceCode,
+    ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
+  });
+  if (result.status === "complete") {
+    assertGrantOutputs({ selection: args, result: result.token });
+  }
+  return result;
+}
+
+export async function refreshConnectorAuthProviderAccessTokenWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient?: ConnectorAuthClient;
+    readonly inputs: Readonly<Record<string, string>>;
+    readonly signal: AbortSignal;
+  },
+): Promise<ConnectorAuthProviderRefreshResultBase> {
+  const access = connectorRefreshTokenAccessProviderFor(args);
+  const accessMetadata = connectorAuthMethodAccessMetadata(args.method);
+  if (accessMetadata.kind !== "refresh-token") {
+    throw new Error(
+      `Refresh-token access required for ${args.connectorRef}:${args.authMethodId}`,
+    );
+  }
+  assertOptionalConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  assertDeclaredProviderInputs({
+    selection: args,
+    operation: "refresh",
+    declaredInputNames: Object.keys(accessMetadata.inputs),
+    inputs: args.inputs,
+  });
+  const result = await invokeRuntimeProvider<
+    RuntimeRefreshTokenAccessArgs,
+    Promise<ConnectorAuthProviderRefreshResultBase>
+  >(access.refresh, {
+    ...(args.authClient === undefined ? {} : { authClient: args.authClient }),
+    inputs: args.inputs,
+    signal: args.signal,
+  });
+  assertDeclaredProviderOutputs({
+    selection: args,
+    operation: "refresh",
+    declaredOutputNames: Object.keys(accessMetadata.outputs),
+    outputs: result.outputs,
+  });
+  return result;
+}
+
+export async function revokeConnectorAuthMethodAccessTokenWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly readEnv: ConnectorEnvReader;
+    readonly signal: AbortSignal;
+    readonly loadInputs: () =>
+      | Readonly<Record<string, string>>
+      | Promise<Readonly<Record<string, string>>>;
+  },
+): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
+  if (args.method.revoke.kind !== "token-revoke") {
+    return { status: "unsupported" };
+  }
+  const revoke = connectorTokenRevokeProviderFor(args);
+  const clientConfig = args.method.client;
+  if (clientConfig === undefined) {
+    return { status: "unsupported" };
+  }
+  const authClient = resolveConnectorAuthClient(clientConfig, args.readEnv);
+  if (!authClient || !isStaticConnectorAuthClient(authClient)) {
+    return { status: "unsupported" };
+  }
+  const inputs = await args.loadInputs();
+  assertDeclaredProviderInputs({
+    selection: args,
+    operation: "revoke",
+    declaredInputNames: Object.keys(args.method.revoke.inputs),
+    inputs,
+  });
+  await invokeRuntimeProvider<RuntimeTokenRevokeArgs, Promise<void>>(
+    revoke.revokeToken,
+    { authClient, inputs, signal: args.signal },
+  );
+  return { status: "revoked" };
+}
+
 export function buildConnectorAuthCodeAuthorizationUrl<
   T extends AuthCodeGrantConnectorType,
   Method extends ConnectorAuthCodeGrantAuthMethodId<T>,
@@ -1134,17 +1659,11 @@ export async function buildConnectorAuthCodeAuthorizationUrl<
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
-  const provider = connectorAuthCodeGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const authCodeGrant = getConnectorAuthMethodAuthCodeGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.buildAuthUrl({
-    authClient: connectorAuthClientIdentityForMethod(args.authClient),
-    authCodeGrant,
+  return await buildConnectorAuthCodeAuthorizationUrlWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
+    authClient: args.authClient,
     redirectUri: args.redirectUri,
     state: args.state,
   });
@@ -1173,16 +1692,10 @@ export async function buildConnectorOpenIdAuthAuthorizationUrl<
   readonly realm: string;
   readonly state: string;
 }): Promise<string | AuthUrlResult> {
-  const provider = connectorOpenIdAuthGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const openIdAuthGrant = getConnectorAuthMethodOpenIdAuthGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.buildAuthUrl({
-    openIdAuthGrant,
+  return await buildConnectorOpenIdAuthAuthorizationUrlWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
     returnTo: args.returnTo,
     realm: args.realm,
     state: args.state,
@@ -1218,23 +1731,17 @@ export async function exchangeConnectorAuthCode<
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
 }): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>> {
-  const provider = connectorAuthCodeGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const authCodeGrant = getConnectorAuthMethodAuthCodeGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.exchangeCode({
+  return (await exchangeConnectorAuthCodeWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
     authClient: args.authClient,
-    authCodeGrant,
     code: args.code,
     redirectUri: args.redirectUri,
     state: args.state,
     codeVerifier: args.codeVerifier,
     oauthContext: args.oauthContext,
-  });
+  })) as ConnectorAuthProviderGrantResultForMethod<T, Method>;
 }
 
 export function verifyConnectorOpenIdAuthCallback<
@@ -1262,21 +1769,15 @@ export async function verifyConnectorOpenIdAuthCallback<
   readonly expectedRealm: string;
   readonly signal: AbortSignal;
 }): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>> {
-  const provider = connectorOpenIdAuthGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const openIdAuthGrant = getConnectorAuthMethodOpenIdAuthGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.verifyCallback({
-    openIdAuthGrant,
+  return (await verifyConnectorOpenIdAuthCallbackWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
     callbackParams: args.callbackParams,
     expectedReturnTo: args.expectedReturnTo,
     expectedRealm: args.expectedRealm,
     signal: args.signal,
-  });
+  })) as ConnectorAuthProviderGrantResultForMethod<T, Method>;
 }
 
 export function startConnectorExternalCodeAuthorization<
@@ -1298,17 +1799,11 @@ export async function startConnectorExternalCodeAuthorization<
   readonly authMethod: Method;
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
 }): Promise<ExternalCodeAuthorizationStartResult> {
-  const provider = connectorExternalCodeGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const externalCodeGrant = getConnectorAuthMethodExternalCodeGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.startExternalCodeAuthorization({
-    authClient: connectorAuthClientIdentityForMethod(args.authClient),
-    externalCodeGrant,
+  return await startConnectorExternalCodeAuthorizationWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
+    authClient: args.authClient,
   });
 }
 
@@ -1337,21 +1832,15 @@ export async function completeConnectorExternalCodeAuthorization<
   readonly providerState: string;
   readonly signal: AbortSignal;
 }): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>> {
-  const provider = connectorExternalCodeGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const externalCodeGrant = getConnectorAuthMethodExternalCodeGrantConfig(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.completeExternalCodeAuthorization({
+  return (await completeConnectorExternalCodeAuthorizationWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
     authClient: args.authClient,
-    externalCodeGrant,
     code: args.code,
     providerState: args.providerState,
     signal: args.signal,
-  });
+  })) as ConnectorAuthProviderGrantResultForMethod<T, Method>;
 }
 
 export function startConnectorDeviceAuthorization<
@@ -1375,22 +1864,12 @@ export async function startConnectorDeviceAuthorization<
   readonly authClient: ConnectorAuthClientForMethod<T, Method>;
   readonly options: ConnectorDeviceAuthStartOptions;
 }): Promise<OAuthDeviceAuthStartResult> {
-  const provider = connectorDeviceAuthGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const startOptionsResult = parseConnectorDeviceAuthStartOptions({
-    type: args.type,
-    authMethod: args.authMethod,
+  return await startConnectorDeviceAuthorizationWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
+    authClient: args.authClient,
     options: args.options,
-  });
-  if (!startOptionsResult.success) {
-    throw new Error(startOptionsResult.message);
-  }
-  return await provider.startDeviceAuth({
-    authClient: connectorAuthClientIdentityForMethod(args.authClient),
-    scopes: getConnectorAuthMethodGrantScopes(args.type, args.authMethod),
-    options: startOptionsResult.options,
   });
 }
 
@@ -1417,15 +1896,14 @@ export async function pollConnectorDeviceAuthorization<
   readonly deviceCode: string;
   readonly pollState?: string;
 }): Promise<OAuthDeviceAuthPollResult<T, Method>> {
-  const provider = connectorDeviceAuthGrantProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  return await provider.pollDeviceAuth({
+  return (await pollConnectorDeviceAuthorizationWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
     authClient: args.authClient,
     deviceCode: args.deviceCode,
     ...(args.pollState === undefined ? {} : { pollState: args.pollState }),
-  });
+  })) as OAuthDeviceAuthPollResult<T, Method>;
 }
 
 export function refreshConnectorAuthProviderAccessToken<
@@ -1440,24 +1918,14 @@ export function refreshConnectorAuthProviderAccessToken(
 export async function refreshConnectorAuthProviderAccessToken(
   args: ConnectorRefreshTokenAccessDynamicCallArgs,
 ): Promise<ConnectorAuthProviderRefreshResultBase> {
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(
-    args.type,
-    args.authMethod,
-  );
-  const access = connectorRefreshTokenAccessProviderFor(
-    args.type,
-    args.authMethod,
-  );
-  const result = await access.refresh(args);
-  const declaredOutputs = new Set(Object.keys(accessMetadata.outputs));
-  for (const outputName of Object.keys(result.outputs)) {
-    if (!declaredOutputs.has(outputName)) {
-      throw new Error(
-        `${args.type} connector auth method ${args.authMethod} returned undeclared refresh output ${outputName}`,
-      );
-    }
-  }
-  return result;
+  return await refreshConnectorAuthProviderAccessTokenWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method: getStaticConnectorAuthProviderMethod(args.type, args.authMethod),
+    ...("authClient" in args ? { authClient: args.authClient } : {}),
+    inputs: args.inputs,
+    signal: args.signal,
+  });
 }
 
 export async function revokeConnectorAuthMethodAccessToken(args: {
@@ -1469,26 +1937,14 @@ export async function revokeConnectorAuthMethodAccessToken(args: {
     | Readonly<Record<string, string>>
     | Promise<Readonly<Record<string, string>>>;
 }): Promise<ConnectorAuthProviderAccessTokenRevokeResult> {
-  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
-    args.authMethod,
-  );
-  if (!parsedAuthMethod.success) {
+  const method = getConnectorAuthMethod(args.type, args.authMethod);
+  if (method === undefined) {
     return { status: "unsupported" };
   }
-
-  const authMethodRef = {
-    type: args.type,
-    authMethod: parsedAuthMethod.data,
-  };
-  if (!connectorAuthMethodRefHasRevokeKind(authMethodRef, "token-revoke")) {
-    return { status: "unsupported" };
-  }
-  // The guard above is the runtime source of truth for dynamic revoke refs.
-  const tokenRevokeAuthMethodRef = authMethodRef as TokenRevokeAuthMethodRef;
-
-  return await revokeTokenRevokeConnectorAccessToken({
-    type: tokenRevokeAuthMethodRef.type,
-    authMethod: tokenRevokeAuthMethodRef.authMethod,
+  return await revokeConnectorAuthMethodAccessTokenWithMethod({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    method,
     readEnv: args.readEnv,
     signal: args.signal,
     loadInputs: args.loadInputs,

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -225,6 +225,12 @@ function createTestOauthApiTokenAccess(): RefreshTokenAccessProvider<
         },
         expiresIn: 3600,
       };
+      if (refreshArgs.inputs.inputSecret === "undeclared-output") {
+        Object.defineProperty(providerResult.outputs, "unexpectedToken", {
+          enumerable: true,
+          value: "unexpected-token",
+        });
+      }
       return providerResult;
     },
   };

--- a/turbo/packages/connectors/src/connector-config.ts
+++ b/turbo/packages/connectors/src/connector-config.ts
@@ -272,7 +272,7 @@ export type ConnectorRevokeConfig =
       readonly revokePreviousOnReplace?: boolean;
     };
 
-interface ConnectorAuthMethodConfigBase {
+interface ConnectorAuthMethodDisplayConfig {
   label: string;
   helpText?: string;
   /** When false, this auth method is unavailable for new connector actions. */
@@ -281,6 +281,9 @@ interface ConnectorAuthMethodConfigBase {
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */
   showExperimentalLabel?: boolean;
+}
+
+interface ConnectorAuthMethodRuntimeConfigBase {
   /**
    * Connector-scoped storage names owned by this auth method.
    *
@@ -291,10 +294,12 @@ interface ConnectorAuthMethodConfigBase {
 }
 
 /**
- * Auth method configuration for user-selectable connector connection flows.
+ * Normalized auth method configuration used to materialize and execute a
+ * connector connection lifecycle. External catalogs produce this shape by
+ * joining their accepted public and private method data.
  */
-export type ConnectorAuthMethodConfig =
-  | (ConnectorAuthMethodConfigBase & {
+export type ConnectorAuthMethodRuntimeConfig =
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client?: never;
       readonly grant: ConnectorNoAuthGrantConfig;
       readonly access: ConnectorNoAccessConfig;
@@ -303,36 +308,42 @@ export type ConnectorAuthMethodConfig =
         { readonly kind: "none" }
       >;
     })
-  | (ConnectorAuthMethodConfigBase & {
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client: ConnectorAuthClientConfig;
       readonly grant: ConnectorAuthCodeGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     })
-  | (ConnectorAuthMethodConfigBase & {
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client?: ConnectorAuthClientConfig;
       readonly grant: ConnectorOpenIdAuthGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     })
-  | (ConnectorAuthMethodConfigBase & {
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client: ConnectorAuthClientConfig;
       readonly grant: ConnectorExternalCodeGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     })
-  | (ConnectorAuthMethodConfigBase & {
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client: PublicConnectorAuthClientConfig;
       readonly grant: ConnectorDeviceAuthGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     })
-  | (ConnectorAuthMethodConfigBase & {
+  | (ConnectorAuthMethodRuntimeConfigBase & {
       readonly client?: ConnectorAuthClientConfig;
       readonly grant: ConnectorManualGrantConfig | ConnectorManagedGrantConfig;
       readonly access: ConnectorAccessConfig;
       readonly revoke: ConnectorRevokeConfig;
     });
+
+/**
+ * Auth method configuration for user-selectable connector connection flows.
+ */
+export type ConnectorAuthMethodConfig = ConnectorAuthMethodRuntimeConfig &
+  ConnectorAuthMethodDisplayConfig;
 
 /**
  * Connector auth method ids exposed as configured connection flows.

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -3,6 +3,7 @@ import {
   CONNECTOR_TYPES,
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodRuntimeConfig,
   type ConnectorAuthMethodId,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorDeviceAuthGrantAuthMethodId,
@@ -678,6 +679,12 @@ export function getConnectorAuthMethodAccessMetadata(
     return undefined;
   }
 
+  return connectorAuthMethodAccessMetadata(method);
+}
+
+export function connectorAuthMethodAccessMetadata(
+  method: ConnectorAuthMethodRuntimeConfig,
+): ConnectorAuthMethodAccessMetadata {
   switch (method.access.kind) {
     case "static": {
       return {
@@ -721,6 +728,12 @@ export function getConnectorAuthMethodGrantMetadata(
     return undefined;
   }
 
+  return connectorAuthMethodGrantMetadata(method);
+}
+
+export function connectorAuthMethodGrantMetadata(
+  method: ConnectorAuthMethodRuntimeConfig,
+): ConnectorAuthMethodGrantMetadata {
   switch (method.grant.kind) {
     case "auth-code":
     case "openid-auth":
@@ -766,6 +779,12 @@ export function getConnectorAuthMethodRevokeMetadata(
     return undefined;
   }
 
+  return connectorAuthMethodRevokeMetadata(method);
+}
+
+export function connectorAuthMethodRevokeMetadata(
+  method: ConnectorAuthMethodRuntimeConfig,
+): ConnectorAuthMethodRevokeMetadata {
   switch (method.revoke.kind) {
     case "token-revoke":
       return {
@@ -909,6 +928,13 @@ export function getConnectorAuthMethodRuntimeMetadata(
   if (!method) {
     return undefined;
   }
+
+  return connectorAuthMethodRuntimeMetadata(method);
+}
+
+export function connectorAuthMethodRuntimeMetadata(
+  method: ConnectorAuthMethodRuntimeConfig,
+): ConnectorAuthMethodRuntimeMetadata {
   const platformSecrets = connectorAccessPlatformSecrets(method.access);
   return {
     storage: {
@@ -1149,8 +1175,8 @@ export type ConnectorDeviceAuthStartOptionsParseResult =
     };
 
 function parseConnectorDeviceAuthStartOption(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+  readonly connectorRef: string;
+  readonly authMethodId: string;
   readonly optionName: string;
   readonly config: ConnectorDeviceAuthStartOptionConfig;
   readonly requestedValue: string | undefined;
@@ -1160,7 +1186,7 @@ function parseConnectorDeviceAuthStartOption(args: {
     if (args.config.required) {
       return {
         success: false,
-        message: `${args.type} ${args.authMethod} device-auth start option ${args.optionName} is required`,
+        message: `${args.connectorRef} ${args.authMethodId} device-auth start option ${args.optionName} is required`,
       };
     }
     return { success: true, options: {} };
@@ -1175,7 +1201,7 @@ function parseConnectorDeviceAuthStartOption(args: {
       ) {
         return {
           success: false,
-          message: `${args.type} ${args.authMethod} device-auth start option ${args.optionName} must be one of: ${args.config.options
+          message: `${args.connectorRef} ${args.authMethodId} device-auth start option ${args.optionName} must be one of: ${args.config.options
             .map((option) => {
               return option.value;
             })
@@ -1202,10 +1228,24 @@ export function parseConnectorDeviceAuthStartOptions(args: {
   readonly authMethod: string;
   readonly options: ConnectorDeviceAuthStartOptions | undefined;
 }): ConnectorDeviceAuthStartOptionsParseResult {
-  const configuredOptions = getConnectorAuthMethodDeviceAuthStartOptionsConfig(
-    args.type,
-    args.authMethod,
-  );
+  return parseConnectorDeviceAuthStartOptionsConfig({
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    startOptions: getConnectorAuthMethodDeviceAuthStartOptionsConfig(
+      args.type,
+      args.authMethod,
+    ),
+    options: args.options,
+  });
+}
+
+export function parseConnectorDeviceAuthStartOptionsConfig(args: {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined;
+  readonly options: ConnectorDeviceAuthStartOptions | undefined;
+}): ConnectorDeviceAuthStartOptionsParseResult {
+  const configuredOptions = args.startOptions;
   const requestedOptionKeys = Object.keys(args.options ?? {});
 
   if (!configuredOptions || Object.keys(configuredOptions).length === 0) {
@@ -1214,7 +1254,7 @@ export function parseConnectorDeviceAuthStartOptions(args: {
     }
     return {
       success: false,
-      message: `${args.type} ${args.authMethod} device-auth start options are not supported: ${requestedOptionKeys.join(", ")}`,
+      message: `${args.connectorRef} ${args.authMethodId} device-auth start options are not supported: ${requestedOptionKeys.join(", ")}`,
     };
   }
 
@@ -1222,7 +1262,7 @@ export function parseConnectorDeviceAuthStartOptions(args: {
     if (!Object.hasOwn(configuredOptions, optionName)) {
       return {
         success: false,
-        message: `${args.type} ${args.authMethod} device-auth start option ${optionName} is not supported`,
+        message: `${args.connectorRef} ${args.authMethodId} device-auth start option ${optionName} is not supported`,
       };
     }
   }
@@ -1230,8 +1270,8 @@ export function parseConnectorDeviceAuthStartOptions(args: {
   const normalizedOptions: Record<string, string> = {};
   for (const [optionName, config] of Object.entries(configuredOptions)) {
     const parsedOption = parseConnectorDeviceAuthStartOption({
-      type: args.type,
-      authMethod: args.authMethod,
+      connectorRef: args.connectorRef,
+      authMethodId: args.authMethodId,
       optionName,
       config,
       requestedValue: connectorDeviceAuthStartOptionValue(
@@ -1252,7 +1292,7 @@ export function parseConnectorDeviceAuthStartOptions(args: {
   return { success: true, options: normalizedOptions };
 }
 
-function connectorGrantScopes(
+export function connectorGrantScopes(
   grant: ConnectorGrantConfig | undefined,
 ): readonly string[] {
   switch (grant?.kind) {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -340,6 +340,7 @@ export type {
   ConnectorAuthCodeCallbackOrigin,
   ConnectorAuthCodeGrantConfig,
   ConnectorAuthMethodConfig,
+  ConnectorAuthMethodRuntimeConfig,
   ConnectorAuthMethodId,
   ConnectorConfig,
   ConnectorDeviceAuthGrantConfig,


### PR DESCRIPTION
## Summary

- add a normalized connector auth runtime contract and pure method-based metadata helpers
- resolve open connector and auth-method identities against the same code-owned registry used for capability reconciliation
- validate handler kind, method contract, resolved client, declared inputs, and provider outputs at the execution boundary
- preserve current static APIs as deployment-compatible delegates through the explicit contract path
- cover supplied catalog data, fail-closed dispatch, output validation, and existing API lifecycle behavior with integration tests

## Exclusions

- no connector catalog DB reader or source-mode change
- no external catalog activation or public/runner protocol change
- no credential persistence, skill mounting, or firewall composition migration

## Validation

- `pnpm exec prettier --check packages/connectors/src/__tests__/connectors.test.ts packages/connectors/src/auth-providers/connector-auth.ts packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts packages/connectors/src/connector-config.ts packages/connectors/src/connector-utils.ts packages/connectors/src/connectors.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/connectors-openid.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/auth-device.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm check-types`
- `pnpm knip`

Closes #21813

Parent delivery: #19396
