### PR TITLE
fix(runner): reject spoofed sandbox source addresses

### DIFF
--- a/.github/scripts/runner-behavior-cancel.sh
+++ b/.github/scripts/runner-behavior-cancel.sh
@@ -2,6 +2,18 @@
 set -euo pipefail
 
 REMOTE="${METAL_USER}@${HOST}"
+SVC="${JOB_REF}-cancel"
+RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+GROUP="vm0/cancel-${JOB_REF}"
+GROUP_DIR="/var/lib/vm0-runner/groups/${GROUP}"
+
+echo "=== Cleaning stale cancel runner state ==="
+ssh "$REMOTE" bash -s -- "$BIN_DIR" "$SVC" "$GROUP_DIR" "$RUNNER_DIR" <<'REMOTE_SCRIPT'
+set -euo pipefail
+BIN_DIR=$1; SVC=$2; GROUP_DIR=$3; RUNNER_DIR=$4
+sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+REMOTE_SCRIPT
 
 echo "=== Generating config ==="
 # shellcheck disable=SC2029
@@ -9,22 +21,27 @@ ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
   --profile vm0/default \
   --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
   --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-  --name ${JOB_REF}-cancel \
-  --group vm0/cancel-${JOB_REF} \
-  --runner-dirname ${JOB_REF}-cancel \
-  --max-concurrent 2 \
+  --name ${SVC} \
+  --group ${GROUP} \
+  --runner-dirname ${SVC} \
+  --max-concurrent 1 \
   --api-url https://not-a-real-server.test \
   --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
 echo "=== Running cancel test ==="
-ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
-BIN_DIR=$1; JOB_REF=$2
-RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-cancel"
-SVC="${JOB_REF}-cancel"
-GROUP="vm0/cancel-${JOB_REF}"
+ssh "$REMOTE" bash -s -- \
+  "$BIN_DIR" "$SVC" "$GROUP" "$GROUP_DIR" "$RUNNER_DIR" <<'REMOTE_SCRIPT'
+set -euo pipefail
+BIN_DIR=$1; SVC=$2; GROUP=$3; GROUP_DIR=$4; RUNNER_DIR=$5
 SUBMIT_PID=""
+SUBMIT_OUTPUT=$(mktemp)
 
 fail() { echo "FAIL: $1"; exit 1; }
+
+print_service_logs() {
+  echo "--- ${SVC} service logs ---"
+  sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
+}
 
 cleanup_submit_pid() {
   local pid=$1
@@ -34,15 +51,19 @@ cleanup_submit_pid() {
 }
 
 cleanup() {
+  local status=$?
+  trap - EXIT
+  if [ "$status" -ne 0 ]; then
+    print_service_logs
+  fi
   echo "--- Cleanup ---"
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   cleanup_submit_pid "$SUBMIT_PID"
+  sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+  rm -f "$SUBMIT_OUTPUT"
+  exit "$status"
 }
 trap cleanup EXIT
-
-# Clean up any residual transient unit from a previous CI run.
-# stop() returns Ok when no service exists, so no need for || true.
-sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 
 # Start transient runner service
 echo "--- Starting runner ---"
@@ -51,26 +72,38 @@ sudo "$BIN_DIR/runner" service start --name "$SVC" \
 
 # Submit a long-running job in background
 echo "--- Submitting long-running job ---"
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+sudo "$BIN_DIR/runner" local submit \
+  --group "$GROUP" --prompt 'sleep 60 && echo done' >"$SUBMIT_OUTPUT" 2>&1 &
 SUBMIT_PID=$!
 
-# Wait for sandbox to be running. Post #9552, run_id and sandbox_id
-# are distinct: `runner local cancel` takes the run_id (what submit
-# returned), while the socket path uses sandbox_id. Read both from
-# status.json rather than picking the first UUID we see.
+# Resolve this submission from its claim instead of selecting the first active
+# run. A failed prior attempt must never redirect cancellation to stale work.
 echo "--- Waiting for sandbox ---"
-for i in $(seq 1 60); do
-  RUN_ID=$(sudo jq -r '.active_runs[0].run_id // empty' \
-    "$RUNNER_DIR/status.json" 2>/dev/null)
-  SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
-    "$RUNNER_DIR/status.json" 2>/dev/null)
-  [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] \
-    && [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] && break
-  RUN_ID=""
+RUN_ID=""
+SANDBOX_ID=""
+SANDBOX_READY=false
+for _ in $(seq 1 60); do
+  mapfile -t CLAIM_FILES < <(
+    sudo find "$GROUP_DIR/claims" -maxdepth 1 -type f -name '*.claim' \
+      -printf '%f\n' 2>/dev/null | sort
+  )
+  [ "${#CLAIM_FILES[@]}" -le 1 ] \
+    || fail "expected one claimed job, found ${#CLAIM_FILES[@]}"
+  if [ "${#CLAIM_FILES[@]}" -eq 1 ]; then
+    RUN_ID=${CLAIM_FILES[0]%.claim}
+    SANDBOX_ID=$(sudo jq -r --arg run_id "$RUN_ID" \
+      '.active_runs[]? | select(.run_id == $run_id) | .sandbox_id' \
+      "$RUNNER_DIR/status.json" 2>/dev/null)
+    if [ -n "$SANDBOX_ID" ] \
+      && [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ]; then
+      SANDBOX_READY=true
+      break
+    fi
+  fi
   SANDBOX_ID=""
   sleep 1
 done
-[ -z "$RUN_ID" ] && fail "sandbox not found after 60s"
+[ "$SANDBOX_READY" = true ] || fail "sandbox not found after 60s"
 echo "Found run $RUN_ID (sandbox $SANDBOX_ID)"
 
 # Test 1: cancel the job via runner local cancel
@@ -78,15 +111,23 @@ echo "--- Test: runner local cancel ---"
 sudo "$BIN_DIR/runner" local cancel --run "$RUN_ID" --group "$GROUP" || fail "cancel command failed"
 echo "PASS: cancel command succeeded"
 
-# Test 2: submit should exit quickly (not after 300s timeout)
+# Test 2: submit should exit quickly, well before the prompt completes.
 echo "--- Test: waiting for submit to finish ---"
 SECONDS=0
-wait "$SUBMIT_PID"
-SUBMIT_EXIT=$?
+if wait "$SUBMIT_PID"; then
+  SUBMIT_EXIT=0
+else
+  SUBMIT_EXIT=$?
+fi
 SUBMIT_PID=""
 ELAPSED=$SECONDS
+cat "$SUBMIT_OUTPUT"
 echo "Submit exited with code $SUBMIT_EXIT in ${ELAPSED}s"
-# Cancel should kill the job within 30s, not after the 300s submit timeout
+SUBMIT_JSON=$(awk '/^\{/{line=$0} END{print line}' "$SUBMIT_OUTPUT")
+SUBMIT_RUN_ID=$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")
+[ "$SUBMIT_RUN_ID" = "$RUN_ID" ] \
+  || fail "cancelled run $RUN_ID but submit returned ${SUBMIT_RUN_ID:-missing}"
+# Cancel should kill the job within 30s, not after the 60s prompt.
 [ "$ELAPSED" -lt 30 ] || fail "submit took ${ELAPSED}s to exit — cancel likely did not work"
 # Cancelled job returns non-zero exit code
 [ "$SUBMIT_EXIT" -ne 0 ] || fail "expected non-zero exit from cancelled job, got 0"
@@ -94,6 +135,8 @@ echo "PASS: submit exited with non-zero after cancel (${ELAPSED}s)"
 
 # Stop transient service
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+rm -f "$SUBMIT_OUTPUT"
 trap - EXIT
 
 echo "=== Cancel test passed ==="

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -446,8 +446,20 @@ RUNNER_NAMESPACE_COUNT=${#RUNNER_NAMESPACES[@]}
 [ "$RUNNER_NAMESPACE_COUNT" -ge 2 ] \
   || fail "expected at least two runner namespaces, found $RUNNER_NAMESPACE_COUNT"
 
-ATTACKER_NS=${RUNNER_NAMESPACES[0]}
-VICTIM_NS=${RUNNER_NAMESPACES[1]}
+IDLE_RUNNER_NAMESPACES=()
+for namespace in "${RUNNER_NAMESPACES[@]}"; do
+  NAMESPACE_PIDS=$(sudo ip netns pids "$namespace") \
+    || fail "failed to inspect namespace processes: $namespace"
+  if [ -z "$NAMESPACE_PIDS" ]; then
+    IDLE_RUNNER_NAMESPACES+=("$namespace")
+  fi
+done
+IDLE_RUNNER_NAMESPACE_COUNT=${#IDLE_RUNNER_NAMESPACES[@]}
+[ "$IDLE_RUNNER_NAMESPACE_COUNT" -ge 2 ] \
+  || fail "expected at least two idle runner namespaces, found $IDLE_RUNNER_NAMESPACE_COUNT"
+
+ATTACKER_NS=${IDLE_RUNNER_NAMESPACES[0]}
+VICTIM_NS=${IDLE_RUNNER_NAMESPACES[1]}
 ATTACKER_IF=${ATTACKER_NS/vm0-ns-/vm0-ve-}
 VICTIM_IF=${VICTIM_NS/vm0-ns-/vm0-ve-}
 

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -26,6 +26,8 @@ SUBMIT_PID=""
 DNS_ISOLATION_NS=""
 DNS_ISOLATION_HOST_IF=""
 DNS_ISOLATION_LOCK_FD=""
+SPOOF_NS=""
+SPOOF_IP=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 
@@ -36,8 +38,68 @@ cleanup_submit_pid() {
   wait "$pid" 2>/dev/null || true
 }
 
+cleanup_spoof_address() {
+  if [ -n "$SPOOF_NS" ] && [ -n "$SPOOF_IP" ]; then
+    sudo ip -n "$SPOOF_NS" address delete "${SPOOF_IP}/32" \
+      dev veth0 2>/dev/null || true
+  fi
+  SPOOF_NS=""
+  SPOOF_IP=""
+}
+
+rule_values() {
+  local option=$1
+  awk -v option="$option" '
+    {
+      for (i = 1; i < NF; i++) {
+        if ($i == option) {
+          value = $(i + 1)
+          gsub(/^"|"$/, "", value)
+          print value
+        }
+      }
+    }
+  '
+}
+
+rule_value() {
+  local rule=$1 option=$2
+  printf '%s\n' "$rule" | rule_values "$option" | head -n 1
+}
+
+rule_packet_count() {
+  local rule=$1
+  printf '%s\n' "$rule" | awk '
+    $1 ~ /^\[[0-9]+:[0-9]+\]$/ {
+      gsub(/^\[/, "", $1)
+      split($1, counter, ":")
+      print counter[1]
+      exit
+    }
+  '
+}
+
+send_udp_dns_query() {
+  local namespace=$1 source_ip=$2
+  sudo ip netns exec "$namespace" python3 - "$source_ip" <<'PY'
+import socket
+import sys
+
+query = bytes.fromhex(
+    "123401000001000000000000"
+    "0c736f757263652d6775617264"
+    "07696e76616c69640000010001"
+)
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind((sys.argv[1], 0))
+sock.sendto(query, ("192.0.2.1", 53))
+sock.close()
+PY
+}
+
 cleanup() {
   echo "--- Cleanup ---"
+  cleanup_spoof_address
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   cleanup_submit_pid "$SUBMIT_PID"
   if [ -n "$DNS_ISOLATION_NS" ]; then
@@ -349,6 +411,7 @@ fi
 
 NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
 FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
+RAW_RULES=$(sudo iptables-save -t raw) || fail "failed to read raw rules"
 
 PROXY_RULES=$(printf '%s\n' "$NAT_RULES" \
   | grep -E -- "--to-ports? ${PROXY_PORT}([[:space:]]|$)" || true)
@@ -370,6 +433,179 @@ printf '%s\n' "$FILTER_RULES" \
 printf '%s\n' "$FILTER_RULES" \
   | grep -E -- "-A FORWARD .* -p tcp .*--dport 853 .* -j DROP" >/dev/null \
   || fail "TCP/853 FORWARD drop rule not found"
+
+# Verify that source IP is an identity only after the packet arrives on its
+# owning host veth. Then inject one namespace's peer IP through another veth
+# and prove the raw guard rejects it before the victim DNS rule can attribute it.
+mapfile -t RUNNER_NAMESPACES < <(
+  printf '%s\n' "$PROXY_RULES" \
+    | rule_values --comment \
+    | sort -u
+)
+RUNNER_NAMESPACE_COUNT=${#RUNNER_NAMESPACES[@]}
+[ "$RUNNER_NAMESPACE_COUNT" -ge 2 ] \
+  || fail "expected at least two runner namespaces, found $RUNNER_NAMESPACE_COUNT"
+
+ATTACKER_NS=${RUNNER_NAMESPACES[0]}
+VICTIM_NS=${RUNNER_NAMESPACES[1]}
+ATTACKER_IF=${ATTACKER_NS/vm0-ns-/vm0-ve-}
+VICTIM_IF=${VICTIM_NS/vm0-ns-/vm0-ve-}
+
+ATTACKER_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | head -n 1 || true)
+VICTIM_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | head -n 1 || true)
+[ -n "$ATTACKER_PROXY_RULE" ] || fail "attacker proxy rule not found"
+[ -n "$VICTIM_PROXY_RULE" ] || fail "victim proxy rule not found"
+
+ATTACKER_CIDR=$(rule_value "$ATTACKER_PROXY_RULE" -s)
+VICTIM_CIDR=$(rule_value "$VICTIM_PROXY_RULE" -s)
+[ "${ATTACKER_CIDR#*/}" = 32 ] \
+  || fail "attacker proxy source is not an exact /32: $ATTACKER_CIDR"
+[ "${VICTIM_CIDR#*/}" = 32 ] \
+  || fail "victim proxy source is not an exact /32: $VICTIM_CIDR"
+[ "$(rule_value "$ATTACKER_PROXY_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "attacker proxy rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$VICTIM_PROXY_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim proxy rule is not bound to $VICTIM_IF"
+ATTACKER_PEER=${ATTACKER_CIDR%/32}
+VICTIM_PEER=${VICTIM_CIDR%/32}
+
+ATTACKER_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+VICTIM_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+[ -n "$ATTACKER_GUARD_RULE" ] || fail "attacker source guard not found"
+[ -n "$VICTIM_GUARD_RULE" ] || fail "victim source guard not found"
+[ "$(rule_value "$ATTACKER_GUARD_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "attacker source guard is not bound to $ATTACKER_IF"
+[ "$(rule_value "$VICTIM_GUARD_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim source guard is not bound to $VICTIM_IF"
+printf '%s\n' "$ATTACKER_GUARD_RULE" \
+  | grep -F -- "! -s ${ATTACKER_CIDR}" >/dev/null \
+  || fail "attacker source guard does not reject non-peer sources"
+printf '%s\n' "$VICTIM_GUARD_RULE" \
+  | grep -F -- "! -s ${VICTIM_CIDR}" >/dev/null \
+  || fail "victim source guard does not reject non-peer sources"
+
+ATTACKER_MASQUERADE_RULE=$(printf '%s\n' "$NAT_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A POSTROUTING" \
+  | grep -F -- "-j MASQUERADE" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_MASQUERADE_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "host masquerade rule does not use the exact attacker peer"
+
+ATTACKER_OUTBOUND_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A FORWARD" \
+  | grep -F -- "-i ${ATTACKER_IF}" \
+  | grep -F -- "-j ACCEPT" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_OUTBOUND_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "outbound forwarding rule does not use the exact attacker peer"
+
+ATTACKER_RETURN_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A FORWARD" \
+  | grep -F -- "-o ${ATTACKER_IF}" \
+  | grep -F -- "-j ACCEPT" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_RETURN_RULE" -d)" = "$ATTACKER_CIDR" ] \
+  || fail "return forwarding rule does not use the exact attacker peer"
+
+ATTACKER_LOG_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "VM0:${ATTACKER_PEER}:" \
+  | grep -F -- "-j LOG" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_LOG_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "non-TCP log rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$ATTACKER_LOG_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "non-TCP log rule does not use the exact attacker peer"
+
+ATTACKER_DNS_DROP_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "DNS drop rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "DNS drop rule does not use the exact attacker peer"
+
+VICTIM_DNS_RULE=$(printf '%s\n' "$NAT_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+[ "$(rule_value "$VICTIM_DNS_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim DNS redirect is not bound to $VICTIM_IF"
+[ "$(rule_value "$VICTIM_DNS_RULE" -s)" = "$VICTIM_CIDR" ] \
+  || fail "victim DNS redirect does not use the exact peer"
+
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_BEFORE=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+[ -n "$ATTACKER_GUARD_BEFORE" ] || fail "source guard counter missing"
+send_udp_dns_query "$ATTACKER_NS" "$ATTACKER_PEER"
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_AFTER_CONTROL=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+[ "$ATTACKER_GUARD_AFTER_CONTROL" -eq "$ATTACKER_GUARD_BEFORE" ] \
+  || fail "source guard rejected the namespace's assigned peer"
+
+VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+VICTIM_DNS_BEFORE=$(rule_packet_count "$VICTIM_DNS_COUNTED")
+[ -n "$VICTIM_DNS_BEFORE" ] || fail "victim DNS redirect counter missing"
+
+SPOOF_NS=$ATTACKER_NS
+SPOOF_IP=$VICTIM_PEER
+sudo ip -n "$SPOOF_NS" address add "${SPOOF_IP}/32" dev veth0 \
+  || fail "failed to add forged victim source to attacker namespace"
+send_udp_dns_query "$SPOOF_NS" "$SPOOF_IP"
+
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_AFTER_SPOOF=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+VICTIM_DNS_AFTER=$(rule_packet_count "$VICTIM_DNS_COUNTED")
+cleanup_spoof_address
+
+[ "$ATTACKER_GUARD_AFTER_SPOOF" -gt "$ATTACKER_GUARD_AFTER_CONTROL" ] \
+  || fail "source guard did not reject the forged victim source"
+[ "$VICTIM_DNS_AFTER" -eq "$VICTIM_DNS_BEFORE" ] \
+  || fail "forged source reached the victim DNS attribution rule"
+echo "  source identity: forged $VICTIM_PEER rejected on $ATTACKER_IF"
 
 DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
   | grep -E -- "-A INPUT .*--dport ${DNS_PORT} .*--comment vm0-ns-[0-9a-f]{2}-dns.*-j REJECT" \
@@ -486,6 +722,12 @@ if sudo ip6tables-save -t filter \
   | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
   fail "IPv6 DNS INPUT filter leaked after runner stop"
 fi
+for namespace in "${RUNNER_NAMESPACES[@]}"; do
+  if sudo iptables-save -t raw \
+    | grep -F -- "$namespace" >/dev/null; then
+    fail "IPv4 source guard leaked after runner stop: $namespace"
+  fi
+done
 cleanup_submit_pid "$SUBMIT_PID"
 SUBMIT_PID=""
 trap - EXIT

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -142,6 +142,248 @@ done
 [ "$DNS_READINESS_LOGGED" = true ] \
   || fail "runner did not activate namespace DNS readiness"
 
+# Inspect the rules while the prewarmed namespace pool is fully idle. Matching
+# by this runner's unique proxy and DNS ports avoids parallel CI runners on the
+# host, and running before local submit avoids holding a Firecracker VM during
+# the source-identity probe.
+PROXY_PORT=""
+DNS_PORT=""
+for _ in $(seq 1 30); do
+  if sudo jq -e '.proxy_port != null and .dns_port != null' \
+    "$RUNNER_DIR/status.json" >/dev/null 2>&1; then
+    PROXY_PORT=$(sudo jq -r '.proxy_port' "$RUNNER_DIR/status.json")
+    DNS_PORT=$(sudo jq -r '.dns_port' "$RUNNER_DIR/status.json")
+    break
+  fi
+  sleep 1
+done
+[ -n "$PROXY_PORT" ] || fail "proxy port missing from runner status"
+[ -n "$DNS_PORT" ] || fail "DNS port missing from runner status"
+
+DNS_LISTENERS=$(sudo ss -H -luntp \
+  | grep -E ":${DNS_PORT}[[:space:]]" || true)
+DNS_LISTENER_COUNT=$(printf '%s\n' "$DNS_LISTENERS" \
+  | grep -c . || true)
+[ "$DNS_LISTENER_COUNT" -ge 2 ] \
+  || fail "expected UDP/TCP dnsmasq wildcard listeners, found $DNS_LISTENER_COUNT"
+[ "$DNS_LISTENER_COUNT" -le 4 ] \
+  || fail "dnsmasq created per-address listeners: $DNS_LISTENERS"
+if printf '%s\n' "$DNS_LISTENERS" \
+  | grep -E '10\.200\.|%vm0-ve-' >/dev/null; then
+  fail "dnsmasq listener set contains VM interface addresses: $DNS_LISTENERS"
+fi
+
+NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
+FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
+RAW_RULES=$(sudo iptables-save -t raw) || fail "failed to read raw rules"
+
+PROXY_RULES=$(printf '%s\n' "$NAT_RULES" \
+  | grep -E -- "--to-ports? ${PROXY_PORT}([[:space:]]|$)" || true)
+[ -n "$PROXY_RULES" ] || fail "generic TCP proxy rules not found"
+if printf '%s\n' "$PROXY_RULES" \
+  | grep -Fv -- "-m multiport ! --dports 53,853" >/dev/null; then
+  fail "generic TCP proxy rule does not exclude ports 53 and 853"
+fi
+
+DNS_TCP_RULES=$(printf '%s\n' "$NAT_RULES" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | grep -F -- "-p tcp" \
+  | grep -F -- "--dport 53" || true)
+[ -n "$DNS_TCP_RULES" ] || fail "TCP/53 dnsmasq redirect rule not found"
+
+printf '%s\n' "$FILTER_RULES" \
+  | grep -E -- "-A FORWARD .* -p tcp .*--dport 53 .* -j DROP" >/dev/null \
+  || fail "TCP/53 FORWARD drop rule not found"
+printf '%s\n' "$FILTER_RULES" \
+  | grep -E -- "-A FORWARD .* -p tcp .*--dport 853 .* -j DROP" >/dev/null \
+  || fail "TCP/853 FORWARD drop rule not found"
+
+# Verify that source IP is an identity only after the packet arrives on its
+# owning host veth. Then inject one namespace's peer IP through another veth
+# and prove the raw guard rejects it before the victim DNS rule can attribute it.
+mapfile -t RUNNER_NAMESPACES < <(
+  printf '%s\n' "$PROXY_RULES" \
+    | rule_values --comment \
+    | sort -u
+)
+RUNNER_NAMESPACE_COUNT=${#RUNNER_NAMESPACES[@]}
+[ "$RUNNER_NAMESPACE_COUNT" -ge 2 ] \
+  || fail "expected at least two runner namespaces, found $RUNNER_NAMESPACE_COUNT"
+
+ATTACKER_NS=${RUNNER_NAMESPACES[0]}
+VICTIM_NS=${RUNNER_NAMESPACES[1]}
+for namespace in "$ATTACKER_NS" "$VICTIM_NS"; do
+  NAMESPACE_PIDS=$(sudo ip netns pids "$namespace") \
+    || fail "failed to inspect namespace processes: $namespace"
+  [ -z "$NAMESPACE_PIDS" ] \
+    || fail "pre-submit namespace unexpectedly active: $namespace"
+done
+RUNNER_POOL_PREFIX="${ATTACKER_NS%-*}-"
+ATTACKER_IF=${ATTACKER_NS/vm0-ns-/vm0-ve-}
+VICTIM_IF=${VICTIM_NS/vm0-ns-/vm0-ve-}
+
+ATTACKER_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | head -n 1 || true)
+VICTIM_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | head -n 1 || true)
+[ -n "$ATTACKER_PROXY_RULE" ] || fail "attacker proxy rule not found"
+[ -n "$VICTIM_PROXY_RULE" ] || fail "victim proxy rule not found"
+
+ATTACKER_CIDR=$(rule_value "$ATTACKER_PROXY_RULE" -s)
+VICTIM_CIDR=$(rule_value "$VICTIM_PROXY_RULE" -s)
+[ "${ATTACKER_CIDR#*/}" = 32 ] \
+  || fail "attacker proxy source is not an exact /32: $ATTACKER_CIDR"
+[ "${VICTIM_CIDR#*/}" = 32 ] \
+  || fail "victim proxy source is not an exact /32: $VICTIM_CIDR"
+[ "$(rule_value "$ATTACKER_PROXY_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "attacker proxy rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$VICTIM_PROXY_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim proxy rule is not bound to $VICTIM_IF"
+ATTACKER_PEER=${ATTACKER_CIDR%/32}
+VICTIM_PEER=${VICTIM_CIDR%/32}
+
+ATTACKER_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+VICTIM_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+[ -n "$ATTACKER_GUARD_RULE" ] || fail "attacker source guard not found"
+[ -n "$VICTIM_GUARD_RULE" ] || fail "victim source guard not found"
+[ "$(rule_value "$ATTACKER_GUARD_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "attacker source guard is not bound to $ATTACKER_IF"
+[ "$(rule_value "$VICTIM_GUARD_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim source guard is not bound to $VICTIM_IF"
+printf '%s\n' "$ATTACKER_GUARD_RULE" \
+  | grep -F -- "! -s ${ATTACKER_CIDR}" >/dev/null \
+  || fail "attacker source guard does not reject non-peer sources"
+printf '%s\n' "$VICTIM_GUARD_RULE" \
+  | grep -F -- "! -s ${VICTIM_CIDR}" >/dev/null \
+  || fail "victim source guard does not reject non-peer sources"
+
+ATTACKER_MASQUERADE_RULE=$(printf '%s\n' "$NAT_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A POSTROUTING" \
+  | grep -F -- "-j MASQUERADE" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_MASQUERADE_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "host masquerade rule does not use the exact attacker peer"
+
+ATTACKER_OUTBOUND_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A FORWARD" \
+  | grep -F -- "-i ${ATTACKER_IF}" \
+  | grep -F -- "-j ACCEPT" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_OUTBOUND_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "outbound forwarding rule does not use the exact attacker peer"
+
+ATTACKER_RETURN_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A FORWARD" \
+  | grep -F -- "-o ${ATTACKER_IF}" \
+  | grep -F -- "-j ACCEPT" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_RETURN_RULE" -d)" = "$ATTACKER_CIDR" ] \
+  || fail "return forwarding rule does not use the exact attacker peer"
+
+ATTACKER_LOG_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "VM0:${ATTACKER_PEER}:" \
+  | grep -F -- "-j LOG" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_LOG_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "non-TCP log rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$ATTACKER_LOG_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "non-TCP log rule does not use the exact attacker peer"
+
+ATTACKER_DNS_DROP_RULE=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -i)" = "$ATTACKER_IF" ] \
+  || fail "DNS drop rule is not bound to $ATTACKER_IF"
+[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -s)" = "$ATTACKER_CIDR" ] \
+  || fail "DNS drop rule does not use the exact attacker peer"
+
+VICTIM_DNS_RULE=$(printf '%s\n' "$NAT_RULES" \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+[ "$(rule_value "$VICTIM_DNS_RULE" -i)" = "$VICTIM_IF" ] \
+  || fail "victim DNS redirect is not bound to $VICTIM_IF"
+[ "$(rule_value "$VICTIM_DNS_RULE" -s)" = "$VICTIM_CIDR" ] \
+  || fail "victim DNS redirect does not use the exact peer"
+
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_BEFORE=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+[ -n "$ATTACKER_GUARD_BEFORE" ] || fail "source guard counter missing"
+send_udp_dns_query "$ATTACKER_NS" "$ATTACKER_PEER"
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_AFTER_CONTROL=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+[ "$ATTACKER_GUARD_AFTER_CONTROL" -eq "$ATTACKER_GUARD_BEFORE" ] \
+  || fail "source guard rejected the namespace's assigned peer"
+
+VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+VICTIM_DNS_BEFORE=$(rule_packet_count "$VICTIM_DNS_COUNTED")
+[ -n "$VICTIM_DNS_BEFORE" ] || fail "victim DNS redirect counter missing"
+
+SPOOF_NS=$ATTACKER_NS
+SPOOF_IP=$VICTIM_PEER
+sudo ip -n "$SPOOF_NS" address add "${SPOOF_IP}/32" dev veth0 \
+  || fail "failed to add forged victim source to attacker namespace"
+send_udp_dns_query "$SPOOF_NS" "$SPOOF_IP"
+
+ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
+  | grep -F -- "$ATTACKER_NS" \
+  | grep -F -- "-A PREROUTING" \
+  | grep -F -- "-j DROP" \
+  | head -n 1 || true)
+ATTACKER_GUARD_AFTER_SPOOF=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
+VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
+  | grep -F -- "$VICTIM_NS" \
+  | grep -F -- "-p udp" \
+  | grep -F -- "--dport 53" \
+  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+  | head -n 1 || true)
+VICTIM_DNS_AFTER=$(rule_packet_count "$VICTIM_DNS_COUNTED")
+cleanup_spoof_address
+
+[ "$ATTACKER_GUARD_AFTER_SPOOF" -gt "$ATTACKER_GUARD_AFTER_CONTROL" ] \
+  || fail "source guard did not reject the forged victim source"
+[ "$VICTIM_DNS_AFTER" -eq "$VICTIM_DNS_BEFORE" ] \
+  || fail "forged source reached the victim DNS attribution rule"
+echo "PASS: source identity guard"
+
+DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
+  | grep -E -- "-A INPUT .*--dport ${DNS_PORT} .*--comment vm0-ns-[0-9a-f]{2}-dns.*-j REJECT" \
+  | sed -nE 's/.*--comment "?([^ " ]+)"?.*/\1/p' \
+  | head -n 1)
+[ -n "$DNS_FILTER_COMMENT" ] || fail "DNS INPUT filter comment missing"
+
 # Submit a long-running job in background (keeps sandbox alive during tests)
 echo "--- Submitting long-running job ---"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
@@ -389,241 +631,6 @@ OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "$TCP
 [ "$OUTPUT" = "TCP_DNS_OK=true" ] || fail "unexpected TCP DNS output: $OUTPUT"
 echo "  tcp: $OUTPUT"
 
-# Inspect the actual rules installed for this runner. Matching by its
-# unique proxy and DNS ports avoids parallel CI runners on the host.
-PROXY_PORT=$(sudo jq -r '.proxy_port // empty' "$RUNNER_DIR/status.json")
-DNS_PORT=$(sudo jq -r '.dns_port // empty' "$RUNNER_DIR/status.json")
-[ -n "$PROXY_PORT" ] || fail "proxy port missing from runner status"
-[ -n "$DNS_PORT" ] || fail "DNS port missing from runner status"
-
-DNS_LISTENERS=$(sudo ss -H -luntp \
-  | grep -E ":${DNS_PORT}[[:space:]]" || true)
-DNS_LISTENER_COUNT=$(printf '%s\n' "$DNS_LISTENERS" \
-  | grep -c . || true)
-[ "$DNS_LISTENER_COUNT" -ge 2 ] \
-  || fail "expected UDP/TCP dnsmasq wildcard listeners, found $DNS_LISTENER_COUNT"
-[ "$DNS_LISTENER_COUNT" -le 4 ] \
-  || fail "dnsmasq created per-address listeners: $DNS_LISTENERS"
-if printf '%s\n' "$DNS_LISTENERS" \
-  | grep -E '10\.200\.|%vm0-ve-' >/dev/null; then
-  fail "dnsmasq listener set contains VM interface addresses: $DNS_LISTENERS"
-fi
-
-NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
-FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
-RAW_RULES=$(sudo iptables-save -t raw) || fail "failed to read raw rules"
-
-PROXY_RULES=$(printf '%s\n' "$NAT_RULES" \
-  | grep -E -- "--to-ports? ${PROXY_PORT}([[:space:]]|$)" || true)
-[ -n "$PROXY_RULES" ] || fail "generic TCP proxy rules not found"
-if printf '%s\n' "$PROXY_RULES" \
-  | grep -Fv -- "-m multiport ! --dports 53,853" >/dev/null; then
-  fail "generic TCP proxy rule does not exclude ports 53 and 853"
-fi
-
-DNS_TCP_RULES=$(printf '%s\n' "$NAT_RULES" \
-  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
-  | grep -F -- "-p tcp" \
-  | grep -F -- "--dport 53" || true)
-[ -n "$DNS_TCP_RULES" ] || fail "TCP/53 dnsmasq redirect rule not found"
-
-printf '%s\n' "$FILTER_RULES" \
-  | grep -E -- "-A FORWARD .* -p tcp .*--dport 53 .* -j DROP" >/dev/null \
-  || fail "TCP/53 FORWARD drop rule not found"
-printf '%s\n' "$FILTER_RULES" \
-  | grep -E -- "-A FORWARD .* -p tcp .*--dport 853 .* -j DROP" >/dev/null \
-  || fail "TCP/853 FORWARD drop rule not found"
-
-# Verify that source IP is an identity only after the packet arrives on its
-# owning host veth. Then inject one namespace's peer IP through another veth
-# and prove the raw guard rejects it before the victim DNS rule can attribute it.
-mapfile -t RUNNER_NAMESPACES < <(
-  printf '%s\n' "$PROXY_RULES" \
-    | rule_values --comment \
-    | sort -u
-)
-RUNNER_NAMESPACE_COUNT=${#RUNNER_NAMESPACES[@]}
-[ "$RUNNER_NAMESPACE_COUNT" -ge 2 ] \
-  || fail "expected at least two runner namespaces, found $RUNNER_NAMESPACE_COUNT"
-
-IDLE_RUNNER_NAMESPACES=()
-for namespace in "${RUNNER_NAMESPACES[@]}"; do
-  NAMESPACE_PIDS=$(sudo ip netns pids "$namespace") \
-    || fail "failed to inspect namespace processes: $namespace"
-  if [ -z "$NAMESPACE_PIDS" ]; then
-    IDLE_RUNNER_NAMESPACES+=("$namespace")
-  fi
-done
-IDLE_RUNNER_NAMESPACE_COUNT=${#IDLE_RUNNER_NAMESPACES[@]}
-[ "$IDLE_RUNNER_NAMESPACE_COUNT" -ge 2 ] \
-  || fail "expected at least two idle runner namespaces, found $IDLE_RUNNER_NAMESPACE_COUNT"
-
-ATTACKER_NS=${IDLE_RUNNER_NAMESPACES[0]}
-VICTIM_NS=${IDLE_RUNNER_NAMESPACES[1]}
-ATTACKER_IF=${ATTACKER_NS/vm0-ns-/vm0-ve-}
-VICTIM_IF=${VICTIM_NS/vm0-ns-/vm0-ve-}
-
-ATTACKER_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | head -n 1 || true)
-VICTIM_PROXY_RULE=$(printf '%s\n' "$PROXY_RULES" \
-  | grep -F -- "$VICTIM_NS" \
-  | head -n 1 || true)
-[ -n "$ATTACKER_PROXY_RULE" ] || fail "attacker proxy rule not found"
-[ -n "$VICTIM_PROXY_RULE" ] || fail "victim proxy rule not found"
-
-ATTACKER_CIDR=$(rule_value "$ATTACKER_PROXY_RULE" -s)
-VICTIM_CIDR=$(rule_value "$VICTIM_PROXY_RULE" -s)
-[ "${ATTACKER_CIDR#*/}" = 32 ] \
-  || fail "attacker proxy source is not an exact /32: $ATTACKER_CIDR"
-[ "${VICTIM_CIDR#*/}" = 32 ] \
-  || fail "victim proxy source is not an exact /32: $VICTIM_CIDR"
-[ "$(rule_value "$ATTACKER_PROXY_RULE" -i)" = "$ATTACKER_IF" ] \
-  || fail "attacker proxy rule is not bound to $ATTACKER_IF"
-[ "$(rule_value "$VICTIM_PROXY_RULE" -i)" = "$VICTIM_IF" ] \
-  || fail "victim proxy rule is not bound to $VICTIM_IF"
-ATTACKER_PEER=${ATTACKER_CIDR%/32}
-VICTIM_PEER=${VICTIM_CIDR%/32}
-
-ATTACKER_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A PREROUTING" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-VICTIM_GUARD_RULE=$(printf '%s\n' "$RAW_RULES" \
-  | grep -F -- "$VICTIM_NS" \
-  | grep -F -- "-A PREROUTING" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-[ -n "$ATTACKER_GUARD_RULE" ] || fail "attacker source guard not found"
-[ -n "$VICTIM_GUARD_RULE" ] || fail "victim source guard not found"
-[ "$(rule_value "$ATTACKER_GUARD_RULE" -i)" = "$ATTACKER_IF" ] \
-  || fail "attacker source guard is not bound to $ATTACKER_IF"
-[ "$(rule_value "$VICTIM_GUARD_RULE" -i)" = "$VICTIM_IF" ] \
-  || fail "victim source guard is not bound to $VICTIM_IF"
-printf '%s\n' "$ATTACKER_GUARD_RULE" \
-  | grep -F -- "! -s ${ATTACKER_CIDR}" >/dev/null \
-  || fail "attacker source guard does not reject non-peer sources"
-printf '%s\n' "$VICTIM_GUARD_RULE" \
-  | grep -F -- "! -s ${VICTIM_CIDR}" >/dev/null \
-  || fail "victim source guard does not reject non-peer sources"
-
-ATTACKER_MASQUERADE_RULE=$(printf '%s\n' "$NAT_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A POSTROUTING" \
-  | grep -F -- "-j MASQUERADE" \
-  | head -n 1 || true)
-[ "$(rule_value "$ATTACKER_MASQUERADE_RULE" -s)" = "$ATTACKER_CIDR" ] \
-  || fail "host masquerade rule does not use the exact attacker peer"
-
-ATTACKER_OUTBOUND_RULE=$(printf '%s\n' "$FILTER_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A FORWARD" \
-  | grep -F -- "-i ${ATTACKER_IF}" \
-  | grep -F -- "-j ACCEPT" \
-  | head -n 1 || true)
-[ "$(rule_value "$ATTACKER_OUTBOUND_RULE" -s)" = "$ATTACKER_CIDR" ] \
-  || fail "outbound forwarding rule does not use the exact attacker peer"
-
-ATTACKER_RETURN_RULE=$(printf '%s\n' "$FILTER_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A FORWARD" \
-  | grep -F -- "-o ${ATTACKER_IF}" \
-  | grep -F -- "-j ACCEPT" \
-  | head -n 1 || true)
-[ "$(rule_value "$ATTACKER_RETURN_RULE" -d)" = "$ATTACKER_CIDR" ] \
-  || fail "return forwarding rule does not use the exact attacker peer"
-
-ATTACKER_LOG_RULE=$(printf '%s\n' "$FILTER_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "VM0:${ATTACKER_PEER}:" \
-  | grep -F -- "-j LOG" \
-  | head -n 1 || true)
-[ "$(rule_value "$ATTACKER_LOG_RULE" -i)" = "$ATTACKER_IF" ] \
-  || fail "non-TCP log rule is not bound to $ATTACKER_IF"
-[ "$(rule_value "$ATTACKER_LOG_RULE" -s)" = "$ATTACKER_CIDR" ] \
-  || fail "non-TCP log rule does not use the exact attacker peer"
-
-ATTACKER_DNS_DROP_RULE=$(printf '%s\n' "$FILTER_RULES" \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-p udp" \
-  | grep -F -- "--dport 53" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -i)" = "$ATTACKER_IF" ] \
-  || fail "DNS drop rule is not bound to $ATTACKER_IF"
-[ "$(rule_value "$ATTACKER_DNS_DROP_RULE" -s)" = "$ATTACKER_CIDR" ] \
-  || fail "DNS drop rule does not use the exact attacker peer"
-
-VICTIM_DNS_RULE=$(printf '%s\n' "$NAT_RULES" \
-  | grep -F -- "$VICTIM_NS" \
-  | grep -F -- "-p udp" \
-  | grep -F -- "--dport 53" \
-  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
-  | head -n 1 || true)
-[ "$(rule_value "$VICTIM_DNS_RULE" -i)" = "$VICTIM_IF" ] \
-  || fail "victim DNS redirect is not bound to $VICTIM_IF"
-[ "$(rule_value "$VICTIM_DNS_RULE" -s)" = "$VICTIM_CIDR" ] \
-  || fail "victim DNS redirect does not use the exact peer"
-
-ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A PREROUTING" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-ATTACKER_GUARD_BEFORE=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
-[ -n "$ATTACKER_GUARD_BEFORE" ] || fail "source guard counter missing"
-send_udp_dns_query "$ATTACKER_NS" "$ATTACKER_PEER"
-ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A PREROUTING" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-ATTACKER_GUARD_AFTER_CONTROL=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
-[ "$ATTACKER_GUARD_AFTER_CONTROL" -eq "$ATTACKER_GUARD_BEFORE" ] \
-  || fail "source guard rejected the namespace's assigned peer"
-
-VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
-  | grep -F -- "$VICTIM_NS" \
-  | grep -F -- "-p udp" \
-  | grep -F -- "--dport 53" \
-  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
-  | head -n 1 || true)
-VICTIM_DNS_BEFORE=$(rule_packet_count "$VICTIM_DNS_COUNTED")
-[ -n "$VICTIM_DNS_BEFORE" ] || fail "victim DNS redirect counter missing"
-
-SPOOF_NS=$ATTACKER_NS
-SPOOF_IP=$VICTIM_PEER
-sudo ip -n "$SPOOF_NS" address add "${SPOOF_IP}/32" dev veth0 \
-  || fail "failed to add forged victim source to attacker namespace"
-send_udp_dns_query "$SPOOF_NS" "$SPOOF_IP"
-
-ATTACKER_GUARD_COUNTED=$(sudo iptables-save -c -t raw \
-  | grep -F -- "$ATTACKER_NS" \
-  | grep -F -- "-A PREROUTING" \
-  | grep -F -- "-j DROP" \
-  | head -n 1 || true)
-ATTACKER_GUARD_AFTER_SPOOF=$(rule_packet_count "$ATTACKER_GUARD_COUNTED")
-VICTIM_DNS_COUNTED=$(sudo iptables-save -c -t nat \
-  | grep -F -- "$VICTIM_NS" \
-  | grep -F -- "-p udp" \
-  | grep -F -- "--dport 53" \
-  | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
-  | head -n 1 || true)
-VICTIM_DNS_AFTER=$(rule_packet_count "$VICTIM_DNS_COUNTED")
-cleanup_spoof_address
-
-[ "$ATTACKER_GUARD_AFTER_SPOOF" -gt "$ATTACKER_GUARD_AFTER_CONTROL" ] \
-  || fail "source guard did not reject the forged victim source"
-[ "$VICTIM_DNS_AFTER" -eq "$VICTIM_DNS_BEFORE" ] \
-  || fail "forged source reached the victim DNS attribution rule"
-echo "  source identity: forged $VICTIM_PEER rejected on $ATTACKER_IF"
-
-DNS_FILTER_COMMENT=$(printf '%s\n' "$FILTER_RULES" \
-  | grep -E -- "-A INPUT .*--dport ${DNS_PORT} .*--comment vm0-ns-[0-9a-f]{2}-dns.*-j REJECT" \
-  | sed -nE 's/.*--comment "?([^ " ]+)"?.*/\1/p' \
-  | head -n 1)
-[ -n "$DNS_FILTER_COMMENT" ] || fail "DNS INPUT filter comment missing"
 
 # Default dnsmasq wildcard sockets must still reject requests that
 # arrive through a non-runner interface before a TCP handshake or
@@ -734,12 +741,12 @@ if sudo ip6tables-save -t filter \
   | grep -F -- "--comment ${DNS_FILTER_COMMENT}" >/dev/null; then
   fail "IPv6 DNS INPUT filter leaked after runner stop"
 fi
-for namespace in "${RUNNER_NAMESPACES[@]}"; do
-  if sudo iptables-save -t raw \
-    | grep -F -- "$namespace" >/dev/null; then
-    fail "IPv4 source guard leaked after runner stop: $namespace"
-  fi
-done
+RAW_RULES_AFTER_STOP=$(sudo iptables-save -t raw) \
+  || fail "failed to read raw rules after runner stop"
+LEAKED_SOURCE_GUARDS=$(printf '%s\n' "$RAW_RULES_AFTER_STOP" \
+  | grep -F -- "$RUNNER_POOL_PREFIX" || true)
+[ -z "$LEAKED_SOURCE_GUARDS" ] \
+  || fail "IPv4 source guards leaked after runner stop: $LEAKED_SOURCE_GUARDS"
 cleanup_submit_pid "$SUBMIT_PID"
 SUBMIT_PID=""
 trap - EXIT

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -304,14 +304,33 @@ async fn setup_host_iptables(
     peer_ip: &str,
     default_iface: &str,
 ) -> Result<()> {
-    let src = format!("{peer_ip}/30");
+    let peer = format!("{peer_ip}/32");
+    exec_iptables(&[
+        "-t",
+        "raw",
+        "-I",
+        "PREROUTING",
+        "1",
+        "-i",
+        host_device,
+        "!",
+        "-s",
+        &peer,
+        "-m",
+        "comment",
+        "--comment",
+        name,
+        "-j",
+        "DROP",
+    ])
+    .await?;
     exec_iptables(&[
         "-t",
         "nat",
         "-A",
         "POSTROUTING",
         "-s",
-        &src,
+        &peer,
         "-o",
         default_iface,
         "-j",
@@ -327,6 +346,8 @@ async fn setup_host_iptables(
         "FORWARD",
         "-i",
         host_device,
+        "-s",
+        &peer,
         "-o",
         default_iface,
         "-j",
@@ -344,6 +365,8 @@ async fn setup_host_iptables(
         default_iface,
         "-o",
         host_device,
+        "-d",
+        &peer,
         "-m",
         "state",
         "--state",
@@ -368,13 +391,25 @@ async fn setup_host_iptables(
 /// proxy, all TCP traffic keeps the existing mitmproxy behavior.
 async fn add_proxy_redirect_rule(
     name: &str,
+    host_device: &str,
     peer_ip: &str,
     proxy_port: u16,
     dns_proxy_enabled: bool,
 ) -> Result<()> {
-    let src = format!("{peer_ip}/30");
+    let src = format!("{peer_ip}/32");
     let port_str = proxy_port.to_string();
-    let mut args: Vec<&str> = vec!["-t", "nat", "-A", "PREROUTING", "-s", &src, "-p", "tcp"];
+    let mut args: Vec<&str> = vec![
+        "-t",
+        "nat",
+        "-A",
+        "PREROUTING",
+        "-i",
+        host_device,
+        "-s",
+        &src,
+        "-p",
+        "tcp",
+    ];
     if dns_proxy_enabled {
         args.extend(["-m", "multiport", "!", "--dports", "53,853"]);
     }
@@ -402,13 +437,15 @@ async fn add_proxy_redirect_rule(
 /// the ACCEPT rules from [`setup_host_iptables`] are already in the chain.
 /// LOG is a non-terminating target (packet continues to the next rule),
 /// so it must come before ACCEPT to fire.
-async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
-    let src = format!("{peer_ip}/30");
+async fn add_non_tcp_log_rule(name: &str, host_device: &str, peer_ip: &str) -> Result<()> {
+    let src = format!("{peer_ip}/32");
     let prefix = format!("VM0:{peer_ip}:");
     exec_iptables(&[
         "-I",
         "FORWARD",
         "1",
+        "-i",
+        host_device,
         "-s",
         &src,
         "!",
@@ -442,8 +479,13 @@ async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
 /// preserving the original source IP (peer veth) for per-VM log routing. TCP
 /// support covers explicit DNS-over-TCP and fallback after truncated UDP
 /// responses.
-async fn add_dns_redirect_rules(name: &str, peer_ip: &str, dns_port: u16) -> Result<()> {
-    let src = format!("{peer_ip}/30");
+async fn add_dns_redirect_rules(
+    name: &str,
+    host_device: &str,
+    peer_ip: &str,
+    dns_port: u16,
+) -> Result<()> {
+    let src = format!("{peer_ip}/32");
     let port_str = dns_port.to_string();
     for protocol in ["udp", "tcp"] {
         exec_iptables(&[
@@ -451,6 +493,8 @@ async fn add_dns_redirect_rules(name: &str, peer_ip: &str, dns_port: u16) -> Res
             "nat",
             "-A",
             "PREROUTING",
+            "-i",
+            host_device,
             "-s",
             &src,
             "-p",
@@ -475,13 +519,15 @@ async fn add_dns_redirect_rules(name: &str, peer_ip: &str, dns_port: u16) -> Res
 ///
 /// Blocks UDP/TCP 53 and TCP 853 (DNS over TLS) in FORWARD chain.
 /// DNS over HTTPS (TCP 443) is handled by mitmproxy at HTTP level.
-async fn add_dns_drop_rules(name: &str, peer_ip: &str) -> Result<()> {
-    let src = format!("{peer_ip}/30");
+async fn add_dns_drop_rules(name: &str, host_device: &str, peer_ip: &str) -> Result<()> {
+    let src = format!("{peer_ip}/32");
     for (protocol, port) in [("udp", "53"), ("tcp", "53"), ("tcp", "853")] {
         exec_iptables(&[
             "-I",
             "FORWARD",
             "1",
+            "-i",
+            host_device,
             "-s",
             &src,
             "-p",
@@ -514,11 +560,13 @@ pub(super) async fn get_default_interface() -> Result<String> {
 
 /// Delete IPv4 iptables rules that contain `comment`.
 async fn delete_iptables_rules_by_comment(comment: &str) -> NamespaceDeleteOutcome {
-    let (nat, filter) = tokio::join!(
+    let (raw, nat, filter) = tokio::join!(
+        delete_firewall_rules_from_table("iptables", "iptables-save", "raw", comment),
         delete_firewall_rules_from_table("iptables", "iptables-save", "nat", comment),
         delete_firewall_rules_from_table("iptables", "iptables-save", "filter", comment),
     );
-    if matches!(nat, NamespaceDeleteOutcome::Deleted)
+    if matches!(raw, NamespaceDeleteOutcome::Deleted)
+        && matches!(nat, NamespaceDeleteOutcome::Deleted)
         && matches!(filter, NamespaceDeleteOutcome::Deleted)
     {
         NamespaceDeleteOutcome::Deleted
@@ -747,26 +795,33 @@ pub(super) async fn create_single_namespace(
     match result {
         Ok(()) => {
             if let Some(port) = proxy_port {
-                if let Err(e) =
-                    add_proxy_redirect_rule(&ns_name, &peer_ip, port, dns_port.is_some()).await
+                if let Err(e) = add_proxy_redirect_rule(
+                    &ns_name,
+                    &host_device,
+                    &peer_ip,
+                    port,
+                    dns_port.is_some(),
+                )
+                .await
                 {
                     error!(name = %ns_name, error = %e, "failed to add proxy rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);
                 }
-                if let Err(e) = add_non_tcp_log_rule(&ns_name, &peer_ip).await {
+                if let Err(e) = add_non_tcp_log_rule(&ns_name, &host_device, &peer_ip).await {
                     error!(name = %ns_name, error = %e, "failed to add non-TCP log rule, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);
                 }
             }
             if let Some(port) = dns_port {
-                if let Err(e) = add_dns_redirect_rules(&ns_name, &peer_ip, port).await {
+                if let Err(e) = add_dns_redirect_rules(&ns_name, &host_device, &peer_ip, port).await
+                {
                     error!(name = %ns_name, error = %e, "failed to add DNS redirect rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);
                 }
-                if let Err(e) = add_dns_drop_rules(&ns_name, &peer_ip).await {
+                if let Err(e) = add_dns_drop_rules(&ns_name, &host_device, &peer_ip).await {
                     error!(name = %ns_name, error = %e, "failed to add DNS drop rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -297,7 +297,11 @@ async fn setup_namespace_routing(
     Ok(())
 }
 
-/// Add host-side iptables rules for forwarding (connectivity only, no proxy).
+/// Add host-side source validation and forwarding rules.
+///
+/// The raw PREROUTING guard establishes the namespace's peer IP as a trusted
+/// identity before conntrack and NAT redirects can attribute the packet. This
+/// must remain independent of host reverse-path-filter configuration.
 async fn setup_host_iptables(
     name: &str,
     host_device: &str,


### PR DESCRIPTION
## Summary

- reject packets at each host veth in `raw/PREROUTING` unless their source is that namespace's exact peer IPv4 address
- bind proxy, DNS, logging, NAT, and forwarding rules to exact peer addresses and owning interfaces
- include raw-table rules in rollback, normal cleanup, pool cleanup, and orphan reconciliation
- extend the metal runner behavior test to inject another namespace's peer source and verify it is dropped before victim attribution
- run the spoof probe against idle prewarmed namespaces and isolate local-cancel retries from stale queue state

## Security model

The host veth is now the trusted identity boundary. Downstream proxy and network-log components may continue using the observed peer IP because packets with a different source are rejected before conntrack and NAT redirect. This does not depend on host `rp_filter` configuration.

## Exclusions

- no proxy registry, credential, queue, API, or persisted-state protocol changes
- no broad namespace SNAT behavior change
- no IPv6 policy redesign

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo doc --workspace --all-features --no-deps --locked`
- `cargo test -p sandbox-fc --all-features --locked` (710 passed)
- `cargo test -p runner --all-features --locked --quiet` (2722 passed; 11 existing ignored fixtures)
- `bash -n .github/scripts/runner-behavior-exec.sh`
- `shellcheck .github/scripts/runner-behavior-exec.sh`
- `bash -n .github/scripts/runner-behavior-cancel.sh`
- `shellcheck .github/scripts/runner-behavior-cancel.sh`
- local privileged netns/veth probe: legitimate-source guard counter stayed at 0; forged-source counter increased to 1
- nft-backed iptables translation and `iptables-save -c` serialization verified for the raw guard

Closes #21765
