### PR TITLE
fix(runner): extend cancel terminal grace for containment

### DIFF
--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -66,16 +66,17 @@ const JOB_TIMEOUT_EXIT_CODE: i32 = 124;
 /// Extra time for the host to receive guest timeout terminal proof.
 ///
 /// The guest process still receives `JOB_TIMEOUT` as its runtime budget. This
-/// grace covers vsock-guest's 5s stdout/stderr drain deadline after timeout
-/// process-tree kill, plus normal scheduling overhead before it sends the
-/// terminal `TimedOut` result.
+/// grace covers vsock-guest's bounded supervised-process cleanup, its 5s
+/// stdout/stderr drain deadline, and normal scheduling overhead before it sends
+/// the terminal `TimedOut` result.
 const JOB_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Maximum time to spend writing the guest cancel frame after a user cancel.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Grace period for the guest to report a terminal status after cancel is sent.
-/// This covers vsock-guest's 5s stdout/stderr drain deadline after it kills
-/// the cancelled process.
-const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(6);
+/// This covers vsock-guest's bounded supervised-process cleanup (500ms TERM
+/// grace, 1s cgroup.kill empty wait, and 250ms cgroup removal), its 5s
+/// stdout/stderr drain deadline, and normal scheduling overhead.
+const PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(8);
 const PROCESS_CANCEL_TIMEOUTS: ProcessCancelTimeouts = ProcessCancelTimeouts {
     write: PROCESS_CANCEL_WRITE_TIMEOUT,
     terminal_grace: PROCESS_CANCEL_TERMINAL_GRACE_TIMEOUT,


### PR DESCRIPTION
## Summary

- Extend the runner's cancel terminal grace from 6 seconds to 8 seconds.
- Account for the bounded supervised-process cleanup added by #21780 before the existing 5-second output-drain deadline.
- Update the job-timeout and cancel-timeout documentation to describe the full guest terminal path.

## Rationale

Supervised containment can spend up to 500 ms in the SIGTERM grace, 1 second waiting for `cgroup.kill` to empty the group, and 250 ms removing the cgroup. Combined with the existing 5-second stdout/stderr drain deadline, the previous 6-second host grace could expire before the guest returned a valid cancellation terminal result.

The 8-second bound covers the 6.75-second guest wait budget plus scheduling overhead. It does not add delay to successful cancellation; it only extends how long the runner waits when terminal proof is delayed.

## Scope

- No guest cleanup interval or cgroup behavior changes.
- No API, protocol, database, queue, or persisted-state changes.
- No feature switch.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner run_in_sandbox_returns_cancelled_when_terminal_grace_times_out`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- pre-commit Rust formatting, Clippy, and documentation checks
- `git diff --check`

Follow-up to #21780.
