### PR TITLE
refactor(mitm-addon): expose websocket test helper api

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -2,7 +2,6 @@
 
 import json
 from collections.abc import Callable
-from pathlib import Path
 
 import pytest
 from mitmproxy import http, websocket
@@ -11,25 +10,15 @@ from wsproto.frame_protocol import Opcode
 import deferred_callbacks
 import mitm_addon
 import response_streaming
-from tests.model_provider_flow_helpers import (
-    make_openai_responses_websocket_flow,
-    model_provider_usage_sources,
-)
 
 _WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
-_ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
+ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
 
 
-def _openai_model_websocket_flow(
-    tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
-) -> http.HTTPFlow:
-    return make_openai_responses_websocket_flow(real_flow, tmp_path)
-
-
-def _capture_deferred_websocket_trims(
+def capture_deferred_websocket_trims(
     monkeypatch: pytest.MonkeyPatch,
-) -> list[_ScheduledWebSocketTrim]:
-    scheduled: list[_ScheduledWebSocketTrim] = []
+) -> list[ScheduledWebSocketTrim]:
+    scheduled: list[ScheduledWebSocketTrim] = []
 
     def call_soon(callback: _WebSocketTrimCallback, flow: http.HTTPFlow) -> None:
         scheduled.append((callback, flow))
@@ -38,7 +27,7 @@ def _capture_deferred_websocket_trims(
     return scheduled
 
 
-def _run_deferred_websocket_trims(scheduled: list[_ScheduledWebSocketTrim]) -> None:
+def run_deferred_websocket_trims(scheduled: list[ScheduledWebSocketTrim]) -> None:
     pending = list(scheduled)
     scheduled.clear()
     for callback, flow in pending:
@@ -57,7 +46,7 @@ def _make_websocket_message(
     )
 
 
-def _append_websocket_message(
+def append_websocket_message(
     flow: http.HTTPFlow,
     *,
     from_client: bool,
@@ -72,7 +61,7 @@ def _append_websocket_message(
     return message
 
 
-def _openai_websocket_usage_frame(
+def openai_websocket_usage_frame(
     response_id: str,
     *,
     input_tokens: int = 10,
@@ -91,33 +80,29 @@ def _openai_websocket_usage_frame(
     ).encode()
 
 
-def _set_websocket_message(
+def set_websocket_message(
     flow: http.HTTPFlow,
     *,
     from_client: bool,
     content: bytes,
 ) -> None:
     flow.websocket = websocket.WebSocketData(messages=[])
-    _append_websocket_message(flow, from_client=from_client, content=content)
+    append_websocket_message(flow, from_client=from_client, content=content)
 
 
 def _assert_model_websocket_usage_started(flow: http.HTTPFlow) -> None:
     assert response_streaming.is_model_websocket_usage_enabled(flow)
 
 
-def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
+def feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
     _assert_model_websocket_usage_started(flow)
-    _set_websocket_message(flow, from_client=False, content=content)
+    set_websocket_message(flow, from_client=False, content=content)
     mitm_addon.websocket_message(flow)
 
 
-def _feed_websocket_server_text_message(flow: http.HTTPFlow, content: str) -> None:
+def feed_websocket_server_text_message(flow: http.HTTPFlow, content: str) -> None:
     _assert_model_websocket_usage_started(flow)
-    _set_websocket_message(flow, from_client=False, content=content.encode())
+    set_websocket_message(flow, from_client=False, content=content.encode())
     assert flow.websocket is not None
     object.__setattr__(flow.websocket.messages[-1], "content", content)
     mitm_addon.websocket_message(flow)
-
-
-def _model_websocket_usage_sources(flow: http.HTTPFlow) -> dict:
-    return model_provider_usage_sources(flow)

--- a/crates/runner/mitm-addon/tests/test_deferred_scheduler.py
+++ b/crates/runner/mitm-addon/tests/test_deferred_scheduler.py
@@ -9,10 +9,10 @@ from mitmproxy import tcp
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
 from tests.model_provider_websocket_helpers import (
-    _append_websocket_message,
-    _openai_model_websocket_flow,
-    _openai_websocket_usage_frame,
+    append_websocket_message,
+    openai_websocket_usage_frame,
 )
 
 
@@ -23,14 +23,14 @@ async def _run_ready_tasks() -> None:
 
 
 async def test_model_websocket_trim_uses_real_event_loop_scheduler(tmp_path, mitm_ctx, real_flow):
-    flow = _openai_model_websocket_flow(tmp_path, real_flow)
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
     mitm_addon.responseheaders(flow)
-    old_client = _append_websocket_message(flow, from_client=True, content=b"client-old")
-    old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
-    latest_server = _append_websocket_message(
+    old_client = append_websocket_message(flow, from_client=True, content=b"client-old")
+    old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
+    latest_server = append_websocket_message(
         flow,
         from_client=False,
-        content=_openai_websocket_usage_frame("resp_ws_latest"),
+        content=openai_websocket_usage_frame("resp_ws_latest"),
     )
     assert flow.websocket is not None
     messages = flow.websocket.messages
@@ -51,21 +51,21 @@ async def test_model_websocket_trim_coalesces_with_real_event_loop_scheduler(
     mitm_ctx,
     real_flow,
 ):
-    flow = _openai_model_websocket_flow(tmp_path, real_flow)
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
     mitm_addon.responseheaders(flow)
-    first_server = _append_websocket_message(
+    first_server = append_websocket_message(
         flow,
         from_client=False,
-        content=_openai_websocket_usage_frame("resp_ws_first"),
+        content=openai_websocket_usage_frame("resp_ws_first"),
     )
 
     with mitm_ctx():
         mitm_addon.websocket_message(flow)
 
-    latest_server = _append_websocket_message(
+    latest_server = append_websocket_message(
         flow,
         from_client=False,
-        content=_openai_websocket_usage_frame("resp_ws_latest"),
+        content=openai_websocket_usage_frame("resp_ws_latest"),
     )
     with mitm_ctx():
         mitm_addon.websocket_message(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
@@ -1,40 +1,31 @@
 """Tests for model-provider WebSocket usage metadata."""
 
 import json
-from collections.abc import Callable
-from pathlib import Path
 
 import pytest
-from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
 from tests.model_provider_websocket_helpers import (
-    _capture_deferred_websocket_trims,
-    _feed_websocket_server_message,
-    _openai_model_websocket_flow,
-    _ScheduledWebSocketTrim,
+    ScheduledWebSocketTrim,
+    capture_deferred_websocket_trims,
+    feed_websocket_server_message,
 )
 
 
 @pytest.fixture(autouse=True)
 def deferred_websocket_trim_scheduler(
     monkeypatch: pytest.MonkeyPatch,
-) -> list[_ScheduledWebSocketTrim]:
-    return _capture_deferred_websocket_trims(monkeypatch)
-
-
-def _openai_model_websocket_metadata_flow(
-    tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
-) -> http.HTTPFlow:
-    return _openai_model_websocket_flow(tmp_path, real_flow)
+) -> list[ScheduledWebSocketTrim]:
+    return capture_deferred_websocket_trims(monkeypatch)
 
 
 class TestModelProviderWebSocketUsageMetadata:
     """Tests for WebSocket usage metadata parsing without webhook reporting."""
 
     def test_model_websocket_malformed_frame_preserves_prior_usage(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "resp_ws_1",
@@ -43,7 +34,7 @@ class TestModelProviderWebSocketUsageMetadata:
             "tokens.output": 4,
         }
 
-        _feed_websocket_server_message(flow, b'{"type":"response.completed"')
+        feed_websocket_server_message(flow, b'{"type":"response.completed"')
 
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
             "message_id": "resp_ws_1",
@@ -55,12 +46,12 @@ class TestModelProviderWebSocketUsageMetadata:
     def test_model_websocket_ignores_invalid_frames_with_non_dict_usage_metadata(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = "invalid"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 
-        _feed_websocket_server_message(
+        feed_websocket_server_message(
             flow,
             json.dumps(
                 {
@@ -72,6 +63,6 @@ class TestModelProviderWebSocketUsageMetadata:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == "invalid"
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] == "invalid"
 
-        _feed_websocket_server_message(flow, b'{"type":"response.completed"')
+        feed_websocket_server_message(flow, b'{"type":"response.completed"')
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == "invalid"
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] == "invalid"

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -14,20 +14,20 @@ import mitm_addon
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
+    make_openai_responses_websocket_flow,
     make_openai_responses_websocket_request_flow,
     make_openai_responses_websocket_response_headers,
+    model_provider_usage_sources,
 )
 from tests.model_provider_websocket_helpers import (
-    _append_websocket_message,
-    _capture_deferred_websocket_trims,
-    _feed_websocket_server_message,
-    _feed_websocket_server_text_message,
-    _model_websocket_usage_sources,
-    _openai_model_websocket_flow,
-    _openai_websocket_usage_frame,
-    _run_deferred_websocket_trims,
-    _ScheduledWebSocketTrim,
-    _set_websocket_message,
+    ScheduledWebSocketTrim,
+    append_websocket_message,
+    capture_deferred_websocket_trims,
+    feed_websocket_server_message,
+    feed_websocket_server_text_message,
+    openai_websocket_usage_frame,
+    run_deferred_websocket_trims,
+    set_websocket_message,
 )
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
@@ -36,8 +36,8 @@ from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 @pytest.fixture(autouse=True)
 def deferred_websocket_trim_scheduler(
     monkeypatch: pytest.MonkeyPatch,
-) -> list[_ScheduledWebSocketTrim]:
-    return _capture_deferred_websocket_trims(monkeypatch)
+) -> list[ScheduledWebSocketTrim]:
+    return capture_deferred_websocket_trims(monkeypatch)
 
 
 def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
@@ -130,7 +130,7 @@ class TestModelProviderWebSocketUsage:
     def _run_websocket_messages_and_end(self, flow: http.HTTPFlow, *messages: bytes):
         with self._usage_webhook_api() as webhook:
             for message in messages:
-                _feed_websocket_server_message(flow, message)
+                feed_websocket_server_message(flow, message)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
         return webhook
@@ -144,7 +144,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_full_pipeline_model_websocket_reports_usage(self, tmp_path, real_flow):
         """Codex Responses WebSocket frames should bill like SSE events."""
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         assert flow.metadata["model_websocket_usage_enabled"] is True
         assert "model_json_usage_finish" not in flow.metadata
@@ -152,7 +152,7 @@ class TestModelProviderWebSocketUsage:
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-        _set_websocket_message(
+        set_websocket_message(
             flow,
             from_client=False,
             content=json.dumps(
@@ -180,7 +180,7 @@ class TestModelProviderWebSocketUsage:
         by_category = _sum_quantities_by_category(events)
         assert len(events) == len(by_category)
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert by_category == {
             "tokens.input": 25,
             "tokens.output": 20,
@@ -191,22 +191,22 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_missing_context_releases_positive_source(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with mitm_ctx(api_url="https://api.vm0.ai"):
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
-                _openai_websocket_usage_frame(
+                openai_websocket_usage_frame(
                     "resp_ws_missing_context",
                     input_tokens=10,
                     output_tokens=4,
                 ),
             )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         entries = read_jsonl_entries_after_flush(proxy_log)
         [entry] = [entry for entry in entries if entry.get("type") == "usage_underbilling"]
         [observation_entry] = [
@@ -228,21 +228,21 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_missing_api_url_releases_positive_source(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with mitm_ctx(api_url=""):
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
-                _openai_websocket_usage_frame(
+                openai_websocket_usage_frame(
                     "resp_ws_missing_api_url",
                     input_tokens=10,
                     output_tokens=4,
                 ),
             )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         [entry] = [
             entry
             for entry in read_jsonl_entries_after_flush(proxy_log)
@@ -253,62 +253,62 @@ class TestModelProviderWebSocketUsage:
         assert entry["missing_api_url"] is True
 
     def test_model_websocket_missing_context_releases_zero_only_source(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
-        _feed_websocket_server_message(
+        feed_websocket_server_message(
             flow,
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_zero_missing_context",
                 input_tokens=0,
                 output_tokens=0,
             ),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert not jsonl_exists_after_flush(proxy_log)
 
     def test_model_websocket_missing_api_url_releases_zero_only_source(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with mitm_ctx(api_url=""):
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
-                _openai_websocket_usage_frame(
+                openai_websocket_usage_frame(
                     "resp_ws_zero_missing_api_url",
                     input_tokens=0,
                     output_tokens=0,
                 ),
             )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert not jsonl_exists_after_flush(proxy_log)
 
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
                 output_tokens=4,
             ),
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_2",
                 input_tokens=3,
                 output_tokens=2,
             ),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 13,
             "tokens.output": 6,
@@ -321,24 +321,24 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_late_same_id_frame_after_release_is_duplicate(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=20,
                 output_tokens=12,
             ),
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
                 output_tokens=7,
             ),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 20,
             "tokens.output": 12,
@@ -351,7 +351,7 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_late_same_id_frame_can_add_new_category_after_release(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -378,7 +378,7 @@ class TestModelProviderWebSocketUsage:
             ).encode(),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 20,
             "tokens.output": 12,
@@ -391,7 +391,7 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_late_same_id_snapshot_does_not_mix_input_partition(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -446,12 +446,12 @@ class TestModelProviderWebSocketUsage:
         assert len({event["idempotencyKey"] for event in observation_events}) == 3
         assert observations_by_category == by_category
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
 
     def test_model_websocket_zero_frame_model_is_used_by_later_positive_frame(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -477,7 +477,7 @@ class TestModelProviderWebSocketUsage:
             ).encode(),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert {
             (event["provider"], event["category"]): event["quantity"]
             for event in webhook.usage_events()
@@ -494,26 +494,26 @@ class TestModelProviderWebSocketUsage:
         }
 
     def test_model_websocket_zero_frame_without_model_releases_source(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         with self._usage_webhook_api() as webhook:
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
                 _openai_websocket_zero_usage_frame("resp_ws_zero_no_model", model=None),
             )
             usage.flush_usage_events(trigger="test")
 
         assert webhook.request_count == 0
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
 
     def test_model_websocket_zero_frame_with_flow_model_releases_source(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-flow-model"
         mitm_addon.responseheaders(flow)
 
         with self._usage_webhook_api() as webhook:
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
                 _openai_websocket_zero_usage_frame(
                     "resp_ws_zero_flow_model", model="gpt-frame-model"
@@ -522,15 +522,15 @@ class TestModelProviderWebSocketUsage:
             usage.flush_usage_events(trigger="test")
 
         assert webhook.request_count == 0
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
 
     def test_model_websocket_zero_frames_are_bounded(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         with self._usage_webhook_api() as webhook:
             for index in range(70):
-                _feed_websocket_server_message(
+                feed_websocket_server_message(
                     flow,
                     _openai_websocket_zero_usage_frame(
                         f"resp_ws_zero_{index}", model=f"gpt-zero-{index}"
@@ -539,27 +539,27 @@ class TestModelProviderWebSocketUsage:
             usage.flush_usage_events(trigger="test")
 
         assert webhook.request_count == 0
-        usage_sources = _model_websocket_usage_sources(flow)
+        usage_sources = model_provider_usage_sources(flow)
         assert usage_sources == {}
 
     def test_model_websocket_flow_model_reports_later_positive_usage_without_zero_hint(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         with self._usage_webhook_api() as webhook:
             for index in range(70):
-                _feed_websocket_server_message(
+                feed_websocket_server_message(
                     flow,
                     _openai_websocket_zero_usage_frame(
                         f"resp_ws_zero_{index}", model=f"gpt-zero-{index}"
                     ),
                 )
 
-            assert "resp_ws_zero_0" not in _model_websocket_usage_sources(flow)
+            assert "resp_ws_zero_0" not in model_provider_usage_sources(flow)
 
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
                 json.dumps(
                     {
@@ -573,7 +573,7 @@ class TestModelProviderWebSocketUsage:
             )
             usage.flush_usage_events(trigger="test")
 
-        usage_sources = _model_websocket_usage_sources(flow)
+        usage_sources = model_provider_usage_sources(flow)
         assert "resp_ws_zero_0" not in usage_sources
         assert usage_sources == {}
         assert {
@@ -592,11 +592,11 @@ class TestModelProviderWebSocketUsage:
         }
 
     def test_model_websocket_text_frame_reports_usage(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         with self._usage_webhook_api() as webhook:
-            _feed_websocket_server_text_message(
+            feed_websocket_server_text_message(
                 flow,
                 json.dumps(
                     {
@@ -611,7 +611,7 @@ class TestModelProviderWebSocketUsage:
             )
             usage.flush_usage_events(trigger="test")
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert {
             (event["provider"], event["category"]): event["quantity"]
             for event in webhook.usage_events()
@@ -630,14 +630,14 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_valid_frame_replaces_invalid_usage_sources_metadata(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 
         with self._usage_webhook_api() as webhook:
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
-                _openai_websocket_usage_frame(
+                openai_websocket_usage_frame(
                     "resp_ws_invalid_sources",
                     input_tokens=10,
                     output_tokens=4,
@@ -645,7 +645,7 @@ class TestModelProviderWebSocketUsage:
             )
             usage.flush_usage_events(trigger="test")
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 10,
@@ -659,24 +659,24 @@ class TestModelProviderWebSocketUsage:
     def test_model_websocket_same_id_zero_after_positive_does_not_double_bill(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=20,
                 output_tokens=12,
             ),
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=0,
                 output_tokens=0,
             ),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 20,
             "tokens.output": 12,
@@ -689,18 +689,18 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_uses_context_model_for_response_ids(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
                 output_tokens=4,
                 model="gpt-5.5",
             ),
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_2",
                 input_tokens=3,
                 output_tokens=2,
@@ -708,7 +708,7 @@ class TestModelProviderWebSocketUsage:
             ),
         )
 
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_field_and_category(webhook.usage_events(), "provider") == {
             ("gpt-5.5", "tokens.input"): 13,
             ("gpt-5.5", "tokens.output"): 6,
@@ -723,7 +723,7 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_reports_id_and_missing_id_usage(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -737,7 +737,7 @@ class TestModelProviderWebSocketUsage:
                     },
                 }
             ).encode(),
-            _openai_websocket_usage_frame(
+            openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
                 output_tokens=4,
@@ -750,7 +750,7 @@ class TestModelProviderWebSocketUsage:
             "tokens.input": 7,
             "tokens.output": 1,
         }
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 17,
             "tokens.output": 5,
@@ -771,7 +771,7 @@ class TestModelProviderWebSocketUsage:
         real_flow,
         later_cache_write_tokens,
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         later_input_details = {"cached_tokens": 20}
         if later_cache_write_tokens is not None:
@@ -831,7 +831,7 @@ class TestModelProviderWebSocketUsage:
         }
         assert len(observation_events) == len(observations_by_category) == 4
         assert observations_by_category == by_category
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
 
     async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
         self,
@@ -877,7 +877,7 @@ class TestModelProviderWebSocketUsage:
                 flush_request_id="after-response",
             )
 
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
                 json.dumps(
                     {
@@ -1064,7 +1064,7 @@ class TestModelProviderWebSocketUsage:
                 flush_request_id="after-response",
             )
 
-            _feed_websocket_server_message(
+            feed_websocket_server_message(
                 flow,
                 json.dumps(
                     {
@@ -1107,7 +1107,7 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
@@ -1144,7 +1144,7 @@ class TestModelProviderWebSocketUsage:
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert by_category == {
             "tokens.input": 100,
             "tokens.output": 40,
@@ -1155,9 +1155,9 @@ class TestModelProviderWebSocketUsage:
         assert {event["provider"] for event in events} == {"gpt-5.5"}
 
     def test_model_websocket_ignores_client_messages(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        _set_websocket_message(
+        set_websocket_message(
             flow,
             from_client=True,
             content=json.dumps(
@@ -1176,22 +1176,22 @@ class TestModelProviderWebSocketUsage:
 
         assert webhook.request_count == 0
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
 
     def test_model_websocket_deferred_trim_keeps_latest_server_message(
         self,
         tmp_path,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        old_client = _append_websocket_message(flow, from_client=True, content=b"client-old")
-        old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
-        latest_server = _append_websocket_message(
+        old_client = append_websocket_message(flow, from_client=True, content=b"client-old")
+        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_server = append_websocket_message(
             flow,
             from_client=False,
-            content=_openai_websocket_usage_frame("resp_ws_latest"),
+            content=openai_websocket_usage_frame("resp_ws_latest"),
         )
         assert flow.websocket is not None
         messages = flow.websocket.messages
@@ -1201,7 +1201,7 @@ class TestModelProviderWebSocketUsage:
             usage.flush_usage_events(trigger="test")
 
         assert messages == [old_client, old_server, latest_server]
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 10,
             "tokens.output": 4,
@@ -1209,7 +1209,7 @@ class TestModelProviderWebSocketUsage:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
-        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 
         assert flow.websocket.messages is messages
         assert flow.websocket.messages == [latest_server]
@@ -1218,24 +1218,24 @@ class TestModelProviderWebSocketUsage:
         self,
         tmp_path,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
-        latest_client = _append_websocket_message(
+        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_client = append_websocket_message(
             flow,
             from_client=True,
-            content=_openai_websocket_usage_frame("resp_ws_client"),
+            content=openai_websocket_usage_frame("resp_ws_client"),
         )
 
         mitm_addon.websocket_message(flow)
 
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
-        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 
         assert flow.websocket is not None
         assert flow.websocket.messages == [latest_client]
@@ -1245,14 +1245,14 @@ class TestModelProviderWebSocketUsage:
         self,
         tmp_path,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        first_server = _append_websocket_message(
+        first_server = append_websocket_message(
             flow,
             from_client=False,
-            content=_openai_websocket_usage_frame(
+            content=openai_websocket_usage_frame(
                 "resp_ws_first",
                 input_tokens=1,
                 output_tokens=1,
@@ -1262,10 +1262,10 @@ class TestModelProviderWebSocketUsage:
             mitm_addon.websocket_message(flow)
             assert len(deferred_websocket_trim_scheduler) == 1
 
-            latest_server = _append_websocket_message(
+            latest_server = append_websocket_message(
                 flow,
                 from_client=False,
-                content=_openai_websocket_usage_frame("resp_ws_latest"),
+                content=openai_websocket_usage_frame("resp_ws_latest"),
             )
             mitm_addon.websocket_message(flow)
             usage.flush_usage_events(trigger="test")
@@ -1274,10 +1274,10 @@ class TestModelProviderWebSocketUsage:
         assert flow.websocket is not None
         assert flow.websocket.messages == [first_server, latest_server]
 
-        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 
         assert flow.websocket.messages == [latest_server]
-        assert _model_websocket_usage_sources(flow) == {}
+        assert model_provider_usage_sources(flow) == {}
         assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 11,
             "tokens.output": 5,
@@ -1287,12 +1287,12 @@ class TestModelProviderWebSocketUsage:
     def test_non_model_websocket_message_retention_is_unchanged(
         self,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
         flow = real_flow(with_response=False, host="example.com")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
-        first = _append_websocket_message(flow, from_client=True, content=b"client")
-        second = _append_websocket_message(flow, from_client=False, content=b"server")
+        first = append_websocket_message(flow, from_client=True, content=b"client")
+        second = append_websocket_message(flow, from_client=False, content=b"server")
 
         mitm_addon.websocket_message(flow)
 
@@ -1304,14 +1304,14 @@ class TestModelProviderWebSocketUsage:
         self,
         tmp_path,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        _append_websocket_message(
+        append_websocket_message(
             flow,
             from_client=False,
-            content=_openai_websocket_usage_frame("resp_ws_1"),
+            content=openai_websocket_usage_frame("resp_ws_1"),
         )
         with self._usage_webhook_api() as webhook:
             mitm_addon.websocket_message(flow)
@@ -1327,22 +1327,22 @@ class TestModelProviderWebSocketUsage:
         assert flow.websocket.messages == []
         assert "model_websocket_usage_enabled" not in flow.metadata
 
-        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
         assert flow.websocket.messages == []
 
     def test_model_websocket_error_clears_final_retained_message(
         self,
         tmp_path,
         real_flow,
-        deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         flow.error = Error("connection reset by peer")
-        _append_websocket_message(
+        append_websocket_message(
             flow,
             from_client=False,
-            content=_openai_websocket_usage_frame("resp_ws_1"),
+            content=openai_websocket_usage_frame("resp_ws_1"),
         )
         with self._usage_webhook_api() as webhook:
             mitm_addon.websocket_message(flow)
@@ -1358,5 +1358,5 @@ class TestModelProviderWebSocketUsage:
         assert flow.websocket.messages == []
         assert "model_websocket_usage_enabled" not in flow.metadata
 
-        _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
         assert flow.websocket.messages == []


### PR DESCRIPTION
## Summary

- expose the model-provider websocket helpers intentionally shared across test modules
- remove pass-through flow and usage-source wrappers in favor of the existing public helper APIs
- keep module-internal helper implementation details private

## Scope

This is a test-only refactor. It does not change production behavior, runtime interfaces, test scenarios, or Ruff configuration.

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright`
- `.venv/bin/pytest tests/test_model_provider_websocket_usage.py tests/test_model_provider_websocket_metadata.py tests/test_deferred_scheduler.py` (40 passed)
- `.venv/bin/pytest` (4,023 passed)

Closes #21788
