### PR TITLE
fix(platform): place artifacts below connectors in sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2259,12 +2259,13 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("shows workflows in the sidebar manage navigation", async () => {
+  it("orders artifacts after connectors in the manage navigation", async () => {
     prepareDefaultAgent();
 
     setupSidebarPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.Artifacts]: true },
     });
 
     const nav = await waitFor(() => {
@@ -2274,8 +2275,13 @@ describe("zero sidebar", () => {
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
     const workflows = within(nav).getByText("Workflows");
     const connectors = within(nav).getByText("Connectors");
+    const artifacts = within(nav).getByText("Artifacts");
     expect(
       workflows.compareDocumentPosition(connectors) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      connectors.compareDocumentPosition(artifacts) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(within(nav).queryByText("Automations")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -72,14 +72,6 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     icon: IconUsers as NavIcon,
   },
   {
-    id: "artifacts",
-    activeKeys: ["artifacts"],
-    pathname: "/artifacts",
-    label: "Artifacts",
-    icon: IconPackage as NavIcon,
-    featureGate: FeatureSwitchKey.Artifacts,
-  },
-  {
     id: "workflows",
     activeKeys: [
       "workflows",
@@ -98,6 +90,14 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     pathname: "/connectors",
     label: "Connectors",
     icon: IconPlug as NavIcon,
+  },
+  {
+    id: "artifacts",
+    activeKeys: ["artifacts"],
+    pathname: "/artifacts",
+    label: "Artifacts",
+    icon: IconPackage as NavIcon,
+    featureGate: FeatureSwitchKey.Artifacts,
   },
   {
     id: "activities",


### PR DESCRIPTION
## Summary

- move Artifacts below Connectors in the Manage sidebar navigation across expanded and collapsed variants
- extend the existing sidebar page test to enforce the Workflows → Connectors → Artifacts order

## Verification

- `pnpm exec prettier --write apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "orders artifacts after connectors in the manage navigation" --silent=passed-only`
- `pnpm knip --workspace @vm0/app`

Browser verification was not run because the repository PR workflow skips starting a local dev server unless explicitly requested.
