### PR TITLE
perf(computer-use): add adaptive desktop command polling

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -242,6 +242,33 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("uses the five-second cold interval for a newly started idle host", async () => {
+    vi.useFakeTimers();
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return jsonResponse({ status: "idle" });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(4_999);
+
+    expect(nextCalls).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(nextCalls).toBe(1);
+
+    await runtime.stop();
+  });
+
   it("clears command polling recovery when the next idle claim succeeds", async () => {
     vi.useFakeTimers();
     const heartbeat = deferred<Response>();
@@ -264,7 +291,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(runtime.getState()).toMatchObject({
       status: "recovering",
@@ -303,7 +330,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     heartbeat.resolve(new Response("{}", { status: 401 }));
     await vi.advanceTimersByTimeAsync(0);
@@ -340,7 +367,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(runtime.getState()).toMatchObject({
       status: "unauthenticated",
@@ -357,6 +384,10 @@ describe("ComputerUseHostRuntime", () => {
         },
       ],
     });
+
+    const requestCount = hostFetch.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(hostFetch).toHaveBeenCalledTimes(requestCount);
   });
 
   it("deactivates for restart when command completion rejects the host token", async () => {
@@ -383,7 +414,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(runtime.getState()).toMatchObject({
       status: "unauthenticated",
@@ -454,7 +485,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch, executeCommand });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     const [entry] = runtime.getState().localCommandLog;
     expect(entry).toMatchObject({
@@ -521,6 +552,9 @@ describe("ComputerUseHostRuntime", () => {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
       if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        if (nextCommandId === 25) {
+          return jsonResponse({ status: "idle" });
+        }
         nextCommandId++;
         return jsonResponse({
           status: "command",
@@ -539,8 +573,9 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
+    await vi.advanceTimersByTimeAsync(5_000);
     for (let index = 0; index < 25; index++) {
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersToNextTimerAsync();
     }
 
     const entries = runtime.getState().localCommandLog;
@@ -602,7 +637,7 @@ describe("ComputerUseHostRuntime", () => {
     });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(onCommandFailure).toHaveBeenCalledWith({ command, failure });
     expect(runtime.getState()).toMatchObject({
@@ -655,7 +690,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch, executeCommand });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(executeCommand).toHaveBeenCalledOnce();
     expect(completeCalls).toBe(0);
@@ -708,7 +743,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(completeCalls).toBe(1);
 
@@ -723,7 +758,7 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
-  it("keeps polling after command completion is already terminal on the server", async () => {
+  it("polls immediately when command completion is already terminal on the server", async () => {
     vi.useFakeTimers();
     let nextCalls = 0;
     let completeCalls = 0;
@@ -753,7 +788,8 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersToNextTimerAsync();
 
     expect(completeCalls).toBe(1);
     expect(runtime.getState()).toMatchObject({
@@ -763,13 +799,107 @@ describe("ComputerUseHostRuntime", () => {
     });
     expect(runtime.getState().lastCommandAt).toEqual(expect.any(String));
 
-    await vi.advanceTimersByTimeAsync(2_000);
-
     expect(nextCalls).toBe(2);
     expect(runtime.getState()).toMatchObject({
       status: "online",
       lastError: null,
     });
+
+    await runtime.stop();
+  });
+
+  it("moves through burst and active polling before returning to cold", async () => {
+    vi.useFakeTimers();
+    const startedAtMs = Date.parse("2026-06-10T10:00:00.000Z");
+    vi.setSystemTime(startedAtMs);
+    const claimOffsets: number[] = [];
+    let firstCommandClaimed = false;
+    let secondCommandClaimed = false;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        const offset = Date.now() - startedAtMs;
+        claimOffsets.push(offset);
+        if (offset === 5_000 && !firstCommandClaimed) {
+          firstCommandClaimed = true;
+          return jsonResponse({
+            status: "command",
+            command: {
+              id: "cmd-1",
+              kind: "app.state",
+              payload: { app: "Chrome" },
+            },
+          });
+        }
+        if (offset === 16_001 && !secondCommandClaimed) {
+          secondCommandClaimed = true;
+          return jsonResponse({
+            status: "command",
+            command: {
+              id: "cmd-2",
+              kind: "app.state",
+              payload: { app: "Chrome" },
+            },
+          });
+        }
+        return jsonResponse({ status: "idle" });
+      }
+      if (url.includes("/api/zero/computer-use/host/commands/cmd-")) {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(claimOffsets).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersToNextTimerAsync();
+    expect(claimOffsets).toEqual([5_000, 5_001]);
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(claimOffsets.at(-1)).toBe(5_001);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(claimOffsets.at(-1)).toBe(5_501);
+
+    await vi.advanceTimersByTimeAsync(9_500);
+    expect(claimOffsets.at(-1)).toBe(15_001);
+    const burstCallCount = claimOffsets.length;
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(claimOffsets).toHaveLength(burstCallCount);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersToNextTimerAsync();
+    expect(claimOffsets.slice(-2)).toEqual([16_001, 16_002]);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(claimOffsets.at(-1)).toBe(16_502);
+
+    await vi.advanceTimersByTimeAsync(9_500);
+    expect(claimOffsets.at(-1)).toBe(26_002);
+    const resetBurstCallCount = claimOffsets.length;
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(claimOffsets).toHaveLength(resetBurstCallCount);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(claimOffsets.at(-1)).toBe(27_002);
+
+    await vi.advanceTimersByTimeAsync(49_000);
+    expect(claimOffsets.at(-1)).toBe(76_002);
+    const activeCallCount = claimOffsets.length;
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(claimOffsets).toHaveLength(activeCallCount);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(claimOffsets.at(-1)).toBe(81_002);
 
     await runtime.stop();
   });
@@ -806,7 +936,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(completeCalls).toBe(1);
 
@@ -942,7 +1072,7 @@ describe("ComputerUseHostRuntime", () => {
     await vi.advanceTimersByTimeAsync(2_000);
 
     expect(heartbeatCalls).toBe(1);
-    expect(nextCalls).toBe(1);
+    expect(nextCalls).toBe(0);
 
     await vi.advanceTimersByTimeAsync(10_000);
 
@@ -988,7 +1118,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(nextCalls).toBe(1);
 
@@ -1016,7 +1146,7 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
-  it("backs off command claim failures and clears recovery after idle", async () => {
+  it("uses recovery backoff instead of burst cadence after a claim failure", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-10T10:00:00.000Z"));
     let nextCalls = 0;
@@ -1026,18 +1156,32 @@ describe("ComputerUseHostRuntime", () => {
       }
       if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
         nextCalls++;
-        return nextCalls === 1
+        if (nextCalls === 1) {
+          return jsonResponse({
+            status: "command",
+            command: {
+              id: "cmd-1",
+              kind: "app.state",
+              payload: { app: "Chrome" },
+            },
+          });
+        }
+        return nextCalls === 2
           ? new Response("{}", { status: 500 })
           : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
     });
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersToNextTimerAsync();
 
-    expect(nextCalls).toBe(1);
+    expect(nextCalls).toBe(2);
     expect(runtime.getState()).toMatchObject({
       status: "recovering",
       lastError: "Computer Use command claim failed: 500",
@@ -1048,9 +1192,12 @@ describe("ComputerUseHostRuntime", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(2_000);
-
+    await vi.advanceTimersByTimeAsync(1_999);
     expect(nextCalls).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(nextCalls).toBe(3);
     expect(runtime.getState()).toMatchObject({
       status: "online",
       lastError: null,
@@ -1082,7 +1229,7 @@ describe("ComputerUseHostRuntime", () => {
     const { runtime } = createRuntime({ hostFetch });
 
     await runtime.start();
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(runtime.getState()).toMatchObject({
       status: "recovering",
@@ -1090,7 +1237,7 @@ describe("ComputerUseHostRuntime", () => {
         phase: "command_poll",
         attempt: 1,
         retryDelayMs: 7_000,
-        nextRetryAt: "2026-06-10T10:00:09.000Z",
+        nextRetryAt: "2026-06-10T10:00:12.000Z",
       },
     });
 
@@ -1146,6 +1293,7 @@ describe("ComputerUseHostRuntime", () => {
   });
 
   it("stops the registered host through the host API", async () => {
+    vi.useFakeTimers();
     const hostFetch = vi.fn<ComputerUseHostFetch>(async () => {
       return jsonResponse({ ok: true, hostId: "host-1" });
     });
@@ -1168,6 +1316,9 @@ describe("ComputerUseHostRuntime", () => {
       hostId: null,
       lastError: null,
     });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(hostFetch).toHaveBeenCalledOnce();
   });
 
   it("reports heartbeat active host conflicts without retrying", async () => {

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -20,7 +20,12 @@ import {
 import { resolveComputerUseApiBaseUrl } from "./desktop-api-base-url";
 import type { DesktopClientHeaderInjector } from "./desktop-client-headers";
 
-const ONLINE_POLL_MS = 2_000;
+const HEARTBEAT_POLL_MS = 2_000;
+const COMMAND_COLD_POLL_MS = 5_000;
+const COMMAND_BURST_POLL_MS = 500;
+const COMMAND_BURST_WINDOW_MS = 10_000;
+const COMMAND_ACTIVE_POLL_MS = 1_000;
+const COMMAND_ACTIVE_WINDOW_MS = 60_000;
 const RECOVERY_RETRY_BASE_MS = 2_000;
 const RECOVERY_RETRY_MAX_MS = 60_000;
 const RECOVERY_RETRY_AFTER_MAX_MS = 5 * 60_000;
@@ -244,6 +249,8 @@ export class ComputerUseHostRuntime {
   private commandTimer: NodeJS.Timeout | null = null;
   private recoveryTimer: NodeJS.Timeout | null = null;
   private commandExecutionRunning = false;
+  private lastCommandActivityAtMs: number | null = null;
+  private lastCommandCompletionAtMs: number | null = null;
   private hostToken: string | null = null;
   private nextErrorLogId = 0;
   private state: ComputerUseHostRuntimeState = {
@@ -290,7 +297,7 @@ export class ComputerUseHostRuntime {
         return;
       }
       this.scheduleHeartbeat(nextDelay);
-      this.scheduleCommandPoll(nextDelay);
+      this.scheduleCommandPoll(this.commandPollDelayMs());
     } catch (error) {
       this.handleRuntimeFailure("start", error);
     }
@@ -301,6 +308,8 @@ export class ComputerUseHostRuntime {
     this.clearHeartbeatTimer();
     this.clearCommandTimer();
     this.clearRecoveryTimer();
+    this.lastCommandActivityAtMs = null;
+    this.lastCommandCompletionAtMs = null;
     const hostToken = this.hostToken;
     this.setState({
       status: "offline",
@@ -579,7 +588,7 @@ export class ComputerUseHostRuntime {
         return;
       }
       this.scheduleHeartbeat(nextDelay);
-      this.scheduleCommandPoll(nextDelay);
+      this.scheduleCommandPoll(this.commandPollDelayMs());
     } catch (error) {
       this.handleRuntimeFailure("start", error);
     }
@@ -592,7 +601,7 @@ export class ComputerUseHostRuntime {
         this.clearCommandTimer();
         return;
       }
-      this.scheduleHeartbeat(ONLINE_POLL_MS);
+      this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
       this.scheduleCommandPoll(0);
     } catch (error) {
       this.handleRuntimeFailure("heartbeat", error);
@@ -626,7 +635,7 @@ export class ComputerUseHostRuntime {
         this.clearCommandTimer();
         return;
       }
-      this.scheduleHeartbeat(ONLINE_POLL_MS);
+      this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
     } catch (error) {
       this.handleRuntimeFailure("heartbeat", error);
     }
@@ -638,8 +647,9 @@ export class ComputerUseHostRuntime {
     }
     this.commandExecutionRunning = true;
     let scheduleNextPoll = true;
+    let pollImmediately = false;
     try {
-      await this.claimAndExecuteCommand();
+      pollImmediately = (await this.claimAndExecuteCommand()) === "completed";
     } catch (error) {
       scheduleNextPoll =
         this.handleRuntimeFailure("command_poll", error) !==
@@ -652,9 +662,28 @@ export class ComputerUseHostRuntime {
         this.hostToken &&
         this.state.recovery?.phase !== "command_poll"
       ) {
-        this.scheduleCommandPoll(ONLINE_POLL_MS);
+        this.scheduleCommandPoll(
+          pollImmediately ? 0 : this.commandPollDelayMs(),
+        );
       }
     }
+  }
+
+  private commandPollDelayMs(): number {
+    const now = Date.now();
+    if (
+      this.lastCommandCompletionAtMs !== null &&
+      now - this.lastCommandCompletionAtMs < COMMAND_BURST_WINDOW_MS
+    ) {
+      return COMMAND_BURST_POLL_MS;
+    }
+    if (
+      this.lastCommandActivityAtMs !== null &&
+      now - this.lastCommandActivityAtMs < COMMAND_ACTIVE_WINDOW_MS
+    ) {
+      return COMMAND_ACTIVE_POLL_MS;
+    }
+    return COMMAND_COLD_POLL_MS;
   }
 
   private async startHost(): Promise<number | null> {
@@ -708,6 +737,8 @@ export class ComputerUseHostRuntime {
 
     const body = (await response.json()) as ComputerUseHostStartResponse;
     this.hostToken = body.hostToken;
+    this.lastCommandActivityAtMs = null;
+    this.lastCommandCompletionAtMs = null;
     this.clearRecoveryTimer();
     this.setState({
       status: "online",
@@ -716,7 +747,7 @@ export class ComputerUseHostRuntime {
       lastError: null,
       recovery: null,
     });
-    return ONLINE_POLL_MS;
+    return HEARTBEAT_POLL_MS;
   }
 
   private async hasAuthenticatedSession(): Promise<boolean> {
@@ -807,7 +838,7 @@ export class ComputerUseHostRuntime {
     return true;
   }
 
-  private async claimAndExecuteCommand(): Promise<void> {
+  private async claimAndExecuteCommand(): Promise<"idle" | "completed"> {
     const next = await this.runHostRequestWithTimeout({
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
@@ -826,7 +857,7 @@ export class ComputerUseHostRuntime {
     });
     if (next.status === 401) {
       this.deactivateInvalidHostToken("command_poll");
-      return;
+      return "idle";
     }
     if (!next.ok) {
       throw new ComputerUseHttpError(
@@ -837,13 +868,14 @@ export class ComputerUseHostRuntime {
     const body = (await next.json()) as ComputerUseHostNextResponse;
     if (body.status === "idle") {
       if (!this.running || !this.hostToken) {
-        return;
+        return "idle";
       }
       this.clearRecoveryState("command_poll");
-      return;
+      return "idle";
     }
 
     const startedAtMs = Date.now();
+    this.lastCommandActivityAtMs = startedAtMs;
     const startedAt = new Date(startedAtMs).toISOString();
     this.startLocalCommandLogEntry(body.command, startedAt);
 
@@ -869,18 +901,22 @@ export class ComputerUseHostRuntime {
       this.onCommandFailure({ command: body.command, failure: completed });
     }
     if (!this.running || !this.hostToken) {
-      return;
+      return "idle";
     }
     await this.completeCommandWithRetry(body.command.id, completed);
     if (!this.running || !this.hostToken) {
-      return;
+      return "idle";
     }
+    const commandActivityAtMs = Date.now();
+    this.lastCommandActivityAtMs = commandActivityAtMs;
+    this.lastCommandCompletionAtMs = commandActivityAtMs;
     this.setState({
       status: "online",
-      lastCommandAt: new Date().toISOString(),
+      lastCommandAt: new Date(commandActivityAtMs).toISOString(),
       lastError: null,
       recovery: null,
     });
+    return "completed";
   }
 
   private async completeCommandWithRetry(


### PR DESCRIPTION
## Summary

- replace the fixed two-second Desktop command poll with a fixed five-second cold interval
- poll immediately after an accepted command completion, then use a 500 ms burst for 10 seconds and a one-second active cadence through 60 seconds
- reset activity windows for consecutive commands while preserving heartbeat scheduling, retry backoff, `Retry-After`, timeouts, and shutdown behavior
- extend the Desktop host integration tests across cold, drain, burst, active, recovery, and timer cleanup paths

## User impact

Consecutive Computer Use actions are claimed faster while inactive Desktop hosts make 60% fewer command-poll requests. Cold polling intentionally uses a fixed five-second interval without jitter.

## Verification

- `pnpm exec prettier --check apps/desktop/src/computer-use-host.ts apps/desktop/src/computer-use-host.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts` (29 passed)

Closes #21841
