### PR TITLE
perf(api): lower postgres dns hedge delay and attribute budget misses

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -32,6 +32,8 @@ const ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
 const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
   "vm0.db.connection.lookup.duration_ms";
 const CONNECTION_LOOKUP_HEDGED_ATTRIBUTE = "vm0.db.connection.lookup.hedged";
+const CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE =
+  "vm0.db.connection.lookup.hedge_budget_unavailable";
 const CONNECTION_LOOKUP_SOURCE_ATTRIBUTE = "vm0.db.connection.lookup.source";
 const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
   "vm0.db.connection.socket_connect.duration_ms";
@@ -45,6 +47,7 @@ const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
 const CONNECTION_ATTRIBUTE_NAMES = [
   CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
   CONNECTION_LOOKUP_HEDGED_ATTRIBUTE,
+  CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE,
   CONNECTION_LOOKUP_SOURCE_ATTRIBUTE,
   CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE,
   CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
@@ -351,6 +354,9 @@ describe("instrumentPgPool", () => {
     const span = findSpan(statement);
     expectConnectionAcquisition(span);
     expect(span.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE]).toBeUndefined();
+    expect(
+      span.attributes[CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE],
+    ).toBeUndefined();
     expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBeUndefined();
   });
 
@@ -385,10 +391,13 @@ describe("instrumentPgPool", () => {
     expect(span.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe(
       "secondary",
     );
+    expect(
+      span.attributes[CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE],
+    ).toBeUndefined();
     expect(span.attributes[CONNECTION_ATTEMPT_COUNT_ATTRIBUTE]).toBe(1);
   });
 
-  it("bounds and releases secondary lookup capacity across connections", async () => {
+  it("attributes, bounds, and releases secondary lookup capacity", async () => {
     const controlledLookup = createControlledLookup(testAbortController.signal);
     const stream: PgStreamFactory = () => {
       return createInstrumentedPgStream({
@@ -422,12 +431,23 @@ describe("instrumentPgPool", () => {
     expect(resultB.rowCount).toBe(1);
     expect(connectedClientCount).toBe(2);
     expect(pool.totalCount).toBe(2);
+    const spanA = findSpan(statementA);
+    const spanB = findSpan(statementB);
+    expect(spanA.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe(
+      "secondary",
+    );
     expect(
-      findSpan(statementA).attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE],
-    ).toBe("secondary");
-    expect(
-      findSpan(statementB).attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE],
+      spanA.attributes[CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE],
     ).toBeUndefined();
+    expect(
+      spanB.attributes[CONNECTION_LOOKUP_HEDGED_ATTRIBUTE],
+    ).toBeUndefined();
+    expect(
+      spanB.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE],
+    ).toBeUndefined();
+    expect(
+      spanB.attributes[CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE],
+    ).toBeTruthy();
 
     const laterPool = createPool({}, stream);
     const laterStatement = "SELECT 117 AS hedge_after_release";
@@ -441,9 +461,15 @@ describe("instrumentPgPool", () => {
     expect(laterResult.rowCount).toBe(1);
     expect(controlledLookup.callCount).toBe(5);
     expect(laterPool.totalCount).toBe(1);
+    const laterSpan = findSpan(laterStatement);
+    expect(laterSpan.attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE]).toBe(
+      "secondary",
+    );
     expect(
-      findSpan(laterStatement).attributes[CONNECTION_LOOKUP_SOURCE_ATTRIBUTE],
-    ).toBe("secondary");
+      laterSpan.attributes[
+        CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE
+      ],
+    ).toBeUndefined();
   });
 
   it("keeps primary errors authoritative after a secondary starts", async () => {

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -21,6 +21,8 @@ const POOL_ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
 const CONNECTION_LOOKUP_DURATION_ATTRIBUTE =
   "vm0.db.connection.lookup.duration_ms";
 const CONNECTION_LOOKUP_HEDGED_ATTRIBUTE = "vm0.db.connection.lookup.hedged";
+const CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE =
+  "vm0.db.connection.lookup.hedge_budget_unavailable";
 const CONNECTION_LOOKUP_SOURCE_ATTRIBUTE = "vm0.db.connection.lookup.source";
 const CONNECTION_SOCKET_CONNECT_DURATION_ATTRIBUTE =
   "vm0.db.connection.socket_connect.duration_ms";
@@ -30,7 +32,7 @@ const CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE =
 const CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE =
   "vm0.db.connection.attempt_timeout_count";
 const CONNECTION_ADDRESS_FAMILY_ATTRIBUTE = "vm0.db.connection.address_family";
-const LOOKUP_HEDGE_DELAY_MS = 250;
+const LOOKUP_HEDGE_DELAY_MS = 150;
 
 type AnyArgs = readonly unknown[];
 type PgQuery = (...args: AnyArgs) => unknown;
@@ -142,12 +144,14 @@ function createHedgedLookup(
     function startSecondaryLookup(): void {
       hedgeDelayController = undefined;
       removePendingHedgeListeners();
-      if (
-        primarySettled ||
-        socket.destroyed ||
-        !socket.connecting ||
-        !claimSecondaryLookup()
-      ) {
+      if (primarySettled || socket.destroyed || !socket.connecting) {
+        return;
+      }
+      if (!claimSecondaryLookup()) {
+        querySpan?.setAttribute(
+          CONNECTION_LOOKUP_HEDGE_BUDGET_UNAVAILABLE_ATTRIBUTE,
+          true,
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary

- lower the fixed PostgreSQL DNS hedge delay from 250 ms to 150 ms based on the observed production lookup distribution
- attribute an otherwise eligible lookup when the single process-wide secondary budget is unavailable
- extend the real-pool integration test to cover budget misses, successful claims, and capacity release without additional socket or PostgreSQL work

## Safety and compatibility

- preserves the one-unresolved-secondary process cap and holds it until both uncancelable lookup callbacks settle
- preserves primary/secondary arbitration, Node lookup shapes, the original TLS hostname, and one socket/TCP/PostgreSQL client/query path
- adds only a sparse, fixed-cardinality query-span attribute; mixed API revisions remain compatible
- no schema, migration, persisted data, public API, queue payload, runner protocol, frontend contract, dependency, environment variable, or pool-policy change

## Validation

- `pnpm -F api exec vitest run src/lib/__tests__/db-instrumentation.test.ts` (12 passed)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- pre-commit hook: Prettier, full Knip, and repository TypeScript checks

## Rollout

After one API revision is stable, validate at least 10,000 new acquisitions and compare lookup/acquisition tails, hedge winners, budget-unavailable outcomes, TCP work, errors, and pool queueing. Filter analysis to revisions containing this change.

Closes #21837

Parent context: #21674
