### PR TITLE
docs(mitm-addon): clarify firewall api id resolution

### DIFF
--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -231,8 +231,13 @@ def resolve_firewall_entries(
     registry pass cannot mix catalog versions.
 
     Inline firewalls are deep-copied and receive per-entry `None` builtin cache
-    keys. API IDs are assigned after expansion and before returning. Callers must
-    validate `vm["runId"]` as a non-empty string before calling.
+    keys. Builtin catalog API IDs are discarded during expansion, so builtin
+    APIs receive generated run-scoped IDs. Inline APIs preserve an existing
+    non-empty string ID; absent, empty, or non-string IDs are generated.
+    Generated IDs use `<runId>:<index>`, where the zero-based index advances over
+    dictionary API entries in resolved firewall order, including entries whose
+    IDs are preserved. Callers must validate `vm["runId"]` as a non-empty string
+    before calling.
 
     Raises `FirewallEntryResolutionError` for malformed firewall lists or
     entries, unsupported entry kinds, unknown builtins, invalid builtin base URL

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1425,9 +1425,17 @@ class TestRegistryBuiltinCache:
     def test_inline_firewall_api_ids_preserve_custom_ids_and_global_positions(self, tmp_path):
         path = tmp_path / "registry.json"
         vm = inline_vm("run-inline")
-        apis = vm["firewalls"][0]["firewall"]["apis"]
-        apis[0]["id"] = "custom-api-id"
-        apis.append({**apis[0], "id": "", "base": "https://upload.example.com"})
+        first_api = vm["firewalls"][0]["firewall"]["apis"][0]
+        first_api["id"] = "custom-api-id"
+        vm["firewalls"].append(
+            {
+                "kind": "inline",
+                "firewall": {
+                    "name": "upload",
+                    "apis": [{**first_api, "id": "", "base": "https://upload.example.com"}],
+                },
+            }
+        )
         write_multi_vm_registry(path, {"10.200.0.1": vm})
 
         context = registry.get_vm_context("10.200.0.1", str(path))
@@ -1435,7 +1443,7 @@ class TestRegistryBuiltinCache:
         assert context is not None
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
-        assert [api["id"] for api in vm_info["firewalls"][0]["apis"]] == [
+        assert [firewall["apis"][0]["id"] for firewall in vm_info["firewalls"]] == [
             "custom-api-id",
             "run-inline:1",
         ]

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1422,10 +1422,12 @@ class TestRegistryBuiltinCache:
         assert second_compiled is not None
         assert _first_firewall_core(first_compiled) is _first_firewall_core(second_compiled)
 
-    def test_inline_firewall_api_ids_are_preserved(self, tmp_path):
+    def test_inline_firewall_api_ids_preserve_custom_ids_and_global_positions(self, tmp_path):
         path = tmp_path / "registry.json"
         vm = inline_vm("run-inline")
-        vm["firewalls"][0]["firewall"]["apis"][0]["id"] = "custom-api-id"
+        apis = vm["firewalls"][0]["firewall"]["apis"]
+        apis[0]["id"] = "custom-api-id"
+        apis.append({**apis[0], "id": "", "base": "https://upload.example.com"})
         write_multi_vm_registry(path, {"10.200.0.1": vm})
 
         context = registry.get_vm_context("10.200.0.1", str(path))
@@ -1433,4 +1435,7 @@ class TestRegistryBuiltinCache:
         assert context is not None
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["id"] == "custom-api-id"
+        assert [api["id"] for api in vm_info["firewalls"][0]["apis"]] == [
+            "custom-api-id",
+            "run-inline:1",
+        ]


### PR DESCRIPTION
## Summary

- document that builtin catalog API IDs are discarded and regenerated while non-empty inline IDs are preserved
- describe generated ID format and global resolved-order indexing, including positions occupied by preserved IDs
- strengthen the existing registry integration test across two inline firewalls to cover preservation and positional generation

## Scope

This PR does not change runtime assignment behavior, API or schema contracts, dependencies, migrations, or deployment behavior.

## Validation

- `ruff format --check .` (236 files formatted)
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_registry_builtin_cache.py -k 'api_ids' -v` (3 passed)
- `python3 -m pytest tests/ -q` (4,023 passed)

Closes #21787.
