### PR TITLE
refactor(mitm-addon): share sync and async loop traversal

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -739,7 +739,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             exit_aliases.update(orelse_aliases)
         self._replace_current_aliases(exit_aliases)
 
-    def visit_For(self, node: ast.For) -> None:
+    def _visit_for_statement(self, node: ast.For | ast.AsyncFor) -> None:
         self._record_metadata_merge_key_violations(node.iter)
         self.visit(node.iter)
         base_aliases = set(self._metadata_aliases)
@@ -755,21 +755,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         )
         self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_for_statement(node)
+
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
-        self._record_metadata_merge_key_violations(node.iter)
-        self.visit(node.iter)
-        base_aliases = set(self._metadata_aliases)
-        self._discard_alias_target(node.target)
-        body_aliases, _body_falls_through = self._visit_branch_body(
-            node.body, set(self._metadata_aliases)
-        )
-        loop_exit_aliases = base_aliases | body_aliases
-        orelse_aliases = (
-            self._visit_branch_body(node.orelse, loop_exit_aliases)[0]
-            if node.orelse
-            else loop_exit_aliases
-        )
-        self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
+        self._visit_for_statement(node)
 
     def visit_While(self, node: ast.While) -> None:
         self._record_metadata_merge_key_violations(node.test)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/for_statement_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/for_statement_flow.base.py.txt
@@ -1,0 +1,47 @@
+def sync_for_iterable():
+    for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
+        pass
+
+async def async_for_iterable():
+    async for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
+        pass
+
+def sync_for_target_rebinding():
+    target_meta = flow.metadata
+    for target_meta in rows:
+        target_meta["vm_run_id"] = "loop-item"
+    target_meta["vm_sandbox_token"] = "sandbox"
+
+async def async_for_target_rebinding():
+    target_meta = flow.metadata
+    async for target_meta in async_rows:
+        target_meta["vm_run_id"] = "loop-item"
+    target_meta["vm_sandbox_token"] = "sandbox"
+
+def sync_for_body_alias():
+    body_meta = {}
+    for item in rows:
+        body_meta = flow.metadata
+    body_meta["capture_body"] = True
+
+async def async_for_body_alias():
+    body_meta = {}
+    async for item in async_rows:
+        body_meta = flow.metadata
+    body_meta["capture_body"] = True
+
+def sync_for_else_alias():
+    else_meta = {}
+    for item in rows:
+        pass
+    else:
+        else_meta = flow.metadata
+    else_meta["original_url"] = "https://api.example.com"
+
+async def async_for_else_alias():
+    else_meta = {}
+    async for item in async_rows:
+        pass
+    else:
+        else_meta = flow.metadata
+    else_meta["original_url"] = "https://api.example.com"

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/for_statement_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/for_statement_flow.expected.txt
@@ -1,0 +1,8 @@
+for_statement_flow.py:2: use metadata_keys.FIREWALL_RULE_MATCH for flow.metadata access
+for_statement_flow.py:6: use metadata_keys.FIREWALL_RULE_MATCH for flow.metadata access
+for_statement_flow.py:13: use metadata_keys.VM_SANDBOX_AUTH_KEY for flow.metadata access
+for_statement_flow.py:19: use metadata_keys.VM_SANDBOX_AUTH_KEY for flow.metadata access
+for_statement_flow.py:25: use metadata_keys.CAPTURE_BODY for flow.metadata access
+for_statement_flow.py:31: use metadata_keys.CAPTURE_BODY for flow.metadata access
+for_statement_flow.py:39: use metadata_keys.ORIGINAL_URL for flow.metadata access
+for_statement_flow.py:47: use metadata_keys.ORIGINAL_URL for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -159,6 +159,17 @@ def test_registered_flow_metadata_guard_flags_composed_iterables(tmp_path):
     )
 
 
+def test_registered_flow_metadata_guard_tracks_for_statement_variants(tmp_path):
+    source_path = tmp_path / "for_statement_flow.py"
+    _write_python_source(source_path, "for_statement_flow.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "for_statement_flow.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_tracks_context_manager_exception_paths(tmp_path):
     source_path = tmp_path / "context_manager_flow.py"
     _write_python_source(source_path, "context_manager_flow.base.py.txt")


### PR DESCRIPTION
## Summary

- move synchronous and asynchronous `for` metadata-alias traversal into one typed visitor helper
- add paired entry-point fixtures for iterable checks, target rebinding, zero-iteration state, body propagation, and loop `else` propagation
- preserve every existing normalized metadata-linter diagnostic

## Scope

- behavior-preserving metadata-linter refactor and contract coverage only
- leaves `while`, `break`, `continue`, and broader loop control-flow precision unchanged
- no runtime addon behavior, API, schema, persisted data, dependency, deployment, or rollout changes

## Validation

- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_flow_metadata_key_contract.py -v` (14 passed)
- `./scripts/check-flow-metadata-keys.py`
- `python3 -m pytest tests/ -v` (4024 passed)
- `git diff --check`

Closes #21789
