### PR TITLE
feat: separate new chat action from unread filter in chat list section menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -647,8 +647,7 @@ describe("zero sidebar", () => {
     });
 
     openChatListMenu();
-    click(screen.getByRole("switch", { name: "Unread" }));
-    fireEvent.keyDown(document, { code: "Escape", key: "Escape" });
+    click(menuItemByText("Unread only"));
 
     await waitFor(() => {
       expect(unreadsRequests).toBeGreaterThan(0);
@@ -683,7 +682,8 @@ describe("zero sidebar", () => {
 
     openChatListMenu();
 
-    expect(screen.queryByRole("switch", { name: "Unread" })).toBeNull();
+    expect(queryMenuItemByText("Unread only")).toBeNull();
+    expect(queryMenuItemByText("All chats")).toBeNull();
   });
 
   it("keeps an event-sourced pinned current chat at the front of the pinned section", async () => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -8,6 +8,7 @@ import {
 import type { Computed } from "ccstate";
 import {
   IconPlus,
+  IconCheck,
   IconChevronRight,
   IconTrash,
   IconPencil,
@@ -29,8 +30,8 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@vm0/ui";
-import { Switch } from "@vm0/ui/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -907,14 +908,33 @@ function ChatThreadsTitle() {
                 New chat
               </DropdownMenuItem>
               {unreadFilterEnabled && (
-                <div className="flex h-9 items-center justify-between gap-3 px-2 text-sm text-popover-foreground">
-                  <span>Unread</span>
-                  <Switch
-                    checked={unreadOnly}
-                    onCheckedChange={toggleUnreadOnly}
-                    aria-label="Unread"
-                  />
-                </div>
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      toggleUnreadOnly(false);
+                    }}
+                  >
+                    <IconCheck
+                      size={16}
+                      stroke={2}
+                      className={`mr-2 ${unreadOnly ? "invisible" : ""}`}
+                    />
+                    All chats
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      toggleUnreadOnly(true);
+                    }}
+                  >
+                    <IconCheck
+                      size={16}
+                      stroke={2}
+                      className={`mr-2 ${unreadOnly ? "" : "invisible"}`}
+                    />
+                    Unread only
+                  </DropdownMenuItem>
+                </>
               )}
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## What & why

The **Chats with Zero** section overflow (`…`) menu mixed two different kinds of controls in one flat menu: a create **action** (New chat) sitting directly next to a filter **toggle** (an `Unread` switch). This read as logically inconsistent — an action and a persistent view-state don't belong in the same undivided group — and the switch left the two rows misaligned.

This restructures the menu so each control matches its semantics, while keeping everything in the single `…` menu:

- **New chat** stays the top action item.
- A **separator** splits the action from the view group.
- The unread filter becomes a **mutually-exclusive pair** — `All chats` / `Unread only` — with a leading check mark on the active view, replacing the in-menu `Switch` (a switch is not a menu-native control per Material/Apple menu guidance).

Because every row now shares the same leading icon column, the labels line up automatically.

## User-visible impact

- Opening the chat list `…` menu shows: `New chat` — divider — `✓ All chats` / `Unread only`.
- The active view carries the check mark; picking the other option moves it and re-filters the list. Selecting `Unread only` still expands the section.
- No `Sort` item (out of scope for this change).
- The view items only appear when the `AgentUnreadIndicators` feature switch is enabled (unchanged gating).

## Implementation

- `turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx`: replace the `Switch` row with a `DropdownMenuSeparator` + two `DropdownMenuItem`s driving the existing `chatThreadOnlyUnread$` state via `toggleUnreadOnly`. Drop the now-unused `Switch` import; add `IconCheck` and `DropdownMenuSeparator`.
- `__tests__/zero-sidebar.test.tsx`: update the two assertions that targeted the old switch to drive the new `Unread only` / `All chats` menu items.

## Verification

Relied on the PR pipeline for lint / type-check / tests (no local vitest or dev server run, per request). Design was reviewed and signed off visually before implementation.