### PR TITLE
feat: add slack-style three-column navigation behind a feature switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2280,4 +2280,49 @@ describe("zero sidebar", () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(within(nav).queryByText("Automations")).not.toBeInTheDocument();
   });
+
+  it("renders the three-column navigation when the flag is on", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const rail = await waitFor(() => {
+      return screen.getByTestId("labeled-nav-rail");
+    });
+
+    // Labeled icon rail carries text captions for its nav destinations.
+    expect(within(rail).getByText("Agents")).toBeInTheDocument();
+    expect(within(rail).getByText("Connectors")).toBeInTheDocument();
+    expect(within(rail).getByLabelText("Insights")).toBeInTheDocument();
+
+    // The middle list column owns the chat header and pinned agents.
+    const list = screen.getByTestId("chat-list-column");
+    expect(within(list).getByText("Chat")).toBeInTheDocument();
+    expect(within(list).getByLabelText("New chat")).toBeInTheDocument();
+    expect(
+      within(list).getByTestId("pinned-agents-horizontal"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the single-column sidebar when the three-column flag is off", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await waitFor(() => {
+      return sidebar();
+    });
+
+    expect(screen.queryByTestId("labeled-nav-rail")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chat-list-column")).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -290,6 +290,27 @@ function PendingInvitationsBadge() {
   );
 }
 
+export function ZeroOrgSwitcherCompact() {
+  const currentOrg = useLastResolved(currentOrgInfo$);
+  const orgName = currentOrg?.name ?? "Organization";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Switch workspace"
+          className="relative flex h-9 w-9 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+        >
+          <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
+          <PendingInvitationsBadge />
+        </button>
+      </DropdownMenuTrigger>
+      <OrgDropdownContent />
+    </DropdownMenu>
+  );
+}
+
 export function ZeroOrgSwitcher() {
   const currentOrg = useLastResolved(currentOrgInfo$);
   const orgName = currentOrg?.name ?? "Organization";

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -193,7 +193,11 @@ function OpenAgentListDialog({
   );
 }
 
-export function PinnedAgentListSection() {
+export function PinnedAgentListSection({
+  layout = "vertical",
+}: {
+  layout?: "vertical" | "horizontal";
+}) {
   const activeRoute = useGet(activeRoute$);
   const pathParams = useGet(pathParams$);
   const routeAgentId =
@@ -228,6 +232,70 @@ export function PinnedAgentListSection() {
         })
       : [];
   const displayedPinnedAgents = [...pinnedAgents, ...unreadOnlyAgents];
+
+  const selectedAgentId =
+    routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
+
+  if (layout === "horizontal") {
+    return (
+      <div className="shrink-0" data-testid="pinned-agents-horizontal">
+        <span className="block px-1 pb-2 text-[13px] font-medium leading-4 text-sidebar-foreground/50">
+          Pinned agents
+        </span>
+        <div className="flex items-start gap-1 overflow-x-auto pb-1">
+          {pinnedAgentsLoadable.state === "hasData" &&
+            displayedPinnedAgents.map((agent) => {
+              const isPrimarySelected =
+                isChatRoute(activeRoute) && selectedAgentId === agent.id;
+              const hasUnread = unreadAgentIds?.has(agent.id) ?? false;
+              const hasUnreadIndicator =
+                agentUnreadIndicatorsEnabled && hasUnread;
+              return (
+                <Link
+                  key={agent.id}
+                  pathname="/agents/:agentId/chat"
+                  options={{ pathParams: { agentId: agent.id } }}
+                  data-testid="pinned-agent-card"
+                  className={`group flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 no-underline transition-colors duration-200 ${
+                    isPrimarySelected
+                      ? "bg-gray-200 text-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent"
+                  }`}
+                >
+                  <span className="relative">
+                    <AgentAvatarImg
+                      name={agent.id}
+                      alt={agent.displayName ?? agent.id}
+                      className="h-9 w-9 rounded-full object-cover object-top"
+                    />
+                    {hasUnreadIndicator && (
+                      <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-[hsl(var(--primary-700))] ring-2 ring-sidebar" />
+                    )}
+                  </span>
+                  <span className="w-full truncate text-center text-[11px] leading-tight">
+                    {agent.displayName ?? agent.id}
+                  </span>
+                </Link>
+              );
+            })}
+          <button
+            type="button"
+            onClick={() => {
+              openAgentListDialog();
+            }}
+            aria-label="Open a conversation"
+            className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
+              <IconPlus size={16} stroke={2} />
+            </span>
+            <span className="text-[11px] leading-tight">New</span>
+          </button>
+        </div>
+        <AgentListDialogContainer />
+      </div>
+    );
+  }
 
   return (
     <div className="shrink-0">
@@ -285,8 +353,6 @@ export function PinnedAgentListSection() {
           )}
           {pinnedAgentsLoadable.state === "hasData" &&
             displayedPinnedAgents.map((agent) => {
-              const selectedAgentId =
-                routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
               const isPrimarySelected =
                 isChatRoute(activeRoute) && selectedAgentId === agent.id;
               const isFromChat = sidebarAgentId === agent.id;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -696,14 +696,21 @@ function ExpandedFooterAccountInsights() {
 
 // --- Three-column (Slack-style) layout, gated behind ThreeColumnNav ---
 
-// Short, single-word rail captions keyed by nav id so labels stay legible in
-// the narrow rail even when the underlying nav label is longer ("Activity
-// logs", "Where Zero works").
-const RAIL_LABELS: Partial<Record<SidebarNavId, string>> = {
-  chat: "New",
-  activities: "Activity",
-  works: "Works",
-};
+// Short, single-word rail captions so labels stay legible in the narrow rail
+// even when the underlying nav label is longer ("Activity logs", "Where Zero
+// works").
+function railLabel(id: SidebarNavId, fallback: string): string {
+  switch (id) {
+    case "chat":
+      return "New";
+    case "activities":
+      return "Activity";
+    case "works":
+      return "Works";
+    default:
+      return fallback;
+  }
+}
 
 function LabeledRailLink({
   id,
@@ -769,7 +776,7 @@ function LabeledRailLink({
             : "text-sidebar-foreground/60"
         }`}
       >
-        {RAIL_LABELS[id] ?? label}
+        {railLabel(id, label)}
       </span>
     </Link>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -701,14 +701,18 @@ function ExpandedFooterAccountInsights() {
 // works").
 function railLabel(id: SidebarNavId, fallback: string): string {
   switch (id) {
-    case "chat":
+    case "chat": {
       return "New";
-    case "activities":
+    }
+    case "activities": {
       return "Activity";
-    case "works":
+    }
+    case "works": {
       return "Works";
-    default:
+    }
+    default: {
       return fallback;
+    }
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconPlug,
   IconSparkles,
+  IconSearch,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -18,6 +19,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from "@vm0/ui";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -37,8 +39,12 @@ import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import {
   manageSectionCollapsed$,
   setManageSectionCollapsed$,
+  openAgentListDialog$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
-import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
+import {
+  ZeroOrgSwitcher,
+  ZeroOrgSwitcherCompact,
+} from "./zero-org-switcher.tsx";
 import { Link } from "../router/link.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { slackOrgScopeMismatch$ } from "../../signals/zero-page/zero-slack.ts";
@@ -345,14 +351,22 @@ function CollapsedFooter() {
 
 // --- Expanded full sidebar (desktop default, mobile overlay when expanded) ---
 
-function ExpandedSidebar() {
+function ExpandedSidebar({ mobileOnly = false }: { mobileOnly?: boolean }) {
   const off = useGet(sidebarOff$);
   const expanded = useGet(sidebarExpanded$);
+  // When the three-column layout owns the desktop columns, this full sidebar is
+  // reused solely as the mobile drawer, so it hides on desktop instead of showing.
+  const visibility = mobileOnly
+    ? "hidden data-[sidebar-expanded]:max-md:flex md:hidden"
+    : "hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex";
   return (
     <aside
       data-sidebar-off={off || undefined}
       data-sidebar-expanded={expanded || undefined}
-      className="zero-nav zero-pwa-fixed-cover zero-mobile-fixed-safe-area hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl"
+      className={cn(
+        "zero-nav zero-pwa-fixed-cover zero-mobile-fixed-safe-area h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl",
+        visibility,
+      )}
     >
       <ExpandedHeader />
       <ExpandedMainNav />
@@ -680,7 +694,244 @@ function ExpandedFooterAccountInsights() {
   );
 }
 
+// --- Three-column (Slack-style) layout, gated behind ThreeColumnNav ---
+
+// Short, single-word rail captions keyed by nav id so labels stay legible in
+// the narrow rail even when the underlying nav label is longer ("Activity
+// logs", "Where Zero works").
+const RAIL_LABELS: Partial<Record<SidebarNavId, string>> = {
+  chat: "New",
+  activities: "Activity",
+  works: "Works",
+};
+
+function LabeledRailLink({
+  id,
+  navPath,
+  label,
+  icon: Icon,
+  iconImg,
+  isActive,
+  showBadge,
+  onSelect,
+}: {
+  id: SidebarNavId;
+  navPath: string;
+  label: string;
+  icon: NavIcon;
+  iconImg?: string | undefined;
+  isActive: boolean;
+  showBadge?: boolean;
+  onSelect: (id: SidebarNavId) => void;
+}) {
+  return (
+    <Link
+      pathname={navPath as Parameters<typeof Link>[0]["pathname"]}
+      onClick={(e) => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+          return;
+        }
+        e.preventDefault();
+        onSelect(id);
+      }}
+      aria-label={label}
+      aria-current={isActive ? "page" : undefined}
+      className="group flex w-full flex-col items-center gap-1 no-underline"
+    >
+      <span
+        className={`relative inline-flex h-9 w-10 items-center justify-center rounded-xl transition-colors duration-200 ${
+          isActive
+            ? "bg-gray-200 text-gray-900"
+            : "text-sidebar-foreground group-hover:bg-sidebar-accent"
+        }`}
+      >
+        {iconImg ? (
+          <span className="inline-flex h-4 w-4 items-center justify-center overflow-hidden">
+            <img
+              src={iconImg}
+              alt=""
+              className="h-4 w-4 scale-[2.2]"
+              width={16}
+              height={16}
+            />
+          </span>
+        ) : (
+          <Icon size={19} className="shrink-0" />
+        )}
+        {showBadge && (
+          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500" />
+        )}
+      </span>
+      <span
+        className={`text-[10px] leading-none ${
+          isActive
+            ? "font-semibold text-sidebar-foreground"
+            : "text-sidebar-foreground/60"
+        }`}
+      >
+        {RAIL_LABELS[id] ?? label}
+      </span>
+    </Link>
+  );
+}
+
+function LabeledNavRail() {
+  const activeId = useGet(activeRoute$);
+  const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
+  const onSelect = useNavSelect();
+  const { manageNav, footerNav } = useResolvedNavItems();
+  const navItems: {
+    id: SidebarNavId;
+    activeKeys: readonly RouteKey[];
+    pathname: string;
+    label: string;
+    icon: NavIcon;
+    iconImg?: string | undefined;
+  }[] = [
+    {
+      id: "chat",
+      activeKeys: ["home", "agentChat", "agentIdeas", "chat"],
+      pathname: "/",
+      label: "New chat",
+      icon: IconEdit as NavIcon,
+    },
+    ...manageNav,
+    ...footerNav,
+  ];
+  return (
+    <aside
+      data-testid="labeled-nav-rail"
+      className="zero-nav hidden md:flex h-full w-[76px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar px-1.5 pb-2 pt-3"
+    >
+      <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
+      <div className="mb-3 shrink-0">
+        <ZeroOrgSwitcherCompact />
+      </div>
+      <nav
+        aria-label="Sidebar"
+        className="flex min-h-0 w-full flex-1 flex-col items-center gap-2 overflow-y-auto pb-2"
+      >
+        {navItems.map((item) => {
+          const isActive =
+            activeId !== null && item.activeKeys.includes(activeId);
+          return (
+            <LabeledRailLink
+              key={item.id}
+              id={item.id}
+              navPath={item.pathname}
+              label={item.label}
+              icon={item.icon}
+              iconImg={item.iconImg}
+              isActive={isActive}
+              showBadge={item.id === "works" && slackScopeMismatch}
+              onSelect={onSelect}
+            />
+          );
+        })}
+      </nav>
+      <div className="flex w-full shrink-0 flex-col items-center gap-2 pt-1">
+        <LabeledRailLink
+          id="insights"
+          navPath="/insights"
+          label="Insights"
+          icon={IconSparkles as NavIcon}
+          isActive={activeId === "insights"}
+          onSelect={onSelect}
+        />
+        <AccountDropdownContainer collapsed />
+      </div>
+    </aside>
+  );
+}
+
+function ChatListColumn() {
+  const onSelect = useNavSelect();
+  const openAgentList = useSet(openAgentListDialog$);
+  const activeId = useGet(activeRoute$);
+  const isNewChatActive =
+    activeId !== null &&
+    (["home", "agentChat", "agentIdeas", "chat"] as RouteKey[]).includes(
+      activeId,
+    );
+  return (
+    <aside
+      data-testid="chat-list-column"
+      className="zero-nav hidden md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar"
+    >
+      <div className="flex shrink-0 items-center gap-1 px-3 pb-2 pt-3">
+        <span className="flex-1 text-[15px] font-semibold text-sidebar-foreground">
+          Chat
+        </span>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  openAgentList();
+                }}
+                aria-label="Search conversations"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+              >
+                <IconSearch size={17} stroke={1.8} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Search conversations</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                pathname="/"
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                    return;
+                  }
+                  e.preventDefault();
+                  onSelect("chat");
+                }}
+                aria-label="New chat"
+                aria-current={isNewChatActive ? "page" : undefined}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 no-underline transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+              >
+                <IconEdit size={17} stroke={1.8} />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">New chat</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-2 pt-1">
+        <PinnedAgentListSection layout="horizontal" />
+        <ChatThreadsSectionWithKey />
+      </div>
+      <div className="px-2 pb-2">
+        <SidebarUpgradeCard />
+      </div>
+    </aside>
+  );
+}
+
+function ThreeColumnNav() {
+  return (
+    <>
+      <LabeledNavRail />
+      <ChatListColumn />
+      {/* Reuse the full sidebar as the mobile drawer only. */}
+      <ExpandedSidebar mobileOnly />
+    </>
+  );
+}
+
 export function ZeroSidebar() {
+  const features = useLastResolved(featureSwitch$);
+  const threeColumnNav = features?.[FeatureSwitchKey.ThreeColumnNav] ?? false;
+  if (threeColumnNav) {
+    return <ThreeColumnNav />;
+  }
   return (
     <>
       <CollapsedSidebar />

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -83,4 +83,5 @@ export enum FeatureSwitchKey {
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ZeroMail = "zeroMail",
+  ThreeColumnNav = "threeColumnNav",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -411,7 +411,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Slack-style three-column navigation: a labeled icon rail, a pinned-agents and chat-threads list column, and the conversation pane.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    // Ming only for the first pass; widen to staff once it settles.
+    enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
   },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -406,6 +406,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ThreeColumnNav]: {
+    maintainer: "ming@vm0.ai",
+    description:
+      "Slack-style three-column navigation: a labeled icon rail, a pinned-agents and chat-threads list column, and the conversation pane.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## What & why

Reworks the Zero platform navigation into a **Slack-style three-column layout**, gated behind the new `FeatureSwitchKey.ThreeColumnNav` (staff-only by default). Today everything — manage nav, pinned agents, and chat threads — is crammed into a single 300px sidebar next to the conversation. This splits that into three clear regions and gives the icon nav accessible text labels. Design was iterated with Ming (Variant 3 of the mockups) and this is the implementation.

## User-visible change (flag on)

- **Column 1 — labeled icon rail (76px):** each destination is an icon with a small text caption underneath (`New`, `Agents`, `Artifacts`, `Workflows`, `Connectors`, `Activity`, `Works`, `Insights`) for accessibility, not icon-only. The workspace switcher sits at the top as a compact avatar dropdown; the account avatar stays at the bottom without a label.
- **Column 2 — chat list:** a dedicated `Chat` header with search + new-chat actions, a new **horizontal pinned-agents avatar row** (avatars with names), and the existing chat-threads list unchanged below it.
- **Column 3 — conversation:** unchanged.
- **Mobile:** the full existing sidebar is reused verbatim as the hamburger drawer, so there is no mobile regression.

When the flag is **off**, the current single-column sidebar renders exactly as before.

## Implementation notes

- Reuses existing pieces rather than rebuilding: the nav item model (`MANAGE_NAV`/`FOOTER_NAV`), `PinnedAgentListSection` (new `layout="horizontal"` variant reusing all its state), `ChatThreadsSection`, `SidebarUpgradeCard`, and `AccountDropdown`. Added a compact `ZeroOrgSwitcherCompact` trigger that reuses the existing org dropdown content.
- `ExpandedSidebar` gains a `mobileOnly` prop so it can serve purely as the mobile drawer under the flag; the full desktop layout is composed in the new `ThreeColumnNav`.
- Feature switch key added in `packages/connectors/src/feature-switch-key.ts` and registered in `packages/core/src/feature-switch.ts` following the `SidebarManageIconCollapse` pattern (`enabled: false`, `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`).
- Sentence case throughout; reuses existing tokens (`gray-0` surface, `gray-200` border/active pill, `sidebar-accent` hover) and the established IconButton hover treatment.

## Tests

- Added two integration tests in `zero-sidebar.test.tsx`: three-column layout renders (labeled rail captions, chat header, new-chat action, horizontal pinned agents) when the flag is on; the single-column sidebar is unchanged when the flag is off.

## Verification

Formatted with the lockfile-pinned Prettier (3.8.1). Type-check and full test/lint suites are left to the PR pipeline per the team's vm0 PR verification preference (no local dev server / full vitest run).