### PR TITLE
chore: graduate workflow template catalog to always-on

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1518,31 +1518,24 @@ function WorkflowTemplateCard({
   );
 }
 
-// Resolves the workflow template tab's data in one place: the feature-gated
-// catalog, the persona pills present in it, the active pill (falling back to
-// "all"), and the items after both the pill and the search filter. Kept out of
+// Resolves the workflow template tab's data in one place: the persona pills
+// present in the catalog, the active pill (falling back to "all"), and the
+// items after both the pill and the search filter. Kept out of
 // TemplatePickerDialog so that component stays under its complexity budget.
 function resolveWorkflowCatalog({
-  showCatalog,
   categoryFilter,
   search,
 }: {
-  showCatalog: boolean;
   categoryFilter: string;
   search: string;
 }): ResolvedWorkflowTemplateCatalog {
-  const catalogItems = showCatalog
-    ? WORKFLOW_TEMPLATE_ITEMS
-    : WORKFLOW_TEMPLATE_ITEMS.filter((item) => {
-        return item.category === WORKFLOW_TEMPLATE_CATEGORIES[0];
-      });
   const pills = WORKFLOW_TEMPLATE_CATEGORIES.filter((categoryName) => {
-    return catalogItems.some((item) => {
+    return WORKFLOW_TEMPLATE_ITEMS.some((item) => {
       return item.category === categoryName;
     });
   });
   const active = pills.includes(categoryFilter) ? categoryFilter : "all";
-  const items = catalogItems.filter((item) => {
+  const items = WORKFLOW_TEMPLATE_ITEMS.filter((item) => {
     const matchesCategory = active === "all" || item.category === active;
     return matchesCategory && workflowTemplateMatchesSearch(item, search);
   });
@@ -4857,16 +4850,12 @@ function TemplatePickerDialog({
   const filteredIllustrationItems = ILLUSTRATION_TEMPLATE_ITEMS;
   const filteredVideoItems = VIDEO_TEMPLATE_ITEMS;
   const filteredWebsiteItems = WEBSITE_TEMPLATE_ITEMS;
-  // The persona catalog rolls out behind a feature switch, and a persona pill
-  // filters the grid, ideation-gallery style. resolveWorkflowCatalog() keeps
-  // that branching out of this component to stay under the complexity budget.
-  const features = useLastResolved(featureSwitch$);
-  const showWorkflowTemplateCatalog =
-    features?.[FeatureSwitchKey.WorkflowTemplateCatalog] ?? false;
+  // A persona pill filters the grid, ideation-gallery style.
+  // resolveWorkflowCatalog() keeps that logic out of this component to stay
+  // under the complexity budget.
   const workflowCategoryFilter = useGet(templatePickerWorkflowCategory$);
   const setWorkflowCategoryFilter = useSet(setTemplatePickerWorkflowCategory$);
   const workflowCatalog = resolveWorkflowCatalog({
-    showCatalog: showWorkflowTemplateCatalog,
     categoryFilter: workflowCategoryFilter,
     search,
   });

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -77,7 +77,6 @@ export enum FeatureSwitchKey {
   Artifacts = "artifacts",
   ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
-  WorkflowTemplateCatalog = "workflowTemplateCatalog",
   WebsiteTemplates = "websiteTemplates",
   WorkflowQueue = "workflowQueue",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -462,13 +462,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.WorkflowTemplateCatalog]: {
-    maintainer: "ming@vm0.ai",
-    description:
-      "Show the full persona-grouped built-in workflow template catalog in the chat composer template picker. Off shows only the General starter template.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.WebsiteTemplates]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## What & why

Removes the `WorkflowTemplateCatalog` feature switch and makes the full persona-grouped built-in workflow template catalog visible to everyone in the chat composer template picker. The feature has been validated behind the staff-only switch; this graduates it to always-on and deletes the flag plumbing.

## User-visible impact

- Every org now sees the complete persona-grouped template catalog (with persona pills + search) in the composer's workflow template tab. Previously, orgs without the switch saw only the single "General" starter template.

## Implementation

- Delete `FeatureSwitchKey.WorkflowTemplateCatalog` from the enum (`@vm0/connectors`) and its config entry (`@vm0/core`).
- `resolveWorkflowCatalog()` no longer takes a `showCatalog` flag — it always resolves against the full `WORKFLOW_TEMPLATE_ITEMS` list; the branch that filtered down to the first category is gone.
- `TemplatePickerDialog` no longer reads the switch. Comments updated to match.

## Verification

- `pnpm turbo run check-types lint` for `@vm0/connectors`, `@vm0/core`, `@vm0/app` — all green.
- `@vm0/core` `feature-switch.test.ts` — 23 passed.
- Confirmed no dangling references to `workflowTemplateCatalog` / `showCatalog` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)