### PR TITLE
ci: extend runner drain exit timeout

### DIFF
--- a/.github/scripts/runner-behavior-upgrade-local.sh
+++ b/.github/scripts/runner-behavior-upgrade-local.sh
@@ -47,9 +47,11 @@ wait_for_exit() {
   # complete on a tick boundary, so anything <10s has no headroom
   # for real teardown work (idle pool + namespace cleanup
   # + mitm/dns/kmsg shutdown) and slow shutdown tails like
-  # background memory prefetch. 30s = 3× tick. See issues #10869
+  # background memory prefetch. Shared metal-host contention can also make
+  # namespace cleanup exceed 30s while it is still making progress, so allow
+  # six heartbeat ticks before treating the drain as stuck. See issues #10869
   # and #13688.
-  local svc=$1 budget=${2:-30}
+  local svc=$1 budget=${2:-60}
   echo "--- Waiting up to ${budget}s for $svc to exit ---"
   for i in $(seq 1 "$budget"); do
     systemctl is-active --quiet "vm0-runner-${svc}" || return 0


### PR DESCRIPTION
## Summary

- allow the runner upgrade test to wait up to 60 seconds for a drained service to exit
- keep the wait bounded while accommodating namespace cleanup under shared metal-host contention

## Scope

- does not change the cancel latency assertion
- does not change the upgrade scenario's five-minute step timeout

## Validation

- `bash -n .github/scripts/runner-behavior-upgrade-local.sh`
- `shellcheck .github/scripts/runner-behavior-upgrade-local.sh`
- `git diff --check`

Failure context: https://github.com/vm0-ai/vm0/actions/runs/29490084214/job/87595010041
