### PR TITLE
feat(connectors): expand playstation api firewall coverage

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -28,6 +28,7 @@ const EXPECTED_CATEGORIZED_CONNECTORS = [
   "google-search-console",
   "google-sheets",
   "nintendo-switch-parental-controls",
+  "playstation",
   "slack",
   "stripe",
   "vercel",

--- a/turbo/packages/connectors/src/__tests__/firewalls/playstation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/playstation.test.ts
@@ -1,52 +1,401 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { findMatchingPermissions } from "../../firewall-rule-matcher";
+import {
+  findMatchingPermissions,
+  matchFirewallRequestDecision,
+} from "../../firewall-rule-matcher";
 import {
   extractSecretNamesFromApis,
   type FirewallConfig,
+  type FirewallPolicy,
+  type NetworkPolicies,
 } from "../../firewall-types";
-import { loadRequiredConnectorFirewall } from "../firewall-test-helpers";
+import {
+  loadDefaultFirewallPolicies,
+  loadRequiredConnectorFirewall,
+} from "../firewall-test-helpers";
+
+const MOBILE_BASE = "https://m.np.playstation.com";
+const COMMUNITY_BASE = "https://us-prof.np.community.playstation.net";
+const WEB_BASE = "https://web.np.playstation.com";
+const DMS_BASE = "https://dms.api.playstation.com";
+const ACCOUNTS_BASE = "https://accounts.api.playstation.com";
+const PUSH_BASE = "https://mobile-pushcl.np.communication.playstation.net";
+const APP_CONFIG_BASE = "https://theia.dl.playstation.net";
+const STATIC_RESOURCE_BASE =
+  "https://static-resource.np.community.playstation.net";
+const BLOG_BASE = "https://blog.playstation.com";
+const REGIONAL_BLOG_BASE = "https://{region}.blog.playstation.com";
+
+interface ExpectedRoute {
+  readonly apiBase: string;
+  readonly permission: string;
+  readonly rule: string;
+}
+
+function expectedRoutes(
+  apiBase: string,
+  permission: string,
+  rules: readonly string[],
+): ExpectedRoute[] {
+  return rules.map((rule) => {
+    return { apiBase, permission, rule };
+  });
+}
+
+const EXPECTED_ROUTES: readonly ExpectedRoute[] = [
+  ...expectedRoutes(MOBILE_BASE, "playstation-profile-read", [
+    "GET /api/cpss/v1/eligibilityCheck/batch",
+    "GET /api/cpss/v1/share/profile/{accountId}",
+    "GET /api/userProfile/v1/internal/users/me/userSettings/appearOffline",
+    "GET /api/userProfile/v1/internal/users/profiles",
+    "GET /api/userProfile/v1/internal/users/{accountId}/basicPresences",
+    "GET /api/userProfile/v1/internal/users/{accountId}/profiles",
+    "GET /api/userProfile/v2/internal/users/basicPresences",
+    "GET /api/userProfile/v2/internal/users/{accountId}/basicPresences",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-social-read", [
+    "GET /api/userProfile/v1/internal/users/me/friends/subscribing/availableToPlay",
+    "GET /api/userProfile/v1/internal/users/me/friends/{accountId}/summary",
+    "GET /api/userProfile/v1/internal/users/{accountId}/blocks",
+    "GET /api/userProfile/v1/internal/users/{accountId}/friends",
+    "GET /api/userProfile/v1/internal/users/{accountId}/friends/receivedRequests",
+    "GET /api/userProfile/v1/internal/users/{accountId}/friends/{friendId}/summary",
+    "GET /api/userProfile/v2/internal/users/{accountId}/friends",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-games-read", [
+    "GET /api/gamelist/v2/users/{accountId}/titles",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-trophies-read", [
+    "GET /api/trophy/v1/npCommunicationIds/{npCommunicationId}/trophies/{trophyId}",
+    "GET /api/trophy/v1/npCommunicationIds/{npCommunicationId}/trophyGroups",
+    "GET /api/trophy/v1/npCommunicationIds/{npCommunicationId}/trophyGroups/{trophyGroupId}/trophies",
+    "GET /api/trophy/v1/users/me/npCommunicationIds/{npCommunicationId}/appearanceSetting",
+    "GET /api/trophy/v1/users/{accountId}/npCommunicationIds/{npCommunicationId}/trophies/{trophyId}",
+    "GET /api/trophy/v1/users/{accountId}/npCommunicationIds/{npCommunicationId}/trophyGroups",
+    "GET /api/trophy/v1/users/{accountId}/npCommunicationIds/{npCommunicationId}/trophyGroups/{trophyGroupId}/trophies",
+    "GET /api/trophy/v1/users/{accountId}/titles/trophyTitles",
+    "GET /api/trophy/v1/users/{accountId}/trophySummary",
+    "GET /api/trophy/v1/users/{accountId}/trophyTitles",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-search-read", [
+    "POST /api/search/v1/universalSearch",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-store-catalog-read", [
+    "GET /api/catalog/v2/titles/{npTitleId}/concepts",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-entitlements-read", [
+    "GET /api/entitlement/v2/users/me/internal/entitlements",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-subscriptions-read", [
+    "GET /api/subscriptions/v2/users/me/services/pssubscriptions",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-console-storage-read", [
+    "GET /api/cloudAssistedNavigation/v2/users/me/clients",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-media-read", [
+    "GET /api/gameMediaService/v2/c2s/category/cloudMediaGallery/ugcType/all",
+    "GET /api/gameMediaService/v2/c2s/content",
+    "GET /api/gameMediaService/v2/c2s/ugc/{ugcId}/url",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-messaging-read", [
+    "GET /api/gamingLoungeGroups/v1/groups/{groupId}/resources/{resourceId}",
+    "GET /api/gamingLoungeGroups/v1/members/me/groups",
+    "GET /api/gamingLoungeGroups/v1/members/me/groups/{groupId}",
+    "GET /api/gamingLoungeGroups/v1/members/me/groups/{groupId}/threads/{threadId}/messages",
+    "GET /api/gamingLoungeGroups/v1/reactions/mobile-v1/definitions",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-sessions-read", [
+    "GET /api/gamingLoungeGroups/v1/members/me/groups/openPartySessions",
+    "GET /api/sessionManager/v2/users/me/partySessionsInvitations",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-notifications-read", [
+    "GET /api/userNotificationManager/v1/users/me/notifications",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-personalization-read", [
+    "GET /api/explore/v2/users/me/hub",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-mobile-graphql-read", [
+    "GET /api/graphql/v1/op",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-operational-metadata-read", [
+    "GET /api/univex/v3/platforms/mobile/variants",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-social-write", [
+    "DELETE /api/userProfile/v1/internal/users/me/friends/{accountId}",
+    "PUT /api/userProfile/v1/internal/users/me/friends/{accountId}",
+  ]),
+  ...expectedRoutes(MOBILE_BASE, "playstation-messaging-write", [
+    "DELETE /api/gamingLoungeGroups/v1/groups/{groupId}/members/me",
+    "DELETE /api/gamingLoungeGroups/v1/groups/{groupId}/members/{accountId}",
+    "PATCH /api/gamingLoungeGroups/v1/groups/{groupId}",
+    "POST /api/gamingLoungeGroups/v1/groups",
+    "POST /api/gamingLoungeGroups/v1/groups/{groupId}/invitees",
+    "POST /api/gamingLoungeGroups/v1/groups/{groupId}/resources",
+    "POST /api/gamingLoungeGroups/v1/groups/{groupId}/threads/{threadId}/messages",
+  ]),
+  ...expectedRoutes(COMMUNITY_BASE, "playstation-legacy-profile-read", [
+    "GET /userProfile/v1/users/{userName}/profile2",
+  ]),
+  ...expectedRoutes(WEB_BASE, "playstation-graphql-games-read", [
+    "GET /api/graphql/v1/op",
+  ]),
+  ...expectedRoutes(WEB_BASE, "playstation-store-graphql-post", [
+    "POST /api/graphql/v1/op",
+  ]),
+  ...expectedRoutes(DMS_BASE, "playstation-devices-read", [
+    "GET /api/v1/devices/accounts/{accountId}",
+  ]),
+  ...expectedRoutes(ACCOUNTS_BASE, "playstation-account-private-read", [
+    "GET /api/v1/accounts/me",
+  ]),
+  ...expectedRoutes(PUSH_BASE, "playstation-push-notifications-read", [
+    "GET /np/serveraddr",
+  ]),
+  ...expectedRoutes(APP_CONFIG_BASE, "playstation-operational-metadata-read", [
+    "GET /metropolis/config/{path+}",
+  ]),
+  ...expectedRoutes(
+    STATIC_RESOURCE_BASE,
+    "playstation-operational-metadata-read",
+    ["GET /sticker/{path+}"],
+  ),
+  ...expectedRoutes(BLOG_BASE, "playstation-operational-metadata-read", [
+    "GET /wp-json/wp/v2/{path+}",
+  ]),
+  ...expectedRoutes(
+    REGIONAL_BLOG_BASE,
+    "playstation-operational-metadata-read",
+    ["GET /wp-json/wp/v2/{path+}"],
+  ),
+];
+
+const PUBLIC_BASES = new Set([
+  APP_CONFIG_BASE,
+  STATIC_RESOURCE_BASE,
+  BLOG_BASE,
+  REGIONAL_BLOG_BASE,
+]);
+
+const DEFAULT_ALLOWED = [
+  "playstation-games-read",
+  "playstation-legacy-profile-read",
+  "playstation-operational-metadata-read",
+  "playstation-profile-read",
+  "playstation-search-read",
+  "playstation-store-catalog-read",
+  "playstation-trophies-read",
+];
 
 let firewall: FirewallConfig;
+let defaultPolicy: FirewallPolicy;
+
+function routeKey(route: ExpectedRoute): string {
+  return `${route.apiBase} ${route.rule} ${route.permission}`;
+}
+
+function sortedRoutes(routes: readonly ExpectedRoute[]): ExpectedRoute[] {
+  return [...routes].sort((a, b) => {
+    return routeKey(a).localeCompare(routeKey(b));
+  });
+}
+
+function actualRoutes(): ExpectedRoute[] {
+  return firewall.apis.flatMap((api) => {
+    return (api.permissions ?? []).flatMap((permission) => {
+      return permission.rules.map((rule) => {
+        return {
+          apiBase: api.base,
+          permission: permission.name,
+          rule,
+        };
+      });
+    });
+  });
+}
 
 function expectPlaystationMatches(
+  apiBase: string,
   method: string,
   path: string,
   permissionNames: readonly string[],
 ): void {
   expect(
-    [...findMatchingPermissions(method, path, firewall)].sort(),
+    [
+      ...findMatchingPermissions(method, path, firewall, {
+        apiBase,
+      }),
+    ].sort(),
   ).toStrictEqual([...permissionNames].sort());
+}
+
+function matcherNetworkPolicies(policy: FirewallPolicy): NetworkPolicies {
+  const allow: string[] = [];
+  const deny: string[] = [];
+  const ask: string[] = [];
+  for (const [permission, value] of Object.entries(policy.policies)) {
+    if (value === "allow") {
+      allow.push(permission);
+    }
+    if (value === "deny") {
+      deny.push(permission);
+    }
+    if (value === "ask") {
+      ask.push(permission);
+    }
+  }
+  return {
+    playstation: {
+      allow,
+      deny,
+      ask,
+      unknownPolicy: policy.unknownPolicy ?? "allow",
+    },
+  };
+}
+
+function runtimeUrl(route: ExpectedRoute): {
+  readonly method: string;
+  readonly url: string;
+} {
+  const separator = route.rule.indexOf(" ");
+  const method = route.rule.slice(0, separator);
+  const path = route.rule.slice(separator + 1).replace(/\{[^}]+\}/gu, "value");
+  const apiBase = route.apiBase.replace(/\{[^}]+\}/gu, "fr");
+  return { method, url: `${apiBase}${path}?probe=value` };
 }
 
 describe("PlayStation firewall", () => {
   beforeAll(async () => {
-    firewall = await loadRequiredConnectorFirewall("playstation");
+    [firewall, defaultPolicy] = await Promise.all([
+      loadRequiredConnectorFirewall("playstation"),
+      loadDefaultFirewallPolicies("playstation"),
+    ]);
   });
 
-  it("registers PlayStation APIs with the runtime token binding", () => {
-    expect(firewall.name).toBe("playstation");
-    expect(
-      firewall.apis.map((api) => {
-        return api.auth;
-      }),
-    ).toStrictEqual(
-      firewall.apis.map(() => {
-        return {
-          headers: {
-            Authorization: "Bearer ${{ secrets.PLAYSTATION_TOKEN }}",
-          },
-        };
-      }),
+  it("registers every audited PlayStation route under one permission", () => {
+    expect(sortedRoutes(actualRoutes())).toStrictEqual(
+      sortedRoutes(EXPECTED_ROUTES),
     );
+  });
+
+  it("injects the runtime token only into authenticated PlayStation APIs", () => {
+    expect(firewall.name).toBe("playstation");
+    for (const api of firewall.apis) {
+      expect(api.auth).toStrictEqual(
+        PUBLIC_BASES.has(api.base)
+          ? {}
+          : {
+              headers: {
+                Authorization: "Bearer ${{ secrets.PLAYSTATION_TOKEN }}",
+              },
+            },
+      );
+    }
     expect(extractSecretNamesFromApis([...firewall.apis])).toStrictEqual([
       "PLAYSTATION_TOKEN",
     ]);
   });
 
-  it("maps PlayStation GraphQL games reads", () => {
-    expectPlaystationMatches("GET", "/api/graphql/v1/op", [
+  it("allows only low-risk read permissions by default", () => {
+    const allowed = Object.entries(defaultPolicy.policies)
+      .filter(([, policy]) => {
+        return policy === "allow";
+      })
+      .map(([name]) => {
+        return name;
+      })
+      .sort();
+
+    expect(allowed).toStrictEqual([...DEFAULT_ALLOWED].sort());
+    expect(defaultPolicy.policies["playstation-account-private-read"]).toBe(
+      "deny",
+    );
+    expect(defaultPolicy.policies["playstation-graphql-games-read"]).toBe(
+      "deny",
+    );
+    expect(defaultPolicy.policies["playstation-messaging-read"]).toBe("deny");
+    expect(defaultPolicy.policies["playstation-social-write"]).toBe("deny");
+    expect(defaultPolicy.policies["playstation-messaging-write"]).toBe("deny");
+    expect(defaultPolicy.policies["playstation-store-graphql-post"]).toBe(
+      "deny",
+    );
+    expect(defaultPolicy.unknownPolicy).toBe("deny");
+  });
+
+  it("enforces the default policy for every audited runtime route", () => {
+    const networkPolicies = matcherNetworkPolicies(defaultPolicy);
+    const defaultAllowed = new Set(DEFAULT_ALLOWED);
+
+    for (const route of EXPECTED_ROUTES) {
+      const request = runtimeUrl(route);
+      const decision = matchFirewallRequestDecision(
+        [firewall],
+        request.method,
+        request.url,
+        networkPolicies,
+      );
+      expect(decision, routeKey(route)).toMatchObject(
+        defaultAllowed.has(route.permission)
+          ? {
+              kind: "allow",
+              firewallName: "playstation",
+              permission: route.permission,
+            }
+          : {
+              kind: "block",
+              firewallName: "playstation",
+              reason: "permission_denied",
+              permissions: [route.permission],
+            },
+      );
+    }
+  });
+
+  it("distinguishes the mobile and web GraphQL transports", () => {
+    expectPlaystationMatches(MOBILE_BASE, "GET", "/api/graphql/v1/op", [
+      "playstation-mobile-graphql-read",
+    ]);
+    expectPlaystationMatches(WEB_BASE, "GET", "/api/graphql/v1/op", [
       "playstation-graphql-games-read",
     ]);
+    expectPlaystationMatches(WEB_BASE, "POST", "/api/graphql/v1/op", [
+      "playstation-store-graphql-post",
+    ]);
+  });
+
+  it("matches sensitive reads and mutations only on their audited methods", () => {
+    expectPlaystationMatches(ACCOUNTS_BASE, "GET", "/api/v1/accounts/me", [
+      "playstation-account-private-read",
+    ]);
+    expectPlaystationMatches(
+      MOBILE_BASE,
+      "GET",
+      "/api/gamingLoungeGroups/v1/members/me/groups/group-1/threads/thread-1/messages",
+      ["playstation-messaging-read"],
+    );
+    expectPlaystationMatches(
+      MOBILE_BASE,
+      "POST",
+      "/api/gamingLoungeGroups/v1/groups/group-1/threads/thread-1/messages",
+      ["playstation-messaging-write"],
+    );
+    expectPlaystationMatches(
+      MOBILE_BASE,
+      "DELETE",
+      "/api/userProfile/v1/internal/users/me/friends/12345",
+      ["playstation-social-write"],
+    );
+    expectPlaystationMatches(
+      MOBILE_BASE,
+      "POST",
+      "/api/userProfile/v1/internal/users/me/friends/12345",
+      [],
+    );
+  });
+
+  it("keeps unknown PlayStation paths outside every permission", () => {
+    expectPlaystationMatches(MOBILE_BASE, "GET", "/api/unknown", []);
+    expectPlaystationMatches(WEB_BASE, "DELETE", "/api/graphql/v1/op", []);
   });
 });

--- a/turbo/packages/firewalls-generator/src/__tests__/playstation.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/playstation.test.ts
@@ -44,16 +44,24 @@ describe("PlayStation psn-api source parser", () => {
       permissionsByBase.get("https://m.np.playstation.com") ?? [];
     const webPermissions =
       permissionsByBase.get("https://web.np.playstation.com") ?? [];
+    const accountPermissions =
+      permissionsByBase.get("https://accounts.api.playstation.com") ?? [];
 
-    expect(
-      mobilePermissions.map((permission) => permission.name),
-    ).toStrictEqual([
-      "playstation-profile-read",
-      "playstation-social-read",
-      "playstation-games-read",
-      "playstation-trophies-read",
-      "playstation-search-read",
-    ]);
+    expect(mobilePermissions.map((permission) => permission.name)).toEqual(
+      expect.arrayContaining([
+        "playstation-profile-read",
+        "playstation-social-read",
+        "playstation-games-read",
+        "playstation-trophies-read",
+        "playstation-search-read",
+        "playstation-entitlements-read",
+        "playstation-media-read",
+        "playstation-messaging-read",
+        "playstation-mobile-graphql-read",
+        "playstation-social-write",
+        "playstation-messaging-write",
+      ]),
+    );
     expect(
       mobilePermissions.find((permission) => {
         return permission.name === "playstation-trophies-read";
@@ -64,12 +72,27 @@ describe("PlayStation psn-api source parser", () => {
         return permission.name === "playstation-search-read";
       })?.rules,
     ).toStrictEqual(["POST /api/search/v1/universalSearch"]);
-    expect(webPermissions).toStrictEqual([
+    expect(
+      mobilePermissions.find((permission) => {
+        return permission.name === "playstation-messaging-write";
+      })?.rules,
+    ).toContain(
+      "POST /api/gamingLoungeGroups/v1/groups/{groupId}/threads/{threadId}/messages",
+    );
+    expect(
+      webPermissions.map((permission) => {
+        return [permission.name, permission.rules] as const;
+      }),
+    ).toStrictEqual([
+      ["playstation-graphql-games-read", ["GET /api/graphql/v1/op"]],
+      ["playstation-store-graphql-post", ["POST /api/graphql/v1/op"]],
+    ]);
+    expect(accountPermissions).toStrictEqual([
       {
-        name: "playstation-graphql-games-read",
+        name: "playstation-account-private-read",
         description:
-          "Read PlayStation purchased and recently played game lists through psn-api GraphQL operations",
-        rules: ["GET /api/graphql/v1/op"],
+          "Read the connected account's full private record, including contact, identity, birth date, address, locale, and account-state fields",
+        rules: ["GET /api/v1/accounts/me"],
       },
     ]);
   });

--- a/turbo/packages/firewalls-generator/src/playstation.ts
+++ b/turbo/packages/firewalls-generator/src/playstation.ts
@@ -1,12 +1,16 @@
 /**
  * Generate PlayStation Network firewall config.
  *
- * Data source: latest psn-api source published to npm,
- * https://www.npmjs.com/package/psn-api
+ * Data sources:
+ * - latest psn-api source published to npm,
+ *   https://www.npmjs.com/package/psn-api
+ * - curated endpoints verified against current PlayStation App, Store, and
+ *   community-client traffic
  *
- * PlayStation Network's consumer APIs are not documented as a stable public API.
- * This curated read-only firewall follows the endpoints currently exposed by
- * psn-api and denies unknown paths by default.
+ * PlayStation Network's consumer APIs are not documented as a stable public
+ * API. The generated baseline follows psn-api while the audited manifest adds
+ * concrete capabilities that psn-api does not expose. Unknown paths are denied
+ * by default, and sensitive reads and mutations are denied by default.
  */
 
 import ts from "typescript";
@@ -14,10 +18,13 @@ import ts from "typescript";
 import {
   listCachedSpecs,
   logStats,
+  renderCategories,
+  renderDefaultAllowed,
   renderDefaultUnknownPolicy,
   renderPermissions,
   sanitizeAndSortRules,
   writeOutput,
+  type CategoryConfig,
   type PermissionGroup,
 } from "./codegen";
 
@@ -28,21 +35,62 @@ export const PLAYSTATION_NPM_LATEST_URL =
 const PLACEHOLDER_VALUE = "psn_access_token_placeholder";
 const PLAYSTATION_RUNTIME_TOKEN_SECRET = "PLAYSTATION_TOKEN";
 
+const PLAYSTATION_MOBILE_API_BASE = "https://m.np.playstation.com";
+const PLAYSTATION_COMMUNITY_API_BASE =
+  "https://us-prof.np.community.playstation.net";
+const PLAYSTATION_WEB_API_BASE = "https://web.np.playstation.com";
+const PLAYSTATION_DMS_API_BASE = "https://dms.api.playstation.com";
+const PLAYSTATION_ACCOUNTS_API_BASE = "https://accounts.api.playstation.com";
+const PLAYSTATION_PUSH_API_BASE =
+  "https://mobile-pushcl.np.communication.playstation.net";
+const PLAYSTATION_APP_CONFIG_BASE = "https://theia.dl.playstation.net";
+const PLAYSTATION_STATIC_RESOURCE_BASE =
+  "https://static-resource.np.community.playstation.net";
+const PLAYSTATION_BLOG_BASE = "https://blog.playstation.com";
+const PLAYSTATION_REGIONAL_BLOG_BASE = "https://{region}.blog.playstation.com";
+
 const PLAYSTATION_API_BASE_ORDER = [
-  "https://m.np.playstation.com",
-  "https://us-prof.np.community.playstation.net",
-  "https://web.np.playstation.com",
-  "https://dms.api.playstation.com",
+  PLAYSTATION_MOBILE_API_BASE,
+  PLAYSTATION_COMMUNITY_API_BASE,
+  PLAYSTATION_WEB_API_BASE,
+  PLAYSTATION_DMS_API_BASE,
+  PLAYSTATION_ACCOUNTS_API_BASE,
+  PLAYSTATION_PUSH_API_BASE,
+  PLAYSTATION_APP_CONFIG_BASE,
+  PLAYSTATION_STATIC_RESOURCE_BASE,
+  PLAYSTATION_BLOG_BASE,
+  PLAYSTATION_REGIONAL_BLOG_BASE,
 ] as const;
 
 const PLAYSTATION_API_BASES = new Set<string>(PLAYSTATION_API_BASE_ORDER);
+const PLAYSTATION_PUBLIC_API_BASES = new Set<string>([
+  PLAYSTATION_APP_CONFIG_BASE,
+  PLAYSTATION_STATIC_RESOURCE_BASE,
+  PLAYSTATION_BLOG_BASE,
+  PLAYSTATION_REGIONAL_BLOG_BASE,
+]);
 
-type HttpMethod = "GET" | "POST";
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+function isHttpMethod(value: string): value is HttpMethod {
+  return HTTP_METHODS.some((candidate) => {
+    return candidate === value;
+  });
+}
+
+interface PlaystationPermissionRoute {
+  readonly method: HttpMethod;
+  readonly base: string;
+  readonly path: string;
+}
 
 interface PlaystationPermissionManifestEntry {
   readonly name: string;
   readonly description: string;
-  readonly functions: readonly string[];
+  readonly defaultAllowed: boolean;
+  readonly functions?: readonly string[];
+  readonly routes?: readonly PlaystationPermissionRoute[];
 }
 
 interface PlaystationSourceFile {
@@ -70,31 +118,84 @@ const PLAYSTATION_PERMISSION_MANIFEST: readonly PlaystationPermissionManifestEnt
     {
       name: "playstation-profile-read",
       description: "Read PlayStation Network profile and presence data",
+      defaultAllowed: true,
       functions: [
         "getBasicPresence",
         "getProfileFromAccountId",
         "getProfileShareableLink",
+      ],
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v2/internal/users/{accountId}/basicPresences",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/profiles",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v2/internal/users/basicPresences",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/me/userSettings/appearOffline",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/cpss/v1/eligibilityCheck/batch",
+        },
       ],
     },
     {
       name: "playstation-social-read",
       description:
         "Read PlayStation Network friend, friend request, and block lists",
+      defaultAllowed: false,
       functions: [
         "getUserBlockedAccountIds",
         "getUserFriendsAccountIds",
         "getUserFriendsRequests",
       ],
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v2/internal/users/{accountId}/friends",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/{accountId}/friends/{friendId}/summary",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/me/friends/{accountId}/summary",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/me/friends/subscribing/availableToPlay",
+        },
+      ],
     },
     {
       name: "playstation-games-read",
       description: "Read PlayStation played games and playtime data",
+      defaultAllowed: true,
       functions: ["getUserPlayedGames"],
     },
     {
       name: "playstation-trophies-read",
       description:
         "Read PlayStation trophy summaries, titles, groups, and lists",
+      defaultAllowed: true,
       functions: [
         "getTitleTrophyGroups",
         "getTitleTrophies",
@@ -104,29 +205,375 @@ const PLAYSTATION_PERMISSION_MANIFEST: readonly PlaystationPermissionManifestEnt
         "getUserTrophyGroupEarningsForTitle",
         "getUserTrophyProfileSummary",
       ],
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/trophy/v1/users/{accountId}/npCommunicationIds/{npCommunicationId}/trophies/{trophyId}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/trophy/v1/npCommunicationIds/{npCommunicationId}/trophies/{trophyId}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/trophy/v1/users/me/npCommunicationIds/{npCommunicationId}/appearanceSetting",
+        },
+      ],
     },
     {
       name: "playstation-search-read",
       description: "Search PlayStation Network users and content",
+      defaultAllowed: true,
       functions: ["makeUniversalSearch"],
     },
     {
       name: "playstation-legacy-profile-read",
       description: "Read legacy PlayStation Network profile data by online ID",
+      defaultAllowed: true,
       functions: ["getProfileFromUserName"],
     },
     {
       name: "playstation-graphql-games-read",
       description:
-        "Read PlayStation purchased and recently played game lists through psn-api GraphQL operations",
+        "Send persisted PlayStation game library, Store, wishlist, subscription, review, and browse queries through the shared web GraphQL GET transport",
+      defaultAllowed: false,
       functions: ["getPurchasedGames", "getRecentlyPlayedGames"],
     },
     {
       name: "playstation-devices-read",
       description: "Read devices associated with a PlayStation Network account",
+      defaultAllowed: false,
       functions: ["getAccountDevices"],
     },
+    {
+      name: "playstation-account-private-read",
+      description:
+        "Read the connected account's full private record, including contact, identity, birth date, address, locale, and account-state fields",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_ACCOUNTS_API_BASE,
+          path: "/api/v1/accounts/me",
+        },
+      ],
+    },
+    {
+      name: "playstation-store-catalog-read",
+      description: "Read PlayStation Store title-to-concept catalog mappings",
+      defaultAllowed: true,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/catalog/v2/titles/{npTitleId}/concepts",
+        },
+      ],
+    },
+    {
+      name: "playstation-entitlements-read",
+      description:
+        "Read the connected account's game, add-on, subscription, and reward entitlement ledger",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/entitlement/v2/users/me/internal/entitlements",
+        },
+      ],
+    },
+    {
+      name: "playstation-subscriptions-read",
+      description:
+        "Read the connected account's PlayStation Plus and partner subscription state",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/subscriptions/v2/users/me/services/pssubscriptions",
+        },
+      ],
+    },
+    {
+      name: "playstation-console-storage-read",
+      description:
+        "Read connected console storage usage and installed-title snapshots",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/cloudAssistedNavigation/v2/users/me/clients",
+        },
+      ],
+    },
+    {
+      name: "playstation-media-read",
+      description:
+        "Read cloud screenshot and video metadata and signed download URLs",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gameMediaService/v2/c2s/category/cloudMediaGallery/ugcType/all",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gameMediaService/v2/c2s/content",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gameMediaService/v2/c2s/ugc/{ugcId}/url",
+        },
+      ],
+    },
+    {
+      name: "playstation-messaging-read",
+      description:
+        "Read PlayStation group and direct-message metadata, history, resources, and reactions",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/members/me/groups",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/members/me/groups/{groupId}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/members/me/groups/{groupId}/threads/{threadId}/messages",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/resources/{resourceId}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/reactions/mobile-v1/definitions",
+        },
+      ],
+    },
+    {
+      name: "playstation-sessions-read",
+      description:
+        "Read PlayStation party invitations and open party-session metadata",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/sessionManager/v2/users/me/partySessionsInvitations",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/members/me/groups/openPartySessions",
+        },
+      ],
+    },
+    {
+      name: "playstation-notifications-read",
+      description: "Read the connected account's notification inbox",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userNotificationManager/v1/users/me/notifications",
+        },
+      ],
+    },
+    {
+      name: "playstation-push-notifications-read",
+      description:
+        "Discover the connected account's PlayStation push-notification server",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_PUSH_API_BASE,
+          path: "/np/serveraddr",
+        },
+      ],
+    },
+    {
+      name: "playstation-personalization-read",
+      description:
+        "Read the connected account's Explore hub, followed concepts, beta enrollments, and story rails",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/explore/v2/users/me/hub",
+        },
+      ],
+    },
+    {
+      name: "playstation-mobile-graphql-read",
+      description:
+        "Send persisted PlayStation App game, Game Help, Store, search, wishlist, and browse queries through the shared mobile GraphQL GET transport",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/graphql/v1/op",
+        },
+      ],
+    },
+    {
+      name: "playstation-operational-metadata-read",
+      description:
+        "Read PlayStation app configuration, experiment variants, sticker indexes, and blog posts",
+      defaultAllowed: true,
+      routes: [
+        {
+          method: "GET",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/univex/v3/platforms/mobile/variants",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_APP_CONFIG_BASE,
+          path: "/metropolis/config/{path+}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_STATIC_RESOURCE_BASE,
+          path: "/sticker/{path+}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_BLOG_BASE,
+          path: "/wp-json/wp/v2/{path+}",
+        },
+        {
+          method: "GET",
+          base: PLAYSTATION_REGIONAL_BLOG_BASE,
+          path: "/wp-json/wp/v2/{path+}",
+        },
+      ],
+    },
+    {
+      name: "playstation-social-write",
+      description:
+        "Accept or decline friend requests and remove PlayStation Network friends",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "PUT",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/me/friends/{accountId}",
+        },
+        {
+          method: "DELETE",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/userProfile/v1/internal/users/me/friends/{accountId}",
+        },
+      ],
+    },
+    {
+      name: "playstation-messaging-write",
+      description:
+        "Create or modify message groups, invite or remove members, send messages, upload resources, or leave groups",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "POST",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups",
+        },
+        {
+          method: "PATCH",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}",
+        },
+        {
+          method: "POST",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/invitees",
+        },
+        {
+          method: "POST",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/threads/{threadId}/messages",
+        },
+        {
+          method: "POST",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/resources",
+        },
+        {
+          method: "DELETE",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/members/{accountId}",
+        },
+        {
+          method: "DELETE",
+          base: PLAYSTATION_MOBILE_API_BASE,
+          path: "/api/gamingLoungeGroups/v1/groups/{groupId}/members/me",
+        },
+      ],
+    },
+    {
+      name: "playstation-store-graphql-post",
+      description:
+        "Send PlayStation Store GraphQL POST operations, including wishlist, eligible library claims, ratings, reviews, votes, and reports",
+      defaultAllowed: false,
+      routes: [
+        {
+          method: "POST",
+          base: PLAYSTATION_WEB_API_BASE,
+          path: "/api/graphql/v1/op",
+        },
+      ],
+    },
   ];
+
+function playstationPermissionCategory(
+  permission: PlaystationPermissionManifestEntry,
+): string {
+  if (
+    permission.name.endsWith("-write") ||
+    permission.name === "playstation-store-graphql-post"
+  ) {
+    return "Write";
+  }
+  return permission.defaultAllowed ? "Read" : "Sensitive read";
+}
+
+const PLAYSTATION_CATEGORIES: CategoryConfig = {
+  categories: Object.fromEntries(
+    PLAYSTATION_PERMISSION_MANIFEST.map((permission) => {
+      return [permission.name, playstationPermissionCategory(permission)];
+    }),
+  ),
+  displayOrder: ["Read", "Sensitive read", "Write"],
+};
+
+const PLAYSTATION_DEFAULT_ALLOWED = PLAYSTATION_PERMISSION_MANIFEST.filter(
+  (permission) => {
+    return permission.defaultAllowed;
+  },
+).map((permission) => {
+  return permission.name;
+});
 
 interface RequestUrlAssignment {
   readonly variableName: string;
@@ -388,7 +835,7 @@ function requestMethodForUrlVariable(
           const methodProperty = objectProperty(configArg, "method");
           if (methodProperty && ts.isPropertyAssignment(methodProperty)) {
             const value = stringValue(methodProperty.initializer);
-            if (value === "GET" || value === "POST") {
+            if (value !== null && isHttpMethod(value)) {
               method = value;
             }
           }
@@ -516,15 +963,17 @@ export function buildPlaystationPermissionsByBase(
 
   const permissionsByBase = new Map<string, PermissionGroup[]>();
   for (const permission of PLAYSTATION_PERMISSION_MANIFEST) {
-    const permissionEndpoints = permission.functions.flatMap((functionName) => {
-      const functionEndpoints = endpointsByFunction.get(functionName);
-      if (!functionEndpoints) {
-        throw new Error(
-          `PlayStation permission ${permission.name} references missing psn-api function: ${functionName}`,
-        );
-      }
-      return functionEndpoints;
-    });
+    const permissionEndpoints = (permission.functions ?? []).flatMap(
+      (functionName) => {
+        const functionEndpoints = endpointsByFunction.get(functionName);
+        if (!functionEndpoints) {
+          throw new Error(
+            `PlayStation permission ${permission.name} references missing psn-api function: ${functionName}`,
+          );
+        }
+        return functionEndpoints;
+      },
+    );
 
     const unsupportedMethods = permissionEndpoints.filter((endpoint) => {
       return (
@@ -545,23 +994,41 @@ export function buildPlaystationPermissionsByBase(
       );
     }
 
-    const endpointsByBase = new Map<string, PlaystationSourceEndpoint[]>();
+    const rulesByBase = new Map<string, string[]>();
     for (const endpoint of permissionEndpoints) {
-      const baseEndpoints = endpointsByBase.get(endpoint.base) ?? [];
-      baseEndpoints.push(endpoint);
-      endpointsByBase.set(endpoint.base, baseEndpoints);
+      const rules = rulesByBase.get(endpoint.base) ?? [];
+      rules.push(endpoint.rule);
+      rulesByBase.set(endpoint.base, rules);
     }
 
-    for (const [base, baseEndpoints] of endpointsByBase) {
+    for (const route of permission.routes ?? []) {
+      if (!PLAYSTATION_API_BASES.has(route.base)) {
+        throw new Error(
+          `PlayStation permission ${permission.name} references unknown API base: ${route.base}`,
+        );
+      }
+      if (!route.path.startsWith("/") || /[?#]/u.test(route.path)) {
+        throw new Error(
+          `PlayStation permission ${permission.name} contains invalid route path: ${route.path}`,
+        );
+      }
+      const rules = rulesByBase.get(route.base) ?? [];
+      rules.push(`${route.method} ${route.path}`);
+      rulesByBase.set(route.base, rules);
+    }
+
+    if (rulesByBase.size === 0) {
+      throw new Error(
+        `PlayStation permission ${permission.name} does not define any endpoint`,
+      );
+    }
+
+    for (const [base, rules] of rulesByBase) {
       const permissions = permissionsByBase.get(base) ?? [];
       permissions.push({
         name: permission.name,
         description: permission.description,
-        rules: sanitizeAndSortRules(
-          baseEndpoints.map((endpoint) => {
-            return endpoint.rule;
-          }),
-        ),
+        rules: sanitizeAndSortRules(rules),
       });
       permissionsByBase.set(base, permissions);
     }
@@ -588,14 +1055,19 @@ function renderApi(args: {
   readonly base: string;
   readonly permissions: readonly PermissionGroup[];
 }): string[] {
+  const auth = PLAYSTATION_PUBLIC_API_BASES.has(args.base)
+    ? ["      auth: {},"]
+    : [
+        "      auth: {",
+        "        headers: {",
+        `          Authorization: "Bearer \${{ secrets.${PLAYSTATION_RUNTIME_TOKEN_SECRET} }}",`,
+        "        },",
+        "      },",
+      ];
   return [
     "    {",
     `      base: "${args.base}",`,
-    "      auth: {",
-    "        headers: {",
-    `          Authorization: "Bearer \${{ secrets.${PLAYSTATION_RUNTIME_TOKEN_SECRET} }}",`,
-    "        },",
-    "      },",
+    ...auth,
     "      permissions: [",
     ...renderPermissions([...args.permissions]),
     "      ],",
@@ -609,14 +1081,14 @@ function generateTypeScript(args: {
 }): string {
   const source = `npm:${PLAYSTATION_NPM_PACKAGE_NAME}@${args.sourcePackage.version}`;
   const lines: string[] = [
-    "// Auto-generated from latest psn-api endpoint definitions.",
+    "// Auto-generated from psn-api endpoint definitions and audited PlayStation App and Store routes.",
     `// Source: ${source}`,
     "// Update source: cd turbo && pnpm -F @vm0/firewalls-generator update-specs:playstation",
     "// Regenerate: cd turbo && pnpm -F @vm0/firewalls-generator generate:playstation",
     "//",
     "// DO NOT EDIT THIS FILE MANUALLY.",
     "",
-    'import type { FirewallConfig, FirewallPolicyValue } from "../firewall-types";',
+    'import type { FirewallConfig, FirewallPolicyValue, PermissionNamesOf } from "../firewall-types";',
     "",
     "export const playstationFirewall = {",
     '  name: "playstation",',
@@ -633,6 +1105,16 @@ function generateTypeScript(args: {
     }),
     "  ],",
     "} as const satisfies FirewallConfig;",
+    ...renderDefaultAllowed(
+      "playstationDefaultAllowed",
+      "playstationFirewall",
+      PLAYSTATION_DEFAULT_ALLOWED,
+    ),
+    ...renderCategories(
+      "playstationCategories",
+      "playstationFirewall",
+      PLAYSTATION_CATEGORIES,
+    ),
     ...renderDefaultUnknownPolicy("playstationDefaultUnknownPolicy", "deny"),
   ];
   return lines.join("\n");


### PR DESCRIPTION
## Summary

- expand the PlayStation firewall to 24 permissions and 64 audited routes across current App, Store, and community API hosts
- separate low-risk reads, sensitive reads, and writes, with only seven narrow read permissions allowed by default
- keep shared GraphQL transports, sensitive account data, and every mutation default denied
- avoid injecting the PlayStation bearer token into public app-config, sticker, and blog hosts
- add generator and connector integration coverage for the complete route inventory, host and method matching, authentication, and runtime default decisions

## Safety and compatibility

- unknown PlayStation routes remain denied
- GraphQL permissions remain broad and default denied because the firewall cannot inspect operation names, persisted-query hashes, query parameters, or request bodies yet
- paid checkout is not enabled
- this does not change a database schema, persisted data, API contract, or runner protocol

## Validation

- `pnpm -F @vm0/firewalls-generator generate:playstation`
- `pnpm -F @vm0/firewalls-generator exec vitest run`
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm check-types`
- `pnpm knip --cache`
