### PR TITLE
fix(platform): prevent duplicate artifact download menus

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1801,6 +1801,44 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("opens only the dialog download menu when the same artifact is in split view", async () => {
+    const user = userEvent.setup({ delay: null });
+    setupHostedSiteArtifactPreview({
+      filename: "split-dialog-download.html",
+      htmlUrl: "https://split-dialog-download.sites.vm7.io",
+      label: "Split dialog download",
+      runId: "run-split-dialog-download",
+    });
+
+    await user.click(
+      await screen.findByLabelText(
+        "Open html preview for Split dialog download",
+      ),
+    );
+    await user.click(await screen.findByLabelText("Open in split view"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    await user.click(
+      await screen.findByLabelText(
+        "Open html preview for Split dialog download",
+      ),
+    );
+    const lightbox = await screen.findByTestId("attachment-lightbox");
+    const sidebarDownload = within(sidebar).getByLabelText("Download artifact");
+    const dialogDownload = within(lightbox).getByLabelText("Download options");
+
+    await user.click(dialogDownload);
+
+    await waitFor(() => {
+      expect(dialogDownload).toHaveAttribute("aria-expanded", "true");
+      expect(sidebarDownload).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getAllByRole("menu")).toHaveLength(1);
+      expect(
+        screen.getAllByTestId("artifact-download-menu-dismiss-layer"),
+      ).toHaveLength(1);
+    });
+  });
+
   it("prepares a hosted-site HTML comment edit session", async () => {
     const htmlUrl = "https://launch-site-demo.sites.vm7.io";
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -764,7 +764,6 @@ export function ArtifactDownloadMenu({
   url,
 }: ArtifactDownloadMenuProps) {
   const artifactDownloadKey = `${url}:${filename}`;
-  const menuKey = `${menuInstanceKey}:${artifactDownloadKey}`;
   const openKey = useGet(artifactDownloadMenuOpenKey$);
   const pendingKey = useGet(artifactDownloadPendingKey$);
   const openMenu = useSet(openArtifactDownloadMenu$);
@@ -773,7 +772,7 @@ export function ArtifactDownloadMenu({
   const finishArtifactDownload = useSet(finishArtifactDownload$);
   const pageSignal = useGet(pageSignal$);
   const features = useGet(featureSwitch$);
-  const open = openKey === menuKey;
+  const open = openKey === `${menuInstanceKey}:${artifactDownloadKey}`;
   const downloadPending = pendingKey === artifactDownloadKey;
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
@@ -787,7 +786,7 @@ export function ArtifactDownloadMenu({
       onOpenChange={(nextOpen) => {
         setArtifactDownloadMenuOpen({
           closeMenu,
-          menuKey,
+          menuKey: `${menuInstanceKey}:${artifactDownloadKey}`,
           nextOpen,
           openMenu,
         });

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -667,6 +667,7 @@ type ArtifactDownloadMenuProps = {
   className?: string;
   filename: string;
   iconSize?: number;
+  menuInstanceKey: string;
   syncTarget?: ArtifactDownloadSyncTarget;
   url: string;
 };
@@ -726,15 +727,15 @@ function startArtifactDownloadWithCleanup(params: {
   readonly closeMenu: () => void;
   readonly description: string;
   readonly download: Promise<void>;
+  readonly downloadKey: string;
   readonly finish: (key: string) => void;
-  readonly menuKey: string;
   readonly start: (key: string) => void;
 }): void {
   params.closeMenu();
-  params.start(params.menuKey);
+  params.start(params.downloadKey);
   detach(
     withCleanup(params.download, () => {
-      params.finish(params.menuKey);
+      params.finish(params.downloadKey);
     }),
     Reason.DomCallback,
     params.description,
@@ -758,10 +759,12 @@ export function ArtifactDownloadMenu({
   className,
   filename,
   iconSize = 16,
+  menuInstanceKey,
   syncTarget,
   url,
 }: ArtifactDownloadMenuProps) {
-  const menuKey = `${url}:${filename}`;
+  const artifactDownloadKey = `${url}:${filename}`;
+  const menuKey = `${menuInstanceKey}:${artifactDownloadKey}`;
   const openKey = useGet(artifactDownloadMenuOpenKey$);
   const pendingKey = useGet(artifactDownloadPendingKey$);
   const openMenu = useSet(openArtifactDownloadMenu$);
@@ -771,7 +774,7 @@ export function ArtifactDownloadMenu({
   const pageSignal = useGet(pageSignal$);
   const features = useGet(featureSwitch$);
   const open = openKey === menuKey;
-  const downloadPending = pendingKey === menuKey;
+  const downloadPending = pendingKey === artifactDownloadKey;
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
     filename,
@@ -834,8 +837,8 @@ export function ArtifactDownloadMenu({
                 pageSignal,
                 downloadFilename,
               ),
+              downloadKey: artifactDownloadKey,
               finish: finishArtifactDownload,
-              menuKey,
               start: startArtifactDownload,
             });
           }}
@@ -854,8 +857,8 @@ export function ArtifactDownloadMenu({
                   signal: pageSignal,
                   url,
                 }),
+                downloadKey: artifactDownloadKey,
                 finish: finishArtifactDownload,
-                menuKey,
                 start: startArtifactDownload,
               });
             }}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1364,6 +1364,7 @@ function ArtifactSidebarPreviewActions({
         ariaLabel="Download artifact"
         artifactKind={artifactKind}
         filename={title}
+        menuInstanceKey="artifact-sidebar"
         syncTarget={syncTarget}
         url={url}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1146,6 +1146,7 @@ function ArtifactPreviewDialogActions({
         artifactKind={artifact?.artifactKind}
         filename={artifact?.filename ?? artifactDialogFilename(preview)}
         iconSize={18}
+        menuInstanceKey="artifact-dialog"
         syncTarget={artifactDialogSyncTarget(artifact)}
         url={preview.url}
       />


### PR DESCRIPTION
## Summary

- scope artifact download menu visibility by preview surface so the split-view and dialog copies cannot open together
- keep download progress keyed to the artifact so pending state remains consistent across preview surfaces
- add integration coverage for reopening the same artifact in a dialog while it remains in split view

## User impact

Opening download options from an artifact preview dialog now shows a single menu, even when the same artifact is already open in split view.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx` (46 passed)
