### PR TITLE
refactor(runner): publish profile-qualified workspace cache state

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -12,8 +12,10 @@ use crate::idle_pool::IdlePool;
 use crate::provider::JobProvider;
 use crate::resource_budget::ResourceBudget;
 use crate::status::RunnerMode;
-use crate::types::{HeartbeatState, HeldSessionState, MAX_HELD_SESSION_STATES};
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::types::{
+    HeartbeatState, HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_SESSION,
+};
+use crate::workspace_image_cache::{SessionWorkspaceCache, cap_workspace_held_session_states};
 
 /// Period between routine heartbeat ticks sent to the server. First tick is
 /// deferred by one period via `interval_at`.
@@ -213,8 +215,7 @@ impl HeldSessionStateSnapshot {
             .iter_mut()
             .find(|existing| existing.session_id == state.session_id)
         {
-            Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
-            Some(existing) => *existing = state,
+            Some(existing) => merge_held_session_state(existing, state),
             None => inner.workspace_cache_states.push(state),
         }
         cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
@@ -269,6 +270,7 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
     let workspace_cache_states = refresh_workspace_cache_held_session_snapshot(
         &hb.held_session_snapshot,
         hb.workspace_cache.as_ref(),
+        hb.profiles,
     )
     .await;
     state.held_session_states = merge_current_held_session_states(
@@ -293,20 +295,33 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
 pub(super) async fn refresh_workspace_cache_held_session_snapshot(
     snapshot: &HeldSessionStateSnapshot,
     workspace_cache: Option<&SessionWorkspaceCache>,
+    profiles: &BTreeMap<String, ProfileConfig>,
 ) -> Vec<HeldSessionState> {
     let refresh = snapshot.begin_workspace_cache_refresh();
-    let states = workspace_cache_held_session_states(workspace_cache).await;
+    let states = workspace_cache_held_session_states(workspace_cache, profiles).await;
     snapshot.finish_workspace_cache_refresh(refresh, states)
 }
 
 async fn workspace_cache_held_session_states(
     workspace_cache: Option<&SessionWorkspaceCache>,
+    profiles: &BTreeMap<String, ProfileConfig>,
 ) -> Vec<HeldSessionState> {
     let Some(cache) = workspace_cache else {
         return Vec::new();
     };
 
-    cache.held_session_states().await
+    let profile_image_sizes_bytes = profiles
+        .iter()
+        .map(|(name, profile)| {
+            (
+                name.as_str(),
+                u64::from(profile.workspace_disk_mb) * 1024 * 1024,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    cache
+        .held_session_states_for_profiles(&profile_image_sizes_bytes)
+        .await
 }
 
 fn merge_current_held_session_states(
@@ -339,27 +354,60 @@ fn merge_held_session_states(
             continue;
         }
         match by_session.get_mut(&state.session_id) {
-            Some(existing) => {
-                let reusable_sandbox = existing.reusable_sandbox.take();
-                if state.last_completed_at > existing.last_completed_at {
-                    *existing = state;
-                }
-                existing.reusable_sandbox = reusable_sandbox.or(existing.reusable_sandbox.take());
-            }
+            Some(existing) => merge_held_session_state(existing, state),
             None => {
                 by_session.insert(state.session_id.clone(), state);
             }
         }
     }
     let mut states: Vec<HeldSessionState> = by_session.into_values().collect();
+    let observed_sessions = states.len();
+    let observed_workspace_caches = states
+        .iter()
+        .map(|state| state.workspace_caches.len())
+        .sum::<usize>();
     states.sort_unstable_by(|a, b| {
         b.last_completed_at
             .cmp(&a.last_completed_at)
             .then_with(|| a.session_id.cmp(&b.session_id))
     });
     states.truncate(MAX_HELD_SESSION_STATES);
+    let retained_workspace_caches = states
+        .iter()
+        .map(|state| state.workspace_caches.len())
+        .sum::<usize>();
+    if states.len() < observed_sessions || retained_workspace_caches < observed_workspace_caches {
+        info!(
+            observed_sessions,
+            retained_sessions = states.len(),
+            observed_workspace_caches,
+            retained_workspace_caches,
+            "heartbeat held session state truncated"
+        );
+    }
     states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
     states
+}
+
+fn merge_held_session_state(existing: &mut HeldSessionState, mut incoming: HeldSessionState) {
+    if incoming.last_completed_at > existing.last_completed_at {
+        existing.last_completed_at = incoming.last_completed_at;
+    }
+    if existing.reusable_sandbox.is_none() {
+        existing.reusable_sandbox = incoming.reusable_sandbox;
+    }
+    existing
+        .workspace_caches
+        .append(&mut incoming.workspace_caches);
+    existing
+        .workspace_caches
+        .sort_unstable_by(|a, b| a.profile.cmp(&b.profile));
+    existing
+        .workspace_caches
+        .dedup_by(|a, b| a.profile == b.profile);
+    existing
+        .workspace_caches
+        .truncate(MAX_WORKSPACE_CACHES_PER_SESSION);
 }
 
 fn merge_workspace_cache_snapshot_states(
@@ -368,9 +416,9 @@ fn merge_workspace_cache_snapshot_states(
 ) -> Vec<HeldSessionState> {
     let mut by_session = std::collections::BTreeMap::<String, HeldSessionState>::new();
     for state in refreshed_states.into_iter().chain(existing_states) {
-        match by_session.get(&state.session_id) {
-            Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
-            _ => {
+        match by_session.get_mut(&state.session_id) {
+            Some(existing) => merge_held_session_state(existing, state),
+            None => {
                 by_session.insert(state.session_id.clone(), state);
             }
         }
@@ -379,16 +427,25 @@ fn merge_workspace_cache_snapshot_states(
 }
 
 fn cap_workspace_cache_snapshot_states(states: &mut Vec<HeldSessionState>) {
-    if states.len() <= MAX_HELD_SESSION_STATES {
-        return;
+    let observed_sessions = states.len();
+    let observed_workspace_caches = states
+        .iter()
+        .map(|state| state.workspace_caches.len())
+        .sum::<usize>();
+    *states = cap_workspace_held_session_states(std::mem::take(states));
+    let retained_workspace_caches = states
+        .iter()
+        .map(|state| state.workspace_caches.len())
+        .sum::<usize>();
+    if states.len() < observed_sessions || retained_workspace_caches < observed_workspace_caches {
+        info!(
+            observed_sessions,
+            retained_sessions = states.len(),
+            observed_workspace_caches,
+            retained_workspace_caches,
+            "workspace cache held session snapshot truncated"
+        );
     }
-    states.sort_unstable_by(|a, b| {
-        b.last_completed_at
-            .cmp(&a.last_completed_at)
-            .then_with(|| a.session_id.cmp(&b.session_id))
-    });
-    states.truncate(MAX_HELD_SESSION_STATES);
-    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
 }
 
 fn admittable_profiles_for_heartbeat(
@@ -466,6 +523,7 @@ mod tests {
     use crate::ids::RunId;
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
+    use crate::types::WorkspaceCacheState;
     use crate::workspace_image_cache::{
         WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
@@ -484,7 +542,7 @@ mod tests {
                 vcpu: 2,
                 memory_mb: 4096,
                 rootfs_disk_mb: 8192,
-                workspace_disk_mb: 10240,
+                workspace_disk_mb: 1,
             },
         );
         m
@@ -505,6 +563,12 @@ mod tests {
         snapshot.finish_workspace_cache_refresh(refresh, states);
     }
 
+    fn workspace_cache(profile: &str) -> WorkspaceCacheState {
+        WorkspaceCacheState {
+            profile: profile.to_owned(),
+        }
+    }
+
     async fn seed_workspace_cache_state(
         cache: &SessionWorkspaceCache,
         paths: &RunnerPaths,
@@ -521,7 +585,7 @@ mod tests {
                     profile_name: "vm0/default",
                     cli_agent_session_id: Some(session_id),
                     working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: b"image".len() as u64,
+                    image_size_bytes: 1024 * 1024,
                 },
                 workspace_drive_required: true,
             })
@@ -530,7 +594,12 @@ mod tests {
         tokio::fs::create_dir_all(active_image.parent().unwrap())
             .await
             .unwrap();
-        tokio::fs::write(&active_image, b"image").await.unwrap();
+        tokio::fs::File::create(&active_image)
+            .await
+            .unwrap()
+            .set_len(1024 * 1024)
+            .await
+            .unwrap();
         assert!(
             lease
                 .promote(
@@ -756,6 +825,10 @@ mod tests {
         );
         assert_eq!(cached_states.len(), 1);
         assert_eq!(cached_states[0].session_id, session_id);
+        assert_eq!(
+            cached_states[0].workspace_caches,
+            vec![workspace_cache("vm0/default")]
+        );
     }
 
     #[tokio::test]
@@ -773,9 +846,11 @@ mod tests {
             session_id: "sess-idle".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: Vec::new(),
         }];
 
-        let cache_states = workspace_cache_held_session_states(Some(&cache)).await;
+        let profiles = test_profiles();
+        let cache_states = workspace_cache_held_session_states(Some(&cache), &profiles).await;
         let states = merge_current_held_session_states(
             idle,
             cache_states,
@@ -809,16 +884,19 @@ mod tests {
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                     reusable_sandbox: None,
+                    workspace_caches: vec![workspace_cache("vm0/default")],
                 },
                 HeldSessionState {
                     session_id: "sess-claimed".into(),
                     last_completed_at: "2026-06-01T00:00:03.000Z".into(),
                     reusable_sandbox: None,
+                    workspace_caches: vec![workspace_cache("vm0/default")],
                 },
                 HeldSessionState {
                     session_id: "sess-active".into(),
                     last_completed_at: "2026-06-01T00:00:04.000Z".into(),
                     reusable_sandbox: None,
+                    workspace_caches: vec![workspace_cache("vm0/default")],
                 },
             ],
         );
@@ -833,11 +911,13 @@ mod tests {
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:01.000Z".into(),
                 reusable_sandbox: None,
+                workspace_caches: Vec::new(),
             },
             HeldSessionState {
                 session_id: "sess-idle".into(),
                 last_completed_at: "2026-06-01T00:00:05.000Z".into(),
                 reusable_sandbox: None,
+                workspace_caches: Vec::new(),
             },
         ];
 
@@ -854,11 +934,13 @@ mod tests {
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                     reusable_sandbox: None,
+                    workspace_caches: vec![workspace_cache("vm0/default")],
                 },
                 HeldSessionState {
                     session_id: "sess-idle".into(),
                     last_completed_at: "2026-06-01T00:00:05.000Z".into(),
                     reusable_sandbox: None,
+                    workspace_caches: Vec::new(),
                 },
             ]
         );
@@ -893,6 +975,7 @@ mod tests {
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                 reusable_sandbox: None,
+                workspace_caches: vec![workspace_cache("vm0/default")],
             }],
         );
         assert!(
@@ -909,6 +992,7 @@ mod tests {
                 session_id: format!("sess-{index:04}"),
                 last_completed_at: timestamp_for_index(index),
                 reusable_sandbox: None,
+                workspace_caches: vec![workspace_cache("vm0/default")],
             });
         }
 
@@ -934,27 +1018,35 @@ mod tests {
     fn held_session_snapshot_refresh_preserves_concurrent_upsert() {
         let snapshot = HeldSessionStateSnapshot::new();
         let original = HeldSessionState {
-            session_id: "sess-original".into(),
+            session_id: "sess-shared".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
         };
         let promoted = HeldSessionState {
-            session_id: "sess-promoted".into(),
+            session_id: "sess-shared".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/large")],
         };
         refresh_snapshot(&snapshot, vec![original.clone()]);
 
         let refresh = snapshot.begin_workspace_cache_refresh();
         snapshot.upsert_workspace_cache_state(promoted.clone());
         let refreshed = snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
-        assert_eq!(refreshed, vec![original.clone(), promoted.clone()]);
+        let merged = HeldSessionState {
+            session_id: "sess-shared".into(),
+            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default"), workspace_cache("vm0/large")],
+        };
+        assert_eq!(refreshed, vec![merged.clone()]);
 
         let active_cli_agent_sessions =
             super::super::active_sessions::new_active_cli_agent_sessions();
         let states =
             snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
-        assert_eq!(states, vec![original.clone(), promoted]);
+        assert_eq!(states, vec![merged]);
 
         let refresh = snapshot.begin_workspace_cache_refresh();
         snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
@@ -974,11 +1066,13 @@ mod tests {
             session_id: "sess-active-idle".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: Vec::new(),
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-active".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
         }];
         let active = std::collections::HashSet::from([
             "sess-active".to_string(),
@@ -999,11 +1093,13 @@ mod tests {
                 profile: "vm0/default".into(),
                 history_generation_run_id: Some(RunId::new_v4()),
             }),
+            workspace_caches: Vec::new(),
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
         }];
 
         let merged = merge_held_session_states(idle, cache, &std::collections::HashSet::new());
@@ -1026,6 +1122,10 @@ mod tests {
                 .is_some(),
             "newer workspace-cache timestamps must preserve idle generation metadata"
         );
+        assert_eq!(
+            merged[0].workspace_caches,
+            vec![workspace_cache("vm0/default")]
+        );
     }
 
     #[test]
@@ -1037,11 +1137,13 @@ mod tests {
                 profile: "vm0/default".into(),
                 history_generation_run_id: None,
             }),
+            workspace_caches: Vec::new(),
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
         }];
 
         let merged = merge_held_session_states(idle, cache, &std::collections::HashSet::new());

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1360,6 +1360,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     refresh_workspace_cache_held_session_snapshot(
         &held_session_snapshot,
         exec_config.workspace_cache.as_ref(),
+        &runner.profiles,
     )
     .await;
     debug_assert!(held_session_snapshot.workspace_cache_loaded());

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -36,7 +36,7 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::HeldSessionState;
+use crate::types::{HeldSessionState, WorkspaceCacheState};
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionRequest,
@@ -61,6 +61,7 @@ fn mark_session_affinity_refresh(
 fn mark_workspace_cache_snapshot_promoted(
     snapshot: &HeldSessionStateSnapshot,
     session_id: Option<&str>,
+    profile_name: &str,
     completed_at: &str,
     promoted: bool,
 ) -> bool {
@@ -69,6 +70,9 @@ fn mark_workspace_cache_snapshot_promoted(
             session_id: session_id.to_owned(),
             last_completed_at: completed_at.to_owned(),
             reusable_sandbox: None,
+            workspace_caches: vec![WorkspaceCacheState {
+                profile: profile_name.to_owned(),
+            }],
         });
     }
     promoted
@@ -231,6 +235,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                     &held_session_snapshot,
                     Some(&cli_agent_session_id),
+                    &profile_name,
                     &completed_at,
                     destroy_result.workspace_cache_promoted,
                 );
@@ -265,6 +270,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
                 &held_session_snapshot,
                 Some(&cli_agent_session_id),
+                &profile_name,
                 &completed_at,
                 destroy_result.workspace_cache_promoted,
             );
@@ -289,6 +295,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
                 &held_session_snapshot,
                 Some(&cli_agent_session_id),
+                &profile_name,
                 &completed_at,
                 destroy_result.workspace_cache_promoted,
             );
@@ -324,6 +331,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                             &held_session_snapshot,
                             Some(&cli_agent_session_id),
+                            &profile_name,
                             &completed_at,
                             destroy_result.workspace_cache_promoted,
                         );
@@ -354,6 +362,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                         &held_session_snapshot,
                         Some(&cli_agent_session_id),
+                        &profile_name,
                         &completed_at,
                         destroy_result.workspace_cache_promoted,
                     );
@@ -440,6 +449,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
                             &held_session_snapshot,
                             Some(&cli_agent_session_id),
+                            &profile_name,
                             &completed_at,
                             destroy_result.workspace_cache_promoted,
                         );
@@ -476,6 +486,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
             &held_session_snapshot,
             workspace_cache_snapshot_session_id,
+            &profile_name,
             &completed_at,
             destroy_result.workspace_cache_promoted,
         );
@@ -1560,6 +1571,11 @@ mod tests {
             held_session_snapshot.current_held_session_states(Vec::new(), &active_sessions, None);
         assert_eq!(snapshot_states.len(), 1);
         assert_eq!(snapshot_states[0].session_id, session_id);
+        assert_eq!(snapshot_states[0].workspace_caches.len(), 1);
+        assert_eq!(
+            snapshot_states[0].workspace_caches[0].profile,
+            "vm0/default"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1207,6 +1207,7 @@ impl IdlePool {
                             profile: entry.metadata.profile_name.clone(),
                             history_generation_run_id: entry.metadata.history_generation_run_id,
                         }),
+                        workspace_caches: Vec::new(),
                     })
             })
             .collect();
@@ -2016,6 +2017,7 @@ mod tests {
                         profile: "vm0/default".to_string(),
                         history_generation_run_id: Some(history_generation_run_id),
                     }),
+                    workspace_caches: Vec::new(),
                 },
                 HeldSessionState {
                     session_id: "sess-b".to_string(),
@@ -2024,6 +2026,7 @@ mod tests {
                         profile: "vm0/default".to_string(),
                         history_generation_run_id: None,
                     }),
+                    workspace_caches: Vec::new(),
                 },
             ],
         );

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1450,6 +1450,7 @@ mod tests {
                 session_id: "held-session-test".to_string(),
                 last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
                 reusable_sandbox: None,
+                workspace_caches: Vec::new(),
             }],
             mode: "running".to_string(),
         }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -11,6 +11,8 @@ use api_contracts::generated::types::runners::storage::StorageManifest;
 use crate::ids::RunId;
 
 pub(crate) const MAX_HELD_SESSION_STATES: usize = 1024;
+pub(crate) const MAX_WORKSPACE_CACHES_PER_SESSION: usize = 8;
+pub(crate) const MAX_WORKSPACE_CACHES_PER_HEARTBEAT: usize = 1024;
 
 fn is_false(value: &bool) -> bool {
     !*value
@@ -1241,6 +1243,12 @@ pub struct ReusableSandboxState {
     pub history_generation_run_id: Option<RunId>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceCacheState {
+    pub profile: String,
+}
+
 /// Runner state snapshot sent to the server via heartbeat.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -1251,6 +1259,8 @@ pub struct HeldSessionState {
     pub last_completed_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reusable_sandbox: Option<ReusableSandboxState>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspace_caches: Vec<WorkspaceCacheState>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1957,6 +1967,9 @@ mod tests {
                         "11111111-1111-4111-8111-111111111111".parse().unwrap(),
                     ),
                 }),
+                workspace_caches: vec![WorkspaceCacheState {
+                    profile: "vm0/large".into(),
+                }],
             }],
             mode: "running".into(),
         };
@@ -1980,7 +1993,8 @@ mod tests {
                 "reusableSandbox": {
                     "profile": "vm0/default",
                     "historyGenerationRunId": "11111111-1111-4111-8111-111111111111"
-                }
+                },
+                "workspaceCaches": [{ "profile": "vm0/large" }]
             }])
         );
         assert_eq!(json["mode"], "running");
@@ -2002,6 +2016,7 @@ mod tests {
                 .as_ref()
                 .is_some_and(|sandbox| sandbox.history_generation_run_id.is_none())
         );
+        assert!(state.workspace_caches.is_empty());
 
         let serialized = serde_json::to_value(state).unwrap();
         assert!(
@@ -2009,5 +2024,6 @@ mod tests {
                 .get("historyGenerationRunId")
                 .is_none()
         );
+        assert!(serialized.get("workspaceCaches").is_none());
     }
 }

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use nix::fcntl::Flock;
 use tokio::fs;
 #[cfg(test)]
@@ -10,7 +11,10 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES};
+use crate::types::{
+    HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
+    MAX_WORKSPACE_CACHES_PER_SESSION, WorkspaceCacheState,
+};
 
 use super::entry::is_cache_key_name;
 use super::fs::{
@@ -18,7 +22,8 @@ use super::fs::{
     remove_non_directory_workspace_cache_entry, remove_workspace_cache_path_if_exists, sparse_copy,
 };
 use super::metadata::{
-    WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
+    WorkspaceCacheMetadata, WorkspaceCacheState as WorkspaceCacheEntryState,
+    WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::path_safety::{
     filter_storage_fingerprints_for_working_dir, is_safe_guest_working_dir,
@@ -568,7 +573,24 @@ impl SessionWorkspaceCache {
         }
     }
 
+    pub(crate) async fn held_session_states_for_profiles(
+        &self,
+        profile_image_sizes_bytes: &BTreeMap<&str, u64>,
+    ) -> Vec<HeldSessionState> {
+        self.held_session_states_matching_profiles(Some(profile_image_sizes_bytes))
+            .await
+    }
+
+    /// Inspect cache state without a running profile configuration in tests.
+    #[cfg(test)]
     pub(crate) async fn held_session_states(&self) -> Vec<HeldSessionState> {
+        self.held_session_states_matching_profiles(None).await
+    }
+
+    async fn held_session_states_matching_profiles(
+        &self,
+        profile_image_sizes_bytes: Option<&BTreeMap<&str, u64>>,
+    ) -> Vec<HeldSessionState> {
         let root = self.workspace_image_cache_dir().to_path_buf();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
@@ -605,32 +627,63 @@ impl SessionWorkspaceCache {
                 }
             };
             if self
-                .metadata_is_publishable_held_session_state(cache_key, &metadata)
+                .metadata_is_publishable_held_session_state(
+                    cache_key,
+                    &metadata,
+                    profile_image_sizes_bytes,
+                )
                 .await
             {
                 states.push(HeldSessionState {
                     session_id: metadata.session_id,
                     last_completed_at: metadata.last_completed_at,
                     reusable_sandbox: None,
+                    workspace_caches: vec![WorkspaceCacheState {
+                        profile: metadata.profile_name,
+                    }],
                 });
             }
             drop(lock);
         }
-        cap_workspace_held_session_states(states)
+        let observed_workspace_caches = states
+            .iter()
+            .map(|state| state.workspace_caches.len())
+            .sum::<usize>();
+        let states = cap_workspace_held_session_states(states);
+        let retained_workspace_caches = states
+            .iter()
+            .map(|state| state.workspace_caches.len())
+            .sum::<usize>();
+        if retained_workspace_caches < observed_workspace_caches {
+            info!(
+                observed_workspace_caches,
+                retained_sessions = states.len(),
+                retained_workspace_caches,
+                "workspace cache held session state truncated"
+            );
+        }
+        states
     }
 
     async fn metadata_is_publishable_held_session_state(
         &self,
         cache_key: &str,
         metadata: &WorkspaceCacheMetadata,
+        profile_image_sizes_bytes: Option<&BTreeMap<&str, u64>>,
     ) -> bool {
         metadata.format_version == CACHE_FORMAT_VERSION
             && metadata.key_version == CACHE_KEY_VERSION
             && metadata.cache_scope == self.inner.cache_scope
             && metadata.drive_layout == WORKSPACE_DRIVE_LAYOUT
-            && metadata.state == WorkspaceCacheState::Current
+            && metadata.state == WorkspaceCacheEntryState::Current
             && metadata.workspace_trust == WorkspaceTrust::Clean
             && is_safe_guest_working_dir(&metadata.working_dir)
+            && profile_image_sizes_bytes.is_none_or(|profile_image_sizes_bytes| {
+                metadata.working_dir == CANONICAL_WORKING_DIR
+                    && profile_image_sizes_bytes
+                        .get(metadata.profile_name.as_str())
+                        .is_some_and(|image_size| *image_size == metadata.logical_image_size_bytes)
+            })
             && self.metadata_matches_cache_key(cache_key, metadata)
             && self
                 .metadata_matches_current_image(cache_key, metadata)
@@ -907,7 +960,7 @@ impl SessionWorkspaceCache {
                 input.storage_fingerprints,
                 input.working_dir,
             ),
-            state: WorkspaceCacheState::Current,
+            state: WorkspaceCacheEntryState::Current,
         };
         if let Err(e) = self
             .write_metadata(input.cache_key, input.run_id, metadata)
@@ -1433,31 +1486,66 @@ impl WorkspaceSessionHistorySidecarEntryGuard {
     }
 }
 
-pub(super) fn cap_workspace_held_session_states(
+pub(crate) fn cap_workspace_held_session_states(
     states: Vec<HeldSessionState>,
 ) -> Vec<HeldSessionState> {
-    let mut newest_by_session = BTreeMap::<String, HeldSessionState>::new();
-    for state in states {
-        match newest_by_session.get_mut(&state.session_id) {
-            Some(existing) if state.last_completed_at > existing.last_completed_at => {
-                *existing = state;
+    let mut by_session = BTreeMap::<String, HeldSessionState>::new();
+    for mut state in states {
+        match by_session.get_mut(&state.session_id) {
+            Some(existing) => {
+                if state.last_completed_at > existing.last_completed_at {
+                    existing.last_completed_at = state.last_completed_at;
+                }
+                if existing.reusable_sandbox.is_none() {
+                    existing.reusable_sandbox = state.reusable_sandbox;
+                }
+                existing
+                    .workspace_caches
+                    .append(&mut state.workspace_caches);
             }
-            Some(_) => {}
             None => {
-                newest_by_session.insert(state.session_id.clone(), state);
+                by_session.insert(state.session_id.clone(), state);
             }
         }
     }
 
-    let mut states: Vec<HeldSessionState> = newest_by_session.into_values().collect();
-    if states.len() > MAX_HELD_SESSION_STATES {
-        states.sort_unstable_by(|a, b| {
-            b.last_completed_at
-                .cmp(&a.last_completed_at)
-                .then_with(|| a.session_id.cmp(&b.session_id))
-        });
-        states.truncate(MAX_HELD_SESSION_STATES);
+    let mut states: Vec<HeldSessionState> = by_session
+        .into_values()
+        .map(|mut state| {
+            state
+                .workspace_caches
+                .sort_unstable_by(|a, b| a.profile.cmp(&b.profile));
+            state
+                .workspace_caches
+                .dedup_by(|a, b| a.profile == b.profile);
+            state
+                .workspace_caches
+                .truncate(MAX_WORKSPACE_CACHES_PER_SESSION);
+            state
+        })
+        .collect();
+    states.sort_unstable_by(|a, b| {
+        b.last_completed_at
+            .cmp(&a.last_completed_at)
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+
+    let mut retained = Vec::new();
+    let mut retained_workspace_caches = 0;
+    for mut state in states {
+        if retained.len() == MAX_HELD_SESSION_STATES
+            || retained_workspace_caches == MAX_WORKSPACE_CACHES_PER_HEARTBEAT
+        {
+            break;
+        }
+        let remaining = MAX_WORKSPACE_CACHES_PER_HEARTBEAT - retained_workspace_caches;
+        state.workspace_caches.truncate(remaining);
+        if state.workspace_caches.is_empty() {
+            continue;
+        }
+        retained_workspace_caches += state.workspace_caches.len();
+        retained.push(state);
     }
-    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
-    states
+    retained.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+    retained
 }

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -51,6 +51,7 @@ mod tests;
 pub(crate) use lifecycle::{
     WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityFailure,
     WorkspaceImagePromotionOutcome, WorkspaceSessionHistorySidecarEntryGuard,
+    cap_workspace_held_session_states,
 };
 pub(crate) use types::{
     CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::MetadataExt;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -24,7 +24,11 @@ use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key, session_work
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::storage_fingerprints::StorageFingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES, ResumeSessionHistoryRefKind};
+use crate::types::{
+    HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
+    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind,
+    WorkspaceCacheState as HeldWorkspaceCacheState,
+};
 use sha2::{Digest, Sha256};
 use tokio::fs;
 
@@ -42,13 +46,29 @@ async fn write_current_cache_entry(
     last_completed_at: &str,
     last_used_at: &str,
 ) -> String {
-    let image = format!("image-{session_id}");
-    let key = cache.scoped_cache_key(
+    write_current_cache_entry_for_profile(
+        cache,
+        run_id,
         TEST_PROFILE_NAME,
         session_id,
         working_dir,
-        image.len() as u64,
-    );
+        last_completed_at,
+        last_used_at,
+    )
+    .await
+}
+
+async fn write_current_cache_entry_for_profile(
+    cache: &SessionWorkspaceCache,
+    run_id: RunId,
+    profile_name: &str,
+    session_id: &str,
+    working_dir: &str,
+    last_completed_at: &str,
+    last_used_at: &str,
+) -> String {
+    let image = format!("image-{session_id}");
+    let key = cache.scoped_cache_key(profile_name, session_id, working_dir, image.len() as u64);
     fs::create_dir_all(cache.session_workspace_cache_entry_dir(&key))
         .await
         .unwrap();
@@ -63,7 +83,7 @@ async fn write_current_cache_entry(
                 format_version: CACHE_FORMAT_VERSION,
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
-                profile_name: TEST_PROFILE_NAME.into(),
+                profile_name: profile_name.into(),
                 session_id: session_id.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: last_completed_at.into(),
@@ -1054,12 +1074,18 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
             session_id: format!("sess-{index:04}"),
             last_completed_at: timestamp_for_index(index),
             reusable_sandbox: None,
+            workspace_caches: vec![HeldWorkspaceCacheState {
+                profile: TEST_PROFILE_NAME.to_owned(),
+            }],
         })
         .collect();
     states.push(HeldSessionState {
         session_id: "sess-0001".into(),
         last_completed_at: timestamp_for_index(MAX_HELD_SESSION_STATES + 1),
         reusable_sandbox: None,
+        workspace_caches: vec![HeldWorkspaceCacheState {
+            profile: TEST_PROFILE_NAME.to_owned(),
+        }],
     });
 
     let capped = cap_workspace_held_session_states(states);
@@ -1077,6 +1103,135 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
         capped
             .iter()
             .any(|state| state.session_id == format!("sess-{MAX_HELD_SESSION_STATES:04}"))
+    );
+}
+
+#[test]
+fn cap_workspace_held_session_states_bounds_nested_resources() {
+    let per_session = (0..=MAX_WORKSPACE_CACHES_PER_SESSION)
+        .map(|index| HeldSessionState {
+            session_id: "sess-multi".into(),
+            last_completed_at: timestamp_for_index(index),
+            reusable_sandbox: None,
+            workspace_caches: vec![HeldWorkspaceCacheState {
+                profile: format!("vm0/profile-{index:02}"),
+            }],
+        })
+        .collect();
+
+    let capped = cap_workspace_held_session_states(per_session);
+
+    assert_eq!(capped.len(), 1);
+    assert_eq!(
+        capped[0].workspace_caches.len(),
+        MAX_WORKSPACE_CACHES_PER_SESSION
+    );
+    assert_eq!(capped[0].workspace_caches[0].profile, "vm0/profile-00");
+    assert_eq!(capped[0].last_completed_at, timestamp_for_index(8));
+
+    let global = (0..=MAX_WORKSPACE_CACHES_PER_HEARTBEAT / 8)
+        .map(|index| HeldSessionState {
+            session_id: format!("sess-{index:04}"),
+            last_completed_at: timestamp_for_index(index),
+            reusable_sandbox: None,
+            workspace_caches: (0..8)
+                .map(|profile| HeldWorkspaceCacheState {
+                    profile: format!("vm0/profile-{profile}"),
+                })
+                .collect(),
+        })
+        .collect();
+
+    let capped = cap_workspace_held_session_states(global);
+
+    assert_eq!(
+        capped
+            .iter()
+            .map(|state| state.workspace_caches.len())
+            .sum::<usize>(),
+        MAX_WORKSPACE_CACHES_PER_HEARTBEAT
+    );
+    assert!(
+        !capped.iter().any(|state| state.session_id == "sess-0000"),
+        "oldest session should be dropped at the global workspace cap"
+    );
+}
+
+#[tokio::test]
+async fn held_session_states_for_profiles_filters_and_aggregates_current_identities() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths);
+    let run_id = RunId::new_v4();
+    let session_id = "sess-multi-profile";
+    let image_size = format!("image-{session_id}").len() as u64;
+    write_current_cache_entry_for_profile(
+        &cache,
+        run_id,
+        "vm0/default",
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:01.000Z",
+        "2026-05-01T00:00:01.000Z",
+    )
+    .await;
+    write_current_cache_entry_for_profile(
+        &cache,
+        run_id,
+        "vm0/large",
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:02.000Z",
+        "2026-05-01T00:00:02.000Z",
+    )
+    .await;
+    write_current_cache_entry_for_profile(
+        &cache,
+        run_id,
+        "vm0/noncanonical",
+        session_id,
+        "/workspace",
+        "2026-05-01T00:00:03.000Z",
+        "2026-05-01T00:00:03.000Z",
+    )
+    .await;
+
+    let configured = BTreeMap::from([
+        ("vm0/default", image_size),
+        ("vm0/large", image_size),
+        ("vm0/noncanonical", image_size),
+    ]);
+    let states = cache.held_session_states_for_profiles(&configured).await;
+
+    assert_eq!(
+        states,
+        vec![HeldSessionState {
+            session_id: session_id.into(),
+            last_completed_at: "2026-05-01T00:00:02.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![
+                HeldWorkspaceCacheState {
+                    profile: "vm0/default".into(),
+                },
+                HeldWorkspaceCacheState {
+                    profile: "vm0/large".into(),
+                },
+            ],
+        }]
+    );
+
+    let default_only = BTreeMap::from([("vm0/default", image_size)]);
+    let states = cache.held_session_states_for_profiles(&default_only).await;
+    assert_eq!(states[0].workspace_caches.len(), 1);
+    assert_eq!(states[0].workspace_caches[0].profile, "vm0/default");
+
+    let wrong_size = BTreeMap::from([("vm0/default", image_size + 1)]);
+    assert!(
+        cache
+            .held_session_states_for_profiles(&wrong_size)
+            .await
+            .is_empty()
     );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -167,6 +167,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
       {
         sessionId: "session-bdd-held",
         lastCompletedAt: new Date(now()).toISOString(),
+        workspaceCaches: [{ profile: "vm0/default" }],
       },
     ];
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -331,6 +331,13 @@ function canonicalizeHeldSessionStates(
             },
           }
         : {}),
+      ...(state.workspaceCaches
+        ? {
+            workspaceCaches: state.workspaceCaches.map((workspaceCache) => {
+              return { profile: workspaceCache.profile };
+            }),
+          }
+        : {}),
     };
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  heartbeatBodySchema,
   heldSessionStateSchema,
   jobSchema,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
@@ -373,10 +374,15 @@ describe("runner resume session contract", () => {
         profile: "vm0/default",
         historyGenerationRunId,
       },
+      workspaceCaches: [{ profile: "vm0/default" }, { profile: "vm0/large" }],
     });
     expect(heldSessionState.reusableSandbox?.historyGenerationRunId).toBe(
       historyGenerationRunId,
     );
+    expect(heldSessionState.workspaceCaches).toEqual([
+      { profile: "vm0/default" },
+      { profile: "vm0/large" },
+    ]);
   });
 
   it("keeps generation-affinity additions optional for legacy runners", () => {
@@ -399,6 +405,61 @@ describe("runner resume session contract", () => {
     expect(heldSessionState.reusableSandbox).toEqual({
       profile: "vm0/default",
     });
+    expect(heldSessionState.workspaceCaches).toBeUndefined();
+  });
+
+  it("bounds profile-qualified workspace cache heartbeat state", () => {
+    const heartbeat = {
+      runnerId: "33333333-3333-4333-8333-333333333333",
+      runnerName: "runner-contract-test",
+      group: "vm0/test",
+      totalVcpu: 8,
+      totalMemoryMb: 16_384,
+      maxConcurrent: 4,
+      allocatedVcpu: 0,
+      allocatedMemoryMb: 0,
+      runningCount: 0,
+      admittableProfiles: ["vm0/default"],
+      mode: "running",
+    } as const;
+    const workspaceCaches = Array.from({ length: 8 }, (_, index) => {
+      return { profile: `vm0/profile-${index}` };
+    });
+    const heldSessionStates = Array.from({ length: 128 }, (_, index) => {
+      return {
+        sessionId: `sess-${index}`,
+        lastCompletedAt: "2026-07-15T00:00:00.000Z",
+        workspaceCaches,
+      };
+    });
+
+    expect(
+      heartbeatBodySchema.safeParse({ ...heartbeat, heldSessionStates })
+        .success,
+    ).toBe(true);
+    expect(
+      heartbeatBodySchema.safeParse({
+        ...heartbeat,
+        heldSessionStates: [
+          ...heldSessionStates,
+          {
+            sessionId: "sess-over-global-cap",
+            lastCompletedAt: "2026-07-15T00:00:00.000Z",
+            workspaceCaches: [{ profile: "vm0/default" }],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      heldSessionStateSchema.safeParse({
+        sessionId: "sess-over-parent-cap",
+        lastCompletedAt: "2026-07-15T00:00:00.000Z",
+        workspaceCaches: [
+          ...workspaceCaches,
+          { profile: "vm0/profile-over-cap" },
+        ],
+      }).success,
+    ).toBe(false);
   });
 
   it("requires a URL for hash-backed claim resume sessions", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -203,6 +203,14 @@ export const heldSessionStateSchema = z.object({
       historyGenerationRunId: z.uuid().optional(),
     })
     .optional(),
+  workspaceCaches: z
+    .array(
+      z.object({
+        profile: z.string(),
+      }),
+    )
+    .max(8)
+    .optional(),
 });
 
 /**
@@ -607,20 +615,38 @@ export const runnersBuiltinFirewallsResolveContract = c.router({
 /**
  * Runner heartbeat body — periodic state report from each runner
  */
-export const heartbeatBodySchema = z.object({
-  runnerId: z.uuid(),
-  runnerName: z.string(),
-  group: runnerGroupSchema,
-  totalVcpu: z.number().int().nonnegative(),
-  totalMemoryMb: z.number().int().nonnegative(),
-  maxConcurrent: z.number().int().nonnegative(),
-  allocatedVcpu: z.number().int().nonnegative(),
-  allocatedMemoryMb: z.number().int().nonnegative(),
-  runningCount: z.number().int().nonnegative(),
-  admittableProfiles: runnerProfileListSchema,
-  heldSessionStates: z.array(heldSessionStateSchema).max(1024),
-  mode: z.enum(["starting", "running", "draining", "stopping"]),
-});
+export const heartbeatBodySchema = z
+  .object({
+    runnerId: z.uuid(),
+    runnerName: z.string(),
+    group: runnerGroupSchema,
+    totalVcpu: z.number().int().nonnegative(),
+    totalMemoryMb: z.number().int().nonnegative(),
+    maxConcurrent: z.number().int().nonnegative(),
+    allocatedVcpu: z.number().int().nonnegative(),
+    allocatedMemoryMb: z.number().int().nonnegative(),
+    runningCount: z.number().int().nonnegative(),
+    admittableProfiles: runnerProfileListSchema,
+    heldSessionStates: z.array(heldSessionStateSchema).max(1024),
+    mode: z.enum(["starting", "running", "draining", "stopping"]),
+  })
+  .superRefine((heartbeat, ctx) => {
+    const workspaceCacheCount = heartbeat.heldSessionStates.reduce(
+      (count, state) => {
+        return count + (state.workspaceCaches?.length ?? 0);
+      },
+      0,
+    );
+    if (workspaceCacheCount <= 1024) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["heldSessionStates"],
+      message: "heldSessionStates may contain at most 1024 workspace caches",
+    });
+  });
 
 /**
  * Runners heartbeat contract - POST /api/runners/heartbeat

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -9,6 +9,9 @@ export interface RunnerHeldSessionState {
     readonly profile: string;
     readonly historyGenerationRunId?: string;
   };
+  readonly workspaceCaches?: readonly {
+    readonly profile: string;
+  }[];
 }
 
 export type RunnerHeldSessionStates = RunnerHeldSessionState[];


### PR DESCRIPTION
## Summary

- add optional, bounded `workspaceCaches[{ profile }]` state to runner heartbeats and the existing runner-state JSONB contract
- validate cache observations against the runner's current profile image size, canonical working directory, cache identity, clean/current metadata, and current image identity
- aggregate workspace profiles under one session parent while preserving reusable-sandbox state, active-session filtering, deterministic caps, and refresh/promotion convergence
- canonicalize the additive state through the real API heartbeat route without changing affinity, polling, admission, claim, checkout, or restore behavior

## Compatibility

- old runner -> new API remains valid because `workspaceCaches` is optional
- new runner -> old API remains behavior-neutral because the unknown nested field is stripped
- no physical PostgreSQL migration, cache-format change, queue change, behavior capability, or cross-claim cache lock

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner` (2,729 runner tests passed; 11 ignored; guest inventory 1 passed)
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint && pnpm -F @vm0/db lint && pnpm -F api lint`
- `cd turbo && pnpm check-types` (13 workspaces passed via pre-commit)
- `cd turbo && pnpm -F @vm0/api-contracts test` (439 passed)
- `cd turbo && pnpm -F @vm0/db test` (12 passed)
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-cron.bdd.test.ts` (9 passed)
- `cd turbo && pnpm knip`

Closes #21867

Parent context: #21861

