### PR TITLE
feat(platform): favorite artifacts from the preview header

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1890,6 +1890,18 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       googleDriveSync: { status: "disconnected" },
     });
 
+    if (!csvFile) {
+      throw new Error("Expected the CSV artifact to be listed");
+    }
+    expect(csvFile.isFavorited).toBeFalsy();
+    await chat.favoriteArtifact(actor, csvFile.url);
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expect(
+      artifacts.runs[0]?.files.find((file) => {
+        return file.id === csvId;
+      })?.isFavorited,
+    ).toBeTruthy();
+
     // Sync requires a connected Drive.
     const noConnector = await chat.requestSyncThreadArtifact(
       actor,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -934,10 +934,19 @@ export function zeroChatThreadArtifacts(args: {
           url: runUploadedFiles.url,
           metadata: runUploadedFiles.metadata,
           createdAt: runUploadedFiles.createdAt,
+          isFavorited: sql<boolean>`${userArtifactFavorites.artifactUrl} IS NOT NULL`,
         })
         .from(runUploadedFiles)
         .innerJoin(zeroRuns, eq(zeroRuns.id, runUploadedFiles.runId))
         .innerJoin(agentRuns, eq(agentRuns.id, runUploadedFiles.runId))
+        .leftJoin(
+          userArtifactFavorites,
+          and(
+            eq(userArtifactFavorites.orgId, agentRuns.orgId),
+            eq(userArtifactFavorites.userId, args.userId),
+            eq(userArtifactFavorites.artifactUrl, runUploadedFiles.url),
+          ),
+        )
         .where(
           and(
             eq(runUploadedFiles.userId, args.userId),
@@ -1000,6 +1009,7 @@ export function zeroChatThreadArtifacts(args: {
           url: row.url,
           ...(artifactKind ? { artifactKind } : {}),
           createdAt: row.createdAt.toISOString(),
+          isFavorited: row.isFavorited,
         });
         byRun.set(row.runId, existing);
       }

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -341,6 +341,13 @@ export const artifactFavoriteOverrides$ = computed((get) => {
   return get(internalArtifactFavoriteOverrides$);
 });
 
+type ArtifactFavoriteTarget =
+  | ArtifactItem
+  | {
+      readonly currentIsFavorited: boolean;
+      readonly url: string;
+    };
+
 // Applies the search / agent / category filters in memory over the active set,
 // so switching filters is instant and never re-fetches or truncates.
 export function filterArtifacts(
@@ -375,25 +382,29 @@ export function filterArtifacts(
 }
 
 export const toggleArtifactFavorite$ = command(
-  async ({ get, set }, item: ArtifactItem, signal: AbortSignal) => {
-    const currentIsFavorited = item.isFavorited === true;
+  async ({ get, set }, target: ArtifactFavoriteTarget, signal: AbortSignal) => {
+    const item = "currentIsFavorited" in target ? undefined : target;
+    const currentIsFavorited =
+      "currentIsFavorited" in target
+        ? target.currentIsFavorited
+        : target.isFavorited === true;
     const nextIsFavorited = !currentIsFavorited;
     set(internalArtifactFavoriteOverrides$, (overrides) => {
-      return { ...overrides, [item.url]: nextIsFavorited };
+      return { ...overrides, [target.url]: nextIsFavorited };
     });
 
     const client = get(zeroClient$)(artifactsContract);
     const request = nextIsFavorited
       ? accept(
           client.favorite({
-            body: { artifactUrl: item.url },
+            body: { artifactUrl: target.url },
             fetchOptions: { signal },
           }),
           [204],
         )
       : accept(
           client.unfavorite({
-            body: { artifactUrl: item.url },
+            body: { artifactUrl: target.url },
             fetchOptions: { signal },
           }),
           [204],
@@ -401,18 +412,20 @@ export const toggleArtifactFavorite$ = command(
     await onRejection(request, () => {
       if (!signal.aborted) {
         set(internalArtifactFavoriteOverrides$, (overrides) => {
-          return { ...overrides, [item.url]: currentIsFavorited };
+          return { ...overrides, [target.url]: currentIsFavorited };
         });
       }
     });
     signal.throwIfAborted();
 
-    const { userId, orgId } = await get(authenticatedIdentity$);
-    signal.throwIfAborted();
-    await artifactItemCacheStores(userId, orgId).writeStore.upsertItems([
-      { ...item, isFavorited: nextIsFavorited },
-    ]);
-    signal.throwIfAborted();
+    if (item) {
+      const { userId, orgId } = await get(authenticatedIdentity$);
+      signal.throwIfAborted();
+      await artifactItemCacheStores(userId, orgId).writeStore.upsertItems([
+        { ...item, isFavorited: nextIsFavorited },
+      ]);
+      signal.throwIfAborted();
+    }
     set(reloadArtifacts$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -16,6 +16,7 @@ export type AttachmentArtifactMetadata = {
   readonly filename: string;
   readonly googleDriveDisconnected: boolean;
   readonly googleDriveSynced: boolean;
+  readonly isFavorited?: boolean;
   readonly onSyncSuccess?: () => void;
   readonly runId: string;
   readonly size: number;

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -237,6 +237,7 @@ function artifactLightboxMetadata(
     filename: item.filename,
     googleDriveDisconnected: item.googleDriveSync?.status === "disconnected",
     googleDriveSynced: item.googleDriveSync?.status === "synced",
+    isFavorited: item.isFavorited,
     onSyncSuccess,
     runId: item.runId,
     size: item.size,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,4 +1,5 @@
 import {
+  artifactsContract,
   chatThreadArtifactsContract,
   type ChatThreadArtifactFile,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -1751,6 +1752,9 @@ describe("zero attachment chips", () => {
       expect(screen.getByLabelText("Open in split view")).toBeInTheDocument();
       expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
     });
+    expect(
+      screen.queryByLabelText("Add quarterly-roadmap.html to favorites"),
+    ).toBeNull();
     expect(screen.getByTestId("artifact-dialog-body-html")).toHaveAttribute(
       "tabindex",
       "-1",
@@ -1798,6 +1802,89 @@ describe("zero attachment chips", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Presentation editor")).toBeInTheDocument();
+    });
+  });
+
+  it("favorites an artifact from the preview header when enabled", async () => {
+    const presentationUrl =
+      "https://cdn.vm7.io/artifacts/test/favorite-preview/quarterly-roadmap.html";
+    const html = presentationHtml();
+    let favoriteBody: { readonly artifactUrl: string } | undefined;
+    let unfavoriteBody: { readonly artifactUrl: string } | undefined;
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(html, {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.api(artifactsContract.favorite, ({ body, respond }) => {
+      favoriteBody = body;
+      return respond(204);
+    });
+    context.mocks.api(artifactsContract.unfavorite, ({ body, respond }) => {
+      unfavoriteBody = body;
+      return respond(204);
+    });
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, {
+        runs: [
+          {
+            runId: "run-favorite-preview",
+            files: [
+              artifactFile(presentationUrl, {
+                isFavorited: true,
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-favorite-preview",
+          role: "assistant",
+          content: `[Quarterly roadmap](${presentationUrl})`,
+          runId: "run-favorite-preview",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ArtifactFavorites]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await screen.findByLabelText("Open html preview for Quarterly roadmap"),
+    );
+
+    const removeFavorite = await screen.findByLabelText(
+      "Remove quarterly-roadmap.html from favorites",
+    );
+    const separator = removeFavorite.nextElementSibling;
+    const share = screen.getByLabelText("Share");
+    expect(separator).toHaveClass("w-px");
+    expect(separator?.nextElementSibling).toBe(share);
+
+    click(removeFavorite);
+    await waitFor(() => {
+      expect(unfavoriteBody).toStrictEqual({ artifactUrl: presentationUrl });
+      expect(
+        screen.getByLabelText("Add quarterly-roadmap.html to favorites"),
+      ).toHaveAttribute("aria-pressed", "false");
+    });
+
+    click(screen.getByLabelText("Add quarterly-roadmap.html to favorites"));
+    await waitFor(() => {
+      expect(favoriteBody).toStrictEqual({ artifactUrl: presentationUrl });
+      expect(
+        screen.getByLabelText("Remove quarterly-roadmap.html from favorites"),
+      ).toHaveAttribute("aria-pressed", "true");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,6 +1,8 @@
 import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
 import {
   IconBrandGoogleDrive,
+  IconCarambola,
+  IconCarambolaFilled,
   IconDownload,
   IconLoader2,
   IconPresentation,
@@ -329,6 +331,42 @@ export function ArtifactActionTooltip({
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
+  );
+}
+
+export function ArtifactFavoriteButton({
+  favorited,
+  filename,
+  iconSize = 16,
+  onToggle,
+}: {
+  favorited: boolean;
+  filename: string;
+  iconSize?: number;
+  onToggle: () => void;
+}) {
+  const label = favorited
+    ? `Remove ${filename} from favorites`
+    : `Add ${filename} to favorites`;
+
+  return (
+    <ArtifactActionTooltip label={label}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={favorited}
+        className={iconButtonClassName(
+          favorited ? "text-amber-500 hover:text-amber-500" : undefined,
+        )}
+        onClick={onToggle}
+      >
+        {favorited ? (
+          <IconCarambolaFilled size={iconSize} aria-hidden />
+        ) : (
+          <IconCarambola size={iconSize} stroke={1.5} aria-hidden />
+        )}
+      </button>
+    </ArtifactActionTooltip>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -66,6 +66,10 @@ import {
 import { openArtifactImageEdit$ } from "../../signals/zero-page/zero-image-edit.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
+  artifactFavoriteOverrides$,
+  toggleArtifactFavorite$,
+} from "../../signals/artifacts-page/artifacts-signals.ts";
+import {
   presentationHtmlPreviewUrl,
   presentationHtmlRefreshVersion$,
 } from "../../signals/zero-page/presentation-html-cache-bust.ts";
@@ -79,6 +83,7 @@ import {
 import {
   ArtifactActionSeparator,
   ArtifactDownloadMenu,
+  ArtifactFavoriteButton,
   ArtifactShareButton,
   type ArtifactDownloadSyncTarget,
 } from "./zero-artifact-actions.tsx";
@@ -445,6 +450,7 @@ function artifactDialogMetadataFromItem(params: {
     googleDriveDisconnected:
       params.item.file.googleDriveSync?.status === "disconnected",
     googleDriveSynced: params.item.file.googleDriveSync?.status === "synced",
+    isFavorited: params.item.file.isFavorited,
     onSyncSuccess: params.onSyncSuccess,
     runId: params.item.runId,
     size: params.item.file.size,
@@ -1073,6 +1079,48 @@ function resetArtifactDialogImageZoom({
   resetZoom(artifactDialogImageZoomKey(preview.url, targetFullscreen));
 }
 
+function ArtifactDialogFavoriteAction({
+  artifact,
+  preview,
+}: {
+  artifact: AttachmentArtifactMetadata | undefined;
+  preview: AttachmentLightboxState;
+}) {
+  const features = useGet(featureSwitch$);
+  const favoriteOverrides = useGet(artifactFavoriteOverrides$);
+  const pageSignal = useGet(pageSignal$);
+  const toggleArtifactFavorite = useSet(toggleArtifactFavorite$);
+
+  if (!artifact || !features?.[FeatureSwitchKey.ArtifactFavorites]) {
+    return null;
+  }
+
+  const favorited =
+    favoriteOverrides[preview.url] ?? artifact.isFavorited === true;
+  return (
+    <>
+      <ArtifactFavoriteButton
+        favorited={favorited}
+        filename={artifact.filename}
+        iconSize={18}
+        onToggle={() => {
+          detach(
+            toggleArtifactFavorite(
+              {
+                currentIsFavorited: favorited,
+                url: preview.url,
+              },
+              pageSignal,
+            ),
+            Reason.DomCallback,
+          );
+        }}
+      />
+      <ArtifactActionSeparator />
+    </>
+  );
+}
+
 function ArtifactPreviewDialogActions({
   artifact,
   fullscreen,
@@ -1140,6 +1188,7 @@ function ArtifactPreviewDialogActions({
 
   return (
     <div className="flex shrink-0 items-center gap-1">
+      <ArtifactDialogFavoriteAction artifact={artifact} preview={preview} />
       <ArtifactShareButton ariaLabel="Share" iconSize={18} url={preview.url} />
       <ArtifactDownloadMenu
         ariaLabel="Download options"

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -5,6 +5,7 @@ import {
   artifactItemSchema,
   artifactsContract,
   artifactsListResponseSchema,
+  chatThreadArtifactRunSchema,
   chatMessagesContract,
   chatThreadModelSelectionContract,
   chatThreadsContract,
@@ -367,6 +368,25 @@ describe("artifacts contract", () => {
       url: "https://static.vm0.io/artifacts/launch-plan.html",
       createdAt: "2026-07-07T00:00:00.000Z",
       isFavorited: true,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts favorite state on thread artifact files", () => {
+    const parsed = chatThreadArtifactRunSchema.safeParse({
+      runId: "run-1",
+      files: [
+        {
+          id: "file-1",
+          filename: "launch-plan.html",
+          contentType: "text/html",
+          size: 1024,
+          url: "https://static.vm0.io/artifacts/launch-plan.html",
+          createdAt: "2026-07-07T00:00:00.000Z",
+          isFavorited: true,
+        },
+      ],
     });
 
     expect(parsed.success).toBe(true);

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -48,6 +48,7 @@ const chatThreadArtifactFileSchema = resolvedAttachFileSchema.extend({
   createdAt: z.string(),
   artifactKind: hostedArtifactKindSchema.optional(),
   googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),
+  isFavorited: z.boolean().optional(),
 });
 
 const chatThreadArtifactRunSchema = z.object({


### PR DESCRIPTION
## Summary

- Add a favorite toggle to artifact preview headers, ordered as favorite, divider, then share.
- Gate the preview control behind `artifactFavorites` and hide it for non-artifact attachments.
- Return each thread artifact's user-scoped favorite state so the preview opens with the correct filled or unfilled icon.
- Reuse the existing optimistic favorite override and favorite/unfavorite API behavior across the Artifacts page and preview dialog.

## User impact

Users with `artifactFavorites` enabled can favorite or unfavorite an artifact without leaving its preview. The icon updates immediately and stays consistent with the Artifacts page.

## Verification

- Targeted Prettier formatting for all changed TypeScript files
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts` (29 tests)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "favorites an artifact from the preview header when enabled"` (1 test)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "opens presentation artifact controls from chat message links"` (1 test)
- `pnpm knip --workspace @vm0/app --workspace api --workspace @vm0/api-contracts`

The targeted API integration test could not run locally because the runtime PostgreSQL installation does not include the `vector` extension required by the repository migrations; the PR pipeline will run it in the project test environment.
