### PR TITLE
fix(runner): reject severe balloon retention from idle reuse

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -261,7 +261,9 @@ mod tests {
             workspace_promotion: Some(fixture.promotion),
         });
         let candidate = match request.park_for_idle().await {
-            Ok(candidate) => candidate.with_last_completed_at(TEST_COMPLETED_AT.into()),
+            Ok(outcome) => outcome
+                .expect_reusable()
+                .with_last_completed_at(TEST_COMPLETED_AT.into()),
             Err(_) => panic!("park should succeed"),
         };
         let mut pool = IdlePool::new(IdlePoolConfig {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -196,8 +196,8 @@ pub(super) async fn finalize_sandbox_for_completion(
             workspace_image_size_bytes,
             workspace_promotion,
         });
-        let candidate = match park_request.park_for_idle().await {
-            Ok(candidate) => candidate,
+        let park_outcome = match park_request.park_for_idle().await {
+            Ok(outcome) => outcome,
             Err(failure) => {
                 let failure = failure.into_active_parts();
                 let IdleParkActiveParts {
@@ -246,6 +246,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 );
             }
         };
+        let (candidate, non_reusable_reason) = park_outcome.into_parts();
         if cancel.is_cancelled() {
             let (payload, budget_lease) = candidate.into_active_destroy_parts();
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
@@ -258,6 +259,30 @@ pub(super) async fn finalize_sandbox_for_completion(
                 payload,
                 budget_lease,
                 "cancelled",
+                destroy_bookkeeping,
+            )
+            .await;
+            session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+                &held_session_snapshot,
+                Some(&cli_agent_session_id),
+                &completed_at,
+                destroy_result.workspace_cache_promoted,
+            );
+            destroy_result.budget
+        } else if let Some(reason) = non_reusable_reason {
+            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            info!(
+                run_id = %run_id,
+                session_id = %cli_agent_session_id,
+                reason = reason.as_str(),
+                admission_action = "reject_and_destroy",
+                "sandbox parked but is not reusable, destroying VM"
+            );
+            let (payload, budget_lease) = candidate.into_active_destroy_parts();
+            let destroy_result = destroy_active_owned_idle_payload(
+                payload,
+                budget_lease,
+                reason.as_str(),
                 destroy_bookkeeping,
             )
             .await;
@@ -1744,6 +1769,7 @@ mod tests {
             let error = failure.into_active_parts().error;
             panic!("existing sandbox should park: {error}");
         })
+        .expect_reusable()
         .with_last_completed_at(local_completed_at());
         assert!(matches!(
             fixture.idle_pool.lock().await.park(existing_candidate),

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -2,7 +2,7 @@ use super::super::super::*;
 use super::super::support::{
     MockRunEnv, context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool,
     shutdown, test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
-    wait_workspace_cache_sessions,
+    wait_status_idle_sessions_and_active_runs, wait_workspace_cache_sessions,
 };
 use super::support::assert_no_completion_for_run;
 
@@ -10,6 +10,12 @@ use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
 use crate::workspace_image_cache::SessionWorkspaceCache;
 use sandbox_mock::MockLifecycleGate;
+
+fn severe_memory_retention() -> sandbox::SandboxParkOutcome {
+    sandbox::SandboxParkOutcome::NonReusable(
+        sandbox::SandboxParkNonReusableReason::SevereMemoryRetention,
+    )
+}
 
 /// When `Sandbox::park()` returns an error, the runner falls back to
 /// `stop_and_destroy_sandbox` and does NOT insert into the idle pool.
@@ -59,7 +65,7 @@ async fn park_failure_destroys_sandbox_and_skips_pool() {
 
 #[tokio::test]
 async fn park_failure_promotes_workspace_cache_before_destroy() {
-    assert_workspace_cache_after_failed_park(
+    assert_workspace_cache_after_park_cleanup(
         "sess-park-fail-cache",
         |overrides| {
             overrides.push_park_result(Err(sandbox::SandboxError::IdleTransition {
@@ -68,24 +74,38 @@ async fn park_failure_promotes_workspace_cache_before_destroy() {
             }));
         },
         true,
+        0,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn non_reusable_park_promotes_workspace_cache_through_parked_path() {
+    assert_workspace_cache_after_park_cleanup(
+        "sess-severe-retention-cache",
+        |overrides| overrides.push_park_result(Ok(severe_memory_retention())),
+        true,
+        1,
     )
     .await;
 }
 
 #[tokio::test]
 async fn park_panic_skips_workspace_cache_before_destroy() {
-    assert_workspace_cache_after_failed_park(
+    assert_workspace_cache_after_park_cleanup(
         "sess-park-panic-cache",
         |overrides| overrides.push_park_panic("simulated park panic"),
         false,
+        0,
     )
     .await;
 }
 
-async fn assert_workspace_cache_after_failed_park(
+async fn assert_workspace_cache_after_park_cleanup(
     session_id: &str,
     configure_park: impl FnOnce(&sandbox_mock::MockSandboxOverrides),
     expect_cache: bool,
+    expected_unpark_calls: u32,
 ) {
     let wait_gate = MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -138,12 +158,13 @@ async fn assert_workspace_cache_after_failed_park(
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await
-        .expect("job should complete normally after park failure destroy");
+        .expect("job should complete normally after park cleanup destroy");
     assert_eq!(completion.exit_code, 0);
 
     wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
     assert_eq!(idle_pool.lock().await.len(), 0);
     assert_eq!(counter.park_call_count(), 1);
+    assert_eq!(counter.unpark_call_count(), expected_unpark_calls);
     assert_eq!(counter.destroy_call_count(), 1);
     if expect_cache {
         wait_workspace_cache_sessions(&workspace_cache, &[session_id], Duration::from_secs(2))
@@ -152,6 +173,159 @@ async fn assert_workspace_cache_after_failed_park(
         let held = workspace_cache.held_session_states().await;
         assert!(held.is_empty());
     }
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn non_reusable_park_keeps_budget_until_destroy_and_never_enters_idle_status() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_park_result(Ok(severe_memory_retention()));
+    let destroy_gate = MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+
+    let counter = Arc::clone(&overrides);
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-severe-retention")),
+    );
+
+    wait_lifecycle_gate_entered(
+        &destroy_gate,
+        "non-reusable parked sandbox should enter destroy gate",
+    )
+    .await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
+        1,
+        "non-reusable parked VM should be sent to destroy exactly once",
+        "non-reusable parked VM must retain budget while destroy is in-flight",
+    );
+    assert_idle_pool_len(
+        &idle_pool,
+        0,
+        "non-reusable parked VM must never enter the idle pool",
+    )
+    .await;
+    wait_status_idle_sessions_and_active_runs(
+        &status_path,
+        &[],
+        &[run_id.to_string()],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_no_completion_for_run(
+        &env,
+        run_id,
+        "provider.complete must wait until non-reusable VM destroy finishes",
+    );
+
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "successful job should complete after non-reusable VM destroy finishes",
+    )
+    .await;
+
+    assert_post_destroy_cleanup(&budget, &idle_pool, None, run_id, 0, 0).await;
+    wait_status_idle_sessions_and_active_runs(&status_path, &[], &[], Duration::from_secs(5)).await;
+    assert_eq!(counter.park_call_count(), 1);
+    assert_eq!(counter.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn repeated_non_reusable_parks_use_fresh_sandboxes() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_park_result(Ok(severe_memory_retention()));
+    overrides.push_park_result(Ok(severe_memory_retention()));
+    let counter = Arc::clone(&overrides);
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    for run_id in [RunId::new_v4(), RunId::new_v4()] {
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(
+                run_id,
+                "sess-repeated-severe-retention",
+            )),
+        );
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("successful job should complete after non-reusable VM destroy");
+        assert_eq!(completion.exit_code, 0);
+        assert!(completion.error.is_none());
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_idle_pool_len(
+            &idle_pool,
+            0,
+            "repeated non-reusable VMs must never cycle through the idle pool",
+        )
+        .await;
+    }
+
+    assert_eq!(counter.create_configs().len(), 2);
+    assert_eq!(counter.park_call_count(), 2);
+    assert_eq!(counter.unpark_call_count(), 0);
+    assert_eq!(counter.destroy_call_count(), 2);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn non_reusable_park_destroy_panic_still_completes_and_releases_budget() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_park_result(Ok(severe_memory_retention()));
+    overrides.push_destroy_panic("simulated non-reusable destroy panic");
+    let counter = Arc::clone(&overrides);
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-severe-destroy-panic")),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("destroy uncertainty must not rewrite or skip provider completion");
+    assert_eq!(completion.exit_code, 0);
+    assert!(completion.error.is_none());
+    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+    assert_idle_pool_len(
+        &idle_pool,
+        0,
+        "destroy uncertainty must not publish a non-reusable VM as idle",
+    )
+    .await;
+    assert_eq!(counter.park_call_count(), 1);
+    assert_eq!(counter.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
 }
@@ -580,6 +754,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
 #[tokio::test(start_paused = true)]
 async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_park_result(Ok(severe_memory_retention()));
     let park_gate = MockLifecycleGate::new();
     let destroy_gate = MockLifecycleGate::new();
     overrides.set_park_lifecycle_gate(park_gate.clone());

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -854,6 +854,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         let error = failure.into_active_parts().error;
         panic!("test sandbox should park: {error}");
     })
+    .expect_reusable()
     .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
 
     let mut pool = IdlePool::new(IdlePoolConfig {
@@ -964,6 +965,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         let error = failure.into_active_parts().error;
         panic!("test sandbox should park: {error}");
     })
+    .expect_reusable()
     .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
 
     let mut pool = IdlePool::new(IdlePoolConfig {

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -213,7 +213,7 @@ impl Sandbox for OperationGateSandbox {
         self.inner.kill().await
     }
 
-    async fn park(&mut self) -> sandbox::Result<()> {
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
     }
 
@@ -298,7 +298,7 @@ impl Sandbox for CancelAtProcessBoundarySandbox {
         self.inner.kill().await
     }
 
-    async fn park(&mut self) -> sandbox::Result<()> {
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
     }
 
@@ -416,7 +416,7 @@ impl Sandbox for QueuedCopyFileSandbox {
         self.inner.kill().await
     }
 
-    async fn park(&mut self) -> sandbox::Result<()> {
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
     }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -8,7 +8,10 @@ use std::time::{Duration, Instant};
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
-use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
+use sandbox::{
+    DeviceRateLimits, Sandbox, SandboxFactory, SandboxId, SandboxParkNonReusableReason,
+    SandboxParkOutcome,
+};
 
 use crate::idle_reuse_preparation::prepare_sandbox_for_idle_reuse;
 use crate::ids::RunId;
@@ -230,6 +233,16 @@ pub struct ParkedIdleCandidate {
     budget_lease: BudgetLease,
 }
 
+/// Result after the sandbox successfully reaches the parked state.
+#[must_use = "parked outcomes must be admitted for reuse or explicitly destroyed"]
+pub(crate) enum IdleParkOutcome {
+    Reusable(ParkedIdleCandidate),
+    NonReusable {
+        candidate: ParkedIdleCandidate,
+        reason: SandboxParkNonReusableReason,
+    },
+}
+
 #[must_use = "idle park failures must be explicitly destroyed or otherwise handled"]
 pub(crate) struct IdleParkFailure {
     resources: IdleSandboxResources,
@@ -258,7 +271,7 @@ impl IdleParkRequest {
         Self { parts }
     }
 
-    pub(crate) async fn park_for_idle(self) -> Result<ParkedIdleCandidate, IdleParkFailure> {
+    pub(crate) async fn park_for_idle(self) -> Result<IdleParkOutcome, IdleParkFailure> {
         let IdleParkRequestParts {
             run_id,
             mut sandbox,
@@ -346,15 +359,23 @@ impl IdleParkRequest {
         }
 
         match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
-            Ok(Ok(())) => Ok(ParkedIdleCandidate {
-                resources: IdleSandboxResources {
-                    sandbox,
-                    factory,
-                    workspace_promotion,
-                },
-                metadata,
-                budget_lease,
-            }),
+            Ok(Ok(outcome)) => {
+                let candidate = ParkedIdleCandidate {
+                    resources: IdleSandboxResources {
+                        sandbox,
+                        factory,
+                        workspace_promotion,
+                    },
+                    metadata,
+                    budget_lease,
+                };
+                Ok(match outcome {
+                    SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
+                    SandboxParkOutcome::NonReusable(reason) => {
+                        IdleParkOutcome::NonReusable { candidate, reason }
+                    }
+                })
+            }
             Ok(Err(e)) => Err(IdleParkFailure {
                 resources: IdleSandboxResources {
                     sandbox,
@@ -379,6 +400,28 @@ impl IdleParkRequest {
                     reason: "park_panicked",
                     error: "sandbox park panicked".into(),
                 })
+            }
+        }
+    }
+}
+
+impl IdleParkOutcome {
+    pub(crate) fn into_parts(self) -> (ParkedIdleCandidate, Option<SandboxParkNonReusableReason>) {
+        match self {
+            Self::Reusable(candidate) => (candidate, None),
+            Self::NonReusable { candidate, reason } => (candidate, Some(reason)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expect_reusable(self) -> ParkedIdleCandidate {
+        match self {
+            Self::Reusable(candidate) => candidate,
+            Self::NonReusable { reason, .. } => {
+                panic!(
+                    "expected reusable parked candidate, got {}",
+                    reason.as_str()
+                )
             }
         }
     }
@@ -1342,7 +1385,7 @@ mod tests {
         .await;
 
         let candidate = match request.park_for_idle().await {
-            Ok(candidate) => candidate,
+            Ok(outcome) => outcome.expect_reusable(),
             Err(_) => panic!("park should succeed"),
         };
 
@@ -1462,7 +1505,7 @@ mod tests {
         });
 
         let candidate = match request.park_for_idle().await {
-            Ok(candidate) => candidate,
+            Ok(outcome) => outcome.expect_reusable(),
             Err(_) => panic!("park should succeed"),
         };
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2277,7 +2277,7 @@ mod tests {
             self.inner.kill().await
         }
 
-        async fn park(&mut self) -> sandbox::Result<()> {
+        async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
             self.inner.park().await
         }
 

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -118,7 +118,7 @@ impl Sandbox for PostCopyGateSandbox {
         self.inner.kill().await
     }
 
-    async fn park(&mut self) -> sandbox::Result<()> {
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
         self.inner.park().await
     }
 
@@ -202,8 +202,8 @@ impl Sandbox for PanicExecSandbox {
         Ok(())
     }
 
-    async fn park(&mut self) -> sandbox::Result<()> {
-        Ok(())
+    async fn park(&mut self) -> sandbox::Result<sandbox::SandboxParkOutcome> {
+        Ok(sandbox::SandboxParkOutcome::Reusable)
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -12,7 +12,8 @@ use sandbox::{
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
     SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, StartProcessRequest, WriteFileEntry,
+    SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome, StartProcessRequest,
+    WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -468,6 +469,10 @@ pub struct FirecrackerSandbox {
     /// touch the balloon controller, and to let `stop()` skip vsock
     /// graceful shutdown (guest can't respond with paused vCPUs).
     is_parked: bool,
+    /// Eligibility returned by the completed park that set `is_parked`.
+    /// Retained so an idempotent repeated park cannot upgrade a non-reusable
+    /// sandbox to reusable.
+    park_outcome: Option<SandboxParkOutcome>,
     /// Host-side normal-operation fence held while this sandbox is parked.
     park_fence: Option<NormalOperationFence>,
 }
@@ -566,6 +571,7 @@ impl FirecrackerSandbox {
             delete_workspace_on_leak_cleanup: true,
             destroyed: false,
             is_parked: false,
+            park_outcome: None,
             park_fence: None,
         }
     }
@@ -1656,7 +1662,11 @@ impl Sandbox for FirecrackerSandbox {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
                 self.guest.lock().await.take();
-                release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
+                release_park_state_for_termination(
+                    &mut self.is_parked,
+                    &mut self.park_outcome,
+                    &mut self.park_fence,
+                );
                 self.runtime.kill_process().await;
             }
             return Ok(());
@@ -1685,7 +1695,11 @@ impl Sandbox for FirecrackerSandbox {
         {
             warn!(id = %self.id, "graceful shutdown timed out");
         }
-        release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
+        release_park_state_for_termination(
+            &mut self.is_parked,
+            &mut self.park_outcome,
+            &mut self.park_fence,
+        );
 
         self.runtime.kill_process().await;
         self.publish_state(SandboxState::Stopped);
@@ -1698,14 +1712,22 @@ impl Sandbox for FirecrackerSandbox {
             if self.current_state() == SandboxState::Crashed {
                 self.runtime.shutdown_services().await;
                 self.guest.lock().await.take();
-                release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
+                release_park_state_for_termination(
+                    &mut self.is_parked,
+                    &mut self.park_outcome,
+                    &mut self.park_fence,
+                );
                 self.runtime.kill_process().await;
             }
             return Ok(());
         }
         self.runtime.shutdown_services().await;
         self.guest.lock().await.take();
-        release_park_state_for_termination(&mut self.is_parked, &mut self.park_fence);
+        release_park_state_for_termination(
+            &mut self.is_parked,
+            &mut self.park_outcome,
+            &mut self.park_fence,
+        );
         self.runtime.kill_process().await;
         self.publish_state(SandboxState::Stopped);
         info!(id = %self.id, "sandbox killed");
@@ -1746,14 +1768,20 @@ impl Sandbox for FirecrackerSandbox {
     // coordinator is still checked on no-op paths so Dirty/desynchronised gates
     // cannot be silently reused.
 
-    async fn park(&mut self) -> sandbox::Result<()> {
+    async fn park(&mut self) -> sandbox::Result<SandboxParkOutcome> {
         if self.is_parked {
             if self.park_fence.is_none() {
                 let message = "sandbox is parked without a normal-operation fence";
                 self.park_coordinator.mark_dirty(DirtyReason::new(message));
                 return Err(idle_transition_error(SandboxIdleTransition::Park, message));
             }
-            return ensure_park_noop_state(&self.park_coordinator);
+            let Some(outcome) = self.park_outcome else {
+                let message = "sandbox is parked without a recorded park outcome";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+            };
+            ensure_park_noop_state(&self.park_coordinator)?;
+            return Ok(outcome);
         }
 
         let coordinator = self.park_coordinator.clone();
@@ -1761,7 +1789,7 @@ impl Sandbox for FirecrackerSandbox {
         let fence_guest = Arc::clone(&guest);
         let id = self.id.clone();
         let api_sock = self.sock_paths.api_sock();
-        let normal_operations_fence = park_with_ready_for_park(
+        let (normal_operations_fence, outcome) = park_with_ready_for_park(
             &id,
             &coordinator,
             || async move {
@@ -1796,13 +1824,22 @@ impl Sandbox for FirecrackerSandbox {
         )
         .await?;
         self.park_fence = Some(normal_operations_fence);
-        Ok(())
+        self.park_outcome = Some(outcome);
+        Ok(outcome)
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
         if !self.is_parked {
             if self.park_fence.is_some() {
                 let message = "sandbox has a normal-operation fence while unpark is a no-op";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(
+                    SandboxIdleTransition::Unpark,
+                    message,
+                ));
+            }
+            if self.park_outcome.is_some() {
+                let message = "sandbox has a recorded park outcome while unpark is a no-op";
                 self.park_coordinator.mark_dirty(DirtyReason::new(message));
                 return Err(idle_transition_error(
                     SandboxIdleTransition::Unpark,
@@ -1855,7 +1892,9 @@ impl Sandbox for FirecrackerSandbox {
                 drop(park_fence.take());
             },
         )
-        .await
+        .await?;
+        self.park_outcome = None;
+        Ok(())
     }
 
     // -- operations --
@@ -2250,25 +2289,30 @@ impl Drop for UnparkBoundaryGuard {
     }
 }
 
-fn release_park_state_for_termination<Fence>(is_parked: &mut bool, park_fence: &mut Option<Fence>) {
+fn release_park_state_for_termination<Fence>(
+    is_parked: &mut bool,
+    park_outcome: &mut Option<SandboxParkOutcome>,
+    park_fence: &mut Option<Fence>,
+) {
     *is_parked = false;
+    *park_outcome = None;
     drop(park_fence.take());
 }
 
-async fn park_with_ready_for_park<Fence, F, FF, Q, QF, P, PF>(
+async fn park_with_ready_for_park<Fence, Outcome, F, FF, Q, QF, P, PF>(
     log_id: &str,
     coordinator: &ParkCoordinator,
     fence_normal_operations: F,
     quiesce_guest: Q,
     park_firecracker: P,
-) -> sandbox::Result<Fence>
+) -> sandbox::Result<(Fence, Outcome)>
 where
     F: FnOnce() -> FF,
     FF: Future<Output = Result<Fence, ParkNormalOperationFenceError>>,
     Q: FnOnce() -> QF,
     QF: Future<Output = io::Result<()>>,
     P: FnOnce() -> PF,
-    PF: Future<Output = sandbox::Result<()>>,
+    PF: Future<Output = sandbox::Result<Outcome>>,
 {
     info!(
         id = %log_id,
@@ -2403,20 +2447,23 @@ where
         phase = "ready_for_park",
         "sandbox park lifecycle ReadyForPark reached"
     );
-    if let Err(error) = park_firecracker().await {
-        warn!(
-            id = %log_id,
-            transition = "park",
-            phase = "firecracker_park",
-            reason_kind = "firecracker",
-            error = %error,
-            "sandbox park lifecycle Firecracker park failed after ReadyForPark"
-        );
-        guard.mark_dirty(format!(
-            "Firecracker park failed after ReadyForPark: {error}"
-        ));
-        return Err(error);
-    }
+    let outcome = match park_firecracker().await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            warn!(
+                id = %log_id,
+                transition = "park",
+                phase = "firecracker_park",
+                reason_kind = "firecracker",
+                error = %error,
+                "sandbox park lifecycle Firecracker park failed after ReadyForPark"
+            );
+            guard.mark_dirty(format!(
+                "Firecracker park failed after ReadyForPark: {error}"
+            ));
+            return Err(error);
+        }
+    };
 
     let normal_operations_fence = match guard.mark_parked() {
         Ok(fence) => fence,
@@ -2445,7 +2492,7 @@ where
         phase = "parked",
         "sandbox park lifecycle marked parked"
     );
-    Ok(normal_operations_fence)
+    Ok((normal_operations_fence, outcome))
 }
 
 async fn unpark_with_ready_for_operations<U, UF, R, RF, F>(
@@ -2780,10 +2827,7 @@ impl BalloonSettleSummary {
             return "target_not_observed";
         }
 
-        if self
-            .last_deficit_mib
-            .is_some_and(|deficit| deficit >= self.severe_deficit_threshold_mib())
-        {
+        if self.is_severe_deficit() {
             return "severe_deficit";
         }
 
@@ -2795,6 +2839,21 @@ impl BalloonSettleSummary {
         }
 
         "actual_stalled"
+    }
+
+    fn is_severe_deficit(&self) -> bool {
+        self.target_observed
+            && self
+                .last_deficit_mib
+                .is_some_and(|deficit| deficit >= self.severe_deficit_threshold_mib())
+    }
+
+    fn park_outcome(&self) -> SandboxParkOutcome {
+        if self.is_severe_deficit() {
+            SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+        } else {
+            SandboxParkOutcome::Reusable
+        }
     }
 
     fn is_pressure_limited_partial_reclaim(&self, deficit_mib: u32, tolerance_mib: u32) -> bool {
@@ -2819,6 +2878,7 @@ fn log_balloon_settle_timeout(
     target_mib: u32,
     tolerance_mib: u32,
     summary: &BalloonSettleSummary,
+    outcome: SandboxParkOutcome,
 ) {
     warn!(
         id = %log_id,
@@ -2839,9 +2899,17 @@ fn log_balloon_settle_timeout(
         reported_available_mib = ?summary.reported_available_mib(),
         reported_total_mib = ?summary.reported_total_mib(),
         reason = summary.reason(),
+        admission_action = park_admission_action(outcome),
         "balloon inflate incomplete after {}s, pausing anyway",
         BALLOON_SETTLE_TIMEOUT.as_secs()
     );
+}
+
+fn park_admission_action(outcome: SandboxParkOutcome) -> &'static str {
+    match outcome {
+        SandboxParkOutcome::Reusable => "reuse",
+        SandboxParkOutcome::NonReusable(_) => "reject_and_destroy",
+    }
 }
 
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
@@ -2850,17 +2918,19 @@ fn log_balloon_settle_timeout(
 /// **before** pausing. Returns when `actual_mib >= target_mib`, when
 /// the remaining deficit is within [`balloon_settle_tolerance_mib`],
 /// when guest pressure indicates further reclaim is unsafe, or after
-/// [`BALLOON_SETTLE_TIMEOUT`] (partial inflation is better than none).
+/// [`BALLOON_SETTLE_TIMEOUT`] (partial inflation is better than none). The
+/// returned outcome rejects only the existing severe-deficit classification.
 /// Errors from stats fetching are non-fatal — we log and
 /// proceed to pause.
-async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
+async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> SandboxParkOutcome {
     let deadline = tokio::time::Instant::now() + BALLOON_SETTLE_TIMEOUT;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
     loop {
         if tokio::time::Instant::now() >= deadline {
-            log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary);
-            return;
+            let outcome = summary.park_outcome();
+            log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
+            return outcome;
         }
 
         match tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await {
@@ -2887,7 +2957,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon fully inflated, proceeding to pause"
                     );
-                    return;
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 if deficit_mib <= tolerance_mib {
@@ -2911,7 +2981,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon inflated within tolerance, proceeding to pause"
                     );
-                    return;
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 if summary.is_pressure_limited_partial_reclaim(deficit_mib, tolerance_mib) {
@@ -2936,7 +3006,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
                         reason = BALLOON_PRESSURE_LIMITED_REASON,
                         "balloon pressure-limited partial reclaim, proceeding to pause"
                     );
-                    return;
+                    return SandboxParkOutcome::Reusable;
                 }
 
                 trace!(
@@ -2951,6 +3021,7 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
                 );
             }
             Ok(Err(e)) => {
+                let outcome = summary.park_outcome();
                 warn!(
                     id = %log_id,
                     actual = ?summary.last_actual_mib,
@@ -2970,14 +3041,16 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
                     reported_available_mib = ?summary.reported_available_mib(),
                     reported_total_mib = ?summary.reported_total_mib(),
                     reason = summary.reason(),
+                    admission_action = park_admission_action(outcome),
                     %e,
                     "balloon stats unavailable, proceeding to pause"
                 );
-                return;
+                return outcome;
             }
             Err(_) => {
-                log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary);
-                return;
+                let outcome = summary.park_outcome();
+                log_balloon_settle_timeout(log_id, target_mib, tolerance_mib, &summary, outcome);
+                return outcome;
             }
         }
 
@@ -2997,9 +3070,9 @@ async fn park_inner(
     balloon_controller: &mut Option<balloon::ControllerHandle>,
     api_sock: &std::path::Path,
     log_id: &str,
-) -> sandbox::Result<()> {
+) -> sandbox::Result<SandboxParkOutcome> {
     if *is_parked {
-        return Ok(());
+        return Ok(SandboxParkOutcome::Reusable);
     }
 
     let target = memory_mb.saturating_sub(balloon::MIN_GUEST_MIB);
@@ -3008,7 +3081,7 @@ async fn park_inner(
         message: format!("create API client: {e}"),
     })?;
 
-    if target > 0 {
+    let outcome = if target > 0 {
         // Stop the reactive controller so we're the sole writer to /balloon.
         // abort() + await ensures any in-flight PATCH from the controller
         // completes (or is cancelled) before ours lands.
@@ -3040,8 +3113,10 @@ async fn park_inner(
         // pausing vCPUs. The guest balloon driver needs running vCPUs to
         // process the inflate — pausing immediately would negate the memory
         // savings.
-        wait_for_balloon(&client, target, log_id).await;
-    }
+        wait_for_balloon(&client, target, log_id).await
+    } else {
+        SandboxParkOutcome::Reusable
+    };
 
     // Pause vCPUs to eliminate idle CPU overhead (timer ticks, kernel
     // scheduling). For small VMs (target == 0) we skip the balloon but
@@ -3066,11 +3141,20 @@ async fn park_inner(
 
     *is_parked = true;
     if target > 0 {
-        info!(id = %log_id, target_mib = target, "sandbox parked (balloon settled, vCPUs paused)");
+        info!(
+            id = %log_id,
+            target_mib = target,
+            admission_action = park_admission_action(outcome),
+            "sandbox parked (balloon settled, vCPUs paused)"
+        );
     } else {
-        info!(id = %log_id, "sandbox parked (vCPUs paused, balloon skipped)");
+        info!(
+            id = %log_id,
+            admission_action = park_admission_action(outcome),
+            "sandbox parked (vCPUs paused, balloon skipped)"
+        );
     }
-    Ok(())
+    Ok(outcome)
 }
 
 async fn unpark_inner(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -108,6 +108,7 @@ fn test_sandbox_with_state(state: SandboxState) -> FirecrackerSandbox {
         delete_workspace_on_leak_cleanup: true,
         destroyed: true,
         is_parked: false,
+        park_outcome: None,
         park_fence: None,
     }
 }
@@ -625,7 +626,10 @@ async fn wait_for_path_removed(path: &Path) {
     .unwrap();
 }
 
-fn assert_idle_transition(result: sandbox::Result<()>, expected: SandboxIdleTransition) {
+fn assert_idle_transition<T: std::fmt::Debug>(
+    result: sandbox::Result<T>,
+    expected: SandboxIdleTransition,
+) {
     match result {
         Err(SandboxError::IdleTransition { transition, .. }) => {
             assert_eq!(transition, expected);
@@ -737,13 +741,15 @@ impl Drop for ClosingStateFence {
 fn termination_releases_park_fence_and_clears_parked_flag() {
     let events = event_log();
     let mut is_parked = true;
+    let mut park_outcome = Some(SandboxParkOutcome::Reusable);
     let mut fence = Some(RecordedFence {
         events: Arc::clone(&events),
     });
 
-    release_park_state_for_termination(&mut is_parked, &mut fence);
+    release_park_state_for_termination(&mut is_parked, &mut park_outcome, &mut fence);
 
     assert!(!is_parked);
+    assert!(park_outcome.is_none());
     assert!(fence.is_none());
     assert_eq!(logged_events(&events), vec!["release_fence"]);
 }
@@ -812,6 +818,31 @@ async fn ready_for_park_boundary_quiesces_before_firecracker_park() {
     assert_eq!(
         logged_events(&events),
         vec!["guest_quiesce", "firecracker_park"]
+    );
+    assert!(matches!(coordinator.state(), CoordinatorState::Parked));
+}
+
+#[tokio::test]
+async fn ready_for_park_boundary_preserves_non_reusable_outcome() {
+    let coordinator = ParkCoordinator::new();
+
+    let (_fence, outcome) = super::park_with_ready_for_park(
+        "test-sandbox",
+        &coordinator,
+        || async { Ok(TestNormalOperationFence) },
+        || async { Ok(()) },
+        || async {
+            Ok(SandboxParkOutcome::NonReusable(
+                SandboxParkNonReusableReason::SevereMemoryRetention,
+            ))
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        outcome,
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
     );
     assert!(matches!(coordinator.state(), CoordinatorState::Parked));
 }
@@ -1148,7 +1179,7 @@ async fn ready_for_park_boundary_firecracker_failure_after_quiesce_marks_dirty()
         },
         || async move {
             park_events.lock().unwrap().push("firecracker_park");
-            Err(idle_transition_error(
+            Err::<(), _>(idle_transition_error(
                 SandboxIdleTransition::Park,
                 "pause failed",
             ))
@@ -3554,9 +3585,10 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "near-target")).await;
 
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
     assert!(!has_captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway"
@@ -3590,9 +3622,10 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "stalled")).await;
 
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -3608,6 +3641,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     assert_event_field(event, "max_actual_mib", "Some(1250)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
     assert_event_field(event, "reason", "actual_stalled");
+    assert_event_field(event, "admission_action", "reuse");
 }
 
 #[tokio::test]
@@ -3621,9 +3655,10 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "pressure-limited")).await;
 
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
     assert!(!has_captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway"
@@ -3670,6 +3705,7 @@ fn balloon_settle_summary_classifies_progressing_timeout() {
     summary.observe(&balloon_statistics(target_mib, 1300));
 
     assert_eq!(summary.reason(), "actual_progressing_timeout");
+    assert_eq!(summary.park_outcome(), SandboxParkOutcome::Reusable);
     assert_eq!(summary.last_actual_mib, Some(1300));
     assert_eq!(summary.last_deficit_mib, Some(236));
     assert_eq!(summary.first_actual_mib, Some(1200));
@@ -3716,9 +3752,10 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "stale-target")).await;
 
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -3742,9 +3779,10 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "slow-stats")).await;
 
+    assert_eq!(outcome, SandboxParkOutcome::Reusable);
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -3767,9 +3805,13 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     .await;
     let client = ApiClient::new(&sock).unwrap();
 
-    let (_, events) =
+    let (outcome, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "severe")).await;
 
+    assert_eq!(
+        outcome,
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+    );
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -3781,6 +3823,7 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     assert_event_field(event, "reported_available_mib", "Some(0)");
     assert_event_field(event, "reported_total_mib", "Some(2048)");
     assert_event_field(event, "reason", "severe_deficit");
+    assert_event_field(event, "admission_action", "reject_and_destroy");
 }
 
 #[tokio::test]
@@ -4481,9 +4524,18 @@ async fn unpark_retry_after_failure_succeeds() {
 
 #[tokio::test]
 async fn park_pause_failure_propagates_as_idle_transition() {
-    // Balloon inflate OK (204), vm pause fails (500).
-    let (sock, reqs, _dir) =
-        spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 500]), None).await;
+    // Balloon inflate succeeds and observes a severe deficit. The next stats
+    // request fails, terminating settle with that severe classification, but
+    // the final VM pause still fails and must remain an operational error.
+    let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let (sock, reqs, _dir) = spawn_mock_fc_api_with_stats(
+        std::collections::VecDeque::from(vec![204, 500]),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, 0)),
+            MockBalloonStatsReply::Status(500),
+        ]),
+    )
+    .await;
 
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
@@ -4732,7 +4784,7 @@ async fn park_pauses_when_balloon_reclaim_is_pressure_limited() {
         "pressure-limited-park",
     ))
     .await;
-    result.unwrap();
+    assert_eq!(result.unwrap(), SandboxParkOutcome::Reusable);
 
     assert!(is_parked);
     assert!(controller.is_none());
@@ -4761,24 +4813,29 @@ async fn park_pauses_when_balloon_reclaim_is_pressure_limited() {
 }
 
 #[tokio::test]
-async fn park_pauses_after_balloon_settle_timeout() {
-    // Balloon never reaches target — wait_for_balloon must time out
-    // and proceed to pause anyway.
-    let balloon_actual = Arc::new(AtomicU32::new(0)); // stuck at 0
-    let (sock, reqs, _dir) = spawn_mock_fc_api(
+async fn park_rejects_severe_balloon_retention_after_pausing() {
+    // Balloon never progresses despite observing the requested target.
+    // Parking must still pause the VM, then report it as non-reusable.
+    let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let (sock, reqs, _dir) = spawn_mock_fc_api_with_stats(
         std::collections::VecDeque::new(),
-        Some(Arc::clone(&balloon_actual)),
+        std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
+            target_mib, 0,
+        ))]),
     )
     .await;
 
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
 
-    park_inner(&mut is_parked, 2048, &mut controller, &sock, "timeout-test")
+    let outcome = park_inner(&mut is_parked, 2048, &mut controller, &sock, "timeout-test")
         .await
         .unwrap();
 
-    // Park must succeed despite balloon never reaching target.
+    assert_eq!(
+        outcome,
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+    );
     assert!(is_parked);
 
     let reqs = reqs.lock().await;

--- a/crates/sandbox-mock/src/lifecycle.rs
+++ b/crates/sandbox-mock/src/lifecycle.rs
@@ -6,13 +6,13 @@ use ::sandbox::Result;
 
 use crate::support::LockIgnoringPoison;
 
-enum LifecycleBehavior {
-    Result(Result<()>),
+enum LifecycleBehavior<T> {
+    Result(Result<T>),
     Panic(String),
 }
 
-impl LifecycleBehavior {
-    fn into_result(self) -> Result<()> {
+impl<T> LifecycleBehavior<T> {
+    fn into_result(self) -> Result<T> {
         match self {
             Self::Result(result) => result,
             #[allow(clippy::panic)]
@@ -21,13 +21,20 @@ impl LifecycleBehavior {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct LifecycleBehaviors {
-    queue: Mutex<VecDeque<LifecycleBehavior>>,
+pub(crate) struct LifecycleBehaviors<T> {
+    queue: Mutex<VecDeque<LifecycleBehavior<T>>>,
 }
 
-impl LifecycleBehaviors {
-    pub(crate) fn push_result(&self, result: Result<()>) {
+impl<T> Default for LifecycleBehaviors<T> {
+    fn default() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
+impl<T> LifecycleBehaviors<T> {
+    pub(crate) fn push_result(&self, result: Result<T>) {
         self.queue
             .lock_ignoring_poison()
             .push_back(LifecycleBehavior::Result(result));
@@ -39,9 +46,9 @@ impl LifecycleBehaviors {
             .push_back(LifecycleBehavior::Panic(message.into()));
     }
 
-    pub(crate) fn next_result(&self) -> Result<()> {
+    pub(crate) fn next_result(&self, default: T) -> Result<T> {
         let behavior = self.queue.lock_ignoring_poison().pop_front();
-        behavior.map_or(Ok(()), LifecycleBehavior::into_result)
+        behavior.map_or(Ok(default), LifecycleBehavior::into_result)
     }
 }
 

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -52,15 +52,15 @@ pub(crate) struct LifecycleOverrideState {
     pub(crate) start_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of stop behaviours consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
-    pub(crate) stop_behaviors: LifecycleBehaviors,
+    pub(crate) stop_behaviors: LifecycleBehaviors<()>,
     /// FIFO queue of park results consumed by every sandbox built with
-    /// these overrides. Empty queue → default Ok(()).
-    pub(crate) park_behaviors: LifecycleBehaviors,
+    /// these overrides. Empty queue → default reusable outcome.
+    pub(crate) park_behaviors: LifecycleBehaviors<SandboxParkOutcome>,
     /// Optional gate that records and blocks every `park()` entry until released.
     pub(crate) park_gate: Mutex<Option<BlockingGate>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
-    pub(crate) unpark_behaviors: LifecycleBehaviors,
+    pub(crate) unpark_behaviors: LifecycleBehaviors<()>,
     /// Optional gate that records and blocks every factory `destroy()` entry
     /// until released.
     pub(crate) destroy_gate: Mutex<Option<BlockingGate>>,
@@ -387,8 +387,8 @@ impl MockSandboxOverrides {
     }
 
     /// Queue a `park()` result applied to the next factory-created sandbox.
-    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
-    pub fn push_park_result(&self, result: Result<()>) {
+    /// Consumed FIFO across all sandboxes; empty queue → reusable.
+    pub fn push_park_result(&self, result: Result<SandboxParkOutcome>) {
         self.lifecycle.park_behaviors.push_result(result);
     }
 

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -292,7 +292,7 @@ impl Sandbox for MockSandbox {
         let Some(o) = &self.overrides else {
             return Ok(());
         };
-        o.lifecycle.stop_behaviors.next_result()
+        o.lifecycle.stop_behaviors.next_result(())
     }
 
     async fn kill(&mut self) -> Result<()> {
@@ -301,17 +301,19 @@ impl Sandbox for MockSandbox {
 
     /// Mock park: bumps the override `park_calls` counter on every call (so
     /// tests can assert exact invocation counts) and consumes one queued
-    /// result (FIFO). Empty queue → `Ok(())`. The trait's idempotency
+    /// result (FIFO). Empty queue → reusable. The trait's idempotency
     /// requirement is satisfied in practice because the default-Ok behavior
     /// is side-effect-free; tests that need to exercise non-idempotent
     /// scenarios queue explicit results.
-    async fn park(&mut self) -> Result<()> {
+    async fn park(&mut self) -> Result<SandboxParkOutcome> {
         let Some(o) = &self.overrides else {
-            return Ok(());
+            return Ok(SandboxParkOutcome::Reusable);
         };
         *o.lifecycle.park_calls.lock_ignoring_poison() += 1;
         wait_blocking_gate(&o.lifecycle.park_gate).await;
-        o.lifecycle.park_behaviors.next_result()
+        o.lifecycle
+            .park_behaviors
+            .next_result(SandboxParkOutcome::Reusable)
     }
 
     /// Mock unpark: counter + queued-result semantics mirror [`park`]
@@ -323,7 +325,7 @@ impl Sandbox for MockSandbox {
             return Ok(());
         };
         *o.lifecycle.unpark_calls.lock_ignoring_poison() += 1;
-        o.lifecycle.unpark_behaviors.next_result()
+        o.lifecycle.unpark_behaviors.next_result(())
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {

--- a/crates/sandbox-mock/src/tests/lifecycle.rs
+++ b/crates/sandbox-mock/src/tests/lifecycle.rs
@@ -29,6 +29,24 @@ async fn overrides_count_park_and_unpark_calls_across_factory_sandboxes() {
 }
 
 #[tokio::test]
+async fn park_outcomes_are_consumed_fifo_and_default_to_reusable() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_park_result(Ok(SandboxParkOutcome::NonReusable(
+        SandboxParkNonReusableReason::SevereMemoryRetention,
+    )));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut first = factory.create(test_sandbox_config()).await.unwrap();
+    let mut second = factory.create(test_sandbox_config()).await.unwrap();
+
+    assert_eq!(
+        first.park().await.unwrap(),
+        SandboxParkOutcome::NonReusable(SandboxParkNonReusableReason::SevereMemoryRetention)
+    );
+    assert_eq!(second.park().await.unwrap(), SandboxParkOutcome::Reusable);
+    assert_eq!(overrides.park_call_count(), 2);
+}
+
+#[tokio::test]
 async fn overrides_count_destroy_calls_across_factory_sandboxes() {
     let overrides = Arc::new(MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -41,7 +41,7 @@ pub use factory::{
     SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
-pub use sandbox::Sandbox;
+pub use sandbox::{Sandbox, SandboxParkNonReusableReason, SandboxParkOutcome};
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -10,6 +10,31 @@ use crate::types::{
     StartProcessRequest, WriteFileEntry,
 };
 
+/// Eligibility result after a sandbox successfully reaches the parked state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxParkOutcome {
+    /// The parked sandbox may be admitted to an idle pool for later reuse.
+    Reusable,
+    /// The sandbox is validly parked but must be destroyed instead of reused.
+    NonReusable(SandboxParkNonReusableReason),
+}
+
+/// Stable reason why a validly parked sandbox cannot be reused.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxParkNonReusableReason {
+    /// The guest retained too much memory after the bounded park-time reclaim.
+    SevereMemoryRetention,
+}
+
+impl SandboxParkNonReusableReason {
+    /// Stable low-cardinality value for lifecycle logs and cleanup context.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SevereMemoryRetention => "severe_memory_retention",
+        }
+    }
+}
+
 /// A process-isolation environment that runs guest workloads for the runner.
 ///
 /// Implementations are created by a [`SandboxFactory`](crate::SandboxFactory)
@@ -116,17 +141,23 @@ pub trait Sandbox: Send + Sync + Any {
     /// implementations must tolerate this — skipping graceful shutdown is
     /// still correct because the sandbox was idle with no user workload.
     ///
+    /// On success, the returned [`SandboxParkOutcome`] states whether the
+    /// validly parked sandbox may enter an idle pool. A non-reusable outcome is
+    /// not an operational failure; the lifecycle owner must destroy the parked
+    /// sandbox through its parked cleanup path.
+    ///
     /// Must be idempotent for a healthy already-parked sandbox: calling
-    /// `park()` again returns `Ok(())` without side effects. Implementations
-    /// may still return `Err` if lifecycle guards detect that the sandbox is
-    /// internally dirty or otherwise not safe to reuse.
+    /// `park()` again returns the same successful eligibility outcome without
+    /// side effects. Implementations may still return `Err` if lifecycle guards
+    /// detect that the sandbox is internally dirty or otherwise not safe to
+    /// reuse.
     ///
     /// On `Err`, the caller must not dispatch further work to the sandbox.
     /// The sandbox may be partially parked or marked internally dirty; the
     /// lifecycle owner should destroy it, or perform an explicit retry only
     /// when the implementation documents that retry as safe.
-    async fn park(&mut self) -> Result<()> {
-        Ok(())
+    async fn park(&mut self) -> Result<SandboxParkOutcome> {
+        Ok(SandboxParkOutcome::Reusable)
     }
 
     /// Transition the sandbox back to the active state.


### PR DESCRIPTION
## Summary

- add a typed sandbox park outcome that distinguishes reusable VMs from successfully parked but non-reusable VMs
- map Firecracker's existing `severe_deficit` balloon classification to `SevereMemoryRetention` only after the final pause succeeds
- bypass idle-pool admission for severe retention and reuse the parked workspace promotion/destroy path while retaining the full budget lease
- preserve successful provider completion, cancellation precedence, pressure-limited reuse, and non-severe timeout behavior

## Scope

- no API, database, queue, persisted-state, or dynamic memory-accounting changes
- no balloon timeout, tolerance, pressure threshold, or workspace promotion policy changes
- parent delivery context: #21740

## Validation

- `cargo test -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-features --no-deps`

Closes #21770
