### PR TITLE
fix(runner): recover from guest dns readiness failures

### DIFF
--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
+use std::io::SeekFrom;
+use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use tokio::io::AsyncBufRead;
+use sandbox_fc::DNS_READINESS_HOSTNAME;
+use tokio::io::{AsyncBufRead, AsyncReadExt, AsyncSeekExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -10,6 +13,46 @@ use crate::network_log_drain::{
     DrainableLineReaderExit, NetworkLogDrainRequest, run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
+
+const DNS_READINESS_LOG_SCAN_MAX_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DnsReadinessLogScanStatus {
+    Complete,
+    Truncated,
+    InvalidOffset,
+    Malformed,
+    Unavailable,
+}
+
+impl DnsReadinessLogScanStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Truncated => "truncated",
+            Self::InvalidOffset => "invalid_offset",
+            Self::Malformed => "malformed",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DnsReadinessLogObservation {
+    pub(crate) query_observed: bool,
+    pub(crate) result_observed: bool,
+    pub(crate) status: DnsReadinessLogScanStatus,
+}
+
+impl DnsReadinessLogObservation {
+    pub(crate) fn unavailable() -> Self {
+        Self {
+            query_observed: false,
+            result_observed: false,
+            status: DnsReadinessLogScanStatus::Unavailable,
+        }
+    }
+}
 
 /// Tail dnsmasq stderr and write DNS log entries to per-VM network JSONL.
 ///
@@ -83,6 +126,80 @@ async fn handle_dns_line(network_log_manager: &NetworkLogManager, line: &str) {
         // it reflects DNS observation time, not delayed write time.
         let timestamp = Utc::now();
         append_dns_entry(network_log_manager, &entry, timestamp).await;
+    }
+}
+
+pub(crate) async fn inspect_readiness_log_segment(
+    path: &Path,
+    start_offset: u64,
+) -> DnsReadinessLogObservation {
+    let mut file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return DnsReadinessLogObservation {
+                query_observed: false,
+                result_observed: false,
+                status: DnsReadinessLogScanStatus::Complete,
+            };
+        }
+        Err(_) => return DnsReadinessLogObservation::unavailable(),
+    };
+    let file_len = match file.metadata().await {
+        Ok(metadata) => metadata.len(),
+        Err(_) => return DnsReadinessLogObservation::unavailable(),
+    };
+    if file_len < start_offset {
+        return DnsReadinessLogObservation {
+            query_observed: false,
+            result_observed: false,
+            status: DnsReadinessLogScanStatus::InvalidOffset,
+        };
+    }
+    if file.seek(SeekFrom::Start(start_offset)).await.is_err() {
+        return DnsReadinessLogObservation::unavailable();
+    }
+
+    let segment_len = file_len - start_offset;
+    let scan_len = segment_len.min(DNS_READINESS_LOG_SCAN_MAX_BYTES);
+    let mut bytes = Vec::new();
+    if file.take(scan_len).read_to_end(&mut bytes).await.is_err() {
+        return DnsReadinessLogObservation::unavailable();
+    }
+
+    let mut query_observed = false;
+    let mut result_observed = false;
+    let mut malformed = false;
+    for line in bytes.split(|byte| *byte == b'\n') {
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let Ok(row) = serde_json::from_slice::<serde_json::Value>(line) else {
+            malformed = true;
+            continue;
+        };
+        if row.get("type").and_then(serde_json::Value::as_str) != Some("dns")
+            || row.get("host").and_then(serde_json::Value::as_str) != Some(DNS_READINESS_HOSTNAME)
+        {
+            continue;
+        }
+        match row.get("dns_event").and_then(serde_json::Value::as_str) {
+            Some("query") => query_observed = true,
+            Some("reply" | "cached" | "config") => result_observed = true,
+            _ => {}
+        }
+    }
+
+    let status = if segment_len > DNS_READINESS_LOG_SCAN_MAX_BYTES {
+        DnsReadinessLogScanStatus::Truncated
+    } else if malformed {
+        DnsReadinessLogScanStatus::Malformed
+    } else {
+        DnsReadinessLogScanStatus::Complete
+    };
+    DnsReadinessLogObservation {
+        query_observed,
+        result_observed,
+        status,
     }
 }
 
@@ -322,6 +439,87 @@ mod tests {
             DnsEvent::Result { result, .. } => assert_eq!(result.as_ref(), expected_result),
             DnsEvent::Query { .. } => panic!("expected result event"),
         }
+    }
+
+    fn readiness_log_row(host: &str, event: &str) -> String {
+        serde_json::json!({
+            "type": "dns",
+            "host": host,
+            "dns_event": event,
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_uses_attempt_offset_and_fixed_hostname() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let old_row = readiness_log_row(DNS_READINESS_HOSTNAME, "query");
+        tokio::fs::write(&path, format!("{old_row}\n"))
+            .await
+            .unwrap();
+        let start_offset = tokio::fs::metadata(&path).await.unwrap().len();
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let current_rows = [
+            readiness_log_row("unrelated.example", "query"),
+            readiness_log_row(DNS_READINESS_HOSTNAME, "query"),
+            readiness_log_row(DNS_READINESS_HOSTNAME, "config"),
+        ]
+        .join("\n");
+        file.write_all(format!("{current_rows}\n").as_bytes())
+            .await
+            .unwrap();
+        file.flush().await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, start_offset).await;
+
+        assert!(observation.query_observed);
+        assert!(observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_reports_missing_file_as_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let observation = inspect_readiness_log_segment(&dir.path().join("missing.jsonl"), 0).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_reports_invalid_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        tokio::fs::write(&path, b"{}\n").await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, 4).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::InvalidOffset);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_bounds_large_attempt_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let query = readiness_log_row(DNS_READINESS_HOSTNAME, "query");
+        let padding_len = usize::try_from(DNS_READINESS_LOG_SCAN_MAX_BYTES).unwrap() + 1;
+        let mut content = format!("{query}\n").into_bytes();
+        content.extend(std::iter::repeat_n(b' ', padding_len));
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, 0).await;
+
+        assert!(observation.query_observed);
+        assert!(!observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Truncated);
     }
 
     #[test]

--- a/crates/runner/src/dns/mod.rs
+++ b/crates/runner/src/dns/mod.rs
@@ -23,5 +23,6 @@ mod log;
 mod port;
 mod proxy;
 
+pub(crate) use log::{DnsReadinessLogObservation, inspect_readiness_log_segment};
 pub(crate) use port::reserve_port;
 pub use proxy::{DnsProxy, start_on_reserved_port};

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{
-    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxId,
-    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
+    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
+    SandboxFactory, SandboxId, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
+    SandboxNbdNetlinkConnectStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -31,6 +32,7 @@ use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
     RunnerResult, SandboxPreparedNotifier, SandboxReuseResult, SessionHistoryMaterializer,
 };
+use crate::dns::{DnsReadinessLogObservation, inspect_readiness_log_segment};
 use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
@@ -114,6 +116,7 @@ const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_re
 const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
     "runner_fresh_sandbox_retry_without_workspace_image";
+const RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY: &str = "runner_fresh_sandbox_dns_readiness_retry";
 
 const WORKSPACE_IMAGE_PREPARE_INVALID_WORKING_DIR: &str =
     "workspace_image_prepare_invalid_working_dir";
@@ -124,6 +127,8 @@ const SANDBOX_FACTORY_CREATE_FAILED: &str = "sandbox_factory_create_failed";
 const SANDBOX_FACTORY_CREATE_STAGE_FAILED: &str = "sandbox_factory_create_stage_failed";
 const SANDBOX_PROXY_REGISTER_FAILED: &str = "sandbox_proxy_register_failed";
 const SANDBOX_START_FAILED: &str = "sandbox_start_failed";
+const DNS_READINESS_RETRY_PREPARE_FAILED: &str = "replacement_prepare_failed";
+const SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN: &str = "cleanup_uncertain";
 
 struct FreshSandboxFactoryCreateObserver<'a> {
     telemetry: &'a mut JobTelemetry,
@@ -339,28 +344,111 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         telemetry,
     )
     .await;
-    let prepared = match create_started_sandbox(
-        factory,
-        context,
-        sandbox_id,
-        config,
-        params,
-        telemetry,
-        StartSandboxOptions {
-            workspace_image: workspace_image.as_ref(),
-            sandbox_prepared,
-        },
-    )
-    .await
-    {
-        Ok(prepared) => prepared,
-        Err(e)
-            if e.retry_without_workspace_image
-                && workspace_image
-                    .as_ref()
-                    .is_some_and(WorkspaceImageLease::is_cache_hit) =>
-        {
-            let error = e.error;
+    let mut used_retry = false;
+    let mut dns_retry_started: Option<Instant> = None;
+    let prepared = loop {
+        let result = create_started_sandbox(
+            factory,
+            context,
+            sandbox_id,
+            config,
+            params,
+            telemetry,
+            StartSandboxOptions {
+                workspace_image: workspace_image.as_ref(),
+                sandbox_prepared,
+            },
+        )
+        .await;
+
+        if let Some(started) = dns_retry_started.take() {
+            let success = result.is_ok();
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY,
+                started.elapsed(),
+                success,
+                (!success).then_some(DNS_READINESS_RETRY_PREPARE_FAILED),
+            );
+        }
+
+        let failure = match result {
+            Ok(prepared) => break prepared,
+            Err(failure) => failure,
+        };
+        if used_retry {
+            let error = failure.error;
+            telemetry.record(
+                "runner_fresh_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return Err(error);
+        }
+
+        let cache_hit = workspace_image
+            .as_ref()
+            .is_some_and(WorkspaceImageLease::is_cache_hit);
+        let retry_guest_dns = failure.retry == SandboxPrepareRetry::GuestDnsReadiness;
+        let retry_without_workspace =
+            failure.retry == SandboxPrepareRetry::WithoutWorkspaceImage && cache_hit;
+        if !failure.cleanup_completed {
+            if retry_guest_dns {
+                telemetry.record(
+                    RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY,
+                    Duration::ZERO,
+                    false,
+                    Some(SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN),
+                );
+                warn!(
+                    run_id = %context.run_id,
+                    sandbox_id = %sandbox_id,
+                    "guest DNS readiness replacement suppressed after uncertain cleanup"
+                );
+            } else if retry_without_workspace {
+                telemetry.record(
+                    RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE,
+                    Duration::ZERO,
+                    false,
+                    Some(SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN),
+                );
+                warn!(
+                    run_id = %context.run_id,
+                    sandbox_id = %sandbox_id,
+                    "workspace image fallback suppressed after uncertain cleanup"
+                );
+            }
+            let error = failure.error;
+            telemetry.record(
+                "runner_fresh_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return Err(error);
+        }
+        if !retry_guest_dns && !retry_without_workspace {
+            let error = failure.error;
+            telemetry.record(
+                "runner_fresh_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return Err(error);
+        }
+
+        if retry_guest_dns {
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %sandbox_id,
+                error = %failure.error,
+                "guest DNS readiness failed; retrying with a fresh sandbox attachment"
+            );
+            dns_retry_started = Some(Instant::now());
+        }
+
+        if cache_hit {
             invalidate_workspace_cache_hit(
                 workspace_image.as_ref(),
                 context.run_id,
@@ -370,7 +458,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
             warn!(
                 run_id = %context.run_id,
                 sandbox_id = %sandbox_id,
-                error = %error,
+                error = %failure.error,
                 "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
             );
             telemetry.record(
@@ -388,43 +476,8 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                     controls.cancel.clone(),
                     telemetry,
                 );
-            match create_started_sandbox(
-                factory,
-                context,
-                sandbox_id,
-                config,
-                params,
-                telemetry,
-                StartSandboxOptions {
-                    workspace_image: None,
-                    sandbox_prepared,
-                },
-            )
-            .await
-            {
-                Ok(prepared) => prepared,
-                Err(e) => {
-                    let error = e.error;
-                    telemetry.record(
-                        "runner_fresh_sandbox_prepare",
-                        prepare_started.elapsed(),
-                        false,
-                        Some(&error.to_string()),
-                    );
-                    return Err(error);
-                }
-            }
         }
-        Err(e) => {
-            let error = e.error;
-            telemetry.record(
-                "runner_fresh_sandbox_prepare",
-                prepare_started.elapsed(),
-                false,
-                Some(&error.to_string()),
-            );
-            return Err(error);
-        }
+        used_retry = true;
     };
     telemetry.record(
         "runner_fresh_sandbox_prepare",
@@ -460,7 +513,15 @@ pub(super) struct PreparedSandboxRun {
 
 pub(super) struct SandboxPrepareError {
     error: RunnerError,
-    retry_without_workspace_image: bool,
+    retry: SandboxPrepareRetry,
+    cleanup_completed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SandboxPrepareRetry {
+    None,
+    WithoutWorkspaceImage,
+    GuestDnsReadiness,
 }
 
 pub(super) struct NewSandboxHooks<'a> {
@@ -474,17 +535,27 @@ struct StartSandboxOptions<'a> {
 }
 
 impl SandboxPrepareError {
-    fn retry(error: RunnerError) -> Self {
+    fn retry_without_workspace_image(error: RunnerError, cleanup_completed: bool) -> Self {
         Self {
             error,
-            retry_without_workspace_image: true,
+            retry: SandboxPrepareRetry::WithoutWorkspaceImage,
+            cleanup_completed,
+        }
+    }
+
+    fn guest_dns_readiness(error: RunnerError, cleanup_completed: bool) -> Self {
+        Self {
+            error,
+            retry: SandboxPrepareRetry::GuestDnsReadiness,
+            cleanup_completed,
         }
     }
 
     fn fatal(error: RunnerError) -> Self {
         Self {
             error,
-            retry_without_workspace_image: false,
+            retry: SandboxPrepareRetry::None,
+            cleanup_completed: false,
         }
     }
 }
@@ -711,7 +782,10 @@ async fn create_started_sandbox(
                 Some(SANDBOX_FACTORY_CREATE_FAILED),
             );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-            return Err(SandboxPrepareError::retry(e.into()));
+            return Err(SandboxPrepareError::retry_without_workspace_image(
+                e.into(),
+                true,
+            ));
         }
     };
 
@@ -750,13 +824,28 @@ async fn create_started_sandbox(
                 &e.to_string(),
             );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-            destroy_sandbox_panic_safe(factory, sandbox).await;
+            let _ = destroy_sandbox_panic_safe(factory, sandbox).await;
             return Err(SandboxPrepareError::fatal(e));
         }
     };
 
+    let network_log_path = config.log_paths.network_log(context.run_id);
+    let network_log_start_offset = match tokio::fs::metadata(&network_log_path).await {
+        Ok(metadata) => Some(metadata.len()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(0),
+        Err(error) => {
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %sandbox_id,
+                io_kind = ?error.kind(),
+                "failed to capture network log offset before sandbox start"
+            );
+            None
+        }
+    };
     let sandbox_start_started = Instant::now();
     if let Err(e) = sandbox.start().await {
+        let guest_dns_readiness = matches!(&e, SandboxError::GuestDnsReadiness { .. });
         telemetry.record(
             RUNNER_FRESH_SANDBOX_START,
             sandbox_start_started.elapsed(),
@@ -764,20 +853,48 @@ async fn create_started_sandbox(
             Some(SANDBOX_START_FAILED),
         );
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        if let Err(unregister_error) =
-            unregister_proxy_registry(config, &source_ip, context.run_id).await
-        {
-            warn!(
-                run_id = %context.run_id,
-                error = %unregister_error,
-                "failed to unregister VM from proxy after sandbox start failure"
-            );
-        }
+        let unregister_completed =
+            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
+                Ok(()) => true,
+                Err(unregister_error) => {
+                    warn!(
+                        run_id = %context.run_id,
+                        error = %unregister_error,
+                        "failed to unregister VM from proxy after sandbox start failure"
+                    );
+                    false
+                }
+            };
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
-        destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::retry(e.into()));
+        if guest_dns_readiness {
+            let observation = match network_log_start_offset {
+                Some(start_offset) => {
+                    inspect_readiness_log_segment(&network_log_path, start_offset).await
+                }
+                None => DnsReadinessLogObservation::unavailable(),
+            };
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %sandbox_id,
+                source_ip,
+                query_observed = observation.query_observed,
+                result_observed = observation.result_observed,
+                scan_status = observation.status.as_str(),
+                "guest DNS readiness network log observation"
+            );
+        }
+        let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
+            .await
+            .is_completed();
+        let cleanup_completed = unregister_completed && destroy_completed;
+        let error = e.into();
+        return Err(if guest_dns_readiness {
+            SandboxPrepareError::guest_dns_readiness(error, cleanup_completed)
+        } else {
+            SandboxPrepareError::retry_without_workspace_image(error, cleanup_completed)
+        });
     }
     telemetry.record(
         RUNNER_FRESH_SANDBOX_START,
@@ -795,20 +912,28 @@ async fn create_started_sandbox(
             false,
             Some(&e.to_string()),
         );
-        if let Err(unregister_error) =
-            unregister_proxy_registry(config, &source_ip, context.run_id).await
-        {
-            warn!(
-                run_id = %context.run_id,
-                error = %unregister_error,
-                "failed to unregister VM from proxy after workspace mount failure"
-            );
-        }
+        let unregister_completed =
+            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
+                Ok(()) => true,
+                Err(unregister_error) => {
+                    warn!(
+                        run_id = %context.run_id,
+                        error = %unregister_error,
+                        "failed to unregister VM from proxy after workspace mount failure"
+                    );
+                    false
+                }
+            };
         network_log_session
             .close_for_upload(context.run_id, &config.network_log_drain)
             .await;
-        destroy_sandbox_panic_safe(factory, sandbox).await;
-        return Err(SandboxPrepareError::retry(e));
+        let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
+            .await
+            .is_completed();
+        return Err(SandboxPrepareError::retry_without_workspace_image(
+            e,
+            unregister_completed && destroy_completed,
+        ));
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
     if let Some(notifier) = sandbox_prepared {
@@ -843,16 +968,31 @@ pub(super) async fn invalidate_workspace_cache_hit(
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DestroySandboxOutcome {
+    Completed,
+    Uncertain,
+}
+
+impl DestroySandboxOutcome {
+    fn is_completed(self) -> bool {
+        matches!(self, Self::Completed)
+    }
+}
+
 pub(super) async fn destroy_sandbox_panic_safe(
     factory: &dyn SandboxFactory,
     sandbox: Box<dyn Sandbox>,
-) {
+) -> DestroySandboxOutcome {
     if AssertUnwindSafe(factory.destroy(sandbox))
         .catch_unwind()
         .await
         .is_err()
     {
         warn!("sandbox destroy panicked after start failure");
+        DestroySandboxOutcome::Uncertain
+    } else {
+        DestroySandboxOutcome::Completed
     }
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+fn guest_dns_readiness_failure(message: &str) -> SandboxError {
+    SandboxError::GuestDnsReadiness {
+        message: message.to_string(),
+    }
+}
+
 #[tokio::test]
 async fn execute_inner_happy_path() {
     let dir = tempfile::tempdir().unwrap();
@@ -56,6 +62,229 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
 
     assert_eq!(outcome.exit_code(), 0);
     assert_eq!(notifications.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(guest_dns_readiness_failure("first attachment failed")));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let sandbox_id = SandboxId::new_v4();
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let notifier = SandboxPreparedNotifier::new(move |_run_id, prepared_sandbox_id| {
+        let notifications = Arc::clone(&notifications_for_callback);
+        async move {
+            assert_eq!(prepared_sandbox_id, sandbox_id);
+            notifications.fetch_add(1, Ordering::SeqCst);
+        }
+        .boxed()
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox_with_prepared_notifier(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: sandbox_id,
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        NewSandboxHooks {
+            controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+            sandbox_prepared: Some(&notifier),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(notifications.load(Ordering::SeqCst), 1);
+    assert_proxy_registry_empty(dir.path()).await;
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        true,
+        None,
+    );
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_stops_after_two_dns_unready_attachments() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(guest_dns_readiness_failure("first attachment failed")));
+    overrides.push_start_result(Err(guest_dns_readiness_failure("second attachment failed")));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    let error = result.err().expect("second DNS failure must be returned");
+    assert!(error.to_string().contains("second attachment failed"));
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 2);
+    assert!(overrides.start_process_calls().is_empty());
+    assert_proxy_registry_empty(dir.path()).await;
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        false,
+        Some("replacement_prepare_failed"),
+    );
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_does_not_retry_an_unrelated_start_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::Start {
+        message: "boot failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    let error = result
+        .err()
+        .expect("ordinary start failure must be returned");
+    assert!(error.to_string().contains("boot failed"));
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_no_telemetry_action(&telemetry, "runner_fresh_sandbox_dns_readiness_retry");
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_suppresses_dns_retry_after_uncertain_destroy() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(guest_dns_readiness_failure("attachment failed")));
+    overrides.push_destroy_panic("simulated destroy panic");
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    let error = result
+        .err()
+        .expect("uncertain cleanup must preserve the readiness error");
+    assert!(error.to_string().contains("attachment failed"));
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_process_calls().is_empty());
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        false,
+        Some("cleanup_uncertain"),
+    );
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_waits_for_destroy_before_dns_retry_create() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(guest_dns_readiness_failure("attachment failed")));
+    overrides.set_destroy_lifecycle_gate(gate.clone());
+    let factory = Arc::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)));
+    let ctx = minimal_context();
+    let sandbox_id = SandboxId::new_v4();
+    let task = tokio::spawn({
+        let factory = Arc::clone(&factory);
+        async move {
+            let mut telemetry = test_telemetry(&config, &ctx);
+            let result = execute_new_sandbox(
+                factory.as_ref(),
+                &ctx,
+                NewSandboxDispatch {
+                    id: sandbox_id,
+                    reuse_result: SandboxReuseResult::PoolMiss,
+                },
+                &config,
+                &default_params(),
+                &mut telemetry,
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await;
+            (result, telemetry)
+        }
+    });
+
+    gate.wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("first failed sandbox should enter explicit destroy");
+    assert_eq!(
+        overrides.create_configs().len(),
+        1,
+        "replacement create must wait for failed-sandbox destroy"
+    );
+
+    gate.release_one();
+    let (result, telemetry) = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("replacement should finish after destroy release")
+        .expect("replacement task should not panic");
+    assert_eq!(result.unwrap().exit_code(), 0);
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        true,
+        None,
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -88,6 +88,135 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
 }
 
 #[tokio::test]
+async fn execute_inner_dns_readiness_retry_replaces_consumed_workspace_cache_hit() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        message: "first attachment failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-cache-dns-retry".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let expected_seed =
+        seed_workspace_image_cache(&cache, &runner_paths, "sess-cache-dns-retry", 16).await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert!(outcome.workspace_image.is_none());
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 2);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                expected_seed.clone(),
+            )),
+        })
+    );
+    assert_eq!(
+        configs[1].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: None,
+        })
+    );
+    assert!(!expected_seed.exists());
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_dns_readiness_retry",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+        true,
+        None,
+    );
+}
+
+#[tokio::test]
+async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(SandboxError::Start {
+        message: "start failed".into(),
+    }));
+    overrides.push_destroy_panic("simulated destroy panic");
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-cache-cleanup-uncertain".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let _seed =
+        seed_workspace_image_cache(&cache, &runner_paths, "sess-cache-cleanup-uncertain", 16).await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+
+    let error = result
+        .err()
+        .expect("uncertain cleanup must preserve the first preparation failure");
+    assert!(error.to_string().contains("start failed"));
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+        false,
+        Some("cleanup_uncertain"),
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_uses_workspace_cache_when_configured() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -1,0 +1,240 @@
+//! Bounded passive evidence for terminal guest DNS readiness failures.
+
+use std::time::Duration;
+
+use tracing::warn;
+use vsock_host::{ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput, VsockHost};
+
+use crate::command::{CommandError, exec_with_timeout};
+
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(2);
+const HOST_COMMAND_TIMEOUT: Duration = Duration::from_millis(1_500);
+const GUEST_PROCESS_TIMEOUT_MS: u32 = 1_500;
+const GUEST_WAIT_TIMEOUT: Duration = Duration::from_millis(1_750);
+const GUEST_OUTPUT_LIMIT_BYTES: u32 = 4 * 1024;
+const LOG_OUTPUT_LIMIT_BYTES: usize = 4 * 1024;
+const GUEST_DIAGNOSTIC_LABEL: &str = "guest-dns-failure-diagnostics";
+
+const GUEST_STATE_COMMAND: &str = r#"set +e
+/usr/sbin/ip -details -statistics link show dev eth0 2>&1
+/usr/sbin/ip -4 address show dev eth0 2>&1
+/usr/sbin/ip -4 route show table all 2>&1
+/usr/sbin/ip neighbor show dev eth0 2>&1
+/usr/bin/cat /etc/resolv.conf 2>&1
+/usr/bin/grep '^hosts:' /etc/nsswitch.conf 2>&1
+true
+"#;
+
+#[derive(Clone, Copy)]
+pub(crate) struct GuestDnsFailureDiagnosticContext<'a> {
+    pub(crate) sandbox_id: &'a str,
+    pub(crate) profile: &'a str,
+    pub(crate) namespace: &'a str,
+    pub(crate) host_device: &'a str,
+    pub(crate) peer_ip: &'a str,
+    pub(crate) dns_port: u16,
+}
+
+pub(crate) async fn capture_guest_dns_failure_snapshot(
+    guest: &VsockHost,
+    context: GuestDnsFailureDiagnosticContext<'_>,
+) {
+    if tokio::time::timeout(SNAPSHOT_TIMEOUT, capture_snapshot(guest, context))
+        .await
+        .is_err()
+    {
+        warn!(
+            id = context.sandbox_id,
+            profile = context.profile,
+            namespace = context.namespace,
+            host_device = context.host_device,
+            peer_ip = context.peer_ip,
+            dns_port = context.dns_port,
+            timeout_ms = SNAPSHOT_TIMEOUT.as_millis() as u64,
+            "guest DNS failure diagnostic snapshot timed out"
+        );
+    }
+}
+
+async fn capture_snapshot(guest: &VsockHost, context: GuestDnsFailureDiagnosticContext<'_>) {
+    let namespace = context.namespace;
+    let peer_ip = context.peer_ip;
+    let listener_filter = format!("sport = :{}", context.dns_port);
+
+    let namespace_links_args = [
+        "netns",
+        "exec",
+        namespace,
+        "ip",
+        "-details",
+        "-statistics",
+        "link",
+        "show",
+    ];
+    let namespace_nat_args = [
+        "netns",
+        "exec",
+        namespace,
+        "iptables-save",
+        "-c",
+        "-t",
+        "nat",
+    ];
+    let raw_rules_args = ["-c", "-t", "raw"];
+    let nat_rules_args = ["-c", "-t", "nat"];
+    let conntrack_source_args = ["-L", "-s", peer_ip];
+    let conntrack_destination_args = ["-L", "-d", peer_ip];
+    let listener_args = ["-H", "-lunt", listener_filter.as_str()];
+
+    let (
+        guest_state,
+        namespace_links,
+        namespace_nat,
+        host_raw_rules,
+        host_nat_rules,
+        conntrack_source,
+        conntrack_destination,
+        dnsmasq_listener,
+    ) = tokio::join!(
+        capture_guest_state(guest),
+        exec_with_timeout("ip", &namespace_links_args, HOST_COMMAND_TIMEOUT),
+        exec_with_timeout("ip", &namespace_nat_args, HOST_COMMAND_TIMEOUT),
+        exec_with_timeout("iptables-save", &raw_rules_args, HOST_COMMAND_TIMEOUT),
+        exec_with_timeout("iptables-save", &nat_rules_args, HOST_COMMAND_TIMEOUT),
+        exec_with_timeout("conntrack", &conntrack_source_args, HOST_COMMAND_TIMEOUT),
+        exec_with_timeout(
+            "conntrack",
+            &conntrack_destination_args,
+            HOST_COMMAND_TIMEOUT,
+        ),
+        exec_with_timeout("ss", &listener_args, HOST_COMMAND_TIMEOUT),
+    );
+
+    log_component(context, "guest_state", guest_state);
+    log_component(context, "namespace_links", command_output(namespace_links));
+    log_component(context, "namespace_nat", command_output(namespace_nat));
+    log_component(
+        context,
+        "host_raw_rules",
+        filtered_command_output(host_raw_rules, namespace),
+    );
+    log_component(
+        context,
+        "host_nat_rules",
+        filtered_command_output(host_nat_rules, namespace),
+    );
+    log_component(
+        context,
+        "conntrack_source",
+        command_output(conntrack_source),
+    );
+    log_component(
+        context,
+        "conntrack_destination",
+        command_output(conntrack_destination),
+    );
+    log_component(
+        context,
+        "dnsmasq_listener",
+        command_output(dnsmasq_listener),
+    );
+}
+
+async fn capture_guest_state(guest: &VsockHost) -> String {
+    let request = ExecCaptureRequest {
+        timeout_ms: GUEST_PROCESS_TIMEOUT_MS,
+        command: GUEST_STATE_COMMAND,
+        env: &[],
+        sudo: false,
+        label: GUEST_DIAGNOSTIC_LABEL,
+        stdout_limit_bytes: GUEST_OUTPUT_LIMIT_BYTES,
+        stderr_limit_bytes: GUEST_OUTPUT_LIMIT_BYTES,
+        expected_exit_codes: &[],
+        stdin_bytes: None,
+        wait_timeout: GUEST_WAIT_TIMEOUT,
+    };
+
+    match guest.exec_operation_capture(request).await {
+        Ok(result) => format_guest_result(result),
+        Err(error) => bounded_output(format!("transport_error={:?}", error.kind())),
+    }
+}
+
+fn format_guest_result(result: ExecOperationResult) -> String {
+    let (stdout, stdout_truncated) = captured_output(result.stdout);
+    let (stderr, stderr_truncated) = captured_output(result.stderr);
+    bounded_output(format!(
+        "termination={:?} duration_ms={} stream_overflowed={} stdout_truncated={} stderr_truncated={}\nstdout:\n{}\nstderr:\n{}",
+        result.termination,
+        result.duration_ms,
+        result.stream_overflowed,
+        stdout_truncated,
+        stderr_truncated,
+        stdout,
+        stderr,
+    ))
+}
+
+fn captured_output(output: ExecOwnedCapturedOutput) -> (String, bool) {
+    match output {
+        ExecOwnedCapturedOutput::Discarded => ("[discarded]".to_string(), false),
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => {
+            (String::from_utf8_lossy(&bytes).into_owned(), truncated)
+        }
+    }
+}
+
+fn command_output(result: Result<String, CommandError>) -> String {
+    match result {
+        Ok(output) if output.is_empty() => "[no output]".to_string(),
+        Ok(output) => bounded_output(output),
+        Err(error) => bounded_output(format!("command_error={error}")),
+    }
+}
+
+fn filtered_command_output(result: Result<String, CommandError>, needle: &str) -> String {
+    match result {
+        Ok(output) => {
+            let filtered = output
+                .lines()
+                .filter(|line| line.contains(needle))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if filtered.is_empty() {
+                "[no matching output]".to_string()
+            } else {
+                bounded_output(filtered)
+            }
+        }
+        Err(error) => bounded_output(format!("command_error={error}")),
+    }
+}
+
+fn bounded_output(output: String) -> String {
+    if output.len() <= LOG_OUTPUT_LIMIT_BYTES {
+        return output;
+    }
+    let mut end = LOG_OUTPUT_LIMIT_BYTES;
+    while !output.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n[output truncated]", &output[..end])
+}
+
+fn log_component(
+    context: GuestDnsFailureDiagnosticContext<'_>,
+    component: &'static str,
+    output: String,
+) {
+    warn!(
+        id = context.sandbox_id,
+        profile = context.profile,
+        namespace = context.namespace,
+        host_device = context.host_device,
+        peer_ip = context.peer_ip,
+        dns_port = context.dns_port,
+        component,
+        output,
+        "guest DNS failure diagnostic component"
+    );
+}

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -238,3 +238,38 @@ fn log_component(
         "guest DNS failure diagnostic component"
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_output_truncates_at_utf8_boundary() {
+        let output = "a".repeat(LOG_OUTPUT_LIMIT_BYTES - 1) + "界";
+
+        let bounded = bounded_output(output);
+
+        assert!(bounded.is_char_boundary(LOG_OUTPUT_LIMIT_BYTES - 1));
+        assert!(bounded.starts_with(&"a".repeat(LOG_OUTPUT_LIMIT_BYTES - 1)));
+        assert!(bounded.ends_with("\n[output truncated]"));
+        assert!(!bounded.contains('界'));
+    }
+
+    #[test]
+    fn filtered_command_output_keeps_only_namespace_rules() {
+        let namespace = "vm0-ns-0c-20";
+        let output = [
+            "-A PREROUTING -m comment --comment vm0-ns-0c-1f -j DROP",
+            "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP",
+            "-A PREROUTING -m comment --comment vm0-ns-0c-21 -j DROP",
+        ]
+        .join("\n");
+
+        let filtered = filtered_command_output(Ok(output), namespace);
+
+        assert_eq!(
+            filtered,
+            "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP"
+        );
+    }
+}

--- a/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
+++ b/crates/sandbox-fc/src/guest_dns_failure_diagnostics.rs
@@ -197,7 +197,7 @@ fn filtered_command_output(result: Result<String, CommandError>, needle: &str) -
         Ok(output) => {
             let filtered = output
                 .lines()
-                .filter(|line| line.contains(needle))
+                .filter(|line| line_has_exact_comment(line, needle))
                 .collect::<Vec<_>>()
                 .join("\n");
             if filtered.is_empty() {
@@ -208,6 +208,18 @@ fn filtered_command_output(result: Result<String, CommandError>, needle: &str) -
         }
         Err(error) => bounded_output(format!("command_error={error}")),
     }
+}
+
+fn line_has_exact_comment(line: &str, expected: &str) -> bool {
+    let mut tokens = line.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if token == "--comment" {
+            return tokens
+                .next()
+                .is_some_and(|comment| comment.trim_matches('"') == expected);
+        }
+    }
+    false
 }
 
 fn bounded_output(output: String) -> String {
@@ -261,6 +273,7 @@ mod tests {
         let output = [
             "-A PREROUTING -m comment --comment vm0-ns-0c-1f -j DROP",
             "-A PREROUTING -m comment --comment vm0-ns-0c-20 -j DROP",
+            "-A PREROUTING -m comment --comment vm0-ns-0c-200 -j DROP",
             "-A PREROUTING -m comment --comment vm0-ns-0c-21 -j DROP",
         ]
         .join("\n");

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -33,6 +33,7 @@ mod cow_pool;
 mod duration;
 mod exec_operation_result;
 mod factory;
+mod guest_dns_failure_diagnostics;
 mod guest_dns_readiness;
 mod guest_operations;
 mod leaked_resources;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -37,6 +37,9 @@ use crate::exec_operation_result::{
     validate_exec_capture_timeout,
 };
 use crate::factory::InvariantConfig;
+use crate::guest_dns_failure_diagnostics::{
+    GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_snapshot,
+};
 use crate::guest_dns_readiness::wait_for_guest_dns_readiness;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::leaked_resources::LeakedResources;
@@ -502,6 +505,10 @@ impl SandboxNetwork {
 
     fn peer_ip(&self) -> &str {
         self.info.peer_ip()
+    }
+
+    fn host_device(&self) -> &str {
+        self.info.host_device()
     }
 
     fn mark_non_reusable(&mut self) -> sandbox::Result<()> {
@@ -1564,7 +1571,7 @@ impl Sandbox for FirecrackerSandbox {
 
         let vsock_guest = Arc::new(vsock_guest);
 
-        if self.factory_config.dns_port.is_some() {
+        if let Some(dns_port) = self.factory_config.dns_port {
             match wait_for_guest_dns_readiness(&vsock_guest).await {
                 Ok(()) => {
                     if let Err(error) = self.network.mark_reusable() {
@@ -1573,6 +1580,18 @@ impl Sandbox for FirecrackerSandbox {
                     }
                 }
                 Err(error) => {
+                    capture_guest_dns_failure_snapshot(
+                        vsock_guest.as_ref(),
+                        GuestDnsFailureDiagnosticContext {
+                            sandbox_id: &self.id,
+                            profile: &self.factory_config.profile,
+                            namespace: self.network.name(),
+                            host_device: self.network.host_device(),
+                            peer_ip: self.network.peer_ip(),
+                            dns_port,
+                        },
+                    )
+                    .await;
                     warn!(
                         id = %self.id,
                         profile = %self.factory_config.profile,
@@ -1585,7 +1604,7 @@ impl Sandbox for FirecrackerSandbox {
                         "guest DNS readiness probe failed"
                     );
                     self.runtime.kill_process().await;
-                    return Err(SandboxError::Start {
+                    return Err(SandboxError::GuestDnsReadiness {
                         message: format!(
                             "guest DNS readiness for namespace {}: {error}",
                             self.network.name(),

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -29,6 +29,10 @@ pub enum SandboxError {
     #[error("sandbox start failed: {message}")]
     Start { message: String },
 
+    /// A created sandbox failed the guest-path DNS readiness admission check.
+    #[error("sandbox start failed: {message}")]
+    GuestDnsReadiness { message: String },
+
     /// The requested action is invalid for the current runtime, factory, or
     /// sandbox state.
     #[error("invalid state for {context} (state: {state}): {message}")]

--- a/crates/sandbox/tests/error.rs
+++ b/crates/sandbox/tests/error.rs
@@ -143,3 +143,15 @@ fn display_includes_file_operation_labels() {
         "got: {copy_state_err}"
     );
 }
+
+#[test]
+fn guest_dns_readiness_preserves_start_error_display_contract() {
+    let err = SandboxError::GuestDnsReadiness {
+        message: "guest resolver unavailable".into(),
+    };
+
+    assert_eq!(
+        err.to_string(),
+        "sandbox start failed: guest resolver unavailable"
+    );
+}


### PR DESCRIPTION
## Summary

- classify terminal guest DNS readiness failures without changing the existing external start-error text
- capture a bounded, passive guest/namespace/host snapshot before the failed attachment is torn down, then inspect only the fixed readiness hostname in the drained log segment for that start attempt
- replace the failed pre-workload sandbox once, only after proxy unregister and explicit sandbox destruction complete
- share one two-attempt budget with the existing consumed workspace-cache fallback so retries cannot stack or duplicate workload execution

## Compatibility and exclusions

- no API, database schema, persisted state, queue payload, frontend, guest protocol, or `status.json` changes
- no active diagnostic DNS/public-network probes and no redesign of the DNS endpoint or firewall topology
- unrelated startup failures do not gain the new DNS retry

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner`
- `git diff --check`

Closes #21873
