### PR TITLE
test(e2e): stabilize clerk auth handoff

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1381,6 +1381,10 @@ jobs:
         run: corepack enable pnpm
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
+      - name: Check Playwright E2E types
+        run: cd e2e && pnpm check-types
+      - name: Run Playwright fixture integration tests
+        run: cd e2e && pnpm test
       - name: Install Playwright browsers
         run: cd e2e && pnpm exec playwright install --with-deps chromium
       - name: Start Stripe webhook forwarding

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test playwright/lib/clerk-api.test.ts"
   },
   "keywords": [],
   "author": "",
@@ -20,6 +21,7 @@
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "tsx": "^4.22.4"
+    "tsx": "^4.22.4",
+    "typescript": "6.0.3"
   }
 }

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -25,9 +25,12 @@ export async function refreshClerkSessionToken(
       { timeout: 30_000 },
     );
   }
-  await page.evaluate(async () => {
-    await window.Clerk?.session?.getToken({ skipCache: true });
+  const tokenRefreshed = await page.evaluate(async () => {
+    return Boolean(await window.Clerk?.session?.getToken({ skipCache: true }));
   });
+  if (!tokenRefreshed) {
+    throw new Error("Clerk session token unavailable after refresh");
+  }
 }
 
 export async function signInThroughHostedAuth(

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { test } from "node:test";
+
+import {
+  createOrganization,
+  createUser,
+  deleteStaleTestUsers,
+  deleteUserByEmail,
+} from "./clerk-api";
+
+interface ObservedRequest {
+  readonly method: string;
+  readonly url: string;
+}
+
+type ClerkServerHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+  requests: readonly ObservedRequest[],
+) => void;
+
+test("does not replay user creation after a transient response", async () => {
+  await withClerkServer(
+    (request, response, requests) => {
+      const postCount = countRequests(requests, "POST", "/v1/users");
+      if (request.method === "POST" && request.url === "/v1/users") {
+        if (postCount === 1) {
+          sendJson(response, 503, { errors: [] });
+        } else {
+          sendJson(response, 200, { id: "user_replayed" });
+        }
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const error = await captureError(async () => {
+        await createUser("single-attempt@example.com");
+      });
+
+      assert.match(
+        error.message,
+        /create Clerk user failed with HTTP 503 \(json\)/,
+      );
+      assert.equal(countRequests(requests, "POST", "/v1/users"), 1);
+    },
+  );
+});
+
+test("retries an idempotent membership role update", async () => {
+  await withClerkServer(
+    (request, response, requests) => {
+      if (request.method === "POST" && request.url === "/v1/organizations") {
+        sendJson(response, 200, { id: "org_test" });
+        return;
+      }
+      if (
+        request.method === "PATCH" &&
+        request.url === "/v1/organizations/org_test/memberships/user_test"
+      ) {
+        const patchCount = countRequests(
+          requests,
+          "PATCH",
+          "/v1/organizations/org_test/memberships/user_test",
+        );
+        if (patchCount === 1) {
+          sendJson(response, 503, { errors: [] }, { "retry-after": "0" });
+        } else {
+          sendJson(response, 200, { role: "org:admin" });
+        }
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const organizationId = await createOrganization(
+        "E2E Test Org",
+        "user_test",
+      );
+
+      assert.equal(organizationId, "org_test");
+      assert.equal(
+        countRequests(
+          requests,
+          "PATCH",
+          "/v1/organizations/org_test/memberships/user_test",
+        ),
+        2,
+      );
+    },
+  );
+});
+
+test("retries exact lookup failures and accepts delete not found", async () => {
+  const email = "cleanup@example.com";
+  await withClerkServer(
+    (request, response, requests) => {
+      if (request.method === "GET" && request.url?.startsWith("/v1/users?")) {
+        const getCount = countRequestsStartingWith(
+          requests,
+          "GET",
+          "/v1/users?",
+        );
+        if (getCount === 1) {
+          request.socket.destroy();
+        } else if (getCount === 2) {
+          sendJson(response, 429, { errors: [] }, { "retry-after": "0" });
+        } else {
+          sendJson(response, 200, [
+            {
+              id: "user_cleanup",
+              email_addresses: [{ email_address: email }],
+            },
+          ]);
+        }
+        return;
+      }
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/users/user_cleanup"
+      ) {
+        sendJson(response, 404, { errors: [] });
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      await deleteUserByEmail(email);
+
+      assert.equal(countRequestsStartingWith(requests, "GET", "/v1/users?"), 3);
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/users/user_cleanup"),
+        1,
+      );
+    },
+  );
+});
+
+test("rejects non-JSON success without exposing its body", async () => {
+  const responseMarker = "sensitive-external-response-marker";
+  await withClerkServer(
+    (request, response) => {
+      if (request.method === "POST" && request.url === "/v1/users") {
+        sendText(response, 200, responseMarker, "text/html; charset=utf-8");
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async () => {
+      const error = await captureError(async () => {
+        await createUser("invalid-response@example.com");
+      });
+
+      assert.match(
+        error.message,
+        /create Clerk user returned invalid JSON: HTTP 200 \(html\)/,
+      );
+      assert.doesNotMatch(error.message, new RegExp(responseMarker));
+      assert.equal(error.cause, undefined);
+    },
+  );
+});
+
+test("keeps bulk stale-user deletion single-attempt and best-effort", async () => {
+  const responseMarker = "bulk-delete-response-marker";
+  await withClerkServer(
+    (request, response) => {
+      if (request.method === "GET" && request.url?.startsWith("/v1/users?")) {
+        sendJson(response, 200, [
+          {
+            id: "user_stale",
+            email_addresses: [
+              {
+                email_address: "test-job+clerk_test@e2e-browser-stale.example",
+              },
+            ],
+          },
+        ]);
+        return;
+      }
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/users/user_stale"
+      ) {
+        sendText(response, 503, responseMarker, "text/html");
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...values: unknown[]): void => {
+        warnings.push(values.map(String).join(" "));
+      };
+      try {
+        await deleteStaleTestUsers();
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/users/user_stale"),
+        1,
+      );
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0] ?? "", /HTTP 503 \(html\)/);
+      assert.doesNotMatch(warnings[0] ?? "", new RegExp(responseMarker));
+    },
+  );
+});
+
+async function withClerkServer(
+  handler: ClerkServerHandler,
+  run: (requests: readonly ObservedRequest[]) => Promise<void>,
+): Promise<void> {
+  const requests: ObservedRequest[] = [];
+  const server = createServer((request, response) => {
+    requests.push({
+      method: request.method ?? "",
+      url: request.url ?? "",
+    });
+    request.resume();
+    handler(request, response, requests);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Expected Clerk test server to listen on a TCP port");
+  }
+
+  const previousBaseUrl = process.env.CLERK_API_BASE_URL;
+  const previousSecretKey = process.env.CLERK_SECRET_KEY;
+  const previousJobRef = process.env.JOB_REF;
+  process.env.CLERK_API_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
+  process.env.CLERK_SECRET_KEY = "sk_test_fixture";
+  process.env.JOB_REF = "test-job";
+
+  try {
+    await run(requests);
+  } finally {
+    restoreEnvironmentVariable("CLERK_API_BASE_URL", previousBaseUrl);
+    restoreEnvironmentVariable("CLERK_SECRET_KEY", previousSecretKey);
+    restoreEnvironmentVariable("JOB_REF", previousJobRef);
+    await closeServer(server);
+  }
+}
+
+async function closeServer(
+  server: ReturnType<typeof createServer>,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function restoreEnvironmentVariable(
+  name: string,
+  previousValue: string | undefined,
+): void {
+  if (previousValue === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = previousValue;
+  }
+}
+
+function countRequests(
+  requests: readonly ObservedRequest[],
+  method: string,
+  url: string,
+): number {
+  return requests.filter(
+    (request) => request.method === method && request.url === url,
+  ).length;
+}
+
+function countRequestsStartingWith(
+  requests: readonly ObservedRequest[],
+  method: string,
+  urlPrefix: string,
+): number {
+  return requests.filter(
+    (request) => request.method === method && request.url.startsWith(urlPrefix),
+  ).length;
+}
+
+async function captureError(action: () => Promise<void>): Promise<Error> {
+  let caught: unknown;
+  try {
+    await action();
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(caught instanceof Error);
+  return caught;
+}
+
+function sendJson(
+  response: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Readonly<Record<string, string>> = {},
+): void {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+function sendText(
+  response: ServerResponse,
+  status: number,
+  body: string,
+  contentType: string,
+): void {
+  response.writeHead(status, { "content-type": contentType });
+  response.end(body);
+}

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -215,6 +215,25 @@ test("keeps bulk stale-user deletion single-attempt and best-effort", async () =
   );
 });
 
+test("rejects a non-loopback Clerk test endpoint", async () => {
+  const previousBaseUrl = process.env.CLERK_API_TEST_BASE_URL;
+  const previousSecretKey = process.env.CLERK_SECRET_KEY;
+  process.env.CLERK_API_TEST_BASE_URL = "https://example.com/v1";
+  process.env.CLERK_SECRET_KEY = "sk_test_fixture";
+  try {
+    const error = await captureError(async () => {
+      await createUser("invalid-endpoint@example.com");
+    });
+    assert.equal(
+      error.message,
+      "CLERK_API_TEST_BASE_URL must use an HTTP 127.0.0.1 URL",
+    );
+  } finally {
+    restoreEnvironmentVariable("CLERK_API_TEST_BASE_URL", previousBaseUrl);
+    restoreEnvironmentVariable("CLERK_SECRET_KEY", previousSecretKey);
+  }
+});
+
 async function withClerkServer(
   handler: ClerkServerHandler,
   run: (requests: readonly ObservedRequest[]) => Promise<void>,
@@ -243,17 +262,17 @@ async function withClerkServer(
     throw new Error("Expected Clerk test server to listen on a TCP port");
   }
 
-  const previousBaseUrl = process.env.CLERK_API_BASE_URL;
+  const previousBaseUrl = process.env.CLERK_API_TEST_BASE_URL;
   const previousSecretKey = process.env.CLERK_SECRET_KEY;
   const previousJobRef = process.env.JOB_REF;
-  process.env.CLERK_API_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
+  process.env.CLERK_API_TEST_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
   process.env.CLERK_SECRET_KEY = "sk_test_fixture";
   process.env.JOB_REF = "test-job";
 
   try {
     await run(requests);
   } finally {
-    restoreEnvironmentVariable("CLERK_API_BASE_URL", previousBaseUrl);
+    restoreEnvironmentVariable("CLERK_API_TEST_BASE_URL", previousBaseUrl);
     restoreEnvironmentVariable("CLERK_SECRET_KEY", previousSecretKey);
     restoreEnvironmentVariable("JOB_REF", previousJobRef);
     await closeServer(server);

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -1,6 +1,25 @@
 import { randomBytes } from "node:crypto";
 
-const CLERK_API_BASE = "https://api.clerk.com/v1";
+const DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1";
+const CLERK_RETRY_DELAYS_MS = [500, 1_500] as const;
+const CLERK_MAX_RETRY_AFTER_MS = 2_000;
+
+interface ClerkEmailAddress {
+  readonly email_address: string;
+}
+
+interface ClerkUserSummary {
+  readonly id: string;
+  readonly email_addresses: readonly ClerkEmailAddress[];
+}
+
+interface RetryableClerkRequestInit extends RequestInit {
+  readonly method: "GET" | "DELETE" | "PATCH";
+}
+
+function getClerkApiBase(): string {
+  return process.env.CLERK_API_BASE_URL ?? DEFAULT_CLERK_API_BASE;
+}
 
 function getClerkHeaders(): Record<string, string> {
   const secretKey = process.env.CLERK_SECRET_KEY;
@@ -20,7 +39,7 @@ export function generateTestEmail(): string {
 }
 
 export async function createUser(email: string): Promise<string> {
-  const response = await fetch(`${CLERK_API_BASE}/users`, {
+  const response = await requestClerk("create Clerk user", "/users", {
     method: "POST",
     headers: getClerkHeaders(),
     body: JSON.stringify({
@@ -29,9 +48,11 @@ export async function createUser(email: string): Promise<string> {
       legal_accepted_at: new Date().toISOString(),
     }),
   });
-  const data = (await response.json()) as { id?: string; errors?: unknown[] };
-  if (!response.ok || !data.id) {
-    throw new Error(`Failed to create Clerk user: ${JSON.stringify(data)}`);
+  const data = await readClerkJson(response, "create Clerk user");
+  if (!hasStringProperty(data, "id")) {
+    throw new Error(
+      `create Clerk user returned an unexpected response: ${formatClerkResponseSummary(response)}`,
+    );
   }
   return data.id;
 }
@@ -40,15 +61,19 @@ export async function createOrganization(
   name: string,
   createdByUserId: string,
 ): Promise<string> {
-  const response = await fetch(`${CLERK_API_BASE}/organizations`, {
-    method: "POST",
-    headers: getClerkHeaders(),
-    body: JSON.stringify({ name, created_by: createdByUserId }),
-  });
-  const data = (await response.json()) as { id?: string; errors?: unknown[] };
-  if (!response.ok || !data.id) {
+  const response = await requestClerk(
+    "create Clerk organization",
+    "/organizations",
+    {
+      method: "POST",
+      headers: getClerkHeaders(),
+      body: JSON.stringify({ name, created_by: createdByUserId }),
+    },
+  );
+  const data = await readClerkJson(response, "create Clerk organization");
+  if (!hasStringProperty(data, "id")) {
     throw new Error(
-      `Failed to create Clerk organization: ${JSON.stringify(data)}`,
+      `create Clerk organization returned an unexpected response: ${formatClerkResponseSummary(response)}`,
     );
   }
   await updateOrganizationMembershipRole(data.id, createdByUserId, "org:admin");
@@ -60,26 +85,22 @@ async function updateOrganizationMembershipRole(
   userId: string,
   role: "org:admin" | "org:member",
 ): Promise<void> {
-  const response = await fetch(
-    `${CLERK_API_BASE}/organizations/${organizationId}/memberships/${userId}`,
+  const response = await requestClerkWithRetry(
+    "update Clerk organization membership",
+    `/organizations/${organizationId}/memberships/${userId}`,
     {
       method: "PATCH",
       headers: getClerkHeaders(),
       body: JSON.stringify({ role }),
     },
   );
-  const data = (await response.json()) as {
-    role?: string;
-    errors?: unknown[];
-  };
-  if (!response.ok) {
+  const data = await readClerkJson(
+    response,
+    "update Clerk organization membership",
+  );
+  if (!hasStringProperty(data, "role") || data.role !== role) {
     throw new Error(
-      `Failed to update Clerk organization membership: ${JSON.stringify(data)}`,
-    );
-  }
-  if (data.role !== role) {
-    throw new Error(
-      `Expected Clerk organization membership role ${role}, got ${data.role ?? "unknown"}`,
+      `update Clerk organization membership returned an unexpected role: ${formatClerkResponseSummary(response)}`,
     );
   }
 }
@@ -87,54 +108,231 @@ async function updateOrganizationMembershipRole(
 export async function deleteStaleTestUsers(): Promise<void> {
   const jobRef = process.env.JOB_REF ?? "local";
   const prefix = `${jobRef}+clerk_test@e2e-browser-`;
-  const searchResponse = await fetch(
-    `${CLERK_API_BASE}/users?query=${encodeURIComponent(`${jobRef}+clerk_test`)}&limit=100`,
-    { headers: getClerkHeaders() },
-  );
-  const users = (await searchResponse.json()) as Array<{
-    id: string;
-    email_addresses: Array<{ email_address: string }>;
-  }>;
+  let users: readonly ClerkUserSummary[];
+  try {
+    const searchResponse = await requestClerkWithRetry(
+      "list stale Clerk test users",
+      `/users?query=${encodeURIComponent(`${jobRef}+clerk_test`)}&limit=100`,
+      { method: "GET", headers: getClerkHeaders() },
+    );
+    users = await readClerkUsers(searchResponse, "list stale Clerk test users");
+  } catch {
+    console.warn(
+      "Failed to list stale Clerk test users; continuing without stale cleanup",
+    );
+    return;
+  }
 
   for (const user of users) {
     const userEmail = user.email_addresses[0]?.email_address;
-    if (userEmail?.startsWith(prefix)) {
-      const deleteResponse = await fetch(`${CLERK_API_BASE}/users/${user.id}`, {
-        method: "DELETE",
-        headers: getClerkHeaders(),
-      });
-      if (!deleteResponse.ok) {
+    if (!userEmail?.startsWith(prefix)) {
+      continue;
+    }
+
+    try {
+      const deleteResponse = await requestClerk(
+        "delete stale Clerk test user",
+        `/users/${user.id}`,
+        { method: "DELETE", headers: getClerkHeaders() },
+      );
+      await deleteResponse.body?.cancel();
+      if (!deleteResponse.ok && deleteResponse.status !== 404) {
         console.warn(
-          `Failed to delete stale user ${user.id} (${userEmail}): ${deleteResponse.status}`,
+          `Failed to delete a stale Clerk test user with ${formatClerkResponseSummary(deleteResponse)}`,
         );
       }
+    } catch {
+      console.warn(
+        "Failed to delete a stale Clerk test user; continuing stale cleanup",
+      );
     }
   }
 }
 
 export async function deleteUserByEmail(email: string): Promise<void> {
-  const searchResponse = await fetch(
-    `${CLERK_API_BASE}/users?query=${encodeURIComponent(email)}&limit=10`,
-    { headers: getClerkHeaders() },
+  const searchResponse = await requestClerkWithRetry(
+    "find Clerk test user",
+    `/users?query=${encodeURIComponent(email)}&limit=10`,
+    { method: "GET", headers: getClerkHeaders() },
   );
-  const users = (await searchResponse.json()) as Array<{
-    id: string;
-    email_addresses: Array<{ email_address: string }>;
-  }>;
+  const users = await readClerkUsers(searchResponse, "find Clerk test user");
 
   for (const user of users) {
     const userEmail = user.email_addresses[0]?.email_address;
-    if (userEmail === email) {
-      const deleteResponse = await fetch(`${CLERK_API_BASE}/users/${user.id}`, {
-        method: "DELETE",
-        headers: getClerkHeaders(),
-      });
-      if (!deleteResponse.ok) {
-        throw new Error(
-          `Failed to delete Clerk user ${user.id}: ${deleteResponse.status}`,
-        );
-      }
-      return;
+    if (userEmail !== email) {
+      continue;
     }
+
+    const deleteResponse = await requestClerkWithRetry(
+      "delete Clerk test user",
+      `/users/${user.id}`,
+      { method: "DELETE", headers: getClerkHeaders() },
+    );
+    await deleteResponse.body?.cancel();
+    if (!deleteResponse.ok && deleteResponse.status !== 404) {
+      throw new Error(
+        `delete Clerk test user failed with ${formatClerkResponseSummary(deleteResponse)}`,
+      );
+    }
+    return;
   }
+}
+
+async function requestClerk(
+  operation: string,
+  path: string,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetch(`${getClerkApiBase()}${path}`, init);
+  } catch (cause) {
+    throw new Error(`${operation} request failed`, { cause });
+  }
+}
+
+async function requestClerkWithRetry(
+  operation: string,
+  path: string,
+  init: RetryableClerkRequestInit,
+): Promise<Response> {
+  for (const fallbackDelayMs of CLERK_RETRY_DELAYS_MS) {
+    let response: Response;
+    try {
+      response = await fetch(`${getClerkApiBase()}${path}`, init);
+    } catch {
+      await wait(fallbackDelayMs);
+      continue;
+    }
+
+    if (!isTransientClerkStatus(response.status)) {
+      return response;
+    }
+
+    const delayMs = clerkRetryDelayMs(response, fallbackDelayMs);
+    if (delayMs === null) {
+      return response;
+    }
+    await response.body?.cancel();
+    await wait(delayMs);
+  }
+
+  return await requestClerk(operation, path, init);
+}
+
+function isTransientClerkStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function clerkRetryDelayMs(
+  response: Response,
+  fallbackDelayMs: number,
+): number | null {
+  const retryAfter = response.headers.get("retry-after");
+  if (!retryAfter) {
+    return fallbackDelayMs;
+  }
+
+  const retryAfterSeconds = Number(retryAfter);
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) {
+    return fallbackDelayMs;
+  }
+
+  const retryAfterMs = Math.ceil(retryAfterSeconds * 1_000);
+  return retryAfterMs <= CLERK_MAX_RETRY_AFTER_MS ? retryAfterMs : null;
+}
+
+async function wait(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function readClerkJson(
+  response: Response,
+  operation: string,
+): Promise<unknown> {
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(
+      `${operation} failed with ${formatClerkResponseSummary(response)}`,
+    );
+  }
+
+  let responseBody: string;
+  try {
+    responseBody = await response.text();
+  } catch (cause) {
+    throw new Error(`${operation} response read failed`, { cause });
+  }
+
+  try {
+    const data: unknown = JSON.parse(responseBody);
+    return data;
+  } catch {
+    throw new Error(
+      `${operation} returned invalid JSON: ${formatClerkResponseSummary(response)}`,
+    );
+  }
+}
+
+async function readClerkUsers(
+  response: Response,
+  operation: string,
+): Promise<readonly ClerkUserSummary[]> {
+  const data = await readClerkJson(response, operation);
+  if (!isClerkUserList(data)) {
+    throw new Error(
+      `${operation} returned an unexpected response: ${formatClerkResponseSummary(response)}`,
+    );
+  }
+  return data;
+}
+
+function isClerkUserList(value: unknown): value is readonly ClerkUserSummary[] {
+  return (
+    Array.isArray(value) &&
+    value.every((user: unknown) => {
+      if (!isRecord(user) || typeof user.id !== "string") {
+        return false;
+      }
+      const emailAddresses = user.email_addresses;
+      return (
+        Array.isArray(emailAddresses) &&
+        emailAddresses.every((emailAddress: unknown) =>
+          hasStringProperty(emailAddress, "email_address"),
+        )
+      );
+    })
+  );
+}
+
+function hasStringProperty<K extends string>(
+  value: unknown,
+  property: K,
+): value is Record<K, string> {
+  return isRecord(value) && typeof value[property] === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatClerkResponseSummary(response: Response): string {
+  return `HTTP ${response.status} (${classifyClerkResponse(response)})`;
+}
+
+function classifyClerkResponse(
+  response: Response,
+): "json" | "html" | "other" | "unknown" {
+  const contentType = response.headers.get("content-type");
+  if (!contentType) {
+    return "unknown";
+  }
+
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType === "application/json" || mediaType?.endsWith("+json")) {
+    return "json";
+  }
+  if (mediaType === "text/html" || mediaType === "application/xhtml+xml") {
+    return "html";
+  }
+  return "other";
 }

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -18,7 +18,16 @@ interface RetryableClerkRequestInit extends RequestInit {
 }
 
 function getClerkApiBase(): string {
-  return process.env.CLERK_API_BASE_URL ?? DEFAULT_CLERK_API_BASE;
+  const testApiBase = process.env.CLERK_API_TEST_BASE_URL;
+  if (!testApiBase) {
+    return DEFAULT_CLERK_API_BASE;
+  }
+
+  const testApiUrl = new URL(testApiBase);
+  if (testApiUrl.protocol !== "http:" || testApiUrl.hostname !== "127.0.0.1") {
+    throw new Error("CLERK_API_TEST_BASE_URL must use an HTTP 127.0.0.1 URL");
+  }
+  return testApiBase;
 }
 
 function getClerkHeaders(): Record<string, string> {
@@ -183,8 +192,9 @@ async function requestClerk(
   path: string,
   init: RequestInit,
 ): Promise<Response> {
+  const url = `${getClerkApiBase()}${path}`;
   try {
-    return await fetch(`${getClerkApiBase()}${path}`, init);
+    return await fetch(url, init);
   } catch (cause) {
     throw new Error(`${operation} request failed`, { cause });
   }
@@ -195,10 +205,11 @@ async function requestClerkWithRetry(
   path: string,
   init: RetryableClerkRequestInit,
 ): Promise<Response> {
+  const url = `${getClerkApiBase()}${path}`;
   for (const fallbackDelayMs of CLERK_RETRY_DELAYS_MS) {
     let response: Response;
     try {
-      response = await fetch(`${getClerkApiBase()}${path}`, init);
+      response = await fetch(url, init);
     } catch {
       await wait(fallbackDelayMs);
       continue;

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,13 +1,16 @@
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test } from "../fixtures";
-import { signInThroughHostedAuth } from "../lib/auth";
+import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
 import {
   completeExploreOnboarding,
   deriveOnboardingUrl,
 } from "../lib/onboarding";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
-test("sign in through onboarding handoff to chat page", async ({ page }) => {
+test("sign in through onboarding handoff to chat page", async ({
+  browser,
+  page,
+}) => {
   test.setTimeout(240_000);
 
   const email = process.env.E2E_CLERK_USER_EMAIL!;
@@ -39,6 +42,33 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   });
   expect(page.url()).toMatch(/\/agents\/.*\/chat/);
 
+  await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
+
   // Save storageState for feature tests (use absolute path to match playwright.config.ts)
   await page.context().storageState({ path: STORAGE_STATE });
+
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  const verificationContext = await browser.newContext({
+    storageState: STORAGE_STATE,
+    extraHTTPHeaders: bypassSecret
+      ? { "x-vercel-protection-bypass": bypassSecret }
+      : undefined,
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const verificationPage = await verificationContext.newPage();
+    await verificationPage.goto(`${appUrl}/agents`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      verificationPage.getByRole("heading", { name: "Agents" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await verificationPage.waitForFunction(
+      (organizationId) => window.Clerk?.organization?.id === organizationId,
+      orgId,
+      { timeout: 30_000 },
+    );
+  } finally {
+    await verificationContext.close();
+  }
 });

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -56,6 +56,7 @@ test("sign in through onboarding handoff to chat page", async ({
     ignoreHTTPSErrors: true,
   });
   try {
+    await setupClerkTestingToken({ context: verificationContext });
     const verificationPage = await verificationContext.newPage();
     await verificationPage.goto(`${appUrl}/agents`, {
       waitUntil: "domcontentloaded",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -283,6 +286,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -472,5 +480,7 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  typescript@6.0.3: {}
 
   undici-types@7.24.6: {}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["playwright/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- refresh the expected Clerk session and organization before persisting Playwright auth state, then prove the serialized state reaches a protected route from a fresh browser context
- replace unchecked Clerk fixture parsing with operation-aware single-attempt and bounded-retry request paths, runtime response narrowing, sanitized diagnostics, and explicit body cleanup
- add real local HTTP integration coverage plus a strict standalone E2E TypeScript gate, and run both before the live Playwright CI suite

## Why

A setup run completed onboarding and wrote shared `storageState`, but a dependent feature context restored that file and was redirected from `/agents` to `/sign-in`. Separately, transient Clerk transport and non-JSON responses produced misleading fixture failures. This change validates the actual state handoff boundary and makes recovery explicit only for replay-safe operations.

Failed reference run: https://github.com/vm0-ai/vm0/actions/runs/29498865112/job/87631574826?pr=21872

## Safety and compatibility

- user and organization POST requests remain single-attempt
- only GET, exact DELETE, and idempotent membership-role PATCH operations use bounded retry
- bulk stale-user deletion remains single-attempt per user and best-effort
- diagnostics never include raw external bodies, raw headers, authorization values, or session tokens
- no existing Playwright test is skipped and no timeout is increased
- no production authentication, API, deployment behavior, database schema, migration, or persisted-data change

## Validation

- `cd e2e && pnpm install --frozen-lockfile`
- `cd turbo && pnpm exec prettier --check ../e2e/playwright/lib/auth.ts ../e2e/playwright/lib/clerk-api.ts ../e2e/playwright/lib/clerk-api.test.ts ../e2e/playwright/tests/smoke.spec.ts ../e2e/package.json ../e2e/tsconfig.json ../e2e/pnpm-lock.yaml ../.github/workflows/turbo.yml`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 6 passed
- `cd e2e && VM0_API_BACKEND_URL=http://localhost:3000 pnpm exec playwright test --config playwright/playwright.config.ts --list` — existing 8 tests selected
- `git diff --check`
- full `cli-e2e-02-playwright` remains CI-only because it requires Clerk credentials and preview deployments

Closes #21881
