### PR TITLE
fix(chat): restore append-only queued message claims

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -133,21 +133,6 @@ export async function publishChatThreadMessageCreatedSafely(
 }
 
 /**
- * Notify a chat thread's UI that an existing message row changed in place.
- * The payload lets clients refetch that exact row instead of relying on the
- * append-only message cursor, which cannot observe updates to an older row.
- */
-export async function publishChatThreadMessageUpdated(
-  userId: string,
-  threadId: string,
-  messageId: string,
-): Promise<void> {
-  await publishUserSignal([userId], `chatThreadMessageUpdated:${threadId}`, {
-    messageId,
-  });
-}
-
-/**
  * Notify a chat thread's UI that its linked automation set changed (created,
  * deleted, enabled, or disabled). The chat-thread header automation menu
  * subscribes to this topic and refetches its thread-scoped list.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1039,31 +1039,34 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected the queued message to be auto-claimed");
     }
     expect(claimed.runId).not.toBe(first.runId);
-    expect(claimed.id).toBe(queued.id);
-    expect(claimed.revokesMessageId).toBeUndefined();
+    expect(claimed.id).not.toBe(queued.id);
+    expect(claimed.revokesMessageId).toBe(queued.id);
     expect(claimed.generationTemplate).toStrictEqual(generationTemplate);
-    // Queue-first claims bind the follow-up run onto the persisted message in
-    // place instead of writing a shadow/revoke copy.
-    expect(
-      userMessages(afterAutoSend.messages)
-        .filter((message) => {
-          return message.content === "queued next turn";
-        })
-        .map((message) => {
-          return message.id;
-        })
-        .sort(),
-    ).toStrictEqual([queued.id]);
+    const original = await chat.getThreadMessage(
+      actor,
+      first.threadId,
+      queued.id,
+    );
+    expect(original.runId).toBeUndefined();
+    // The raw message page contains both immutable rows; the client folds the
+    // original into its run-associated replacement.
+    const matchingMessageIds = userMessages(afterAutoSend.messages)
+      .filter((message) => {
+        return message.content === "queued next turn";
+      })
+      .map((message) => {
+        return message.id;
+      });
+    expect(matchingMessageIds).toHaveLength(2);
+    expect(matchingMessageIds).toStrictEqual(
+      expect.arrayContaining([queued.id, claimed.id]),
+    );
     // The auto-send publishes happen in background callback processing, so
     // poll until each expected channel has been published before asserting.
     await expect
       .poll(() => {
         return context.mocks.ably.publish.mock.calls.some((call) => {
-          return (
-            call[0] === `chatThreadMessageUpdated:${first.threadId}` &&
-            (call[1] as { messageId?: string } | undefined)?.messageId ===
-              queued.id
-          );
+          return call[0] === `chatThreadMessageCreated:${first.threadId}`;
         });
       })
       .toBe(true);
@@ -1075,8 +1078,8 @@ describe("CHAT-02: completed chat callback", () => {
       })
       .toBe(true);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `chatThreadMessageUpdated:${first.threadId}`,
-      { messageId: queued.id },
+      `chatThreadMessageCreated:${first.threadId}`,
+      null,
     );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `chatThreadRunCreated:${first.threadId}`,
@@ -1212,7 +1215,10 @@ describe("CHAT-02: completed chat callback", () => {
       first.threadId,
       (messages) => {
         return userMessages(messages).some((message) => {
-          return message.id === queued.id && message.runId !== undefined;
+          return (
+            message.revokesMessageId === queued.id &&
+            message.runId !== undefined
+          );
         });
       },
     );
@@ -1229,7 +1235,7 @@ describe("CHAT-02: completed chat callback", () => {
     expect(markerBeforeRelease.recommendedFollowups).toBeUndefined();
 
     const claimed = userMessages(afterAutoSend.messages).find((message) => {
-      return message.id === queued.id;
+      return message.revokesMessageId === queued.id;
     });
     if (!claimed?.runId) {
       throw new Error("Expected the queued message to auto-send");
@@ -2158,12 +2164,15 @@ Continue after the long Unicode prefix.`;
       first.threadId,
       (messages) => {
         return userMessages(messages).some((message) => {
-          return message.id === queued.id && message.runId !== undefined;
+          return (
+            message.revokesMessageId === queued.id &&
+            message.runId !== undefined
+          );
         });
       },
     );
     const claimed = userMessages(afterAutoSend.messages).find((message) => {
-      return message.id === queued.id;
+      return message.revokesMessageId === queued.id;
     });
     expect(
       claimed?.runId,
@@ -2230,7 +2239,10 @@ Continue after the long Unicode prefix.`;
       first.threadId,
       (messages) => {
         const claimed = userMessages(messages).find((message) => {
-          return message.id === queued.id && message.runId !== undefined;
+          return (
+            message.revokesMessageId === queued.id &&
+            message.runId !== undefined
+          );
         });
         return (
           claimed !== undefined &&
@@ -2244,7 +2256,7 @@ Continue after the long Unicode prefix.`;
       },
     );
     const claimed = userMessages(afterAutoSend.messages).find((message) => {
-      return message.id === queued.id;
+      return message.revokesMessageId === queued.id;
     });
     if (!claimed?.runId) {
       throw new Error("Expected the queued message to auto-send");
@@ -2544,11 +2556,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     await expect
       .poll(() => {
         return context.mocks.ably.publish.mock.calls.some((call) => {
-          return (
-            call[0] === `chatThreadMessageUpdated:${first.threadId}` &&
-            (call[1] as { messageId?: string } | undefined)?.messageId ===
-              first.messageId
-          );
+          return call[0] === `chatThreadMessageCreated:${first.threadId}`;
         });
       })
       .toBe(true);
@@ -3566,11 +3574,7 @@ describe("CHAT-02: thread deletion while a run is active", () => {
     await expect
       .poll(() => {
         return context.mocks.ably.publish.mock.calls.some((call) => {
-          return (
-            call[0] === `chatThreadMessageUpdated:${run.threadId}` &&
-            (call[1] as { messageId?: string } | undefined)?.messageId ===
-              run.messageId
-          );
+          return call[0] === `chatThreadMessageCreated:${run.threadId}`;
         });
       })
       .toBe(true);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -234,31 +234,36 @@ async function startChatRun(
         : {}
       : { model: body.selectedModel }),
   };
-  let sent = await chat.requestSendMessage(actor, requestBody, [201]);
+  const sent = await chat.requestSendMessage(actor, requestBody, [201]);
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
   }
-  if (sent.body.runId === null) {
-    const threadId = sent.body.threadId;
-    // Queue-first sends may be claimed by a terminal callback drain between
-    // enqueue and the inline dispatch decision. Replay the idempotent client
-    // message id until that winning run association is visible.
-    await expect
-      .poll(async () => {
-        sent = await chat.requestSendMessage(
-          actor,
-          { ...requestBody, threadId },
-          [201],
-        );
-        return sent.status === 201 ? sent.body.runId : null;
-      })
-      .not.toBeNull();
+  let runId: string | null | undefined = sent.body.runId;
+  if (runId === null) {
+    // A terminal callback may claim the queued row between enqueue and the
+    // inline dispatch decision. Recover as a refreshed client does: read the
+    // appended replacement instead of retrying the client message id.
+    const messages = await waitForThreadMessages(
+      actor,
+      sent.body.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === messageId &&
+            message.runId !== undefined
+          );
+        });
+      },
+    );
+    runId = userMessages(messages.messages).find((message) => {
+      return message.revokesMessageId === messageId;
+    })?.runId;
   }
-  if (sent.body.runId === null) {
+  if (runId === undefined || runId === null) {
     throw new Error("Expected the entitled chat send to create a run");
   }
   return {
-    runId: sent.body.runId,
+    runId,
     threadId: sent.body.threadId,
     messageId,
   };
@@ -2588,8 +2593,18 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
       actor,
       first.threadId,
     );
-    expect(progressMessages.messages).toHaveLength(1);
-    expect(progressMessages.messages[0]?.role).toBe("user");
+    const progressUserMessages = userMessages(progressMessages.messages);
+    expect(progressUserMessages).toHaveLength(2);
+    const progressOriginal = progressUserMessages.find((message) => {
+      return message.id === first.messageId;
+    });
+    expect(progressOriginal?.runId).toBeUndefined();
+    expect(progressUserMessages).toContainEqual(
+      expect.objectContaining({
+        runId: first.runId,
+        revokesMessageId: first.messageId,
+      }),
+    );
 
     // Blank assistant text, non-agent_message Codex items, and result-shaped
     // fields on non-result events are skipped.
@@ -2805,7 +2820,22 @@ describe("CHAT-02: failed chat callbacks", () => {
         });
       });
     });
-    expect(userMessages(messages.messages)).toHaveLength(4);
+    const users = userMessages(messages.messages);
+    const originals = users.filter((message) => {
+      return message.runId === undefined;
+    });
+    const replacements = users.filter((message) => {
+      return message.runId !== undefined;
+    });
+    expect(originals).toHaveLength(4);
+    expect(replacements).toHaveLength(4);
+    expect(
+      replacements.every((replacement) => {
+        return originals.some((original) => {
+          return replacement.revokesMessageId === original.id;
+        });
+      }),
+    ).toBeTruthy();
     const failed = assistantMessages(messages.messages).filter((message) => {
       return message.runLifecycleEvent === "failed";
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3868,7 +3868,10 @@ describe("CHAT-02: shared user message queue", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
-    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    // The first waiter is the completion-triggered org run-queue drain; the
+    // second proves the callback's chat-message drain has finished its prior
+    // writes and is blocked at run admission before we pause its claim insert.
+    await expect.poll(admissionLock.waiterCount).toBe(2);
 
     const messageWritesLock = await holdChatMessageWritesFixture({
       signal: context.signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -50,6 +50,7 @@ import { createDeferredPromise } from "../../utils";
 import {
   deleteBddVm0ApiKeys,
   hasVm0ApiKeyLabel,
+  holdChatMessageWritesFixture,
   holdOrgAdmissionLockFixture,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
@@ -3825,6 +3826,109 @@ describe("CHAT-02: shared user message queue", () => {
     ).toStrictEqual([expect.objectContaining({ status: "cancelled" })]);
 
     await cancelChatRun(actor, sent.body.runId);
+  }, 90_000);
+
+  it("preserves an appended claim when recall races the queue drain", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for queue serialization");
+    }
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "recall claim race anchor",
+    });
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+
+    const messageId = randomUUID();
+    const queued = await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "recall races the appended claim",
+        clientMessageId: messageId,
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+
+    // Stop the terminal drain at run admission until its preceding message
+    // writes are complete, then pause only the replacement insert. The claim
+    // holds the queue row while recall reaches the competing queue deletion.
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: actor.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+
+    const messageWritesLock = await holdChatMessageWritesFixture({
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      messageWritesLock.release();
+      await messageWritesLock.done;
+    });
+    admissionLock.release();
+    await admissionLock.done;
+    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(1);
+
+    const recall = chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        revokesMessageId: messageId,
+        clientMessageId: randomUUID(),
+      },
+      [400],
+    );
+    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(2);
+    messageWritesLock.release();
+
+    const recalled = await recall;
+    expectApiError(recalled.body);
+    expect(recalled.body.error.message).toBe(
+      "Only queued user messages can be recalled",
+    );
+    await messageWritesLock.done;
+    await flushWaitUntilForTest();
+
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === messageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const claimed = userMessages(messages.messages).find((message) => {
+      return message.revokesMessageId === messageId;
+    });
+    if (!claimed?.runId) {
+      throw new Error("Expected the queue drain to append a claimed message");
+    }
+    const original = await chat.getThreadMessage(
+      actor,
+      anchor.threadId,
+      messageId,
+    );
+    expect(original.runId).toBeUndefined();
+    expect(claimed.content).toBe("recall races the appended claim");
+
+    await cancelChatRun(actor, claimed.runId);
   }, 90_000);
 
   it("appends replacements on auto-send and recalls queued messages by deletion", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -695,9 +695,9 @@ async function requestSendMessageWithBearer(
   );
 }
 
-describe("CHAT-02: web chat send and client-id idempotency", () => {
-  it("creates a web chat run and replays client ids idempotently", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
+describe("CHAT-02: web chat send and client ids", () => {
+  it("creates a web chat run with client-provided ids", async () => {
+    const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const clientThreadId = randomUUID();
@@ -752,15 +752,37 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
       actor,
       clientThreadId,
       (items) => {
-        return userMessages(items).length === 1;
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === clientMessageId &&
+            message.runId === runId
+          );
+        });
       },
     );
-    expect(userMessages(messages.messages)).toHaveLength(1);
-    expect(userMessages(messages.messages)[0]).toMatchObject({
+    const userRows = userMessages(messages.messages);
+    expect(userRows).toHaveLength(2);
+    expect(userRows).toContainEqual(
+      expect.objectContaining({
+        id: clientMessageId,
+        content: prompt,
+      }),
+    );
+    expect(userRows).toContainEqual(
+      expect.objectContaining({
+        content: prompt,
+        runId,
+        revokesMessageId: clientMessageId,
+      }),
+    );
+    const original = userRows.find((message) => {
+      return message.id === clientMessageId;
+    });
+    expect(original).toMatchObject({
       id: clientMessageId,
       content: prompt,
-      runId,
     });
+    expect(original?.runId).toBeUndefined();
 
     await expect(chat.readThread(actor, clientThreadId)).resolves.toStrictEqual(
       {
@@ -770,48 +792,7 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
       },
     );
 
-    // Identical retry resolves through the associated client message.
-    const retry = await chat.requestSendMessage(
-      actor,
-      { agentId, prompt, clientThreadId, clientMessageId },
-      [201],
-    );
-    expect(retry.body).toStrictEqual(first.body);
-
-    // Same client thread with a fresh client message id resolves to the
-    // thread's first run instead of creating a second one.
-    const threadRetry = await chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        prompt: "retried after losing the response",
-        clientThreadId,
-        clientMessageId: randomUUID(),
-      },
-      [201],
-    );
-    if (threadRetry.status !== 201) {
-      throw new Error("Expected the client-thread retry to resolve");
-    }
-    expect(threadRetry.body.runId).toBe(runId);
-    const afterRetries = await chat.listThreadMessages(actor, clientThreadId);
-    expect(userMessages(afterRetries.messages)).toHaveLength(1);
-
-    const { sandboxHeaders } = await claimChatRun(runnerGroup, runId);
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(runId, sandboxHeaders);
-
-    const completedRetry = await chat.requestSendMessage(
-      actor,
-      { agentId, prompt, clientThreadId, clientMessageId },
-      [201],
-    );
-    expect(completedRetry.body).toStrictEqual({
-      ...first.body,
-      status: "completed",
-    });
-
-    // A pre-created client thread with no runs cannot be replayed into.
+    // A pre-created client thread with no runs cannot be sent into.
     const emptyClientThreadId = randomUUID();
     const created = await chat.createThread(actor, {
       agentId,
@@ -819,7 +800,7 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
       clientThreadId: emptyClientThreadId,
     });
     expect(created.id).toBe(emptyClientThreadId);
-    const emptyRetry = await chat.requestSendMessage(
+    const emptyThreadSend = await chat.requestSendMessage(
       actor,
       {
         agentId,
@@ -828,8 +809,8 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
       },
       [400],
     );
-    expectApiError(emptyRetry.body);
-    expect(emptyRetry.body.error.message).toBe(
+    expectApiError(emptyThreadSend.body);
+    expect(emptyThreadSend.body.error.message).toBe(
       "Client thread id is already in use",
     );
   }, 90_000);
@@ -1245,18 +1226,30 @@ describe("CHAT-02: org queue markers", () => {
       queuedThread,
       (items) => {
         return (
-          userMessages(items).length === 1 &&
+          userMessages(items).some((message) => {
+            return message.runId === queuedRun.body.runId;
+          }) &&
           assistantMessages(items).some((message) => {
             return message.runEventId === "queue:queued";
           })
         );
       },
     );
-    expect(userMessages(beforeDequeue.messages)).toHaveLength(1);
-    expect(userMessages(beforeDequeue.messages)[0]).toMatchObject({
+    const queuedRunUserRows = userMessages(beforeDequeue.messages);
+    expect(queuedRunUserRows).toHaveLength(2);
+    const queuedRunMessage = queuedRunUserRows.find((message) => {
+      return message.runId === queuedRun.body.runId;
+    });
+    expect(queuedRunMessage).toMatchObject({
       content: "wait behind the active run",
       runId: queuedRun.body.runId,
     });
+    expect(queuedRunMessage?.revokesMessageId).toBeDefined();
+    const queuedRunOriginal = queuedRunUserRows.find((message) => {
+      return message.id === queuedRunMessage?.revokesMessageId;
+    });
+    expect(queuedRunOriginal?.content).toBe("wait behind the active run");
+    expect(queuedRunOriginal?.runId).toBeUndefined();
     const marker = assistantMessages(beforeDequeue.messages).find((message) => {
       return message.runEventId === "queue:queued";
     });
@@ -3170,12 +3163,14 @@ describe("CHAT-02: queued attachments on auto-send", () => {
       anchor.threadId,
       (items) => {
         return userMessages(items).some((message) => {
-          return message.id === queuedId && message.runId !== undefined;
+          return (
+            message.revokesMessageId === queuedId && message.runId !== undefined
+          );
         });
       },
     );
     const promoted = userMessages(messages.messages).find((message) => {
-      return message.id === queuedId;
+      return message.revokesMessageId === queuedId;
     });
     if (!promoted?.runId) {
       throw new Error("Expected the queued message to auto-send into a run");
@@ -3188,11 +3183,16 @@ describe("CHAT-02: queued attachments on auto-send", () => {
       size: 12,
       url: expect.stringContaining(`${fileId}/notes.txt`),
     });
-    expect(
-      messages.messages.some((message) => {
-        return message.revokesMessageId === queuedId;
-      }),
-    ).toBeFalsy();
+    const original = await chat.getThreadMessage(
+      actor,
+      anchor.threadId,
+      queuedId,
+    );
+    expect(original).toMatchObject({
+      id: queuedId,
+      content: "queued with attachment",
+    });
+    expect(original.runId).toBeUndefined();
 
     const followUp = await api.readRun(actor, promoted.runId);
     expect(followUp.prompt).toContain("queued with attachment");
@@ -3473,7 +3473,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
 });
 
 describe("CHAT-02: shared user message queue", () => {
-  it("dispatches idle-thread sends by claiming the persisted message in place", async () => {
+  it("dispatches idle-thread sends by appending a run-associated replacement", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -3492,37 +3492,44 @@ describe("CHAT-02: shared user message queue", () => {
     }
     const runId = sent.body.runId;
 
-    // The claim binds the run onto the persisted message in place: the same
-    // row gains the run id and no shadow/revoke copy is ever written.
+    // The queued row stays immutable. Claiming appends the run-associated
+    // replacement and links it back to the queued row.
     const messages = await waitForThreadMessages(
       actor,
       sent.body.threadId,
       (items) => {
         return userMessages(items).some((message) => {
-          return message.id === messageId && message.runId === runId;
+          return (
+            message.revokesMessageId === messageId && message.runId === runId
+          );
         });
       },
     );
     const rows = userMessages(messages.messages);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      id: messageId,
+    expect(rows).toHaveLength(2);
+    const claimed = rows.find((message) => {
+      return message.revokesMessageId === messageId;
+    });
+    expect(claimed).toMatchObject({
       content: "queue-first direct dispatch",
       runId,
+      revokesMessageId: messageId,
     });
-    expect(
-      messages.messages.some((message) => {
-        return message.revokesMessageId === messageId;
-      }),
-    ).toBeFalsy();
+    expect(claimed?.id).not.toBe(messageId);
+    const queued = await chat.getThreadMessage(
+      actor,
+      sent.body.threadId,
+      messageId,
+    );
+    expect(queued).toMatchObject({
+      id: messageId,
+      content: "queue-first direct dispatch",
+    });
+    expect(queued.runId).toBeUndefined();
     await expect
       .poll(() => {
         return context.mocks.ably.publish.mock.calls.some((call) => {
-          return (
-            call[0] === `chatThreadMessageUpdated:${sent.body.threadId}` &&
-            (call[1] as { messageId?: string } | undefined)?.messageId ===
-              messageId
-          );
+          return call[0] === `chatThreadMessageCreated:${sent.body.threadId}`;
         });
       })
       .toBe(true);
@@ -3677,140 +3684,18 @@ describe("CHAT-02: shared user message queue", () => {
       (items) => {
         return userMessages(items).some((message) => {
           return (
-            message.id === queuedMessageId && typeof message.runId === "string"
+            message.revokesMessageId === queuedMessageId &&
+            typeof message.runId === "string"
           );
         });
       },
     );
     const promoted = userMessages(messages.messages).find((message) => {
-      return message.id === queuedMessageId;
+      return message.revokesMessageId === queuedMessageId;
     });
     if (!promoted?.runId) {
       throw new Error("Expected the queued message to remain drainable");
     }
-    await cancelChatRun(actor, promoted.runId);
-  }, 90_000);
-
-  it("publishes the claim run-created signal when the message-updated publish fails", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-
-    let failedMessageUpdatedPublish = false;
-    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
-      if (
-        typeof topic === "string" &&
-        topic.startsWith("chatThreadMessageUpdated:") &&
-        !failedMessageUpdatedPublish
-      ) {
-        failedMessageUpdatedPublish = true;
-        return Promise.reject(new Error("message updated publication failed"));
-      }
-      return Promise.resolve(undefined);
-    });
-
-    const sent = await chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        prompt: "claim signals survive a failed publish",
-        clientMessageId: randomUUID(),
-      },
-      [201],
-    );
-    if (sent.status !== 201 || sent.body.runId === null) {
-      throw new Error("Expected an idle-thread queue-first send to dispatch");
-    }
-    const threadId = sent.body.threadId;
-
-    await expect
-      .poll(() => {
-        return failedMessageUpdatedPublish;
-      })
-      .toBe(true);
-    await expect
-      .poll(() => {
-        return context.mocks.ably.publish.mock.calls.some(([topic]) => {
-          return topic === `chatThreadRunCreated:${threadId}`;
-        });
-      })
-      .toBe(true);
-
-    await cancelChatRun(actor, sent.body.runId);
-  }, 90_000);
-
-  it("publishes the drain run-created signal when the message-updated publish fails", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-
-    const anchor = await sendChatRun(actor, {
-      agentId,
-      prompt: "message updated publication failure anchor",
-    });
-
-    const queuedMessageId = randomUUID();
-    const queued = await chat.requestSendMessage(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        prompt: "queued send drains despite a failed message-updated publish",
-        clientMessageId: queuedMessageId,
-      },
-      [201],
-    );
-    expect(queued.body).toMatchObject({
-      runId: null,
-      threadId: anchor.threadId,
-    });
-
-    context.mocks.ably.publish.mockClear();
-    let failedMessageUpdatedPublish = false;
-    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
-      if (
-        typeof topic === "string" &&
-        topic.startsWith("chatThreadMessageUpdated:") &&
-        !failedMessageUpdatedPublish
-      ) {
-        failedMessageUpdatedPublish = true;
-        return Promise.reject(new Error("message updated publication failed"));
-      }
-      return Promise.resolve(undefined);
-    });
-
-    await cancelChatRun(actor, anchor.runId);
-    const messages = await waitForThreadMessages(
-      actor,
-      anchor.threadId,
-      (items) => {
-        return userMessages(items).some((message) => {
-          return (
-            message.id === queuedMessageId && typeof message.runId === "string"
-          );
-        });
-      },
-    );
-    const promoted = userMessages(messages.messages).find((message) => {
-      return message.id === queuedMessageId;
-    });
-    if (!promoted?.runId) {
-      throw new Error("Expected the queued message to be drained");
-    }
-    // The drain publishes are scheduled side effects, so they can land after
-    // the message row is already observable as drained. Poll instead of
-    // asserting synchronously.
-    await expect
-      .poll(() => {
-        return failedMessageUpdatedPublish;
-      })
-      .toBe(true);
-    await expect
-      .poll(() => {
-        return context.mocks.ably.publish.mock.calls.some(([topic]) => {
-          return topic === `chatThreadRunCreated:${anchor.threadId}`;
-        });
-      })
-      .toBe(true);
-
     await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 
@@ -3902,15 +3787,18 @@ describe("CHAT-02: shared user message queue", () => {
 
     const messages = await chat.listThreadMessages(actor, anchor.threadId);
     const claimed = userMessages(messages.messages).filter((message) => {
-      return message.id === messageId && message.runId !== undefined;
+      return (
+        message.revokesMessageId === messageId && message.runId !== undefined
+      );
     });
     expect(claimed).toHaveLength(1);
     expect(claimed[0]?.runId).toBe(sent.body.runId);
-    expect(
-      messages.messages.some((message) => {
-        return message.revokesMessageId === messageId;
-      }),
-    ).toBeFalsy();
+    const queued = await chat.getThreadMessage(
+      actor,
+      anchor.threadId,
+      messageId,
+    );
+    expect(queued.runId).toBeUndefined();
 
     const runList = await api.listAgentRuns(actor, {
       status: "queued,pending,running,completed,failed,timeout,cancelled",
@@ -3934,7 +3822,7 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, sent.body.runId);
   }, 90_000);
 
-  it("claims queued messages in place on auto-send and recalls by deletion", async () => {
+  it("appends replacements on auto-send and recalls queued messages by deletion", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -4004,8 +3892,9 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(repeatedRecall.body).toMatchObject({ runId: null });
 
-    // Completing the anchor auto-sends the queued message: the original row
-    // itself gains the follow-up run id (no shadow row, no revoke pointer).
+    // Completing the anchor auto-sends the queued message by appending a
+    // run-associated replacement while preserving the queued row.
+    context.mocks.ably.publish.mockClear();
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
     const messages = await waitForThreadMessages(
@@ -4013,30 +3902,30 @@ describe("CHAT-02: shared user message queue", () => {
       anchor.threadId,
       (items) => {
         return userMessages(items).some((message) => {
-          return message.id === queuedId && typeof message.runId === "string";
+          return (
+            message.revokesMessageId === queuedId &&
+            typeof message.runId === "string"
+          );
         });
       },
     );
     const promoted = userMessages(messages.messages).find((message) => {
-      return message.id === queuedId;
+      return message.revokesMessageId === queuedId;
     });
     if (!promoted?.runId) {
-      throw new Error("Expected the queued message to claim a run in place");
+      throw new Error("Expected the queued message to append a replacement");
     }
     expect(promoted.content).toBe("queue-first waits for the anchor");
-    expect(
-      messages.messages.some((message) => {
-        return message.revokesMessageId === queuedId;
-      }),
-    ).toBeFalsy();
+    const original = await chat.getThreadMessage(
+      actor,
+      anchor.threadId,
+      queuedId,
+    );
+    expect(original.runId).toBeUndefined();
     await expect
       .poll(() => {
         return context.mocks.ably.publish.mock.calls.some((call) => {
-          return (
-            call[0] === `chatThreadMessageUpdated:${anchor.threadId}` &&
-            (call[1] as { messageId?: string } | undefined)?.messageId ===
-              queuedId
-          );
+          return call[0] === `chatThreadMessageCreated:${anchor.threadId}`;
         });
       })
       .toBe(true);
@@ -4070,7 +3959,7 @@ describe("CHAT-02: shared user message queue", () => {
     expect(queued.body).toMatchObject({ runId: null });
 
     // Cancelling the anchor frees the thread; the cancel side effects drain
-    // the queue, so the queued message claims a fresh run in place without
+    // the queue, so the queued message gets a fresh associated row without
     // waiting for a completed-run callback or another send (#21392).
     await cancelChatRun(actor, anchor.runId);
     const messages = await waitForThreadMessages(
@@ -4079,7 +3968,7 @@ describe("CHAT-02: shared user message queue", () => {
       (items) => {
         return userMessages(items).some((message) => {
           return (
-            message.id === queuedId &&
+            message.revokesMessageId === queuedId &&
             typeof message.runId === "string" &&
             message.runId !== anchor.runId
           );
@@ -4087,17 +3976,18 @@ describe("CHAT-02: shared user message queue", () => {
       },
     );
     const fired = userMessages(messages.messages).find((message) => {
-      return message.id === queuedId;
+      return message.revokesMessageId === queuedId;
     });
     if (!fired?.runId) {
       throw new Error("Expected the queued message to fire after cancel");
     }
     expect(fired.content).toBe("queue-first fires after cancel");
-    expect(
-      messages.messages.some((message) => {
-        return message.revokesMessageId === queuedId;
-      }),
-    ).toBeFalsy();
+    const original = await chat.getThreadMessage(
+      actor,
+      anchor.threadId,
+      queuedId,
+    );
+    expect(original.runId).toBeUndefined();
 
     const followUp = await api.readRun(actor, fired.runId);
     expect(followUp.prompt).toContain("queue-first fires after cancel");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -225,30 +225,35 @@ async function sendChatRun(
     ...body,
     clientMessageId: body.clientMessageId ?? randomUUID(),
   };
-  let sent = await chat.requestSendMessage(actor, requestBody, [201]);
+  const sent = await chat.requestSendMessage(actor, requestBody, [201]);
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
   }
-  if (sent.body.runId === null) {
-    const threadId = sent.body.threadId;
-    // Queue-first sends may be claimed by a terminal callback drain between
-    // enqueue and the inline dispatch decision. Replay the idempotent client
-    // message id until that winning run association is visible.
-    await expect
-      .poll(async () => {
-        sent = await chat.requestSendMessage(
-          actor,
-          { ...requestBody, threadId },
-          [201],
-        );
-        return sent.status === 201 ? sent.body.runId : null;
-      })
-      .not.toBeNull();
+  let runId: string | null | undefined = sent.body.runId;
+  if (runId === null) {
+    // A terminal callback may claim the queued row between enqueue and the
+    // inline dispatch decision. Recover as a refreshed client does: read the
+    // appended replacement instead of retrying the client message id.
+    const messages = await waitForThreadMessages(
+      actor,
+      sent.body.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === requestBody.clientMessageId &&
+            message.runId !== undefined
+          );
+        });
+      },
+    );
+    runId = userMessages(messages.messages).find((message) => {
+      return message.revokesMessageId === requestBody.clientMessageId;
+    })?.runId;
   }
-  if (sent.body.runId === null) {
+  if (runId === undefined || runId === null) {
     throw new Error("Expected the entitled chat send to create a run");
   }
-  return { runId: sent.body.runId, threadId: sent.body.threadId };
+  return { runId, threadId: sent.body.threadId };
 }
 
 async function expectThreadCreatedModelEvent(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2630,15 +2630,22 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       thread.id,
       (messages) => {
         return userMessages(messages).some((message) => {
-          return message.id === sent.body.messageId && message.runId === run1Id;
+          return (
+            message.revokesMessageId === sent.body.messageId &&
+            message.runId === run1Id
+          );
         });
       },
     );
     expect(
       userMessages(zeroPage.messages).find((message) => {
-        return message.id === sent.body.messageId;
+        return message.revokesMessageId === sent.body.messageId;
       }),
-    ).toMatchObject({ content: "hello from v1", runId: run1Id });
+    ).toMatchObject({
+      content: "hello from v1",
+      runId: run1Id,
+      revokesMessageId: sent.body.messageId,
+    });
     await flushWaitUntilForTest();
     const afterV1SideEffects = await chat.listThreadMessages(actor, thread.id);
     expect(initialThinkingRequests).toBe(0);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2711,23 +2711,25 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       (messages) => {
         return userMessages(messages).some((message) => {
           return (
-            message.id === queued.body.messageId && message.runId !== undefined
+            message.revokesMessageId === queued.body.messageId &&
+            message.runId !== undefined
           );
         });
       },
     );
     const promoted = userMessages(afterQueue.messages).find((message) => {
-      return message.id === queued.body.messageId;
+      return message.revokesMessageId === queued.body.messageId;
     });
     if (!promoted?.runId) {
       throw new Error("Expected the queued v1 message to auto-send into a run");
     }
     expect(promoted.content).toBe("queued from v1");
-    expect(
-      afterQueue.messages.some((message) => {
-        return message.revokesMessageId === queued.body.messageId;
-      }),
-    ).toBeFalsy();
+    const original = await chat.getThreadMessage(
+      actor,
+      thread.id,
+      queued.body.messageId,
+    );
+    expect(original.runId).toBeUndefined();
     await expectZeroPreCreateSource(promoted.runId, "chat_callback_auto_send");
     await flushWaitUntilForTest();
     const afterAutoSendSideEffects = await chat.listThreadMessages(

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -43,7 +43,6 @@ import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
 import {
-  publishChatThreadMessageUpdated,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -97,7 +96,7 @@ import {
 import { loadWebChatIncompleteContext } from "../services/zero-chat-incomplete-context.service";
 import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-marker.service";
 import {
-  claimUserMessageInPlace,
+  claimQueuedUserMessage,
   deleteUserMessageQueueItem,
   discardUnclaimedUserMessage,
   enqueueUserMessageQueueItem,
@@ -2549,7 +2548,6 @@ function scheduleCreatedChatRunSideEffects(params: {
   readonly touchThreadSort: boolean;
   readonly queueFirstClaim:
     | {
-        readonly messageId: string;
         readonly createdAt: Date;
       }
     | undefined;
@@ -2573,7 +2571,6 @@ function scheduleCreatedChatRunSideEffects(params: {
       threadId: params.thread.threadId,
       userId: params.userId,
       runId: params.runId,
-      messageId: params.queueFirstClaim.messageId,
       createdAt: params.queueFirstClaim.createdAt,
       appendQueueMarker: params.runStatus === "queued",
       appendInitialThinking,
@@ -2594,8 +2591,8 @@ function scheduleCreatedChatRunSideEffects(params: {
 
 /**
  * Queue-first counterpart of `scheduleAssociatedUserMessage`: the pre-dispatch
- * gate already claimed the persisted message in place, so only publish its
- * update and append the optional run markers here.
+ * gate already appended the run-associated replacement, so only publish the
+ * append and add the optional run markers here.
  */
 function scheduleClaimedQueueFirstMessageSideEffects(params: {
   readonly db: Db;
@@ -2603,7 +2600,6 @@ function scheduleClaimedQueueFirstMessageSideEffects(params: {
   readonly threadId: string;
   readonly userId: string;
   readonly runId: string;
-  readonly messageId: string;
   readonly createdAt: Date;
   readonly appendQueueMarker: boolean;
   readonly appendInitialThinking: boolean;
@@ -2619,45 +2615,10 @@ function scheduleClaimedQueueFirstMessageSideEffects(params: {
           });
         });
       }
-      // Each publish is independently best-effort: one failed Ably publish
-      // must not drop the remaining signals, or the client can be left with
-      // a stale queued row it can only heal via subscribe-time catchup.
-      await tapError(
-        publishChatThreadMessageUpdated(
-          params.userId,
-          params.threadId,
-          params.messageId,
-        ),
-        (error) => {
-          L.warn("Failed to publish claimed queue-first message updated", {
-            threadId: params.threadId,
-            messageId: params.messageId,
-            error,
-          });
-        },
-      );
-      if (params.appendQueueMarker) {
-        await tapError(
-          publishChatMessageCreated(params.userId, params.threadId),
-          (error) => {
-            L.warn("Failed to publish claimed queue-first message created", {
-              threadId: params.threadId,
-              error,
-            });
-          },
-        );
-      }
-      await tapError(
-        publishUserSignal(
-          [params.userId],
-          `chatThreadRunCreated:${params.threadId}`,
-        ),
-        (error) => {
-          L.warn("Failed to publish claimed queue-first run created", {
-            threadId: params.threadId,
-            error,
-          });
-        },
+      await publishChatMessageCreated(params.userId, params.threadId);
+      await publishUserSignal(
+        [params.userId],
+        `chatThreadRunCreated:${params.threadId}`,
       );
       if (params.appendInitialThinking) {
         await bestEffort(
@@ -3010,7 +2971,7 @@ function buildQueueFirstPreDispatchClaim(params: {
   return {
     state,
     beforeDispatch: async ({ runId }) => {
-      state.current = await claimUserMessageInPlace(params.db, {
+      state.current = await claimQueuedUserMessage(params.db, {
         threadId: params.threadId,
         messageId,
         runId,
@@ -3076,7 +3037,6 @@ function scheduleNormalChatRunSideEffects(params: {
     queueFirstClaim:
       params.queueFirstMessageId && params.queueFirstClaimedAt
         ? {
-            messageId: params.queueFirstMessageId,
             createdAt: params.queueFirstClaimedAt,
           }
         : undefined,
@@ -3089,7 +3049,7 @@ const createNormalChatRun$ = command(
     params: {
       readonly args: NormalSendArgs;
       readonly prepared: PreparedNormalSend;
-      /** Queue-first sends claim this pre-inserted message in place. */
+      /** Queue-first sends replace this queued message at dispatch time. */
       readonly queueFirstMessageId?: string;
     },
     signal: AbortSignal,
@@ -3280,8 +3240,8 @@ export const sendNormalMessage$ = command(
     }
 
     // Normal user messages always enter the shared thread queue first. An
-    // inline drain claims the message in place when the thread is idle and the
-    // message is the queue head.
+    // inline drain appends its run-associated replacement when the thread is
+    // idle and the message is the queue head.
     if (!args.body.revokesMessageId) {
       return await set(
         sendQueueFirstNormalMessage$,
@@ -3313,9 +3273,9 @@ export const sendNormalMessage$ = command(
 
 /**
  * Queue-first send: persist the message and its queue item, then inline-drain
- * — create the run and claim the message in place when the thread is idle and
- * this message is the oldest unclaimed one. Response shapes match the legacy
- * path: `runId` when dispatched, `{runId: null}` when left queued.
+ * — create the run and append a replacement message when the thread is idle
+ * and this message is the oldest unclaimed one. Response shapes match the
+ * legacy path: `runId` when dispatched, `{runId: null}` when left queued.
  */
 const sendQueueFirstNormalMessage$ = command(
   async (

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -100,7 +100,6 @@ import {
   deleteUserMessageQueueItem,
   discardUnclaimedUserMessage,
   enqueueUserMessageQueueItem,
-  hasUserMessageQueueItem,
   loadNextUnclaimedQueuedUserMessage,
 } from "../services/zero-chat-queued-message.service";
 import { appendChatThreadEvent } from "../services/zero-chat-thread-event.service";
@@ -1726,10 +1725,10 @@ function appendRecallUserMessage(params: {
   readonly clientMessageId: string | undefined;
 }): Promise<AppendMessageResult> {
   return params.db.transaction(async (tx) => {
-    // Queue-first messages (identified by their queue item) are recalled by
-    // deletion: consume the queue item and remove the unclaimed message row.
-    // No revoke control row is written.
-    if (await hasUserMessageQueueItem(tx, params.revokesMessageId)) {
+    // Deleting the queue item atomically wins the queued message before
+    // removing its immutable row. If a concurrent claim wins first, its
+    // replacement remains linked and the revoker check below rejects recall.
+    if (await deleteUserMessageQueueItem(tx, params.revokesMessageId)) {
       const [deleted] = await tx
         .delete(chatMessages)
         .where(
@@ -1742,12 +1741,8 @@ function appendRecallUserMessage(params: {
         )
         .returning({ createdAt: chatMessages.createdAt });
       if (!deleted) {
-        return {
-          ok: false,
-          message: "Only queued user messages can be recalled",
-        };
+        throw new Error("Claimed queue item has no recallable user message");
       }
-      await deleteUserMessageQueueItem(tx, params.revokesMessageId);
       return { ok: true, createdAt: nowDate() };
     }
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -38,7 +38,6 @@ import { getDatasetName, queryAxiomDirect } from "../external/axiom";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadMessageCreatedSafely,
-  publishChatThreadMessageUpdated,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -66,7 +65,7 @@ import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.ser
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { recommendedFollowupsMessageIdForRun } from "./assistant-message-id";
 import {
-  deleteUserMessageQueueItem,
+  appendClaimedUserMessage,
   loadNextUnclaimedQueuedUserMessage,
   type QueuedUserMessage,
 } from "./zero-chat-queued-message.service";
@@ -347,15 +346,6 @@ type CreatedQueuedRun = {
   readonly runId: string;
   readonly status: "queued" | "pending" | "running";
 };
-
-interface QueuedUserMessageClaim {
-  readonly messageId: string;
-}
-
-interface CreatedAutoSentQueuedRun {
-  readonly run: CreatedQueuedRun;
-  readonly claim: QueuedUserMessageClaim;
-}
 
 type CreateQueuedRun = (
   input: CreateQueuedChatRunInput,
@@ -1823,7 +1813,7 @@ async function claimQueuedUserMessageForDispatch(args: {
   readonly queuedMessage: QueuedUserMessage;
   readonly runId: string;
   readonly threadId: string;
-}): Promise<QueuedUserMessageClaim | null> {
+}): Promise<boolean> {
   const claimed = await args.db.transaction(async (tx) => {
     // Serialize auto-send dispatch decisions per thread. Otherwise two terminal
     // callbacks can insert candidate runs, each see the other as active, and
@@ -1891,26 +1881,14 @@ async function claimQueuedUserMessageForDispatch(args: {
       return null;
     }
 
-    // Claim both current queue items and persisted pre-convergence rows in
-    // place. Deleting a missing queue pointer is a safe no-op for legacy rows.
-    const [updated] = await tx
-      .update(chatMessages)
-      .set({ runId: args.runId })
-      .where(
-        and(
-          eq(chatMessages.id, args.queuedMessage.id),
-          eq(chatMessages.chatThreadId, args.threadId),
-          isNull(chatMessages.runId),
-        ),
-      )
-      .returning({ id: chatMessages.id });
-    if (updated) {
-      await deleteUserMessageQueueItem(tx, args.queuedMessage.id);
-    }
-    return updated ? { messageId: updated.id } : null;
+    return await appendClaimedUserMessage(tx, {
+      threadId: args.threadId,
+      messageId: args.queuedMessage.id,
+      runId: args.runId,
+    });
   });
 
-  return claimed;
+  return claimed !== null;
 }
 
 async function appendAutoSentQueuedRunMarker(args: {
@@ -1938,7 +1916,7 @@ async function appendAutoSentQueuedRunMarker(args: {
           eq(chatMessages.chatThreadId, args.threadId),
           eq(chatMessages.runId, args.runId),
           eq(chatMessages.role, "user"),
-          eq(chatMessages.id, args.queuedMessageId),
+          eq(chatMessages.revokesMessageId, args.queuedMessageId),
         ),
       )
       .limit(1);
@@ -1963,9 +1941,8 @@ async function createAutoSentQueuedRun(args: {
   readonly queuedMessage: QueuedUserMessage;
   readonly threadId: string;
   readonly timing: ChatCallbackPreCreateTimingCollector;
-}): Promise<CreatedAutoSentQueuedRun | null> {
-  let claim: QueuedUserMessageClaim | null = null;
-  const run = await measureChatCallbackPreCreateTiming(
+}): Promise<CreatedQueuedRun | null> {
+  return await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run",
     "top_level",
@@ -1973,7 +1950,7 @@ async function createAutoSentQueuedRun(args: {
       return args.createRun({
         ...args.runInput,
         beforeDispatch: async ({ runId }) => {
-          claim = await measureChatCallbackPreCreateTiming(
+          const claimed = await measureChatCallbackPreCreateTiming(
             args.timing,
             "api_dispatch_pre_create_zero_chat_callback_auto_send_claim_message",
             "nested",
@@ -1986,7 +1963,7 @@ async function createAutoSentQueuedRun(args: {
               });
             },
           );
-          if (!claim) {
+          if (!claimed) {
             log.warn(
               "Auto-send could not claim queued message before dispatch",
               {
@@ -1996,12 +1973,11 @@ async function createAutoSentQueuedRun(args: {
               },
             );
           }
-          return claim !== null;
+          return claimed;
         },
       });
     },
   );
-  return run && claim ? { run, claim } : null;
 }
 
 async function appendAutoSentQueuedRunMarkerIfQueued(args: {
@@ -2032,8 +2008,6 @@ async function appendAutoSentQueuedRunMarkerIfQueued(args: {
 async function publishAutoSentQueuedRunSignals(args: {
   readonly threadId: string;
   readonly userId: string;
-  readonly claim: QueuedUserMessageClaim;
-  readonly runStatus: CreatedQueuedRun["status"];
   readonly timing: ChatCallbackPreCreateTimingCollector;
 }): Promise<void> {
   await measureChatCallbackPreCreateTiming(
@@ -2041,55 +2015,15 @@ async function publishAutoSentQueuedRunSignals(args: {
     "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals",
     "nested",
     async () => {
-      // Each publish is independently best-effort: one failed Ably publish
-      // must not drop the remaining signals, or the client can be left with
-      // a stale queued row it can only heal via subscribe-time catchup.
-      await tapError(
-        publishChatThreadMessageUpdated(
-          args.userId,
-          args.threadId,
-          args.claim.messageId,
-        ),
-        (error) => {
-          log.warn("Failed to publish auto-sent queued message updated", {
-            threadId: args.threadId,
-            messageId: args.claim.messageId,
-            error,
-          });
-        },
+      await publishUserSignal(
+        [args.userId],
+        `chatThreadMessageCreated:${args.threadId}`,
       );
-      if (args.runStatus === "queued") {
-        await tapError(
-          publishUserSignal(
-            [args.userId],
-            `chatThreadMessageCreated:${args.threadId}`,
-          ),
-          (error) => {
-            log.warn("Failed to publish auto-sent queued message created", {
-              threadId: args.threadId,
-              error,
-            });
-          },
-        );
-      }
-      await tapError(
-        publishUserSignal(
-          [args.userId],
-          `chatThreadRunCreated:${args.threadId}`,
-        ),
-        (error) => {
-          log.warn("Failed to publish auto-sent queued run created", {
-            threadId: args.threadId,
-            error,
-          });
-        },
+      await publishUserSignal(
+        [args.userId],
+        `chatThreadRunCreated:${args.threadId}`,
       );
-      await tapError(publishThreadListChanged(args.userId), (error) => {
-        log.warn("Failed to publish auto-sent queued thread list changed", {
-          threadId: args.threadId,
-          error,
-        });
-      });
+      await publishThreadListChanged(args.userId);
     },
   );
 }
@@ -2172,7 +2106,7 @@ async function autoSendQueuedMessageForThread(args: {
   let createdRunId: string | null = null;
   const run = await onRejection(
     (async () => {
-      const created = await createAutoSentQueuedRun({
+      const createdRun = await createAutoSentQueuedRun({
         createRun: args.createRun,
         db: args.db,
         runInput,
@@ -2180,10 +2114,9 @@ async function autoSendQueuedMessageForThread(args: {
         threadId,
         timing: args.timing,
       });
-      if (!created) {
+      if (!createdRun) {
         return null;
       }
-      const { run: createdRun, claim } = created;
       createdRunId = createdRun.runId;
       await appendAutoSentQueuedRunMarkerIfQueued({
         db: args.db,
@@ -2195,8 +2128,6 @@ async function autoSendQueuedMessageForThread(args: {
       await publishAutoSentQueuedRunSignals({
         threadId,
         userId,
-        claim,
-        runStatus: createdRun.status,
         timing: args.timing,
       });
       return createdRun;

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -128,20 +128,85 @@ export async function hasUserMessageQueueItem(
   return item !== undefined;
 }
 
+interface ClaimedUserMessage {
+  readonly createdAt: Date;
+}
+
 /**
- * Claim a queue-first user message for a created run: bind the run id onto
- * the existing message row and consume its queue item. Serialized on the
- * thread row like the legacy claim. Returns the claimed message's createdAt,
- * or null when the message was already claimed or recalled.
+ * Append the run-associated replacement for a queued user message and consume
+ * its queue item. Callers serialize dispatch decisions before invoking this.
  */
-export async function claimUserMessageInPlace(
+export async function appendClaimedUserMessage(
   db: Db,
   args: {
     readonly threadId: string;
     readonly messageId: string;
     readonly runId: string;
   },
-): Promise<{ readonly createdAt: Date } | null> {
+): Promise<ClaimedUserMessage | null> {
+  const [queued] = await db
+    .select({
+      content: chatMessages.content,
+      attachFiles: chatMessages.attachFiles,
+      attachFileMetadata: chatMessages.attachFileMetadata,
+      generationTemplate: chatMessages.generationTemplate,
+    })
+    .from(chatMessageQueue)
+    .innerJoin(
+      chatMessages,
+      eq(chatMessages.id, chatMessageQueue.chatMessageId),
+    )
+    .where(
+      and(
+        eq(chatMessageQueue.itemType, "user_message"),
+        eq(chatMessageQueue.chatMessageId, args.messageId),
+        eq(chatMessageQueue.chatThreadId, args.threadId),
+        eq(chatMessages.chatThreadId, args.threadId),
+        eq(chatMessages.role, "user"),
+        isNull(chatMessages.runId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!queued) {
+    return null;
+  }
+
+  const [claimed] = await db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: args.threadId,
+      role: "user",
+      content: queued.content,
+      runId: args.runId,
+      revokesMessageId: args.messageId,
+      attachFiles: queued.attachFiles ? [...queued.attachFiles] : null,
+      attachFileMetadata: queued.attachFileMetadata
+        ? [...queued.attachFileMetadata]
+        : null,
+      generationTemplate: queued.generationTemplate,
+    })
+    .onConflictDoNothing({ target: chatMessages.revokesMessageId })
+    .returning({ createdAt: chatMessages.createdAt });
+  if (!claimed) {
+    return null;
+  }
+  await deleteUserMessageQueueItem(db, args.messageId);
+  return claimed;
+}
+
+/**
+ * Serialize an inline queue claim on the thread, append its associated user
+ * message, and consume the queue item.
+ */
+export async function claimQueuedUserMessage(
+  db: Db,
+  args: {
+    readonly threadId: string;
+    readonly messageId: string;
+    readonly runId: string;
+  },
+): Promise<ClaimedUserMessage | null> {
   return await db.transaction(async (tx) => {
     const threadRows = await tx.execute<{ readonly id: string }>(sql`
       SELECT ${chatThreads.id} AS "id"
@@ -152,24 +217,7 @@ export async function claimUserMessageInPlace(
     if (!threadRows.rows[0]) {
       return null;
     }
-
-    const [claimed] = await tx
-      .update(chatMessages)
-      .set({ runId: args.runId })
-      .where(
-        and(
-          eq(chatMessages.id, args.messageId),
-          eq(chatMessages.chatThreadId, args.threadId),
-          eq(chatMessages.role, "user"),
-          isNull(chatMessages.runId),
-        ),
-      )
-      .returning({ createdAt: chatMessages.createdAt });
-    if (!claimed) {
-      return null;
-    }
-    await deleteUserMessageQueueItem(tx, args.messageId);
-    return claimed;
+    return await appendClaimedUserMessage(tx, args);
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -111,23 +111,6 @@ export async function deleteUserMessageQueueItem(
   return deleted.length > 0;
 }
 
-export async function hasUserMessageQueueItem(
-  db: Db,
-  chatMessageId: string,
-): Promise<boolean> {
-  const [item] = await db
-    .select({ id: chatMessageQueue.id })
-    .from(chatMessageQueue)
-    .where(
-      and(
-        eq(chatMessageQueue.itemType, "user_message"),
-        eq(chatMessageQueue.chatMessageId, chatMessageId),
-      ),
-    )
-    .limit(1);
-  return item !== undefined;
-}
-
 interface ClaimedUserMessage {
   readonly createdAt: Date;
 }

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,4 +1,5 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, eq, like, or, sql } from "drizzle-orm";
 
 import { db } from "../lib/db";
@@ -158,6 +159,63 @@ export async function holdOrgAdmissionLockFixture(args: {
               AND held.pid = ${holderPid}
               AND held.granted
           )
+      `);
+      return result.rows[0]?.waiterCount ?? 0;
+    },
+  };
+}
+
+/**
+ * Holds a table lock that permits row selection but pauses chat-message writes.
+ * This is a timing-only boundary exception for proving queue claim races through
+ * the product API; the transaction neither creates nor changes product rows.
+ */
+export async function holdChatMessageWritesFixture(args: {
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    await tx.execute(sql`LOCK TABLE ${chatMessages} IN SHARE MODE`);
+    const result = await tx.execute<{ readonly pid: number }>(sql`
+      SELECT pg_backend_pid() AS "pid"
+    `);
+    const holderPid = result.rows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the chat-message lock holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
+    blockedWaiterCount: async () => {
+      const result = await db().execute<{ readonly waiterCount: number }>(sql`
+        WITH RECURSIVE blocked("pid") AS (
+          SELECT activity.pid
+          FROM pg_stat_activity AS activity
+          WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+
+          UNION
+
+          SELECT activity.pid
+          FROM pg_stat_activity AS activity
+          INNER JOIN blocked AS blocker
+            ON blocker.pid = ANY(pg_blocking_pids(activity.pid))
+        )
+        SELECT count(*)::int AS "waiterCount"
+        FROM blocked
       `);
       return result.rows[0]?.waiterCount ?? 0;
     },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2230,32 +2230,6 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
     writePersistentMessages$,
   });
 
-  // Queued user rows are claimed server-side by updating the persisted row in
-  // place, which a sinceId sync can never observe. Re-fetch every locally
-  // cached row still considered queued so a lost `chatThreadMessageUpdated`
-  // event cannot leave the message pending forever.
-  const reconcileQueuedMessages$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      const persistentIds = new Set(
-        get(persistentChatMessages$).map((message) => {
-          return message.id;
-        }),
-      );
-      const queuedIds = new Set(
-        queuedMessagesFromRaw(get(rawMessages$))
-          .map((message) => {
-            return message.id;
-          })
-          .filter((id) => {
-            return persistentIds.has(id);
-          }),
-      );
-      for (const messageId of queuedIds) {
-        await set(fetchUpdatedMessage$, { messageId }, signal);
-      }
-    },
-  );
-
   return {
     initializeIndexedDbMessages$,
     writePersistentMessages$,
@@ -2269,7 +2243,6 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
     activeGoalObjective$,
     syncRemoteMessages$,
     fetchUpdatedMessage$,
-    reconcileQueuedMessages$,
   };
 }
 
@@ -2410,7 +2383,6 @@ interface RunTrackingDeps {
   initializeIndexedDbMessages$: Command<Promise<void>, [AbortSignal]>;
   syncRemoteMessages$: Command<Promise<void>, [AbortSignal]>;
   fetchUpdatedMessage$: Command<Promise<boolean>, [unknown, AbortSignal]>;
-  reconcileQueuedMessages$: Command<Promise<void>, [AbortSignal]>;
   reloadArtifacts$: Command<void, []>;
   autoScroll$: Command<void, []>;
   dataSource: ChatThreadRemote;
@@ -2596,33 +2568,33 @@ function createMarkThreadReadIfNeeded({
   });
 }
 
-function createOnSubscribedCatchup({
+function createRunTracking({
   threadId,
   reloadThread$,
   remoteThreadDetail$,
   latestChatMessageId$,
+  latestRunFinishCreatedAt$,
+  initializeIndexedDbMessages$,
   syncRemoteMessages$,
   fetchUpdatedMessage$,
-  reconcileQueuedMessages$,
   reloadArtifacts$,
-  markThreadReadIfNeeded$,
-}: Pick<
-  RunTrackingDeps,
-  | "threadId"
-  | "reloadThread$"
-  | "remoteThreadDetail$"
-  | "latestChatMessageId$"
-  | "syncRemoteMessages$"
-  | "fetchUpdatedMessage$"
-  | "reconcileQueuedMessages$"
-  | "reloadArtifacts$"
-> & {
-  markThreadReadIfNeeded$: Command<Promise<void>, [AbortSignal]>;
-}) {
+  autoScroll$,
+  dataSource,
+}: RunTrackingDeps) {
+  const locallyMarkedReadAt$ = state<string | undefined>(undefined);
+  const resetChatSubscriptionSignal$ = resetSignalScope();
   const optimisticCreateUnsettled$ =
     optimisticChatThreadCreateUnsettled(threadId);
 
-  return command(async ({ get, set }, sig: AbortSignal) => {
+  const markThreadReadIfNeeded$ = createMarkThreadReadIfNeeded({
+    threadId,
+    remoteThreadDetail$,
+    latestRunFinishCreatedAt$,
+    locallyMarkedReadAt$,
+    dataSource,
+  });
+
+  const onSubscribed$ = command(async ({ get, set }, sig: AbortSignal) => {
     L.debug("subscribeChatThread$ catchup start", { threadId });
     set(reloadThread$);
     set(reloadArtifacts$);
@@ -2643,49 +2615,9 @@ function createOnSubscribedCatchup({
       // fetch are queued instead of missed.
       await set(fetchUpdatedMessage$, { messageId: latestMessageId }, sig);
     }
-    // In-place queue claims are equally invisible to the sinceId fetch.
-    await set(reconcileQueuedMessages$, sig);
     await set(markThreadReadIfNeeded$, sig);
     sig.throwIfAborted();
     L.debug("subscribeChatThread$ catchup done", { threadId });
-  });
-}
-
-function createRunTracking({
-  threadId,
-  reloadThread$,
-  remoteThreadDetail$,
-  latestChatMessageId$,
-  latestRunFinishCreatedAt$,
-  initializeIndexedDbMessages$,
-  syncRemoteMessages$,
-  fetchUpdatedMessage$,
-  reconcileQueuedMessages$,
-  reloadArtifacts$,
-  autoScroll$,
-  dataSource,
-}: RunTrackingDeps) {
-  const locallyMarkedReadAt$ = state<string | undefined>(undefined);
-  const resetChatSubscriptionSignal$ = resetSignalScope();
-
-  const markThreadReadIfNeeded$ = createMarkThreadReadIfNeeded({
-    threadId,
-    remoteThreadDetail$,
-    latestRunFinishCreatedAt$,
-    locallyMarkedReadAt$,
-    dataSource,
-  });
-
-  const onSubscribed$ = createOnSubscribedCatchup({
-    threadId,
-    reloadThread$,
-    remoteThreadDetail$,
-    latestChatMessageId$,
-    syncRemoteMessages$,
-    fetchUpdatedMessage$,
-    reconcileQueuedMessages$,
-    reloadArtifacts$,
-    markThreadReadIfNeeded$,
   });
 
   const subscribeChatThread$ = command(async ({ set }, signal: AbortSignal) => {
@@ -2717,9 +2649,6 @@ function createRunTracking({
     const onRunChanged$ = command(async ({ set }, sig: AbortSignal) => {
       L.debug("onRunChanged$ fired", { threadId });
       await set(syncRemoteMessages$, sig);
-      // A run change is exactly when a queued row gets claimed in place, so
-      // reconcile stale queued rows even if messageUpdated was lost.
-      await set(reconcileQueuedMessages$, sig);
       sig.throwIfAborted();
       animationFrame(
         () => {
@@ -3948,7 +3877,6 @@ export function createChatThreadSignals(
     initializeIndexedDbMessages$: messages.initializeIndexedDbMessages$,
     syncRemoteMessages$: messages.syncRemoteMessages$,
     fetchUpdatedMessage$: messages.fetchUpdatedMessage$,
-    reconcileQueuedMessages$: messages.reconcileQueuedMessages$,
     reloadArtifacts$: artifact.reloadArtifacts$,
     autoScroll$: scrollSignals.autoScroll$,
     dataSource,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5944,87 +5944,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
-  it("shows a later in-place claimed run after the previous run completes", async () => {
-    const threadId = "b0000000-0000-4000-a000-000000000731";
-    const messageId = "00000000-0000-4000-8000-000000004031";
-    const previousRunId = "run-before-queue-first-claim";
-    const runId = "run-queue-first-claimed";
-    const prompt = "Run this message immediately";
-    const queuedMessage: {
-      id: string;
-      role: "user";
-      content: string;
-      runId: string | undefined;
-      createdAt: string;
-    } = {
-      id: messageId,
-      role: "user",
-      content: prompt,
-      runId: undefined,
-      createdAt: "2026-06-09T10:00:00Z",
-    };
-    const fetchedMessageIds: string[] = [];
-
-    mockChatLifecycle(context, {
-      threadId,
-      chatMessages: [
-        {
-          id: "msg-before-queue-first-user",
-          role: "user",
-          content: "Finish the current task first",
-          runId: previousRunId,
-          createdAt: "2026-06-09T09:59:00Z",
-        },
-        queuedMessage,
-        {
-          id: "msg-before-queue-first-assistant",
-          role: "assistant",
-          content: "The current task is complete.",
-          runId: previousRunId,
-          runEventId: "event-before-queue-first-assistant",
-          createdAt: "2026-06-09T10:00:01Z",
-        },
-        {
-          id: "msg-before-queue-first-completed",
-          role: "assistant",
-          content: null,
-          runId: previousRunId,
-          runLifecycleEvent: "completed",
-          createdAt: "2026-06-09T10:00:02Z",
-        },
-      ],
-      activeRunIds: [runId],
-      onMessageGet: (fetchedMessageId) => {
-        fetchedMessageIds.push(fetchedMessageId);
-      },
-    });
-
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
-
-    await waitFor(() => {
-      expect(screen.getByText("1 message waiting to send")).toBeInTheDocument();
-      expect(screen.getByLabelText("Queued message")).toHaveTextContent(prompt);
-    });
-
-    queuedMessage.runId = runId;
-    context.mocks.ably.trigger(`chatThreadMessageUpdated:${threadId}`, {
-      messageId,
-    });
-
-    await waitFor(() => {
-      expect(fetchedMessageIds).toContain(messageId);
-      expect(
-        screen.queryByText("1 message waiting to send"),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
-      expect(screen.getByText(prompt)).toBeInTheDocument();
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
-      expect(
-        document.querySelector("[data-thinking-indicator]"),
-      ).not.toBeNull();
-    });
-  });
-
   it("catches recommended follow-ups written before realtime subscription is ready", async () => {
     const assistantReply = "I can turn this into a launch package.";
     const followupPrompt = "Create a presentation outline";
@@ -6088,76 +6007,49 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
   });
 
-  it("reconciles stale locally-queued messages claimed before realtime subscription is ready", async () => {
-    const claimedQueued: Extract<PagedChatMessage, { role: "user" }> = {
-      id: "00000000-0000-4000-8000-000000004101",
-      role: "user",
-      content: "First queued send",
-      runId: undefined,
-      createdAt: "2026-06-09T10:02:00Z",
-    };
-    const stillQueued: Extract<PagedChatMessage, { role: "user" }> = {
-      id: "00000000-0000-4000-8000-000000004102",
-      role: "user",
-      content: "Second queued send",
-      runId: undefined,
-      createdAt: "2026-06-09T10:03:00Z",
-    };
-    const fetchedMessageIds: string[] = [];
-    let claimedAfterInitialList = false;
+  it("restores an appended queued-message claim after refresh", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000731";
+    const queuedMessageId = "00000000-0000-4000-8000-000000004031";
+    const claimedMessageId = "00000000-0000-4000-8000-000000004032";
+    const runId = "run-queue-first-claimed";
+    const prompt = "Run this message immediately";
 
     mockChatLifecycle(context, {
-      threadId: FOLLOWUP_THREAD_ID,
-      threadTitle: "Queued reconciliation",
+      threadId,
       chatMessages: [
         {
-          id: "msg-reconcile-user",
+          id: queuedMessageId,
           role: "user",
-          content: "Original prompt",
-          runId: "run-reconcile-done",
+          content: prompt,
+          runId: undefined,
           createdAt: "2026-06-09T10:00:00Z",
         },
         {
-          id: "msg-reconcile-assistant",
-          role: "assistant",
-          content: "Original reply.",
-          runId: "run-reconcile-done",
-          createdAt: "2026-06-09T10:01:00Z",
+          id: claimedMessageId,
+          role: "user",
+          content: prompt,
+          runId,
+          revokesMessageId: queuedMessageId,
+          createdAt: "2026-06-09T10:00:01Z",
         },
-        claimedQueued,
-        stillQueued,
       ],
-      afterInitialMessagesList: () => {
-        if (claimedAfterInitialList) {
-          return;
-        }
-        claimedAfterInitialList = true;
-        // Simulate the server claiming the queued row in place while the
-        // dedicated chatThreadMessageUpdated event is lost: only a targeted
-        // refetch of the row can observe the new runId.
-        claimedQueued.runId = "run-reconcile-claimed";
-      },
-      onMessageGet: (messageId) => {
-        fetchedMessageIds.push(messageId);
-      },
+      activeRunIds: [runId],
     });
 
-    detachedSetupPage({
-      context,
-      path: `/chats/${FOLLOWUP_THREAD_ID}`,
-    });
+    // Optimistic sends are not persisted to IndexedDB. A refreshed page must
+    // recover entirely from the immutable queued row and its replacement.
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
 
     await waitFor(() => {
-      // The claimed row is not the latest message, so only the queued-row
-      // reconciliation pass can have refetched it.
-      expect(fetchedMessageIds).toContain(claimedQueued.id);
-      // Healed row is now associated with an in-flight run, so the thread
-      // shows the running indicator instead of a queued-only transcript.
+      expect(
+        screen.queryByText("1 message waiting to send"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+      expect(screen.getByText(prompt)).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
       expect(
         document.querySelector("[data-thinking-indicator]"),
       ).not.toBeNull();
-      expect(screen.getByText("First queued send")).toBeInTheDocument();
-      expect(screen.getByText("Second queued send")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- keep queued `chat_messages` immutable when a run claims them
- atomically append a run-associated user message with `revokes_message_id`, then delete the `chat_message_queue` row
- publish `chatThreadMessageCreated` for inline and callback drains instead of mutating and publishing `chatThreadMessageUpdated`
- fully remove the client reconciliation and per-publish Ably isolation introduced by #21851
- cover refresh recovery from the immutable original/replacement pair and align raw API-page assertions with append-only storage

## User impact

Queued messages now converge through the existing append-only `sinceId` synchronization model. The original queued row remains unchanged, while the existing revoke folding behavior renders the associated replacement as the active message. On refresh, the client reconstructs the active run from the server rows without persisting the optimistic message to IndexedDB. No schema migration, replacement retry lookup, additional locking, or second client data source is required.

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "restores an appended queued-message claim after refresh"`
- API BDD coverage is delegated to the PR pipeline because local PostgreSQL is not running

Fixes #21832