### PR TITLE
fix(chat): append insufficient-credit replacements

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -303,19 +303,28 @@ describe("CHAT-02 chat messages and visible validation", () => {
     });
 
     const messages = await api.listThreadMessages(actor, threadId);
-    expect(messages.messages).toHaveLength(2);
+    expect(messages.messages).toHaveLength(3);
 
+    const queuedMessage = messages.messages.find((message) => {
+      return message.id === clientMessageId;
+    });
     const userMessage = messages.messages.find((message) => {
-      return message.role === "user";
+      return message.revokesMessageId === clientMessageId;
     });
     const assistantMessage = messages.messages.find((message) => {
       return message.role === "assistant";
     });
 
+    expect(queuedMessage).toMatchObject({
+      role: "user",
+      content: "Build a launch-plan presentation",
+    });
+    expect(queuedMessage?.error).toBeUndefined();
     expect(userMessage).toMatchObject({
       role: "user",
       content: "Build a launch-plan presentation",
       error: "insufficient_credits",
+      revokesMessageId: clientMessageId,
       attachFiles: [
         {
           id: uploadId,
@@ -345,7 +354,7 @@ describe("CHAT-02 chat messages and visible validation", () => {
     });
 
     const afterRetry = await api.listThreadMessages(actor, threadId);
-    expect(afterRetry.messages).toHaveLength(2);
+    expect(afterRetry.messages).toHaveLength(3);
 
     const secondThread = await api.createThread(actor, {
       agentId: agent.agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1457,16 +1457,52 @@ describe("CHAT-02: admission without spendable credits", () => {
     expect(sent.body.runId).toBeNull();
 
     const messages = await chat.listThreadMessages(actor, sent.body.threadId);
-    const blockedUser = userMessages(messages.messages)[0];
+    const blockedUsers = userMessages(messages.messages);
+    expect(blockedUsers).toHaveLength(2);
+    const queuedUser = blockedUsers.find((message) => {
+      return message.id === clientMessageId;
+    });
+    if (!queuedUser) {
+      throw new Error("Expected the original queued user message");
+    }
+    expect(queuedUser).toMatchObject({
+      content: "blocked by suspended plan",
+      runId: undefined,
+    });
+    expect(queuedUser.error).toBeUndefined();
+    const blockedUser = blockedUsers.find((message) => {
+      return message.revokesMessageId === clientMessageId;
+    });
+    if (!blockedUser) {
+      throw new Error("Expected an insufficient-credits replacement message");
+    }
     expect(blockedUser).toMatchObject({
-      id: clientMessageId,
       content: "blocked by suspended plan",
       error: "insufficient_credits",
+      revokesMessageId: clientMessageId,
     });
-    expect(blockedUser?.runId).toBeUndefined();
+    expect(blockedUser.runId).toBeUndefined();
     const guidance = assistantMessages(messages.messages)[0];
-    expect(guidance?.content).toContain("Upgrade to Pro");
-    expect(guidance?.error).toBe("insufficient_credits");
+    if (!guidance) {
+      throw new Error("Expected insufficient-credits assistant guidance");
+    }
+    expect(guidance.content).toContain("Upgrade to Pro");
+    expect(guidance.error).toBe("insufficient_credits");
+
+    const appended = await chat.listThreadMessages(actor, sent.body.threadId, {
+      sinceId: clientMessageId,
+    });
+    expect(appended.messages).toStrictEqual([
+      expect.objectContaining({
+        id: blockedUser.id,
+        revokesMessageId: clientMessageId,
+        error: "insufficient_credits",
+      }),
+      expect.objectContaining({
+        id: guidance.id,
+        error: "insufficient_credits",
+      }),
+    ]);
 
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).toHaveLength(0);
@@ -1479,7 +1515,7 @@ describe("CHAT-02: admission without spendable credits", () => {
     );
     expect(retry.body).toStrictEqual(sent.body);
     const afterRetry = await chat.listThreadMessages(actor, sent.body.threadId);
-    expect(afterRetry.messages).toHaveLength(2);
+    expect(afterRetry.messages).toHaveLength(3);
   }, 60_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1467,8 +1467,8 @@ describe("CHAT-02: admission without spendable credits", () => {
     }
     expect(queuedUser).toMatchObject({
       content: "blocked by suspended plan",
-      runId: undefined,
     });
+    expect(queuedUser.runId).toBeUndefined();
     expect(queuedUser.error).toBeUndefined();
     const blockedUser = blockedUsers.find((message) => {
       return message.revokesMessageId === clientMessageId;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1345,17 +1345,43 @@ describe("CHAT-01 chat thread read state", () => {
       }),
     ).toStrictEqual([
       ["user", "cursor round one"],
+      ["user", "cursor round one"],
       ["assistant", expect.stringContaining("Insufficient credits")],
+      ["user", "cursor round two"],
       ["user", "cursor round two"],
       ["assistant", expect.stringContaining("Insufficient credits")],
     ]);
     const ids = full.messages.map((message) => {
       return message.id;
     });
-    const [firstUser, firstAssistant, secondUser, secondAssistant] = ids;
-    if (!firstUser || !firstAssistant || !secondUser || !secondAssistant) {
-      throw new Error("Expected four messages across the two sends");
+    const [
+      firstQueuedUser,
+      firstReplacement,
+      firstAssistant,
+      secondQueuedUser,
+      secondReplacement,
+      secondAssistant,
+    ] = ids;
+    if (
+      !firstQueuedUser ||
+      !firstReplacement ||
+      !firstAssistant ||
+      !secondQueuedUser ||
+      !secondReplacement ||
+      !secondAssistant
+    ) {
+      throw new Error("Expected six messages across the two sends");
     }
+    expect(full.messages[0]?.error).toBeUndefined();
+    expect(full.messages[1]).toMatchObject({
+      error: "insufficient_credits",
+      revokesMessageId: firstQueuedUser,
+    });
+    expect(full.messages[3]?.error).toBeUndefined();
+    expect(full.messages[4]).toMatchObject({
+      error: "insufficient_credits",
+      revokesMessageId: secondQueuedUser,
+    });
 
     // Latest page overflow: only the newest rows, with history behind them.
     const latest = await chat.listThreadMessages(owner, threadId, {
@@ -1365,7 +1391,7 @@ describe("CHAT-01 chat thread read state", () => {
       latest.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([secondUser, secondAssistant]);
+    ).toStrictEqual([secondReplacement, secondAssistant]);
     expect(latest.hasHistoryBefore).toBeTruthy();
 
     // Forward pagination strictly after the cursor.
@@ -1376,18 +1402,18 @@ describe("CHAT-01 chat thread read state", () => {
       since.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([secondUser, secondAssistant]);
+    ).toStrictEqual([secondQueuedUser, secondReplacement, secondAssistant]);
 
     // Backward pagination strictly before the cursor.
     const before = await chat.listThreadMessages(owner, threadId, {
-      beforeId: secondUser,
-      limit: 2,
+      beforeId: secondQueuedUser,
+      limit: 3,
     });
     expect(
       before.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([firstUser, firstAssistant]);
+    ).toStrictEqual([firstQueuedUser, firstReplacement, firstAssistant]);
     expect(before.hasHistoryBefore).toBeFalsy();
 
     const beforeOverflow = await chat.listThreadMessages(owner, threadId, {
@@ -1398,7 +1424,7 @@ describe("CHAT-01 chat thread read state", () => {
       beforeOverflow.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([firstAssistant, secondUser]);
+    ).toStrictEqual([secondQueuedUser, secondReplacement]);
     expect(beforeOverflow.hasHistoryBefore).toBeTruthy();
   }, 30_000);
 });
@@ -2297,10 +2323,32 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
     const ids = page.messages.map((message) => {
       return message.id;
     });
-    const [m1, m2, m3, m4] = ids;
-    if (!m1 || !m2 || !m3 || !m4) {
-      throw new Error("Expected four seeded thread messages");
+    const [
+      firstQueuedUser,
+      firstReplacement,
+      firstAssistant,
+      secondQueuedUser,
+      secondReplacement,
+      secondAssistant,
+    ] = ids;
+    if (
+      !firstQueuedUser ||
+      !firstReplacement ||
+      !firstAssistant ||
+      !secondQueuedUser ||
+      !secondReplacement ||
+      !secondAssistant
+    ) {
+      throw new Error("Expected six seeded thread messages");
     }
+    expect(page.messages[1]).toMatchObject({
+      error: "insufficient_credits",
+      revokesMessageId: firstQueuedUser,
+    });
+    expect(page.messages[4]).toMatchObject({
+      error: "insufficient_credits",
+      revokesMessageId: secondQueuedUser,
+    });
 
     // Path validation runs before auth.
     const app = createApp({ signal: context.signal });
@@ -2434,7 +2482,14 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       chronological.body.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([m1, m2, m3, m4]);
+    ).toStrictEqual([
+      firstQueuedUser,
+      firstReplacement,
+      firstAssistant,
+      secondQueuedUser,
+      secondReplacement,
+      secondAssistant,
+    ]);
     expect(chronological.body.messages[0]).toMatchObject({
       role: "user",
       content: "v1 round one",
@@ -2443,7 +2498,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
     const since = await chat.requestV1ThreadMessages(
       bearer,
       threadId,
-      { sinceId: m2 },
+      { sinceId: firstAssistant },
       [200],
     );
     if (since.status !== 200) {
@@ -2453,12 +2508,12 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       since.body.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([m3, m4]);
+    ).toStrictEqual([secondQueuedUser, secondReplacement, secondAssistant]);
 
     const before = await chat.requestV1ThreadMessages(
       bearer,
       threadId,
-      { beforeId: m3, limit: 2 },
+      { beforeId: secondQueuedUser, limit: 3 },
       [200],
     );
     if (before.status !== 200) {
@@ -2468,7 +2523,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       before.body.messages.map((message) => {
         return message.id;
       }),
-    ).toStrictEqual([m1, m2]);
+    ).toStrictEqual([firstQueuedUser, firstReplacement, firstAssistant]);
   }, 60_000);
 
   it("sends v1 chat messages with a personal access token", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -2700,6 +2700,89 @@ async function buildInsufficientCreditsAssistantMessage(params: {
   ].join("\n");
 }
 
+async function appendQueueFirstInsufficientCreditsMessages(params: {
+  readonly prepared: PreparedNormalSend;
+  readonly userId: string;
+  readonly messageId: string;
+  readonly assistantContent: string;
+}): Promise<CreatedChatMessageResponse> {
+  // The queue-first send already persisted the user message. Append an
+  // error-bearing replacement so the original row remains immutable, then
+  // consume its queue item so it can never auto-dispatch.
+  const userCreatedAt = nowDate();
+  const assistantCreatedAt = new Date(userCreatedAt.getTime() + 1);
+  const createdAt = await params.prepared.db.transaction(async (tx) => {
+    const [queuedMessage] = await tx
+      .select({
+        content: chatMessages.content,
+        attachFiles: chatMessages.attachFiles,
+        attachFileMetadata: chatMessages.attachFileMetadata,
+        generationTemplate: chatMessages.generationTemplate,
+        createdAt: chatMessages.createdAt,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.id, params.messageId),
+          eq(chatMessages.chatThreadId, params.prepared.thread.threadId),
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+        ),
+      )
+      .limit(1);
+    if (!queuedMessage) {
+      throw new Error("Queue-first message is no longer available");
+    }
+
+    await deleteUserMessageQueueItem(tx, params.messageId);
+    const [replacement] = await tx
+      .insert(chatMessages)
+      .values({
+        chatThreadId: params.prepared.thread.threadId,
+        role: "user",
+        content: queuedMessage.content,
+        runId: null,
+        revokesMessageId: params.messageId,
+        error: INSUFFICIENT_CREDITS_MARKER,
+        sequenceNumber: 0,
+        createdAt: userCreatedAt,
+        attachFiles: queuedMessage.attachFiles
+          ? [...queuedMessage.attachFiles]
+          : null,
+        attachFileMetadata: queuedMessage.attachFileMetadata
+          ? [...queuedMessage.attachFileMetadata]
+          : null,
+        generationTemplate: queuedMessage.generationTemplate,
+      })
+      .onConflictDoNothing({ target: chatMessages.revokesMessageId })
+      .returning({ id: chatMessages.id });
+    if (replacement) {
+      await tx.insert(chatMessages).values({
+        chatThreadId: params.prepared.thread.threadId,
+        role: "assistant",
+        content: params.assistantContent,
+        error: INSUFFICIENT_CREDITS_MARKER,
+        sequenceNumber: 1,
+        createdAt: assistantCreatedAt,
+        runId: null,
+      });
+    }
+    return queuedMessage.createdAt;
+  });
+  await publishChatMessageCreated(
+    params.userId,
+    params.prepared.thread.threadId,
+  );
+  return {
+    status: 201,
+    body: {
+      runId: null,
+      threadId: params.prepared.thread.threadId,
+      createdAt: createdAt.toISOString(),
+    },
+  };
+}
+
 async function appendInsufficientCreditsMessages(params: {
   readonly prepared: PreparedNormalSend;
   readonly body: NormalSendBody;
@@ -2712,44 +2795,16 @@ async function appendInsufficientCreditsMessages(params: {
     db: params.prepared.db,
     orgId: params.orgId,
   });
+  if (params.queueFirstMessageId) {
+    return appendQueueFirstInsufficientCreditsMessages({
+      prepared: params.prepared,
+      userId: params.userId,
+      messageId: params.queueFirstMessageId,
+      assistantContent,
+    });
+  }
   const userCreatedAt = nowDate();
   const assistantCreatedAt = new Date(userCreatedAt.getTime() + 1);
-  if (params.queueFirstMessageId) {
-    // The queue-first send already persisted the user message. Mark it with
-    // the credits error (so it never auto-dispatches) and consume its queue
-    // item instead of inserting a copy.
-    const messageId = params.queueFirstMessageId;
-    const createdAt = await params.prepared.db.transaction(async (tx) => {
-      await deleteUserMessageQueueItem(tx, messageId);
-      const [marked] = await tx
-        .update(chatMessages)
-        .set({ error: INSUFFICIENT_CREDITS_MARKER, sequenceNumber: 0 })
-        .where(and(eq(chatMessages.id, messageId), isNull(chatMessages.runId)))
-        .returning({ createdAt: chatMessages.createdAt });
-      await tx.insert(chatMessages).values({
-        chatThreadId: params.prepared.thread.threadId,
-        role: "assistant",
-        content: assistantContent,
-        error: INSUFFICIENT_CREDITS_MARKER,
-        sequenceNumber: 1,
-        createdAt: assistantCreatedAt,
-        runId: null,
-      });
-      return marked?.createdAt ?? userCreatedAt;
-    });
-    await publishChatMessageCreated(
-      params.userId,
-      params.prepared.thread.threadId,
-    );
-    return {
-      status: 201,
-      body: {
-        runId: null,
-        threadId: params.prepared.thread.threadId,
-        createdAt: createdAt.toISOString(),
-      },
-    };
-  }
   const result = await params.prepared.db.transaction(async (tx) => {
     await tx
       .update(chatThreads)

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1782,7 +1782,10 @@ function appendRecallUserMessage(params: {
     }
 
     const [target] = await tx
-      .select({ id: chatMessages.id })
+      .select({
+        error: chatMessages.error,
+        revokesMessageId: chatMessages.revokesMessageId,
+      })
       .from(chatMessages)
       .where(
         and(
@@ -1790,11 +1793,14 @@ function appendRecallUserMessage(params: {
           eq(chatMessages.chatThreadId, params.threadId),
           eq(chatMessages.role, "user"),
           isNull(chatMessages.runId),
-          isNull(chatMessages.revokesMessageId),
         ),
       )
       .limit(1);
-    if (!target) {
+    if (
+      !target ||
+      (target.revokesMessageId !== null &&
+        target.error !== INSUFFICIENT_CREDITS_MARKER)
+    ) {
       const [exists] = await tx
         .select({ id: chatMessages.id })
         .from(chatMessages)


### PR DESCRIPTION
## Summary

- keep the original queue-first user message immutable when model admission fails for insufficient credits
- append a complete user replacement linked through `revokesMessageId`, followed by the existing assistant billing guidance
- preserve retry response identity while making the failure transition visible to `sinceId` synchronization

## User impact

Users continue to see one failed user message followed by billing guidance. Cached chat clients now receive that state transition through appended messages instead of depending on an update to an older message row.

## Implementation

- copy the queued message content, attachments, metadata, and generation template into the replacement
- consume the queue item and append both failure messages in one transaction
- use the unique `revokesMessageId` constraint to keep concurrent replacement insertion idempotent

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- attempted the focused BDD scenario; the local run stopped at test setup because PostgreSQL was unavailable (`ECONNREFUSED`), so the PR pipeline will execute the database-backed assertion
