### PR TITLE
fix: emit one complete usage chat message per run

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { cronCompactChatThreadSnapshotsContract } from "@vm0/api-contracts/contracts/cron";
 import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import {
   zeroWorkflowsCollectionContract,
@@ -44,6 +45,15 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import {
+  deleteVm0ManagedDefaultModelKey,
+  seedVm0ManagedDefaultModelKey,
+} from "./helpers/runtime-state";
+import {
+  generatedStripeCustomerId,
+  generatedStripeSubscriptionId,
+  postUsageAllowanceInvoicePaid,
+} from "./helpers/stripe-billing-webhook";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -1533,6 +1543,148 @@ describe("CHAT-03 run usage messages", () => {
     await billing.processUsageEvents();
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(initialUsageMessageCount + 2);
+  }, 60_000);
+
+  it("appends allowance-covered usage revisions without mutating prior messages", async () => {
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const seededModel = await seedVm0ManagedDefaultModelKey(context);
+    const selectedModel = DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+    expect(seededModel).toBe(selectedModel);
+    onTestFinished(async () => {
+      await deleteVm0ManagedDefaultModelKey(context);
+    });
+
+    // Keep runner infrastructure disabled so the chat run reaches a terminal
+    // state during creation and usage messages can be emitted by settlement.
+    const actor = bdd.user();
+    chatCallbacks.acceptChatObjectStorage();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    chatCallbacks.disableVapid();
+    await api.grantProEntitlement(actor);
+    await api.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Allowance usage message agent",
+      visibility: "private",
+    });
+    const agentId = agent.agentId;
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected allowance chat actor to have an org");
+    }
+    await seedOrgMetadata({ orgId, tier: "pro", credits: 10 });
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      orgId,
+      userId: actor.userId,
+      customerId: generatedStripeCustomerId(),
+      subscriptionId: generatedStripeSubscriptionId(),
+      effectiveAt: new Date(now()),
+      expiresAt: new Date(now() + 365 * 24 * 60 * 60 * 1000),
+      shortWindowSeconds: 5 * 60 * 60,
+      shortWindowUnits: 100,
+      weeklyWindowSeconds: 7 * 24 * 60 * 60,
+      weeklyWindowUnits: 100,
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: selectedModel,
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+
+    const provider = `allowance-chat-${randomUUID().slice(0, 8)}`;
+    const category = "api_request";
+    await seedUsagePricingRows([
+      { kind: "connector", provider, category, unitPrice: 1, unitSize: 1 },
+    ]);
+    const { runId, threadId } = await sendChatRun(actor, {
+      agentId,
+      prompt: "record allowance-covered usage",
+      model: selectedModel,
+    });
+    const sandboxHeaders = {
+      authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}`,
+    };
+    const settlementTime = new Date(now());
+    await webhooks.requestAgentUsageEvent(
+      {
+        runId,
+        events: [
+          {
+            idempotencyKey: randomUUID(),
+            kind: "connector",
+            provider,
+            category,
+            quantity: 40,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    mockNow(settlementTime);
+    await createBillingMediaApi(context).processUsageEvents();
+
+    let usageMessages = await usageMessagesForRun(actor, threadId, runId);
+    expect(usageMessages).toHaveLength(1);
+    const initialUsageMessage = usageMessages[0];
+    if (!initialUsageMessage?.usage) {
+      throw new Error("Expected initial allowance usage message");
+    }
+    expect(initialUsageMessage.usage.totalCredits).toBe(40);
+
+    clearMockNow();
+    await webhooks.requestAgentUsageEvent(
+      {
+        runId,
+        events: [
+          {
+            idempotencyKey: randomUUID(),
+            kind: "connector",
+            provider,
+            category,
+            quantity: 30,
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    mockNow(settlementTime);
+    await createBillingMediaApi(context).processUsageEvents();
+
+    usageMessages = await usageMessagesForRun(actor, threadId, runId);
+    expect(usageMessages).toHaveLength(2);
+    expect(
+      usageMessages.find((message) => {
+        return message.id === initialUsageMessage.id;
+      })?.usage?.totalCredits,
+    ).toBe(40);
+    expect(
+      usageMessages.find((message) => {
+        return message.id !== initialUsageMessage.id;
+      })?.usage,
+    ).toMatchObject({
+      totalCredits: 70,
+      settledAt: initialUsageMessage.usage.settledAt,
+    });
+    const billingStatus = await api.readBillingStatus(actor);
+    if (!billingStatus.usageAllowance) {
+      throw new Error("Expected allowance windows for chat usage");
+    }
+    expect(
+      Object.fromEntries(
+        billingStatus.usageAllowance.windows.map((window) => {
+          return [window.kind, window.consumedUnits];
+        }),
+      ),
+    ).toStrictEqual({ short: 70, weekly: 70 });
   }, 60_000);
 
   it("emits zero-credit usage messages and skips runs without usage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -142,23 +142,34 @@ interface EntitledChatActor {
   readonly runnerGroup: string;
 }
 
-async function entitledChatActor(
+type EntitledChatActorWithoutRunner = Omit<EntitledChatActor, "runnerGroup">;
+
+async function entitledChatActorWithoutRunner(
   displayName: string,
-): Promise<EntitledChatActor> {
+): Promise<EntitledChatActorWithoutRunner> {
   const actor = bdd.user();
   chatCallbacks.acceptChatObjectStorage();
   api.acceptStorageDownloads();
   api.acceptTelemetryIngest();
   mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   chatCallbacks.disableVapid();
-  const runnerGroup = api.configureRunnerGroup();
   await api.grantProEntitlement(actor);
   await api.ensureOrgModelProvider(actor);
   const agent = await bdd.createAgent(actor, {
     displayName,
     visibility: "private",
   });
-  return { actor, agentId: agent.agentId, runnerGroup };
+  return { actor, agentId: agent.agentId };
+}
+
+async function entitledChatActor(
+  displayName: string,
+): Promise<EntitledChatActor> {
+  const runnerGroup = api.configureRunnerGroup();
+  return {
+    ...(await entitledChatActorWithoutRunner(displayName)),
+    runnerGroup,
+  };
 }
 
 async function sendChatRun(
@@ -1414,8 +1425,8 @@ describe("CHAT-01 chat thread read state", () => {
 });
 
 describe("CHAT-03 run usage messages", () => {
-  it("appends immutable usage messages as settled usage changes", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor(
+  it("emits one immutable usage message per run", async () => {
+    const { actor, agentId } = await entitledChatActorWithoutRunner(
       "Usage message agent",
     );
     const provider = `bdd-usage-${randomUUID().slice(0, 8)}`;
@@ -1429,7 +1440,9 @@ describe("CHAT-03 run usage messages", () => {
       agentId,
       prompt: "record billable usage",
     });
-    const { sandboxHeaders } = await claimChatRun(runnerGroup, runId);
+    const sandboxHeaders = {
+      authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}`,
+    };
     await webhooks.requestAgentUsageEvent(
       {
         runId,
@@ -1453,13 +1466,16 @@ describe("CHAT-03 run usage messages", () => {
       sandboxHeaders,
       [200],
     );
-
-    await completeChatRunOk(runId, sandboxHeaders);
-    await flushWaitUntilForTest();
+    const billing = createBillingMediaApi(context);
+    await billing.processUsageEvents();
 
     let usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages.length).toBeGreaterThanOrEqual(1);
-    expect(usageMessages.at(-1)).toMatchObject({
+    expect(usageMessages).toHaveLength(1);
+    const usageMessage = usageMessages[0];
+    if (!usageMessage) {
+      throw new Error("Expected one usage message");
+    }
+    expect(usageMessage).toMatchObject({
       role: "assistant",
       content: null,
       usage: {
@@ -1479,15 +1495,11 @@ describe("CHAT-03 run usage messages", () => {
       },
     });
 
-    const initialUsageMessageCount = usageMessages.length;
-    const billing = createBillingMediaApi(context);
-
     onTestFinished(() => {
       clearMockNow();
     });
-    // Sandbox tokens are validated against the mockable clock, so record the
-    // late usage through the webhook first and only advance time for the
-    // settlement cron that charges it and re-emits the usage message.
+    // Sandbox tokens are validated against the mockable clock, so record late
+    // usage before advancing time for settlement.
     await webhooks.requestAgentUsageEvent(
       {
         runId,
@@ -1507,11 +1519,7 @@ describe("CHAT-03 run usage messages", () => {
     mockNow(new Date("2030-01-01T00:00:00.000Z"));
     await billing.processUsageEvents();
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(initialUsageMessageCount + 1);
-    expect(usageMessages.at(-1)?.usage).toMatchObject({
-      totalCredits: 18,
-      settledAt: "2030-01-01T00:00:00.000Z",
-    });
+    expect(usageMessages).toStrictEqual([usageMessage]);
 
     clearMockNow();
     await webhooks.requestAgentUsageEvent(
@@ -1533,22 +1541,10 @@ describe("CHAT-03 run usage messages", () => {
     mockNow(new Date("2030-01-01T00:00:01.000Z"));
     await billing.processUsageEvents();
     usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(initialUsageMessageCount + 2);
-    expect(usageMessages.at(-1)?.usage).toMatchObject({
-      totalCredits: 29,
-      settledAt: "2030-01-01T00:00:01.000Z",
-    });
-    // With no pending usage left the settlement cron has nothing to charge,
-    // so re-running it must not append another usage message.
-    await billing.processUsageEvents();
-    usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(initialUsageMessageCount + 2);
+    expect(usageMessages).toStrictEqual([usageMessage]);
   }, 60_000);
 
-  it("appends allowance-covered usage revisions without mutating prior messages", async () => {
-    onTestFinished(() => {
-      clearMockNow();
-    });
+  it("emits complete allowance-covered usage in one message", async () => {
     const seededModel = await seedVm0ManagedDefaultModelKey(context);
     const selectedModel = DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
     expect(seededModel).toBe(selectedModel);
@@ -1556,21 +1552,9 @@ describe("CHAT-03 run usage messages", () => {
       await deleteVm0ManagedDefaultModelKey(context);
     });
 
-    // Keep runner infrastructure disabled so the chat run reaches a terminal
-    // state during creation and usage messages can be emitted by settlement.
-    const actor = bdd.user();
-    chatCallbacks.acceptChatObjectStorage();
-    api.acceptStorageDownloads();
-    api.acceptTelemetryIngest();
-    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
-    chatCallbacks.disableVapid();
-    await api.grantProEntitlement(actor);
-    await api.ensureOrgModelProvider(actor);
-    const agent = await bdd.createAgent(actor, {
-      displayName: "Allowance usage message agent",
-      visibility: "private",
-    });
-    const agentId = agent.agentId;
+    const { actor, agentId } = await entitledChatActorWithoutRunner(
+      "Allowance usage message agent",
+    );
     const orgId = actor.orgId;
     if (!orgId) {
       throw new Error("Expected allowance chat actor to have an org");
@@ -1611,7 +1595,6 @@ describe("CHAT-03 run usage messages", () => {
     const sandboxHeaders = {
       authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}`,
     };
-    const settlementTime = new Date(now());
     await webhooks.requestAgentUsageEvent(
       {
         runId,
@@ -1621,58 +1604,32 @@ describe("CHAT-03 run usage messages", () => {
             kind: "connector",
             provider,
             category,
-            quantity: 40,
+            quantity: 70,
           },
         ],
       },
       sandboxHeaders,
       [200],
     );
-    mockNow(settlementTime);
     await createBillingMediaApi(context).processUsageEvents();
 
-    let usageMessages = await usageMessagesForRun(actor, threadId, runId);
+    const usageMessages = await usageMessagesForRun(actor, threadId, runId);
     expect(usageMessages).toHaveLength(1);
-    const initialUsageMessage = usageMessages[0];
-    if (!initialUsageMessage?.usage) {
-      throw new Error("Expected initial allowance usage message");
-    }
-    expect(initialUsageMessage.usage.totalCredits).toBe(40);
-
-    clearMockNow();
-    await webhooks.requestAgentUsageEvent(
-      {
-        runId,
-        events: [
+    expect(usageMessages[0]).toMatchObject({
+      role: "assistant",
+      content: null,
+      usage: {
+        version: 1,
+        breakdown: [
           {
-            idempotencyKey: randomUUID(),
             kind: "connector",
-            provider,
-            category,
-            quantity: 30,
+            credits: 70,
+            providers: [{ provider, credits: 70 }],
           },
         ],
+        totalCredits: 70,
+        settledAt: expect.any(String),
       },
-      sandboxHeaders,
-      [200],
-    );
-    mockNow(settlementTime);
-    await createBillingMediaApi(context).processUsageEvents();
-
-    usageMessages = await usageMessagesForRun(actor, threadId, runId);
-    expect(usageMessages).toHaveLength(2);
-    expect(
-      usageMessages.find((message) => {
-        return message.id === initialUsageMessage.id;
-      })?.usage?.totalCredits,
-    ).toBe(40);
-    expect(
-      usageMessages.find((message) => {
-        return message.id !== initialUsageMessage.id;
-      })?.usage,
-    ).toMatchObject({
-      totalCredits: 70,
-      settledAt: initialUsageMessage.usage.settledAt,
     });
     const billingStatus = await api.readBillingStatus(actor);
     if (!billingStatus.usageAllowance) {

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -121,13 +121,6 @@ function usageMessageMatchesPayload(
   );
 }
 
-function isSameUsageSettledAt(
-  message: { readonly createdAt: Date },
-  payload: ChatMessageUsagePayload,
-): boolean {
-  return message.createdAt.getTime() === new Date(payload.settledAt).getTime();
-}
-
 function usageCreditsExpression() {
   return sql`COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)`;
 }
@@ -224,7 +217,6 @@ export const maybeEmitRunUsageMessage$ = command(
 
       const existingUsageMessages = await tx
         .select({
-          id: chatMessages.id,
           createdAt: chatMessages.createdAt,
           usagePayload: chatMessages.usagePayload,
         })
@@ -244,24 +236,20 @@ export const maybeEmitRunUsageMessage$ = command(
         return null;
       }
 
-      const staleSameSettledAtMessage = existingUsageMessages.find(
-        (message) => {
-          return isSameUsageSettledAt(message, payload);
-        },
-      );
-      if (staleSameSettledAtMessage) {
-        await tx
-          .update(chatMessages)
-          .set({ usagePayload: payload })
-          .where(eq(chatMessages.id, staleSameSettledAtMessage.id));
-        signal.throwIfAborted();
+      const [latestThreadMessage] = await tx
+        .select({ createdAt: chatMessages.createdAt })
+        .from(chatMessages)
+        .where(eq(chatMessages.chatThreadId, context.chatThreadId))
+        .orderBy(desc(chatMessages.createdAt))
+        .limit(1);
+      signal.throwIfAborted();
 
-        return {
-          chatThreadId: context.chatThreadId,
-          userId: context.userId,
-          totalCredits: payload.totalCredits,
-        };
-      }
+      // Keep appended revisions after the current thread cursor even when the
+      // business settlement timestamp has not advanced.
+      const createdAtMs = Math.max(
+        new Date(payload.settledAt).getTime(),
+        (latestThreadMessage?.createdAt.getTime() ?? 0) + 1,
+      );
 
       const [inserted] = await tx
         .insert(chatMessages)
@@ -272,7 +260,7 @@ export const maybeEmitRunUsageMessage$ = command(
           runId,
           runGroupId: context.runGroupId,
           usagePayload: payload,
-          createdAt: new Date(payload.settledAt),
+          createdAt: new Date(createdAtMs),
         })
         .returning({ id: chatMessages.id });
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -72,53 +72,6 @@ function buildUsageBreakdown(
     }, 0);
     return { kind, credits, providers };
   });
-}
-
-function usagePayloadKey(payload: ChatMessageUsagePayload): string {
-  return JSON.stringify({
-    version: payload.version,
-    totalCredits: payload.totalCredits,
-    settledAt: payload.settledAt,
-    breakdown: payload.breakdown
-      .map((kind) => {
-        return {
-          kind: kind.kind,
-          credits: kind.credits,
-          providers: [...kind.providers]
-            .sort((a, b) => {
-              return a.provider.localeCompare(b.provider);
-            })
-            .map((provider) => {
-              return {
-                provider: provider.provider,
-                credits: provider.credits,
-              };
-            }),
-        };
-      })
-      .sort((a, b) => {
-        return a.kind.localeCompare(b.kind);
-      }),
-  });
-}
-
-function usagePayloadEquals(
-  left: ChatMessageUsagePayload,
-  right: ChatMessageUsagePayload,
-): boolean {
-  return usagePayloadKey(left) === usagePayloadKey(right);
-}
-
-function usageMessageMatchesPayload(
-  message: {
-    readonly usagePayload: ChatMessageUsagePayload | null;
-  },
-  payload: ChatMessageUsagePayload,
-): boolean {
-  return (
-    message.usagePayload !== null &&
-    usagePayloadEquals(message.usagePayload, payload)
-  );
 }
 
 function usageCreditsExpression() {
@@ -205,6 +158,22 @@ export const maybeEmitRunUsageMessage$ = command(
         return null;
       }
 
+      const [existingUsageMessage] = await tx
+        .select({ id: chatMessages.id })
+        .from(chatMessages)
+        .where(
+          and(
+            eq(chatMessages.runId, runId),
+            sql`${chatMessages.usagePayload} IS NOT NULL`,
+          ),
+        )
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (existingUsageMessage) {
+        return null;
+      }
+
       const breakdownRows = await loadUsageBreakdownRows(tx, runId);
       signal.throwIfAborted();
 
@@ -215,42 +184,6 @@ export const maybeEmitRunUsageMessage$ = command(
         breakdown: buildUsageBreakdown(breakdownRows),
       };
 
-      const existingUsageMessages = await tx
-        .select({
-          createdAt: chatMessages.createdAt,
-          usagePayload: chatMessages.usagePayload,
-        })
-        .from(chatMessages)
-        .where(
-          and(
-            eq(chatMessages.runId, runId),
-            sql`${chatMessages.usagePayload} IS NOT NULL`,
-          ),
-        );
-      signal.throwIfAborted();
-
-      const hasExistingPayload = existingUsageMessages.some((message) => {
-        return usageMessageMatchesPayload(message, payload);
-      });
-      if (hasExistingPayload) {
-        return null;
-      }
-
-      const [latestThreadMessage] = await tx
-        .select({ createdAt: chatMessages.createdAt })
-        .from(chatMessages)
-        .where(eq(chatMessages.chatThreadId, context.chatThreadId))
-        .orderBy(desc(chatMessages.createdAt))
-        .limit(1);
-      signal.throwIfAborted();
-
-      // Keep appended revisions after the current thread cursor even when the
-      // business settlement timestamp has not advanced.
-      const createdAtMs = Math.max(
-        new Date(payload.settledAt).getTime(),
-        (latestThreadMessage?.createdAt.getTime() ?? 0) + 1,
-      );
-
       const [inserted] = await tx
         .insert(chatMessages)
         .values({
@@ -260,7 +193,7 @@ export const maybeEmitRunUsageMessage$ = command(
           runId,
           runGroupId: context.runGroupId,
           usagePayload: payload,
-          createdAt: new Date(createdAtMs),
+          createdAt: new Date(payload.settledAt),
         })
         .returning({ id: chatMessages.id });
       signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- emit at most one usage-only chat message for each run
- calculate the first message from settled gross usage, including allowance allocations
- make every later emission attempt a no-op without updating the existing row or appending a revision

## User impact

Each run has one immutable usage message whose payload already includes allowance-covered credits, preserving append-only chat history without duplicate usage revisions.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/zero-chat-usage-message.service.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api check-types`
- `NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api lint`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'emits one immutable usage message per run'`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'emits complete allowance-covered usage in one message'`
