### PR TITLE
feat(api): drive connector credentials from runtime catalog

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -881,7 +881,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("rejects completion after the AWS connector switch is disabled", async () => {
+  it("completes after the AWS connector switch is disabled", async () => {
     const provider = mockAwsExternalCodeProvider();
     const actor = await awsActor();
 
@@ -890,21 +890,13 @@ describe("CONN-02: external-code session lifecycle", () => {
       [FeatureSwitchKey.AwsConnector]: false,
     });
 
-    const disabled = await connectorsApi.requestExternalCodeComplete(
-      actor,
-      "aws",
-      {
-        sessionId: session.sessionId,
-        sessionToken: session.sessionToken,
-        code: awsVerificationCode(session.authorizationUrl),
-      },
-      [403],
-    );
-    expectApiError(disabled.body);
-    expect(disabled.body.error.message).toBe(
-      "External-code authorization is not enabled for this connector",
-    );
-    expect(provider.tokenRequests).toStrictEqual([]);
+    const completed = await connectorsApi.completeExternalCode(actor, "aws", {
+      sessionId: session.sessionId,
+      sessionToken: session.sessionToken,
+      code: awsVerificationCode(session.authorizationUrl),
+    });
+    expect(completed.status).toBe("complete");
+    expect(provider.tokenRequests).toHaveLength(1);
   });
 
   it("keeps an in-flight completion exclusive without superseding it", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -409,7 +409,7 @@ describe("CONN-02: OAuth start and callback", () => {
     expectNoVisibleSecret(connected, "bdd-datadog-refresh-token");
   });
 
-  it("rejects OAuth start requests that target unsupported or unavailable auth methods", async () => {
+  it("rejects OAuth start requests that target unsupported auth methods", async () => {
     mockGitHubConnectorOAuth();
 
     const bdd = createBddApi(context);
@@ -594,7 +594,7 @@ describe("CONN-02: OAuth device authorization", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("rejects device-auth starts through visible validation, grant, and availability boundaries", async () => {
+  it("validates device-auth identity, grant, options, and session boundaries without using rollout as authorization", async () => {
     const testOauthProvider = mockTestOAuthDeviceConnectorProvider();
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -709,19 +709,18 @@ describe("CONN-02: OAuth device authorization", () => {
       "stripe cli device-auth start option mode must be one of: test, live",
     );
 
-    const disabled = await connectorsApi.requestDeviceAuthStart(
+    const switchlessStart = await connectorsApi.requestDeviceAuthStart(
       switchlessActor,
       "test-oauth-device",
       "oauth",
       undefined,
-      [403],
+      [200],
     );
-    expectApiError(disabled.body);
-    expect(disabled.body.error.message).toBe(
-      "OAuth device authorization is not enabled for this connector",
-    );
-
-    expect(testOauthProvider.deviceCodeBodies).toStrictEqual([]);
+    expect(switchlessStart.body).toMatchObject({
+      type: "test-oauth-device",
+      status: "pending",
+    });
+    expect(testOauthProvider.deviceCodeBodies).toHaveLength(1);
 
     const missingSession = await connectorsApi.requestDeviceAuthPoll(
       actor,
@@ -1301,7 +1300,7 @@ describe("CONN-02: OAuth device authorization", () => {
     });
   });
 
-  it("rejects polls after the connector auth method becomes unavailable", async () => {
+  it("continues polls after the connector feature switch is disabled", async () => {
     mockTestOAuthDeviceConnectorProvider({ deviceCode: "pending" });
 
     const bdd = createBddApi(context);
@@ -1320,22 +1319,22 @@ describe("CONN-02: OAuth device authorization", () => {
       [FeatureSwitchKey.TestOauthConnector]: false,
     });
 
-    const disabledPoll = await connectorsApi.requestDeviceAuthPoll(
+    const continuedPoll = await connectorsApi.requestDeviceAuthPoll(
       actor,
       "test-oauth-device",
       session.sessionId,
       session.sessionToken,
-      [403],
+      [200],
     );
-    expectApiError(disabledPoll.body);
-    expect(disabledPoll.body.error.message).toBe(
-      "OAuth device authorization is not enabled for this connector",
-    );
+    expect(continuedPoll.body).toStrictEqual({
+      status: "pending",
+      interval: 0,
+    });
   });
 });
 
 describe("CONN-02: external-code authorization", () => {
-  it("rejects external-code sessions through visible auth, grant, switch, and session boundaries", async () => {
+  it("validates external-code auth, grant, and session boundaries without using rollout as authorization", async () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();
     const missingSessionId = randomUUID();
@@ -1360,16 +1359,16 @@ describe("CONN-02: external-code authorization", () => {
       "openai api-token auth method does not use an external-code grant",
     );
 
-    const disabled = await connectorsApi.requestExternalCodeStart(
+    const switchlessStart = await connectorsApi.requestExternalCodeStart(
       actor,
       "aws",
       "cli",
-      [403],
+      [200],
     );
-    expectApiError(disabled.body);
-    expect(disabled.body.error.message).toBe(
-      "External-code authorization is not enabled for this connector",
-    );
+    expect(switchlessStart.body).toMatchObject({
+      type: "aws",
+      status: "pending",
+    });
 
     const invalidCompleteBody = await connectorsApi.requestExternalCodeComplete(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -39,7 +39,7 @@ import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise, settle } from "../../utils";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { assertPublicConnectorCatalogHasNoPrivateFields } from "./helpers/connector-catalog-public-leak";
-import { createBddApi } from "./helpers/api-bdd";
+import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import {
   awsVerificationCode,
   createConnectorBddApi,
@@ -2190,6 +2190,41 @@ describe("connector catalog valid lifecycle", () => {
       ]),
     );
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("rejects new auth-code actions for an authored-hidden external method", async () => {
+    configureSource();
+    const hidden = publicAuthMethod({
+      id: "oauth",
+      grantKind: "auth-code",
+    });
+    hidden.visible = false;
+    const release = buildRelease({
+      version: "2026-07-15.external-hidden-auth-code",
+      connectorRef: "slack",
+      label: "Catalog Slack",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [hidden]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [slackPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const response = await connectorsApi.requestOauthStart(
+      bdd.user(),
+      "slack",
+      "oauth",
+      { statuses: [403] },
+    );
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      message: "slack connector is not available",
+      code: "FORBIDDEN",
+    });
   });
 
   it("revokes an external auth-code credential through its selected method", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2193,6 +2193,8 @@ describe("connector catalog valid lifecycle", () => {
   });
 
   it("rejects new auth-code actions for an authored-hidden external method", async () => {
+    mockOptionalEnv("SLACK_OAUTH_CLIENT_ID", undefined);
+    mockOptionalEnv("SLACK_OAUTH_CLIENT_SECRET", undefined);
     configureSource();
     const hidden = publicAuthMethod({
       id: "oauth",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -48,6 +48,7 @@ import {
   mockGmailConnectorOAuth,
   mockSlackConnectorOAuth,
   mockTestOAuthDeviceConnectorProvider,
+  requestOauthCallbackRaw,
 } from "./helpers/api-bdd-connectors";
 import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
@@ -531,6 +532,76 @@ function gmailPrivateAuthMethod(): JsonRecord {
         refreshToken: `$secrets.${refreshTokenName}`,
       },
       refreshableSecrets: [accessTokenName],
+    },
+    revoke: { kind: "none" },
+  };
+}
+
+function cloudflarePrivateAuthMethod(): JsonRecord {
+  const accessTokenName = "CATALOG_CLOUDFLARE_ACCESS_TOKEN";
+  const refreshTokenName = "CATALOG_CLOUDFLARE_REFRESH_TOKEN";
+  return {
+    id: "oauth",
+    client: {
+      clientRegistration: "static",
+      clientType: "confidential",
+      clientIdEnv: "CLOUDFLARE_OAUTH_CLIENT_ID",
+      clientSecretEnv: "CLOUDFLARE_OAUTH_CLIENT_SECRET",
+    },
+    storage: {
+      secrets: [accessTokenName, refreshTokenName],
+      variables: [],
+    },
+    grant: {
+      kind: "auth-code",
+      scopes: [],
+      callbackOrigin: "api",
+      outputs: {
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      envBindings: {
+        CLOUDFLARE_TOKEN: `$secrets.${accessTokenName}`,
+      },
+      inputs: {
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+      outputs: {
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+      refreshableSecrets: [accessTokenName],
+    },
+    revoke: {
+      kind: "token-revoke",
+      inputs: { refreshToken: `$secrets.${refreshTokenName}` },
+    },
+  };
+}
+
+function unsupportedWebAuthCodePrivateAuthMethod(): JsonRecord {
+  const accessTokenName = "FUTURE_WEB_ACCESS_TOKEN";
+  return {
+    id: "future-web",
+    client: {
+      clientRegistration: "static",
+      clientType: "confidential",
+      clientIdEnv: "CLOUDFLARE_OAUTH_CLIENT_ID",
+      clientSecretEnv: "CLOUDFLARE_OAUTH_CLIENT_SECRET",
+    },
+    storage: { secrets: [accessTokenName], variables: [] },
+    grant: {
+      kind: "auth-code",
+      scopes: [],
+      callbackOrigin: "web",
+      outputs: { accessToken: `$secrets.${accessTokenName}` },
+    },
+    access: {
+      kind: "static",
+      envBindings: { FUTURE_WEB_TOKEN: `$secrets.${accessTokenName}` },
     },
     revoke: { kind: "none" },
   };
@@ -2333,6 +2404,198 @@ describe("connector catalog valid lifecycle", () => {
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeReadiness);
   });
 
+  it("does not persist an in-flight refresh after the connector is replaced", async () => {
+    mockGmailConnectorOAuth({ email: "refresh-race@example.test" });
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-refresh-replacement",
+      connectorRef: "gmail",
+      label: "Catalog Gmail",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [gmailPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    mockOptionalEnv(
+      "GMAIL_PUBSUB_TOPIC_NAME",
+      "projects/vm0-ai-488909/topics/gmail-events",
+    );
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: JSON.stringify({ connectors: [] }) },
+            },
+          ],
+        });
+      }),
+    );
+
+    const actor = bdd.user({ orgId: STAFF_ORG_ID });
+    const created: { agentId?: string; workflowId?: string } = {};
+    const refreshResume = deferredGate();
+    onTestFinished(async () => {
+      refreshResume.release();
+      context.mocks.s3.send.mockResolvedValue({ Contents: [] });
+      await connectorsApi.deleteConnectorByType(actor, "gmail", [204, 404]);
+      if (created.workflowId) {
+        await miscApi.deleteWorkflow(actor, created.workflowId, [204, 404]);
+      }
+      if (created.agentId) {
+        await bdd.deleteAgent(actor, created.agentId);
+      }
+      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+    });
+    await upsertOrgPlanEntitlementFixture({
+      orgId: STAFF_ORG_ID,
+      status: "active",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+    const initialOauth = await connectorsApi.startOauth(
+      actor,
+      "gmail",
+      "oauth",
+    );
+    const initialState = new URL(
+      initialOauth.authorizationUrl,
+    ).searchParams.get("state");
+    if (!initialState) {
+      throw new Error("Expected initial Gmail authorization state");
+    }
+    await connectorsApi.completeOauthCallback("gmail", {
+      code: "initial",
+      state: initialState,
+    });
+
+    mockNow(new Date("2026-07-15T10:00:00.000Z"));
+    bdd.acceptAgentStorageWrites();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Refresh replacement agent",
+      visibility: "private",
+    });
+    created.agentId = agent.agentId;
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const headers = { authorization: "Bearer clerk-session" };
+    const workflow = await accept(
+      setupApp({ context })(zeroWorkflowsCollectionContract).create({
+        headers,
+        body: {
+          agentId: agent.agentId,
+          name: `refresh-replacement-${randomUUID().slice(0, 8)}`,
+          instruction: "Handle incoming Gmail messages.",
+        },
+      }),
+      [201],
+    );
+    created.workflowId = workflow.body.id;
+
+    const refreshEntered = deferredGate();
+    const watchAuthorizations: string[] = [];
+    server.use(
+      http.post(GOOGLE_OAUTH_TOKEN_URL, async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        if (body.get("grant_type") === "refresh_token") {
+          refreshEntered.release();
+          await refreshResume.promise;
+          return HttpResponse.json({
+            access_token: "stale-refreshed-gmail-token",
+            refresh_token: "stale-rotated-gmail-refresh-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "https://www.googleapis.com/auth/gmail.modify",
+          });
+        }
+        return HttpResponse.json({
+          access_token: "replacement-gmail-token",
+          refresh_token: "replacement-gmail-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        });
+      }),
+      http.post(
+        "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+        ({ request }) => {
+          watchAuthorizations.push(request.headers.get("authorization") ?? "");
+          return HttpResponse.json({
+            historyId: "100",
+            expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
+          });
+        },
+      ),
+    );
+
+    const firstCreate = accept(
+      setupApp({ context })(zeroWorkflowAutomationsContract).create({
+        headers,
+        params: { workflowId: workflow.body.id },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: { provider: "gmail", event: "new_message" },
+        },
+      }),
+      [400],
+    );
+    await refreshEntered.promise;
+
+    const replacementOauth = await connectorsApi.startOauth(
+      actor,
+      "gmail",
+      "oauth",
+    );
+    const replacementState = new URL(
+      replacementOauth.authorizationUrl,
+    ).searchParams.get("state");
+    if (!replacementState) {
+      throw new Error("Expected replacement Gmail authorization state");
+    }
+    await connectorsApi.completeOauthCallback("gmail", {
+      code: "replacement",
+      state: replacementState,
+    });
+    refreshResume.release();
+
+    const rejected = await firstCreate;
+    expect(rejected.body.error.message).toBe(
+      "Reconnect Gmail before using Gmail event automations",
+    );
+    await expect(
+      connectorsApi.readConnectorByType(actor, "gmail"),
+    ).resolves.toMatchObject({
+      connectionStatus: "connected",
+      reconnectReason: null,
+    });
+
+    await accept(
+      setupApp({ context })(zeroWorkflowAutomationsContract).create({
+        headers,
+        params: { workflowId: workflow.body.id },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: { provider: "gmail", event: "new_message" },
+        },
+      }),
+      [201],
+    );
+    expect(watchAuthorizations).toStrictEqual([
+      "Bearer replacement-gmail-token",
+    ]);
+  });
+
   it("derives connected scope and refresh status from the accepted release", async () => {
     mockDatadogConnectorOAuth();
     configureSource();
@@ -2862,6 +3125,57 @@ describe("connector catalog executable compatibility", () => {
     expect(
       (await syncCatalog()).body.filtering.filteredAuthMethods,
     ).toHaveLength(3);
+  });
+
+  it("ignores filtered sibling methods when choosing the callback origin", async () => {
+    configureSource();
+    mockEnv("VM0_WEB_URL", "https://app.vm0.test");
+    mockOptionalEnv("CLOUDFLARE_OAUTH_CLIENT_ID", "cloudflare-client-id");
+    mockOptionalEnv(
+      "CLOUDFLARE_OAUTH_CLIENT_SECRET",
+      "cloudflare-client-secret",
+    );
+    const release = buildRelease({
+      version: "2026-07-15.filtered-callback-origin",
+      connectorRef: "cloudflare",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+          publicAuthMethod({ id: "future-web", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          cloudflarePrivateAuthMethod(),
+          unsupportedWebAuthCodePrivateAuthMethod(),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect(
+      (await syncCatalog()).body.filtering.filteredAuthMethods,
+    ).toStrictEqual([
+      {
+        connectorRef: "cloudflare",
+        authMethodId: "future-web",
+        reasons: ["missing-grant-provider", "provider-contract-mismatch"],
+      },
+    ]);
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const response = await requestOauthCallbackRaw(context, {
+      origin: "https://api.vm0.ai",
+      type: "cloudflare",
+      query: { code: "missing-state" },
+    });
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location") ?? "");
+    expect(location.origin).toBe("https://app.vm0.test");
+    expect(location.pathname).toBe("/connector/error");
+    expect(location.searchParams.get("message")).toBe(
+      "Missing state parameter",
+    );
   });
 
   it("rejects unapproved configuration identities without reading them", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1,7 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { cronConnectorCatalogContract } from "@vm0/api-contracts/contracts/cron";
-import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
+import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
+import { zeroSteamPlayerContract } from "@vm0/api-contracts/contracts/zero-steam-player";
+import {
+  zeroConnectorOpenIdStartContract,
+  zeroConnectorsSearchContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import {
@@ -35,11 +41,17 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { assertPublicConnectorCatalogHasNoPrivateFields } from "./helpers/connector-catalog-public-leak";
 import { createBddApi } from "./helpers/api-bdd";
 import {
+  awsVerificationCode,
   createConnectorBddApi,
+  mockAwsExternalCodeProvider,
   mockDatadogConnectorOAuth,
   mockGmailConnectorOAuth,
+  mockSlackConnectorOAuth,
+  mockTestOAuthDeviceConnectorProvider,
 } from "./helpers/api-bdd-connectors";
+import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
+import { createRunsApi } from "./helpers/api-bdd-runs";
 
 const context = testContext();
 const zeroMocks = createZeroRouteMocks(context);
@@ -52,7 +64,11 @@ const FIRST_SYNC_TIME = "2026-07-15T08:00:00.000Z";
 const PRIVATE_VALUE = "SECRET_TOKEN";
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
+const SLACK_REVOKE_URL = "https://slack.com/api/auth.revoke";
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+const STEAM_TEST_ID = "76561198000000000";
 
 type JsonRecord = Record<string, unknown>;
 type JsonMutation = (value: JsonRecord) => void;
@@ -311,24 +327,31 @@ function manualPrivateAuthMethod(args: {
   };
 }
 
-function devicePrivateAuthMethod(): JsonRecord {
+function devicePrivateAuthMethod(args?: {
+  readonly accessTokenName?: string;
+  readonly clientId?: string;
+  readonly scopes?: readonly string[];
+}): JsonRecord {
+  const accessTokenName = args?.accessTokenName ?? "DEVICE_ACCESS_TOKEN";
   return {
     id: "oauth",
     client: {
       clientRegistration: "static",
       clientType: "public",
-      clientId: "external-device-client",
+      clientId: args?.clientId ?? "external-device-client",
     },
-    storage: { secrets: ["DEVICE_ACCESS_TOKEN"], variables: [] },
+    storage: { secrets: [accessTokenName], variables: [] },
     grant: {
       kind: "device-auth",
-      scopes: [],
-      outputs: { accessToken: "$secrets.DEVICE_ACCESS_TOKEN" },
+      scopes: [...(args?.scopes ?? [])],
+      outputs: { accessToken: `$secrets.${accessTokenName}` },
       startOptionMappings: [],
     },
     access: {
       kind: "static",
-      envBindings: { SERVICE_TOKEN: "$secrets.DEVICE_ACCESS_TOKEN" },
+      envBindings: {
+        TEST_OAUTH_DEVICE_TOKEN: `$secrets.${accessTokenName}`,
+      },
     },
     revoke: { kind: "none" },
   };
@@ -337,22 +360,92 @@ function devicePrivateAuthMethod(): JsonRecord {
 function steamPrivateAuthMethod(args?: {
   readonly callbackOrigin?: "web" | "api";
   readonly platformSecret?: string;
+  readonly steamIdName?: string;
 }): JsonRecord {
   const platformSecret = args?.platformSecret ?? "STEAM_WEB_API_KEY";
+  const steamIdName = args?.steamIdName ?? "STEAM_ID";
   return {
     id: "openid",
-    storage: { secrets: [], variables: ["STEAM_ID"] },
+    storage: { secrets: [], variables: [steamIdName] },
     grant: {
       kind: "openid-auth",
       callbackOrigin: args?.callbackOrigin ?? "api",
-      outputs: { steamId: "$vars.STEAM_ID" },
+      outputs: { steamId: `$vars.${steamIdName}` },
     },
     access: {
       kind: "static",
       platformSecrets: [platformSecret],
       envBindings: {
-        STEAM_ID: "$vars.STEAM_ID",
+        STEAM_ID: `$vars.${steamIdName}`,
         STEAM_WEB_API_KEY: `$secrets.${platformSecret}`,
+      },
+    },
+    revoke: { kind: "none" },
+  };
+}
+
+function awsPrivateAuthMethod(): JsonRecord {
+  const refreshTokenName = "CATALOG_AWS_LOGIN_REFRESH_TOKEN";
+  const dpopKeyName = "CATALOG_AWS_LOGIN_DPOP_KEY";
+  const accessKeyIdName = "CATALOG_AWS_ACCESS_KEY_ID";
+  const secretAccessKeyName = "CATALOG_AWS_SECRET_ACCESS_KEY";
+  const sessionTokenName = "CATALOG_AWS_SESSION_TOKEN";
+  const signinRegionName = "CATALOG_AWS_SIGNIN_REGION";
+  const runtimeRegionName = "CATALOG_AWS_REGION";
+  return {
+    id: "cli",
+    client: {
+      clientRegistration: "static",
+      clientType: "public",
+      clientId: "arn:aws:signin:::devtools/cross-device",
+    },
+    storage: {
+      secrets: [
+        refreshTokenName,
+        dpopKeyName,
+        accessKeyIdName,
+        secretAccessKeyName,
+        sessionTokenName,
+      ],
+      variables: [signinRegionName, runtimeRegionName],
+    },
+    grant: {
+      kind: "external-code",
+      scopes: ["openid"],
+      outputs: {
+        refreshToken: `$secrets.${refreshTokenName}`,
+        dpopKey: `$secrets.${dpopKeyName}`,
+        accessKeyId: `$secrets.${accessKeyIdName}`,
+        secretAccessKey: `$secrets.${secretAccessKeyName}`,
+        sessionToken: `$secrets.${sessionTokenName}`,
+        signinRegion: `$vars.${signinRegionName}`,
+        runtimeRegion: `$vars.${runtimeRegionName}`,
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      inputs: {
+        refreshToken: `$secrets.${refreshTokenName}`,
+        dpopKey: `$secrets.${dpopKeyName}`,
+        signinRegion: `$vars.${signinRegionName}`,
+      },
+      outputs: {
+        refreshToken: `$secrets.${refreshTokenName}`,
+        accessKeyId: `$secrets.${accessKeyIdName}`,
+        secretAccessKey: `$secrets.${secretAccessKeyName}`,
+        sessionToken: `$secrets.${sessionTokenName}`,
+      },
+      refreshableSecrets: [
+        accessKeyIdName,
+        secretAccessKeyName,
+        sessionTokenName,
+      ],
+      envBindings: {
+        AWS_ACCESS_KEY_ID: `$secrets.${accessKeyIdName}`,
+        AWS_SECRET_ACCESS_KEY: `$secrets.${secretAccessKeyName}`,
+        AWS_SESSION_TOKEN: `$secrets.${sessionTokenName}`,
+        AWS_REGION: `$vars.${runtimeRegionName}`,
+        AWS_DEFAULT_REGION: `$vars.${runtimeRegionName}`,
       },
     },
     revoke: { kind: "none" },
@@ -401,7 +494,81 @@ function deelPrivateAuthMethod(): JsonRecord {
   };
 }
 
+function gmailPrivateAuthMethod(): JsonRecord {
+  const accessTokenName = "CATALOG_GMAIL_ACCESS_TOKEN";
+  const refreshTokenName = "CATALOG_GMAIL_REFRESH_TOKEN";
+  return {
+    id: "oauth",
+    client: {
+      clientRegistration: "static",
+      clientType: "confidential",
+      clientIdEnv: "GOOGLE_OAUTH_CLIENT_ID",
+      clientSecretEnv: "GOOGLE_OAUTH_CLIENT_SECRET",
+    },
+    storage: {
+      secrets: [accessTokenName, refreshTokenName],
+      variables: [],
+    },
+    grant: {
+      kind: "auth-code",
+      scopes: ["https://www.googleapis.com/auth/gmail.modify"],
+      callbackOrigin: "web",
+      outputs: {
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      envBindings: {
+        GMAIL_TOKEN: `$secrets.${accessTokenName}`,
+      },
+      inputs: {
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+      outputs: {
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
+      },
+      refreshableSecrets: [accessTokenName],
+    },
+    revoke: { kind: "none" },
+  };
+}
+
+function slackPrivateAuthMethod(
+  accessTokenName = "CATALOG_SLACK_ACCESS_TOKEN",
+): JsonRecord {
+  return {
+    id: "oauth",
+    client: {
+      clientRegistration: "static",
+      clientType: "confidential",
+      clientIdEnv: "SLACK_OAUTH_CLIENT_ID",
+      clientSecretEnv: "SLACK_OAUTH_CLIENT_SECRET",
+    },
+    storage: { secrets: [accessTokenName], variables: [] },
+    grant: {
+      kind: "auth-code",
+      scopes: ["channels:read", "chat:write"],
+      callbackOrigin: "web",
+      outputs: { accessToken: `$secrets.${accessTokenName}` },
+    },
+    access: {
+      kind: "static",
+      envBindings: { SLACK_TOKEN: `$secrets.${accessTokenName}` },
+    },
+    revoke: {
+      kind: "token-revoke",
+      inputs: { accessToken: `$secrets.${accessTokenName}` },
+    },
+  };
+}
+
 function datadogPrivateAuthMethod(scopes: readonly string[]): JsonRecord {
+  const accessTokenName = "CATALOG_DATADOG_ACCESS_TOKEN";
+  const refreshTokenName = "CATALOG_DATADOG_REFRESH_TOKEN";
+  const domainName = "CATALOG_DATADOG_DOMAIN";
   return {
     id: "oauth",
     client: {
@@ -411,34 +578,34 @@ function datadogPrivateAuthMethod(scopes: readonly string[]): JsonRecord {
       clientSecretEnv: "DATADOG_OAUTH_CLIENT_SECRET",
     },
     storage: {
-      secrets: ["DATADOG_ACCESS_TOKEN", "DATADOG_REFRESH_TOKEN"],
-      variables: ["DATADOG_DOMAIN"],
+      secrets: [accessTokenName, refreshTokenName],
+      variables: [domainName],
     },
     grant: {
       kind: "auth-code",
       scopes: [...scopes],
       callbackOrigin: "web",
       outputs: {
-        accessToken: "$secrets.DATADOG_ACCESS_TOKEN",
-        refreshToken: "$secrets.DATADOG_REFRESH_TOKEN",
-        domain: "$vars.DATADOG_DOMAIN",
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
+        domain: `$vars.${domainName}`,
       },
     },
     access: {
       kind: "refresh-token",
       envBindings: {
-        DATADOG_TOKEN: "$secrets.DATADOG_ACCESS_TOKEN",
-        DATADOG_DOMAIN: "$vars.DATADOG_DOMAIN",
+        DATADOG_TOKEN: `$secrets.${accessTokenName}`,
+        DATADOG_DOMAIN: `$vars.${domainName}`,
       },
       inputs: {
-        refreshToken: "$secrets.DATADOG_REFRESH_TOKEN",
-        domain: "$vars.DATADOG_DOMAIN",
+        refreshToken: `$secrets.${refreshTokenName}`,
+        domain: `$vars.${domainName}`,
       },
       outputs: {
-        accessToken: "$secrets.DATADOG_ACCESS_TOKEN",
-        refreshToken: "$secrets.DATADOG_REFRESH_TOKEN",
+        accessToken: `$secrets.${accessTokenName}`,
+        refreshToken: `$secrets.${refreshTokenName}`,
       },
-      refreshableSecrets: ["DATADOG_ACCESS_TOKEN"],
+      refreshableSecrets: [accessTokenName],
     },
     revoke: { kind: "none" },
   };
@@ -681,6 +848,112 @@ function commandInput(command: unknown): JsonRecord {
     return {};
   }
   return isJsonRecord(command.input) ? command.input : {};
+}
+
+function steamOpenIdCallbackQuery(authorizationUrl: string) {
+  const url = new URL(authorizationUrl);
+  const returnTo = url.searchParams.get("openid.return_to");
+  if (!returnTo) {
+    throw new Error("Steam authorization URL is missing openid.return_to");
+  }
+  const state = new URL(returnTo).searchParams.get("state");
+  if (!state) {
+    throw new Error("Steam return_to is missing state");
+  }
+  const claimedId = `https://steamcommunity.com/openid/id/${STEAM_TEST_ID}`;
+  return {
+    state,
+    "openid.ns": "http://specs.openid.net/auth/2.0",
+    "openid.mode": "id_res",
+    "openid.op_endpoint": "https://steamcommunity.com/openid/login",
+    "openid.claimed_id": claimedId,
+    "openid.identity": claimedId,
+    "openid.return_to": returnTo,
+    "openid.response_nonce": "2026-07-15T08:00:00Znonce",
+    "openid.assoc_handle": "catalog-assoc-handle",
+    "openid.signed":
+      "op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle",
+    "openid.sig": "catalog-signature",
+  };
+}
+
+function mockSteamOpenIdVerification(): void {
+  server.use(
+    http.post(
+      "https://steamcommunity.com/openid/login",
+      async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        expect(body.get("openid.mode")).toBe("check_authentication");
+        return new HttpResponse(
+          ["ns:http://specs.openid.net/auth/2.0", "is_valid:true", ""].join(
+            "\n",
+          ),
+          { headers: { "content-type": "text/plain" } },
+        );
+      },
+    ),
+  );
+}
+
+function mockSteamPlayerApisForCatalog(): void {
+  server.use(
+    http.get(/https:\/\/api\.steampowered\.com\/.*/u, ({ request }) => {
+      const url = new URL(request.url);
+      expect(url.searchParams.get("key")).toBe("catalog-steam-api-key");
+      expect(
+        url.searchParams.get("steamid") ?? url.searchParams.get("steamids"),
+      ).toBe(STEAM_TEST_ID);
+      switch (url.pathname) {
+        case "/ISteamUser/GetPlayerSummaries/v0002/": {
+          return HttpResponse.json({
+            response: {
+              players: [
+                {
+                  steamid: STEAM_TEST_ID,
+                  personaname: "catalog-player",
+                },
+              ],
+            },
+          });
+        }
+        case "/IPlayerService/GetOwnedGames/v0001/": {
+          return HttpResponse.json({
+            response: { game_count: 0, games: [] },
+          });
+        }
+        case "/IPlayerService/GetRecentlyPlayedGames/v0001/": {
+          return HttpResponse.json({
+            response: { total_count: 0, games: [] },
+          });
+        }
+        case "/IPlayerService/GetSteamLevel/v1/": {
+          return HttpResponse.json({ response: { player_level: 1 } });
+        }
+        case "/IPlayerService/GetBadges/v1/": {
+          return HttpResponse.json({ response: { badges: [] } });
+        }
+        case "/IWishlistService/GetWishlist/v1/": {
+          return HttpResponse.json({ response: { items: [] } });
+        }
+        case "/IWishlistService/GetWishlistItemCount/v1/": {
+          return HttpResponse.json({ response: { count: 0 } });
+        }
+        case "/IStoreService/GetGamesFollowed/v1/": {
+          return HttpResponse.json({ response: { appids: [] } });
+        }
+        case "/IStoreService/GetGamesFollowedCount/v1/": {
+          return HttpResponse.json({
+            response: { followed_game_count: 0 },
+          });
+        }
+        default: {
+          return HttpResponse.text("Unexpected Steam API path", {
+            status: 404,
+          });
+        }
+      }
+    }),
+  );
 }
 
 function s3Body(bytes: Uint8Array): AsyncIterable<Uint8Array> {
@@ -1155,22 +1428,747 @@ describe("connector catalog valid lifecycle", () => {
     });
   });
 
+  it("executes an external manual grant with catalog-owned storage", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-manual-grant",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "agora", [204, 404]);
+    });
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const connected = await connectorsApi.connectManualGrant(
+      actor,
+      "agora",
+      "api-token",
+      { credential: "catalog-manual-secret" },
+    );
+    expect(connected).toMatchObject({
+      type: "agora",
+      authMethod: "api-token",
+      connectionStatus: "connected",
+    });
+
+    const listed = await connectorsApi.listConnectors(actor);
+    expect(listed.connectorProvidedBindings).toContainEqual(
+      expect.objectContaining({
+        connectorType: "agora",
+        authMethod: "api-token",
+        namespace: "secrets",
+        name: "SERVICE_TOKEN",
+      }),
+    );
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(secrets.body.secrets).toContainEqual(
+      expect.objectContaining({ name: PRIVATE_VALUE, type: "connector" }),
+    );
+    expect(JSON.stringify(secrets.body)).not.toContain("catalog-manual-secret");
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("replaces and deletes connections with compatibility-filtered auth methods", async () => {
+    configureSource();
+    const legacyMethod = publicAuthMethod({
+      id: "legacy",
+      grantKind: "manual",
+      manual: true,
+    });
+    const currentMethod = publicAuthMethod({
+      id: "current",
+      grantKind: "manual",
+      manual: true,
+    });
+    const initial = buildRelease({
+      version: "2026-07-15.external-legacy-method",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [legacyMethod]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "legacy",
+            prefix: "LEGACY",
+            access: "static",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([initial], initial));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "agora", [204, 404]);
+    });
+    await connectorsApi.connectManualGrant(actor, "agora", "legacy", {
+      credential: "legacy-catalog-secret",
+    });
+
+    const replacement = buildRelease({
+      version: "2026-07-15.external-replacement-method",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [legacyMethod, currentMethod]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "legacy",
+            prefix: "LEGACY",
+            access: "refresh-token",
+            revoke: "none",
+          }),
+          manualPrivateAuthMethod({
+            id: "current",
+            prefix: "CURRENT",
+            access: "static",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([initial, replacement], replacement));
+    const synced = await syncCatalog();
+    expect(synced.body.filtering.filteredAuthMethods).toStrictEqual([
+      {
+        connectorRef: "agora",
+        authMethodId: "legacy",
+        reasons: ["missing-access-provider"],
+      },
+    ]);
+
+    const connected = await connectorsApi.connectManualGrant(
+      actor,
+      "agora",
+      "current",
+      { credential: "current-catalog-secret" },
+    );
+    expect(connected).toMatchObject({
+      type: "agora",
+      authMethod: "current",
+      connectionStatus: "connected",
+    });
+
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const names = secrets.body.secrets.map((secret) => {
+      return secret.name;
+    });
+    expect(names).toContain("CURRENT_CREDENTIAL");
+    expect(names).not.toContain("LEGACY_CREDENTIAL");
+
+    const unavailable = buildRelease({
+      version: "2026-07-15.external-all-methods-filtered",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [legacyMethod, currentMethod]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "legacy",
+            prefix: "LEGACY",
+            access: "refresh-token",
+            revoke: "none",
+          }),
+          manualPrivateAuthMethod({
+            id: "current",
+            prefix: "CURRENT",
+            access: "refresh-token",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(
+      catalogObjects([initial, replacement, unavailable], unavailable),
+    );
+    const filtered = await syncCatalog();
+    expect(filtered.body.filtering.filteredAuthMethods).toHaveLength(2);
+
+    await connectorsApi.deleteConnectorByType(actor, "agora");
+    const secretsAfterDelete = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      secretsAfterDelete.body.secrets.map((secret) => {
+        return secret.name;
+      }),
+    ).not.toContain("CURRENT_CREDENTIAL");
+  });
+
+  it("materializes external runtime bindings for runs and firewall auth", async () => {
+    const connectorRef = "external-runtime";
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-run-materialization",
+      connectorRef,
+      label: "External Runtime",
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const runs = createRunsApi(context);
+    const firewall = createFirewallApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "External catalog runtime agent",
+      visibility: "private",
+    });
+    const created: { runId?: string } = {};
+    onTestFinished(async () => {
+      context.mocks.s3.send.mockResolvedValue({ Contents: [] });
+      if (created.runId) {
+        await runs.requestCancelRun(actor, created.runId, [200, 404]);
+      }
+      await connectorsApi.deleteConnectorByType(
+        actor,
+        connectorRef,
+        [204, 404],
+      );
+      await bdd.deleteAgent(actor, agent.agentId);
+    });
+    await connectorsApi.connectManualGrant(
+      actor,
+      connectorRef,
+      "api-token",
+      { credential: "catalog-runtime-secret" },
+      agent.agentId,
+    );
+
+    const callsBeforeRun = context.mocks.s3.send.mock.calls.length;
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "Use the externally sourced connector credential",
+      modelProvider: "anthropic-api-key",
+    });
+    created.runId = run.runId;
+    await runs.heartbeatRunner(runnerGroup);
+    await expect
+      .poll(
+        async () => {
+          return (await runs.pollRunner(runnerGroup)).body.job?.runId;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(run.runId);
+    const claim = await runs.claimRunnerJob(run.runId);
+    expect(claim.environment?.SERVICE_TOKEN).toBeTruthy();
+    expect(claim.secretConnectorMap).toMatchObject({
+      SERVICE_TOKEN: connectorRef,
+    });
+    expect(
+      claim.storageManifest?.storages.some((storage) => {
+        return storage.mountPath.endsWith(`/skills/${connectorRef}`);
+      }),
+    ).toBeFalsy();
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected encrypted connector secrets in the run claim");
+    }
+    const resolved = await firewall.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: ["Bearer $", "{{ secrets.SERVICE_TOKEN }}"].join(""),
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected firewall auth to resolve connector secrets");
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      Authorization: "Bearer catalog-runtime-secret",
+    });
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeRun);
+    await runs.requestCancelRun(actor, run.runId, [200]);
+  }, 15_000);
+
+  it("executes an external device grant with catalog-owned storage", async () => {
+    mockTestOAuthDeviceConnectorProvider();
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-device-grant",
+      connectorRef: "test-oauth-device",
+      label: "Catalog Device OAuth",
+      mutatePublic: (artifact) => {
+        const method = publicAuthMethod({
+          id: "oauth",
+          grantKind: "device-auth",
+        });
+        method.featureSwitch = "testOauthConnector";
+        setArtifactAuthMethods(artifact, [method]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          devicePrivateAuthMethod({
+            accessTokenName: "CATALOG_DEVICE_ACCESS_TOKEN",
+            clientId: "test-oauth-device-client",
+            scopes: ["read"],
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(
+        actor,
+        "test-oauth-device",
+        [204, 404],
+      );
+      await connectorsApi.deleteFeatureSwitches(actor);
+    });
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const session = await connectorsApi.startDeviceAuth(
+      actor,
+      "test-oauth-device",
+      "oauth",
+    );
+    const completed = await connectorsApi.pollDeviceAuth(
+      actor,
+      "test-oauth-device",
+      session.sessionId,
+      session.sessionToken,
+    );
+    expect(completed.status).toBe("complete");
+    if (completed.status !== "complete") {
+      throw new Error(
+        `Expected completed device grant, got ${completed.status}`,
+      );
+    }
+    expect(completed.connector).toMatchObject({
+      type: "test-oauth-device",
+      authMethod: "oauth",
+      oauthScopes: ["read"],
+    });
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(secrets.body.secrets).toContainEqual(
+      expect.objectContaining({
+        name: "CATALOG_DEVICE_ACCESS_TOKEN",
+        type: "connector",
+      }),
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("executes an external OpenID grant with catalog-owned storage", async () => {
+    mockEnv("VM0_API_BACKEND_URL", "https://api.vm0.ai");
+    mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+    mockEnv("STEAM_WEB_API_KEY", "catalog-steam-api-key");
+    mockOptionalEnv("STEAM_WEB_API_KEY", "catalog-steam-api-key");
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-openid-grant",
+      connectorRef: "steam",
+      label: "Catalog Steam",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "openid", grantKind: "openid-auth" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          steamPrivateAuthMethod({ steamIdName: "CATALOG_STEAM_ID" }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "steam", [204, 404]);
+    });
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const headers = { authorization: "Bearer clerk-session" };
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const start = await accept(
+      setupApp({ context })(zeroConnectorOpenIdStartContract).start({
+        params: { type: "steam" },
+        headers,
+        body: { authMethod: "openid" },
+      }),
+      [200],
+    );
+    mockSteamOpenIdVerification();
+    await accept(
+      setupApp({ context })(connectorsTypeCallbackContract).callback({
+        params: { type: "steam" },
+        headers: {},
+        query: steamOpenIdCallbackQuery(start.body.authorizationUrl),
+      }),
+      [307],
+    );
+    mockSteamPlayerApisForCatalog();
+    const player = await accept(
+      setupApp({ context })(zeroSteamPlayerContract).getPlayer({ headers }),
+      [200],
+    );
+    expect(player.body).toMatchObject({
+      steamId: STEAM_TEST_ID,
+      profile: { personaName: "catalog-player" },
+    });
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("executes an external-code grant with catalog-owned storage", async () => {
+    mockAwsExternalCodeProvider();
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-code-grant",
+      connectorRef: "aws",
+      label: "Catalog AWS",
+      mutatePublic: (artifact) => {
+        const method = publicAuthMethod({
+          id: "cli",
+          grantKind: "external-code",
+        });
+        method.featureSwitch = "awsConnector";
+        setArtifactAuthMethods(artifact, [method]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [awsPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.AwsConnector]: true,
+    });
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "aws", [204, 404]);
+      await connectorsApi.deleteFeatureSwitches(actor);
+    });
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
+    const completed = await connectorsApi.completeExternalCode(actor, "aws", {
+      sessionId: session.sessionId,
+      sessionToken: session.sessionToken,
+      code: awsVerificationCode(session.authorizationUrl),
+    });
+    expect(completed.connector).toMatchObject({
+      type: "aws",
+      authMethod: "cli",
+      externalId: "123456789012",
+      oauthScopes: ["openid"],
+    });
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      secrets.body.secrets.map((secret) => {
+        return secret.name;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        "CATALOG_AWS_ACCESS_KEY_ID",
+        "CATALOG_AWS_LOGIN_DPOP_KEY",
+        "CATALOG_AWS_LOGIN_REFRESH_TOKEN",
+        "CATALOG_AWS_SECRET_ACCESS_KEY",
+        "CATALOG_AWS_SESSION_TOKEN",
+      ]),
+    );
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("revokes an external auth-code credential through its selected method", async () => {
+    mockSlackConnectorOAuth();
+    let revokeCalls = 0;
+    server.use(
+      http.post(SLACK_REVOKE_URL, ({ request }) => {
+        revokeCalls += 1;
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer xoxp-bdd-user-token",
+        );
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-auth-code-revoke",
+      connectorRef: "slack",
+      label: "Catalog Slack",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [slackPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const start = await connectorsApi.startOauth(actor, "slack", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Slack authorization state");
+    }
+    await connectorsApi.completeOauthCallback("slack", {
+      code: "catalog-slack-code",
+      state,
+    });
+    await connectorsApi.deleteConnectorByType(actor, "slack");
+    expect(revokeCalls).toBe(1);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
+  it("keeps an in-flight provider operation on its selected external snapshot", async () => {
+    mockSlackConnectorOAuth();
+    configureSource();
+    const firstRelease = buildRelease({
+      version: "2026-07-15.external-in-flight-first",
+      connectorRef: "slack",
+      label: "Catalog Slack",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          slackPrivateAuthMethod("FIRST_RELEASE_SLACK_TOKEN"),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([firstRelease], firstRelease));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const providerEntered = deferredGate();
+    const providerResume = deferredGate();
+    server.use(
+      http.post(SLACK_OAUTH_TOKEN_URL, async () => {
+        providerEntered.release();
+        await providerResume.promise;
+        return HttpResponse.json({
+          ok: true,
+          authed_user: {
+            id: "U012AB3CD",
+            access_token: "xoxp-in-flight-token",
+            scope: "channels:read,chat:write",
+          },
+        });
+      }),
+      http.post(SLACK_REVOKE_URL, () => {
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      providerResume.release();
+      await connectorsApi.deleteConnectorByType(actor, "slack", [204, 404]);
+    });
+    const firstStart = await connectorsApi.startOauth(actor, "slack", "oauth");
+    const firstState = new URL(firstStart.authorizationUrl).searchParams.get(
+      "state",
+    );
+    if (!firstState) {
+      throw new Error("Expected Slack authorization state");
+    }
+    const firstCallback = connectorsApi.completeOauthCallback("slack", {
+      code: "first-release",
+      state: firstState,
+    });
+    await providerEntered.promise;
+
+    const secondRelease = buildRelease({
+      version: "2026-07-15.external-in-flight-second",
+      connectorRef: "slack",
+      label: "Catalog Slack",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          slackPrivateAuthMethod("SECOND_RELEASE_SLACK_TOKEN"),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([firstRelease, secondRelease], secondRelease));
+    await syncCatalog();
+    const callsBeforeProviderResume = context.mocks.s3.send.mock.calls.length;
+    providerResume.release();
+    await firstCallback;
+
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const headers = { authorization: "Bearer clerk-session" };
+    const firstSecrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({ headers }),
+      [200],
+    );
+    expect(
+      firstSecrets.body.secrets.map((secret) => {
+        return secret.name;
+      }),
+    ).toContain("FIRST_RELEASE_SLACK_TOKEN");
+
+    const secondStart = await connectorsApi.startOauth(actor, "slack", "oauth");
+    const secondState = new URL(secondStart.authorizationUrl).searchParams.get(
+      "state",
+    );
+    if (!secondState) {
+      throw new Error("Expected Slack authorization state");
+    }
+    await connectorsApi.completeOauthCallback("slack", {
+      code: "second-release",
+      state: secondState,
+    });
+    const secondSecrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({ headers }),
+      [200],
+    );
+    expect(
+      secondSecrets.body.secrets.map((secret) => {
+        return secret.name;
+      }),
+    ).toContain("SECOND_RELEASE_SLACK_TOKEN");
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(
+      callsBeforeProviderResume,
+    );
+  });
+
+  it("does not duplicate provider side effects in shadow mode", async () => {
+    mockSlackConnectorOAuth();
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.shadow-provider-side-effect",
+      connectorRef: "slack",
+      label: "Catalog Slack",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [slackPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "shadow");
+
+    let tokenExchangeCount = 0;
+    server.use(
+      http.post(SLACK_OAUTH_TOKEN_URL, () => {
+        tokenExchangeCount += 1;
+        return HttpResponse.json({
+          ok: true,
+          authed_user: {
+            id: "U012AB3CD",
+            access_token: "xoxp-shadow-token",
+            scope: "channels:read,chat:write",
+          },
+        });
+      }),
+      http.post(SLACK_REVOKE_URL, () => {
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "slack", [204, 404]);
+    });
+    const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
+    const start = await connectorsApi.startOauth(actor, "slack", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Slack authorization state");
+    }
+    await connectorsApi.completeOauthCallback("slack", {
+      code: "shadow-side-effect",
+      state,
+    });
+    await flushWaitUntilForTest();
+
+    expect(tokenExchangeCount).toBe(1);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
+  });
+
   it("uses one external release for readiness status and fallback metadata", async () => {
     mockGmailConnectorOAuth({ email: "readiness@example.test" });
     configureSource();
-    const release = buildRelease({
+    const connectedRelease = buildRelease({
       version: "2026-07-15.external-readiness",
       connectorRef: "gmail",
       label: "Catalog Gmail",
       mutatePublic: (artifact) => {
-        const method = firstRecord(
-          firstRecord(artifact.connectors, "connectors").authMethods,
-          "authMethods",
-        );
-        method.visible = false;
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [gmailPrivateAuthMethod()]);
       },
     });
-    serveObjects(catalogObjects([release], release));
+    serveObjects(catalogObjects([connectedRelease], connectedRelease));
     await syncCatalog();
 
     mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
@@ -1190,12 +2188,18 @@ describe("connector catalog valid lifecycle", () => {
           ],
         });
       }),
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        return HttpResponse.json({
-          historyId: "100",
-          expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
-        });
-      }),
+      http.post(
+        "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+        ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer catalog-refreshed-gmail-token",
+          );
+          return HttpResponse.json({
+            historyId: "100",
+            expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
+          });
+        },
+      ),
     );
 
     const actor = bdd.user({ orgId: STAFF_ORG_ID });
@@ -1228,6 +2232,20 @@ describe("connector catalog valid lifecycle", () => {
       code: "external-readiness",
       state: oauthState,
     });
+    mockNow(new Date("2026-07-15T10:00:00.000Z"));
+    const refreshBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(GOOGLE_OAUTH_TOKEN_URL, async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        refreshBodies.push(body);
+        return HttpResponse.json({
+          access_token: "catalog-refreshed-gmail-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        });
+      }),
+    );
     bdd.acceptAgentStorageWrites();
     const agent = await bdd.createAgent(actor, {
       displayName: "External readiness agent",
@@ -1263,6 +2281,32 @@ describe("connector catalog valid lifecycle", () => {
       }),
       [201],
     );
+    expect(refreshBodies).toHaveLength(1);
+    expect(refreshBodies[0]?.get("grant_type")).toBe("refresh_token");
+    expect(refreshBodies[0]?.get("refresh_token")).toBe("gmail-refresh-token");
+    const unavailableRelease = buildRelease({
+      version: "2026-07-15.external-readiness-unavailable",
+      connectorRef: "gmail",
+      label: "Catalog Gmail",
+      mutatePublic: (artifact) => {
+        const method = publicAuthMethod({
+          id: "oauth",
+          grantKind: "auth-code",
+        });
+        method.visible = false;
+        setArtifactAuthMethods(artifact, [method]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [gmailPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(
+      catalogObjects(
+        [connectedRelease, unavailableRelease],
+        unavailableRelease,
+      ),
+    );
+    await syncCatalog();
 
     const callsBeforeReadiness = context.mocks.s3.send.mock.calls.length;
     const readiness = await accept(
@@ -1291,28 +2335,6 @@ describe("connector catalog valid lifecycle", () => {
 
   it("derives connected scope and refresh status from the accepted release", async () => {
     mockDatadogConnectorOAuth();
-    // Connector actions remain on the static execution boundary in this PR,
-    // even while public catalog reads use the external backend.
-    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
-    const actor = bdd.user();
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.DatadogConnector]: true,
-    });
-    onTestFinished(async () => {
-      await connectorsApi.deleteConnectorByType(actor, "datadog", [204, 404]);
-      await connectorsApi.deleteFeatureSwitches(actor);
-    });
-    const start = await connectorsApi.startOauth(actor, "datadog", "oauth");
-    const state = new URL(start.authorizationUrl).searchParams.get("state");
-    if (!state) {
-      throw new Error("Expected Datadog authorization state");
-    }
-    await connectorsApi.completeOauthCallback("datadog", {
-      code: "external-catalog-status",
-      state,
-      domain: "us3.datadoghq.com",
-    });
-
     configureSource();
     const matching = buildRelease({
       version: "2026-07-15.external-connected-status",
@@ -1334,6 +2356,25 @@ describe("connector catalog valid lifecycle", () => {
     });
     serveObjects(catalogObjects([matching], matching));
     await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.DatadogConnector]: true,
+    });
+    onTestFinished(async () => {
+      await connectorsApi.deleteConnectorByType(actor, "datadog", [204, 404]);
+      await connectorsApi.deleteFeatureSwitches(actor);
+    });
+    const start = await connectorsApi.startOauth(actor, "datadog", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Datadog authorization state");
+    }
+    await connectorsApi.completeOauthCallback("datadog", {
+      code: "external-catalog-status",
+      state,
+      domain: "us3.datadoghq.com",
+    });
 
     zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const headers = { authorization: "Bearer clerk-session" };
@@ -1476,8 +2517,12 @@ describe("connector catalog valid lifecycle", () => {
     ).toBeFalsy();
 
     await flushWaitUntilForTest();
-    const [message, data] =
-      context.mocks.axiomLogging.debug.mock.calls.at(-1) ?? [];
+    const catalogComparison = [...context.mocks.axiomLogging.debug.mock.calls]
+      .reverse()
+      .find(([message]) => {
+        return message === "Connector catalog shadow comparison completed";
+      });
+    const [message, data] = catalogComparison ?? [];
     expect(message).toBe("Connector catalog shadow comparison completed");
     expect(data).toMatchObject({
       type: "connector_catalog_shadow_comparison",
@@ -1491,8 +2536,23 @@ describe("connector catalog valid lifecycle", () => {
       externalConnectorCount: 1,
       context: "connector-catalog:shadow",
     });
+    const runtimeComparison = [...context.mocks.axiomLogging.debug.mock.calls]
+      .reverse()
+      .find(([runtimeMessage]) => {
+        return (
+          runtimeMessage ===
+          "Connector runtime catalog shadow comparison completed"
+        );
+      });
+    expect(runtimeComparison?.[1]).toMatchObject({
+      type: "connector_runtime_catalog_shadow_comparison",
+      outcome: "difference",
+      schemaVersion: 1,
+      catalogVersion: release.version,
+      externalConnectorCount: 1,
+    });
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforePublicRead);
-    const logged = JSON.stringify([message, data]);
+    const logged = JSON.stringify(context.mocks.axiomLogging.debug.mock.calls);
     expect(logged).not.toContain(userId);
     expect(logged).not.toContain(orgId);
     expect(logged).not.toContain(PRIVATE_VALUE);

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2303,6 +2303,20 @@ describe("connector catalog valid lifecycle", () => {
       code: "external-readiness",
       state: oauthState,
     });
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const headers = { authorization: "Bearer clerk-session" };
+    const initialSecrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({ headers }),
+      [200],
+    );
+    const initialAccessTokenDescription = initialSecrets.body.secrets.find(
+      (secret) => {
+        return secret.name === "CATALOG_GMAIL_ACCESS_TOKEN";
+      },
+    )?.description;
+    expect(initialAccessTokenDescription).toBe(
+      "Connector token output for gmail: CATALOG_GMAIL_ACCESS_TOKEN",
+    );
     mockNow(new Date("2026-07-15T10:00:00.000Z"));
     const refreshBodies: URLSearchParams[] = [];
     server.use(
@@ -2323,8 +2337,6 @@ describe("connector catalog valid lifecycle", () => {
       visibility: "private",
     });
     created.agentId = agent.agentId;
-    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-    const headers = { authorization: "Bearer clerk-session" };
     const workflow = await accept(
       setupApp({ context })(zeroWorkflowsCollectionContract).create({
         headers,
@@ -2355,6 +2367,15 @@ describe("connector catalog valid lifecycle", () => {
     expect(refreshBodies).toHaveLength(1);
     expect(refreshBodies[0]?.get("grant_type")).toBe("refresh_token");
     expect(refreshBodies[0]?.get("refresh_token")).toBe("gmail-refresh-token");
+    const refreshedSecrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({ headers }),
+      [200],
+    );
+    expect(
+      refreshedSecrets.body.secrets.find((secret) => {
+        return secret.name === "CATALOG_GMAIL_ACCESS_TOKEN";
+      })?.description,
+    ).toBe(initialAccessTokenDescription);
     const unavailableRelease = buildRelease({
       version: "2026-07-15.external-readiness-unavailable",
       connectorRef: "gmail",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1695,6 +1695,191 @@ describe("connector catalog valid lifecycle", () => {
     ).not.toContain("CURRENT_CREDENTIAL");
   });
 
+  it("fails stored connector replacement and deletion closed when its method is removed", async () => {
+    configureSource();
+    const legacyMethod = publicAuthMethod({
+      id: "legacy",
+      grantKind: "manual",
+      manual: true,
+    });
+    const currentMethod = publicAuthMethod({
+      id: "current",
+      grantKind: "manual",
+      manual: true,
+    });
+    const initial = buildRelease({
+      version: "2026-07-15.external-stored-method-present",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [legacyMethod]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "legacy",
+            prefix: "LEGACY",
+            access: "static",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([initial], initial));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      mockEnv("CRON_SECRET", CRON_SECRET);
+      configureSource();
+      serveObjects(catalogObjects([initial], initial));
+      await syncCatalog();
+      await connectorsApi.deleteConnectorByType(actor, "agora", [204, 404]);
+    });
+    await connectorsApi.connectManualGrant(actor, "agora", "legacy", {
+      credential: "legacy-catalog-secret",
+    });
+
+    const removed = buildRelease({
+      version: "2026-07-15.external-stored-method-removed",
+      connectorRef: "agora",
+      label: "Catalog Agora",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [currentMethod]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "current",
+            prefix: "CURRENT",
+            access: "static",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([initial, removed], removed));
+    await syncCatalog();
+
+    const replacement = await connectorsApi.requestManualGrant(
+      actor,
+      "agora",
+      "current",
+      { credential: "current-catalog-secret" },
+      { statuses: [500] },
+    );
+    expect(replacement.status).toBe(500);
+    await connectorsApi.deleteConnectorByType(actor, "agora", [404]);
+
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      secrets.body.secrets.map((secret) => {
+        return secret.name;
+      }),
+    ).toContain("LEGACY_CREDENTIAL");
+
+    serveObjects(catalogObjects([initial, removed], initial));
+    await syncCatalog();
+    await expect(
+      connectorsApi.readConnectorByType(actor, "agora"),
+    ).resolves.toMatchObject({ authMethod: "legacy" });
+  });
+
+  it("fails token replacement closed when the stored method is removed", async () => {
+    configureSource();
+    const initial = buildRelease({
+      version: "2026-07-15.external-token-stored-method-present",
+      connectorRef: "gmail",
+      label: "Catalog Gmail",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "legacy", grantKind: "manual", manual: true }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          manualPrivateAuthMethod({
+            id: "legacy",
+            prefix: "LEGACY_GMAIL",
+            access: "static",
+            revoke: "none",
+          }),
+        ]);
+      },
+    });
+    serveObjects(catalogObjects([initial], initial));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const actor = bdd.user();
+    onTestFinished(async () => {
+      mockEnv("CRON_SECRET", CRON_SECRET);
+      configureSource();
+      serveObjects(catalogObjects([initial], initial));
+      await syncCatalog();
+      await connectorsApi.deleteConnectorByType(actor, "gmail", [204, 404]);
+    });
+    await connectorsApi.connectManualGrant(actor, "gmail", "legacy", {
+      credential: "legacy-gmail-secret",
+    });
+
+    mockGmailConnectorOAuth({ email: "removed-method@example.test" });
+    const replacement = buildRelease({
+      version: "2026-07-15.external-token-stored-method-removed",
+      connectorRef: "gmail",
+      label: "Catalog Gmail",
+      mutatePublic: (artifact) => {
+        setArtifactAuthMethods(artifact, [
+          publicAuthMethod({ id: "oauth", grantKind: "auth-code" }),
+        ]);
+      },
+      mutatePrivate: (artifact) => {
+        setArtifactAuthMethods(artifact, [gmailPrivateAuthMethod()]);
+      },
+    });
+    serveObjects(catalogObjects([initial, replacement], replacement));
+    await syncCatalog();
+
+    const oauth = await connectorsApi.startOauth(actor, "gmail", "oauth");
+    const state = new URL(oauth.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Gmail authorization state");
+    }
+    const callback = await connectorsApi.completeOauthCallback("gmail", {
+      code: "removed-stored-method",
+      state,
+    });
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.pathname).toBe("/connector/error");
+
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const secrets = await accept(
+      setupApp({ context })(zeroSecretsContract).list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const secretNames = secrets.body.secrets.map((secret) => {
+      return secret.name;
+    });
+    expect(secretNames).toContain("LEGACY_GMAIL_CREDENTIAL");
+    expect(secretNames).not.toContain("CATALOG_GMAIL_ACCESS_TOKEN");
+    expect(secretNames).not.toContain("CATALOG_GMAIL_REFRESH_TOKEN");
+
+    serveObjects(catalogObjects([initial, replacement], initial));
+    await syncCatalog();
+    await expect(
+      connectorsApi.readConnectorByType(actor, "gmail"),
+    ).resolves.toMatchObject({ authMethod: "legacy" });
+  });
+
   it("materializes external runtime bindings for runs and firewall auth", async () => {
     const connectorRef = "external-runtime";
     configureSource();

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -1840,6 +1840,9 @@ describe("connector catalog valid lifecycle", () => {
       "test-oauth-device",
       "oauth",
     );
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: false,
+    });
     const completed = await connectorsApi.pollDeviceAuth(
       actor,
       "test-oauth-device",
@@ -1967,6 +1970,9 @@ describe("connector catalog valid lifecycle", () => {
     });
     const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
     const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.AwsConnector]: false,
+    });
     const completed = await connectorsApi.completeExternalCode(actor, "aws", {
       sessionId: session.sessionId,
       sessionToken: session.sessionToken,
@@ -2643,7 +2649,7 @@ describe("connector catalog valid lifecycle", () => {
     mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
     const actor = bdd.user();
     await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.DatadogConnector]: true,
+      [FeatureSwitchKey.DatadogConnector]: false,
     });
     onTestFinished(async () => {
       await connectorsApi.deleteConnectorByType(actor, "datadog", [204, 404]);
@@ -2654,10 +2660,33 @@ describe("connector catalog valid lifecycle", () => {
     if (!state) {
       throw new Error("Expected Datadog authorization state");
     }
-    await connectorsApi.completeOauthCallback("datadog", {
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.DatadogConnector]: false,
+    });
+    const callback = await connectorsApi.completeOauthCallback("datadog", {
       code: "external-catalog-status",
       state,
       domain: "us3.datadoghq.com",
+    });
+    const callbackLocation = callback.headers.get("location");
+    expect(callbackLocation).not.toBeNull();
+    expect(
+      new URL(callbackLocation ?? "https://invalid.example").pathname,
+    ).toBe("/connector/success");
+    const hiddenConnectedList = await connectorsApi.listConnectors(actor);
+    expect(hiddenConnectedList.configuredTypes).not.toContain("datadog");
+    expect(hiddenConnectedList.connectors).toContainEqual(
+      expect.objectContaining({ type: "datadog", authMethod: "oauth" }),
+    );
+    expect(hiddenConnectedList.connectorProvidedBindings).toContainEqual(
+      expect.objectContaining({
+        connectorType: "datadog",
+        authMethod: "oauth",
+        name: "DATADOG_TOKEN",
+      }),
+    );
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.DatadogConnector]: true,
     });
 
     zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -11,6 +11,10 @@ import type {
   ConnectorResponse,
   ScopeDiffResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
+import type {
+  ConnectorCatalogAuthMethodId,
+  ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
 import {
@@ -41,10 +45,6 @@ import {
   zeroConnectorsSearchContract,
   type ConnectorSearchResponse,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import type {
-  ConnectorAuthMethodId,
-  ConnectorType,
-} from "@vm0/connectors/connectors";
 import { http, HttpResponse } from "msw";
 import { onTestFinished } from "vitest";
 import { z } from "zod";
@@ -1139,7 +1139,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestReadConnectorByType(
       actor: ApiTestUser | null,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupApp({ context })(zeroConnectorsByTypeContract);
@@ -1151,7 +1151,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async readConnectorByType(
       actor: ApiTestUser,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
     ): Promise<ConnectorResponse> {
       const response = await api.requestReadConnectorByType(actor, type, [200]);
       expectStatus(response, 200);
@@ -1160,7 +1160,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async deleteConnectorByType(
       actor: ApiTestUser,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       statuses: readonly (204 | 401 | 404)[] = [204],
     ): Promise<void> {
       const client = setupApp({ context })(zeroConnectorsByTypeContract);
@@ -1172,7 +1172,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestScopeDiff(
       actor: ApiTestUser | null,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupApp({ context })(zeroConnectorScopeDiffContract);
@@ -1187,7 +1187,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async readScopeDiff(
       actor: ApiTestUser,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
     ): Promise<ScopeDiffResponse> {
       const response = await api.requestScopeDiff(actor, type, [200]);
       expectStatus(response, 200);
@@ -1196,8 +1196,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestManualGrant(
       actor: ApiTestUser | null,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       values: Readonly<Record<string, string>>,
       options: {
         readonly statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[];
@@ -1223,8 +1223,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async connectManualGrant(
       actor: ApiTestUser,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       values: Readonly<Record<string, string>>,
       agentId?: string,
     ): Promise<ConnectorResponse> {
@@ -1241,8 +1241,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestOauthStart(
       actor: ApiTestUser | null,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       options: {
         readonly statuses: readonly (200 | 400 | 401 | 403 | 500)[];
         readonly agentId?: string;
@@ -1266,8 +1266,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startOauth(
       actor: ApiTestUser,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       agentId?: string,
     ): Promise<ConnectorOauthStartResponse> {
       const response = await api.requestOauthStart(actor, type, authMethod, {
@@ -1372,8 +1372,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestDeviceAuthStart(
       actor: ApiTestUser | null,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       options: Readonly<Record<string, string>> | undefined,
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
     ) {
@@ -1392,8 +1392,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startDeviceAuth(
       actor: ApiTestUser,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       options?: Readonly<Record<string, string>>,
     ): Promise<ConnectorOauthDeviceAuthSessionStartResponse> {
       const response = await api.requestDeviceAuthStart(
@@ -1409,7 +1409,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestDeviceAuthPoll(
       actor: ApiTestUser | null,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       sessionId: string,
       sessionToken: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
@@ -1429,7 +1429,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async pollDeviceAuth(
       actor: ApiTestUser,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       sessionId: string,
       sessionToken: string,
     ): Promise<ConnectorOauthDeviceAuthSessionPollResponse> {
@@ -1446,8 +1446,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestExternalCodeStart(
       actor: ApiTestUser | null,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
     ) {
       const client = setupApp({ context })(
@@ -1465,7 +1465,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestExternalCodeComplete(
       actor: ApiTestUser | null,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       args: {
         readonly sessionId: string;
         readonly sessionToken: string;
@@ -1488,8 +1488,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startExternalCode(
       actor: ApiTestUser,
-      type: ConnectorType,
-      authMethod: ConnectorAuthMethodId,
+      type: ConnectorCatalogRef,
+      authMethod: ConnectorCatalogAuthMethodId,
     ): Promise<ConnectorExternalCodeSessionStartResponse> {
       const response = await api.requestExternalCodeStart(
         actor,
@@ -1503,7 +1503,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async completeExternalCode(
       actor: ApiTestUser,
-      type: ConnectorType,
+      type: ConnectorCatalogRef,
       args: {
         readonly sessionId: string;
         readonly sessionToken: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -294,19 +294,14 @@ describe("AUTH-03 agent user connectors", () => {
       code: "VALIDATION_ERROR",
     });
 
-    const gated = await cfg.requestUpdateUserConnectors(
+    const discoveryHidden = await cfg.updateUserConnectors(
       admin,
       agent.agentId,
       ["bentoml"],
-      [400],
     );
-    expectApiError(gated.body);
-    expect(gated.body.error).toStrictEqual({
-      message: "Connector types are not available: bentoml",
-      code: "VALIDATION_ERROR",
-    });
-    const readAfterGated = await cfg.readUserConnectors(admin, agent.agentId);
-    expect(readAfterGated.enabledTypes).toStrictEqual([]);
+    expect(discoveryHidden.enabledTypes).toStrictEqual(["bentoml"]);
+    const readAfterHidden = await cfg.readUserConnectors(admin, agent.agentId);
+    expect(readAfterHidden.enabledTypes).toStrictEqual(["bentoml"]);
 
     const missingAgentId = randomUUID();
     const missingRead = await cfg.requestReadUserConnectors(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents.test.ts
@@ -42,7 +42,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     }
   });
 
-  it("filters connector grants for connector types removed from the registry", async () => {
+  it("keeps connector grants when their auth methods become hidden", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
@@ -77,6 +77,6 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
       [200],
     );
 
-    expect(response.body.enabledTypes).toStrictEqual(["github"]);
+    expect(response.body.enabledTypes).toStrictEqual(["github", "slack"]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
@@ -776,7 +776,7 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
     );
   });
 
-  it("rejects feature-gated manual grant auth when unavailable", async () => {
+  it("allows feature-gated manual grant auth outside discovery", async () => {
     await seedFixture();
     const client = setupApp({ context })(zeroConnectorManualGrantContract);
 
@@ -792,10 +792,33 @@ describe("POST /api/zero/connectors/:type/manual-grant", () => {
         },
         headers: { authorization: "Bearer clerk-session" },
       }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      type: "bentoml",
+      authMethod: "api-token",
+      connectionStatus: "connected",
+    });
+  });
+
+  it("rejects authored-hidden manual grant auth", async () => {
+    await seedFixture();
+    const client = setupApp({ context })(zeroConnectorManualGrantContract);
+
+    const response = await accept(
+      client.connect({
+        params: { type: "cloudflare" },
+        body: { authMethod: "api-token", values: {} },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
       [403],
     );
 
-    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error).toStrictEqual({
+      message: "cloudflare connector is not available",
+      code: "FORBIDDEN",
+    });
   });
 
   it("publishes one connector change event on successful replacement", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -1,12 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import {
-  CONNECTOR_TYPES,
-  type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
-} from "@vm0/connectors/connectors";
+import type { ConnectorAuthMethodId } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethodAuthCodeGrantConfig } from "@vm0/connectors/connector-utils";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -154,66 +150,20 @@ async function rejectProviderAuthorization(
 }
 
 describe("POST /api/zero/connectors/:type/oauth/start", () => {
-  const restoreConnectorRegistry: (() => void)[] = [];
-
   beforeEach(() => {
     mockEnv("VM0_API_BACKEND_URL", API_ORIGIN);
     mockEnv("VM0_WEB_URL", WEB_ORIGIN);
     mockOAuthEnv();
   });
 
-  afterEach(() => {
-    while (restoreConnectorRegistry.length > 0) {
-      restoreConnectorRegistry.pop()?.();
-    }
-  });
-
-  it("rejects auth-code OAuth start when the connector feature is disabled", async () => {
+  it("allows auth-code OAuth start when the connector feature is disabled", async () => {
     const response = await requestOauthStart("test-oauth", {
       authenticated: true,
     });
 
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message: "test-oauth connector is not available",
-        code: "FORBIDDEN",
-      },
-    });
-  });
-
-  it("rejects OAuth start when the auth method is statically hidden", async () => {
-    mockAuthenticatedSession();
-
-    const authMethods = CONNECTOR_TYPES["google-cloud"].authMethods;
-    const originalOauth = authMethods.oauth;
-    restoreConnectorRegistry.push(() => {
-      Object.defineProperty(authMethods, "oauth", {
-        value: originalOauth,
-        configurable: true,
-        enumerable: true,
-      });
-    });
-    Object.defineProperty(authMethods, "oauth", {
-      value: {
-        ...originalOauth,
-        visible: false,
-      } satisfies ConnectorAuthMethodConfig,
-      configurable: true,
-      enumerable: true,
-    });
-
-    const response = await requestOauthStart("google-cloud", {
-      headers: authHeaders(),
-    });
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message: "google-cloud connector is not available",
-        code: "FORBIDDEN",
-      },
-    });
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expectOauthState(authorizationUrl);
   });
 
   it("starts Google Cloud OAuth without a feature switch", async () => {

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -41,7 +41,7 @@ import {
   ensureTestOrg$,
 } from "../services/cli-auth.service";
 import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
-import { userConnectorActionResolverForSnapshot } from "../services/connector-action-resolver.service";
+import { connectorActionResolverForSnapshot } from "../services/connector-action-resolver.service";
 import {
   getConnectorRuntimeConnector,
   loadConnectorRuntimeSnapshot,
@@ -268,13 +268,10 @@ const createTestConnector$ = command(
     }
 
     const authMethod = bodyResult.data.authMethod;
-    const resolver = await get(
-      userConnectorActionResolverForSnapshot(orgId, userId, snapshot),
-    );
+    const resolver = await get(connectorActionResolverForSnapshot(snapshot));
     signal.throwIfAborted();
     const resolvedRef = await resolver.resolveRef({
       connectorRef,
-      requireAvailable: false,
       requireExecutable: true,
     });
     signal.throwIfAborted();
@@ -306,7 +303,6 @@ const createTestConnector$ = command(
       connectorRef,
       authMethodId: authMethod,
       expectedGrantKind: catalogMethod.grantKind,
-      requireAvailable: false,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -402,13 +398,10 @@ const enableTestConnectors$ = command(
       return stringError(400, "Test user has no org — run test-token first");
     }
 
-    const resolver = await get(
-      userConnectorActionResolverForSnapshot(orgId, userId, snapshot),
-    );
+    const resolver = await get(connectorActionResolverForSnapshot(snapshot));
     signal.throwIfAborted();
     const resolvedRefs = await resolver.resolveRefs({
       connectorRefs,
-      requireAvailable: false,
       requireExecutable: true,
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -6,16 +6,15 @@ import {
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import {
-  type AuthGrantConnectorType,
-  type ConnectorAuthMethodId,
-  type ConnectorType,
-  connectorTypeSchema,
-} from "@vm0/connectors/connectors";
+  connectorCatalogRefSchema,
+  type ConnectorCatalogAuthMethodId,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
 import {
-  getConnectorAuthMethod,
-  getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodGrantMetadata,
-  getConnectorAuthMethodRuntimeMetadata,
+  connectorAuthMethodAccessMetadata,
+  connectorAuthMethodGrantMetadata,
+  connectorAuthMethodRuntimeMetadata,
   type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -27,7 +26,7 @@ import { and, eq } from "drizzle-orm";
 
 import { bodyResultOf, queryOf } from "../context/request";
 import { request$ } from "../context/hono";
-import { writeDb$ } from "../external/db";
+import { db$, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 import type { RouteEntry } from "../route-entry";
 import {
@@ -42,6 +41,11 @@ import {
   ensureTestOrg$,
 } from "../services/cli-auth.service";
 import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
+import { userConnectorActionResolverForSnapshot } from "../services/connector-action-resolver.service";
+import {
+  getConnectorRuntimeConnector,
+  loadConnectorRuntimeSnapshot,
+} from "../services/connector-catalog-runtime.service";
 import { upsertOrgMultiAuthModelProvider$ } from "../services/zero-model-provider.service";
 import {
   isCodexAuthJsonFreePlanError,
@@ -68,12 +72,21 @@ function stringError(status: 400 | 404, error: string) {
   return { status, body: { error } };
 }
 
-function connectorTypeHasSelectedAuthGrant(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): type is AuthGrantConnectorType {
-  const grantKind = getConnectorAuthMethod(type, authMethod)?.grant.kind;
-  return grantKind === "auth-code" || grantKind === "device-auth";
+function parseConnectorRefs(connectorTypes: readonly string[]): {
+  readonly connectorRefs: readonly ConnectorCatalogRef[];
+  readonly invalidTypes: readonly string[];
+} {
+  const connectorRefs: ConnectorCatalogRef[] = [];
+  const invalidTypes: string[] = [];
+  for (const type of connectorTypes) {
+    const result = connectorCatalogRefSchema.safeParse(type);
+    if (result.success) {
+      connectorRefs.push(result.data);
+    } else {
+      invalidTypes.push(type);
+    }
+  }
+  return { connectorRefs, invalidTypes };
 }
 
 function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
@@ -81,24 +94,14 @@ function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
 }
 
 function testConnectorTokenOutputs(args: {
-  readonly connectorType: AuthGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly accessToken: string;
   readonly refreshToken: string | undefined;
 }): Readonly<Record<string, string>> {
-  const grantMetadata = getConnectorAuthMethodGrantMetadata(
-    args.connectorType,
-    args.authMethod,
-  );
-  const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
-    args.connectorType,
-    args.authMethod,
-  );
-  if (!grantMetadata || !runtimeMetadata) {
-    throw new Error(
-      `${args.connectorType} connector auth method ${args.authMethod} does not expose token outputs`,
-    );
-  }
+  const grantMetadata = connectorAuthMethodGrantMetadata(args.method);
+  const runtimeMetadata = connectorAuthMethodRuntimeMetadata(args.method);
 
   const outputNameByTargetKey = new Map(
     Object.entries(grantMetadata.outputs).map(([outputName, output]) => {
@@ -116,7 +119,7 @@ function testConnectorTokenOutputs(args: {
     });
   if (!accessOutputName) {
     throw new Error(
-      `${args.connectorType} connector auth method ${args.authMethod} does not expose a runtime token output`,
+      `${args.connectorRef} connector auth method ${args.authMethodId} does not expose a runtime token output`,
     );
   }
 
@@ -129,18 +132,15 @@ function testConnectorTokenOutputs(args: {
       outputs[outputName] === undefined
     ) {
       outputs[outputName] =
-        `${args.connectorType}-${args.authMethod}-${outputName}`;
+        `${args.connectorRef}-${args.authMethodId}-${outputName}`;
     }
   }
   if (!args.refreshToken) {
     return outputs;
   }
 
-  const accessMetadata = getConnectorAuthMethodAccessMetadata(
-    args.connectorType,
-    args.authMethod,
-  );
-  if (accessMetadata?.kind !== "refresh-token") {
+  const accessMetadata = connectorAuthMethodAccessMetadata(args.method);
+  if (accessMetadata.kind !== "refresh-token") {
     return outputs;
   }
 
@@ -238,7 +238,7 @@ const createTestConnector$ = command(
       );
     }
 
-    const connectorParsed = connectorTypeSchema.safeParse(
+    const connectorParsed = connectorCatalogRefSchema.safeParse(
       bodyResult.data.connectorName,
     );
     if (!connectorParsed.success) {
@@ -247,7 +247,12 @@ const createTestConnector$ = command(
         `Unknown connector type: "${bodyResult.data.connectorName}"`,
       );
     }
-    const connectorType = connectorParsed.data;
+    const connectorRef = connectorParsed.data;
+    const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
+    signal.throwIfAborted();
+    if (getConnectorRuntimeConnector(snapshot, connectorRef) === undefined) {
+      return stringError(400, `Unknown connector type: "${connectorRef}"`);
+    }
 
     const query = get(testConnectorQuery$);
     const userId = await set(
@@ -263,17 +268,51 @@ const createTestConnector$ = command(
     }
 
     const authMethod = bodyResult.data.authMethod;
-    if (!getConnectorAuthMethod(connectorType, authMethod)) {
+    const resolver = await get(
+      userConnectorActionResolverForSnapshot(orgId, userId, snapshot),
+    );
+    signal.throwIfAborted();
+    const resolvedRef = await resolver.resolveRef({
+      connectorRef,
+      requireAvailable: false,
+      requireExecutable: true,
+    });
+    signal.throwIfAborted();
+    if (!resolvedRef.ok) {
+      return stringError(400, `Unknown connector type: "${connectorRef}"`);
+    }
+    const catalogMethod =
+      resolvedRef.runtimeConnector.catalogConnector.authMethods.find(
+        (method) => {
+          return method.id === authMethod;
+        },
+      );
+    if (!catalogMethod) {
       return stringError(
         400,
-        `${connectorType} connector does not configure auth method ${authMethod}`,
+        `${connectorRef} connector does not configure auth method ${authMethod}`,
       );
     }
-
-    if (!connectorTypeHasSelectedAuthGrant(connectorType, authMethod)) {
+    if (
+      catalogMethod.grantKind !== "auth-code" &&
+      catalogMethod.grantKind !== "device-auth"
+    ) {
       return stringError(
         400,
-        `${connectorType} connector auth method ${authMethod} does not use an auth-code or device-auth grant`,
+        `${connectorRef} connector auth method ${authMethod} does not use an auth-code or device-auth grant`,
+      );
+    }
+    const resolved = await resolver.resolveMethod({
+      connectorRef,
+      authMethodId: authMethod,
+      expectedGrantKind: catalogMethod.grantKind,
+      requireAvailable: false,
+    });
+    signal.throwIfAborted();
+    if (!resolved.ok) {
+      return stringError(
+        400,
+        `${connectorRef} connector auth method ${authMethod} is not available`,
       );
     }
 
@@ -282,18 +321,19 @@ const createTestConnector$ = command(
       {
         orgId,
         userId,
-        type: connectorType,
-        authMethod,
+        runtimeMethod: resolved.runtimeMethod,
+        snapshot: resolved.snapshot,
         outputs: testConnectorTokenOutputs({
-          connectorType,
-          authMethod,
+          connectorRef,
+          authMethodId: authMethod,
+          method: resolved.method,
           accessToken: bodyResult.data.accessToken,
           refreshToken: bodyResult.data.refreshToken,
         }),
         userInfo: {
-          id: `e2e-test-${connectorType}`,
-          username: `e2e-${connectorType}`,
-          email: `e2e-${connectorType}@test.vm0.ai`,
+          id: `e2e-test-${connectorRef}`,
+          username: `e2e-${connectorRef}`,
+          email: `e2e-${connectorRef}@test.vm0.ai`,
         },
         oauthScopes: [],
         expiresIn: bodyResult.data.expiresIn,
@@ -304,7 +344,7 @@ const createTestConnector$ = command(
 
     return {
       status: 200 as const,
-      body: { ok: true as const, connectorType, orgId },
+      body: { ok: true as const, connectorType: connectorRef, orgId },
     };
   },
 );
@@ -327,13 +367,25 @@ const enableTestConnectors$ = command(
       return stringError(400, "composeId and connectorTypes are required");
     }
 
-    const invalidTypes = bodyResult.data.connectorTypes.filter((type) => {
-      return !connectorTypeSchema.safeParse(type).success;
-    });
+    const { connectorRefs, invalidTypes } = parseConnectorRefs(
+      bodyResult.data.connectorTypes,
+    );
     if (invalidTypes.length > 0) {
       return stringError(
         400,
         `Unknown connector types: ${invalidTypes.join(", ")}`,
+      );
+    }
+
+    const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
+    signal.throwIfAborted();
+    const unknownConnectorRef = connectorRefs.find((connectorRef) => {
+      return getConnectorRuntimeConnector(snapshot, connectorRef) === undefined;
+    });
+    if (unknownConnectorRef !== undefined) {
+      return stringError(
+        400,
+        `Unknown connector types: ${unknownConnectorRef}`,
       );
     }
 
@@ -348,6 +400,23 @@ const enableTestConnectors$ = command(
     signal.throwIfAborted();
     if (!orgId) {
       return stringError(400, "Test user has no org — run test-token first");
+    }
+
+    const resolver = await get(
+      userConnectorActionResolverForSnapshot(orgId, userId, snapshot),
+    );
+    signal.throwIfAborted();
+    const resolvedRefs = await resolver.resolveRefs({
+      connectorRefs,
+      requireAvailable: false,
+      requireExecutable: true,
+    });
+    signal.throwIfAborted();
+    if (!resolvedRefs.ok) {
+      return stringError(
+        400,
+        `Unknown connector types: ${resolvedRefs.connectorRef}`,
+      );
     }
 
     const writeDb = set(writeDb$);
@@ -395,7 +464,7 @@ const enableTestConnectors$ = command(
     signal.throwIfAborted();
 
     await writeDb.insert(userConnectors).values(
-      bodyResult.data.connectorTypes.map((connectorType) => {
+      connectorRefs.map((connectorType) => {
         return {
           orgId,
           userId,
@@ -411,7 +480,7 @@ const enableTestConnectors$ = command(
       body: {
         ok: true as const,
         composeId: bodyResult.data.composeId,
-        connectorTypes: bodyResult.data.connectorTypes,
+        connectorTypes: connectorRefs,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -21,7 +21,7 @@ import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { command } from "ccstate";
+import { command, type Computed } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { bodyResultOf, queryOf } from "../context/request";
@@ -211,7 +211,7 @@ const createTestToken$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 async function testOrgForUser(
-  get: <T>(value: import("ccstate").Computed<T>) => T,
+  get: <T>(value: Computed<T>) => T,
   userId: string,
 ): Promise<string | null> {
   return await get(testUserOrgId(userId));

--- a/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-auth-code-start.ts
@@ -1,108 +1,68 @@
 import {
-  connectorAuthMethodRefHasGrantKind,
-  getConnectorAuthMethod,
-  resolveConnectorAuthClientForMethod,
+  resolveConnectorAuthClient,
+  type ConnectorAuthClient,
   type ConnectorEnvReader,
-  type ConnectorAuthMethodRefByGrantKind,
-  type ConnectorAuthClientForMethod,
 } from "@vm0/connectors/connector-utils";
-import type {
-  AuthCodeGrantConnectorType,
-  ConnectorAuthCodeGrantAuthMethodId,
-  ConnectorAuthMethodId,
-  ConnectorType,
-} from "@vm0/connectors/connectors";
-import { buildConnectorAuthCodeAuthorizationUrl } from "@vm0/connectors/auth-providers";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
+import { buildConnectorAuthCodeAuthorizationUrlWithMethod } from "@vm0/connectors/auth-providers";
 import type { AuthUrlResult } from "@vm0/connectors/auth-providers/provider-flow-types";
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
-
-type PrepareResolvedConnectorAuthCodeStartResult<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
-> =
-  | {
-      readonly ok: true;
-      readonly state: string;
-      readonly redirectUri: string;
-      readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
-    }
-  | {
-      readonly ok: false;
-      readonly reason: "auth_client_not_configured";
-    };
-
-type ResolveConnectorAuthCodeStartMethodResult =
-  | ({ readonly ok: true } & ConnectorAuthMethodRefByGrantKind<"auth-code">)
-  | {
-      readonly ok: false;
-      readonly reason: "missing_auth_method" | "wrong_grant_kind";
-    };
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
   return typeof result === "string" ? { url: result } : result;
 }
 
-export function resolveConnectorAuthCodeStartMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): ResolveConnectorAuthCodeStartMethodResult {
-  const authMethodRef = { type, authMethod };
-  const method = getConnectorAuthMethod(type, authMethod);
-  if (!method) {
-    return { ok: false, reason: "missing_auth_method" };
-  }
-  if (!connectorAuthMethodRefHasGrantKind(authMethodRef, "auth-code")) {
-    return { ok: false, reason: "wrong_grant_kind" };
-  }
+type PrepareConnectorAuthCodeStartWithMethodResult =
+  | {
+      readonly ok: true;
+      readonly state: string;
+      readonly redirectUri: string;
+      readonly authClient: ConnectorAuthClient;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "auth_client_not_configured" | "wrong_grant_kind";
+    };
 
-  return { ok: true, ...authMethodRef };
-}
-
-// Prepare only synchronous auth-code start data after callers have validated
-// the selected auth method for this auth-code flow.
-export function prepareResolvedConnectorAuthCodeStart<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
->(args: {
-  readonly type: Type;
-  readonly authMethod: Method;
+export function prepareConnectorAuthCodeStartWithMethod(args: {
+  readonly connectorRef: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly origin: string;
   readonly readEnv: ConnectorEnvReader;
-}): PrepareResolvedConnectorAuthCodeStartResult<Type, Method> {
-  const state = generateConnectorOAuthState();
-  const redirectUri = `${args.origin}/api/connectors/${args.type}/callback`;
-  const authClient = resolveConnectorAuthClientForMethod(
-    args.type,
-    args.authMethod,
+}): PrepareConnectorAuthCodeStartWithMethodResult {
+  if (args.method.grant.kind !== "auth-code" || !args.method.client) {
+    return { ok: false, reason: "wrong_grant_kind" };
+  }
+  const authClient = resolveConnectorAuthClient(
+    args.method.client,
     args.readEnv,
   );
   if (!authClient) {
     return { ok: false, reason: "auth_client_not_configured" };
   }
-
+  const state = generateConnectorOAuthState();
   return {
     ok: true,
     state,
-    redirectUri,
+    redirectUri: `${args.origin}/api/connectors/${args.connectorRef}/callback`,
     authClient,
   };
 }
 
-export async function buildResolvedConnectorAuthCodeAuthUrl<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
->(args: {
-  readonly type: Type;
-  readonly authMethod: Method;
-  readonly authClient: ConnectorAuthClientForMethod<Type, Method>;
+export async function buildConnectorAuthCodeAuthUrlWithMethod(args: {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly authClient: ConnectorAuthClient;
   readonly redirectUri: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {
   return normalizeAuthUrlResult(
-    await buildConnectorAuthCodeAuthorizationUrl({
-      type: args.type,
-      authMethod: args.authMethod,
+    await buildConnectorAuthCodeAuthorizationUrlWithMethod({
+      connectorRef: args.connectorRef,
+      authMethodId: args.authMethodId,
+      method: args.method,
       authClient: args.authClient,
       redirectUri: args.redirectUri,
       state: args.state,

--- a/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
@@ -1,14 +1,10 @@
 import {
-  connectorAuthCodeCallbacksUseOnlyApiOrigin,
-  getConnectorAuthMethodAuthCodeCallbackOrigin,
-  getConnectorAuthMethodOpenIdAuthCallbackOrigin,
+  connectorAuthCodeGrantCallbackOrigin,
+  connectorOpenIdAuthGrantCallbackOrigin,
 } from "@vm0/connectors/connector-utils";
 import type {
-  AuthCodeGrantConnectorType,
+  ConnectorAuthMethodRuntimeConfig,
   ConnectorBrowserAuthCallbackOrigin,
-  ConnectorAuthCodeGrantAuthMethodId,
-  ConnectorOpenIdAuthGrantAuthMethodId,
-  OpenIdAuthGrantConnectorType,
 } from "@vm0/connectors/connectors";
 
 import {
@@ -33,39 +29,51 @@ function resolveCallbackOrigin(
   }
 }
 
-export function getConnectorOAuthCallbackOrigin<
-  Type extends AuthCodeGrantConnectorType,
->(args: {
+export function getConnectorOAuthCallbackOriginForMethod(args: {
   readonly request: Request;
-  readonly type: Type;
-  readonly authMethod: ConnectorAuthCodeGrantAuthMethodId<Type>;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
 }): string {
-  const callbackOrigin = getConnectorAuthMethodAuthCodeCallbackOrigin(
-    args.type,
-    args.authMethod,
+  if (args.method.grant.kind !== "auth-code") {
+    throw new Error("Auth-code connector method required");
+  }
+  return resolveCallbackOrigin(
+    args.request,
+    connectorAuthCodeGrantCallbackOrigin(args.method.grant),
   );
-  return resolveCallbackOrigin(args.request, callbackOrigin);
 }
 
-export function getConnectorOpenIdCallbackOrigin<
-  Type extends OpenIdAuthGrantConnectorType,
->(args: {
+export function getConnectorOpenIdCallbackOriginForMethod(args: {
   readonly request: Request;
-  readonly type: Type;
-  readonly authMethod: ConnectorOpenIdAuthGrantAuthMethodId<Type>;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
 }): string {
-  const callbackOrigin = getConnectorAuthMethodOpenIdAuthCallbackOrigin(
-    args.type,
-    args.authMethod,
+  if (args.method.grant.kind !== "openid-auth") {
+    throw new Error("OpenID connector method required");
+  }
+  return resolveCallbackOrigin(
+    args.request,
+    connectorOpenIdAuthGrantCallbackOrigin(args.method.grant),
   );
-  return resolveCallbackOrigin(args.request, callbackOrigin);
 }
 
-export function getConnectorOAuthCanonicalRedirectUrl(
+export function getConnectorOAuthCanonicalRedirectUrlForMethods(
   request: Request,
-  type: AuthCodeGrantConnectorType,
+  methods: readonly ConnectorAuthMethodRuntimeConfig[],
 ): string | null {
-  if (connectorAuthCodeCallbacksUseOnlyApiOrigin(type)) {
+  const authCodeMethods = methods.filter(
+    (
+      method,
+    ): method is Extract<
+      ConnectorAuthMethodRuntimeConfig,
+      { readonly grant: { readonly kind: "auth-code" } }
+    > => {
+      return method.grant.kind === "auth-code";
+    },
+  );
+  if (
+    authCodeMethods.every((method) => {
+      return connectorAuthCodeGrantCallbackOrigin(method.grant) === "api";
+    })
+  ) {
     return null;
   }
   return getOAuthCanonicalRedirectUrl(request);

--- a/turbo/apps/api/src/signals/routes/connector-openid-auth-start.ts
+++ b/turbo/apps/api/src/signals/routes/connector-openid-auth-start.ts
@@ -1,15 +1,5 @@
-import {
-  connectorAuthMethodRefHasGrantKind,
-  getConnectorAuthMethod,
-  type ConnectorAuthMethodRefByGrantKind,
-} from "@vm0/connectors/connector-utils";
-import type {
-  ConnectorAuthMethodId,
-  ConnectorType,
-  OpenIdAuthGrantConnectorType,
-  ConnectorOpenIdAuthGrantAuthMethodId,
-} from "@vm0/connectors/connectors";
-import { buildConnectorOpenIdAuthAuthorizationUrl } from "@vm0/connectors/auth-providers";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
+import { buildConnectorOpenIdAuthAuthorizationUrlWithMethod } from "@vm0/connectors/auth-providers";
 import type { AuthUrlResult } from "@vm0/connectors/auth-providers/provider-flow-types";
 
 import { generateConnectorOAuthState } from "./connector-oauth-route-state";
@@ -21,13 +11,6 @@ type PrepareResolvedConnectorOpenIdAuthStartResult = {
   readonly realm: string;
   readonly expectedReturnTo: string;
 };
-
-type ResolveConnectorOpenIdAuthStartMethodResult =
-  | ({ readonly ok: true } & ConnectorAuthMethodRefByGrantKind<"openid-auth">)
-  | {
-      readonly ok: false;
-      readonly reason: "missing_auth_method" | "wrong_grant_kind";
-    };
 
 function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
   return typeof result === "string" ? { url: result } : result;
@@ -41,35 +24,20 @@ export function openIdRealmForOrigin(origin: string): string {
   return url.toString();
 }
 
-export function resolveConnectorOpenIdAuthStartMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): ResolveConnectorOpenIdAuthStartMethodResult {
-  const authMethodRef = { type, authMethod };
-  const method = getConnectorAuthMethod(type, authMethod);
-  if (!method) {
-    return { ok: false, reason: "missing_auth_method" };
-  }
-  if (!connectorAuthMethodRefHasGrantKind(authMethodRef, "openid-auth")) {
-    return { ok: false, reason: "wrong_grant_kind" };
-  }
-
-  return { ok: true, ...authMethodRef };
-}
-
-export function prepareResolvedConnectorOpenIdAuthStart<
-  Type extends OpenIdAuthGrantConnectorType,
->(args: {
-  readonly type: Type;
+export function prepareConnectorOpenIdAuthStartWithMethod(args: {
+  readonly connectorRef: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly origin: string;
 }): PrepareResolvedConnectorOpenIdAuthStartResult {
+  if (args.method.grant.kind !== "openid-auth") {
+    throw new Error("OpenID auth method required");
+  }
   const state = generateConnectorOAuthState();
   const returnTo = new URL(
-    `/api/connectors/${args.type}/callback`,
+    `/api/connectors/${args.connectorRef}/callback`,
     args.origin,
   );
   returnTo.searchParams.set("state", state);
-
   return {
     ok: true,
     state,
@@ -79,20 +47,19 @@ export function prepareResolvedConnectorOpenIdAuthStart<
   };
 }
 
-export async function buildResolvedConnectorOpenIdAuthUrl<
-  Type extends OpenIdAuthGrantConnectorType,
-  Method extends ConnectorOpenIdAuthGrantAuthMethodId<Type>,
->(args: {
-  readonly type: Type;
-  readonly authMethod: Method;
+export async function buildConnectorOpenIdAuthUrlWithMethod(args: {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly returnTo: string;
   readonly realm: string;
   readonly state: string;
 }): Promise<AuthUrlResult> {
   return normalizeAuthUrlResult(
-    await buildConnectorOpenIdAuthAuthorizationUrl({
-      type: args.type,
-      authMethod: args.authMethod,
+    await buildConnectorOpenIdAuthAuthorizationUrlWithMethod({
+      connectorRef: args.connectorRef,
+      authMethodId: args.authMethodId,
+      method: args.method,
       returnTo: args.returnTo,
       realm: args.realm,
       state: args.state,

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,31 +1,22 @@
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  connectorAuthMethodHasGrantKind,
-  getConnectorAuthMethod,
-  resolveConnectorAuthClientForMethod,
-  getConnectorAuthMethodGrantScopes,
-  hasConnectorAuthCodeGrant,
-  hasConnectorOpenIdAuthGrant,
+  connectorCatalogAuthMethodIdSchema,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  connectorGrantScopes,
+  resolveConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
-  connectorAuthMethodIdSchema,
-  connectorTypeSchema,
-  type AuthGrantConnectorType,
-  type AuthCodeGrantConnectorType,
-  type ConnectorAuthCodeGrantAuthMethodId,
-  type ConnectorOpenIdAuthGrantAuthMethodId,
-  type OpenIdAuthGrantConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  exchangeConnectorAuthCode,
-  verifyConnectorOpenIdAuthCallback,
+  exchangeConnectorAuthCodeWithMethod,
+  verifyConnectorOpenIdAuthCallbackWithMethod,
   type ConnectorAuthProviderGrantResult,
 } from "@vm0/connectors/auth-providers";
 
 import { request$ } from "../context/hono";
 import { pathParamsOf, queryOf } from "../context/request";
-import { writeDb$, type Db } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { optionalEnv } from "../../lib/env";
 import {
@@ -34,6 +25,17 @@ import {
   type StoredOAuthState,
 } from "../services/connector-oauth-state.service";
 import { authorizeConnectedConnector$ } from "../services/connected-connector-authorization.service";
+import {
+  userConnectorActionResolverForSnapshot,
+  type ConnectorActionResolver,
+  type ResolvedConnectorActionMethod,
+} from "../services/connector-action-resolver.service";
+import {
+  getConnectorRuntimeConnector,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeConnector,
+  type ConnectorRuntimeSnapshot,
+} from "../services/connector-catalog-runtime.service";
 import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
 import {
   linkGithubVm0User,
@@ -42,7 +44,7 @@ import {
 import { safeJsonParse, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import {
-  getConnectorOAuthCanonicalRedirectUrl,
+  getConnectorOAuthCanonicalRedirectUrlForMethods,
   getConnectorOAuthOrigin,
 } from "./connector-oauth-origin";
 import {
@@ -56,29 +58,8 @@ type CallbackIdentity = {
   readonly orgId: string;
 };
 
-type ConnectorAuthCodeExchangeResult = Awaited<
-  ReturnType<typeof exchangeConnectorAuthCode>
->;
-
-type AuthCodeCallbackMethodRef<
-  Type extends AuthCodeGrantConnectorType = AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type> =
-    ConnectorAuthCodeGrantAuthMethodId<Type>,
-> = {
-  readonly connectorType: Type;
-  readonly authMethod: Method;
-};
-
-type OpenIdCallbackMethodRef<
-  Type extends OpenIdAuthGrantConnectorType = OpenIdAuthGrantConnectorType,
-  Method extends ConnectorOpenIdAuthGrantAuthMethodId<Type> =
-    ConnectorOpenIdAuthGrantAuthMethodId<Type>,
-> = {
-  readonly connectorType: Type;
-  readonly authMethod: Method;
-};
-
-type CompleteOAuthCallbackInput = AuthCodeCallbackMethodRef & {
+type CompleteOAuthCallbackInput = {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
   readonly code: string;
   readonly redirectUri: string;
   readonly state: string;
@@ -91,7 +72,8 @@ type CompleteOAuthCallbackInput = AuthCodeCallbackMethodRef & {
   readonly type: string;
 };
 
-type CompleteOpenIdCallbackInput = OpenIdCallbackMethodRef & {
+type CompleteOpenIdCallbackInput = {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
   readonly callbackParams: Readonly<Record<string, string>>;
   readonly expectedReturnTo: string;
   readonly expectedRealm: string;
@@ -105,19 +87,21 @@ type CompleteOpenIdCallbackInput = OpenIdCallbackMethodRef & {
 type ResolveCallbackStateInput = {
   readonly origin: string;
   readonly type: string;
-  readonly connectorType: AuthCodeGrantConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly storedState: StoredOAuthState;
+  readonly resolver: ConnectorActionResolver;
 };
 
 type ResolveOpenIdCallbackStateInput = {
   readonly origin: string;
   readonly type: string;
-  readonly connectorType: OpenIdAuthGrantConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly storedState: StoredOAuthState;
+  readonly resolver: ConnectorActionResolver;
 };
 
 type ResolvedCallbackState =
-  | ({
+  | {
       readonly ok: true;
       readonly identity: CallbackIdentity;
       readonly agentId: string | null;
@@ -125,21 +109,23 @@ type ResolvedCallbackState =
       readonly codeVerifier: string | undefined;
       readonly oauthContext: string | undefined;
       readonly redirectUri: string;
-    } & AuthCodeCallbackMethodRef)
+      readonly resolvedMethod: ResolvedConnectorActionMethod;
+    }
   | {
       readonly ok: false;
       readonly response: Response;
     };
 
 type ResolvedOpenIdCallbackState =
-  | ({
+  | {
       readonly ok: true;
       readonly identity: CallbackIdentity;
       readonly agentId: string | null;
       readonly authorizeAgent: boolean;
       readonly expectedReturnTo: string;
       readonly expectedRealm: string;
-    } & OpenIdCallbackMethodRef)
+      readonly resolvedMethod: ResolvedConnectorActionMethod;
+    }
   | {
       readonly ok: false;
       readonly response: Response;
@@ -156,26 +142,6 @@ type ClaimedCallbackState =
     };
 
 type ConnectorCallbackQuery = Readonly<Record<string, string | undefined>>;
-
-type ResolvedAuthCodeConnectorType =
-  | {
-      readonly ok: true;
-      readonly connectorType: AuthCodeGrantConnectorType;
-    }
-  | {
-      readonly ok: false;
-      readonly response: Response;
-    };
-
-type ResolvedOpenIdConnectorType =
-  | {
-      readonly ok: true;
-      readonly connectorType: OpenIdAuthGrantConnectorType;
-    }
-  | {
-      readonly ok: false;
-      readonly response: Response;
-    };
 
 function redirectWithError(
   origin: string,
@@ -214,30 +180,34 @@ function missingStateRedirectResponse(origin: string, type: string): Response {
   return redirectWithError(origin, type, "Missing state parameter", true);
 }
 
-async function exchangeTokenForConnector<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
->(
-  args: AuthCodeCallbackMethodRef<Type, Method> & {
-    readonly code: string;
-    readonly redirectUri: string;
-    readonly state: string | undefined;
-    readonly codeVerifier: string | undefined;
-    readonly oauthContext: string | undefined;
-  },
-): Promise<ConnectorAuthCodeExchangeResult> {
-  const authClient = resolveConnectorAuthClientForMethod(
-    args.connectorType,
-    args.authMethod,
+async function exchangeTokenForConnector(args: {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly state: string | undefined;
+  readonly codeVerifier: string | undefined;
+  readonly oauthContext: string | undefined;
+}): Promise<ConnectorAuthProviderGrantResult> {
+  if (
+    args.resolvedMethod.method.grant.kind !== "auth-code" ||
+    args.resolvedMethod.method.client === undefined
+  ) {
+    throw new Error("Connector execution is not configured");
+  }
+  const authClient = resolveConnectorAuthClient(
+    args.resolvedMethod.method.client,
     optionalEnv,
   );
   if (!authClient) {
-    throw new Error(`${args.connectorType} auth client not configured`);
+    throw new Error(
+      `${args.resolvedMethod.connectorRef} auth client not configured`,
+    );
   }
 
-  return await exchangeConnectorAuthCode({
-    type: args.connectorType,
-    authMethod: args.authMethod,
+  return await exchangeConnectorAuthCodeWithMethod({
+    connectorRef: args.resolvedMethod.connectorRef,
+    authMethodId: args.resolvedMethod.authMethodId,
+    method: args.resolvedMethod.method,
     authClient,
     code: args.code,
     redirectUri: args.redirectUri,
@@ -247,27 +217,17 @@ async function exchangeTokenForConnector<
   });
 }
 
-function getRequestedScopes<
-  Type extends AuthCodeGrantConnectorType,
-  Method extends ConnectorAuthCodeGrantAuthMethodId<Type>,
->(args: AuthCodeCallbackMethodRef<Type, Method>): readonly string[] {
-  return getConnectorAuthMethodGrantScopes(args.connectorType, args.authMethod);
-}
-
-async function verifyOpenIdForConnector<
-  Type extends OpenIdAuthGrantConnectorType,
-  Method extends ConnectorOpenIdAuthGrantAuthMethodId<Type>,
->(
-  args: OpenIdCallbackMethodRef<Type, Method> & {
-    readonly callbackParams: Readonly<Record<string, string>>;
-    readonly expectedReturnTo: string;
-    readonly expectedRealm: string;
-    readonly signal: AbortSignal;
-  },
-): Promise<ConnectorAuthProviderGrantResult> {
-  return await verifyConnectorOpenIdAuthCallback({
-    type: args.connectorType,
-    authMethod: args.authMethod,
+async function verifyOpenIdForConnector(args: {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly callbackParams: Readonly<Record<string, string>>;
+  readonly expectedReturnTo: string;
+  readonly expectedRealm: string;
+  readonly signal: AbortSignal;
+}): Promise<ConnectorAuthProviderGrantResult> {
+  return await verifyConnectorOpenIdAuthCallbackWithMethod({
+    connectorRef: args.resolvedMethod.connectorRef,
+    authMethodId: args.resolvedMethod.authMethodId,
+    method: args.resolvedMethod.method,
     callbackParams: args.callbackParams,
     expectedReturnTo: args.expectedReturnTo,
     expectedRealm: args.expectedRealm,
@@ -275,74 +235,58 @@ async function verifyOpenIdForConnector<
   });
 }
 
-function resolveAuthCodeConnectorType(
-  origin: string,
-  type: string,
-): ResolvedAuthCodeConnectorType {
-  const typeResult = connectorTypeSchema.safeParse(type);
-  if (!typeResult.success) {
-    return {
-      ok: false,
-      response: redirectWithError(origin, type, "Unknown connector type"),
-    };
-  }
-
-  const connectorType = typeResult.data;
-  if (!hasConnectorAuthCodeGrant(connectorType)) {
-    return {
-      ok: false,
-      response: redirectWithError(
-        origin,
-        type,
-        `${type} connector does not use an auth-code grant`,
-      ),
-    };
-  }
-
-  return { ok: true, connectorType };
-}
-
-function resolveOpenIdConnectorType(
-  origin: string,
-  type: string,
-): ResolvedOpenIdConnectorType {
-  const typeResult = connectorTypeSchema.safeParse(type);
-  if (!typeResult.success) {
-    return {
-      ok: false,
-      response: redirectWithError(origin, type, "Unknown connector type"),
-    };
-  }
-
-  const connectorType = typeResult.data;
-  if (!hasConnectorOpenIdAuthGrant(connectorType)) {
+function resolveConnectorWithGrant(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly grantKind: "auth-code" | "openid-auth";
+  readonly origin: string;
+  readonly type: string;
+}):
+  | { readonly ok: true; readonly connector: ConnectorRuntimeConnector }
+  | { readonly ok: false; readonly response: Response } {
+  const connector = getConnectorRuntimeConnector(
+    args.snapshot,
+    args.connectorRef,
+  );
+  if (!connector) {
     return {
       ok: false,
       response: redirectWithError(
-        origin,
-        type,
-        `${type} connector does not use an OpenID auth grant`,
+        args.origin,
+        args.type,
+        "Unknown connector type",
       ),
     };
   }
-
-  return {
-    ok: true,
-    connectorType,
-  };
+  if (
+    ![...connector.methods.values()].some((runtimeMethod) => {
+      return runtimeMethod.method.grant.kind === args.grantKind;
+    })
+  ) {
+    const label = args.grantKind === "auth-code" ? "auth-code" : "OpenID auth";
+    return {
+      ok: false,
+      response: redirectWithError(
+        args.origin,
+        args.type,
+        `${args.type} connector does not use an ${label} grant`,
+      ),
+    };
+  }
+  return { ok: true, connector };
 }
 
 async function claimStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: AuthGrantConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
 }): Promise<ClaimedCallbackState> {
   const storedStateResolution = await claimConnectorOAuthState(
     args.db,
-    { state: args.state, connectorType: args.connectorType },
+    { state: args.state, connectorType: args.connectorRef },
     args.signal,
   );
   if (storedStateResolution.kind === "invalid") {
@@ -367,14 +311,14 @@ async function claimStoredOAuthStateForCallback(args: {
 async function rejectInvalidStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorType: AuthGrantConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
 }): Promise<Response | undefined> {
   const status = await getConnectorOAuthStateStatus(
     args.db,
-    { state: args.state, connectorType: args.connectorType },
+    { state: args.state, connectorType: args.connectorRef },
     args.signal,
   );
   if (status.kind === "usable") {
@@ -396,17 +340,21 @@ function invalidStoredAuthMethodResponse(
   );
 }
 
-function validateStoredAuthCodeMethod<
-  Type extends AuthCodeGrantConnectorType,
->(args: {
-  readonly connectorType: Type;
+async function resolveStoredCallbackMethod(args: {
+  readonly resolver: ConnectorActionResolver;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly authMethod: string;
+  readonly expectedGrantKind: "auth-code" | "openid-auth";
   readonly origin: string;
   readonly type: string;
-}):
-  | ({ readonly ok: true } & AuthCodeCallbackMethodRef<Type>)
-  | { readonly ok: false; readonly response: Response } {
-  const authMethodResult = connectorAuthMethodIdSchema.safeParse(
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly resolvedMethod: ResolvedConnectorActionMethod;
+    }
+  | { readonly ok: false; readonly response: Response }
+> {
+  const authMethodResult = connectorCatalogAuthMethodIdSchema.safeParse(
     args.authMethod,
   );
   if (!authMethodResult.success) {
@@ -416,23 +364,13 @@ function validateStoredAuthCodeMethod<
     };
   }
 
-  const method = getConnectorAuthMethod(
-    args.connectorType,
-    authMethodResult.data,
-  );
-  if (!method) {
-    return {
-      ok: false,
-      response: invalidStoredAuthMethodResponse(args.origin, args.type),
-    };
-  }
-  if (
-    !connectorAuthMethodHasGrantKind(
-      args.connectorType,
-      authMethodResult.data,
-      "auth-code",
-    )
-  ) {
+  const resolvedMethod = await args.resolver.resolveMethod({
+    connectorRef: args.connectorRef,
+    authMethodId: authMethodResult.data,
+    expectedGrantKind: args.expectedGrantKind,
+    requireAvailable: true,
+  });
+  if (!resolvedMethod.ok) {
     return {
       ok: false,
       response: invalidStoredAuthMethodResponse(args.origin, args.type),
@@ -441,69 +379,18 @@ function validateStoredAuthCodeMethod<
 
   return {
     ok: true,
-    connectorType: args.connectorType,
-    authMethod: authMethodResult.data,
-  };
-}
-
-function validateStoredOpenIdMethod<
-  Type extends OpenIdAuthGrantConnectorType,
->(args: {
-  readonly connectorType: Type;
-  readonly authMethod: string;
-  readonly origin: string;
-  readonly type: string;
-}):
-  | ({ readonly ok: true } & OpenIdCallbackMethodRef<Type>)
-  | { readonly ok: false; readonly response: Response } {
-  const authMethodResult = connectorAuthMethodIdSchema.safeParse(
-    args.authMethod,
-  );
-  if (!authMethodResult.success) {
-    return {
-      ok: false,
-      response: invalidStoredAuthMethodResponse(args.origin, args.type),
-    };
-  }
-
-  const method = getConnectorAuthMethod(
-    args.connectorType,
-    authMethodResult.data,
-  );
-  if (!method) {
-    return {
-      ok: false,
-      response: invalidStoredAuthMethodResponse(args.origin, args.type),
-    };
-  }
-  if (
-    !connectorAuthMethodHasGrantKind(
-      args.connectorType,
-      authMethodResult.data,
-      "openid-auth",
-    )
-  ) {
-    return {
-      ok: false,
-      response: invalidStoredAuthMethodResponse(args.origin, args.type),
-    };
-  }
-
-  return {
-    ok: true,
-    connectorType: args.connectorType,
-    authMethod: authMethodResult.data,
+    resolvedMethod,
   };
 }
 
 async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
-  readonly connectorType: AuthCodeGrantConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly identity: CallbackIdentity;
-  readonly token: ConnectorAuthCodeExchangeResult;
+  readonly token: ConnectorAuthProviderGrantResult;
   readonly signal: AbortSignal;
 }): Promise<void> {
-  if (args.connectorType !== "github") {
+  if (args.connectorRef !== "github") {
     return;
   }
 
@@ -566,8 +453,7 @@ const completeOAuthCallback$ = command(
     signal: AbortSignal,
   ): Promise<Response> => {
     const token = await exchangeTokenForConnector({
-      connectorType: args.connectorType,
-      authMethod: args.authMethod,
+      resolvedMethod: args.resolvedMethod,
       code: args.code,
       redirectUri: args.redirectUri,
       state: args.state,
@@ -581,14 +467,11 @@ const completeOAuthCallback$ = command(
       {
         orgId: args.identity.orgId,
         userId: args.identity.userId,
-        type: args.connectorType,
-        authMethod: args.authMethod,
+        runtimeMethod: args.resolvedMethod.runtimeMethod,
+        snapshot: args.resolvedMethod.snapshot,
         outputs: token.outputs,
         userInfo: token.userInfo,
-        oauthScopes: getRequestedScopes({
-          connectorType: args.connectorType,
-          authMethod: args.authMethod,
-        }),
+        oauthScopes: connectorGrantScopes(args.resolvedMethod.method.grant),
         expiresIn: token.expiresIn,
         extraConnectorSecrets: token.extraConnectorSecrets,
       },
@@ -603,7 +486,7 @@ const completeOAuthCallback$ = command(
           orgId: args.identity.orgId,
           userId: args.identity.userId,
           agentId: args.agentId,
-          connectorType: args.connectorType,
+          connectorType: args.resolvedMethod.connectorRef,
         },
         signal,
       );
@@ -619,7 +502,7 @@ const completeOAuthCallback$ = command(
 
     await linkGithubIntegrationAfterConnectorConnect({
       db: set(writeDb$),
-      connectorType: args.connectorType,
+      connectorRef: args.resolvedMethod.connectorRef,
       identity: args.identity,
       token,
       signal,
@@ -641,8 +524,7 @@ const completeOpenIdCallback$ = command(
     signal: AbortSignal,
   ): Promise<Response> => {
     const token = await verifyOpenIdForConnector({
-      connectorType: args.connectorType,
-      authMethod: args.authMethod,
+      resolvedMethod: args.resolvedMethod,
       callbackParams: args.callbackParams,
       expectedReturnTo: args.expectedReturnTo,
       expectedRealm: args.expectedRealm,
@@ -655,8 +537,8 @@ const completeOpenIdCallback$ = command(
       {
         orgId: args.identity.orgId,
         userId: args.identity.userId,
-        type: args.connectorType,
-        authMethod: args.authMethod,
+        runtimeMethod: args.resolvedMethod.runtimeMethod,
+        snapshot: args.resolvedMethod.snapshot,
         outputs: token.outputs,
         userInfo: token.userInfo,
         oauthScopes: token.scopes,
@@ -674,7 +556,7 @@ const completeOpenIdCallback$ = command(
           orgId: args.identity.orgId,
           userId: args.identity.userId,
           agentId: args.agentId,
-          connectorType: args.connectorType,
+          connectorType: args.resolvedMethod.connectorRef,
         },
         signal,
       );
@@ -696,13 +578,15 @@ const completeOpenIdCallback$ = command(
   },
 );
 
-function resolveCallbackState(
+async function resolveCallbackState(
   args: ResolveCallbackStateInput,
   signal: AbortSignal,
-): ResolvedCallbackState {
-  const authMethodResult = validateStoredAuthCodeMethod({
-    connectorType: args.connectorType,
+): Promise<ResolvedCallbackState> {
+  const authMethodResult = await resolveStoredCallbackMethod({
+    resolver: args.resolver,
+    connectorRef: args.connectorRef,
     authMethod: args.storedState.authMethod,
+    expectedGrantKind: "auth-code",
     origin: args.origin,
     type: args.type,
   });
@@ -719,8 +603,7 @@ function resolveCallbackState(
     },
     agentId: args.storedState.agentId,
     authorizeAgent: args.storedState.authorizeAgent,
-    connectorType: authMethodResult.connectorType,
-    authMethod: authMethodResult.authMethod,
+    resolvedMethod: authMethodResult.resolvedMethod,
     codeVerifier: args.storedState.codeVerifier ?? undefined,
     oauthContext: args.storedState.oauthContext ?? undefined,
     redirectUri: args.storedState.redirectUri,
@@ -745,13 +628,15 @@ function storedOpenIdRealm(
   return openIdRealmForOrigin(new URL(expectedReturnTo).origin);
 }
 
-function resolveOpenIdCallbackState(
+async function resolveOpenIdCallbackState(
   args: ResolveOpenIdCallbackStateInput,
   signal: AbortSignal,
-): ResolvedOpenIdCallbackState {
-  const authMethodResult = validateStoredOpenIdMethod({
-    connectorType: args.connectorType,
+): Promise<ResolvedOpenIdCallbackState> {
+  const authMethodResult = await resolveStoredCallbackMethod({
+    resolver: args.resolver,
+    connectorRef: args.connectorRef,
     authMethod: args.storedState.authMethod,
+    expectedGrantKind: "openid-auth",
     origin: args.origin,
     type: args.type,
   });
@@ -768,8 +653,7 @@ function resolveOpenIdCallbackState(
     },
     agentId: args.storedState.agentId,
     authorizeAgent: args.storedState.authorizeAgent,
-    connectorType: authMethodResult.connectorType,
-    authMethod: authMethodResult.authMethod,
+    resolvedMethod: authMethodResult.resolvedMethod,
     expectedReturnTo: args.storedState.redirectUri,
     expectedRealm: storedOpenIdRealm(
       args.storedState.oauthContext,
@@ -798,22 +682,25 @@ function openIdCallbackParamsFromQuery(
 
 const handleOpenIdConnectorCallback$ = command(
   async (
-    { set },
+    { get, set },
     args: {
-      readonly type: string;
+      readonly type: ConnectorCatalogRef;
       readonly query: ConnectorCallbackQuery;
       readonly origin: string;
+      readonly snapshot: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<Response> => {
-    const connectorTypeResult = resolveOpenIdConnectorType(
-      args.origin,
-      args.type,
-    );
-    if (!connectorTypeResult.ok) {
-      return connectorTypeResult.response;
+    const connectorResult = resolveConnectorWithGrant({
+      snapshot: args.snapshot,
+      connectorRef: args.type,
+      grantKind: "openid-auth",
+      origin: args.origin,
+      type: args.type,
+    });
+    if (!connectorResult.ok) {
+      return connectorResult.response;
     }
-    const { connectorType } = connectorTypeResult;
     const state = args.query.state;
     if (!state) {
       return missingStateRedirectResponse(args.origin, args.type);
@@ -821,7 +708,7 @@ const handleOpenIdConnectorCallback$ = command(
 
     const claimedState = await claimStoredOAuthStateForCallback({
       db: set(writeDb$),
-      connectorType,
+      connectorRef: args.type,
       origin: args.origin,
       type: args.type,
       signal,
@@ -832,12 +719,21 @@ const handleOpenIdConnectorCallback$ = command(
       return claimedState.response;
     }
 
-    const resolvedState = resolveOpenIdCallbackState(
+    const resolver = await get(
+      userConnectorActionResolverForSnapshot(
+        claimedState.storedState.orgId,
+        claimedState.storedState.userId,
+        args.snapshot,
+      ),
+    );
+    signal.throwIfAborted();
+    const resolvedState = await resolveOpenIdCallbackState(
       {
         origin: args.origin,
         type: args.type,
-        connectorType,
+        connectorRef: args.type,
         storedState: claimedState.storedState,
+        resolver,
       },
       signal,
     );
@@ -849,8 +745,7 @@ const handleOpenIdConnectorCallback$ = command(
       set(
         completeOpenIdCallback$,
         {
-          connectorType: resolvedState.connectorType,
-          authMethod: resolvedState.authMethod,
+          resolvedMethod: resolvedState.resolvedMethod,
           callbackParams: openIdCallbackParamsFromQuery(args.query),
           expectedReturnTo: resolvedState.expectedReturnTo,
           expectedRealm: resolvedState.expectedRealm,
@@ -878,37 +773,54 @@ const handleOpenIdConnectorCallback$ = command(
   },
 );
 
+function authCodeCallbackPreflight(args: {
+  readonly type: ConnectorCatalogRef;
+  readonly request: Request;
+  readonly origin: string;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): Response | null {
+  const connectorResult = resolveConnectorWithGrant({
+    snapshot: args.snapshot,
+    connectorRef: args.type,
+    grantKind: "auth-code",
+    origin: args.origin,
+    type: args.type,
+  });
+  if (!connectorResult.ok) {
+    return connectorResult.response;
+  }
+  const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrlForMethods(
+    args.request,
+    [...connectorResult.connector.methods.values()].map((runtimeMethod) => {
+      return runtimeMethod.method;
+    }),
+  );
+  return canonicalRedirectUrl
+    ? connectorOAuthRedirectResponse(canonicalRedirectUrl)
+    : null;
+}
+
 const handleAuthCodeConnectorCallback$ = command(
   async (
-    { set },
+    { get, set },
     args: {
-      readonly type: string;
+      readonly type: ConnectorCatalogRef;
       readonly query: ConnectorCallbackQuery;
       readonly request: Request;
       readonly origin: string;
+      readonly snapshot: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<Response> => {
-    const connectorTypeResult = resolveAuthCodeConnectorType(
-      args.origin,
-      args.type,
-    );
-    if (!connectorTypeResult.ok) {
-      return connectorTypeResult.response;
-    }
-    const { connectorType } = connectorTypeResult;
-    const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrl(
-      args.request,
-      connectorType,
-    );
-    if (canonicalRedirectUrl) {
-      return connectorOAuthRedirectResponse(canonicalRedirectUrl);
+    const preflightResponse = authCodeCallbackPreflight(args);
+    if (preflightResponse) {
+      return preflightResponse;
     }
 
     const state = args.query.state;
     const storedStateCallbackArgs = {
       db: set(writeDb$),
-      connectorType,
+      connectorRef: args.type,
       origin: args.origin,
       type: args.type,
       signal,
@@ -964,12 +876,21 @@ const handleAuthCodeConnectorCallback$ = command(
       return claimedState.response;
     }
 
-    const resolvedState = resolveCallbackState(
+    const resolver = await get(
+      userConnectorActionResolverForSnapshot(
+        claimedState.storedState.orgId,
+        claimedState.storedState.userId,
+        args.snapshot,
+      ),
+    );
+    signal.throwIfAborted();
+    const resolvedState = await resolveCallbackState(
       {
         origin: args.origin,
         type: args.type,
-        connectorType,
+        connectorRef: args.type,
         storedState: claimedState.storedState,
+        resolver,
       },
       signal,
     );
@@ -981,8 +902,7 @@ const handleAuthCodeConnectorCallback$ = command(
       set(
         completeOAuthCallback$,
         {
-          connectorType: resolvedState.connectorType,
-          authMethod: resolvedState.authMethod,
+          resolvedMethod: resolvedState.resolvedMethod,
           code,
           redirectUri: resolvedState.redirectUri,
           state,
@@ -1022,6 +942,8 @@ const callbackConnectorInner$ = command(
     const query = get(queryOf(connectorsTypeCallbackContract.callback));
     const request = get(request$).raw;
     const origin = getConnectorOAuthOrigin(request);
+    const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
+    signal.throwIfAborted();
 
     if (hasOpenIdCallbackFields(query)) {
       return await set(
@@ -1030,6 +952,7 @@ const callbackConnectorInner$ = command(
           type,
           query,
           origin,
+          snapshot,
         },
         signal,
       );
@@ -1042,6 +965,7 @@ const callbackConnectorInner$ = command(
         query,
         request,
         origin,
+        snapshot,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -26,7 +26,7 @@ import {
 } from "../services/connector-oauth-state.service";
 import { authorizeConnectedConnector$ } from "../services/connected-connector-authorization.service";
 import {
-  userConnectorActionResolverForSnapshot,
+  connectorActionResolverForSnapshot,
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
 } from "../services/connector-action-resolver.service";
@@ -368,7 +368,6 @@ async function resolveStoredCallbackMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: authMethodResult.data,
     expectedGrantKind: args.expectedGrantKind,
-    requireAvailable: true,
   });
   if (!resolvedMethod.ok) {
     return {
@@ -720,11 +719,7 @@ const handleOpenIdConnectorCallback$ = command(
     }
 
     const resolver = await get(
-      userConnectorActionResolverForSnapshot(
-        claimedState.storedState.orgId,
-        claimedState.storedState.userId,
-        args.snapshot,
-      ),
+      connectorActionResolverForSnapshot(args.snapshot),
     );
     signal.throwIfAborted();
     const resolvedState = await resolveOpenIdCallbackState(
@@ -881,11 +876,7 @@ const handleAuthCodeConnectorCallback$ = command(
     }
 
     const resolver = await get(
-      userConnectorActionResolverForSnapshot(
-        claimedState.storedState.orgId,
-        claimedState.storedState.userId,
-        args.snapshot,
-      ),
+      connectorActionResolverForSnapshot(args.snapshot),
     );
     signal.throwIfAborted();
     const resolvedState = await resolveCallbackState(

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -791,9 +791,13 @@ function authCodeCallbackPreflight(args: {
   }
   const canonicalRedirectUrl = getConnectorOAuthCanonicalRedirectUrlForMethods(
     args.request,
-    [...connectorResult.connector.methods.values()].map((runtimeMethod) => {
-      return runtimeMethod.method;
-    }),
+    [...connectorResult.connector.methods.values()]
+      .filter((runtimeMethod) => {
+        return runtimeMethod.executable;
+      })
+      .map((runtimeMethod) => {
+        return runtimeMethod.method;
+      }),
   );
   return canonicalRedirectUrl
     ? connectorOAuthRedirectResponse(canonicalRedirectUrl)

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -3,15 +3,13 @@ import {
   githubOauthContract,
   type GithubOauthConnectQuery,
 } from "@vm0/api-contracts/contracts/github-oauth";
-import type { AuthCodeGrantConnectorType } from "@vm0/connectors/connectors";
 import {
-  getConnectorAuthMethodAuthCodeGrantConfig,
-  getConnectorAuthMethodGrantScopes,
-  resolveConnectorAuthClientForMethod,
+  connectorGrantScopes,
+  resolveConnectorAuthClient,
   isStaticConfidentialConnectorAuthClient,
   type StaticConfidentialConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
-import { exchangeConnectorAuthCode } from "@vm0/connectors/auth-providers";
+import { exchangeConnectorAuthCodeWithMethod } from "@vm0/connectors/auth-providers";
 import {
   exchangeGitHubCode,
   fetchGitHubUserInfo,
@@ -25,6 +23,11 @@ import { publishUserSignal } from "../external/realtime";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
+import {
+  userConnectorActionResolver,
+  type ConnectorActionResolver,
+  type ResolvedConnectorActionMethod,
+} from "../services/connector-action-resolver.service";
 import {
   buildGithubOauthState,
   buildGithubUserConnectAuthorizationUrl,
@@ -54,7 +57,7 @@ import {
 } from "./oauth-web-origin";
 
 const REDIRECT_STATUS = 307;
-const GITHUB_CONNECTOR_TYPE = "github" satisfies AuthCodeGrantConnectorType;
+const GITHUB_CONNECTOR_TYPE = "github";
 const GITHUB_APP_SETUP_CALLBACK_PATH = "/api/github/app/setup/callback";
 const L = logger("GithubOAuthRoute");
 
@@ -87,13 +90,14 @@ function githubAppSetupCallbackRedirectUri(origin: string): string {
   return `${origin}${GITHUB_APP_SETUP_CALLBACK_PATH}`;
 }
 
-function githubUserOauthClient():
-  | StaticConfidentialConnectorAuthClient
-  | undefined {
-  const authMethod = getGithubOAuthAuthMethod();
-  const authClient = resolveConnectorAuthClientForMethod(
-    GITHUB_CONNECTOR_TYPE,
-    authMethod,
+function githubUserOauthClient(
+  method: ResolvedConnectorActionMethod,
+): StaticConfidentialConnectorAuthClient | undefined {
+  if (method.method.grant.kind !== "auth-code" || !method.method.client) {
+    return undefined;
+  }
+  const authClient = resolveConnectorAuthClient(
+    method.method.client,
     optionalEnv,
   );
   if (!authClient) {
@@ -103,6 +107,19 @@ function githubUserOauthClient():
     return undefined;
   }
   return authClient;
+}
+
+async function resolveGithubOauthMethod(
+  resolver: ConnectorActionResolver,
+  requireAvailable: boolean,
+): Promise<ResolvedConnectorActionMethod | null> {
+  const resolved = await resolver.resolveMethod({
+    connectorRef: GITHUB_CONNECTOR_TYPE,
+    authMethodId: getGithubOAuthAuthMethod(),
+    expectedGrantKind: "auth-code",
+    requireAvailable,
+  });
+  return resolved.ok ? resolved : null;
 }
 
 function githubAppUserOauthCredentials():
@@ -310,9 +327,29 @@ const resolveGithubCallbackAccess$ = command(
   },
 );
 
+async function linkGithubUserWithoutSetupCode(
+  args: GithubSetupUserConnectionArgs,
+  vm0UserId: string,
+  signal: AbortSignal,
+): Promise<GithubSetupUserConnectionResolution> {
+  const githubUserId = await linkGithubVm0User({
+    db: args.db,
+    installRecordId: args.installRecordId,
+    vm0UserId,
+    knownGithubUserId: args.knownGithubUserId,
+    signal,
+  });
+  signal.throwIfAborted();
+  if (githubUserId) {
+    await publishUserSignal([vm0UserId], "github:changed");
+    signal.throwIfAborted();
+  }
+  return { ok: true, connected: githubUserId !== null };
+}
+
 const connectGithubUserAfterSetup$ = command(
   async (
-    { set },
+    { get, set },
     args: GithubSetupUserConnectionArgs,
     signal: AbortSignal,
   ): Promise<GithubSetupUserConnectionResolution> => {
@@ -347,11 +384,23 @@ const connectGithubUserAfterSetup$ = command(
         sendsRedirectUri: false,
       });
 
-      const authMethod = getGithubOAuthAuthMethod();
+      const resolver = await get(
+        userConnectorActionResolver(args.orgId, vm0UserId),
+      );
+      signal.throwIfAborted();
+      const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+      signal.throwIfAborted();
+      if (!resolvedMethod || resolvedMethod.method.grant.kind !== "auth-code") {
+        return {
+          ok: false,
+          response: worksErrorRedirect("GitHub OAuth is not available"),
+        };
+      }
+      const authCodeGrant = resolvedMethod.method.grant;
       const tokenResult = await settle(
         (async () => {
           const { accessToken, scopes } = await exchangeGitHubCode(
-            getConnectorAuthMethodAuthCodeGrantConfig("github", authMethod),
+            authCodeGrant,
             credentials.clientId,
             credentials.clientSecret,
             code,
@@ -389,17 +438,14 @@ const connectGithubUserAfterSetup$ = command(
         {
           orgId: args.orgId,
           userId: vm0UserId,
-          type: GITHUB_CONNECTOR_TYPE,
-          authMethod,
+          runtimeMethod: resolvedMethod.runtimeMethod,
+          snapshot: resolvedMethod.snapshot,
           outputs: { accessToken },
           userInfo,
           oauthScopes:
             scopes.length > 0
               ? scopes
-              : getConnectorAuthMethodGrantScopes(
-                  GITHUB_CONNECTOR_TYPE,
-                  authMethod,
-                ),
+              : connectorGrantScopes(resolvedMethod.method.grant),
         },
         signal,
       );
@@ -429,21 +475,7 @@ const connectGithubUserAfterSetup$ = command(
       return { ok: true, connected: true };
     }
 
-    const githubUserId = await linkGithubVm0User({
-      db: args.db,
-      installRecordId: args.installRecordId,
-      vm0UserId,
-      knownGithubUserId: args.knownGithubUserId,
-      signal,
-    });
-    signal.throwIfAborted();
-
-    if (githubUserId) {
-      await publishUserSignal([vm0UserId], "github:changed");
-      signal.throwIfAborted();
-    }
-
-    return { ok: true, connected: githubUserId !== null };
+    return await linkGithubUserWithoutSetupCode(args, vm0UserId, signal);
   },
 );
 
@@ -685,11 +717,20 @@ const connectGithubUserOauth$ = command(
 
     const origin = getOAuthWebOrigin(request);
     const db = set(writeDb$);
+    const resolver = await get(userConnectorActionResolver(orgId, auth.userId));
+    signal.throwIfAborted();
+    const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+    signal.throwIfAborted();
+    if (!resolvedMethod) {
+      return worksErrorRedirect("GitHub OAuth is not available");
+    }
     const authorizationUrl = await buildGithubUserConnectAuthorizationUrl({
       db,
       vm0UserId: auth.userId,
       orgId,
       origin,
+      authMethodId: resolvedMethod.authMethodId,
+      method: resolvedMethod.method,
       readEnv: optionalEnv,
       signal,
     });
@@ -739,17 +780,26 @@ const callbackGithubUserOauth$ = command(
       );
     }
 
-    const authClient = githubUserOauthClient();
+    const resolver = await get(
+      userConnectorActionResolver(state.orgId, state.vm0UserId),
+    );
+    signal.throwIfAborted();
+    const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+    signal.throwIfAborted();
+    if (!resolvedMethod) {
+      return worksErrorRedirect("GitHub OAuth is not available");
+    }
+    const authClient = githubUserOauthClient(resolvedMethod);
     if (!authClient) {
       return worksErrorRedirect("GitHub OAuth is not configured");
     }
 
-    const authMethod = getGithubOAuthAuthMethod();
     const origin = getOAuthWebOrigin(request);
     const redirectUri = githubUserConnectCallbackRedirectUri(origin);
-    const token = await exchangeConnectorAuthCode({
-      type: "github",
-      authMethod,
+    const token = await exchangeConnectorAuthCodeWithMethod({
+      connectorRef: resolvedMethod.connectorRef,
+      authMethodId: resolvedMethod.authMethodId,
+      method: resolvedMethod.method,
       authClient,
       code: query.code,
       redirectUri,
@@ -774,14 +824,11 @@ const callbackGithubUserOauth$ = command(
       {
         orgId: state.orgId,
         userId: state.vm0UserId,
-        type: GITHUB_CONNECTOR_TYPE,
-        authMethod,
+        runtimeMethod: resolvedMethod.runtimeMethod,
+        snapshot: resolvedMethod.snapshot,
         outputs: token.outputs,
         userInfo: token.userInfo,
-        oauthScopes: getConnectorAuthMethodGrantScopes(
-          GITHUB_CONNECTOR_TYPE,
-          authMethod,
-        ),
+        oauthScopes: connectorGrantScopes(resolvedMethod.method.grant),
         extraConnectorSecrets: token.extraConnectorSecrets,
       },
       signal,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -24,7 +24,7 @@ import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
 import {
-  userConnectorActionResolver,
+  connectorActionResolver,
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
 } from "../services/connector-action-resolver.service";
@@ -111,13 +111,22 @@ function githubUserOauthClient(
 
 async function resolveGithubOauthMethod(
   resolver: ConnectorActionResolver,
-  requireAvailable: boolean,
 ): Promise<ResolvedConnectorActionMethod | null> {
   const resolved = await resolver.resolveMethod({
     connectorRef: GITHUB_CONNECTOR_TYPE,
     authMethodId: getGithubOAuthAuthMethod(),
     expectedGrantKind: "auth-code",
-    requireAvailable,
+  });
+  return resolved.ok ? resolved : null;
+}
+
+async function resolveGithubOauthMethodForNewAction(
+  resolver: ConnectorActionResolver,
+): Promise<ResolvedConnectorActionMethod | null> {
+  const resolved = await resolver.resolveNewActionMethod({
+    connectorRef: GITHUB_CONNECTOR_TYPE,
+    authMethodId: getGithubOAuthAuthMethod(),
+    expectedGrantKind: "auth-code",
   });
   return resolved.ok ? resolved : null;
 }
@@ -384,11 +393,9 @@ const connectGithubUserAfterSetup$ = command(
         sendsRedirectUri: false,
       });
 
-      const resolver = await get(
-        userConnectorActionResolver(args.orgId, vm0UserId),
-      );
+      const resolver = await get(connectorActionResolver());
       signal.throwIfAborted();
-      const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+      const resolvedMethod = await resolveGithubOauthMethod(resolver);
       signal.throwIfAborted();
       if (!resolvedMethod || resolvedMethod.method.grant.kind !== "auth-code") {
         return {
@@ -717,9 +724,9 @@ const connectGithubUserOauth$ = command(
 
     const origin = getOAuthWebOrigin(request);
     const db = set(writeDb$);
-    const resolver = await get(userConnectorActionResolver(orgId, auth.userId));
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+    const resolvedMethod = await resolveGithubOauthMethodForNewAction(resolver);
     signal.throwIfAborted();
     if (!resolvedMethod) {
       return worksErrorRedirect("GitHub OAuth is not available");
@@ -780,11 +787,9 @@ const callbackGithubUserOauth$ = command(
       );
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(state.orgId, state.vm0UserId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolvedMethod = await resolveGithubOauthMethod(resolver, true);
+    const resolvedMethod = await resolveGithubOauthMethod(resolver);
     signal.throwIfAborted();
     if (!resolvedMethod) {
       return worksErrorRedirect("GitHub OAuth is not available");

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -493,6 +493,7 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
     const resolved = await resolver.resolveRef({
       connectorRef,
       requireAvailable: true,
+      requireExecutable: true,
     });
     if (resolved.ok) {
       availableEnabledTypes.push(connectorRef);
@@ -828,6 +829,7 @@ const updateAgentUserConnectorsInner$ = command(
       const resolved = await resolver.resolveRefs({
         connectorRefs: uniqueTypes,
         requireAvailable: true,
+        requireExecutable: true,
       });
       signal.throwIfAborted();
       if (!resolved.ok) {

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -819,6 +819,10 @@ const updateAgentUserConnectorsInner$ = command(
     const uniqueTypes = Array.from(new Set(body.data.enabledTypes));
     const operation = body.data.operation ?? "replace";
     if (operation !== "remove") {
+      // Agent connector selection is persisted execution configuration, not a
+      // discovery surface. Validate that each connector can execute, but do
+      // not consult feature switches or authored visibility: rollout changes
+      // must not invalidate direct API updates or an existing agent config.
       const resolver = await get(connectorActionResolver());
       signal.throwIfAborted();
       const resolved = await resolver.resolveRefs({

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -38,7 +38,7 @@ import {
   zeroAgentList,
   visibleJoinedZeroAgentCondition,
 } from "../services/zero-agent-data.service";
-import { userConnectorActionResolver } from "../services/connector-action-resolver.service";
+import { connectorActionResolver } from "../services/connector-action-resolver.service";
 import {
   updateUserConnectors,
   updateUserCustomConnectors,
@@ -485,14 +485,11 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
       agentId: params.id,
     }),
   );
-  const resolver = await get(
-    userConnectorActionResolver(auth.orgId, auth.userId),
-  );
+  const resolver = await get(connectorActionResolver());
   const availableEnabledTypes: (typeof enabledTypes)[number][] = [];
   for (const connectorRef of enabledTypes) {
     const resolved = await resolver.resolveRef({
       connectorRef,
-      requireAvailable: true,
       requireExecutable: true,
     });
     if (resolved.ok) {
@@ -822,22 +819,14 @@ const updateAgentUserConnectorsInner$ = command(
     const uniqueTypes = Array.from(new Set(body.data.enabledTypes));
     const operation = body.data.operation ?? "replace";
     if (operation !== "remove") {
-      const resolver = await get(
-        userConnectorActionResolver(auth.orgId, auth.userId),
-      );
+      const resolver = await get(connectorActionResolver());
       signal.throwIfAborted();
       const resolved = await resolver.resolveRefs({
         connectorRefs: uniqueTypes,
-        requireAvailable: true,
         requireExecutable: true,
       });
       signal.throwIfAborted();
       if (!resolved.ok) {
-        if (resolved.reason === "unavailable_connector") {
-          return validationError(
-            `Connector types are not available: ${resolved.connectorRef}`,
-          );
-        }
         return validationError(
           `Invalid connector types: ${resolved.connectorRef}`,
         );

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -39,7 +39,7 @@ import {
   zeroConnectorSearch,
 } from "../services/zero-connector-data.service";
 import {
-  userConnectorActionResolver,
+  connectorActionResolver,
   type ConnectorActionMethodResolution,
   type ConnectorRefResolution,
 } from "../services/connector-action-resolver.service";
@@ -145,8 +145,7 @@ function connectorMethodResolutionError(
         `${args.connectorRef} ${args.authMethodId} auth method does not use ${args.expectedGrantLabel}`,
       );
     }
-    case "unavailable_connector":
-    case "unavailable_auth_method": {
+    case "hidden_auth_method": {
       return connectorUnavailable(args.connectorRef);
     }
     case "missing_executable_capability": {
@@ -157,14 +156,10 @@ function connectorMethodResolutionError(
 
 function connectorRefResolutionError(
   resolution: Exclude<ConnectorRefResolution, { readonly ok: true }>,
-  connectorRef: string,
 ) {
   switch (resolution.reason) {
     case "unknown_connector": {
       return notFound("Connector not found");
-    }
-    case "unavailable_connector": {
-      return connectorUnavailable(connectorRef);
     }
     case "missing_executable_capability": {
       return internalServerError("Connector execution is not configured");
@@ -183,16 +178,13 @@ const getConnectorListInner$ = computed(async (get) => {
 const getConnectorByTypeInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorsByTypeContract.get));
-  const resolver = await get(
-    userConnectorActionResolver(auth.orgId, auth.userId),
-  );
+  const resolver = await get(connectorActionResolver());
   const resolved = await resolver.resolveRef({
     connectorRef: params.type,
-    requireAvailable: false,
     requireExecutable: false,
   });
   if (!resolved.ok) {
-    return connectorRefResolutionError(resolved, params.type);
+    return connectorRefResolutionError(resolved);
   }
   const connector = await get(
     zeroConnectorByType({
@@ -213,18 +205,15 @@ const deleteConnectorByTypeInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(zeroConnectorsByTypeContract.delete));
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolved = await resolver.resolveRef({
       connectorRef: params.type,
-      requireAvailable: false,
       requireExecutable: false,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
-      return connectorRefResolutionError(resolved, params.type);
+      return connectorRefResolutionError(resolved);
     }
     const deleted = await set(
       deleteZeroConnectorLocalState$,
@@ -249,16 +238,13 @@ const deleteConnectorByTypeInner$ = command(
 const getScopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
-  const resolver = await get(
-    userConnectorActionResolver(auth.orgId, auth.userId),
-  );
+  const resolver = await get(connectorActionResolver());
   const resolved = await resolver.resolveRef({
     connectorRef: params.type,
-    requireAvailable: false,
     requireExecutable: false,
   });
   if (!resolved.ok) {
-    return connectorRefResolutionError(resolved, params.type);
+    return connectorRefResolutionError(resolved);
   }
   const diff = await get(
     zeroConnectorScopeDiff({
@@ -326,15 +312,12 @@ const connectManualGrantConnectorInner$ = command(
       return notFound(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolved = await resolver.resolveMethod({
+    const resolved = await resolver.resolveNewActionMethod({
       connectorRef: params.type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "manual",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -408,15 +391,12 @@ const connectNoAuthConnectorInner$ = command(
       return notFound(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolved = await resolver.resolveMethod({
+    const resolved = await resolver.resolveNewActionMethod({
       connectorRef: params.type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "none",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -493,15 +473,12 @@ const startConnectorOauthInner$ = command(
       return badRequestMessage(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolved = await resolver.resolveMethod({
+    const resolved = await resolver.resolveNewActionMethod({
       connectorRef: type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "auth-code",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -614,15 +591,12 @@ const startConnectorOpenIdInner$ = command(
       return badRequestMessage(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolved = await resolver.resolveMethod({
+    const resolved = await resolver.resolveNewActionMethod({
       connectorRef: type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "openid-auth",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -9,10 +9,6 @@ import {
   zeroConnectorsMainContract,
   zeroConnectorsSearchContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import type {
-  ConnectorAuthMethodId,
-  ConnectorType,
-} from "@vm0/connectors/connectors";
 import type { PublicConnectorCatalogDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 
@@ -45,33 +41,24 @@ import {
 import {
   userConnectorActionResolver,
   type ConnectorActionMethodResolution,
-  type ConnectorExecutableRefResolution,
+  type ConnectorRefResolution,
 } from "../services/connector-action-resolver.service";
 import { isConnectorCatalogUnavailableError } from "../services/connector-catalog-reader.service";
 import type { RouteEntry } from "../route-entry";
 import { settle } from "../utils";
 import {
-  getConnectorOAuthCallbackOrigin,
-  getConnectorOpenIdCallbackOrigin,
+  getConnectorOAuthCallbackOriginForMethod,
+  getConnectorOpenIdCallbackOriginForMethod,
 } from "./connector-oauth-origin";
 import { CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS } from "./connector-oauth-route-state";
 import {
-  buildResolvedConnectorAuthCodeAuthUrl,
-  prepareResolvedConnectorAuthCodeStart,
-  resolveConnectorAuthCodeStartMethod,
+  buildConnectorAuthCodeAuthUrlWithMethod,
+  prepareConnectorAuthCodeStartWithMethod,
 } from "./connector-auth-code-start";
 import {
-  buildResolvedConnectorOpenIdAuthUrl,
-  prepareResolvedConnectorOpenIdAuthStart,
-  resolveConnectorOpenIdAuthStartMethod,
+  buildConnectorOpenIdAuthUrlWithMethod,
+  prepareConnectorOpenIdAuthStartWithMethod,
 } from "./connector-openid-auth-start";
-
-type ResolvedAuthCodeStartMethod = ReturnType<
-  typeof resolveConnectorAuthCodeStartMethod
->;
-type ResolvedOpenIdAuthStartMethod = ReturnType<
-  typeof resolveConnectorOpenIdAuthStartMethod
->;
 
 const connectorReadAuth = {
   requireOrganization: true,
@@ -94,28 +81,6 @@ function connectorUnavailable(type: string) {
       },
     },
   };
-}
-
-function resolveRequestedAuthCodeStartMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): ResolvedAuthCodeStartMethod {
-  const result = resolveConnectorAuthCodeStartMethod(type, authMethod);
-  if (result.ok || result.reason === "missing_auth_method") {
-    return result;
-  }
-  return { ok: false, reason: "wrong_grant_kind" };
-}
-
-function resolveRequestedOpenIdAuthStartMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): ResolvedOpenIdAuthStartMethod {
-  const result = resolveConnectorOpenIdAuthStartMethod(type, authMethod);
-  if (result.ok || result.reason === "missing_auth_method") {
-    return result;
-  }
-  return { ok: false, reason: "wrong_grant_kind" };
 }
 
 function internalServerError(message: string) {
@@ -191,7 +156,7 @@ function connectorMethodResolutionError(
 }
 
 function connectorRefResolutionError(
-  resolution: Exclude<ConnectorExecutableRefResolution, { readonly ok: true }>,
+  resolution: Exclude<ConnectorRefResolution, { readonly ok: true }>,
   connectorRef: string,
 ) {
   switch (resolution.reason) {
@@ -224,6 +189,7 @@ const getConnectorByTypeInner$ = computed(async (get) => {
   const resolved = await resolver.resolveRef({
     connectorRef: params.type,
     requireAvailable: false,
+    requireExecutable: false,
   });
   if (!resolved.ok) {
     return connectorRefResolutionError(resolved, params.type);
@@ -232,7 +198,8 @@ const getConnectorByTypeInner$ = computed(async (get) => {
     zeroConnectorByType({
       orgId: auth.orgId,
       userId: auth.userId,
-      type: resolved.type,
+      type: resolved.connectorRef,
+      snapshot: resolved.snapshot,
     }),
   );
   if (!connector) {
@@ -253,6 +220,7 @@ const deleteConnectorByTypeInner$ = command(
     const resolved = await resolver.resolveRef({
       connectorRef: params.type,
       requireAvailable: false,
+      requireExecutable: false,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -263,7 +231,8 @@ const deleteConnectorByTypeInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        type: resolved.type,
+        type: resolved.connectorRef,
+        snapshot: resolved.snapshot,
       },
       signal,
     );
@@ -286,6 +255,7 @@ const getScopeDiffInner$ = computed(async (get) => {
   const resolved = await resolver.resolveRef({
     connectorRef: params.type,
     requireAvailable: false,
+    requireExecutable: false,
   });
   if (!resolved.ok) {
     return connectorRefResolutionError(resolved, params.type);
@@ -294,7 +264,8 @@ const getScopeDiffInner$ = computed(async (get) => {
     zeroConnectorScopeDiff({
       orgId: auth.orgId,
       userId: auth.userId,
-      type: resolved.type,
+      type: resolved.connectorRef,
+      snapshot: resolved.snapshot,
     }),
   );
   if (!diff) {
@@ -363,6 +334,7 @@ const connectManualGrantConnectorInner$ = command(
       connectorRef: params.type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "manual",
+      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -379,8 +351,8 @@ const connectManualGrantConnectorInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        type: resolved.type,
-        authMethod: resolved.authMethod,
+        runtimeMethod: resolved.runtimeMethod,
+        snapshot: resolved.snapshot,
         values: bodyResult.data.values,
       },
       signal,
@@ -398,7 +370,7 @@ const connectManualGrantConnectorInner$ = command(
           orgId: auth.orgId,
           userId: auth.userId,
           agentId: bodyResult.data.agentId ?? null,
-          connectorType: resolved.type,
+          connectorType: resolved.connectorRef,
         },
         signal,
       );
@@ -444,6 +416,7 @@ const connectNoAuthConnectorInner$ = command(
       connectorRef: params.type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "none",
+      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -460,8 +433,8 @@ const connectNoAuthConnectorInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        type: resolved.type,
-        authMethod: resolved.authMethod,
+        runtimeMethod: resolved.runtimeMethod,
+        snapshot: resolved.snapshot,
       },
       signal,
     );
@@ -474,7 +447,7 @@ const connectNoAuthConnectorInner$ = command(
           orgId: auth.orgId,
           userId: auth.userId,
           agentId: bodyResult.data.agentId ?? null,
-          connectorType: resolved.type,
+          connectorType: resolved.connectorRef,
         },
         signal,
       );
@@ -528,6 +501,7 @@ const startConnectorOauthInner$ = command(
       connectorRef: type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "auth-code",
+      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -540,31 +514,28 @@ const startConnectorOauthInner$ = command(
       });
     }
 
-    const authCodeStartType = resolveRequestedAuthCodeStartMethod(
-      resolved.type,
-      resolved.authMethod,
-    );
-    if (!authCodeStartType.ok) {
+    const method = resolved.method;
+    if (method.grant.kind !== "auth-code") {
       return internalServerError("Connector execution is not configured");
     }
 
-    const origin = getConnectorOAuthCallbackOrigin({
+    const origin = getConnectorOAuthCallbackOriginForMethod({
       request,
-      type: authCodeStartType.type,
-      authMethod: authCodeStartType.authMethod,
+      method,
     });
-    const prepared = prepareResolvedConnectorAuthCodeStart({
-      type: authCodeStartType.type,
-      authMethod: authCodeStartType.authMethod,
+    const prepared = prepareConnectorAuthCodeStartWithMethod({
+      connectorRef: resolved.connectorRef,
+      method,
       origin,
       readEnv: optionalEnv,
     });
     if (!prepared.ok) {
       return internalServerError(`${type} auth client not configured`);
     }
-    const authResult = await buildResolvedConnectorAuthCodeAuthUrl({
-      type: authCodeStartType.type,
-      authMethod: authCodeStartType.authMethod,
+    const authResult = await buildConnectorAuthCodeAuthUrlWithMethod({
+      connectorRef: resolved.connectorRef,
+      authMethodId: resolved.authMethodId,
+      method,
       authClient: prepared.authClient,
       redirectUri: prepared.redirectUri,
       state: prepared.state,
@@ -576,7 +547,8 @@ const startConnectorOauthInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        type: authCodeStartType.type,
+        type: resolved.connectorRef,
+        snapshot: resolved.snapshot,
       },
       signal,
     );
@@ -585,8 +557,8 @@ const startConnectorOauthInner$ = command(
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
       state: prepared.state,
-      type: authCodeStartType.type,
-      authMethod: authCodeStartType.authMethod,
+      type: resolved.connectorRef,
+      authMethod: resolved.authMethodId,
       userId: auth.userId,
       orgId: auth.orgId,
       agentId: bodyResult.data.agentId,
@@ -650,6 +622,7 @@ const startConnectorOpenIdInner$ = command(
       connectorRef: type,
       authMethodId: bodyResult.data.authMethod,
       expectedGrantKind: "openid-auth",
+      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -662,25 +635,22 @@ const startConnectorOpenIdInner$ = command(
       });
     }
 
-    const openIdStartType = resolveRequestedOpenIdAuthStartMethod(
-      resolved.type,
-      resolved.authMethod,
-    );
-    if (!openIdStartType.ok) {
+    if (resolved.method.grant.kind !== "openid-auth") {
       return internalServerError("Connector execution is not configured");
     }
 
-    const prepared = prepareResolvedConnectorOpenIdAuthStart({
-      type: openIdStartType.type,
-      origin: getConnectorOpenIdCallbackOrigin({
+    const prepared = prepareConnectorOpenIdAuthStartWithMethod({
+      connectorRef: resolved.connectorRef,
+      method: resolved.method,
+      origin: getConnectorOpenIdCallbackOriginForMethod({
         request,
-        type: openIdStartType.type,
-        authMethod: openIdStartType.authMethod,
+        method: resolved.method,
       }),
     });
-    const authResult = await buildResolvedConnectorOpenIdAuthUrl({
-      type: openIdStartType.type,
-      authMethod: openIdStartType.authMethod,
+    const authResult = await buildConnectorOpenIdAuthUrlWithMethod({
+      connectorRef: resolved.connectorRef,
+      authMethodId: resolved.authMethodId,
+      method: resolved.method,
       returnTo: prepared.returnTo,
       realm: prepared.realm,
       state: prepared.state,
@@ -692,7 +662,8 @@ const startConnectorOpenIdInner$ = command(
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        type: openIdStartType.type,
+        type: resolved.connectorRef,
+        snapshot: resolved.snapshot,
       },
       signal,
     );
@@ -701,8 +672,8 @@ const startConnectorOpenIdInner$ = command(
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
       state: prepared.state,
-      type: openIdStartType.type,
-      authMethod: openIdStartType.authMethod,
+      type: resolved.connectorRef,
+      authMethod: resolved.authMethodId,
       userId: auth.userId,
       orgId: auth.orgId,
       agentId: bodyResult.data.agentId,

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -4,11 +4,11 @@ import {
   zeroVariablesContract,
 } from "@vm0/api-contracts/contracts/zero-secrets";
 import type { SecretListResponse } from "@vm0/api-contracts/contracts/secrets";
-import { getConnectorStoredSecretDisplayInfo } from "@vm0/connectors/connector-utils";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
+import { db$ } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import {
   setUserSecret$,
@@ -16,6 +16,10 @@ import {
   userSecrets,
   userVariables,
 } from "../services/zero-user-data.service";
+import {
+  getConnectorRuntimeStoredSecretDisplayInfo,
+  loadConnectorRuntimeSnapshot,
+} from "../services/connector-catalog-runtime.service";
 import { zeroSecretsDeleteRoutes } from "./zero-secrets-delete";
 import { zeroVariablesDeleteRoutes } from "./zero-variables-delete";
 
@@ -26,18 +30,19 @@ const listSecretsInner$ = computed(async (get): Promise<unknown> => {
   const storedSecrets = await get(
     userSecrets({ orgId: auth.orgId, userId: auth.userId }),
   );
+  const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
   const body: SecretListResponse = {
     secrets: storedSecrets.secrets.map((secret) => {
       const display =
         secret.type === "connector" || secret.type === "user"
-          ? getConnectorStoredSecretDisplayInfo(secret.name)
+          ? getConnectorRuntimeStoredSecretDisplayInfo(snapshot, secret.name)
           : null;
       return {
         ...secret,
         connectorDisplay: display
           ? {
-              label: display.connectorLabel,
-              environmentNames: display.envNames,
+              label: display.label,
+              environmentNames: [...display.environmentNames],
             }
           : null,
       };

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -1,7 +1,7 @@
 import {
-  connectorTypeSchema,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+  connectorCatalogRefSchema,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import {
@@ -13,7 +13,7 @@ import { and, eq } from "drizzle-orm";
 import type { ReadonlyDb } from "../external/db";
 
 interface AgentConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
 }
 
@@ -29,7 +29,7 @@ async function loadAgentAllowedConnectorTypes(
     readonly orgId: string;
     readonly agentId: string;
   },
-): Promise<readonly ConnectorType[]> {
+): Promise<readonly ConnectorCatalogRef[]> {
   const rows = await db
     .select({ connectorType: userConnectors.connectorType })
     .from(userConnectors)
@@ -42,7 +42,7 @@ async function loadAgentAllowedConnectorTypes(
     );
 
   return rows.flatMap((row) => {
-    const parsed = connectorTypeSchema.safeParse(row.connectorType);
+    const parsed = connectorCatalogRefSchema.safeParse(row.connectorType);
     return parsed.success ? [parsed.data] : [];
   });
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -10,6 +10,12 @@ import {
 } from "@vm0/api-contracts/contracts/runners";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import {
+  connectorCatalogAuthMethodIdSchema,
+  connectorCatalogRefSchema,
+  type ConnectorCatalogAuthMethodId,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import {
   getDefaultModel,
   getModelProviderFirewall,
   getModelProviderCodexRuntimeConfig,
@@ -35,14 +41,10 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  getConnectorAuthMethod,
-  getConnectorAuthMethodRuntimeMetadata,
+  connectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
 } from "@vm0/connectors/connector-utils";
-import {
-  connectorTypeSchema,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import {
   getFirewallExecutionMetadata,
   isFirewallExecutionMetadataConnectorType,
@@ -166,9 +168,16 @@ import { drainOrgQueue$ } from "./zero-run-queue.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
 import { runnerJobQueueTimestamps } from "./runner-job-queue-lifecycle.service";
 import {
-  connectorRuntimeCredentialStatus,
+  connectorRuntimeCredentialStatusWithMethod,
   type ConnectorCredentialStatus,
 } from "./connector-credential-status.service";
+import {
+  getConnectorRuntimeConnector,
+  getConnectorRuntimeMethod,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeMethod,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 import {
   defaultFirewallPolicyForPermissionIndex,
   networkPolicyForFirewallPolicy,
@@ -365,13 +374,13 @@ interface ResolvedCompose {
 type ConnectorScopeSource = "explicit" | "zero_agent" | "legacy_all" | "empty";
 
 interface EffectiveConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
   readonly allowedCustomConnectorIds: readonly string[] | undefined;
   readonly source: ConnectorScopeSource;
 }
 
 interface ExplicitConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly source?: Exclude<ConnectorScopeSource, "legacy_all" | "empty">;
 }
@@ -620,7 +629,7 @@ interface ConnectorRuntimeContext {
   readonly secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
     | undefined;
-  readonly connectorTypes: readonly ConnectorType[];
+  readonly connectorTypes: readonly ConnectorCatalogRef[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
 
@@ -761,11 +770,19 @@ function skillMountPath(
 // differs from the compose, and skills mounted at the wrong path are invisible
 // to the agent.
 function buildSystemSkillVolumes(
-  connectorTypes: readonly ConnectorType[],
+  connectorTypes: readonly ConnectorCatalogRef[],
   framework: SupportedFramework,
 ): readonly AdditionalVolume[] {
   const seedNames = [...SEED_SKILLS, GOAL_SKILL_NAME];
-  const allSkillNames = [...new Set([...seedNames, ...connectorTypes])];
+  // Exact catalog skill selection is owned by #21815. Until then, preserve
+  // the existing vm0-skills mounts only for locally known connector names.
+  const staticConnectorSkillNames = connectorTypes.flatMap((connectorRef) => {
+    const parsed = connectorTypeSchema.safeParse(connectorRef);
+    return parsed.success ? [parsed.data] : [];
+  });
+  const allSkillNames = [
+    ...new Set([...seedNames, ...staticConnectorSkillNames]),
+  ];
   return allSkillNames.flatMap((skillName) => {
     const url = resolveSkillRef(skillName);
     const parsed = parseGitHubTreeUrl(url);
@@ -802,7 +819,7 @@ function buildWorkflowSkillVolumes(
 function buildInjectedSkillVolumes(
   args: {
     readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
   },
   framework: SupportedFramework,
 ): readonly PreparedAdditionalVolume[] | undefined {
@@ -2221,8 +2238,9 @@ function filterSecretConnectorMetadataMap(args: {
 }
 
 interface StoredConnectorRuntimeRow {
-  readonly connectorType: ConnectorType;
-  readonly authMethod: string;
+  readonly connectorType: ConnectorCatalogRef;
+  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly needsReconnect: boolean;
   readonly tokenExpiresAt: Date | null;
 }
@@ -2235,8 +2253,8 @@ interface StoredConnectorRuntimeRowCandidate {
 }
 
 interface ConnectorEnvBindingSet {
-  readonly connectorType: ConnectorType;
-  readonly authMethod: string;
+  readonly connectorType: ConnectorCatalogRef;
+  readonly authMethod: ConnectorCatalogAuthMethodId;
   readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
 }
 
@@ -2293,16 +2311,30 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
 
 function allowedStoredConnectorRows(
   rows: readonly StoredConnectorRuntimeRowCandidate[],
-  allowedConnectorTypes: readonly ConnectorType[] | undefined,
+  allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined,
+  snapshot: ConnectorRuntimeSnapshot,
   now: Date,
 ): readonly StoredConnectorRuntimeRow[] {
   const validRows = rows.flatMap((row) => {
-    const parsed = connectorTypeSchema.safeParse(row.type);
-    return parsed.success
+    const connectorRef = connectorCatalogRefSchema.safeParse(row.type);
+    const authMethodId = connectorCatalogAuthMethodIdSchema.safeParse(
+      row.authMethod,
+    );
+    if (!connectorRef.success || !authMethodId.success) {
+      return [];
+    }
+    const runtimeMethod = getConnectorRuntimeMethod({
+      snapshot,
+      connectorRef: connectorRef.data,
+      authMethodId: authMethodId.data,
+      requireExecutable: true,
+    });
+    return runtimeMethod
       ? [
           {
-            connectorType: parsed.data,
-            authMethod: row.authMethod,
+            connectorType: connectorRef.data,
+            authMethod: authMethodId.data,
+            runtimeMethod,
             needsReconnect: row.needsReconnect,
             tokenExpiresAt: row.tokenExpiresAt,
           },
@@ -2322,9 +2354,8 @@ function storedConnectorRuntimeCredentialStatus(
   row: StoredConnectorRuntimeRow,
   now: Date,
 ): ConnectorCredentialStatus {
-  return connectorRuntimeCredentialStatus({
-    type: row.connectorType,
-    authMethod: row.authMethod,
+  return connectorRuntimeCredentialStatusWithMethod({
+    method: row.runtimeMethod.method,
     storedNeedsReconnect: row.needsReconnect,
     tokenExpiresAt: row.tokenExpiresAt,
     now,
@@ -2335,16 +2366,9 @@ function connectorEnvBindingSets(
   rows: readonly StoredConnectorRuntimeRow[],
 ): readonly ConnectorEnvBindingSet[] {
   return rows.map((row) => {
-    const method = getConnectorAuthMethod(row.connectorType, row.authMethod);
-    const metadata = getConnectorAuthMethodRuntimeMetadata(
-      row.connectorType,
-      row.authMethod,
+    const metadata = connectorAuthMethodRuntimeMetadata(
+      row.runtimeMethod.method,
     );
-    if (!method || !metadata) {
-      throw new Error(
-        `Invalid auth method "${row.authMethod}" for stored connector "${row.connectorType}"`,
-      );
-    }
     return {
       connectorType: row.connectorType,
       authMethod: row.authMethod,
@@ -2962,8 +2986,9 @@ async function loadStoredConnectorMaterializationPlan(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
     readonly scopeSource: ConnectorScopeSource;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
@@ -2982,6 +3007,7 @@ async function loadStoredConnectorMaterializationPlan(
       userId: args.userId,
       allowedConnectorTypes,
       scopeSource: args.scopeSource,
+      connectorCatalogSnapshot: args.connectorCatalogSnapshot,
     },
     timing,
   );
@@ -2993,7 +3019,7 @@ async function loadStoredConnectorRows(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -3047,11 +3073,13 @@ async function loadStoredConnectorRows(
 
 function buildStoredConnectorMaterializationPlan(args: {
   readonly connectorRows: readonly StoredConnectorRuntimeRowCandidate[];
-  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
 }): StoredConnectorMaterializationPlan | null {
   const allowedConnectorRows = allowedStoredConnectorRows(
     args.connectorRows,
     args.allowedConnectorTypes,
+    args.connectorCatalogSnapshot,
     nowDate(),
   );
   if (allowedConnectorRows.length === 0) {
@@ -3069,7 +3097,8 @@ function buildStoredConnectorMaterializationPlan(args: {
 function filterStoredConnectorRows(
   args: {
     readonly connectorRows: readonly StoredConnectorRuntimeRowCandidate[];
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -3115,8 +3144,9 @@ async function loadStoredConnectorMaterializationSnapshot(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
     readonly scopeSource: ConnectorScopeSource;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
@@ -3142,6 +3172,7 @@ async function loadStoredConnectorMaterializationSnapshot(
       {
         connectorRows,
         allowedConnectorTypes: args.allowedConnectorTypes,
+        connectorCatalogSnapshot: args.connectorCatalogSnapshot,
         timingDimensions: baseTimingDimensions,
       },
       timing,
@@ -3773,7 +3804,7 @@ async function buildPermissionManifest(args: {
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly connectorVars?: Record<string, string>;
-  readonly connectorTypes?: readonly ConnectorType[];
+  readonly connectorTypes?: readonly ConnectorCatalogRef[];
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<PermissionManifest | undefined> {
@@ -6206,6 +6237,7 @@ async function loadRunConnectorContexts(
     readonly userId: string;
     readonly connectorScope: EffectiveConnectorScope;
   },
+  connectorCatalogSnapshot: ConnectorRuntimeSnapshot,
   featureSwitchContext: FeatureSwitchContext,
   timing?: ApiDispatchTimingCollector,
 ): Promise<{
@@ -6226,6 +6258,7 @@ async function loadRunConnectorContexts(
             userId: args.userId,
             allowedConnectorTypes: args.connectorScope.allowedConnectorTypes,
             scopeSource: args.connectorScope.source,
+            connectorCatalogSnapshot,
           },
           timing,
         );
@@ -6399,6 +6432,30 @@ interface PreparedRuntimeContext {
   readonly permissionManifest: PermissionManifest | undefined;
   readonly billableFirewalls: readonly string[];
   readonly modelUsageProvider: string | undefined;
+  readonly connectorScope: EffectiveConnectorScope;
+}
+
+function connectorScopeForRuntimeSnapshot(
+  scope: EffectiveConnectorScope,
+  snapshot: ConnectorRuntimeSnapshot,
+): EffectiveConnectorScope {
+  if (scope.allowedConnectorTypes === undefined) {
+    return scope;
+  }
+  return {
+    ...scope,
+    allowedConnectorTypes: scope.allowedConnectorTypes.filter(
+      (connectorRef) => {
+        const connector = getConnectorRuntimeConnector(snapshot, connectorRef);
+        return (
+          connector !== undefined &&
+          [...connector.methods.values()].some((method) => {
+            return method.executable;
+          })
+        );
+      },
+    ),
+  };
 }
 
 function connectorScopeFromCreateArgs(
@@ -6590,6 +6647,7 @@ async function prepareRunConnectorContexts(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
   readonly featureSwitchContext: FeatureSwitchContext;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<
   Awaited<ReturnType<typeof loadRunConnectorContexts>> | CreateRunErrorResult
@@ -6606,6 +6664,7 @@ async function prepareRunConnectorContexts(args: {
             userId: args.createArgs.userId,
             connectorScope: args.connectorScope,
           },
+          args.connectorCatalogSnapshot,
           args.featureSwitchContext,
           args.timing,
         );
@@ -6634,6 +6693,12 @@ async function prepareRunRuntimeContext(args: {
 }): Promise<PreparedRuntimeContext | CreateRunErrorResult> {
   const { body, resolved, requestedFramework, featureSwitchContext } =
     args.bodyContext;
+  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(args.db);
+  args.signal.throwIfAborted();
+  const connectorScope = connectorScopeForRuntimeSnapshot(
+    args.connectorScope,
+    connectorCatalogSnapshot,
+  );
   const modelProvider = await args.timing.measure(
     "api_dispatch_prepare_context_resolve_model_provider",
     "nested",
@@ -6655,8 +6720,9 @@ async function prepareRunRuntimeContext(args: {
   const connectorContexts = await prepareRunConnectorContexts({
     db: args.db,
     createArgs: args.createArgs,
-    connectorScope: args.connectorScope,
+    connectorScope,
     featureSwitchContext,
+    connectorCatalogSnapshot,
     timing: args.timing,
   });
   if (isRouteError(connectorContexts)) {
@@ -6670,7 +6736,7 @@ async function prepareRunRuntimeContext(args: {
   args.signal.throwIfAborted();
 
   const storedConnectorTiming = storedConnectorTimingDimensions({
-    scopeSource: args.connectorScope.source,
+    scopeSource: connectorScope.source,
     connectorCount: storedConnectorSnapshot?.allowedConnectorRows.length ?? 0,
   });
   const overriddenConnectorSecretAliases = overriddenRuntimeSecretAliases([
@@ -6743,6 +6809,7 @@ async function prepareRunRuntimeContext(args: {
     permissionManifest,
     billableFirewalls: modelUsageContext.billableFirewalls,
     modelUsageProvider: modelUsageContext.modelUsageProvider,
+    connectorScope,
   };
 }
 
@@ -6861,7 +6928,7 @@ function prepareRunContext(
           return await Promise.resolve(
             prepareRunOutputMetadata({
               createArgs: args,
-              connectorScope: bodyContext.connectorScope,
+              connectorScope: runtimeContext.connectorScope,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
               body,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -358,6 +358,7 @@ interface RefreshTokenContext {
 }
 
 interface RefreshState {
+  readonly authMethod: string | null;
   readonly outputValues: Readonly<Record<string, string | null>>;
   readonly inputValues: Readonly<Record<string, string | null>>;
   readonly tokenExpiresAt: Date | null;
@@ -367,6 +368,7 @@ interface RefreshState {
 }
 
 interface RefreshStateRow {
+  readonly authMethod: string | null;
   readonly tokenExpiresAt: Date | null;
   readonly needsReconnect: boolean;
   readonly lastRefreshErrorCode: string | null;
@@ -1672,6 +1674,7 @@ async function loadModelProviderRefreshStateRow(
 ): Promise<RefreshStateRow | null> {
   const query = db
     .select({
+      authMethod: sql<string | null>`NULL`,
       tokenExpiresAt: modelProviders.tokenExpiresAt,
       needsReconnect: modelProviders.needsReconnect,
       lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
@@ -1698,6 +1701,7 @@ async function loadConnectorRefreshStateRow(
 ): Promise<RefreshStateRow | null> {
   const query = db
     .select({
+      authMethod: connectors.authMethod,
       tokenExpiresAt: connectors.tokenExpiresAt,
       needsReconnect: connectors.needsReconnect,
       lastRefreshErrorCode: sql<string | null>`NULL`,
@@ -1770,6 +1774,7 @@ async function loadRefreshState(
   }
 
   return {
+    authMethod: row.authMethod,
     outputValues,
     inputValues,
     tokenExpiresAt: row.tokenExpiresAt,
@@ -2012,6 +2017,43 @@ async function lockPreparedRefreshSource(
   });
 }
 
+function preparedRefreshSourceMatchesState(
+  args: RefreshAccessTokenArgs,
+  prepared: PreparedRefreshTokenContext,
+  state: RefreshState,
+): boolean {
+  if (prepared.sourceType === "model-provider") {
+    return true;
+  }
+  return (
+    args.connectorType === prepared.connectorRef &&
+    state.authMethod === prepared.authMethodId
+  );
+}
+
+function currentPreparedRefreshState(args: {
+  readonly refreshArgs: RefreshAccessTokenArgs;
+  readonly prepared: PreparedRefreshTokenContext;
+  readonly state: RefreshState | null;
+}): RefreshState | null {
+  if (!args.state) {
+    L.warn(`${args.refreshArgs.connectorType} token refresh source missing`, {
+      connectorType: args.refreshArgs.connectorType,
+      orgId: args.refreshArgs.orgId,
+      userId: args.refreshArgs.userId,
+      sourceType: args.refreshArgs.sourceType,
+    });
+    return null;
+  }
+  return preparedRefreshSourceMatchesState(
+    args.refreshArgs,
+    args.prepared,
+    args.state,
+  )
+    ? args.state
+    : null;
+}
+
 function currentRefreshAccessResult(args: {
   readonly connectorType: string;
   readonly context: RefreshTokenContext;
@@ -2118,19 +2160,17 @@ async function refreshLockedAccessToken(args: {
   readonly initialState: RefreshState | null;
   readonly requestStartedAtMicros: bigint | null;
 }): Promise<RefreshAccessTokenResult> {
-  const lockedState = await loadRefreshState(
-    args.refreshArgs.db,
-    args.refreshArgs,
-    args.prepared.context,
-    { lockRow: true },
-  );
+  const lockedState = currentPreparedRefreshState({
+    refreshArgs: args.refreshArgs,
+    prepared: args.prepared,
+    state: await loadRefreshState(
+      args.refreshArgs.db,
+      args.refreshArgs,
+      args.prepared.context,
+      { lockRow: true },
+    ),
+  });
   if (!lockedState) {
-    L.warn(`${args.refreshArgs.connectorType} token refresh source missing`, {
-      connectorType: args.refreshArgs.connectorType,
-      orgId: args.refreshArgs.orgId,
-      userId: args.refreshArgs.userId,
-      sourceType: args.refreshArgs.sourceType,
-    });
     return sourceMissingResult();
   }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,30 +9,24 @@ import {
 import type { ConnectorReconnectReason } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import {
+  connectorCatalogAuthMethodIdSchema,
+  connectorCatalogRefSchema,
+  type ConnectorCatalogAuthMethodId,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  connectorAuthMethodAccessMetadata,
+  connectorAuthMethodRuntimeMetadata,
   connectorRefreshMetadataHasRefreshableSecret,
-  getConnectorAuthClientConfigForMethod,
-  getConnectorAuthMethodAccessMetadata,
-  getConnectorAuthMethodRuntimeMetadata,
   getConnectorRuntimeBindingPlatformSecretName,
   getConnectorRuntimeBindingSecretName,
-  resolveConnectorResolvedAuthMethodClientByAccessKind,
-  connectorAuthMethodRefHasAccessKind,
-  type ConnectorResolvedAuthMethodClientByAccessKind,
-  type ConnectorAuthMethodRef,
-  type ConnectorAuthMethodRefByAccessKind,
+  resolveConnectorAuthClient,
   type ConnectorAuthMethodAccessMetadata,
+  type ConnectorAuthClient,
   type ConnectorRefreshTokenInputMetadata,
   type ConnectorAuthMethodRuntimeMetadata,
-  type ConnectorAuthClientForMethod,
   type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
-import {
-  type ConnectorAuthClientConfigForMethod,
-  type ConnectorAuthMethodIdsByAccessKind,
-  connectorAuthMethodIdSchema,
-  connectorTypeSchema,
-  type RefreshTokenAccessConnectorType,
-} from "@vm0/connectors/connectors";
 import {
   parseBasicAuthTemplates,
   replaceBasicAuthTemplates,
@@ -41,7 +35,7 @@ import {
 } from "@vm0/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
-  refreshConnectorAuthProviderAccessToken,
+  refreshConnectorAuthProviderAccessTokenWithMethod,
   type ProviderEnv,
 } from "@vm0/connectors/auth-providers";
 import {
@@ -88,6 +82,12 @@ import {
   connectorRuntimeCredentialStatusForAccess,
   type ConnectorCredentialStatus,
 } from "./connector-credential-status.service";
+import {
+  getConnectorRuntimeMethod,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeMethod,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 
 type AccessSecretSource = SecretConnectorMetadata["sourceType"];
 type StorageSecretSource = Exclude<AccessSecretSource, "platform-secret">;
@@ -392,60 +392,14 @@ type PreparedRefreshTokenContext =
   | ConnectorPreparedRefreshTokenContext
   | ModelProviderPreparedRefreshTokenContext;
 
-type ConnectorRefreshTokenAccessResolvedClient =
-  ConnectorResolvedAuthMethodClientByAccessKind<"refresh-token">;
-
-type ConnectorRefreshTokenAccessMethodRef =
-  ConnectorAuthMethodRefByAccessKind<"refresh-token">;
-
-type ConnectorRefreshTokenAccessClientMethodRef = {
-  readonly [Type in RefreshTokenAccessConnectorType]: {
-    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
-      Type,
-      "refresh-token"
-    >]: [ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
-      ? never
-      : {
-          readonly type: Type;
-          readonly authMethod: Method;
-        };
-  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
-}[RefreshTokenAccessConnectorType];
-
-type ConnectorRefreshTokenAccessNoClientMethodRef = {
-  readonly [Type in RefreshTokenAccessConnectorType]: {
-    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
-      Type,
-      "refresh-token"
-    >]: [ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
-      ? {
-          readonly type: Type;
-          readonly authMethod: Method;
-        }
-      : never;
-  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
-}[RefreshTokenAccessConnectorType];
-
-type ConnectorPreparedRefreshTokenContextFor<
-  Type extends RefreshTokenAccessConnectorType,
-  Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">,
-> = {
-  readonly sourceType: "connector";
-  readonly type: Type;
-  readonly authMethod: Method;
-  readonly context: RefreshTokenContext;
-} & ([ConnectorAuthClientConfigForMethod<Type, Method>] extends [never]
-  ? unknown
-  : { readonly authClient: ConnectorAuthClientForMethod<Type, Method> });
-
 type ConnectorPreparedRefreshTokenContext = {
-  readonly [Type in RefreshTokenAccessConnectorType]: {
-    readonly [Method in ConnectorAuthMethodIdsByAccessKind<
-      Type,
-      "refresh-token"
-    >]: ConnectorPreparedRefreshTokenContextFor<Type, Method>;
-  }[ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token">];
-}[RefreshTokenAccessConnectorType];
+  readonly sourceType: "connector";
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly authClient?: ConnectorAuthClient;
+  readonly context: RefreshTokenContext;
+};
 
 type ModelProviderPreparedRefreshTokenContext = {
   readonly sourceType: "model-provider";
@@ -453,56 +407,6 @@ type ModelProviderPreparedRefreshTokenContext = {
   readonly currentEnv: ProviderEnv;
   readonly context: RefreshTokenContext;
 };
-
-function resolveRefreshTokenAccessClient(
-  authMethodRef: ConnectorRefreshTokenAccessClientMethodRef,
-): ConnectorRefreshTokenAccessResolvedClient | undefined {
-  return resolveConnectorResolvedAuthMethodClientByAccessKind(
-    authMethodRef,
-    (name) => {
-      return optionalEnv(name);
-    },
-  );
-}
-
-function connectorRefreshTokenAccessMethodHasClient(
-  authMethodRef: ConnectorRefreshTokenAccessMethodRef,
-): authMethodRef is ConnectorRefreshTokenAccessClientMethodRef {
-  return (
-    getConnectorAuthClientConfigForMethod(
-      authMethodRef.type,
-      authMethodRef.authMethod,
-    ) !== undefined
-  );
-}
-
-function connectorRefreshTokenAccessMethodHasNoClient(
-  authMethodRef: ConnectorRefreshTokenAccessMethodRef,
-): authMethodRef is ConnectorRefreshTokenAccessNoClientMethodRef {
-  return !connectorRefreshTokenAccessMethodHasClient(authMethodRef);
-}
-
-function connectorPreparedRefreshTokenContextWithClient(args: {
-  readonly resolvedClient: ConnectorRefreshTokenAccessResolvedClient;
-  readonly context: RefreshTokenContext;
-}): ConnectorPreparedRefreshTokenContext {
-  return {
-    sourceType: "connector",
-    ...args.resolvedClient,
-    context: args.context,
-  };
-}
-
-function connectorPreparedRefreshTokenContextWithoutClient(args: {
-  readonly authMethodRef: ConnectorRefreshTokenAccessNoClientMethodRef;
-  readonly context: RefreshTokenContext;
-}): ConnectorPreparedRefreshTokenContext {
-  return {
-    sourceType: "connector",
-    ...args.authMethodRef,
-    context: args.context,
-  };
-}
 
 type PrepareRefreshTokenContextResult =
   | {
@@ -561,6 +465,7 @@ function refreshFailedResult(
 
 interface RefreshExpiredTokensArgs {
   readonly db: Db;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly auth: SandboxAuth;
   readonly orgId: string;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -577,6 +482,7 @@ interface RefreshExpiredTokensArgs {
 
 interface RefreshBatchContext {
   readonly db: Db;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly auth: SandboxAuth;
   readonly orgId: string;
   readonly userId: string;
@@ -595,7 +501,8 @@ interface RefreshSourceState {
 }
 
 interface ConnectorAccessState extends RefreshSourceState {
-  readonly authMethod: string;
+  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;
   readonly runtimeMetadata: ConnectorAuthMethodRuntimeMetadata;
 }
@@ -1084,6 +991,7 @@ async function loadConnectorAccessStates(
   orgId: string,
   userId: string,
   connectorTypes: readonly string[],
+  snapshot: ConnectorRuntimeSnapshot,
 ): Promise<Map<string, ConnectorAccessState>> {
   const result = new Map<string, ConnectorAccessState>();
   if (connectorTypes.length === 0) {
@@ -1107,25 +1015,27 @@ async function loadConnectorAccessStates(
     );
 
   for (const row of rows) {
-    const parsed = connectorTypeSchema.safeParse(row.type);
-    if (!parsed.success) {
+    const connectorRef = connectorCatalogRefSchema.safeParse(row.type);
+    const authMethodId = connectorCatalogAuthMethodIdSchema.safeParse(
+      row.authMethod,
+    );
+    if (!connectorRef.success || !authMethodId.success) {
       continue;
     }
-    const accessMetadata = getConnectorAuthMethodAccessMetadata(
-      parsed.data,
-      row.authMethod,
-    );
-    const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
-      parsed.data,
-      row.authMethod,
-    );
-    if (!accessMetadata || !runtimeMetadata) {
+    const runtimeMethod = getConnectorRuntimeMethod({
+      snapshot,
+      connectorRef: connectorRef.data,
+      authMethodId: authMethodId.data,
+      requireExecutable: true,
+    });
+    if (!runtimeMethod) {
       continue;
     }
     result.set(row.type, {
-      authMethod: row.authMethod,
-      accessMetadata,
-      runtimeMetadata,
+      authMethod: authMethodId.data,
+      runtimeMethod,
+      accessMetadata: connectorAuthMethodAccessMetadata(runtimeMethod.method),
+      runtimeMetadata: connectorAuthMethodRuntimeMetadata(runtimeMethod.method),
       ...refreshSourceStateFromRow(row),
     });
   }
@@ -1344,6 +1254,7 @@ async function getSourceStateByProviderKey(args: {
 
 async function loadCurrentSourceStateSnapshot(args: {
   readonly db: Db;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly connectorTypes: readonly string[];
@@ -1362,6 +1273,7 @@ async function loadCurrentSourceStateSnapshot(args: {
     args.orgId,
     args.userId,
     connectorOnly,
+    args.connectorCatalogSnapshot,
   );
   return {
     connectorAccessByType,
@@ -1455,21 +1367,7 @@ function prepareRefreshTokenContext(
     return { ok: false, reason: "not-refreshable" };
   }
   const accessMetadata = connectorAccess.accessMetadata;
-  const parsedConnectorType = connectorTypeSchema.safeParse(args.connectorType);
-  if (!parsedConnectorType.success) {
-    return { ok: false, reason: "not-refreshable" };
-  }
-  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
-    connectorAccess.authMethod,
-  );
-  if (!parsedAuthMethod.success) {
-    return { ok: false, reason: "not-refreshable" };
-  }
-  const authMethodRef: ConnectorAuthMethodRef = {
-    type: parsedConnectorType.data,
-    authMethod: parsedAuthMethod.data,
-  };
-  if (!connectorAuthMethodRefHasAccessKind(authMethodRef, "refresh-token")) {
+  if (connectorAccess.runtimeMethod.method.access.kind !== "refresh-token") {
     return { ok: false, reason: "not-refreshable" };
   }
 
@@ -1484,35 +1382,28 @@ function prepareRefreshTokenContext(
     ),
   };
 
-  if (connectorRefreshTokenAccessMethodHasClient(authMethodRef)) {
-    const resolvedClient = resolveRefreshTokenAccessClient(authMethodRef);
-    if (!resolvedClient) {
-      L.debug(
-        `${args.connectorType} connector client not configured, skipping token refresh`,
-      );
-      return { ok: false, reason: "client-unconfigured" };
-    }
-
-    return {
-      ok: true,
-      prepared: connectorPreparedRefreshTokenContextWithClient({
-        resolvedClient,
-        context,
-      }),
-    };
+  const clientConfig = connectorAccess.runtimeMethod.method.client;
+  const authClient = clientConfig
+    ? resolveConnectorAuthClient(clientConfig, optionalEnv)
+    : undefined;
+  if (clientConfig && !authClient) {
+    L.debug(
+      `${args.connectorType} connector client not configured, skipping token refresh`,
+    );
+    return { ok: false, reason: "client-unconfigured" };
   }
 
-  if (connectorRefreshTokenAccessMethodHasNoClient(authMethodRef)) {
-    return {
-      ok: true,
-      prepared: connectorPreparedRefreshTokenContextWithoutClient({
-        authMethodRef,
-        context,
-      }),
-    };
-  }
-
-  return { ok: false, reason: "not-refreshable" };
+  return {
+    ok: true,
+    prepared: {
+      sourceType: "connector",
+      connectorRef: connectorAccess.runtimeMethod.connectorRef,
+      authMethodId: connectorAccess.runtimeMethod.authMethodId,
+      runtimeMethod: connectorAccess.runtimeMethod,
+      ...(authClient ? { authClient } : {}),
+      context,
+    },
+  };
 }
 
 function tokenExpiresAtNeedsRefresh(tokenExpiresAt: Date | null): boolean {
@@ -2088,8 +1979,13 @@ function refreshPreparedConnectorAccessToken(args: {
   readonly inputs: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
 }) {
-  return refreshConnectorAuthProviderAccessToken({
-    ...args.prepared,
+  return refreshConnectorAuthProviderAccessTokenWithMethod({
+    connectorRef: args.prepared.connectorRef,
+    authMethodId: args.prepared.authMethodId,
+    method: args.prepared.runtimeMethod.method,
+    ...(args.prepared.authClient
+      ? { authClient: args.prepared.authClient }
+      : {}),
     inputs: args.inputs,
     signal: args.signal,
   });
@@ -2104,7 +2000,7 @@ async function lockPreparedRefreshSource(
     await lockConnectorState(db, {
       orgId: args.orgId,
       userId: args.userId,
-      type: prepared.type,
+      type: prepared.connectorRef,
     });
     return;
   }
@@ -3165,6 +3061,7 @@ function hasMissingUnresolvableSecrets(args: {
 
 async function prepareFirewallAuthResolutionContext(args: {
   readonly db: Db;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly auth: SandboxAuth;
   readonly body: FirewallAuthBody;
   readonly orgId: string;
@@ -3201,6 +3098,7 @@ async function prepareFirewallAuthResolutionContext(args: {
       secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
       referencedKeys: referenced.secrets,
     }),
+    args.connectorCatalogSnapshot,
   );
   const modelProviderRefreshable = referencedModelProviderAccessMap({
     secretConnectorMap: args.body.secretConnectorMap,
@@ -3666,6 +3564,7 @@ async function refreshExpiredTokens(
 
   const context = {
     db: args.db,
+    connectorCatalogSnapshot: args.connectorCatalogSnapshot,
     auth: args.auth,
     orgId: args.orgId,
     userId: args.auth.userId,
@@ -3689,6 +3588,7 @@ async function refreshExpiredTokens(
       ? { connectorAccessByType: context.connectorAccessByType, sourceStateMap }
       : await loadCurrentSourceStateSnapshot({
           db: args.db,
+          connectorCatalogSnapshot: args.connectorCatalogSnapshot,
           orgId: args.orgId,
           userId: args.auth.userId,
           connectorTypes: skippedTypes,
@@ -3716,6 +3616,7 @@ async function refreshExpiredTokens(
           args.orgId,
           args.auth.userId,
           connectorTypes,
+          args.connectorCatalogSnapshot,
         )),
       ])
     : args.connectorAccessByType;
@@ -3948,6 +3849,7 @@ export async function resolveFirewallAuth(
   auth: SandboxAuth,
   body: FirewallAuthBody,
 ): Promise<ResolveFirewallAuthResult> {
+  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db);
   const forceRefreshStartedAtMicros =
     body.forceRefresh === true
       ? await currentDatabaseTimestampMicros(db)
@@ -3968,6 +3870,7 @@ export async function resolveFirewallAuth(
 
   const prepared = await prepareFirewallAuthResolutionContext({
     db,
+    connectorCatalogSnapshot,
     auth,
     body,
     orgId: decrypted.orgId,
@@ -3998,6 +3901,7 @@ export async function resolveFirewallAuth(
   if (body.secretConnectorMap) {
     const result = await refreshExpiredTokens({
       db,
+      connectorCatalogSnapshot,
       auth,
       secrets: decryptedSecrets,
       secretConnectorMap: body.secretConnectorMap,

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -8,11 +8,9 @@ import type {
   PublicConnectorCatalogDetail,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
-import { getAllFeatureStates } from "@vm0/core/feature-switch";
 
 import { db$ } from "../external/db";
 import {
-  getConnectorRuntimeAvailableCatalogDetail,
   getConnectorRuntimeConnector,
   getConnectorRuntimeMethod,
   loadConnectorRuntimeSnapshot,
@@ -20,14 +18,12 @@ import {
   type ConnectorRuntimeMethod,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 type ConnectorCatalogGrantKind =
   PublicConnectorCatalogAuthMethodDetail["grantKind"];
 
 export type ConnectorRefResolutionFailure =
   | { readonly ok: false; readonly reason: "unknown_connector" }
-  | { readonly ok: false; readonly reason: "unavailable_connector" }
   | {
       readonly ok: false;
       readonly reason: "missing_executable_capability";
@@ -46,7 +42,7 @@ export type ConnectorActionResolutionFailure =
       readonly actualGrantKind: ConnectorCatalogGrantKind;
       readonly catalogConnector: PublicConnectorCatalogDetail;
     }
-  | { readonly ok: false; readonly reason: "unavailable_auth_method" };
+  | { readonly ok: false; readonly reason: "hidden_auth_method" };
 
 export type ResolvedConnectorRef = {
   readonly ok: true;
@@ -80,23 +76,36 @@ export type ConnectorRefsResolution =
       readonly connectorRef: ConnectorCatalogRef;
     });
 
+/**
+ * Resolves connector execution contracts, never connector discovery policy.
+ *
+ * Feature switches only filter UI/discovery projections. They are not
+ * authorization or compatibility boundaries and are never read here. Authored
+ * method visibility is separate: it controls new actions through
+ * resolveNewActionMethod, while resolveMethod deliberately lets in-flight and
+ * persisted credentials continue. Execution fails closed when the connector or
+ * method is absent, has the wrong grant kind, is incompatible, or lacks its
+ * local executable capability.
+ */
 export interface ConnectorActionResolver {
   readonly resolveRef: (args: {
     readonly connectorRef: ConnectorCatalogRef;
-    readonly requireAvailable: boolean;
     readonly requireExecutable: boolean;
-  }) => Promise<ConnectorRefResolution>;
+  }) => ConnectorRefResolution;
   readonly resolveMethod: (args: {
     readonly connectorRef: ConnectorCatalogRef;
     readonly authMethodId: ConnectorCatalogAuthMethodId;
     readonly expectedGrantKind: ConnectorCatalogGrantKind;
-    readonly requireAvailable: boolean;
-  }) => Promise<ConnectorActionMethodResolution>;
+  }) => ConnectorActionMethodResolution;
+  readonly resolveNewActionMethod: (args: {
+    readonly connectorRef: ConnectorCatalogRef;
+    readonly authMethodId: ConnectorCatalogAuthMethodId;
+    readonly expectedGrantKind: ConnectorCatalogGrantKind;
+  }) => ConnectorActionMethodResolution;
   readonly resolveRefs: (args: {
     readonly connectorRefs: readonly ConnectorCatalogRef[];
-    readonly requireAvailable: boolean;
     readonly requireExecutable: boolean;
-  }) => Promise<ConnectorRefsResolution>;
+  }) => ConnectorRefsResolution;
 }
 
 function resolvedRef(args: {
@@ -148,111 +157,86 @@ function executableMethod(args: {
   };
 }
 
-function createConnectorActionResolver(args: {
-  readonly featureStates: ReturnType<typeof getAllFeatureStates>;
-  readonly snapshot: ConnectorRuntimeSnapshot;
-}): ConnectorActionResolver {
-  const readAvailableConnector = async (connectorRef: ConnectorCatalogRef) => {
-    return await getConnectorRuntimeAvailableCatalogDetail({
-      snapshot: args.snapshot,
-      connectorRef,
-      featureStates: args.featureStates,
-    });
-  };
-
-  const resolveRef: ConnectorActionResolver["resolveRef"] = async (input) => {
+function createConnectorActionResolver(
+  snapshot: ConnectorRuntimeSnapshot,
+): ConnectorActionResolver {
+  const resolveRef: ConnectorActionResolver["resolveRef"] = (input) => {
     const runtimeConnector = getConnectorRuntimeConnector(
-      args.snapshot,
+      snapshot,
       input.connectorRef,
     );
     if (runtimeConnector === undefined) {
       return { ok: false, reason: "unknown_connector" };
     }
-    if (input.requireAvailable) {
-      const availableConnector = await readAvailableConnector(
-        input.connectorRef,
-      );
-      if (!availableConnector) {
-        return { ok: false, reason: "unavailable_connector" };
-      }
-    }
     return resolvedRef({
       connectorRef: input.connectorRef,
       requireExecutable: input.requireExecutable,
       runtimeConnector,
-      snapshot: args.snapshot,
+      snapshot,
+    });
+  };
+
+  const resolveMethod: ConnectorActionResolver["resolveMethod"] = (input) => {
+    const runtimeConnector = getConnectorRuntimeConnector(
+      snapshot,
+      input.connectorRef,
+    );
+    if (runtimeConnector === undefined) {
+      return { ok: false, reason: "unknown_connector" };
+    }
+    const catalogConnector = runtimeConnector.catalogConnector;
+    const catalogMethod = catalogConnector.authMethods.find((method) => {
+      return method.id === input.authMethodId;
+    });
+    if (!catalogMethod) {
+      return {
+        ok: false,
+        reason: "unknown_auth_method",
+        catalogConnector,
+      };
+    }
+    if (catalogMethod.grantKind !== input.expectedGrantKind) {
+      return {
+        ok: false,
+        reason: "wrong_grant_kind",
+        actualGrantKind: catalogMethod.grantKind,
+        catalogConnector,
+      };
+    }
+
+    const selectedRef = resolvedRef({
+      connectorRef: input.connectorRef,
+      requireExecutable: true,
+      runtimeConnector,
+      snapshot,
+    });
+    if (!selectedRef.ok) {
+      return selectedRef;
+    }
+    return executableMethod({
+      resolvedRef: selectedRef,
+      authMethodId: input.authMethodId,
+      catalogMethod,
     });
   };
 
   return {
     resolveRef,
+    resolveMethod,
 
-    async resolveMethod(input) {
-      const runtimeConnector = getConnectorRuntimeConnector(
-        args.snapshot,
-        input.connectorRef,
-      );
-      if (runtimeConnector === undefined) {
-        return { ok: false, reason: "unknown_connector" };
+    resolveNewActionMethod(input) {
+      const resolved = resolveMethod(input);
+      if (resolved.ok && !resolved.runtimeMethod.availableForNewActions) {
+        return { ok: false, reason: "hidden_auth_method" };
       }
-      const catalogConnector = runtimeConnector.catalogConnector;
-      const catalogMethod = catalogConnector.authMethods.find((method) => {
-        return method.id === input.authMethodId;
-      });
-      if (!catalogMethod) {
-        return {
-          ok: false,
-          reason: "unknown_auth_method",
-          catalogConnector,
-        };
-      }
-      if (catalogMethod.grantKind !== input.expectedGrantKind) {
-        return {
-          ok: false,
-          reason: "wrong_grant_kind",
-          actualGrantKind: catalogMethod.grantKind,
-          catalogConnector,
-        };
-      }
-
-      if (input.requireAvailable) {
-        const availableConnector = await readAvailableConnector(
-          input.connectorRef,
-        );
-        if (!availableConnector) {
-          return { ok: false, reason: "unavailable_connector" };
-        }
-        if (
-          !availableConnector.authMethods.some((method) => {
-            return method.id === input.authMethodId;
-          })
-        ) {
-          return { ok: false, reason: "unavailable_auth_method" };
-        }
-      }
-
-      const selectedRef = resolvedRef({
-        connectorRef: input.connectorRef,
-        requireExecutable: true,
-        runtimeConnector,
-        snapshot: args.snapshot,
-      });
-      if (!selectedRef.ok) {
-        return selectedRef;
-      }
-      return executableMethod({
-        resolvedRef: selectedRef,
-        authMethodId: input.authMethodId,
-        catalogMethod,
-      });
+      return resolved;
     },
 
-    async resolveRefs(input) {
+    resolveRefs(input) {
       const connectors: ResolvedConnectorRef[] = [];
       for (const connectorRef of input.connectorRefs) {
-        const resolved = await resolveRef({
+        const resolved = resolveRef({
           connectorRef,
-          requireAvailable: input.requireAvailable,
           requireExecutable: input.requireExecutable,
         });
         if (!resolved.ok) {
@@ -265,32 +249,19 @@ function createConnectorActionResolver(args: {
   };
 }
 
-export function userConnectorActionResolver(
-  orgId: string,
-  userId: string,
-): Computed<Promise<ConnectorActionResolver>> {
+export function connectorActionResolver(): Computed<
+  Promise<ConnectorActionResolver>
+> {
   return computed(async (get): Promise<ConnectorActionResolver> => {
-    const [overrides, snapshot] = await Promise.all([
-      get(userFeatureSwitchOverrides(orgId, userId)),
-      loadConnectorRuntimeSnapshot(get(db$)),
-    ]);
-    return createConnectorActionResolver({
-      featureStates: getAllFeatureStates({ orgId, userId, overrides }),
-      snapshot,
-    });
+    const snapshot = await loadConnectorRuntimeSnapshot(get(db$));
+    return createConnectorActionResolver(snapshot);
   });
 }
 
-export function userConnectorActionResolverForSnapshot(
-  orgId: string,
-  userId: string,
+export function connectorActionResolverForSnapshot(
   snapshot: ConnectorRuntimeSnapshot,
-): Computed<Promise<ConnectorActionResolver>> {
-  return computed(async (get): Promise<ConnectorActionResolver> => {
-    const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
-    return createConnectorActionResolver({
-      featureStates: getAllFeatureStates({ orgId, userId, overrides }),
-      snapshot,
-    });
+): Computed<ConnectorActionResolver> {
+  return computed((): ConnectorActionResolver => {
+    return createConnectorActionResolver(snapshot);
   });
 }

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -225,11 +225,23 @@ function createConnectorActionResolver(
     resolveMethod,
 
     resolveNewActionMethod(input) {
-      const resolved = resolveMethod(input);
-      if (resolved.ok && !resolved.runtimeMethod.availableForNewActions) {
-        return { ok: false, reason: "hidden_auth_method" };
+      const runtimeConnector = getConnectorRuntimeConnector(
+        snapshot,
+        input.connectorRef,
+      );
+      const catalogMethod = runtimeConnector?.catalogConnector.authMethods.find(
+        (method) => {
+          return method.id === input.authMethodId;
+        },
+      );
+      if (catalogMethod?.grantKind === input.expectedGrantKind) {
+        const runtimeMethod = runtimeConnector?.methods.get(input.authMethodId);
+        if (runtimeMethod && !runtimeMethod.availableForNewActions) {
+          return { ok: false, reason: "hidden_auth_method" };
+        }
       }
-      return resolved;
+
+      return resolveMethod(input);
     },
 
     resolveRefs(input) {

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -7,21 +7,19 @@ import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogDetail,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import {
-  connectorAuthMethodIdSchema,
-  connectorTypeSchema,
-  type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import { getConnectorAuthProviderRegistryCapabilities } from "@vm0/connectors/auth-providers";
-import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 
+import { db$ } from "../external/db";
 import {
-  getStaticConnectorCatalogResolutionDetail,
-  getStaticPublicConnectorCatalogDetail,
-} from "./connector-catalog-reader.service";
+  getConnectorRuntimeAvailableCatalogDetail,
+  getConnectorRuntimeConnector,
+  getConnectorRuntimeMethod,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeConnector,
+  type ConnectorRuntimeMethod,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 type ConnectorCatalogGrantKind =
@@ -50,32 +48,33 @@ export type ConnectorActionResolutionFailure =
     }
   | { readonly ok: false; readonly reason: "unavailable_auth_method" };
 
-export type ResolvedConnectorExecutableRef = {
+export type ResolvedConnectorRef = {
   readonly ok: true;
   readonly connectorRef: ConnectorCatalogRef;
   readonly catalogConnector: PublicConnectorCatalogDetail;
-  readonly type: ConnectorType;
+  readonly runtimeConnector: ConnectorRuntimeConnector;
+  readonly snapshot: ConnectorRuntimeSnapshot;
 };
 
-export type ResolvedConnectorActionMethod = ResolvedConnectorExecutableRef & {
+export type ResolvedConnectorActionMethod = ResolvedConnectorRef & {
   readonly authMethodId: ConnectorCatalogAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
-  readonly authMethod: ConnectorAuthMethodId;
-  readonly method: ConnectorAuthMethodConfig;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
 };
 
-export type ConnectorExecutableRefResolution =
-  | ResolvedConnectorExecutableRef
+export type ConnectorRefResolution =
+  | ResolvedConnectorRef
   | ConnectorRefResolutionFailure;
 
 export type ConnectorActionMethodResolution =
   | ResolvedConnectorActionMethod
   | ConnectorActionResolutionFailure;
 
-export type ConnectorExecutableRefsResolution =
+export type ConnectorRefsResolution =
   | {
       readonly ok: true;
-      readonly connectors: readonly ResolvedConnectorExecutableRef[];
+      readonly connectors: readonly ResolvedConnectorRef[];
     }
   | (ConnectorRefResolutionFailure & {
       readonly connectorRef: ConnectorCatalogRef;
@@ -85,90 +84,88 @@ export interface ConnectorActionResolver {
   readonly resolveRef: (args: {
     readonly connectorRef: ConnectorCatalogRef;
     readonly requireAvailable: boolean;
-  }) => Promise<ConnectorExecutableRefResolution>;
+    readonly requireExecutable: boolean;
+  }) => Promise<ConnectorRefResolution>;
   readonly resolveMethod: (args: {
     readonly connectorRef: ConnectorCatalogRef;
     readonly authMethodId: ConnectorCatalogAuthMethodId;
     readonly expectedGrantKind: ConnectorCatalogGrantKind;
+    readonly requireAvailable: boolean;
   }) => Promise<ConnectorActionMethodResolution>;
   readonly resolveRefs: (args: {
     readonly connectorRefs: readonly ConnectorCatalogRef[];
     readonly requireAvailable: boolean;
-  }) => Promise<ConnectorExecutableRefsResolution>;
+    readonly requireExecutable: boolean;
+  }) => Promise<ConnectorRefsResolution>;
 }
 
-function providerBackedGrantKind(
-  grantKind: ConnectorCatalogGrantKind,
-): grantKind is "auth-code" | "device-auth" | "external-code" | "openid-auth" {
-  return (
-    grantKind === "auth-code" ||
-    grantKind === "device-auth" ||
-    grantKind === "external-code" ||
-    grantKind === "openid-auth"
-  );
-}
-
-function executableRef(
-  connectorRef: ConnectorCatalogRef,
-  catalogConnector: PublicConnectorCatalogDetail,
-): ResolvedConnectorExecutableRef | ConnectorRefResolutionFailure {
-  const type = connectorTypeSchema.safeParse(connectorRef);
-  if (!type.success) {
+function resolvedRef(args: {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly requireExecutable: boolean;
+  readonly runtimeConnector: ConnectorRuntimeConnector;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): ResolvedConnectorRef | ConnectorRefResolutionFailure {
+  if (
+    args.requireExecutable &&
+    ![...args.runtimeConnector.methods.values()].some((method) => {
+      return method.executable;
+    })
+  ) {
     return { ok: false, reason: "missing_executable_capability" };
   }
-  return { ok: true, connectorRef, catalogConnector, type: type.data };
+  return {
+    ok: true,
+    connectorRef: args.connectorRef,
+    catalogConnector: args.runtimeConnector.catalogConnector,
+    runtimeConnector: args.runtimeConnector,
+    snapshot: args.snapshot,
+  };
 }
 
-const CONNECTOR_AUTH_PROVIDER_CAPABILITIES =
-  getConnectorAuthProviderRegistryCapabilities();
-
 function executableMethod(args: {
-  readonly resolvedRef: ResolvedConnectorExecutableRef;
+  readonly resolvedRef: ResolvedConnectorRef;
   readonly authMethodId: ConnectorCatalogAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
 }): ResolvedConnectorActionMethod | ConnectorActionResolutionFailure {
-  const authMethod = connectorAuthMethodIdSchema.safeParse(args.authMethodId);
-  if (!authMethod.success) {
+  const runtimeMethod = getConnectorRuntimeMethod({
+    snapshot: args.resolvedRef.snapshot,
+    connectorRef: args.resolvedRef.connectorRef,
+    authMethodId: args.authMethodId,
+    requireExecutable: true,
+  });
+  if (
+    runtimeMethod === undefined ||
+    runtimeMethod.method.grant.kind !== args.catalogMethod.grantKind
+  ) {
     return { ok: false, reason: "missing_executable_capability" };
-  }
-  const method = getConnectorAuthMethod(args.resolvedRef.type, authMethod.data);
-  if (!method || method.grant.kind !== args.catalogMethod.grantKind) {
-    return { ok: false, reason: "missing_executable_capability" };
-  }
-  if (providerBackedGrantKind(args.catalogMethod.grantKind)) {
-    const capability =
-      CONNECTOR_AUTH_PROVIDER_CAPABILITIES[args.resolvedRef.type]?.[
-        authMethod.data
-      ];
-    if (capability?.grant !== args.catalogMethod.grantKind) {
-      return { ok: false, reason: "missing_executable_capability" };
-    }
   }
   return {
     ...args.resolvedRef,
     authMethodId: args.authMethodId,
     catalogMethod: args.catalogMethod,
-    authMethod: authMethod.data,
-    method,
+    method: runtimeMethod.method,
+    runtimeMethod,
   };
 }
 
 function createConnectorActionResolver(args: {
   readonly featureStates: ReturnType<typeof getAllFeatureStates>;
+  readonly snapshot: ConnectorRuntimeSnapshot;
 }): ConnectorActionResolver {
   const readAvailableConnector = async (connectorRef: ConnectorCatalogRef) => {
-    return await getStaticPublicConnectorCatalogDetail({
+    return await getConnectorRuntimeAvailableCatalogDetail({
+      snapshot: args.snapshot,
       connectorRef,
       featureStates: args.featureStates,
-      apiAuthMethodPolicy: "include",
     });
   };
 
   const resolveRef: ConnectorActionResolver["resolveRef"] = async (input) => {
-    const catalogConnector = await getStaticConnectorCatalogResolutionDetail(
+    const runtimeConnector = getConnectorRuntimeConnector(
+      args.snapshot,
       input.connectorRef,
     );
-    if (!catalogConnector) {
+    if (runtimeConnector === undefined) {
       return { ok: false, reason: "unknown_connector" };
     }
     if (input.requireAvailable) {
@@ -179,19 +176,26 @@ function createConnectorActionResolver(args: {
         return { ok: false, reason: "unavailable_connector" };
       }
     }
-    return executableRef(input.connectorRef, catalogConnector);
+    return resolvedRef({
+      connectorRef: input.connectorRef,
+      requireExecutable: input.requireExecutable,
+      runtimeConnector,
+      snapshot: args.snapshot,
+    });
   };
 
   return {
     resolveRef,
 
     async resolveMethod(input) {
-      const catalogConnector = await getStaticConnectorCatalogResolutionDetail(
+      const runtimeConnector = getConnectorRuntimeConnector(
+        args.snapshot,
         input.connectorRef,
       );
-      if (!catalogConnector) {
+      if (runtimeConnector === undefined) {
         return { ok: false, reason: "unknown_connector" };
       }
+      const catalogConnector = runtimeConnector.catalogConnector;
       const catalogMethod = catalogConnector.authMethods.find((method) => {
         return method.id === input.authMethodId;
       });
@@ -211,37 +215,45 @@ function createConnectorActionResolver(args: {
         };
       }
 
-      const availableConnector = await readAvailableConnector(
-        input.connectorRef,
-      );
-      if (!availableConnector) {
-        return { ok: false, reason: "unavailable_connector" };
-      }
-      if (
-        !availableConnector.authMethods.some((method) => {
-          return method.id === input.authMethodId;
-        })
-      ) {
-        return { ok: false, reason: "unavailable_auth_method" };
+      if (input.requireAvailable) {
+        const availableConnector = await readAvailableConnector(
+          input.connectorRef,
+        );
+        if (!availableConnector) {
+          return { ok: false, reason: "unavailable_connector" };
+        }
+        if (
+          !availableConnector.authMethods.some((method) => {
+            return method.id === input.authMethodId;
+          })
+        ) {
+          return { ok: false, reason: "unavailable_auth_method" };
+        }
       }
 
-      const resolvedRef = executableRef(input.connectorRef, catalogConnector);
-      if (!resolvedRef.ok) {
-        return resolvedRef;
+      const selectedRef = resolvedRef({
+        connectorRef: input.connectorRef,
+        requireExecutable: true,
+        runtimeConnector,
+        snapshot: args.snapshot,
+      });
+      if (!selectedRef.ok) {
+        return selectedRef;
       }
       return executableMethod({
-        resolvedRef,
+        resolvedRef: selectedRef,
         authMethodId: input.authMethodId,
         catalogMethod,
       });
     },
 
     async resolveRefs(input) {
-      const connectors: ResolvedConnectorExecutableRef[] = [];
+      const connectors: ResolvedConnectorRef[] = [];
       for (const connectorRef of input.connectorRefs) {
         const resolved = await resolveRef({
           connectorRef,
           requireAvailable: input.requireAvailable,
+          requireExecutable: input.requireExecutable,
         });
         if (!resolved.ok) {
           return { ...resolved, connectorRef };
@@ -258,9 +270,27 @@ export function userConnectorActionResolver(
   userId: string,
 ): Computed<Promise<ConnectorActionResolver>> {
   return computed(async (get): Promise<ConnectorActionResolver> => {
+    const [overrides, snapshot] = await Promise.all([
+      get(userFeatureSwitchOverrides(orgId, userId)),
+      loadConnectorRuntimeSnapshot(get(db$)),
+    ]);
+    return createConnectorActionResolver({
+      featureStates: getAllFeatureStates({ orgId, userId, overrides }),
+      snapshot,
+    });
+  });
+}
+
+export function userConnectorActionResolverForSnapshot(
+  orgId: string,
+  userId: string,
+  snapshot: ConnectorRuntimeSnapshot,
+): Computed<Promise<ConnectorActionResolver>> {
+  return computed(async (get): Promise<ConnectorActionResolver> => {
     const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
     return createConnectorActionResolver({
       featureStates: getAllFeatureStates({ orgId, userId, overrides }),
+      snapshot,
     });
   });
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -3,6 +3,7 @@ import {
   type ConnectorCatalogCompatibilityReason,
   type ConnectorCatalogFilteredAuthMethod,
 } from "@vm0/api-contracts/contracts/cron";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import type {
@@ -625,6 +626,20 @@ export function getAcceptedConnectorCatalogAvailableDetail(args: {
     return entry.connector.connectorRef === args.connectorRef;
   });
   return connector ? connectorCatalogDetail(connector) : null;
+}
+
+export function listAcceptedConnectorCatalogAvailableRefs(args: {
+  readonly snapshot: AcceptedConnectorCatalogSnapshot;
+  readonly featureStates: ConnectorFeatureStates;
+}): readonly ConnectorCatalogRef[] {
+  return effectiveConnectors({
+    catalog: args.snapshot,
+    featureStates: args.featureStates,
+  })
+    .connectors.map((entry) => {
+      return entry.connector.connectorRef;
+    })
+    .sort();
 }
 
 export function acceptedConnectorCatalogMethodIsCompatible(args: {

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -412,6 +412,11 @@ export async function loadAcceptedConnectorCatalogSnapshot(
   return catalog;
 }
 
+/**
+ * Applies rollout policy to discovery projections only. Feature switches must
+ * never be reused as connector authorization or execution checks;
+ * ConnectorActionResolver intentionally does not read them.
+ */
 function featureSwitchEnabled(
   method: PublicArtifactAuthMethod,
   featureStates: ConnectorFeatureStates,

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -32,11 +32,17 @@ import type { ReadonlyDb } from "../external/db";
 import { safeJsonParse } from "../utils";
 import { singleton } from "../../lib/singleton";
 import {
+  connectorCatalogIntegrityArtifactSchema,
   connectorCatalogPrivateArtifactSchema,
+  connectorCatalogPrivateFirewallsArtifactSchema,
   connectorCatalogPublicArtifactSchema,
+  connectorCatalogRunnerFirewallsArtifactSchema,
   SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
   type ConnectorCatalogPrivateArtifact,
+  type ConnectorCatalogPrivateFirewallsArtifact,
   type ConnectorCatalogPublicArtifact,
+  type ConnectorCatalogRunnerFirewallsArtifact,
+  validateConnectorCatalogArtifacts,
 } from "./connector-catalog-artifacts/artifacts";
 import { connectorCatalogExecutableCapabilityDigest } from "./connector-catalog-compatibility.service";
 import { connectorCatalogSource } from "./connector-catalog-sync.service";
@@ -47,7 +53,7 @@ type PublicArtifactAuthMethod = PublicArtifactConnector["authMethods"][number];
 type PrivateArtifactAuthMethod =
   ConnectorCatalogPrivateArtifact["connectors"][number]["authMethods"][number];
 
-interface ExternalCatalogIdentity {
+export interface ExternalCatalogIdentity {
   readonly sourceId: string;
   readonly schemaVersion: number;
   readonly catalogVersion: string;
@@ -60,9 +66,12 @@ interface PrivateAuthMethodFacts {
   readonly supportsRefresh: boolean;
 }
 
-interface PreparedExternalCatalog {
+export interface AcceptedConnectorCatalogSnapshot {
   readonly identity: ExternalCatalogIdentity;
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runnerFirewallsArtifact: ConnectorCatalogRunnerFirewallsArtifact;
   readonly privateMethodFacts: ReadonlyMap<string, PrivateAuthMethodFacts>;
   readonly filteredMethodKeys: ReadonlySet<string>;
   readonly compatibilityReasonCounts: Readonly<
@@ -75,7 +84,7 @@ interface PreparedExternalCatalog {
 
 interface PreparedExternalCatalogCache {
   key: string | undefined;
-  catalog: PreparedExternalCatalog | undefined;
+  catalog: AcceptedConnectorCatalogSnapshot | undefined;
 }
 
 interface RequestFilteringCounts {
@@ -272,14 +281,22 @@ async function readCurrentCatalog(args: {
   readonly db: ReadonlyDb;
   readonly sourceId: string;
   readonly capabilityDigest: string;
-}): Promise<PreparedExternalCatalog | undefined> {
+}): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
   const [row] = await args.db
     .select({
       schemaVersion: connectorCatalogActiveSnapshot.schemaVersion,
       catalogVersion: connectorCatalogActiveSnapshot.catalogVersion,
       integrityDigest: connectorCatalogActiveSnapshot.integrityDigest,
+      publicCatalogDigest: connectorCatalogActiveSnapshot.publicCatalogDigest,
+      privateCatalogDigest: connectorCatalogActiveSnapshot.privateCatalogDigest,
+      privateFirewallsDigest:
+        connectorCatalogActiveSnapshot.privateFirewallsDigest,
+      runnerFirewallsDigest:
+        connectorCatalogActiveSnapshot.runnerFirewallsDigest,
       publicCatalog: connectorCatalogActiveSnapshot.publicCatalog,
       privateCatalog: connectorCatalogActiveSnapshot.privateCatalog,
+      privateFirewalls: connectorCatalogActiveSnapshot.privateFirewalls,
+      runnerFirewalls: connectorCatalogActiveSnapshot.runnerFirewalls,
       filteredAuthMethods:
         connectorCatalogCompatibilityEvaluation.filteredAuthMethods,
     })
@@ -309,12 +326,31 @@ async function readCurrentCatalog(args: {
   const privateArtifact = connectorCatalogPrivateArtifactSchema.parse(
     safeJsonParse(row.privateCatalog),
   );
-  if (
-    publicArtifact.catalogVersion !== row.catalogVersion ||
-    privateArtifact.catalogVersion !== row.catalogVersion
-  ) {
-    throw new Error("Stored connector catalog identity mismatch");
-  }
+  const privateFirewallsArtifact =
+    connectorCatalogPrivateFirewallsArtifactSchema.parse(
+      safeJsonParse(row.privateFirewalls),
+    );
+  const runnerFirewallsArtifact =
+    connectorCatalogRunnerFirewallsArtifactSchema.parse(
+      safeJsonParse(row.runnerFirewalls),
+    );
+  const integrity = connectorCatalogIntegrityArtifactSchema.parse({
+    artifactSchemaVersion: row.schemaVersion,
+    catalogVersion: row.catalogVersion,
+    artifacts: {
+      publicCatalog: row.publicCatalogDigest,
+      privateCatalog: row.privateCatalogDigest,
+      privateFirewalls: row.privateFirewallsDigest,
+      runnerFirewalls: row.runnerFirewallsDigest,
+    },
+  });
+  validateConnectorCatalogArtifacts({
+    publicArtifact,
+    privateArtifact,
+    privateFirewallsArtifact,
+    runnerFirewallsArtifact,
+    integrity,
+  });
   const filteredAuthMethods = connectorCatalogFilteredAuthMethodsSchema.parse(
     row.filteredAuthMethods,
   );
@@ -329,6 +365,9 @@ async function readCurrentCatalog(args: {
   return {
     identity,
     publicArtifact,
+    privateArtifact,
+    privateFirewallsArtifact,
+    runnerFirewallsArtifact,
     privateMethodFacts: privateMethodFacts(privateArtifact),
     filteredMethodKeys: new Set(
       filteredAuthMethods.map((filtered) => {
@@ -344,9 +383,9 @@ async function readCurrentCatalog(args: {
   };
 }
 
-async function loadPreparedCatalog(
+export async function loadAcceptedConnectorCatalogSnapshot(
   db: ReadonlyDb,
-): Promise<PreparedExternalCatalog> {
+): Promise<AcceptedConnectorCatalogSnapshot> {
   const sourceId = connectorCatalogSource().sourceId;
   const capabilityDigest = connectorCatalogExecutableCapabilityDigest();
   const currentIdentity = await readCurrentIdentity({
@@ -386,7 +425,7 @@ function featureSwitchEnabled(
 }
 
 function effectiveConnectors(args: {
-  readonly catalog: PreparedExternalCatalog;
+  readonly catalog: AcceptedConnectorCatalogSnapshot;
   readonly featureStates: ConnectorFeatureStates;
 }): {
   readonly connectors: readonly EffectiveConnector[];
@@ -436,7 +475,7 @@ function effectiveConnectors(args: {
 }
 
 function diagnostics(
-  catalog: PreparedExternalCatalog,
+  catalog: AcceptedConnectorCatalogSnapshot,
   counts: RequestFilteringCounts,
 ): ExternalConnectorCatalogDiagnostics {
   return {
@@ -462,7 +501,7 @@ function iconForCatalog(
 }
 
 function referenceMetadataForCatalog(
-  catalog: PreparedExternalCatalog,
+  catalog: AcceptedConnectorCatalogSnapshot,
   connectorRefs: readonly string[],
 ): readonly ConnectorCatalogReferenceMetadata[] {
   const requestedRefs = new Set(connectorRefs);
@@ -558,8 +597,48 @@ function connectorCatalogDetail(
   };
 }
 
+export function getAcceptedConnectorCatalogResolutionDetail(args: {
+  readonly snapshot: AcceptedConnectorCatalogSnapshot;
+  readonly connectorRef: string;
+}): PublicConnectorCatalogDetail | null {
+  const connector = args.snapshot.publicArtifact.connectors.find((entry) => {
+    return entry.connectorRef === args.connectorRef;
+  });
+  return connector
+    ? connectorCatalogDetail({
+        connector,
+        authMethods: connector.authMethods,
+      })
+    : null;
+}
+
+export function getAcceptedConnectorCatalogAvailableDetail(args: {
+  readonly snapshot: AcceptedConnectorCatalogSnapshot;
+  readonly connectorRef: string;
+  readonly featureStates: ConnectorFeatureStates;
+}): PublicConnectorCatalogDetail | null {
+  const effective = effectiveConnectors({
+    catalog: args.snapshot,
+    featureStates: args.featureStates,
+  });
+  const connector = effective.connectors.find((entry) => {
+    return entry.connector.connectorRef === args.connectorRef;
+  });
+  return connector ? connectorCatalogDetail(connector) : null;
+}
+
+export function acceptedConnectorCatalogMethodIsCompatible(args: {
+  readonly snapshot: AcceptedConnectorCatalogSnapshot;
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+}): boolean {
+  return !args.snapshot.filteredMethodKeys.has(
+    authMethodKey(args.connectorRef, args.authMethodId),
+  );
+}
+
 function categoryMetadataForConnectors(
-  catalog: PreparedExternalCatalog,
+  catalog: AcceptedConnectorCatalogSnapshot,
   connectors: readonly EffectiveConnector[],
 ): PublicConnectorCatalogListResponse["categoryMetadata"] {
   const visibleCategories = new Set(
@@ -622,7 +701,7 @@ function hasRequiredScopes(
 }
 
 function connectorCatalogStatusItem(args: {
-  readonly catalog: PreparedExternalCatalog;
+  readonly catalog: AcceptedConnectorCatalogSnapshot;
   readonly effective: EffectiveConnector;
   readonly connector: ConnectorResponse | null;
 }): PublicConnectorCatalogStatusItem {
@@ -725,7 +804,7 @@ function compactDefaultPolicy(
 export async function listExternalPublicConnectorCatalog(
   args: ExternalCatalogReadArgs,
 ): Promise<ExternalConnectorCatalogRead<PublicConnectorCatalogListResponse>> {
-  const catalog = await loadPreparedCatalog(args.db);
+  const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,
@@ -745,7 +824,7 @@ export async function listExternalPublicConnectorCatalog(
 export async function searchExternalConnectorCatalog(
   args: ExternalCatalogSearchArgs,
 ): Promise<ExternalConnectorCatalogRead<ConnectorSearchItem[]>> {
-  const catalog = await loadPreparedCatalog(args.db);
+  const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,
@@ -783,7 +862,7 @@ export async function searchExternalConnectorCatalog(
 export async function getExternalPublicConnectorCatalogDetail(
   args: ExternalCatalogConnectorReadArgs,
 ): Promise<ExternalConnectorCatalogRead<PublicConnectorCatalogDetail | null>> {
-  const catalog = await loadPreparedCatalog(args.db);
+  const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,
@@ -800,7 +879,7 @@ export async function getExternalPublicConnectorCatalogDetail(
 export async function listExternalPublicConnectorCatalogStatus(
   args: ExternalCatalogStatusArgs,
 ): Promise<ExternalConnectorCatalogRead<ConnectorCatalogStatusRead>> {
-  const catalog = await loadPreparedCatalog(args.db);
+  const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,
@@ -840,7 +919,7 @@ export async function getExternalPublicConnectorCatalogPermissionDetail(
 ): Promise<
   ExternalConnectorCatalogRead<PublicConnectorCatalogPermissionDetail | null>
 > {
-  const catalog = await loadPreparedCatalog(args.db);
+  const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -1,11 +1,16 @@
 import type {
   ConnectorAuthMethodId,
+  ConnectorAuthMethodRuntimeConfig,
   ConnectorDeviceAuthStartOptionConfig,
   ConnectorDeviceAuthStartOptions,
+  ConnectorDeviceAuthStartOptionsConfig,
   ConnectorManualGrantFieldConfig,
   ConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
+import {
+  getConnectorAuthMethod,
+  parseConnectorDeviceAuthStartOptionsConfig,
+} from "@vm0/connectors/connector-utils";
 
 interface PublicManualGrantFieldDescriptor {
   readonly publicId: string;
@@ -46,7 +51,16 @@ export function getPublicManualGrantFieldDescriptors(
   if (method?.grant.kind !== "manual") {
     return null;
   }
-  return Object.entries(method.grant.fields).map(([privateName, config]) => {
+  return publicManualGrantFieldDescriptors(method.grant);
+}
+
+function publicManualGrantFieldDescriptors(
+  grant: Extract<
+    ConnectorAuthMethodRuntimeConfig["grant"],
+    { readonly kind: "manual" }
+  >,
+): readonly PublicManualGrantFieldDescriptor[] {
+  return Object.entries(grant.fields).map(([privateName, config]) => {
     return {
       publicId: config.publicId,
       privateName,
@@ -63,7 +77,16 @@ export function getPublicDeviceAuthStartOptionDescriptors(
   if (method?.grant.kind !== "device-auth") {
     return null;
   }
-  return Object.entries(method.grant.startOptions ?? {}).map(
+  return publicDeviceAuthStartOptionDescriptors(method.grant);
+}
+
+function publicDeviceAuthStartOptionDescriptors(
+  grant: Extract<
+    ConnectorAuthMethodRuntimeConfig["grant"],
+    { readonly kind: "device-auth" }
+  >,
+): readonly PublicDeviceAuthStartOptionDescriptor[] {
+  return Object.entries(grant.startOptions ?? {}).map(
     ([privateName, config]) => {
       return {
         publicId: config.publicId,
@@ -74,19 +97,35 @@ export function getPublicDeviceAuthStartOptionDescriptors(
   );
 }
 
-export function normalizeManualGrantSubmittedValues(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+export function normalizeManualGrantSubmittedValuesWithMethod(args: {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly values: Readonly<Record<string, string>>;
 }): ManualGrantSubmittedValuesNormalizationResult {
-  const descriptors = getPublicManualGrantFieldDescriptors(
-    args.type,
-    args.authMethod,
-  );
+  const descriptors =
+    args.method.grant.kind === "manual"
+      ? publicManualGrantFieldDescriptors(args.method.grant)
+      : null;
+  return normalizeManualGrantSubmittedValuesFromDescriptors({
+    connectorRef: args.connectorRef,
+    authMethodId: args.authMethodId,
+    descriptors,
+    values: args.values,
+  });
+}
+
+function normalizeManualGrantSubmittedValuesFromDescriptors(args: {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly descriptors: readonly PublicManualGrantFieldDescriptor[] | null;
+  readonly values: Readonly<Record<string, string>>;
+}): ManualGrantSubmittedValuesNormalizationResult {
+  const descriptors = args.descriptors;
   if (!descriptors) {
     return {
       ok: false,
-      message: `${args.type} ${args.authMethod} auth method does not use a manual grant`,
+      message: `${args.connectorRef} ${args.authMethodId} auth method does not use a manual grant`,
     };
   }
 
@@ -171,21 +210,47 @@ export function normalizeManualGrantSubmittedValues(args: {
   };
 }
 
-export function normalizeDeviceAuthStartOptions(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+export function normalizeDeviceAuthStartOptionsWithMethod(args: {
+  readonly authMethodId: string;
+  readonly connectorRef: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly options: ConnectorDeviceAuthStartOptions | undefined;
 }): DeviceAuthStartOptionsNormalizationResult {
   if (!args.options) {
     return { ok: true, options: undefined };
   }
+  const descriptors =
+    args.method.grant.kind === "device-auth"
+      ? publicDeviceAuthStartOptionDescriptors(args.method.grant)
+      : null;
+  return normalizeDeviceAuthStartOptionsFromDescriptors({
+    authMethodId: args.authMethodId,
+    connectorRef: args.connectorRef,
+    descriptors,
+    startOptions:
+      args.method.grant.kind === "device-auth"
+        ? args.method.grant.startOptions
+        : undefined,
+    options: args.options,
+  });
+}
 
-  const descriptors = getPublicDeviceAuthStartOptionDescriptors(
-    args.type,
-    args.authMethod,
-  );
-  if (!descriptors || descriptors.length === 0) {
-    return { ok: true, options: args.options };
+function normalizeDeviceAuthStartOptionsFromDescriptors(args: {
+  readonly authMethodId: string;
+  readonly connectorRef: string;
+  readonly descriptors: readonly PublicDeviceAuthStartOptionDescriptor[] | null;
+  readonly options: ConnectorDeviceAuthStartOptions | undefined;
+  readonly startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined;
+}): DeviceAuthStartOptionsNormalizationResult {
+  if (!args.options) {
+    return { ok: true, options: undefined };
+  }
+  const descriptors = args.descriptors;
+  if (!descriptors) {
+    return {
+      ok: false,
+      message: `${args.connectorRef} ${args.authMethodId} auth method does not use a device-auth grant`,
+    };
   }
 
   const descriptorByPublicId = new Map(
@@ -239,5 +304,13 @@ export function normalizeDeviceAuthStartOptions(args: {
     };
   }
 
-  return { ok: true, options: Object.fromEntries(normalizedOptions) };
+  const parsed = parseConnectorDeviceAuthStartOptionsConfig({
+    connectorRef: args.connectorRef,
+    authMethodId: args.authMethodId,
+    startOptions: args.startOptions,
+    options: Object.fromEntries(normalizedOptions),
+  });
+  return parsed.success
+    ? { ok: true, options: parsed.options }
+    : { ok: false, message: parsed.message };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -1,0 +1,922 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ConnectorCatalogAuthMethodId,
+  ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  getConnectorAuthProviderRegistrationCapabilities,
+  type ConnectorAuthProviderRegistrationCapability,
+} from "@vm0/connectors/auth-providers";
+import {
+  CONNECTOR_PLATFORM_SECRET_NAMES,
+  CONNECTOR_TYPE_KEYS,
+  type ConnectorAccessConfig,
+  type ConnectorAuthClientConfig,
+  type ConnectorAuthMethodRuntimeConfig,
+  type ConnectorDeviceAuthStartOptionConfig,
+  type ConnectorEnvBindingValue,
+  type ConnectorGrantOutputBindings,
+  type ConnectorPlatformSecretName,
+  type PublicConnectorAuthClientConfig,
+  type ConnectorRefreshTokenInputBindings,
+  type ConnectorRefreshTokenOutputBindings,
+  type ConnectorRevokeInputBindings,
+  type ConnectorSecretValueRef,
+  type ConnectorVariableValueRef,
+} from "@vm0/connectors/connectors";
+import {
+  connectorAuthMethodOwnedSecretNames,
+  connectorAuthMethodRuntimeMetadata,
+  getConnectorAuthMethod,
+  getRuntimeAvailableConnectorTypes,
+  type ConnectorEnvReader,
+  type ConnectorFeatureStates,
+} from "@vm0/connectors/connector-utils";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
+import { waitUntil } from "../context/wait-until";
+import type { ReadonlyDb } from "../external/db";
+import { settle } from "../utils";
+import type {
+  ConnectorCatalogPrivateArtifact,
+  ConnectorCatalogPrivateFirewallsArtifact,
+  ConnectorCatalogPublicArtifact,
+  ConnectorCatalogRunnerFirewallsArtifact,
+} from "./connector-catalog-artifacts/artifacts";
+import {
+  acceptedConnectorCatalogMethodIsCompatible,
+  ExternalConnectorCatalogUnavailableError,
+  getAcceptedConnectorCatalogAvailableDetail,
+  getAcceptedConnectorCatalogResolutionDetail,
+  loadAcceptedConnectorCatalogSnapshot,
+  type AcceptedConnectorCatalogSnapshot,
+  type ExternalCatalogIdentity,
+} from "./connector-catalog-external-reader.service";
+import {
+  getStaticConnectorCatalogResolutionDetail,
+  getStaticPublicConnectorCatalogDetail,
+} from "./connector-catalog-reader.service";
+
+type AcceptedPrivateConnector =
+  ConnectorCatalogPrivateArtifact["connectors"][number];
+type AcceptedPrivateAuthMethod =
+  AcceptedPrivateConnector["authMethods"][number];
+type AcceptedPrivateSkill = AcceptedPrivateConnector["skill"];
+type AcceptedPublicAuthMethod =
+  ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
+type AcceptedServerFirewall =
+  ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
+type AcceptedRunnerFirewall =
+  ConnectorCatalogRunnerFirewallsArtifact["firewalls"][number];
+
+export type ConnectorRuntimeSnapshotIdentity =
+  | { readonly source: "static" }
+  | ({ readonly source: "external" } & ExternalCatalogIdentity);
+
+export interface ConnectorRuntimeMethod {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly compatible: boolean;
+  readonly executable: boolean;
+  readonly registration: ConnectorAuthProviderRegistrationCapability | null;
+}
+
+export interface ConnectorRuntimeConnector {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly catalogConnector: PublicConnectorCatalogDetail;
+  readonly methods: ReadonlyMap<
+    ConnectorCatalogAuthMethodId,
+    ConnectorRuntimeMethod
+  >;
+  readonly skill: AcceptedPrivateSkill | null;
+  readonly serverFirewall: AcceptedServerFirewall | null;
+  readonly runnerFirewall: AcceptedRunnerFirewall | null;
+}
+
+interface ConnectorRuntimeSnapshotBase {
+  readonly connectors: ReadonlyMap<
+    ConnectorCatalogRef,
+    ConnectorRuntimeConnector
+  >;
+}
+
+export type ConnectorRuntimeSnapshot =
+  | (ConnectorRuntimeSnapshotBase & {
+      readonly identity: Extract<
+        ConnectorRuntimeSnapshotIdentity,
+        { readonly source: "static" }
+      >;
+      readonly acceptedSnapshot: null;
+    })
+  | (ConnectorRuntimeSnapshotBase & {
+      readonly identity: Extract<
+        ConnectorRuntimeSnapshotIdentity,
+        { readonly source: "external" }
+      >;
+      readonly acceptedSnapshot: AcceptedConnectorCatalogSnapshot;
+    });
+
+const log = logger("connector-catalog:runtime-shadow");
+
+function methodKey(connectorRef: string, authMethodId: string): string {
+  return `${connectorRef}\0${authMethodId}`;
+}
+
+const providerRegistrations = singleton(() => {
+  return new Map(
+    getConnectorAuthProviderRegistrationCapabilities().map((registration) => {
+      return [
+        methodKey(registration.connectorRef, registration.authMethodId),
+        registration,
+      ];
+    }),
+  );
+});
+
+function providerRegistrationFor(
+  connectorRef: string,
+  authMethodId: string,
+): ConnectorAuthProviderRegistrationCapability | null {
+  return (
+    providerRegistrations().get(methodKey(connectorRef, authMethodId)) ?? null
+  );
+}
+
+function providerBackedGrant(
+  kind: ConnectorAuthMethodRuntimeConfig["grant"]["kind"],
+): kind is "auth-code" | "device-auth" | "external-code" | "openid-auth" {
+  return (
+    kind === "auth-code" ||
+    kind === "device-auth" ||
+    kind === "external-code" ||
+    kind === "openid-auth"
+  );
+}
+
+function registrationSupportsMethod(args: {
+  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly registration: ConnectorAuthProviderRegistrationCapability | null;
+}): boolean {
+  if (
+    providerBackedGrant(args.method.grant.kind) &&
+    args.registration?.handlers.grant !== args.method.grant.kind
+  ) {
+    return false;
+  }
+  if (
+    args.method.access.kind === "refresh-token" &&
+    args.registration?.handlers.access !== "refresh-token"
+  ) {
+    return false;
+  }
+  if (
+    args.method.revoke.kind === "token-revoke" &&
+    args.registration?.handlers.revoke !== "token-revoke"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isSecretValueRef(value: string): value is ConnectorSecretValueRef {
+  return /^\$secrets\.[A-Z][A-Z0-9_]*$/u.test(value);
+}
+
+function isVariableValueRef(value: string): value is ConnectorVariableValueRef {
+  return /^\$vars\.[A-Z][A-Z0-9_]*$/u.test(value);
+}
+
+function outputValueRef(
+  value: string,
+): ConnectorSecretValueRef | ConnectorVariableValueRef {
+  if (isSecretValueRef(value) || isVariableValueRef(value)) {
+    return value;
+  }
+  throw new Error("Invalid accepted connector value reference");
+}
+
+function secretValueRef(value: string): ConnectorSecretValueRef {
+  if (isSecretValueRef(value)) {
+    return value;
+  }
+  throw new Error("Invalid accepted connector secret reference");
+}
+
+function outputBindings(
+  bindings: Readonly<Record<string, string>>,
+): ConnectorGrantOutputBindings {
+  const result: ConnectorGrantOutputBindings = {};
+  for (const [name, value] of Object.entries(bindings)) {
+    result[name] = outputValueRef(value);
+  }
+  return result;
+}
+
+function refreshInputBindings(
+  bindings: Readonly<Record<string, string>>,
+): ConnectorRefreshTokenInputBindings {
+  const result: ConnectorRefreshTokenInputBindings = {};
+  for (const [name, value] of Object.entries(bindings)) {
+    result[name] = outputValueRef(value);
+  }
+  return result;
+}
+
+function refreshOutputBindings(
+  bindings: Readonly<Record<string, string>>,
+): ConnectorRefreshTokenOutputBindings {
+  const result: ConnectorRefreshTokenOutputBindings = {};
+  for (const [name, value] of Object.entries(bindings)) {
+    result[name] = outputValueRef(value);
+  }
+  return result;
+}
+
+function revokeInputBindings(
+  bindings: Readonly<Record<string, string>>,
+): ConnectorRevokeInputBindings {
+  const result: ConnectorRevokeInputBindings = {};
+  for (const [name, value] of Object.entries(bindings)) {
+    result[name] = secretValueRef(value);
+  }
+  return result;
+}
+
+function envBindingValue(
+  binding: string | { readonly valueRef: string; readonly optional: true },
+): ConnectorEnvBindingValue {
+  return typeof binding === "string"
+    ? outputValueRef(binding)
+    : { valueRef: outputValueRef(binding.valueRef), optional: true };
+}
+
+function platformSecretName(value: string): ConnectorPlatformSecretName {
+  const name = CONNECTOR_PLATFORM_SECRET_NAMES.find((candidate) => {
+    return candidate === value;
+  });
+  if (name === undefined) {
+    throw new Error("Unsupported accepted connector platform secret");
+  }
+  return name;
+}
+
+function runtimeAccess(
+  access: AcceptedPrivateAuthMethod["access"],
+): ConnectorAccessConfig {
+  const envBindings: Record<string, ConnectorEnvBindingValue> = {};
+  for (const [name, binding] of Object.entries(access.envBindings)) {
+    envBindings[name] = envBindingValue(binding);
+  }
+  const platformSecrets = access.platformSecrets?.map(platformSecretName);
+  if (access.kind === "static") {
+    return {
+      kind: "static",
+      envBindings,
+      ...(platformSecrets === undefined ? {} : { platformSecrets }),
+    };
+  }
+  return {
+    kind: "refresh-token",
+    envBindings,
+    ...(platformSecrets === undefined ? {} : { platformSecrets }),
+    inputs: refreshInputBindings(access.inputs),
+    outputs: refreshOutputBindings(access.outputs),
+    refreshableSecrets: [...access.refreshableSecrets],
+  };
+}
+
+function runtimeClient(
+  client: AcceptedPrivateAuthMethod["client"],
+): ConnectorAuthClientConfig | undefined {
+  return client === undefined ? undefined : { ...client };
+}
+
+function requiredRuntimeClient(
+  method: AcceptedPrivateAuthMethod,
+): ConnectorAuthClientConfig {
+  const client = runtimeClient(method.client);
+  if (client === undefined) {
+    throw new Error("Accepted connector auth method is missing its client");
+  }
+  return client;
+}
+
+function requiredPublicRuntimeClient(
+  method: AcceptedPrivateAuthMethod,
+): PublicConnectorAuthClientConfig {
+  const client = requiredRuntimeClient(method);
+  if (client.clientType !== "public") {
+    throw new Error("Accepted device auth method requires a public client");
+  }
+  return client;
+}
+
+function manualGrant(args: {
+  readonly publicMethod: AcceptedPublicAuthMethod;
+  readonly privateMethod: AcceptedPrivateAuthMethod & {
+    readonly grant: Extract<
+      AcceptedPrivateAuthMethod["grant"],
+      { kind: "manual" }
+    >;
+  };
+}): Extract<ConnectorAuthMethodRuntimeConfig["grant"], { kind: "manual" }> {
+  const fields: Record<
+    string,
+    Extract<
+      ConnectorAuthMethodRuntimeConfig["grant"],
+      { kind: "manual" }
+    >["fields"][string]
+  > = {};
+  for (const privateField of args.privateMethod.grant.fields) {
+    const publicField = args.publicMethod.manualFields.find((candidate) => {
+      return candidate.id === privateField.publicId;
+    });
+    if (publicField === undefined) {
+      throw new Error("Accepted connector manual field alignment is missing");
+    }
+    fields[privateField.privateName] = {
+      publicId: privateField.publicId,
+      label: publicField.label,
+      required: publicField.required,
+      ...(publicField.placeholder === null
+        ? {}
+        : { placeholder: publicField.placeholder }),
+      storage: privateField.storage,
+      ...(privateField.normalize === undefined
+        ? {}
+        : { normalize: privateField.normalize }),
+    };
+  }
+  return { kind: "manual", fields };
+}
+
+function deviceStartOption(
+  option: AcceptedPublicAuthMethod["startOptions"][number],
+): ConnectorDeviceAuthStartOptionConfig {
+  const [first, ...rest] = option.options;
+  if (first === undefined) {
+    throw new Error("Accepted connector device option has no choices");
+  }
+  return {
+    kind: "select",
+    publicId: option.id,
+    label: option.label,
+    required: option.required,
+    ...(option.defaultValue === null
+      ? {}
+      : { defaultValue: option.defaultValue }),
+    options: [
+      { ...first },
+      ...rest.map((choice) => {
+        return { ...choice };
+      }),
+    ],
+  };
+}
+
+function deviceStartOptions(args: {
+  readonly publicMethod: AcceptedPublicAuthMethod;
+  readonly privateMethod: AcceptedPrivateAuthMethod & {
+    readonly grant: Extract<
+      AcceptedPrivateAuthMethod["grant"],
+      { kind: "device-auth" }
+    >;
+  };
+}): Readonly<Record<string, ConnectorDeviceAuthStartOptionConfig>> | undefined {
+  const options: Record<string, ConnectorDeviceAuthStartOptionConfig> = {};
+  for (const mapping of args.privateMethod.grant.startOptionMappings) {
+    const publicOption = args.publicMethod.startOptions.find((candidate) => {
+      return candidate.id === mapping.publicId;
+    });
+    if (publicOption === undefined) {
+      throw new Error("Accepted connector device option alignment is missing");
+    }
+    options[mapping.privateName] = deviceStartOption(publicOption);
+  }
+  return Object.keys(options).length === 0 ? undefined : options;
+}
+
+function runtimeMethod(args: {
+  readonly publicMethod: AcceptedPublicAuthMethod;
+  readonly privateMethod: AcceptedPrivateAuthMethod;
+}): ConnectorAuthMethodRuntimeConfig {
+  const access = runtimeAccess(args.privateMethod.access);
+  const revoke =
+    args.privateMethod.revoke.kind === "none"
+      ? { kind: "none" as const }
+      : {
+          kind: "token-revoke" as const,
+          inputs: revokeInputBindings(args.privateMethod.revoke.inputs),
+          ...(args.privateMethod.revoke.revokePreviousOnReplace === undefined
+            ? {}
+            : {
+                revokePreviousOnReplace:
+                  args.privateMethod.revoke.revokePreviousOnReplace,
+              }),
+        };
+  const storage = {
+    secrets: [...args.privateMethod.storage.secrets],
+    variables: [...args.privateMethod.storage.variables],
+  };
+
+  switch (args.privateMethod.grant.kind) {
+    case "manual": {
+      return {
+        storage,
+        grant: manualGrant({
+          publicMethod: args.publicMethod,
+          privateMethod: {
+            ...args.privateMethod,
+            grant: args.privateMethod.grant,
+          },
+        }),
+        access,
+        revoke,
+        ...(args.privateMethod.client === undefined
+          ? {}
+          : { client: runtimeClient(args.privateMethod.client) }),
+      };
+    }
+    case "auth-code": {
+      return {
+        client: requiredRuntimeClient(args.privateMethod),
+        storage,
+        grant: {
+          kind: "auth-code",
+          scopes: [...args.privateMethod.grant.scopes],
+          callbackOrigin: args.privateMethod.grant.callbackOrigin,
+          outputs: outputBindings(args.privateMethod.grant.outputs),
+        },
+        access,
+        revoke,
+      };
+    }
+    case "openid-auth": {
+      return {
+        ...(args.privateMethod.client === undefined
+          ? {}
+          : { client: runtimeClient(args.privateMethod.client) }),
+        storage,
+        grant: {
+          kind: "openid-auth",
+          callbackOrigin: args.privateMethod.grant.callbackOrigin,
+          outputs: outputBindings(args.privateMethod.grant.outputs),
+        },
+        access,
+        revoke,
+      };
+    }
+    case "external-code": {
+      return {
+        client: requiredRuntimeClient(args.privateMethod),
+        storage,
+        grant: {
+          kind: "external-code",
+          scopes: [...args.privateMethod.grant.scopes],
+          outputs: outputBindings(args.privateMethod.grant.outputs),
+        },
+        access,
+        revoke,
+      };
+    }
+    case "device-auth": {
+      const startOptions = deviceStartOptions({
+        publicMethod: args.publicMethod,
+        privateMethod: {
+          ...args.privateMethod,
+          grant: args.privateMethod.grant,
+        },
+      });
+      return {
+        client: requiredPublicRuntimeClient(args.privateMethod),
+        storage,
+        grant: {
+          kind: "device-auth",
+          scopes: [...args.privateMethod.grant.scopes],
+          outputs: outputBindings(args.privateMethod.grant.outputs),
+          ...(startOptions === undefined ? {} : { startOptions }),
+        },
+        access,
+        revoke,
+      };
+    }
+  }
+}
+
+function runtimeMethodEntry(args: {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly compatible: boolean;
+}): ConnectorRuntimeMethod {
+  const registration = providerRegistrationFor(
+    args.connectorRef,
+    args.catalogMethod.id,
+  );
+  return {
+    connectorRef: args.connectorRef,
+    authMethodId: args.catalogMethod.id,
+    catalogMethod: args.catalogMethod,
+    method: args.method,
+    compatible: args.compatible,
+    registration,
+    executable:
+      args.compatible &&
+      registrationSupportsMethod({ method: args.method, registration }),
+  };
+}
+
+const staticRuntimeSnapshot = singleton(() => {
+  return (async (): Promise<ConnectorRuntimeSnapshot> => {
+    const connectors = new Map<
+      ConnectorCatalogRef,
+      ConnectorRuntimeConnector
+    >();
+    for (const connectorRef of CONNECTOR_TYPE_KEYS) {
+      const catalogConnector =
+        await getStaticConnectorCatalogResolutionDetail(connectorRef);
+      if (catalogConnector === null) {
+        throw new Error(`Static connector catalog is missing ${connectorRef}`);
+      }
+      const methods = new Map<
+        ConnectorCatalogAuthMethodId,
+        ConnectorRuntimeMethod
+      >();
+      for (const catalogMethod of catalogConnector.authMethods) {
+        const method = getConnectorAuthMethod(connectorRef, catalogMethod.id);
+        if (method === undefined) {
+          throw new Error(
+            `Static connector auth method is missing ${connectorRef}:${catalogMethod.id}`,
+          );
+        }
+        methods.set(
+          catalogMethod.id,
+          runtimeMethodEntry({
+            connectorRef,
+            catalogMethod,
+            method,
+            compatible: true,
+          }),
+        );
+      }
+      connectors.set(connectorRef, {
+        connectorRef,
+        catalogConnector,
+        methods,
+        skill: null,
+        serverFirewall: null,
+        runnerFirewall: null,
+      });
+    }
+    return {
+      identity: { source: "static" },
+      acceptedSnapshot: null,
+      connectors,
+    };
+  })();
+});
+
+function externalRuntimeSnapshot(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+): ConnectorRuntimeSnapshot {
+  const privateByRef = new Map(
+    acceptedSnapshot.privateArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+  const serverFirewallByRef = new Map(
+    acceptedSnapshot.privateFirewallsArtifact.connectors.map((firewall) => {
+      return [firewall.connectorRef, firewall];
+    }),
+  );
+  const runnerFirewallByRef = new Map(
+    acceptedSnapshot.runnerFirewallsArtifact.firewalls.map((firewall) => {
+      return [firewall.name, firewall];
+    }),
+  );
+  const connectors = new Map<ConnectorCatalogRef, ConnectorRuntimeConnector>();
+
+  for (const publicConnector of acceptedSnapshot.publicArtifact.connectors) {
+    const privateConnector = privateByRef.get(publicConnector.connectorRef);
+    const catalogConnector = getAcceptedConnectorCatalogResolutionDetail({
+      snapshot: acceptedSnapshot,
+      connectorRef: publicConnector.connectorRef,
+    });
+    if (privateConnector === undefined || catalogConnector === null) {
+      throw new Error("Accepted connector runtime relationship is incomplete");
+    }
+    const privateMethods = new Map(
+      privateConnector.authMethods.map((method) => {
+        return [method.id, method];
+      }),
+    );
+    const catalogMethods = new Map(
+      catalogConnector.authMethods.map((method) => {
+        return [method.id, method];
+      }),
+    );
+    const methods = new Map<
+      ConnectorCatalogAuthMethodId,
+      ConnectorRuntimeMethod
+    >();
+    for (const publicMethod of publicConnector.authMethods) {
+      const privateMethod = privateMethods.get(publicMethod.id);
+      const catalogMethod = catalogMethods.get(publicMethod.id);
+      if (privateMethod === undefined || catalogMethod === undefined) {
+        throw new Error(
+          "Accepted connector auth method alignment is incomplete",
+        );
+      }
+      const method = runtimeMethod({ publicMethod, privateMethod });
+      methods.set(
+        publicMethod.id,
+        runtimeMethodEntry({
+          connectorRef: publicConnector.connectorRef,
+          catalogMethod,
+          method,
+          compatible: acceptedConnectorCatalogMethodIsCompatible({
+            snapshot: acceptedSnapshot,
+            connectorRef: publicConnector.connectorRef,
+            authMethodId: publicMethod.id,
+          }),
+        }),
+      );
+    }
+    connectors.set(publicConnector.connectorRef, {
+      connectorRef: publicConnector.connectorRef,
+      catalogConnector,
+      methods,
+      skill: privateConnector.skill,
+      serverFirewall:
+        serverFirewallByRef.get(publicConnector.connectorRef) ?? null,
+      runnerFirewall:
+        runnerFirewallByRef.get(publicConnector.connectorRef) ?? null,
+    });
+  }
+  return {
+    identity: { source: "external", ...acceptedSnapshot.identity },
+    acceptedSnapshot,
+    connectors,
+  };
+}
+
+function externalSnapshotKey(identity: ExternalCatalogIdentity): string {
+  return [
+    identity.sourceId,
+    identity.schemaVersion,
+    identity.catalogVersion,
+    identity.integrityDigest,
+    identity.capabilityDigest,
+  ].join("\0");
+}
+
+interface ExternalRuntimeSnapshotCache {
+  key: string | undefined;
+  snapshot: ConnectorRuntimeSnapshot | undefined;
+}
+
+const externalRuntimeSnapshotCache = singleton(
+  (): ExternalRuntimeSnapshotCache => {
+    return { key: undefined, snapshot: undefined };
+  },
+);
+
+async function loadExternalRuntimeSnapshot(
+  db: ReadonlyDb,
+): Promise<ConnectorRuntimeSnapshot> {
+  const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(db);
+  const key = externalSnapshotKey(acceptedSnapshot.identity);
+  const cache = externalRuntimeSnapshotCache();
+  if (cache.key === key && cache.snapshot !== undefined) {
+    return cache.snapshot;
+  }
+  const snapshot = externalRuntimeSnapshot(acceptedSnapshot);
+  cache.key = key;
+  cache.snapshot = snapshot;
+  return snapshot;
+}
+
+interface RuntimeShadowMethod {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly grantKind: ConnectorAuthMethodRuntimeConfig["grant"]["kind"];
+  readonly accessKind: ConnectorAuthMethodRuntimeConfig["access"]["kind"];
+  readonly revokeKind: ConnectorAuthMethodRuntimeConfig["revoke"]["kind"];
+  readonly executable: boolean;
+}
+
+function runtimeShadowMethods(
+  snapshot: ConnectorRuntimeSnapshot,
+): readonly RuntimeShadowMethod[] {
+  return [...snapshot.connectors.values()]
+    .flatMap((connector) => {
+      return [...connector.methods.values()].map((method) => {
+        return {
+          connectorRef: method.connectorRef,
+          authMethodId: method.authMethodId,
+          grantKind: method.method.grant.kind,
+          accessKind: method.method.access.kind,
+          revokeKind: method.method.revoke.kind,
+          executable: method.executable,
+        };
+      });
+    })
+    .sort((left, right) => {
+      return (
+        left.connectorRef.localeCompare(right.connectorRef) ||
+        left.authMethodId.localeCompare(right.authMethodId)
+      );
+    });
+}
+
+function runtimeShadowDigest(methods: readonly RuntimeShadowMethod[]): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(methods))
+    .digest("hex")}`;
+}
+
+async function compareRuntimeSnapshots(
+  staticSnapshot: ConnectorRuntimeSnapshot,
+  db: ReadonlyDb,
+): Promise<void> {
+  const result = await settle(loadExternalRuntimeSnapshot(db));
+  if (!result.ok) {
+    log.warn("Connector runtime catalog shadow comparison unavailable", {
+      type: "connector_runtime_catalog_shadow_comparison",
+      outcome:
+        result.error instanceof ExternalConnectorCatalogUnavailableError
+          ? "unavailable"
+          : "error",
+    });
+    return;
+  }
+  const staticMethods = runtimeShadowMethods(staticSnapshot);
+  const externalMethods = runtimeShadowMethods(result.value);
+  const staticDigest = runtimeShadowDigest(staticMethods);
+  const externalDigest = runtimeShadowDigest(externalMethods);
+  log.debug("Connector runtime catalog shadow comparison completed", {
+    type: "connector_runtime_catalog_shadow_comparison",
+    outcome: staticDigest === externalDigest ? "match" : "difference",
+    staticConnectorCount: staticSnapshot.connectors.size,
+    externalConnectorCount: result.value.connectors.size,
+    staticMethodCount: staticMethods.length,
+    externalMethodCount: externalMethods.length,
+    staticDigest,
+    externalDigest,
+    ...(result.value.identity.source === "external"
+      ? {
+          sourceId: result.value.identity.sourceId,
+          schemaVersion: result.value.identity.schemaVersion,
+          catalogVersion: result.value.identity.catalogVersion,
+          integrityDigest: result.value.identity.integrityDigest,
+          capabilityDigest: result.value.identity.capabilityDigest,
+        }
+      : {}),
+  });
+}
+
+export async function loadConnectorRuntimeSnapshot(
+  db: ReadonlyDb,
+): Promise<ConnectorRuntimeSnapshot> {
+  const sourceMode = env("CONNECTOR_CATALOG_SOURCE_MODE");
+  if (sourceMode === "external") {
+    return await loadExternalRuntimeSnapshot(db);
+  }
+  const snapshot = await staticRuntimeSnapshot();
+  if (sourceMode === "shadow") {
+    waitUntil(compareRuntimeSnapshots(snapshot, db));
+  }
+  return snapshot;
+}
+
+export function getConnectorRuntimeConnector(
+  snapshot: ConnectorRuntimeSnapshot,
+  connectorRef: string,
+): ConnectorRuntimeConnector | undefined {
+  return snapshot.connectors.get(connectorRef);
+}
+
+export function getConnectorRuntimeMethod(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+  readonly requireExecutable?: boolean;
+}): ConnectorRuntimeMethod | undefined {
+  const method = args.snapshot.connectors
+    .get(args.connectorRef)
+    ?.methods.get(args.authMethodId);
+  if (args.requireExecutable === true && method?.executable !== true) {
+    return undefined;
+  }
+  return method;
+}
+
+export function getConnectorRuntimeStoredSecretDisplayInfo(
+  snapshot: ConnectorRuntimeSnapshot,
+  secretName: string,
+): {
+  readonly label: string;
+  readonly environmentNames: readonly string[];
+} | null {
+  for (const connector of snapshot.connectors.values()) {
+    const methods = [...connector.methods.values()];
+    if (
+      !methods.some((runtimeMethod) => {
+        return connectorAuthMethodOwnedSecretNames(
+          runtimeMethod.method,
+        ).includes(secretName);
+      })
+    ) {
+      continue;
+    }
+    const environmentNames = [
+      ...new Set(
+        methods.flatMap((runtimeMethod) => {
+          return connectorAuthMethodRuntimeMetadata(runtimeMethod.method)
+            .runtimeBindings.filter((binding) => {
+              return (
+                binding.source.kind === "connector-secret" &&
+                binding.source.name === secretName
+              );
+            })
+            .map((binding) => {
+              return binding.envName;
+            });
+        }),
+      ),
+    ];
+    if (environmentNames.length > 0) {
+      return {
+        label: connector.catalogConnector.label,
+        environmentNames,
+      };
+    }
+  }
+  return null;
+}
+
+export async function getConnectorRuntimeAvailableCatalogDetail(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorRef: string;
+  readonly featureStates: ConnectorFeatureStates;
+}): Promise<PublicConnectorCatalogDetail | null> {
+  if (args.snapshot.identity.source === "external") {
+    const acceptedSnapshot = args.snapshot.acceptedSnapshot;
+    if (acceptedSnapshot === null) {
+      throw new Error("External connector runtime snapshot is incomplete");
+    }
+    return getAcceptedConnectorCatalogAvailableDetail({
+      snapshot: acceptedSnapshot,
+      connectorRef: args.connectorRef,
+      featureStates: args.featureStates,
+    });
+  }
+  return await getStaticPublicConnectorCatalogDetail({
+    connectorRef: args.connectorRef,
+    featureStates: args.featureStates,
+    apiAuthMethodPolicy: "include",
+  });
+}
+
+export async function listConnectorRuntimeVisibleRefs(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly featureStates: ConnectorFeatureStates;
+}): Promise<readonly ConnectorCatalogRef[]> {
+  const refs: ConnectorCatalogRef[] = [];
+  for (const connector of args.snapshot.connectors.values()) {
+    const available = await getConnectorRuntimeAvailableCatalogDetail({
+      snapshot: args.snapshot,
+      connectorRef: connector.connectorRef,
+      featureStates: args.featureStates,
+    });
+    if (available !== null) {
+      refs.push(connector.connectorRef);
+    }
+  }
+  return refs.sort();
+}
+
+export function filterConnectorRuntimeConfiguredRefs(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly visibleRefs: readonly ConnectorCatalogRef[];
+  readonly readEnv: ConnectorEnvReader;
+}): readonly ConnectorCatalogRef[] {
+  if (args.snapshot.identity.source === "external") {
+    return args.visibleRefs;
+  }
+  const configuredRefs = new Set<string>(
+    getRuntimeAvailableConnectorTypes(args.readEnv),
+  );
+  return args.visibleRefs.filter((connectorRef) => {
+    return configuredRefs.has(connectorRef);
+  });
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -86,6 +86,7 @@ export interface ConnectorRuntimeMethod {
   readonly authMethodId: ConnectorCatalogAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
   readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly availableForNewActions: boolean;
   readonly compatible: boolean;
   readonly executable: boolean;
   readonly registration: ConnectorAuthProviderRegistrationCapability | null;
@@ -517,6 +518,7 @@ function runtimeMethodEntry(args: {
   readonly connectorRef: ConnectorCatalogRef;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
   readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly availableForNewActions: boolean;
   readonly compatible: boolean;
 }): ConnectorRuntimeMethod {
   const registration = providerRegistrationFor(
@@ -528,6 +530,7 @@ function runtimeMethodEntry(args: {
     authMethodId: args.catalogMethod.id,
     catalogMethod: args.catalogMethod,
     method: args.method,
+    availableForNewActions: args.availableForNewActions,
     compatible: args.compatible,
     registration,
     executable:
@@ -565,6 +568,7 @@ const staticRuntimeSnapshot = singleton(() => {
             connectorRef,
             catalogMethod,
             method,
+            availableForNewActions: method.visible !== false,
             compatible: true,
           }),
         );
@@ -644,6 +648,7 @@ function externalRuntimeSnapshot(
           connectorRef: publicConnector.connectorRef,
           catalogMethod,
           method,
+          availableForNewActions: publicMethod.visible,
           compatible: acceptedConnectorCatalogMethodIsCompatible({
             snapshot: acceptedSnapshot,
             connectorRef: publicConnector.connectorRef,
@@ -712,6 +717,7 @@ interface RuntimeShadowMethod {
   readonly grantKind: ConnectorAuthMethodRuntimeConfig["grant"]["kind"];
   readonly accessKind: ConnectorAuthMethodRuntimeConfig["access"]["kind"];
   readonly revokeKind: ConnectorAuthMethodRuntimeConfig["revoke"]["kind"];
+  readonly availableForNewActions: boolean;
   readonly executable: boolean;
 }
 
@@ -727,6 +733,7 @@ function runtimeShadowMethods(
           grantKind: method.method.grant.kind,
           accessKind: method.method.access.kind,
           revokeKind: method.method.revoke.kind,
+          availableForNewActions: method.availableForNewActions,
           executable: method.executable,
         };
       });
@@ -865,7 +872,7 @@ export function getConnectorRuntimeStoredSecretDisplayInfo(
   return null;
 }
 
-export async function getConnectorRuntimeAvailableCatalogDetail(args: {
+async function getConnectorRuntimeAvailableCatalogDetail(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly connectorRef: string;
   readonly featureStates: ConnectorFeatureStates;

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -55,6 +55,7 @@ import {
   ExternalConnectorCatalogUnavailableError,
   getAcceptedConnectorCatalogAvailableDetail,
   getAcceptedConnectorCatalogResolutionDetail,
+  listAcceptedConnectorCatalogAvailableRefs,
   loadAcceptedConnectorCatalogSnapshot,
   type AcceptedConnectorCatalogSnapshot,
   type ExternalCatalogIdentity,
@@ -891,6 +892,16 @@ export async function listConnectorRuntimeVisibleRefs(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly featureStates: ConnectorFeatureStates;
 }): Promise<readonly ConnectorCatalogRef[]> {
+  if (args.snapshot.identity.source === "external") {
+    const acceptedSnapshot = args.snapshot.acceptedSnapshot;
+    if (acceptedSnapshot === null) {
+      throw new Error("External connector runtime snapshot is incomplete");
+    }
+    return listAcceptedConnectorCatalogAvailableRefs({
+      snapshot: acceptedSnapshot,
+      featureStates: args.featureStates,
+    });
+  }
   const refs: ConnectorCatalogRef[] = [];
   for (const connector of args.snapshot.connectors.values()) {
     const available = await getConnectorRuntimeAvailableCatalogDetail({

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -6,7 +6,7 @@ import type {
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import {
   getAvailableConnectorAuthMethodIds,
-  getConnectorAuthMethodRuntimeMetadata,
+  connectorAuthMethodRuntimeMetadata,
   getConnectorEnvBindingEntries,
 } from "@vm0/connectors/connector-utils";
 import {
@@ -44,6 +44,11 @@ import {
 } from "./connector-diagnostic-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { zeroRunContext } from "./zero-run-detail.service";
+import {
+  getConnectorRuntimeMethod,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
@@ -144,7 +149,11 @@ const connectorCheckFeatureStates$ = command(
 
 async function loadStoredRuntimeState(
   db: Db,
-  args: { readonly orgId: string; readonly userId: string },
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly snapshot: ConnectorRuntimeSnapshot;
+  },
 ): Promise<StoredRuntimeState> {
   return await db.transaction(async (tx) => {
     await tx.execute(
@@ -181,13 +190,18 @@ async function loadStoredRuntimeState(
         continue;
       }
 
-      const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
-        row.type,
-        row.authMethod,
-      );
-      if (!runtimeMetadata) {
+      const runtimeMethod = getConnectorRuntimeMethod({
+        snapshot: args.snapshot,
+        connectorRef: row.type,
+        authMethodId: row.authMethod,
+        requireExecutable: true,
+      });
+      if (!runtimeMethod) {
         throw new Error(`Invalid stored auth method for ${row.type}`);
       }
+      const runtimeMetadata = connectorAuthMethodRuntimeMetadata(
+        runtimeMethod.method,
+      );
       const requiredNameSet = new Set(requiredRuntimeNames);
       const storageNameByRuntimeName = new Map<string, string>();
       for (const binding of runtimeMetadata.runtimeBindings) {
@@ -1060,10 +1074,15 @@ export const resolveConnectorCheck$ = command(
     } else {
       const state =
         args.request.mode === "url"
-          ? await loadStoredRuntimeState(set(writeDb$), {
-              orgId: args.orgId,
-              userId: args.userId,
-            })
+          ? await (async () => {
+              const db = set(writeDb$);
+              const snapshot = await loadConnectorRuntimeSnapshot(db);
+              return await loadStoredRuntimeState(db, {
+                orgId: args.orgId,
+                userId: args.userId,
+                snapshot,
+              });
+            })()
           : { baseUrlVarsByType: new Map() };
       signal.throwIfAborted();
       timeline = { kind: "stored", state };

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -34,6 +34,7 @@ export interface ConnectorCredentialConnection {
   readonly needsReconnect: boolean;
   readonly oauthScopes: readonly string[] | null;
   readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly stateRevision: string;
   readonly tokenExpiresAt: Date | null;
 }
 
@@ -59,12 +60,33 @@ type ConnectorCredentialRefreshResult =
     }
   | {
       readonly kind:
+        | "connection-changed"
         | "configuration-unavailable"
         | "invalid-output"
         | "missing-input"
         | "not-refreshable"
         | "provider-failed";
     };
+
+interface ConnectorCredentialRefreshArgs {
+  readonly connection: ConnectorCredentialConnection;
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext?: FeatureSwitchContext;
+  readonly orgId: string;
+  readonly persist?: {
+    readonly db: Db;
+    readonly defaultExpiresInMs?: number;
+    readonly markNeedsReconnectOnFailure?: boolean;
+  };
+  readonly runtimeEnvironmentName: string;
+  readonly signal: AbortSignal;
+  readonly userId: string;
+}
+
+type ConnectorRefreshTokenAccess = Extract<
+  ConnectorRuntimeMethod["method"]["access"],
+  { readonly kind: "refresh-token" }
+>;
 
 function parseOauthScopes(value: string | null): readonly string[] | null {
   return value === null ? null : oauthScopesSchema.parse(JSON.parse(value));
@@ -112,6 +134,7 @@ export async function loadConnectorCredentialConnection(args: {
       externalId: connectors.externalId,
       needsReconnect: connectors.needsReconnect,
       oauthScopes: connectors.oauthScopes,
+      stateRevision: sql<string>`${connectors.updatedAt}::text`,
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
     .from(connectors)
@@ -139,6 +162,7 @@ export async function loadConnectorCredentialConnection(args: {
       needsReconnect: row.needsReconnect,
       oauthScopes: parseOauthScopes(row.oauthScopes),
       runtimeMethod,
+      stateRevision: row.stateRevision,
       tokenExpiresAt: row.tokenExpiresAt,
     },
   };
@@ -296,12 +320,17 @@ async function persistConnectorRefresh(args: {
   readonly connection: ConnectorCredentialConnection;
   readonly db: Db;
   readonly defaultExpiresInMs?: number;
+  readonly featureSwitchContext?: FeatureSwitchContext;
+  readonly inputs: Readonly<Record<string, string>>;
   readonly orgId: string;
   readonly outputs: Readonly<Record<string, string | undefined>>;
   readonly signal: AbortSignal;
   readonly userId: string;
   readonly expiresIn: number | undefined;
-}): Promise<Date | null> {
+}): Promise<
+  | { readonly kind: "ok"; readonly tokenExpiresAt: Date | null }
+  | { readonly kind: "connection-changed" }
+> {
   const access = args.connection.runtimeMethod.method.access;
   if (access.kind !== "refresh-token") {
     throw new Error("Connector credential is not refreshable");
@@ -310,13 +339,61 @@ async function persistConnectorRefresh(args: {
     args.expiresIn,
     args.defaultExpiresInMs,
   );
-  await args.db.transaction(async (tx) => {
+  const result = await args.db.transaction(async (tx) => {
     await lockConnectorState(tx, {
       orgId: args.orgId,
       userId: args.userId,
       type: args.connection.connectorRef,
     });
     args.signal.throwIfAborted();
+    const [currentConnector] = await tx
+      .select({
+        authMethod: connectors.authMethod,
+        externalEmail: connectors.externalEmail,
+        externalId: connectors.externalId,
+        needsReconnect: connectors.needsReconnect,
+        reconnectReason: connectors.reconnectReason,
+        stateRevision: sql<string>`${connectors.updatedAt}::text`,
+      })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.id, args.connection.connectorId),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.type, args.connection.connectorRef),
+        ),
+      )
+      .limit(1);
+    const currentRevisionCanAcceptRefresh =
+      currentConnector?.stateRevision === args.connection.stateRevision ||
+      (currentConnector !== undefined &&
+        !args.connection.needsReconnect &&
+        currentConnector.needsReconnect &&
+        currentConnector.reconnectReason === null);
+    if (
+      currentConnector?.authMethod !==
+        args.connection.runtimeMethod.authMethodId ||
+      currentConnector.externalEmail !== args.connection.externalEmail ||
+      currentConnector.externalId !== args.connection.externalId ||
+      !currentRevisionCanAcceptRefresh
+    ) {
+      return { kind: "connection-changed" } as const;
+    }
+    const currentInputValues = await loadConnectorCredentialValues({
+      db: tx,
+      orgId: args.orgId,
+      userId: args.userId,
+      valueRefs: Object.values(access.inputs),
+      ...(args.featureSwitchContext === undefined
+        ? {}
+        : { featureSwitchContext: args.featureSwitchContext }),
+    });
+    for (const [inputName, valueRef] of Object.entries(access.inputs)) {
+      if (currentInputValues.get(valueRef) !== args.inputs[inputName]) {
+        return { kind: "connection-changed" } as const;
+      }
+    }
     for (const [outputName, value] of Object.entries(args.outputs)) {
       if (value === undefined) {
         continue;
@@ -354,37 +431,70 @@ async function persistConnectorRefresh(args: {
         updatedAt: sql`clock_timestamp()`,
       })
       .where(eq(connectors.id, args.connection.connectorId));
+    return { kind: "ok", tokenExpiresAt } as const;
   });
   args.signal.throwIfAborted();
-  return tokenExpiresAt;
+  return result;
 }
 
-export async function refreshConnectorCredentialAccess(args: {
+async function markConnectorCredentialNeedsReconnectAfterRefreshFailure(args: {
   readonly connection: ConnectorCredentialConnection;
-  readonly db: ReadonlyDb;
-  readonly featureSwitchContext?: FeatureSwitchContext;
+  readonly db: Db;
   readonly orgId: string;
-  readonly persist?: {
-    readonly db: Db;
-    readonly defaultExpiresInMs?: number;
-  };
-  readonly runtimeEnvironmentName: string;
   readonly signal: AbortSignal;
   readonly userId: string;
-}): Promise<ConnectorCredentialRefreshResult> {
-  const access = args.connection.runtimeMethod.method.access;
-  if (access.kind !== "refresh-token") {
-    return { kind: "not-refreshable" };
+}): Promise<void> {
+  await args.db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.connection.connectorRef,
+    });
+    args.signal.throwIfAborted();
+    await tx
+      .update(connectors)
+      .set({ needsReconnect: true, updatedAt: sql`clock_timestamp()` })
+      .where(
+        and(
+          eq(connectors.id, args.connection.connectorId),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.type, args.connection.connectorRef),
+          eq(connectors.authMethod, args.connection.runtimeMethod.authMethodId),
+          sql`${connectors.updatedAt}::text = ${args.connection.stateRevision}`,
+        ),
+      );
+  });
+  args.signal.throwIfAborted();
+}
+
+async function connectorCredentialRefreshFailure(
+  args: ConnectorCredentialRefreshArgs,
+  kind:
+    | "invalid-output"
+    | "missing-input"
+    | "not-refreshable"
+    | "provider-failed",
+): Promise<ConnectorCredentialRefreshResult> {
+  if (args.persist?.markNeedsReconnectOnFailure === true) {
+    await markConnectorCredentialNeedsReconnectAfterRefreshFailure({
+      connection: args.connection,
+      db: args.persist.db,
+      orgId: args.orgId,
+      signal: args.signal,
+      userId: args.userId,
+    });
   }
-  const authClient = args.connection.runtimeMethod.method.client
-    ? resolveConnectorAuthClient(
-        args.connection.runtimeMethod.method.client,
-        optionalEnv,
-      )
-    : undefined;
-  if (args.connection.runtimeMethod.method.client && !authClient) {
-    return { kind: "configuration-unavailable" };
-  }
+  return { kind };
+}
+
+async function loadConnectorRefreshInputs(
+  args: ConnectorCredentialRefreshArgs,
+  access: ConnectorRefreshTokenAccess,
+): Promise<
+  | { readonly kind: "ok"; readonly inputs: Readonly<Record<string, string>> }
+  | { readonly kind: "missing-input" }
+> {
   const inputValues = await loadConnectorCredentialValues({
     db: args.db,
     orgId: args.orgId,
@@ -402,13 +512,59 @@ export async function refreshConnectorCredentialAccess(args: {
     }
     inputs[inputName] = value;
   }
+  return { kind: "ok", inputs };
+}
+
+function connectorRefreshAccessToken(args: {
+  readonly access: ConnectorRefreshTokenAccess;
+  readonly connection: ConnectorCredentialConnection;
+  readonly outputs: Readonly<Record<string, string | undefined>>;
+  readonly runtimeEnvironmentName: string;
+}): string | null {
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    args.connection,
+    args.runtimeEnvironmentName,
+  );
+  if (accessTokenValueRef === null) {
+    return null;
+  }
+  const accessTokenOutputName = Object.entries(args.access.outputs).find(
+    ([, valueRef]) => {
+      return valueRef === accessTokenValueRef;
+    },
+  )?.[0];
+  return accessTokenOutputName === undefined
+    ? null
+    : (args.outputs[accessTokenOutputName] ?? null);
+}
+
+export async function refreshConnectorCredentialAccess(
+  args: ConnectorCredentialRefreshArgs,
+): Promise<ConnectorCredentialRefreshResult> {
+  const access = args.connection.runtimeMethod.method.access;
+  if (access.kind !== "refresh-token") {
+    return await connectorCredentialRefreshFailure(args, "not-refreshable");
+  }
+  const authClient = args.connection.runtimeMethod.method.client
+    ? resolveConnectorAuthClient(
+        args.connection.runtimeMethod.method.client,
+        optionalEnv,
+      )
+    : undefined;
+  if (args.connection.runtimeMethod.method.client && !authClient) {
+    return { kind: "configuration-unavailable" };
+  }
+  const loadedInputs = await loadConnectorRefreshInputs(args, access);
+  if (loadedInputs.kind === "missing-input") {
+    return await connectorCredentialRefreshFailure(args, "missing-input");
+  }
   const refreshed = await settleIncludingAbort(
     refreshConnectorAuthProviderAccessTokenWithMethod({
       connectorRef: args.connection.runtimeMethod.connectorRef,
       authMethodId: args.connection.runtimeMethod.authMethodId,
       method: args.connection.runtimeMethod.method,
       ...(authClient === undefined ? {} : { authClient }),
-      inputs,
+      inputs: loadedInputs.inputs,
       signal: args.signal,
     }),
   );
@@ -419,51 +575,47 @@ export async function refreshConnectorCredentialAccess(args: {
       authMethodId: args.connection.runtimeMethod.authMethodId,
       error: refreshed.error,
     });
-    return { kind: "provider-failed" };
+    return await connectorCredentialRefreshFailure(args, "provider-failed");
   }
-  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
-    args.connection,
-    args.runtimeEnvironmentName,
-  );
-  if (accessTokenValueRef === null) {
-    return { kind: "invalid-output" };
+  const accessToken = connectorRefreshAccessToken({
+    access,
+    connection: args.connection,
+    outputs: refreshed.value.outputs,
+    runtimeEnvironmentName: args.runtimeEnvironmentName,
+  });
+  if (accessToken === null) {
+    return await connectorCredentialRefreshFailure(args, "invalid-output");
   }
-  const accessTokenOutput = Object.entries(access.outputs).find(
-    ([, valueRef]) => {
-      return valueRef === accessTokenValueRef;
-    },
-  );
-  const accessToken = accessTokenOutput
-    ? refreshed.value.outputs[accessTokenOutput[0]]
-    : undefined;
-  if (accessToken === undefined) {
-    return { kind: "invalid-output" };
-  }
-  const tokenExpiresAt = args.persist
+  const persisted = args.persist
     ? await persistConnectorRefresh({
         connection: args.connection,
         db: args.persist.db,
+        inputs: loadedInputs.inputs,
         orgId: args.orgId,
         outputs: refreshed.value.outputs,
         signal: args.signal,
         userId: args.userId,
         expiresIn: refreshed.value.expiresIn,
+        ...(args.featureSwitchContext === undefined
+          ? {}
+          : { featureSwitchContext: args.featureSwitchContext }),
         ...(args.persist.defaultExpiresInMs === undefined
           ? {}
           : { defaultExpiresInMs: args.persist.defaultExpiresInMs }),
       })
-    : refreshTokenExpiresAt(refreshed.value.expiresIn, undefined);
-  return { kind: "ok", accessToken, tokenExpiresAt };
-}
-
-export async function markConnectorCredentialNeedsReconnect(args: {
-  readonly connectorId: string;
-  readonly db: Db;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db
-    .update(connectors)
-    .set({ needsReconnect: true, updatedAt: sql`clock_timestamp()` })
-    .where(eq(connectors.id, args.connectorId));
-  args.signal.throwIfAborted();
+    : {
+        kind: "ok" as const,
+        tokenExpiresAt: refreshTokenExpiresAt(
+          refreshed.value.expiresIn,
+          undefined,
+        ),
+      };
+  if (persisted.kind === "connection-changed") {
+    return persisted;
+  }
+  return {
+    kind: "ok",
+    accessToken,
+    tokenExpiresAt: persisted.tokenExpiresAt,
+  };
 }

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -246,6 +246,7 @@ export async function loadConnectorCredentialValues(args: {
 
 async function upsertConnectorSecret(args: {
   readonly db: Db;
+  readonly description: string;
   readonly name: string;
   readonly orgId: string;
   readonly userId: string;
@@ -259,14 +260,13 @@ async function upsertConnectorSecret(args: {
       userId: args.userId,
       name: args.name,
       encryptedValue,
-      description: null,
+      description: args.description,
       type: "connector",
     })
     .onConflictDoUpdate({
       target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: {
         encryptedValue,
-        description: null,
         updatedAt: sql`clock_timestamp()`,
       },
     });
@@ -298,7 +298,6 @@ async function upsertConnectorVariable(args: {
       ],
       set: {
         value: args.value,
-        description: null,
         updatedAt: sql`clock_timestamp()`,
       },
     });
@@ -406,6 +405,7 @@ async function persistConnectorRefresh(args: {
       if (target.kind === "secret") {
         await upsertConnectorSecret({
           db: tx,
+          description: `Connector token output for ${args.connection.connectorRef}: ${target.name}`,
           name: target.name,
           orgId: args.orgId,
           userId: args.userId,

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -1,0 +1,469 @@
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import { refreshConnectorAuthProviderAccessTokenWithMethod } from "@vm0/connectors/auth-providers";
+import { resolveConnectorAuthClient } from "@vm0/connectors/connector-utils";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import type { Db, ReadonlyDb } from "../external/db";
+import { nowDate } from "../external/time";
+import { settleIncludingAbort } from "../utils";
+import { lockConnectorState } from "./auth-state-lock.service";
+import {
+  getConnectorRuntimeMethod,
+  type ConnectorRuntimeMethod,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import {
+  decryptStoredSecretValue,
+  encryptStoredSecretValue,
+} from "./crypto.utils";
+
+const log = logger("api:connector-credential-runtime");
+const oauthScopesSchema = z.array(z.string());
+
+export interface ConnectorCredentialConnection {
+  readonly connectorId: string;
+  readonly connectorRef: string;
+  readonly externalEmail: string | null;
+  readonly externalId: string | null;
+  readonly needsReconnect: boolean;
+  readonly oauthScopes: readonly string[] | null;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly tokenExpiresAt: Date | null;
+}
+
+type ConnectorCredentialConnectionResult =
+  | { readonly kind: "missing" }
+  | { readonly kind: "unavailable" }
+  | {
+      readonly kind: "ok";
+      readonly connection: ConnectorCredentialConnection;
+    };
+
+interface ConnectorStoredValueRef {
+  readonly kind: "secret" | "variable";
+  readonly name: string;
+  readonly valueRef: string;
+}
+
+type ConnectorCredentialRefreshResult =
+  | {
+      readonly kind: "ok";
+      readonly accessToken: string;
+      readonly tokenExpiresAt: Date | null;
+    }
+  | {
+      readonly kind:
+        | "configuration-unavailable"
+        | "invalid-output"
+        | "missing-input"
+        | "not-refreshable"
+        | "provider-failed";
+    };
+
+function parseOauthScopes(value: string | null): readonly string[] | null {
+  return value === null ? null : oauthScopesSchema.parse(JSON.parse(value));
+}
+
+function connectorStoredValueRef(valueRef: string): ConnectorStoredValueRef {
+  if (valueRef.startsWith("$secrets.")) {
+    return {
+      kind: "secret",
+      name: valueRef.slice("$secrets.".length),
+      valueRef,
+    };
+  }
+  if (valueRef.startsWith("$vars.")) {
+    return {
+      kind: "variable",
+      name: valueRef.slice("$vars.".length),
+      valueRef,
+    };
+  }
+  throw new Error("Invalid connector stored value reference");
+}
+
+export async function loadConnectorCredentialConnection(args: {
+  readonly connectorId?: string;
+  readonly connectorRef: string;
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly userId: string;
+}): Promise<ConnectorCredentialConnectionResult> {
+  const conditions = [
+    eq(connectors.orgId, args.orgId),
+    eq(connectors.userId, args.userId),
+    eq(connectors.type, args.connectorRef),
+  ];
+  if (args.connectorId !== undefined) {
+    conditions.push(eq(connectors.id, args.connectorId));
+  }
+  const [row] = await args.db
+    .select({
+      authMethod: connectors.authMethod,
+      connectorId: connectors.id,
+      externalEmail: connectors.externalEmail,
+      externalId: connectors.externalId,
+      needsReconnect: connectors.needsReconnect,
+      oauthScopes: connectors.oauthScopes,
+      tokenExpiresAt: connectors.tokenExpiresAt,
+    })
+    .from(connectors)
+    .where(and(...conditions))
+    .limit(1);
+  if (!row) {
+    return { kind: "missing" };
+  }
+  const runtimeMethod = getConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    connectorRef: args.connectorRef,
+    authMethodId: row.authMethod,
+    requireExecutable: true,
+  });
+  if (!runtimeMethod) {
+    return { kind: "unavailable" };
+  }
+  return {
+    kind: "ok",
+    connection: {
+      connectorId: row.connectorId,
+      connectorRef: args.connectorRef,
+      externalEmail: row.externalEmail,
+      externalId: row.externalId,
+      needsReconnect: row.needsReconnect,
+      oauthScopes: parseOauthScopes(row.oauthScopes),
+      runtimeMethod,
+      tokenExpiresAt: row.tokenExpiresAt,
+    },
+  };
+}
+
+export function connectorCredentialRuntimeValueRef(
+  connection: ConnectorCredentialConnection,
+  environmentName: string,
+): string | null {
+  const access = connection.runtimeMethod.method.access;
+  if (access.kind === "none") {
+    return null;
+  }
+  const binding = access.envBindings[environmentName];
+  if (binding === undefined) {
+    return null;
+  }
+  return typeof binding === "string" ? binding : binding.valueRef;
+}
+
+export async function loadConnectorCredentialValues(args: {
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext?: FeatureSwitchContext;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly valueRefs: readonly string[];
+}): Promise<ReadonlyMap<string, string>> {
+  const refs = args.valueRefs.map(connectorStoredValueRef);
+  const secretNames = refs.flatMap((ref) => {
+    return ref.kind === "secret" ? [ref.name] : [];
+  });
+  const variableNames = refs.flatMap((ref) => {
+    return ref.kind === "variable" ? [ref.name] : [];
+  });
+  const secretRows =
+    secretNames.length === 0
+      ? []
+      : await args.db
+          .select({
+            name: secrets.name,
+            encryptedValue: secrets.encryptedValue,
+          })
+          .from(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, args.orgId),
+              eq(secrets.userId, args.userId),
+              eq(secrets.type, "connector"),
+              inArray(secrets.name, secretNames),
+            ),
+          );
+  const variableRows =
+    variableNames.length === 0
+      ? []
+      : await args.db
+          .select({ name: variables.name, value: variables.value })
+          .from(variables)
+          .where(
+            and(
+              eq(variables.orgId, args.orgId),
+              eq(variables.userId, args.userId),
+              eq(variables.type, "connector"),
+              inArray(variables.name, variableNames),
+            ),
+          );
+  const values = new Map<string, string>();
+  for (const row of secretRows) {
+    values.set(
+      `$secrets.${row.name}`,
+      await decryptStoredSecretValue(
+        row.encryptedValue,
+        args.featureSwitchContext,
+      ),
+    );
+  }
+  for (const row of variableRows) {
+    values.set(`$vars.${row.name}`, row.value);
+  }
+  return values;
+}
+
+async function upsertConnectorSecret(args: {
+  readonly db: Db;
+  readonly name: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly value: string;
+}): Promise<void> {
+  const encryptedValue = await encryptStoredSecretValue(args.value);
+  await args.db
+    .insert(secrets)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: args.name,
+      encryptedValue,
+      description: null,
+      type: "connector",
+    })
+    .onConflictDoUpdate({
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
+      set: {
+        encryptedValue,
+        description: null,
+        updatedAt: sql`clock_timestamp()`,
+      },
+    });
+}
+
+async function upsertConnectorVariable(args: {
+  readonly db: Db;
+  readonly name: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly value: string;
+}): Promise<void> {
+  await args.db
+    .insert(variables)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      name: args.name,
+      value: args.value,
+      description: null,
+      type: "connector",
+    })
+    .onConflictDoUpdate({
+      target: [
+        variables.orgId,
+        variables.userId,
+        variables.name,
+        variables.type,
+      ],
+      set: {
+        value: args.value,
+        description: null,
+        updatedAt: sql`clock_timestamp()`,
+      },
+    });
+}
+
+function refreshTokenExpiresAt(
+  expiresIn: number | undefined,
+  defaultExpiresInMs: number | undefined,
+): Date | null {
+  if (expiresIn !== undefined) {
+    return new Date(nowDate().getTime() + expiresIn * 1000);
+  }
+  return defaultExpiresInMs === undefined
+    ? null
+    : new Date(nowDate().getTime() + defaultExpiresInMs);
+}
+
+async function persistConnectorRefresh(args: {
+  readonly connection: ConnectorCredentialConnection;
+  readonly db: Db;
+  readonly defaultExpiresInMs?: number;
+  readonly orgId: string;
+  readonly outputs: Readonly<Record<string, string | undefined>>;
+  readonly signal: AbortSignal;
+  readonly userId: string;
+  readonly expiresIn: number | undefined;
+}): Promise<Date | null> {
+  const access = args.connection.runtimeMethod.method.access;
+  if (access.kind !== "refresh-token") {
+    throw new Error("Connector credential is not refreshable");
+  }
+  const tokenExpiresAt = refreshTokenExpiresAt(
+    args.expiresIn,
+    args.defaultExpiresInMs,
+  );
+  await args.db.transaction(async (tx) => {
+    await lockConnectorState(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      type: args.connection.connectorRef,
+    });
+    args.signal.throwIfAborted();
+    for (const [outputName, value] of Object.entries(args.outputs)) {
+      if (value === undefined) {
+        continue;
+      }
+      const valueRef = access.outputs[outputName];
+      if (valueRef === undefined) {
+        throw new Error("Connector refresh returned an undeclared output");
+      }
+      const target = connectorStoredValueRef(valueRef);
+      if (target.kind === "secret") {
+        await upsertConnectorSecret({
+          db: tx,
+          name: target.name,
+          orgId: args.orgId,
+          userId: args.userId,
+          value,
+        });
+      } else {
+        await upsertConnectorVariable({
+          db: tx,
+          name: target.name,
+          orgId: args.orgId,
+          userId: args.userId,
+          value,
+        });
+      }
+      args.signal.throwIfAborted();
+    }
+    await tx
+      .update(connectors)
+      .set({
+        tokenExpiresAt,
+        needsReconnect: false,
+        reconnectReason: null,
+        updatedAt: sql`clock_timestamp()`,
+      })
+      .where(eq(connectors.id, args.connection.connectorId));
+  });
+  args.signal.throwIfAborted();
+  return tokenExpiresAt;
+}
+
+export async function refreshConnectorCredentialAccess(args: {
+  readonly connection: ConnectorCredentialConnection;
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext?: FeatureSwitchContext;
+  readonly orgId: string;
+  readonly persist?: {
+    readonly db: Db;
+    readonly defaultExpiresInMs?: number;
+  };
+  readonly runtimeEnvironmentName: string;
+  readonly signal: AbortSignal;
+  readonly userId: string;
+}): Promise<ConnectorCredentialRefreshResult> {
+  const access = args.connection.runtimeMethod.method.access;
+  if (access.kind !== "refresh-token") {
+    return { kind: "not-refreshable" };
+  }
+  const authClient = args.connection.runtimeMethod.method.client
+    ? resolveConnectorAuthClient(
+        args.connection.runtimeMethod.method.client,
+        optionalEnv,
+      )
+    : undefined;
+  if (args.connection.runtimeMethod.method.client && !authClient) {
+    return { kind: "configuration-unavailable" };
+  }
+  const inputValues = await loadConnectorCredentialValues({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    valueRefs: Object.values(access.inputs),
+    ...(args.featureSwitchContext === undefined
+      ? {}
+      : { featureSwitchContext: args.featureSwitchContext }),
+  });
+  const inputs: Record<string, string> = {};
+  for (const [inputName, valueRef] of Object.entries(access.inputs)) {
+    const value = inputValues.get(valueRef);
+    if (value === undefined) {
+      return { kind: "missing-input" };
+    }
+    inputs[inputName] = value;
+  }
+  const refreshed = await settleIncludingAbort(
+    refreshConnectorAuthProviderAccessTokenWithMethod({
+      connectorRef: args.connection.runtimeMethod.connectorRef,
+      authMethodId: args.connection.runtimeMethod.authMethodId,
+      method: args.connection.runtimeMethod.method,
+      ...(authClient === undefined ? {} : { authClient }),
+      inputs,
+      signal: args.signal,
+    }),
+  );
+  args.signal.throwIfAborted();
+  if (!refreshed.ok) {
+    log.warn("Connector credential refresh failed", {
+      connectorRef: args.connection.connectorRef,
+      authMethodId: args.connection.runtimeMethod.authMethodId,
+      error: refreshed.error,
+    });
+    return { kind: "provider-failed" };
+  }
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    args.connection,
+    args.runtimeEnvironmentName,
+  );
+  if (accessTokenValueRef === null) {
+    return { kind: "invalid-output" };
+  }
+  const accessTokenOutput = Object.entries(access.outputs).find(
+    ([, valueRef]) => {
+      return valueRef === accessTokenValueRef;
+    },
+  );
+  const accessToken = accessTokenOutput
+    ? refreshed.value.outputs[accessTokenOutput[0]]
+    : undefined;
+  if (accessToken === undefined) {
+    return { kind: "invalid-output" };
+  }
+  const tokenExpiresAt = args.persist
+    ? await persistConnectorRefresh({
+        connection: args.connection,
+        db: args.persist.db,
+        orgId: args.orgId,
+        outputs: refreshed.value.outputs,
+        signal: args.signal,
+        userId: args.userId,
+        expiresIn: refreshed.value.expiresIn,
+        ...(args.persist.defaultExpiresInMs === undefined
+          ? {}
+          : { defaultExpiresInMs: args.persist.defaultExpiresInMs }),
+      })
+    : refreshTokenExpiresAt(refreshed.value.expiresIn, undefined);
+  return { kind: "ok", accessToken, tokenExpiresAt };
+}
+
+export async function markConnectorCredentialNeedsReconnect(args: {
+  readonly connectorId: string;
+  readonly db: Db;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await args.db
+    .update(connectors)
+    .set({ needsReconnect: true, updatedAt: sql`clock_timestamp()` })
+    .where(eq(connectors.id, args.connectorId));
+  args.signal.throwIfAborted();
+}

--- a/turbo/apps/api/src/signals/services/connector-credential-status.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-status.service.ts
@@ -1,18 +1,7 @@
-import { getConnectorAuthMethodAccessMetadata } from "@vm0/connectors/connector-utils";
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
 import type { ConnectorReconnectReason } from "@vm0/api-contracts/contracts/connector-schemas";
 
 export type ConnectorCredentialStatus = "available" | "reconnect-required";
-
-function connectorAuthMethodSupportsRefresh(
-  type: ConnectorType,
-  authMethod: string,
-): boolean {
-  return (
-    getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
-    "refresh-token"
-  );
-}
 
 function connectorCredentialStatusForAccess(args: {
   readonly storedNeedsReconnect: boolean;
@@ -46,9 +35,8 @@ export function connectorRuntimeCredentialStatusForAccess(args: {
   return connectorCredentialStatusForAccess(args);
 }
 
-export function connectorCredentialStatus(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+export function connectorCredentialStatusWithMethod(args: {
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly storedNeedsReconnect: boolean;
   readonly tokenExpiresAt: Date | null;
   readonly now: Date;
@@ -57,44 +45,35 @@ export function connectorCredentialStatus(args: {
     storedNeedsReconnect: args.storedNeedsReconnect,
     tokenExpiresAt: args.tokenExpiresAt,
     now: args.now,
-    isRefreshable: connectorAuthMethodSupportsRefresh(
-      args.type,
-      args.authMethod,
-    ),
+    isRefreshable: connectorAuthMethodSupportsRefreshWithMethod(args.method),
   });
 }
 
-export function connectorCredentialReconnectReason(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+export function connectorCredentialReconnectReasonWithMethod(args: {
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly storedNeedsReconnect: boolean;
   readonly tokenExpiresAt: Date | null;
   readonly now: Date;
 }): ConnectorReconnectReason | null {
-  const isRefreshable = connectorAuthMethodSupportsRefresh(
-    args.type,
-    args.authMethod,
-  );
   const credentialStatus = connectorCredentialStatusForAccess({
     storedNeedsReconnect: args.storedNeedsReconnect,
     tokenExpiresAt: args.tokenExpiresAt,
     now: args.now,
-    isRefreshable,
+    isRefreshable: connectorAuthMethodSupportsRefreshWithMethod(args.method),
   });
   if (
     credentialStatus !== "reconnect-required" ||
     args.storedNeedsReconnect ||
     args.tokenExpiresAt === null ||
-    isRefreshable
+    connectorAuthMethodSupportsRefreshWithMethod(args.method)
   ) {
     return null;
   }
   return "credential_expired";
 }
 
-export function connectorRuntimeCredentialStatus(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+export function connectorRuntimeCredentialStatusWithMethod(args: {
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly storedNeedsReconnect: boolean;
   readonly tokenExpiresAt: Date | null;
   readonly now: Date;
@@ -103,9 +82,12 @@ export function connectorRuntimeCredentialStatus(args: {
     storedNeedsReconnect: args.storedNeedsReconnect,
     tokenExpiresAt: args.tokenExpiresAt,
     now: args.now,
-    isRefreshable: connectorAuthMethodSupportsRefresh(
-      args.type,
-      args.authMethod,
-    ),
+    isRefreshable: connectorAuthMethodSupportsRefreshWithMethod(args.method),
   });
+}
+
+function connectorAuthMethodSupportsRefreshWithMethod(
+  method: ConnectorAuthMethodRuntimeConfig,
+): boolean {
+  return method.access.kind === "refresh-token";
 }

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -36,7 +36,7 @@ import {
   encryptPersistentSecretValue,
 } from "./crypto.utils";
 import {
-  userConnectorActionResolver,
+  connectorActionResolver,
   type ConnectorActionMethodResolution,
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
@@ -123,8 +123,7 @@ function externalCodeResolutionError(
         `${args.connectorRef} ${args.authMethodId} auth method does not use an external-code grant`,
       );
     }
-    case "unavailable_connector":
-    case "unavailable_auth_method": {
+    case "hidden_auth_method": {
       return connectorExternalCodeDisabled;
     }
     case "missing_executable_capability": {
@@ -193,15 +192,8 @@ async function resolveStoredExternalCodeMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: storedAuthMethod.data,
     expectedGrantKind: "external-code",
-    requireAvailable: true,
   });
   if (!resolved.ok) {
-    if (
-      resolved.reason === "unavailable_connector" ||
-      resolved.reason === "unavailable_auth_method"
-    ) {
-      return connectorExternalCodeDisabled;
-    }
     return internalServerError("Invalid external-code authorization session");
   }
   return resolved;
@@ -598,7 +590,6 @@ const completedExternalCodeSessionResponse$ = command(
             orgId: args.orgId,
             userId: args.userId,
             type: args.method.connectorRef,
-            includeHiddenStoredConnector: true,
             snapshot: args.method.snapshot,
           }),
         );
@@ -756,15 +747,12 @@ export const startConnectorExternalCodeSession$ = command(
       return badRequestMessage(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(args.orgId, args.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolved = await resolver.resolveMethod({
+    const resolved = await resolver.resolveNewActionMethod({
       connectorRef: args.type,
       authMethodId: args.authMethod,
       expectedGrantKind: "external-code",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -884,9 +872,7 @@ export const completeConnectorExternalCodeSession$ = command(
       return notFound("External-code authorization session not found");
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(args.orgId, args.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolvedMethod = await resolveStoredExternalCodeMethod({
       resolver,

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -12,21 +12,12 @@ import {
   type ConnectorCatalogRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
-  connectorAuthMethodIdSchema,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  connectorAuthMethodRefHasGrantKind,
-  getConnectorAuthMethod,
-  getConnectorAuthMethodIdsForGrantKind,
-  resolveConnectorResolvedAuthMethodClientByGrantKind,
-  type ConnectorAuthMethodRef,
-  type ConnectorAuthMethodRefByGrantKind,
-  type ConnectorResolvedAuthMethodClientByGrantKind,
+  resolveConnectorAuthClient,
+  type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
-  completeConnectorExternalCodeAuthorization,
-  startConnectorExternalCodeAuthorization,
+  completeConnectorExternalCodeAuthorizationWithMethod,
+  startConnectorExternalCodeAuthorizationWithMethod,
   type ConnectorAuthProviderGrantResult,
 } from "@vm0/connectors/auth-providers";
 import { isOAuthProviderHttpError } from "@vm0/connectors/auth-providers/oauth/error";
@@ -48,6 +39,7 @@ import {
   userConnectorActionResolver,
   type ConnectorActionMethodResolution,
   type ConnectorActionResolver,
+  type ResolvedConnectorActionMethod,
 } from "./connector-action-resolver.service";
 import {
   upsertConnectorTokenConnection$,
@@ -68,13 +60,16 @@ const COMPLETING_SESSION_STALE_AFTER_MS = 30 * 60 * 1000;
 
 type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
 
-type ExternalCodeMethodRef = ConnectorAuthMethodRefByGrantKind<"external-code">;
-type ExternalCodeResolvedMethodClient =
-  ConnectorResolvedAuthMethodClientByGrantKind<"external-code">;
-
-type ExternalCodeSessionOwner = ExternalCodeMethodRef & {
+type ExternalCodeSessionOwner = {
+  readonly type: ConnectorCatalogRef;
+  readonly authMethod: ConnectorCatalogAuthMethodId;
   readonly orgId: string;
   readonly userId: string;
+};
+
+type ResolvedExternalCodeClient = {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly authClient: ConnectorAuthClient;
 };
 
 type CompleteSuccess = {
@@ -162,50 +157,25 @@ function connectorMissingExternalCodeGrantMessage(type: string): string {
   return `${type} connector does not support an external-code grant`;
 }
 
-function resolveExternalCodeMethod(
-  type: ConnectorType,
-  authMethod: string,
-): ExternalCodeMethodRef | ReturnType<typeof badRequestMessage> {
-  const authMethodResult = connectorAuthMethodIdSchema.safeParse(authMethod);
-  if (!authMethodResult.success) {
-    return badRequestMessage(`${type} connector auth method is invalid`);
-  }
-
-  const authMethodRef: ConnectorAuthMethodRef = {
-    type,
-    authMethod: authMethodResult.data,
-  };
-  const method = getConnectorAuthMethod(type, authMethodResult.data);
-  if (!method) {
-    if (
-      getConnectorAuthMethodIdsForGrantKind(type, "external-code").length === 0
-    ) {
-      return badRequestMessage(connectorMissingExternalCodeGrantMessage(type));
-    }
-    return badRequestMessage(
-      `${type} connector does not have ${authMethod} auth method`,
-    );
-  }
-  if (!connectorAuthMethodRefHasGrantKind(authMethodRef, "external-code")) {
-    return badRequestMessage(
-      `${type} ${authMethod} auth method does not use an external-code grant`,
-    );
-  }
-
-  return authMethodRef;
-}
-
 function resolveRequiredAuthClient(
-  method: ExternalCodeMethodRef,
-): ExternalCodeResolvedMethodClient | ReturnType<typeof internalServerError> {
-  const resolvedClient = resolveConnectorResolvedAuthMethodClientByGrantKind(
-    method,
+  resolvedMethod: ResolvedConnectorActionMethod,
+): ResolvedExternalCodeClient | ReturnType<typeof internalServerError> {
+  if (
+    resolvedMethod.method.grant.kind !== "external-code" ||
+    resolvedMethod.method.client === undefined
+  ) {
+    return internalServerError("Connector execution is not configured");
+  }
+  const authClient = resolveConnectorAuthClient(
+    resolvedMethod.method.client,
     optionalEnv,
   );
-  if (!resolvedClient) {
-    return internalServerError(`${method.type} auth client not configured`);
+  if (!authClient) {
+    return internalServerError(
+      `${resolvedMethod.connectorRef} auth client not configured`,
+    );
   }
-  return resolvedClient;
+  return { resolvedMethod, authClient };
 }
 
 async function resolveStoredExternalCodeMethod(args: {
@@ -223,6 +193,7 @@ async function resolveStoredExternalCodeMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: storedAuthMethod.data,
     expectedGrantKind: "external-code",
+    requireAvailable: true,
   });
   if (!resolved.ok) {
     if (
@@ -233,13 +204,7 @@ async function resolveStoredExternalCodeMethod(args: {
     }
     return internalServerError("Invalid external-code authorization session");
   }
-  const resolvedMethod = resolveExternalCodeMethod(
-    resolved.type,
-    resolved.authMethod,
-  );
-  return "status" in resolvedMethod
-    ? internalServerError("Invalid external-code authorization session")
-    : resolvedMethod;
+  return resolved;
 }
 
 async function lockExternalCodeSessionOwner(
@@ -311,7 +276,7 @@ async function loadOwnedSession(args: {
 
 async function parseEncryptedProviderState(args: {
   readonly session: ExternalCodeSessionRow;
-  readonly method: ExternalCodeMethodRef;
+  readonly method: ResolvedConnectorActionMethod;
 }): Promise<string> {
   const decrypted = await decryptPersistentSecretValue(
     args.session.encryptedProviderState,
@@ -324,8 +289,8 @@ async function parseEncryptedProviderState(args: {
     JSON.parse(decrypted) as unknown,
   );
   if (
-    providerState.connectorType !== args.method.type ||
-    providerState.authMethod !== args.method.authMethod
+    providerState.connectorType !== args.method.connectorRef ||
+    providerState.authMethod !== args.method.authMethodId
   ) {
     throw new Error("External-code provider state connector method mismatch");
   }
@@ -505,7 +470,7 @@ async function markClaimComplete(args: {
 }
 
 async function persistClaimedConnector(
-  args: ExternalCodeMethodRef & {
+  args: ExternalCodeSessionOwner & {
     readonly writeDb: Db;
     readonly orgId: string;
     readonly userId: string;
@@ -622,7 +587,7 @@ const completedExternalCodeSessionResponse$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly session: ExternalCodeSessionRow;
-      readonly method: ExternalCodeMethodRef;
+      readonly method: ResolvedConnectorActionMethod;
     },
     signal: AbortSignal,
   ) => {
@@ -632,8 +597,9 @@ const completedExternalCodeSessionResponse$ = command(
           zeroConnectorByType({
             orgId: args.orgId,
             userId: args.userId,
-            type: args.method.type,
+            type: args.method.connectorRef,
             includeHiddenStoredConnector: true,
+            snapshot: args.method.snapshot,
           }),
         );
       },
@@ -641,7 +607,7 @@ const completedExternalCodeSessionResponse$ = command(
     });
     const error = await set(
       authorizeExternalCodeSessionConnector$,
-      { ...args, connectorType: args.method.type },
+      { ...args, connectorType: args.method.connectorRef },
       signal,
     );
     return error ?? response;
@@ -649,7 +615,7 @@ const completedExternalCodeSessionResponse$ = command(
 );
 
 async function completeClaimedExternalCodeSession(
-  args: ExternalCodeResolvedMethodClient & {
+  args: ResolvedExternalCodeClient & {
     readonly writeDb: Db;
     readonly orgId: string;
     readonly userId: string;
@@ -667,10 +633,13 @@ async function completeClaimedExternalCodeSession(
     (async () => {
       const providerState = await parseEncryptedProviderState({
         session: args.session,
-        method: args,
+        method: args.resolvedMethod,
       });
-      return await completeConnectorExternalCodeAuthorization({
-        ...args,
+      return await completeConnectorExternalCodeAuthorizationWithMethod({
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+        method: args.resolvedMethod.method,
+        authClient: args.authClient,
         code: args.code,
         providerState,
         signal: args.signal,
@@ -708,7 +677,14 @@ async function completeClaimedExternalCodeSession(
   const commitSignal = new AbortController().signal;
   const persistedConnector = await onRejection(
     persistClaimedConnector({
-      ...args,
+      type: args.resolvedMethod.connectorRef,
+      authMethod: args.resolvedMethod.authMethodId,
+      writeDb: args.writeDb,
+      orgId: args.orgId,
+      userId: args.userId,
+      session: args.session,
+      claimStartedAt: args.claimStartedAt,
+      persistConnector: args.persistConnector,
       token: providerResult.value,
       signal: commitSignal,
     }),
@@ -788,6 +764,7 @@ export const startConnectorExternalCodeSession$ = command(
       connectorRef: args.type,
       authMethodId: args.authMethod,
       expectedGrantKind: "external-code",
+      requireAvailable: true,
     });
     signal.throwIfAborted();
     if (!resolved.ok) {
@@ -796,21 +773,19 @@ export const startConnectorExternalCodeSession$ = command(
         authMethodId: args.authMethod,
       });
     }
-    const resolvedMethod = resolveExternalCodeMethod(
-      resolved.type,
-      resolved.authMethod,
-    );
-    if ("status" in resolvedMethod) {
-      return internalServerError("Connector execution is not configured");
-    }
-
-    const resolvedClient = resolveRequiredAuthClient(resolvedMethod);
+    const resolvedClient = resolveRequiredAuthClient(resolved);
     if ("status" in resolvedClient) {
       return resolvedClient;
     }
 
-    const startResult =
-      await startConnectorExternalCodeAuthorization(resolvedClient);
+    const startResult = await startConnectorExternalCodeAuthorizationWithMethod(
+      {
+        connectorRef: resolved.connectorRef,
+        authMethodId: resolved.authMethodId,
+        method: resolved.method,
+        authClient: resolvedClient.authClient,
+      },
+    );
     signal.throwIfAborted();
 
     const sessionToken = generateSessionToken();
@@ -818,8 +793,8 @@ export const startConnectorExternalCodeSession$ = command(
     const expiresAt = new Date(now.getTime() + startResult.expiresIn * 1000);
     const encryptedProviderState = await encryptPersistentSecretValue(
       JSON.stringify({
-        connectorType: resolvedMethod.type,
-        authMethod: resolvedMethod.authMethod,
+        connectorType: resolved.connectorRef,
+        authMethod: resolved.authMethodId,
         providerState: providerStateWithinLimit(startResult.providerState),
       }),
       {
@@ -831,13 +806,15 @@ export const startConnectorExternalCodeSession$ = command(
 
     const [session] = await set(writeDb$).transaction(async (tx) => {
       await lockExternalCodeSessionOwner({
-        ...resolvedMethod,
+        type: resolved.connectorRef,
+        authMethod: resolved.authMethodId,
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
       });
       await markPendingSessionsSuperseded({
-        ...resolvedMethod,
+        type: resolved.connectorRef,
+        authMethod: resolved.authMethodId,
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
@@ -850,8 +827,8 @@ export const startConnectorExternalCodeSession$ = command(
           userId: args.userId,
           agentId: args.agentId,
           authorizeAgent: connectorAgentAuthorizationRequested(args),
-          connectorType: resolvedMethod.type,
-          authMethod: resolvedMethod.authMethod,
+          connectorType: resolved.connectorRef,
+          authMethod: resolved.authMethodId,
           status: "pending",
           sessionTokenHash: sessionTokenHash(sessionToken),
           encryptedProviderState,
@@ -871,7 +848,7 @@ export const startConnectorExternalCodeSession$ = command(
     const body: ConnectorExternalCodeSessionStartResponse = {
       sessionId: session.id,
       sessionToken,
-      type: resolvedMethod.type,
+      type: resolved.connectorRef,
       status: "pending",
       authorizationUrl: startResult.authorizationUrl,
       expiresIn: startResult.expiresIn,
@@ -983,8 +960,8 @@ export const completeConnectorExternalCodeSession$ = command(
           {
             orgId: args.orgId,
             userId: args.userId,
-            type: resolvedMethod.type,
-            authMethod: resolvedMethod.authMethod,
+            runtimeMethod: resolvedMethod.runtimeMethod,
+            snapshot: resolvedMethod.snapshot,
             outputs: token.outputs,
             userInfo: token.userInfo,
             oauthScopes: token.scopes,
@@ -1001,7 +978,7 @@ export const completeConnectorExternalCodeSession$ = command(
     }
     const authorizationError = await set(
       authorizeExternalCodeSessionConnector$,
-      { ...args, session, connectorType: resolvedMethod.type },
+      { ...args, session, connectorType: resolvedMethod.connectorRef },
       signal,
     );
     return authorizationError ?? response;

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -12,23 +12,12 @@ import {
   type ConnectorCatalogRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
-  connectorAuthMethodIdSchema,
-  type ConnectorType,
-  type DeviceAuthGrantConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  connectorAuthMethodRefHasGrantKind,
-  getConnectorAuthMethod,
-  getConnectorAuthMethodIdsForGrantKind,
-  parseConnectorDeviceAuthStartOptions,
-  resolveConnectorResolvedAuthMethodClientByGrantKind,
-  type ConnectorResolvedAuthMethodClientByGrantKind,
-  type ConnectorAuthMethodRef,
-  type ConnectorAuthMethodRefByGrantKind,
+  resolveConnectorAuthClient,
+  type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
-  pollConnectorDeviceAuthorization,
-  startConnectorDeviceAuthorization,
+  pollConnectorDeviceAuthorizationWithMethod,
+  startConnectorDeviceAuthorizationWithMethod,
 } from "@vm0/connectors/auth-providers";
 import type {
   OAuthDeviceAuthCompleteResultBase,
@@ -52,12 +41,13 @@ import {
   userConnectorActionResolver,
   type ConnectorActionMethodResolution,
   type ConnectorActionResolver,
+  type ResolvedConnectorActionMethod,
 } from "./connector-action-resolver.service";
 import {
   upsertConnectorTokenConnection$,
   zeroConnectorByType,
 } from "./zero-connector-data.service";
-import { normalizeDeviceAuthStartOptions } from "./connector-catalog-form-fields.service";
+import { normalizeDeviceAuthStartOptionsWithMethod } from "./connector-catalog-form-fields.service";
 import {
   authorizeConnectedConnector$,
   connectorAgentAuthorizationRequested,
@@ -98,7 +88,7 @@ function deviceAuthStartResponse(args: {
   readonly sessionToken: string;
   readonly type: ConnectorCatalogRef;
   readonly startResult: Awaited<
-    ReturnType<typeof startConnectorDeviceAuthorization>
+    ReturnType<typeof startConnectorDeviceAuthorizationWithMethod>
   >;
   readonly intervalSeconds: number;
 }): ConnectorOauthDeviceAuthSessionStartResponse {
@@ -139,11 +129,12 @@ function validatedDeviceAuthPollState(
   return pollState;
 }
 
-type DeviceAuthMethodRef = ConnectorAuthMethodRefByGrantKind<"device-auth">;
-type DeviceAuthResolvedMethodClient =
-  ConnectorResolvedAuthMethodClientByGrantKind<"device-auth">;
+type ResolvedDeviceAuthClient = {
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly authClient: ConnectorAuthClient;
+};
 
-type PollClaimedSessionArgs = DeviceAuthResolvedMethodClient & {
+type PollClaimedSessionArgs = ResolvedDeviceAuthClient & {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
@@ -155,9 +146,9 @@ type PollClaimedSessionArgs = DeviceAuthResolvedMethodClient & {
   }) => Promise<ConnectorResponse>;
 };
 
-type ResolvedDeviceAuthMethod = DeviceAuthMethodRef;
-
-type DeviceAuthSessionOwner = DeviceAuthMethodRef & {
+type DeviceAuthSessionOwner = {
+  readonly type: ConnectorCatalogRef;
+  readonly authMethod: ConnectorCatalogAuthMethodId;
   readonly orgId: string;
   readonly userId: string;
 };
@@ -294,62 +285,25 @@ function isFreshPollingSession(
   );
 }
 
-function connectorMissingDeviceAuthGrantMessage(type: ConnectorType): string {
-  if (getConnectorAuthMethodIdsForGrantKind(type, "auth-code").length === 0) {
-    return `${type} connector does not use an auth-code or device-auth grant`;
-  }
-  return `${type} connector does not support a device-auth grant`;
-}
-
-function resolveDeviceAuthMethod(
-  type: ConnectorType,
-  authMethod: string,
-): ResolvedDeviceAuthMethod | ReturnType<typeof badRequestMessage> {
-  const authMethodResult = connectorAuthMethodIdSchema.safeParse(authMethod);
-  if (!authMethodResult.success) {
-    return badRequestMessage(`${type} connector auth method is invalid`);
-  }
-
-  const authMethodRef: ConnectorAuthMethodRef = {
-    type,
-    authMethod: authMethodResult.data,
-  };
-  const method = getConnectorAuthMethod(type, authMethodResult.data);
-  if (!method) {
-    if (
-      getConnectorAuthMethodIdsForGrantKind(type, "device-auth").length === 0
-    ) {
-      return badRequestMessage(connectorMissingDeviceAuthGrantMessage(type));
-    }
-    return badRequestMessage(
-      `${type} connector does not have ${authMethod} auth method`,
-    );
-  }
-  if (!connectorAuthMethodRefHasGrantKind(authMethodRef, "device-auth")) {
-    if (
-      getConnectorAuthMethodIdsForGrantKind(type, "device-auth").length === 0
-    ) {
-      return badRequestMessage(connectorMissingDeviceAuthGrantMessage(type));
-    }
-    return badRequestMessage(
-      `${type} ${authMethod} auth method does not use a device-auth grant`,
-    );
-  }
-
-  return authMethodRef;
-}
-
 function resolveRequiredAuthClient(
-  method: DeviceAuthMethodRef,
-): DeviceAuthResolvedMethodClient | ReturnType<typeof internalServerError> {
-  const resolvedClient = resolveConnectorResolvedAuthMethodClientByGrantKind(
-    method,
+  resolvedMethod: ResolvedConnectorActionMethod,
+): ResolvedDeviceAuthClient | ReturnType<typeof internalServerError> {
+  if (
+    resolvedMethod.method.grant.kind !== "device-auth" ||
+    resolvedMethod.method.client === undefined
+  ) {
+    return internalServerError("Connector execution is not configured");
+  }
+  const authClient = resolveConnectorAuthClient(
+    resolvedMethod.method.client,
     optionalEnv,
   );
-  if (!resolvedClient) {
-    return internalServerError(`${method.type} auth client not configured`);
+  if (!authClient) {
+    return internalServerError(
+      `${resolvedMethod.connectorRef} auth client not configured`,
+    );
   }
-  return resolvedClient;
+  return { resolvedMethod, authClient };
 }
 
 async function resolveRequestedDeviceAuthMethod(args: {
@@ -361,17 +315,12 @@ async function resolveRequestedDeviceAuthMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: args.authMethodId,
     expectedGrantKind: "device-auth",
+    requireAvailable: true,
   });
   if (!resolved.ok) {
     return deviceAuthResolutionError(resolved, args);
   }
-  const resolvedMethod = resolveDeviceAuthMethod(
-    resolved.type,
-    resolved.authMethod,
-  );
-  return "status" in resolvedMethod
-    ? internalServerError("Connector execution is not configured")
-    : resolvedMethod;
+  return resolved;
 }
 
 async function resolveStoredDeviceAuthMethod(args: {
@@ -389,6 +338,7 @@ async function resolveStoredDeviceAuthMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: storedAuthMethod.data,
     expectedGrantKind: "device-auth",
+    requireAvailable: true,
   });
   if (!resolved.ok) {
     if (
@@ -399,13 +349,7 @@ async function resolveStoredDeviceAuthMethod(args: {
     }
     return internalServerError("Invalid OAuth device authorization session");
   }
-  const resolvedMethod = resolveDeviceAuthMethod(
-    resolved.type,
-    resolved.authMethod,
-  );
-  return "status" in resolvedMethod
-    ? internalServerError("Invalid OAuth device authorization session")
-    : resolvedMethod;
+  return resolved;
 }
 
 async function lockDeviceAuthSessionOwner(
@@ -584,7 +528,7 @@ async function claimSession(args: {
 
 async function parseEncryptedProviderState(args: {
   readonly session: DeviceAuthSessionRow;
-  readonly type: DeviceAuthGrantConnectorType;
+  readonly type: ConnectorCatalogRef;
 }): Promise<EncryptedProviderState> {
   const decrypted = await decryptPersistentSecretValue(
     args.session.encryptedProviderState,
@@ -727,7 +671,7 @@ async function markClaimComplete(args: {
 }
 
 async function completeClaimedSession(
-  args: DeviceAuthMethodRef & {
+  args: DeviceAuthSessionOwner & {
     readonly writeDb: Db;
     readonly orgId: string;
     readonly userId: string;
@@ -822,7 +766,7 @@ const completedDeviceSessionResponse$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly session: DeviceAuthSessionRow;
-      readonly method: ResolvedDeviceAuthMethod;
+      readonly method: ResolvedConnectorActionMethod;
     },
     signal: AbortSignal,
   ) => {
@@ -832,8 +776,9 @@ const completedDeviceSessionResponse$ = command(
           zeroConnectorByType({
             orgId: args.orgId,
             userId: args.userId,
-            type: args.method.type,
+            type: args.method.connectorRef,
             includeHiddenStoredConnector: true,
+            snapshot: args.method.snapshot,
           }),
         );
       },
@@ -841,7 +786,7 @@ const completedDeviceSessionResponse$ = command(
     });
     const error = await set(
       authorizeDeviceSessionConnector$,
-      { ...args, connectorType: args.method.type },
+      { ...args, connectorType: args.method.connectorRef },
       signal,
     );
     return error ?? response;
@@ -853,10 +798,13 @@ async function runClaimedSession(
 ): Promise<PollSuccess> {
   const providerState = await parseEncryptedProviderState({
     session: args.session,
-    type: args.type,
+    type: args.resolvedMethod.connectorRef,
   });
-  const pollResult = await pollConnectorDeviceAuthorization({
-    ...args,
+  const pollResult = await pollConnectorDeviceAuthorizationWithMethod({
+    connectorRef: args.resolvedMethod.connectorRef,
+    authMethodId: args.resolvedMethod.authMethodId,
+    method: args.resolvedMethod.method,
+    authClient: args.authClient,
     deviceCode: providerState.deviceCode,
     ...(providerState.pollState === undefined
       ? {}
@@ -900,7 +848,15 @@ async function runClaimedSession(
   }
 
   return await completeClaimedSession({
-    ...args,
+    type: args.resolvedMethod.connectorRef,
+    authMethod: args.resolvedMethod.authMethodId,
+    writeDb: args.writeDb,
+    orgId: args.orgId,
+    userId: args.userId,
+    session: args.session,
+    claimStartedAt: args.claimStartedAt,
+    signal: args.signal,
+    persistConnector: args.persistConnector,
     result: pollResult,
   });
 }
@@ -972,27 +928,22 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return resolvedClient;
     }
 
-    const normalizedStartOptions = normalizeDeviceAuthStartOptions({
-      type: resolvedMethod.type,
-      authMethod: resolvedMethod.authMethod,
+    const normalizedStartOptions = normalizeDeviceAuthStartOptionsWithMethod({
+      connectorRef: resolvedMethod.connectorRef,
+      authMethodId: resolvedMethod.authMethodId,
+      method: resolvedMethod.method,
       options: args.options,
     });
     if (!normalizedStartOptions.ok) {
       return badRequestMessage(normalizedStartOptions.message);
     }
 
-    const startOptionsResult = parseConnectorDeviceAuthStartOptions({
-      type: resolvedMethod.type,
-      authMethod: resolvedMethod.authMethod,
-      options: normalizedStartOptions.options,
-    });
-    if (!startOptionsResult.success) {
-      return badRequestMessage(startOptionsResult.message);
-    }
-
-    const startResult = await startConnectorDeviceAuthorization({
-      ...resolvedClient,
-      options: startOptionsResult.options,
+    const startResult = await startConnectorDeviceAuthorizationWithMethod({
+      connectorRef: resolvedMethod.connectorRef,
+      authMethodId: resolvedMethod.authMethodId,
+      method: resolvedMethod.method,
+      authClient: resolvedClient.authClient,
+      options: normalizedStartOptions.options ?? {},
     });
     signal.throwIfAborted();
 
@@ -1004,7 +955,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     const pollState = validatedDeviceAuthPollState(startResult.pollState);
     const encryptedProviderState = await encryptPersistentSecretValue(
       JSON.stringify({
-        connectorType: resolvedMethod.type,
+        connectorType: resolvedMethod.connectorRef,
         deviceCode: startResult.deviceCode,
         ...(pollState === undefined ? {} : { pollState }),
       }),
@@ -1017,13 +968,15 @@ export const startConnectorOauthDeviceAuthSession$ = command(
 
     const [session] = await set(writeDb$).transaction(async (tx) => {
       await lockDeviceAuthSessionOwner({
-        ...resolvedMethod,
+        type: resolvedMethod.connectorRef,
+        authMethod: resolvedMethod.authMethodId,
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
       });
       await markActiveSessionsSuperseded({
-        ...resolvedMethod,
+        type: resolvedMethod.connectorRef,
+        authMethod: resolvedMethod.authMethodId,
         writeDb: tx,
         orgId: args.orgId,
         userId: args.userId,
@@ -1036,8 +989,8 @@ export const startConnectorOauthDeviceAuthSession$ = command(
           userId: args.userId,
           agentId: args.agentId,
           authorizeAgent: connectorAgentAuthorizationRequested(args),
-          connectorType: resolvedMethod.type,
-          authMethod: resolvedMethod.authMethod,
+          connectorType: resolvedMethod.connectorRef,
+          authMethod: resolvedMethod.authMethodId,
           status: "awaiting_user_authorization",
           sessionTokenHash: sessionTokenHash(sessionToken),
           encryptedProviderState,
@@ -1062,7 +1015,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     const body = deviceAuthStartResponse({
       sessionId: session.id,
       sessionToken,
-      type: resolvedMethod.type,
+      type: resolvedMethod.connectorRef,
       startResult,
       intervalSeconds,
     });
@@ -1169,8 +1122,8 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
           {
             orgId: args.orgId,
             userId: args.userId,
-            type: resolvedMethod.type,
-            authMethod: resolvedMethod.authMethod,
+            runtimeMethod: resolvedMethod.runtimeMethod,
+            snapshot: resolvedMethod.snapshot,
             outputs: result.token.outputs,
             userInfo: result.token.userInfo,
             oauthScopes: result.token.scopes,
@@ -1187,7 +1140,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     }
     const authorizationError = await set(
       authorizeDeviceSessionConnector$,
-      { ...args, session, connectorType: resolvedMethod.type },
+      { ...args, session, connectorType: resolvedMethod.connectorRef },
       signal,
     );
     return authorizationError ?? response;

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -38,7 +38,7 @@ import {
   encryptPersistentSecretValue,
 } from "./crypto.utils";
 import {
-  userConnectorActionResolver,
+  connectorActionResolver,
   type ConnectorActionMethodResolution,
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
@@ -204,8 +204,7 @@ function deviceAuthResolutionError(
         `${args.connectorRef} ${args.authMethodId} auth method does not use a device-auth grant`,
       );
     }
-    case "unavailable_connector":
-    case "unavailable_auth_method": {
+    case "hidden_auth_method": {
       return connectorOauthDeviceAuthDisabled;
     }
     case "missing_executable_capability": {
@@ -311,11 +310,10 @@ async function resolveRequestedDeviceAuthMethod(args: {
   readonly connectorRef: ConnectorCatalogRef;
   readonly authMethodId: ConnectorCatalogAuthMethodId;
 }) {
-  const resolved = await args.resolver.resolveMethod({
+  const resolved = await args.resolver.resolveNewActionMethod({
     connectorRef: args.connectorRef,
     authMethodId: args.authMethodId,
     expectedGrantKind: "device-auth",
-    requireAvailable: true,
   });
   if (!resolved.ok) {
     return deviceAuthResolutionError(resolved, args);
@@ -338,15 +336,8 @@ async function resolveStoredDeviceAuthMethod(args: {
     connectorRef: args.connectorRef,
     authMethodId: storedAuthMethod.data,
     expectedGrantKind: "device-auth",
-    requireAvailable: true,
   });
   if (!resolved.ok) {
-    if (
-      resolved.reason === "unavailable_connector" ||
-      resolved.reason === "unavailable_auth_method"
-    ) {
-      return connectorOauthDeviceAuthDisabled;
-    }
     return internalServerError("Invalid OAuth device authorization session");
   }
   return resolved;
@@ -777,7 +768,6 @@ const completedDeviceSessionResponse$ = command(
             orgId: args.orgId,
             userId: args.userId,
             type: args.method.connectorRef,
-            includeHiddenStoredConnector: true,
             snapshot: args.method.snapshot,
           }),
         );
@@ -909,9 +899,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       return badRequestMessage(agentTarget.message);
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(args.orgId, args.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolvedMethod = await resolveRequestedDeviceAuthMethod({
       resolver,
@@ -1049,9 +1037,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       return notFound("OAuth device authorization session not found");
     }
 
-    const resolver = await get(
-      userConnectorActionResolver(args.orgId, args.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
     const resolvedMethod = await resolveStoredDeviceAuthMethod({
       resolver,

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { AuthGrantConnectorType } from "@vm0/connectors/connectors";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: AuthGrantConnectorType;
+    readonly connectorType: ConnectorCatalogRef;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: AuthGrantConnectorType;
+    readonly connectorType: ConnectorCatalogRef;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -7,15 +7,15 @@ import {
 } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
-import { buildConnectorAuthCodeAuthorizationUrl } from "@vm0/connectors/auth-providers";
+import { buildConnectorAuthCodeAuthorizationUrlWithMethod } from "@vm0/connectors/auth-providers";
 import type { AuthUrlResult } from "@vm0/connectors/auth-providers/provider-flow-types";
 import {
-  connectorAuthMethodHasGrantKind,
-  resolveConnectorAuthClientForMethod,
+  resolveConnectorAuthClient,
   isStaticConfidentialConnectorAuthClient,
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
-import type { ConnectorAuthCodeGrantAuthMethodId } from "@vm0/connectors/connectors";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
+import type { ConnectorCatalogAuthMethodId } from "@vm0/api-contracts/contracts/connector-identity";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -58,16 +58,7 @@ interface GithubOAuthState {
   readonly sig: string | null;
 }
 
-export function getGithubOAuthAuthMethod(): ConnectorAuthCodeGrantAuthMethodId<"github"> {
-  if (
-    !connectorAuthMethodHasGrantKind(
-      "github",
-      GITHUB_OAUTH_AUTH_METHOD,
-      "auth-code",
-    )
-  ) {
-    throw new Error("github oauth auth method must use an auth-code grant");
-  }
+export function getGithubOAuthAuthMethod(): ConnectorCatalogAuthMethodId {
   return GITHUB_OAUTH_AUTH_METHOD;
 }
 
@@ -381,13 +372,16 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   readonly vm0UserId: string;
   readonly orgId: string;
   readonly origin: string;
+  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly readEnv: ConnectorEnvReader;
   readonly signal: AbortSignal;
 }): Promise<string | null> {
-  const authMethod = getGithubOAuthAuthMethod();
-  const authClient = resolveConnectorAuthClientForMethod(
-    "github",
-    authMethod,
+  if (args.method.grant.kind !== "auth-code" || !args.method.client) {
+    return null;
+  }
+  const authClient = resolveConnectorAuthClient(
+    args.method.client,
     args.readEnv,
   );
   if (!authClient || !isStaticConfidentialConnectorAuthClient(authClient)) {
@@ -397,9 +391,10 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   const state = generateConnectorOAuthState();
   const redirectUri = `${args.origin}/api/connectors/github/callback`;
   const authResult = normalizeAuthUrlResult(
-    await buildConnectorAuthCodeAuthorizationUrl({
-      type: "github",
-      authMethod,
+    await buildConnectorAuthCodeAuthorizationUrlWithMethod({
+      connectorRef: "github",
+      authMethodId: args.authMethodId,
+      method: args.method,
       authClient,
       redirectUri,
       state,
@@ -409,7 +404,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   await args.db.insert(connectorOauthStates).values({
     state,
     type: "github",
-    authMethod,
+    authMethod: args.authMethodId,
     userId: args.vm0UserId,
     orgId: args.orgId,
     redirectUri,

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -12,13 +12,10 @@ import {
   type GmailNewMessageEventConfig,
   type GmailWorkflowEventConfig,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import { refreshGoogleToken } from "@vm0/connectors/auth-providers/oauth/google";
-import { connectors } from "@vm0/db/schema/connector";
 import {
   gmailProcessedEvents,
   gmailWatchStates,
 } from "@vm0/db/schema/gmail-event";
-import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -32,10 +29,14 @@ import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { safeJsonParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
-  decryptStoredSecretValue,
-  encryptStoredSecretValue,
-} from "./crypto.utils";
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  markConnectorCredentialNeedsReconnect,
+  refreshConnectorCredentialAccess,
+} from "./connector-credential-runtime.service";
 import {
   WorkflowEventSourceTiming,
   type WorkflowEventRunTiming,
@@ -50,9 +51,7 @@ import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automat
 
 const log = logger("api:gmail-workflow-event");
 
-const GMAIL_ACCESS_TOKEN_SECRET = "GMAIL_ACCESS_TOKEN";
-const GMAIL_REFRESH_TOKEN_SECRET = "GMAIL_REFRESH_TOKEN";
-const CONNECTOR_SECRET_TYPE = "connector";
+const GMAIL_ACCESS_TOKEN_ENVIRONMENT_NAME = "GMAIL_TOKEN";
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const WATCH_RENEWAL_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -178,23 +177,6 @@ type GmailAccessResult =
   | { readonly kind: "ok"; readonly access: GmailAccess }
   | { readonly kind: "bad_request"; readonly message: string };
 
-interface GmailConnectorAccessRow {
-  readonly id: string;
-  readonly externalEmail: string | null;
-  readonly tokenExpiresAt: Date | null;
-  readonly needsReconnect: boolean;
-}
-
-interface ConnectorSecretRow {
-  readonly name: string;
-  readonly encryptedValue: string;
-}
-
-interface GmailConnectorSecrets {
-  readonly accessSecret: ConnectorSecretRow | null;
-  readonly refreshSecret: ConnectorSecretRow | null;
-}
-
 type EnsureGmailWatchResult =
   | { readonly kind: "ok" }
   | { readonly kind: "bad_request"; readonly message: string };
@@ -277,176 +259,6 @@ function tokenNeedsRefresh(tokenExpiresAt: Date | null, currentTime: Date) {
   );
 }
 
-function tokenExpiresAtFromExpiresIn(
-  expiresIn: number | undefined,
-  currentTime: Date,
-): Date | null {
-  return expiresIn === undefined
-    ? null
-    : new Date(currentTime.getTime() + expiresIn * 1000);
-}
-
-async function loadGmailConnector(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId?: string;
-  readonly signal: AbortSignal;
-}): Promise<GmailConnectorAccessRow | null> {
-  const connectorConditions = [
-    eq(connectors.orgId, args.orgId),
-    eq(connectors.userId, args.userId),
-    eq(connectors.type, "gmail"),
-  ];
-  if (args.connectorId !== undefined) {
-    connectorConditions.push(eq(connectors.id, args.connectorId));
-  }
-
-  const [connector] = await args.db
-    .select({
-      id: connectors.id,
-      externalEmail: connectors.externalEmail,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      needsReconnect: connectors.needsReconnect,
-    })
-    .from(connectors)
-    .where(and(...connectorConditions))
-    .limit(1);
-  args.signal.throwIfAborted();
-
-  return connector ?? null;
-}
-
-async function loadGmailConnectorSecrets(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): Promise<GmailConnectorSecrets> {
-  const secretRows = await args.db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  return {
-    accessSecret:
-      secretRows.find((row) => {
-        return row.name === GMAIL_ACCESS_TOKEN_SECRET;
-      }) ?? null,
-    refreshSecret:
-      secretRows.find((row) => {
-        return row.name === GMAIL_REFRESH_TOKEN_SECRET;
-      }) ?? null,
-  };
-}
-
-async function markGmailConnectorNeedsReconnect(args: {
-  readonly db: Db;
-  readonly connectorId: string;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db
-    .update(connectors)
-    .set({ needsReconnect: true, updatedAt: args.currentTime })
-    .where(eq(connectors.id, args.connectorId));
-  args.signal.throwIfAborted();
-}
-
-async function refreshGmailAccessToken(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connector: GmailConnectorAccessRow;
-  readonly refreshSecret: ConnectorSecretRow;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<GmailAccessResult> {
-  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return {
-      kind: "bad_request",
-      message: "Google OAuth client env vars are not configured",
-    };
-  }
-
-  const refreshToken = await decryptStoredSecretValue(
-    args.refreshSecret.encryptedValue,
-  );
-  const refreshed = await tapError(
-    refreshGoogleToken(
-      "gmail",
-      clientId,
-      clientSecret,
-      refreshToken,
-      args.signal,
-    ),
-  );
-  args.signal.throwIfAborted();
-  if (!refreshed) {
-    await markGmailConnectorNeedsReconnect({
-      db: args.db,
-      connectorId: args.connector.id,
-      currentTime: args.currentTime,
-      signal: args.signal,
-    });
-    return {
-      kind: "bad_request",
-      message: "Reconnect Gmail before using Gmail event automations",
-    };
-  }
-
-  const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshed.expiresIn,
-    args.currentTime,
-  );
-  await args.db
-    .update(secretsTable)
-    .set({
-      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
-      updatedAt: args.currentTime,
-    })
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-        eq(secretsTable.name, GMAIL_ACCESS_TOKEN_SECRET),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  await args.db
-    .update(connectors)
-    .set({
-      tokenExpiresAt,
-      needsReconnect: false,
-      updatedAt: args.currentTime,
-    })
-    .where(eq(connectors.id, args.connector.id));
-  args.signal.throwIfAborted();
-
-  return {
-    kind: "ok",
-    access: {
-      connectorId: args.connector.id,
-      emailAddress: args.connector.externalEmail,
-      accessToken: refreshed.accessToken,
-    },
-  };
-}
-
 async function resolveGmailAccess(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -455,46 +267,85 @@ async function resolveGmailAccess(args: {
   readonly signal: AbortSignal;
 }): Promise<GmailAccessResult> {
   const currentTime = nowDate();
-  const connector = await loadGmailConnector(args);
-  if (!connector) {
+  const snapshot = await loadConnectorRuntimeSnapshot(args.db);
+  args.signal.throwIfAborted();
+  const loaded = await loadConnectorCredentialConnection({
+    db: args.db,
+    snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorRef: "gmail",
+    ...(args.connectorId === undefined
+      ? {}
+      : { connectorId: args.connectorId }),
+  });
+  args.signal.throwIfAborted();
+  if (loaded.kind === "missing") {
     return {
       kind: "bad_request",
       message: "Connect Gmail before adding a Gmail event automation",
     };
   }
-  if (connector.needsReconnect) {
+  if (loaded.kind === "unavailable" || loaded.connection.needsReconnect) {
     return {
       kind: "bad_request",
       message: "Reconnect Gmail before using Gmail event automations",
     };
   }
-
-  const { accessSecret, refreshSecret } = await loadGmailConnectorSecrets(args);
-  if (!accessSecret) {
+  const connection = loaded.connection;
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    connection,
+    GMAIL_ACCESS_TOKEN_ENVIRONMENT_NAME,
+  );
+  if (accessTokenValueRef === null) {
     return {
       kind: "bad_request",
       message: "Reconnect Gmail before using Gmail event automations",
     };
   }
-
-  if (!tokenNeedsRefresh(connector.tokenExpiresAt, currentTime)) {
+  const values = await loadConnectorCredentialValues({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    valueRefs: [accessTokenValueRef],
+  });
+  args.signal.throwIfAborted();
+  const accessToken = values.get(accessTokenValueRef);
+  if (!accessToken) {
+    return {
+      kind: "bad_request",
+      message: "Reconnect Gmail before using Gmail event automations",
+    };
+  }
+  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
     return {
       kind: "ok",
       access: {
-        connectorId: connector.id,
-        emailAddress: connector.externalEmail,
-        accessToken: await decryptStoredSecretValue(
-          accessSecret.encryptedValue,
-        ),
+        connectorId: connection.connectorId,
+        emailAddress: connection.externalEmail,
+        accessToken,
       },
     };
   }
-
-  if (!refreshSecret) {
-    await markGmailConnectorNeedsReconnect({
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection,
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: GMAIL_ACCESS_TOKEN_ENVIRONMENT_NAME,
+    signal: args.signal,
+    persist: { db: args.db },
+  });
+  if (refreshed.kind === "configuration-unavailable") {
+    return {
+      kind: "bad_request",
+      message: "Google OAuth client env vars are not configured",
+    };
+  }
+  if (refreshed.kind !== "ok") {
+    await markConnectorCredentialNeedsReconnect({
       db: args.db,
-      connectorId: connector.id,
-      currentTime,
+      connectorId: connection.connectorId,
       signal: args.signal,
     });
     return {
@@ -502,16 +353,14 @@ async function resolveGmailAccess(args: {
       message: "Reconnect Gmail before using Gmail event automations",
     };
   }
-
-  return await refreshGmailAccessToken({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    connector,
-    refreshSecret,
-    currentTime,
-    signal: args.signal,
-  });
+  return {
+    kind: "ok",
+    access: {
+      connectorId: connection.connectorId,
+      emailAddress: connection.externalEmail,
+      accessToken: refreshed.accessToken,
+    },
+  };
 }
 
 async function gmailFetchJson<T>(

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -34,7 +34,6 @@ import {
   connectorCredentialRuntimeValueRef,
   loadConnectorCredentialConnection,
   loadConnectorCredentialValues,
-  markConnectorCredentialNeedsReconnect,
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
@@ -334,7 +333,7 @@ async function resolveGmailAccess(args: {
     userId: args.userId,
     runtimeEnvironmentName: GMAIL_ACCESS_TOKEN_ENVIRONMENT_NAME,
     signal: args.signal,
-    persist: { db: args.db },
+    persist: { db: args.db, markNeedsReconnectOnFailure: true },
   });
   if (refreshed.kind === "configuration-unavailable") {
     return {
@@ -343,11 +342,6 @@ async function resolveGmailAccess(args: {
     };
   }
   if (refreshed.kind !== "ok") {
-    await markConnectorCredentialNeedsReconnect({
-      db: args.db,
-      connectorId: connection.connectorId,
-      signal: args.signal,
-    });
     return {
       kind: "bad_request",
       message: "Reconnect Gmail before using Gmail event automations",

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -31,7 +31,6 @@ import {
   connectorCredentialRuntimeValueRef,
   loadConnectorCredentialConnection,
   loadConnectorCredentialValues,
-  markConnectorCredentialNeedsReconnect,
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
@@ -328,7 +327,7 @@ async function resolveGoogleCalendarAccess(args: {
     userId: args.userId,
     runtimeEnvironmentName: GOOGLE_CALENDAR_ACCESS_TOKEN_ENVIRONMENT_NAME,
     signal: args.signal,
-    persist: { db: args.db },
+    persist: { db: args.db, markNeedsReconnectOnFailure: true },
   });
   if (refreshed.kind === "configuration-unavailable") {
     return {
@@ -337,11 +336,6 @@ async function resolveGoogleCalendarAccess(args: {
     };
   }
   if (refreshed.kind !== "ok") {
-    await markConnectorCredentialNeedsReconnect({
-      db: args.db,
-      connectorId: connection.connectorId,
-      signal: args.signal,
-    });
     return {
       kind: "bad_request",
       message:

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -9,14 +9,11 @@ import {
   googleCalendarEventCreatedEventConfigSchema,
   googleCalendarEventUpdatedEventConfigSchema,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import { refreshGoogleToken } from "@vm0/connectors/auth-providers/oauth/google";
-import { connectors } from "@vm0/db/schema/connector";
 import {
   googleCalendarEventSnapshots,
   googleCalendarProcessedEvents,
   googleCalendarWatchStates,
 } from "@vm0/db/schema/google-calendar-event";
-import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -28,12 +25,15 @@ import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
-import { tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
-  decryptStoredSecretValue,
-  encryptStoredSecretValue,
-} from "./crypto.utils";
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  markConnectorCredentialNeedsReconnect,
+  refreshConnectorCredentialAccess,
+} from "./connector-credential-runtime.service";
 import {
   WorkflowEventSourceTiming,
   type WorkflowEventRunTiming,
@@ -48,9 +48,7 @@ import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automat
 
 const log = logger("api:google-calendar-workflow-event");
 
-const GOOGLE_CALENDAR_ACCESS_TOKEN_SECRET = "GOOGLE_CALENDAR_ACCESS_TOKEN";
-const GOOGLE_CALENDAR_REFRESH_TOKEN_SECRET = "GOOGLE_CALENDAR_REFRESH_TOKEN";
-const CONNECTOR_SECRET_TYPE = "connector";
+const GOOGLE_CALENDAR_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_CALENDAR_TOKEN";
 const GOOGLE_CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const WATCH_RENEWAL_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -68,23 +66,6 @@ interface GoogleCalendarAccess {
 type GoogleCalendarAccessResult =
   | { readonly kind: "ok"; readonly access: GoogleCalendarAccess }
   | { readonly kind: "bad_request"; readonly message: string };
-
-interface GoogleCalendarConnectorAccessRow {
-  readonly id: string;
-  readonly externalEmail: string | null;
-  readonly tokenExpiresAt: Date | null;
-  readonly needsReconnect: boolean;
-}
-
-interface ConnectorSecretRow {
-  readonly name: string;
-  readonly encryptedValue: string;
-}
-
-interface GoogleCalendarConnectorSecrets {
-  readonly accessSecret: ConnectorSecretRow | null;
-  readonly refreshSecret: ConnectorSecretRow | null;
-}
 
 type EnsureGoogleCalendarWatchResult =
   | { readonly kind: "ok" }
@@ -268,177 +249,6 @@ function tokenNeedsRefresh(
   );
 }
 
-function tokenExpiresAtFromExpiresIn(
-  expiresIn: number | undefined,
-  currentTime: Date,
-): Date | null {
-  return expiresIn === undefined
-    ? null
-    : new Date(currentTime.getTime() + expiresIn * 1000);
-}
-
-async function loadGoogleCalendarConnector(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId?: string;
-  readonly signal: AbortSignal;
-}): Promise<GoogleCalendarConnectorAccessRow | null> {
-  const connectorConditions = [
-    eq(connectors.orgId, args.orgId),
-    eq(connectors.userId, args.userId),
-    eq(connectors.type, "google-calendar"),
-  ];
-  if (args.connectorId !== undefined) {
-    connectorConditions.push(eq(connectors.id, args.connectorId));
-  }
-
-  const [connector] = await args.db
-    .select({
-      id: connectors.id,
-      externalEmail: connectors.externalEmail,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      needsReconnect: connectors.needsReconnect,
-    })
-    .from(connectors)
-    .where(and(...connectorConditions))
-    .limit(1);
-  args.signal.throwIfAborted();
-
-  return connector ?? null;
-}
-
-async function loadGoogleCalendarConnectorSecrets(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): Promise<GoogleCalendarConnectorSecrets> {
-  const secretRows = await args.db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  return {
-    accessSecret:
-      secretRows.find((row) => {
-        return row.name === GOOGLE_CALENDAR_ACCESS_TOKEN_SECRET;
-      }) ?? null,
-    refreshSecret:
-      secretRows.find((row) => {
-        return row.name === GOOGLE_CALENDAR_REFRESH_TOKEN_SECRET;
-      }) ?? null,
-  };
-}
-
-async function markGoogleCalendarConnectorNeedsReconnect(args: {
-  readonly db: Db;
-  readonly connectorId: string;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db
-    .update(connectors)
-    .set({ needsReconnect: true, updatedAt: args.currentTime })
-    .where(eq(connectors.id, args.connectorId));
-  args.signal.throwIfAborted();
-}
-
-async function refreshGoogleCalendarAccessToken(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connector: GoogleCalendarConnectorAccessRow;
-  readonly refreshSecret: ConnectorSecretRow;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<GoogleCalendarAccessResult> {
-  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return {
-      kind: "bad_request",
-      message: "Google OAuth client env vars are not configured",
-    };
-  }
-
-  const refreshToken = await decryptStoredSecretValue(
-    args.refreshSecret.encryptedValue,
-  );
-  const refreshed = await tapError(
-    refreshGoogleToken(
-      "google-calendar",
-      clientId,
-      clientSecret,
-      refreshToken,
-      args.signal,
-    ),
-  );
-  args.signal.throwIfAborted();
-  if (!refreshed) {
-    await markGoogleCalendarConnectorNeedsReconnect({
-      db: args.db,
-      connectorId: args.connector.id,
-      currentTime: args.currentTime,
-      signal: args.signal,
-    });
-    return {
-      kind: "bad_request",
-      message:
-        "Reconnect Google Calendar before using Google Calendar event automations",
-    };
-  }
-
-  const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshed.expiresIn,
-    args.currentTime,
-  );
-  await args.db
-    .update(secretsTable)
-    .set({
-      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
-      updatedAt: args.currentTime,
-    })
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-        eq(secretsTable.name, GOOGLE_CALENDAR_ACCESS_TOKEN_SECRET),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  await args.db
-    .update(connectors)
-    .set({
-      tokenExpiresAt,
-      needsReconnect: false,
-      updatedAt: args.currentTime,
-    })
-    .where(eq(connectors.id, args.connector.id));
-  args.signal.throwIfAborted();
-
-  return {
-    kind: "ok",
-    access: {
-      connectorId: args.connector.id,
-      emailAddress: args.connector.externalEmail,
-      accessToken: refreshed.accessToken,
-    },
-  };
-}
-
 async function resolveGoogleCalendarAccess(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -447,50 +257,89 @@ async function resolveGoogleCalendarAccess(args: {
   readonly signal: AbortSignal;
 }): Promise<GoogleCalendarAccessResult> {
   const currentTime = nowDate();
-  const connector = await loadGoogleCalendarConnector(args);
-  if (!connector) {
+  const snapshot = await loadConnectorRuntimeSnapshot(args.db);
+  args.signal.throwIfAborted();
+  const loaded = await loadConnectorCredentialConnection({
+    db: args.db,
+    snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorRef: "google-calendar",
+    ...(args.connectorId === undefined
+      ? {}
+      : { connectorId: args.connectorId }),
+  });
+  args.signal.throwIfAborted();
+  if (loaded.kind === "missing") {
     return {
       kind: "bad_request",
       message:
         "Connect Google Calendar before adding a Google Calendar event automation",
     };
   }
-  if (connector.needsReconnect) {
+  if (loaded.kind === "unavailable" || loaded.connection.needsReconnect) {
     return {
       kind: "bad_request",
       message:
         "Reconnect Google Calendar before using Google Calendar event automations",
     };
   }
-
-  const { accessSecret, refreshSecret } =
-    await loadGoogleCalendarConnectorSecrets(args);
-  if (!accessSecret) {
+  const connection = loaded.connection;
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    connection,
+    GOOGLE_CALENDAR_ACCESS_TOKEN_ENVIRONMENT_NAME,
+  );
+  if (accessTokenValueRef === null) {
     return {
       kind: "bad_request",
       message:
         "Reconnect Google Calendar before using Google Calendar event automations",
     };
   }
-
-  if (!tokenNeedsRefresh(connector.tokenExpiresAt, currentTime)) {
+  const values = await loadConnectorCredentialValues({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    valueRefs: [accessTokenValueRef],
+  });
+  args.signal.throwIfAborted();
+  const accessToken = values.get(accessTokenValueRef);
+  if (!accessToken) {
+    return {
+      kind: "bad_request",
+      message:
+        "Reconnect Google Calendar before using Google Calendar event automations",
+    };
+  }
+  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
     return {
       kind: "ok",
       access: {
-        connectorId: connector.id,
-        emailAddress: connector.externalEmail,
-        accessToken: await decryptStoredSecretValue(
-          accessSecret.encryptedValue,
-        ),
+        connectorId: connection.connectorId,
+        emailAddress: connection.externalEmail,
+        accessToken,
       },
     };
   }
-
-  if (!refreshSecret) {
-    await markGoogleCalendarConnectorNeedsReconnect({
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection,
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: GOOGLE_CALENDAR_ACCESS_TOKEN_ENVIRONMENT_NAME,
+    signal: args.signal,
+    persist: { db: args.db },
+  });
+  if (refreshed.kind === "configuration-unavailable") {
+    return {
+      kind: "bad_request",
+      message: "Google OAuth client env vars are not configured",
+    };
+  }
+  if (refreshed.kind !== "ok") {
+    await markConnectorCredentialNeedsReconnect({
       db: args.db,
-      connectorId: connector.id,
-      currentTime,
+      connectorId: connection.connectorId,
       signal: args.signal,
     });
     return {
@@ -499,16 +348,14 @@ async function resolveGoogleCalendarAccess(args: {
         "Reconnect Google Calendar before using Google Calendar event automations",
     };
   }
-
-  return await refreshGoogleCalendarAccessToken({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    connector,
-    refreshSecret,
-    currentTime,
-    signal: args.signal,
-  });
+  return {
+    kind: "ok",
+    access: {
+      connectorId: connection.connectorId,
+      emailAddress: connection.externalEmail,
+      accessToken: refreshed.accessToken,
+    },
+  };
 }
 
 function calendarApiUrl(path: string): string {

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -8,10 +8,8 @@ import type {
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { connectors } from "@vm0/db/schema/connector";
 import { hostedDeployments } from "@vm0/db/schema/hosted-site";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
-import { secrets } from "@vm0/db/schema/secret";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, or, sql } from "drizzle-orm";
@@ -40,22 +38,29 @@ import {
   safeSync,
   tapError,
 } from "../utils";
-import { decryptStoredSecretValue } from "./crypto.utils";
+import {
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import {
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  refreshConnectorCredentialAccess,
+  type ConnectorCredentialConnection,
+} from "./connector-credential-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
 const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
 const GOOGLE_DRIVE_UPLOAD_URL =
   "https://www.googleapis.com/upload/drive/v3/files";
-const GOOGLE_DRIVE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
 const GOOGLE_DRIVE_STATUS_TIMEOUT_MS = 2000;
 const GOOGLE_DRIVE_ARTIFACT_APP_PROPERTY = "vm0Artifact";
 const GOOGLE_DRIVE_THREAD_APP_PROPERTY = "vm0ThreadId";
 const GOOGLE_DRIVE_RUN_APP_PROPERTY = "vm0RunId";
 const GOOGLE_DRIVE_FILE_APP_PROPERTY = "vm0FileId";
-const ACCESS_SECRET = "GOOGLE_DRIVE_ACCESS_TOKEN";
-const REFRESH_SECRET = "GOOGLE_DRIVE_REFRESH_TOKEN";
-const SECRET_TYPE = "connector";
+const GOOGLE_DRIVE_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_DRIVE_TOKEN";
 
 const driveFileSchema = z.object({
   id: z.string(),
@@ -64,11 +69,6 @@ const driveFileSchema = z.object({
   appProperties: z.record(z.string(), z.string()).optional(),
 });
 const driveFileListSchema = z.object({ files: z.array(driveFileSchema) });
-const refreshResponseSchema = z.object({
-  access_token: z.string().optional(),
-  expires_in: z.number().optional(),
-  error: z.string().optional(),
-});
 
 interface DriveSyncResult {
   readonly id: string;
@@ -86,7 +86,7 @@ type DriveStatusLookup =
 
 interface ConnectorTokens {
   readonly accessToken: string;
-  readonly refreshToken: string | null;
+  readonly connection: ConnectorCredentialConnection;
   readonly needsReconnect: boolean;
 }
 
@@ -133,85 +133,62 @@ async function loadDriveTokens(
   orgId: string,
   userId: string,
   featureSwitchContext: FeatureSwitchContext,
+  snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorTokens | null> {
-  const [connector] = await db
-    .select({ needsReconnect: connectors.needsReconnect })
-    .from(connectors)
-    .where(
-      and(
-        eq(connectors.orgId, orgId),
-        eq(connectors.userId, userId),
-        eq(connectors.type, "google-drive"),
-      ),
-    )
-    .limit(1);
-  if (!connector) {
+  const loaded = await loadConnectorCredentialConnection({
+    db,
+    snapshot,
+    orgId,
+    userId,
+    connectorRef: "google-drive",
+  });
+  if (loaded.kind !== "ok") {
     return null;
   }
-
-  const secretRows = await db
-    .select({ name: secrets.name, encryptedValue: secrets.encryptedValue })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.orgId, orgId),
-        eq(secrets.userId, userId),
-        eq(secrets.type, SECRET_TYPE),
-      ),
-    );
-
-  let accessEncrypted: string | undefined;
-  let refreshEncrypted: string | undefined;
-  for (const row of secretRows) {
-    if (row.name === ACCESS_SECRET) {
-      accessEncrypted = row.encryptedValue;
-    }
-    if (row.name === REFRESH_SECRET) {
-      refreshEncrypted = row.encryptedValue;
-    }
-  }
-  if (!accessEncrypted) {
+  const connection = loaded.connection;
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    connection,
+    GOOGLE_DRIVE_ACCESS_TOKEN_ENVIRONMENT_NAME,
+  );
+  if (accessTokenValueRef === null) {
     return null;
   }
-
+  const values = await loadConnectorCredentialValues({
+    db,
+    orgId,
+    userId,
+    featureSwitchContext,
+    valueRefs: [accessTokenValueRef],
+  });
+  const accessToken = values.get(accessTokenValueRef);
+  if (!accessToken) {
+    return null;
+  }
   return {
-    accessToken: await decryptStoredSecretValue(
-      accessEncrypted,
-      featureSwitchContext,
-    ),
-    refreshToken: refreshEncrypted
-      ? await decryptStoredSecretValue(refreshEncrypted, featureSwitchContext)
-      : null,
-    needsReconnect: connector.needsReconnect,
+    accessToken,
+    connection,
+    needsReconnect: connection.needsReconnect,
   };
 }
 
-async function refreshDriveAccessToken(
-  refreshToken: string,
-): Promise<string | null> {
-  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return null;
-  }
-  const response = await fetch(GOOGLE_DRIVE_TOKEN_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      client_id: clientId,
-      client_secret: clientSecret,
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-    }),
+async function refreshDriveAccessToken(args: {
+  readonly connection: ConnectorCredentialConnection;
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+  readonly userId: string;
+}): Promise<string | null> {
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection: args.connection,
+    db: args.db,
+    featureSwitchContext: args.featureSwitchContext,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: GOOGLE_DRIVE_ACCESS_TOKEN_ENVIRONMENT_NAME,
+    signal: args.signal,
   });
-  if (!response.ok) {
-    return null;
-  }
-  const parsed = refreshResponseSchema.safeParse(await response.json());
-  if (!parsed.success || !parsed.data.access_token) {
-    return null;
-  }
-  return parsed.data.access_token;
+  return refreshed.kind === "ok" ? refreshed.accessToken : null;
 }
 
 type DriveListResult =
@@ -252,9 +229,13 @@ async function listArtifactFiles(args: {
 }
 
 async function listArtifactFilesWithRefresh(args: {
+  readonly db: ReadonlyDb;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly orgId: string;
   readonly tokens: ConnectorTokens;
   readonly threadId: string;
   readonly signal: AbortSignal;
+  readonly userId: string;
 }): Promise<z.infer<typeof driveFileSchema>[] | "unauthorized"> {
   const first = await listArtifactFiles({
     accessToken: args.tokens.accessToken,
@@ -264,12 +245,14 @@ async function listArtifactFilesWithRefresh(args: {
   if (first.type === "ok") {
     return first.files;
   }
-  if (!args.tokens.refreshToken) {
-    return "unauthorized";
-  }
-  const refreshedAccessToken = await refreshDriveAccessToken(
-    args.tokens.refreshToken,
-  );
+  const refreshedAccessToken = await refreshDriveAccessToken({
+    connection: args.tokens.connection,
+    db: args.db,
+    featureSwitchContext: args.featureSwitchContext,
+    orgId: args.orgId,
+    signal: args.signal,
+    userId: args.userId,
+  });
   if (!refreshedAccessToken) {
     return "unauthorized";
   }
@@ -342,15 +325,12 @@ export function applyGoogleDriveArtifactSyncStatuses(
 /**
  * Compute the Drive sync status lookup for a chat thread's artifacts.
  *
- * Scoped to Google Drive only (no generic provider registry) since this is the
- * sole API consumer of OAuth refresh today.
- *
- * Token persistence is intentionally deferred. When the in-flight access
- * token is rejected and the refresh succeeds, the new token is used for
- * the retry but is NOT written back to `secrets`; the next request will
- * refresh again. Keeps the route handler a read-only `computed`. Drive
- * status check is a UI poll, not a hot path; refresh tokens don't rotate
- * (Google), so the cost is one extra RTT per stale-token request.
+ * Token persistence is intentionally deferred. The selected runtime method is
+ * still rechecked through the provider registry, but a successful refresh is
+ * used only for this retry and is not written back to connector storage. This
+ * keeps the route handler a read-only `computed`. Drive status check is a UI
+ * poll, not a hot path; refresh tokens don't rotate (Google), so the cost is
+ * one extra RTT per stale-token request.
  * Track in epic #12290 follow-up if telemetry shows this matters.
  */
 export function googleDriveArtifactStatusLookup(args: {
@@ -374,11 +354,19 @@ export function googleDriveArtifactStatusLookup(args: {
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
-    const tokens = await loadDriveTokens(db, args.orgId, args.userId, {
+    const featureSwitchContext = {
       orgId: args.orgId,
       userId: args.userId,
       overrides: featureSwitchOverrides,
-    });
+    };
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    const tokens = await loadDriveTokens(
+      db,
+      args.orgId,
+      args.userId,
+      featureSwitchContext,
+      snapshot,
+    );
     if (!tokens || tokens.needsReconnect) {
       return { type: "disconnected" };
     }
@@ -388,9 +376,13 @@ export function googleDriveArtifactStatusLookup(args: {
     // swallowing aborts.
     const files = await tapError(
       listArtifactFilesWithRefresh({
+        db,
+        featureSwitchContext,
+        orgId: args.orgId,
         tokens,
         threadId: args.threadId,
         signal: AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
+        userId: args.userId,
       }),
     );
     if (files === undefined) {
@@ -1090,11 +1082,20 @@ export const syncArtifactToGoogleDrive$ = command(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens(db, args.orgId, args.userId, {
+    const featureSwitchContext = {
       orgId: args.orgId,
       userId: args.userId,
       overrides: featureSwitchOverrides,
-    });
+    };
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+    const tokens = await loadDriveTokens(
+      db,
+      args.orgId,
+      args.userId,
+      featureSwitchContext,
+      snapshot,
+    );
     signal.throwIfAborted();
     if (!tokens || tokens.needsReconnect) {
       return badRequestMessage("Connect Google Drive before syncing artifacts");
@@ -1152,8 +1153,15 @@ export const syncArtifactToGoogleDrive$ = command(
     });
     signal.throwIfAborted();
 
-    if (result.type === "unauthorized" && tokens.refreshToken) {
-      const refreshed = await refreshDriveAccessToken(tokens.refreshToken);
+    if (result.type === "unauthorized") {
+      const refreshed = await refreshDriveAccessToken({
+        connection: tokens.connection,
+        db,
+        featureSwitchContext,
+        orgId: args.orgId,
+        signal,
+        userId: args.userId,
+      });
       signal.throwIfAborted();
       if (refreshed) {
         result = await uploadArtifactWithToken({
@@ -1380,11 +1388,20 @@ export const uploadPresentationToGoogleSlides$ = command(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
     signal.throwIfAborted();
-    const tokens = await loadDriveTokens(db, args.orgId, args.userId, {
+    const featureSwitchContext = {
       orgId: args.orgId,
       userId: args.userId,
       overrides: featureSwitchOverrides,
-    });
+    };
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+    const tokens = await loadDriveTokens(
+      db,
+      args.orgId,
+      args.userId,
+      featureSwitchContext,
+      snapshot,
+    );
     signal.throwIfAborted();
     if (!tokens || tokens.needsReconnect) {
       return badRequestMessage(
@@ -1408,8 +1425,15 @@ export const uploadPresentationToGoogleSlides$ = command(
     });
     signal.throwIfAborted();
 
-    if (result.type === "unauthorized" && tokens.refreshToken) {
-      const refreshed = await refreshDriveAccessToken(tokens.refreshToken);
+    if (result.type === "unauthorized") {
+      const refreshed = await refreshDriveAccessToken({
+        connection: tokens.connection,
+        db,
+        featureSwitchContext,
+        orgId: args.orgId,
+        signal,
+        userId: args.userId,
+      });
       signal.throwIfAborted();
       if (refreshed) {
         result = await uploadSlidesWithToken({

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -6,13 +6,10 @@ import { and, eq, lte, or } from "drizzle-orm";
 import { z } from "zod";
 
 import { googleMeetTranscriptGeneratedEventConfigSchema } from "@vm0/api-contracts/contracts/zero-workflows";
-import { refreshGoogleToken } from "@vm0/connectors/auth-providers/oauth/google";
-import { connectors } from "@vm0/db/schema/connector";
 import {
   googleWorkspaceEventSubscriptionStates,
   googleWorkspaceProcessedEvents,
 } from "@vm0/db/schema/google-workspace-event";
-import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -25,10 +22,14 @@ import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { safeJsonParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
-  decryptStoredSecretValue,
-  encryptStoredSecretValue,
-} from "./crypto.utils";
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  markConnectorCredentialNeedsReconnect,
+  refreshConnectorCredentialAccess,
+} from "./connector-credential-runtime.service";
 import {
   WorkflowEventSourceTiming,
   type WorkflowEventRunTiming,
@@ -42,9 +43,7 @@ import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automat
 
 const log = logger("api:google-meet-workflow-event");
 
-const GOOGLE_MEET_ACCESS_TOKEN_SECRET = "GOOGLE_MEET_ACCESS_TOKEN";
-const GOOGLE_MEET_REFRESH_TOKEN_SECRET = "GOOGLE_MEET_REFRESH_TOKEN";
-const CONNECTOR_SECRET_TYPE = "connector";
+const GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_MEET_TOKEN";
 const GOOGLE_WORKSPACE_EVENTS_API_BASE =
   "https://workspaceevents.googleapis.com/v1";
 const GOOGLE_MEET_TRANSCRIPT_GENERATED_EVENT_TYPE =
@@ -143,24 +142,6 @@ type GoogleMeetAccessResult =
   | { readonly kind: "ok"; readonly access: GoogleMeetAccess }
   | { readonly kind: "bad_request"; readonly message: string };
 
-interface GoogleMeetConnectorAccessRow {
-  readonly id: string;
-  readonly externalId: string | null;
-  readonly externalEmail: string | null;
-  readonly tokenExpiresAt: Date | null;
-  readonly needsReconnect: boolean;
-}
-
-interface ConnectorSecretRow {
-  readonly name: string;
-  readonly encryptedValue: string;
-}
-
-interface GoogleMeetConnectorSecrets {
-  readonly accessSecret: ConnectorSecretRow | null;
-  readonly refreshSecret: ConnectorSecretRow | null;
-}
-
 interface WorkspaceEventsFetchOk<T> {
   readonly kind: "ok";
   readonly value: T;
@@ -233,15 +214,6 @@ function tokenNeedsRefresh(
   );
 }
 
-function tokenExpiresAtFromExpiresIn(
-  expiresIn: number | undefined,
-  currentTime: Date,
-): Date | null {
-  return expiresIn === undefined
-    ? null
-    : new Date(currentTime.getTime() + expiresIn * 1000);
-}
-
 function googleWorkspaceEventsTopicName():
   | { readonly kind: "ok"; readonly topicName: string }
   | { readonly kind: "bad_request"; readonly message: string } {
@@ -254,170 +226,6 @@ function googleWorkspaceEventsTopicName():
       };
 }
 
-async function loadGoogleMeetConnector(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId?: string;
-  readonly signal: AbortSignal;
-}): Promise<GoogleMeetConnectorAccessRow | null> {
-  const connectorConditions = [
-    eq(connectors.orgId, args.orgId),
-    eq(connectors.userId, args.userId),
-    eq(connectors.type, "google-meet"),
-  ];
-  if (args.connectorId !== undefined) {
-    connectorConditions.push(eq(connectors.id, args.connectorId));
-  }
-
-  const [connector] = await args.db
-    .select({
-      id: connectors.id,
-      externalId: connectors.externalId,
-      externalEmail: connectors.externalEmail,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      needsReconnect: connectors.needsReconnect,
-    })
-    .from(connectors)
-    .where(and(...connectorConditions))
-    .limit(1);
-  args.signal.throwIfAborted();
-
-  return connector ?? null;
-}
-
-async function loadGoogleMeetConnectorSecrets(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): Promise<GoogleMeetConnectorSecrets> {
-  const secretRows = await args.db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  return {
-    accessSecret:
-      secretRows.find((row) => {
-        return row.name === GOOGLE_MEET_ACCESS_TOKEN_SECRET;
-      }) ?? null,
-    refreshSecret:
-      secretRows.find((row) => {
-        return row.name === GOOGLE_MEET_REFRESH_TOKEN_SECRET;
-      }) ?? null,
-  };
-}
-
-async function markGoogleMeetConnectorNeedsReconnect(args: {
-  readonly db: Db;
-  readonly connectorId: string;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db
-    .update(connectors)
-    .set({ needsReconnect: true, updatedAt: args.currentTime })
-    .where(eq(connectors.id, args.connectorId));
-  args.signal.throwIfAborted();
-}
-
-async function refreshGoogleMeetAccessToken(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connector: GoogleMeetConnectorAccessRow;
-  readonly refreshSecret: ConnectorSecretRow;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<GoogleMeetAccessResult> {
-  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return {
-      kind: "bad_request",
-      message: "Google OAuth client env vars are not configured",
-    };
-  }
-
-  const refreshToken = await decryptStoredSecretValue(
-    args.refreshSecret.encryptedValue,
-  );
-  const refreshed = await tapError(
-    refreshGoogleToken(
-      "google-meet",
-      clientId,
-      clientSecret,
-      refreshToken,
-      args.signal,
-    ),
-  );
-  args.signal.throwIfAborted();
-  if (!refreshed) {
-    await markGoogleMeetConnectorNeedsReconnect({
-      db: args.db,
-      connectorId: args.connector.id,
-      currentTime: args.currentTime,
-      signal: args.signal,
-    });
-    return {
-      kind: "bad_request",
-      message:
-        "Reconnect Google Meet before using Google Meet event automations",
-    };
-  }
-
-  const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshed.expiresIn,
-    args.currentTime,
-  );
-  await args.db
-    .update(secretsTable)
-    .set({
-      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
-      updatedAt: args.currentTime,
-    })
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-        eq(secretsTable.name, GOOGLE_MEET_ACCESS_TOKEN_SECRET),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  await args.db
-    .update(connectors)
-    .set({
-      tokenExpiresAt,
-      needsReconnect: false,
-      updatedAt: args.currentTime,
-    })
-    .where(eq(connectors.id, args.connector.id));
-  args.signal.throwIfAborted();
-
-  return {
-    kind: "ok",
-    access: {
-      connectorId: args.connector.id,
-      externalId: args.connector.externalId,
-      emailAddress: args.connector.externalEmail,
-      accessToken: refreshed.accessToken,
-    },
-  };
-}
-
 async function resolveGoogleMeetAccess(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -426,51 +234,90 @@ async function resolveGoogleMeetAccess(args: {
   readonly signal: AbortSignal;
 }): Promise<GoogleMeetAccessResult> {
   const currentTime = nowDate();
-  const connector = await loadGoogleMeetConnector(args);
-  if (!connector) {
+  const snapshot = await loadConnectorRuntimeSnapshot(args.db);
+  args.signal.throwIfAborted();
+  const loaded = await loadConnectorCredentialConnection({
+    db: args.db,
+    snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorRef: "google-meet",
+    ...(args.connectorId === undefined
+      ? {}
+      : { connectorId: args.connectorId }),
+  });
+  args.signal.throwIfAborted();
+  if (loaded.kind === "missing") {
     return {
       kind: "bad_request",
       message:
         "Connect Google Meet before adding a Google Meet event automation",
     };
   }
-  if (connector.needsReconnect) {
+  if (loaded.kind === "unavailable" || loaded.connection.needsReconnect) {
     return {
       kind: "bad_request",
       message:
         "Reconnect Google Meet before using Google Meet event automations",
     };
   }
-
-  const { accessSecret, refreshSecret } =
-    await loadGoogleMeetConnectorSecrets(args);
-  if (!accessSecret) {
+  const connection = loaded.connection;
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    connection,
+    GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME,
+  );
+  if (accessTokenValueRef === null) {
     return {
       kind: "bad_request",
       message:
         "Reconnect Google Meet before using Google Meet event automations",
     };
   }
-
-  if (!tokenNeedsRefresh(connector.tokenExpiresAt, currentTime)) {
+  const values = await loadConnectorCredentialValues({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    valueRefs: [accessTokenValueRef],
+  });
+  args.signal.throwIfAborted();
+  const accessToken = values.get(accessTokenValueRef);
+  if (!accessToken) {
+    return {
+      kind: "bad_request",
+      message:
+        "Reconnect Google Meet before using Google Meet event automations",
+    };
+  }
+  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
     return {
       kind: "ok",
       access: {
-        connectorId: connector.id,
-        externalId: connector.externalId,
-        emailAddress: connector.externalEmail,
-        accessToken: await decryptStoredSecretValue(
-          accessSecret.encryptedValue,
-        ),
+        connectorId: connection.connectorId,
+        externalId: connection.externalId,
+        emailAddress: connection.externalEmail,
+        accessToken,
       },
     };
   }
-
-  if (!refreshSecret) {
-    await markGoogleMeetConnectorNeedsReconnect({
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection,
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME,
+    signal: args.signal,
+    persist: { db: args.db },
+  });
+  if (refreshed.kind === "configuration-unavailable") {
+    return {
+      kind: "bad_request",
+      message: "Google OAuth client env vars are not configured",
+    };
+  }
+  if (refreshed.kind !== "ok") {
+    await markConnectorCredentialNeedsReconnect({
       db: args.db,
-      connectorId: connector.id,
-      currentTime,
+      connectorId: connection.connectorId,
       signal: args.signal,
     });
     return {
@@ -479,16 +326,15 @@ async function resolveGoogleMeetAccess(args: {
         "Reconnect Google Meet before using Google Meet event automations",
     };
   }
-
-  return await refreshGoogleMeetAccessToken({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    connector,
-    refreshSecret,
-    currentTime,
-    signal: args.signal,
-  });
+  return {
+    kind: "ok",
+    access: {
+      connectorId: connection.connectorId,
+      externalId: connection.externalId,
+      emailAddress: connection.externalEmail,
+      accessToken: refreshed.accessToken,
+    },
+  };
 }
 
 function workspaceEventsApiUrl(path: string): string {

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -27,7 +27,6 @@ import {
   connectorCredentialRuntimeValueRef,
   loadConnectorCredentialConnection,
   loadConnectorCredentialValues,
-  markConnectorCredentialNeedsReconnect,
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
@@ -306,7 +305,7 @@ async function resolveGoogleMeetAccess(args: {
     userId: args.userId,
     runtimeEnvironmentName: GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME,
     signal: args.signal,
-    persist: { db: args.db },
+    persist: { db: args.db, markNeedsReconnectOnFailure: true },
   });
   if (refreshed.kind === "configuration-unavailable") {
     return {
@@ -315,11 +314,6 @@ async function resolveGoogleMeetAccess(args: {
     };
   }
   if (refreshed.kind !== "ok") {
-    await markConnectorCredentialNeedsReconnect({
-      db: args.db,
-      connectorId: connection.connectorId,
-      signal: args.signal,
-    });
     return {
       kind: "bad_request",
       message:

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -17,9 +17,11 @@ import { getOAuthWebOrigin } from "../routes/oauth-web-origin";
 import {
   buildGithubUserConnectAuthorizationUrl,
   findGithubInstallationByInstallationId,
+  getGithubOAuthAuthMethod,
   linkGithubVm0User,
   verifyGithubConnectSignature,
 } from "./github-oauth.service";
+import { userConnectorActionResolver } from "./connector-action-resolver.service";
 
 function errorResponse(status: 400 | 404 | 409, message: string, code: string) {
   return { status, body: { error: { message, code } } };
@@ -211,13 +213,26 @@ export const getGithubInstallation$ = command(
           });
     signal.throwIfAborted();
 
+    const resolver = await get(
+      userConnectorActionResolver(auth.orgId, auth.userId),
+    );
+    signal.throwIfAborted();
+    const resolvedMethod = await resolver.resolveMethod({
+      connectorRef: "github",
+      authMethodId: getGithubOAuthAuthMethod(),
+      expectedGrantKind: "auth-code",
+      requireAvailable: true,
+    });
+    signal.throwIfAborted();
     const connectUrl =
-      link === null
+      link === null && resolvedMethod.ok
         ? ((await buildGithubUserConnectAuthorizationUrl({
             db,
             vm0UserId: auth.userId,
             orgId: auth.orgId,
             origin,
+            authMethodId: resolvedMethod.authMethodId,
+            method: resolvedMethod.method,
             readEnv: optionalEnv,
             signal,
           })) ?? githubConnectStartUrl(origin))

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -21,7 +21,7 @@ import {
   linkGithubVm0User,
   verifyGithubConnectSignature,
 } from "./github-oauth.service";
-import { userConnectorActionResolver } from "./connector-action-resolver.service";
+import { connectorActionResolver } from "./connector-action-resolver.service";
 
 function errorResponse(status: 400 | 404 | 409, message: string, code: string) {
   return { status, body: { error: { message, code } } };
@@ -213,15 +213,12 @@ export const getGithubInstallation$ = command(
           });
     signal.throwIfAborted();
 
-    const resolver = await get(
-      userConnectorActionResolver(auth.orgId, auth.userId),
-    );
+    const resolver = await get(connectorActionResolver());
     signal.throwIfAborted();
-    const resolvedMethod = await resolver.resolveMethod({
+    const resolvedMethod = await resolver.resolveNewActionMethod({
       connectorRef: "github",
       authMethodId: getGithubOAuthAuthMethod(),
       expectedGrantKind: "auth-code",
-      requireAvailable: true,
     });
     signal.throwIfAborted();
     const connectUrl =

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -15,15 +15,12 @@ import {
   type NotionPageContentUpdatedScope,
   type NotionPageReference,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import { refreshNotionToken } from "@vm0/connectors/auth-providers/connectors/notion/oauth";
-import { connectors } from "@vm0/db/schema/connector";
 import {
   notionWebhookEvents,
   notionWebhookSecrets,
   notionWorkflowPendingEvents,
   type NotionWorkflowPendingEventContext,
 } from "@vm0/db/schema/notion-event";
-import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -33,12 +30,19 @@ import { command } from "ccstate";
 import { and, asc, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { safeJsonParse, safeUrlParse, tapError } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import {
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  markConnectorCredentialNeedsReconnect,
+  refreshConnectorCredentialAccess,
+} from "./connector-credential-runtime.service";
 import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
@@ -53,9 +57,7 @@ import {
 
 const log = logger("api:notion-workflow-event");
 
-const NOTION_ACCESS_TOKEN_SECRET = "NOTION_ACCESS_TOKEN";
-const NOTION_REFRESH_TOKEN_SECRET = "NOTION_REFRESH_TOKEN";
-const CONNECTOR_SECRET_TYPE = "connector";
+const NOTION_ACCESS_TOKEN_ENVIRONMENT_NAME = "NOTION_TOKEN";
 const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_VERSION = "2026-03-11";
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -247,22 +249,6 @@ function notionPendingEventColumns() {
   };
 }
 
-interface ConnectorSecretRow {
-  readonly name: string;
-  readonly encryptedValue: string;
-}
-
-interface NotionConnectorAccessRow {
-  readonly id: string;
-  readonly tokenExpiresAt: Date | null;
-  readonly needsReconnect: boolean;
-}
-
-interface NotionConnectorSecrets {
-  readonly accessSecret: ConnectorSecretRow | null;
-  readonly refreshSecret: ConnectorSecretRow | null;
-}
-
 interface NotionAccess {
   readonly connectorId: string;
   readonly accessToken: string;
@@ -336,15 +322,6 @@ function tokenNeedsRefresh(tokenExpiresAt: Date | null, currentTime: Date) {
   return (
     tokenExpiresAt.getTime() <= currentTime.getTime() + TOKEN_REFRESH_BUFFER_MS
   );
-}
-
-function tokenExpiresAtFromExpiresIn(
-  expiresIn: number | undefined,
-  currentTime: Date,
-): Date | null {
-  return expiresIn === undefined
-    ? null
-    : new Date(currentTime.getTime() + expiresIn * 1000);
 }
 
 function normalizeNotionUuid(value: string): string | null {
@@ -484,175 +461,6 @@ function notionEventContext(
   };
 }
 
-async function loadNotionConnector(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId?: string;
-  readonly signal: AbortSignal;
-}): Promise<NotionConnectorAccessRow | null> {
-  const connectorConditions = [
-    eq(connectors.orgId, args.orgId),
-    eq(connectors.userId, args.userId),
-    eq(connectors.type, "notion"),
-  ];
-  if (args.connectorId !== undefined) {
-    connectorConditions.push(eq(connectors.id, args.connectorId));
-  }
-
-  const [connector] = await args.db
-    .select({
-      id: connectors.id,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      needsReconnect: connectors.needsReconnect,
-    })
-    .from(connectors)
-    .where(and(...connectorConditions))
-    .limit(1);
-  args.signal.throwIfAborted();
-  return connector ?? null;
-}
-
-async function loadNotionConnectorSecrets(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-}): Promise<NotionConnectorSecrets> {
-  const secretRows = await args.db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-      ),
-    );
-  args.signal.throwIfAborted();
-  return {
-    accessSecret:
-      secretRows.find((row) => {
-        return row.name === NOTION_ACCESS_TOKEN_SECRET;
-      }) ?? null,
-    refreshSecret:
-      secretRows.find((row) => {
-        return row.name === NOTION_REFRESH_TOKEN_SECRET;
-      }) ?? null,
-  };
-}
-
-async function markNotionConnectorNeedsReconnect(args: {
-  readonly db: Db;
-  readonly connectorId: string;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<void> {
-  await args.db
-    .update(connectors)
-    .set({ needsReconnect: true, updatedAt: args.currentTime })
-    .where(eq(connectors.id, args.connectorId));
-  args.signal.throwIfAborted();
-}
-
-async function refreshNotionAccessToken(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connector: NotionConnectorAccessRow;
-  readonly refreshSecret: ConnectorSecretRow;
-  readonly currentTime: Date;
-  readonly signal: AbortSignal;
-}): Promise<NotionAccessResult> {
-  const clientId = optionalEnv("NOTION_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("NOTION_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return {
-      kind: "bad_request",
-      message: "Notion OAuth client env vars are not configured",
-    };
-  }
-
-  const refreshToken = await decryptStoredSecretValue(
-    args.refreshSecret.encryptedValue,
-  );
-  const refreshed = await tapError(
-    refreshNotionToken(clientId, clientSecret, refreshToken, args.signal),
-  );
-  args.signal.throwIfAborted();
-  if (!refreshed) {
-    await markNotionConnectorNeedsReconnect({
-      db: args.db,
-      connectorId: args.connector.id,
-      currentTime: args.currentTime,
-      signal: args.signal,
-    });
-    return {
-      kind: "bad_request",
-      message: "Reconnect Notion before using Notion event automations",
-    };
-  }
-
-  const tokenExpiresAt = tokenExpiresAtFromExpiresIn(
-    refreshed.expiresIn,
-    args.currentTime,
-  );
-  await args.db
-    .update(secretsTable)
-    .set({
-      encryptedValue: await encryptStoredSecretValue(refreshed.accessToken),
-      updatedAt: args.currentTime,
-    })
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-        eq(secretsTable.name, NOTION_ACCESS_TOKEN_SECRET),
-      ),
-    );
-  args.signal.throwIfAborted();
-
-  if (refreshed.refreshToken) {
-    await args.db
-      .update(secretsTable)
-      .set({
-        encryptedValue: await encryptStoredSecretValue(refreshed.refreshToken),
-        updatedAt: args.currentTime,
-      })
-      .where(
-        and(
-          eq(secretsTable.orgId, args.orgId),
-          eq(secretsTable.userId, args.userId),
-          eq(secretsTable.type, CONNECTOR_SECRET_TYPE),
-          eq(secretsTable.name, NOTION_REFRESH_TOKEN_SECRET),
-        ),
-      );
-    args.signal.throwIfAborted();
-  }
-
-  await args.db
-    .update(connectors)
-    .set({
-      tokenExpiresAt,
-      needsReconnect: false,
-      updatedAt: args.currentTime,
-    })
-    .where(eq(connectors.id, args.connector.id));
-  args.signal.throwIfAborted();
-
-  return {
-    kind: "ok",
-    access: {
-      connectorId: args.connector.id,
-      accessToken: refreshed.accessToken,
-    },
-  };
-}
-
 async function resolveNotionAccess(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -661,46 +469,84 @@ async function resolveNotionAccess(args: {
   readonly signal: AbortSignal;
 }): Promise<NotionAccessResult> {
   const currentTime = nowDate();
-  const connector = await loadNotionConnector(args);
-  if (!connector) {
+  const snapshot = await loadConnectorRuntimeSnapshot(args.db);
+  args.signal.throwIfAborted();
+  const loaded = await loadConnectorCredentialConnection({
+    db: args.db,
+    snapshot,
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorRef: "notion",
+    ...(args.connectorId === undefined
+      ? {}
+      : { connectorId: args.connectorId }),
+  });
+  args.signal.throwIfAborted();
+  if (loaded.kind === "missing") {
     return {
       kind: "bad_request",
       message: "Connect Notion before adding a Notion event automation",
     };
   }
-  if (connector.needsReconnect) {
+  if (loaded.kind === "unavailable" || loaded.connection.needsReconnect) {
     return {
       kind: "bad_request",
       message: "Reconnect Notion before using Notion event automations",
     };
   }
-
-  const { accessSecret, refreshSecret } =
-    await loadNotionConnectorSecrets(args);
-  if (!accessSecret) {
+  const connection = loaded.connection;
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    connection,
+    NOTION_ACCESS_TOKEN_ENVIRONMENT_NAME,
+  );
+  if (accessTokenValueRef === null) {
     return {
       kind: "bad_request",
       message: "Reconnect Notion before using Notion event automations",
     };
   }
-
-  if (!tokenNeedsRefresh(connector.tokenExpiresAt, currentTime)) {
+  const values = await loadConnectorCredentialValues({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    valueRefs: [accessTokenValueRef],
+  });
+  args.signal.throwIfAborted();
+  const accessToken = values.get(accessTokenValueRef);
+  if (!accessToken) {
+    return {
+      kind: "bad_request",
+      message: "Reconnect Notion before using Notion event automations",
+    };
+  }
+  if (!tokenNeedsRefresh(connection.tokenExpiresAt, currentTime)) {
     return {
       kind: "ok",
       access: {
-        connectorId: connector.id,
-        accessToken: await decryptStoredSecretValue(
-          accessSecret.encryptedValue,
-        ),
+        connectorId: connection.connectorId,
+        accessToken,
       },
     };
   }
-
-  if (!refreshSecret) {
-    await markNotionConnectorNeedsReconnect({
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection,
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: NOTION_ACCESS_TOKEN_ENVIRONMENT_NAME,
+    signal: args.signal,
+    persist: { db: args.db },
+  });
+  if (refreshed.kind === "configuration-unavailable") {
+    return {
+      kind: "bad_request",
+      message: "Notion OAuth client env vars are not configured",
+    };
+  }
+  if (refreshed.kind !== "ok") {
+    await markConnectorCredentialNeedsReconnect({
       db: args.db,
-      connectorId: connector.id,
-      currentTime,
+      connectorId: connection.connectorId,
       signal: args.signal,
     });
     return {
@@ -708,16 +554,13 @@ async function resolveNotionAccess(args: {
       message: "Reconnect Notion before using Notion event automations",
     };
   }
-
-  return await refreshNotionAccessToken({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    connector,
-    refreshSecret,
-    currentTime,
-    signal: args.signal,
-  });
+  return {
+    kind: "ok",
+    access: {
+      connectorId: connection.connectorId,
+      accessToken: refreshed.accessToken,
+    },
+  };
 }
 
 async function notionFetchJson<T>(

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -40,7 +40,6 @@ import {
   connectorCredentialRuntimeValueRef,
   loadConnectorCredentialConnection,
   loadConnectorCredentialValues,
-  markConnectorCredentialNeedsReconnect,
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
@@ -535,7 +534,7 @@ async function resolveNotionAccess(args: {
     userId: args.userId,
     runtimeEnvironmentName: NOTION_ACCESS_TOKEN_ENVIRONMENT_NAME,
     signal: args.signal,
-    persist: { db: args.db },
+    persist: { db: args.db, markNeedsReconnectOnFailure: true },
   });
   if (refreshed.kind === "configuration-unavailable") {
     return {
@@ -544,11 +543,6 @@ async function resolveNotionAccess(args: {
     };
   }
   if (refreshed.kind !== "ok") {
-    await markConnectorCredentialNeedsReconnect({
-      db: args.db,
-      connectorId: connection.connectorId,
-      signal: args.signal,
-    });
     return {
       kind: "bad_request",
       message: "Reconnect Notion before using Notion event automations",

--- a/turbo/apps/api/src/signals/services/steam-player.service.ts
+++ b/turbo/apps/api/src/signals/services/steam-player.service.ts
@@ -1,13 +1,16 @@
 import { command } from "ccstate";
 import type { ZeroSteamPlayerResponse } from "@vm0/api-contracts/contracts/zero-steam-player";
-import { connectors } from "@vm0/db/schema/connector";
-import { variables } from "@vm0/db/schema/variable";
-import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { db$ } from "../external/db";
 import { safeJsonParse, tapError } from "../utils";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import {
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+} from "./connector-credential-runtime.service";
 
 class SteamUpstreamError extends Error {
   constructor(message: string) {
@@ -380,31 +383,34 @@ export const steamPlayerData$ = command(
     signal: AbortSignal,
   ): Promise<ZeroSteamPlayerResponse | null> => {
     const db = get(db$);
-    const [row] = await db
-      .select({ steamId: variables.value })
-      .from(connectors)
-      .innerJoin(
-        variables,
-        and(
-          eq(variables.orgId, connectors.orgId),
-          eq(variables.userId, connectors.userId),
-          eq(variables.type, "connector"),
-          eq(variables.name, "STEAM_ID"),
-        ),
-      )
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.type, "steam"),
-          eq(connectors.authMethod, "openid"),
-          eq(connectors.needsReconnect, false),
-        ),
-      )
-      .limit(1);
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
-
-    const steamId = row?.steamId;
+    const loaded = await loadConnectorCredentialConnection({
+      db,
+      snapshot,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorRef: "steam",
+    });
+    signal.throwIfAborted();
+    if (loaded.kind !== "ok" || loaded.connection.needsReconnect) {
+      return null;
+    }
+    const steamIdValueRef = connectorCredentialRuntimeValueRef(
+      loaded.connection,
+      "STEAM_ID",
+    );
+    if (steamIdValueRef === null) {
+      return null;
+    }
+    const values = await loadConnectorCredentialValues({
+      db,
+      orgId: args.orgId,
+      userId: args.userId,
+      valueRefs: [steamIdValueRef],
+    });
+    signal.throwIfAborted();
+    const steamId = values.get(steamIdValueRef);
     if (!steamId || !STEAM_ID_PATTERN.test(steamId)) {
       return null;
     }

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -1,4 +1,4 @@
-import { connectorTypeSchema } from "@vm0/connectors/connectors";
+import { connectorCatalogRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   agentComposes,
   agentComposeVersions,
@@ -50,6 +50,7 @@ import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { cleanupOrgMemberResources } from "./org-member-cleanup.service";
 import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 
 const L = logger("WebhookClerkCleanup");
 const CLERK_ORG_MEMBERSHIP_PAGE_SIZE = 100;
@@ -359,6 +360,8 @@ const revokeOrgConnectorTokens$ = command(
     orgId: string,
     signal: AbortSignal,
   ): Promise<void> => {
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const rows = await db
       .select({ userId: connectors.userId, type: connectors.type })
       .from(connectors)
@@ -366,7 +369,7 @@ const revokeOrgConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorTypeSchema.safeParse(row.type);
+      const parsed = connectorCatalogRefSchema.safeParse(row.type);
       if (!parsed.success) {
         L.warn("unknown connector type, skipping revocation", {
           orgId,
@@ -377,7 +380,7 @@ const revokeOrgConnectorTokens$ = command(
 
       await set(
         deleteZeroConnectorLocalState$,
-        { orgId, userId: row.userId, type: parsed.data },
+        { orgId, userId: row.userId, type: parsed.data, snapshot },
         signal,
       );
     }
@@ -391,6 +394,8 @@ const revokeUserConnectorTokens$ = command(
     userId: string,
     signal: AbortSignal,
   ): Promise<void> => {
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const rows = await db
       .select({ orgId: connectors.orgId, type: connectors.type })
       .from(connectors)
@@ -398,7 +403,7 @@ const revokeUserConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorTypeSchema.safeParse(row.type);
+      const parsed = connectorCatalogRefSchema.safeParse(row.type);
       if (!parsed.success) {
         L.warn("unknown connector type, skipping revocation", {
           userId,
@@ -409,7 +414,7 @@ const revokeUserConnectorTokens$ = command(
 
       await set(
         deleteZeroConnectorLocalState$,
-        { orgId: row.orgId, userId, type: parsed.data },
+        { orgId: row.orgId, userId, type: parsed.data, snapshot },
         signal,
       );
     }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -700,6 +700,25 @@ function resolveTokenRevokeRuntimeMethod(args: {
     : null;
 }
 
+function requireStoredConnectorRuntimeMethod(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly type: string;
+  readonly authMethod: string;
+}): ConnectorRuntimeMethod {
+  const runtimeMethod = getConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    requireExecutable: false,
+  });
+  if (runtimeMethod === undefined) {
+    throw new Error(
+      `Current connector catalog cannot describe stored method ${args.type}:${args.authMethod}`,
+    );
+  }
+  return runtimeMethod;
+}
+
 function resolveReplaceTokenRevokeRuntimeMethod(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly type: string;
@@ -812,20 +831,16 @@ async function deleteManualGrantConnectorLocalStateForAuthMethods(args: {
 
   for (const authMethod of cleanupAuthMethods) {
     args.signal.throwIfAborted();
-    const runtimeMethod = getConnectorRuntimeMethod({
+    const runtimeMethod = requireStoredConnectorRuntimeMethod({
       snapshot: args.snapshot,
-      connectorRef: args.type,
-      authMethodId: authMethod,
-      requireExecutable: false,
+      type: args.type,
+      authMethod,
     });
     await deleteManualGrantConnectorLocalState({
       db: args.db,
       orgId: args.orgId,
       userId: args.userId,
-      fields:
-        runtimeMethod === undefined
-          ? null
-          : connectorAuthMethodManualGrantFieldNames(runtimeMethod.method),
+      fields: connectorAuthMethodManualGrantFieldNames(runtimeMethod.method),
       signal: args.signal,
     });
   }
@@ -888,6 +903,9 @@ export const deleteZeroConnectorLocalState$ = command(
         authMethodId: existing.authMethod,
         requireExecutable: false,
       });
+      if (existingRuntimeMethod === undefined) {
+        return { deleted: false, pendingTokenRevoke: null };
+      }
 
       let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
       const tokenRevokeRuntimeMethod = resolveTokenRevokeRuntimeMethod({
@@ -914,7 +932,7 @@ export const deleteZeroConnectorLocalState$ = command(
         orgId: args.orgId,
         userId: args.userId,
         names: connectorAuthMethodOwnedSecretNames(
-          existingRuntimeMethod?.method,
+          existingRuntimeMethod.method,
         ),
         signal,
       });
@@ -922,7 +940,7 @@ export const deleteZeroConnectorLocalState$ = command(
         orgId: args.orgId,
         userId: args.userId,
         names: connectorAuthMethodOwnedVariableNames(
-          existingRuntimeMethod?.method,
+          existingRuntimeMethod.method,
         ),
         signal,
       });
@@ -1199,11 +1217,10 @@ async function cleanupExistingStoredConnectorForLocalConnect(
   }
 
   let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-  const existingRuntimeMethod = getConnectorRuntimeMethod({
+  const existingRuntimeMethod = requireStoredConnectorRuntimeMethod({
     snapshot: args.snapshot,
-    connectorRef: args.type,
-    authMethodId: existing.authMethod,
-    requireExecutable: false,
+    type: args.type,
+    authMethod: existing.authMethod,
   });
   const tokenRevokeRuntimeMethod = resolveTokenRevokeRuntimeMethod({
     snapshot: args.snapshot,
@@ -1224,13 +1241,13 @@ async function cleanupExistingStoredConnectorForLocalConnect(
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: connectorAuthMethodOwnedSecretNames(existingRuntimeMethod?.method),
+    names: connectorAuthMethodOwnedSecretNames(existingRuntimeMethod.method),
     signal: args.signal,
   });
   await deleteConnectorScopedVariableNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: connectorAuthMethodOwnedVariableNames(existingRuntimeMethod?.method),
+    names: connectorAuthMethodOwnedVariableNames(existingRuntimeMethod.method),
     signal: args.signal,
   });
 
@@ -2004,11 +2021,10 @@ async function commitConnectorTokenConnection(args: {
     signal: args.signal,
   });
   const existingRuntimeMethod = existingAuthMethod
-    ? getConnectorRuntimeMethod({
+    ? requireStoredConnectorRuntimeMethod({
         snapshot: args.snapshot,
-        connectorRef: args.runtimeMethod.connectorRef,
-        authMethodId: existingAuthMethod,
-        requireExecutable: false,
+        type: args.runtimeMethod.connectorRef,
+        authMethod: existingAuthMethod,
       })
     : null;
   const replaceTokenRevokeMethod = resolveReplaceTokenRevokeRuntimeMethod({
@@ -2051,7 +2067,7 @@ async function commitConnectorTokenConnection(args: {
     orgId: args.orgId,
     userId: args.userId,
     runtimeMethod: args.runtimeMethod,
-    existingRuntimeMethod: existingRuntimeMethod ?? null,
+    existingRuntimeMethod,
     signal: args.signal,
   });
   await deleteManualGrantConnectorLocalStateForAuthMethods({

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -465,14 +465,12 @@ export function zeroConnectorList(args: {
       visibleRefs,
       readEnv: optionalEnv,
     });
-    const visibleConnectorRefs = new Set(visibleRefs);
 
+    // Feature switches filter configuredTypes for discovery only. Stored
+    // connections remain manageable and executable after rollout is disabled.
     const now = nowDate();
     const connectorList: ConnectorWithRuntimeMethod[] = storedRows.flatMap(
       (row) => {
-        if (!visibleConnectorRefs.has(row.type)) {
-          return [];
-        }
         const runtimeMethod = getConnectorRuntimeMethod({
           snapshot,
           connectorRef: row.type,
@@ -602,36 +600,12 @@ export function zeroConnectorByType(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly type: string;
-  readonly includeHiddenStoredConnector?: boolean;
   readonly snapshot?: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ConnectorResponse | null>> {
   return computed(async (get): Promise<ConnectorResponse | null> => {
-    const overrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
-    );
-    const featureStates = getAllFeatureStates({
-      userId: args.userId,
-      orgId: args.orgId,
-      overrides,
-    });
     const snapshot =
       args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
-    const storedConnector = await get(
-      storedConnectorByType({ ...args, snapshot }),
-    );
-    if (storedConnector) {
-      if (args.includeHiddenStoredConnector) {
-        return storedConnector;
-      }
-      const visibleConnectorRefs = await listConnectorRuntimeVisibleRefs({
-        snapshot,
-        featureStates,
-      });
-      if (visibleConnectorRefs.includes(args.type)) {
-        return storedConnector;
-      }
-    }
-    return null;
+    return await get(storedConnectorByType({ ...args, snapshot }));
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -9,30 +9,20 @@ import {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
-  connectorAuthMethodRefHasRevokeKind,
-  getAvailableConnectorAuthMethodIds,
-  getConnectorAuthMethodGrantMetadata,
-  getConnectorAuthMethodRevokeMetadata,
-  getConnectorAuthMethodRuntimeMetadata,
-  getConnectorAuthMethodScopeDiff,
-  getConnectorAuthMethod,
-  getConnectorManualGrantFieldNamesForAuthMethod,
-  getConnectorOwnedSecretNames,
-  getConnectorOwnedVariableNames,
-  getRuntimeAvailableConnectorTypes,
-  type ConnectorAuthMethodRef,
-  type ConnectorAuthMethodRefByRevokeKind,
+  connectorAuthMethodGrantMetadata,
+  connectorAuthMethodManualGrantFieldNames,
+  connectorAuthMethodOwnedSecretNames,
+  connectorAuthMethodOwnedVariableNames,
+  connectorAuthMethodRevokeMetadata,
+  connectorAuthMethodRuntimeMetadata,
+  connectorAuthMethodScopeDiff,
   type ConnectorManualGrantFieldNames,
   type ConnectorOutputTarget,
 } from "@vm0/connectors/connector-utils";
-import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
-import {
-  connectorAuthMethodIdSchema,
-  connectorTypeSchema,
-  type ConnectorAuthMethodId,
-  type ConnectorManualGrantFieldConfig,
-  type ConnectorType,
-  type AuthGrantConnectorType,
+import { revokeConnectorAuthMethodAccessTokenWithMethod } from "@vm0/connectors/auth-providers";
+import type {
+  ConnectorAuthMethodRuntimeConfig,
+  ConnectorManualGrantFieldConfig,
 } from "@vm0/connectors/connectors";
 import {
   getAllFeatureStates,
@@ -59,11 +49,19 @@ import {
   userFeatureSwitchOverrides,
 } from "./feature-switches.service";
 import {
-  connectorCredentialReconnectReason,
-  connectorCredentialStatus,
+  connectorCredentialReconnectReasonWithMethod,
+  connectorCredentialStatusWithMethod,
 } from "./connector-credential-status.service";
-import { normalizeManualGrantSubmittedValues } from "./connector-catalog-form-fields.service";
+import { normalizeManualGrantSubmittedValuesWithMethod } from "./connector-catalog-form-fields.service";
 import { searchConnectorCatalog } from "./connector-catalog-reader.service";
+import {
+  getConnectorRuntimeMethod,
+  filterConnectorRuntimeConfiguredRefs,
+  listConnectorRuntimeVisibleRefs,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeMethod,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
 
 type StoredConnectorRow = {
   readonly id: string;
@@ -77,11 +75,6 @@ type StoredConnectorRow = {
   readonly tokenExpiresAt: Date | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
-};
-
-type ExecutableConnectorResponse = ConnectorResponse & {
-  readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
 };
 
 const oauthScopesSchema = z.array(z.string());
@@ -161,9 +154,13 @@ interface ConnectorTokenOutputRequirements {
   readonly requiredExtraSecretNames: readonly string[];
 }
 
-type TokenRevokeMethodRef = ConnectorAuthMethodRefByRevokeKind<"token-revoke">;
+interface ConnectorWithRuntimeMethod {
+  readonly response: ConnectorResponse;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+}
 
-type PendingConnectorTokenRevoke = TokenRevokeMethodRef & {
+type PendingConnectorTokenRevoke = {
+  readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly encryptedInputs: Readonly<Record<string, string>>;
   readonly featureSwitchContext: FeatureSwitchContext;
 };
@@ -184,13 +181,11 @@ function parseStoredReconnectReason(
 
 function storedConnectorRowToResponse(
   row: StoredConnectorRow,
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  runtimeMethod: ConnectorRuntimeMethod,
   now: Date,
-): ExecutableConnectorResponse {
-  const credentialStatus = connectorCredentialStatus({
-    type,
-    authMethod,
+): ConnectorResponse {
+  const credentialStatus = connectorCredentialStatusWithMethod({
+    method: runtimeMethod.method,
     storedNeedsReconnect: row.needsReconnect,
     tokenExpiresAt: row.tokenExpiresAt,
     now,
@@ -201,8 +196,8 @@ function storedConnectorRowToResponse(
       : "connected";
   return {
     id: row.id,
-    type,
-    authMethod,
+    type: runtimeMethod.connectorRef,
+    authMethod: runtimeMethod.authMethodId,
     externalId: row.externalId,
     externalUsername: row.externalUsername,
     externalEmail: row.externalEmail,
@@ -211,9 +206,8 @@ function storedConnectorRowToResponse(
     reconnectReason:
       connectionStatus === "reconnect-required"
         ? (parseStoredReconnectReason(row.reconnectReason) ??
-          connectorCredentialReconnectReason({
-            type,
-            authMethod,
+          connectorCredentialReconnectReasonWithMethod({
+            method: runtimeMethod.method,
             storedNeedsReconnect: row.needsReconnect,
             tokenExpiresAt: row.tokenExpiresAt,
             now,
@@ -225,22 +219,9 @@ function storedConnectorRowToResponse(
   };
 }
 
-function storedConnectorTypeIsVisible(
-  type: ConnectorType,
-  featureStates: FeatureStates,
-): boolean {
-  return (
-    getAvailableConnectorAuthMethodIds(type, featureStates, {
-      apiAuthMethodPolicy: "include",
-    }).length > 0
-  );
-}
-
 function manualGrantFieldsForAuthMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  method: ConnectorAuthMethodRuntimeConfig,
 ): Record<string, ConnectorManualGrantFieldConfig> | null {
-  const method = getConnectorAuthMethod(type, authMethod);
   return method?.grant.kind === "manual" ? method.grant.fields : null;
 }
 
@@ -305,13 +286,13 @@ async function finalizeConnectorStateChangeAfterCommit(args: {
 }
 
 function prepareManualGrantConnect(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  runtimeMethod: ConnectorRuntimeMethod,
   values: Readonly<Record<string, string>>,
 ): PreparedManualGrantConnectResult {
-  const normalizedValuesResult = normalizeManualGrantSubmittedValues({
-    type,
-    authMethod,
+  const normalizedValuesResult = normalizeManualGrantSubmittedValuesWithMethod({
+    connectorRef: runtimeMethod.connectorRef,
+    authMethodId: runtimeMethod.authMethodId,
+    method: runtimeMethod.method,
     values,
   });
   if (!normalizedValuesResult.ok) {
@@ -321,11 +302,11 @@ function prepareManualGrantConnect(
     };
   }
 
-  const fields = manualGrantFieldsForAuthMethod(type, authMethod);
+  const fields = manualGrantFieldsForAuthMethod(runtimeMethod.method);
   if (!fields) {
     return {
       ok: false,
-      message: `${type} ${authMethod} auth method does not use a manual grant`,
+      message: `${runtimeMethod.connectorRef} ${runtimeMethod.authMethodId} auth method does not use a manual grant`,
     };
   }
 
@@ -470,73 +451,75 @@ export function zeroConnectorList(args: {
         overrides,
       });
     })();
-    const [storedRows, featureStates] = await Promise.all([
+    const [storedRows, featureStates, snapshot] = await Promise.all([
       storedRowsPromise,
       featureStatesPromise,
+      loadConnectorRuntimeSnapshot(db),
     ]);
+    const visibleRefs = await listConnectorRuntimeVisibleRefs({
+      snapshot,
+      featureStates,
+    });
+    const configuredTypes = filterConnectorRuntimeConfiguredRefs({
+      snapshot,
+      visibleRefs,
+      readEnv: optionalEnv,
+    });
+    const visibleConnectorRefs = new Set(visibleRefs);
 
     const now = nowDate();
-    const connectorList: ExecutableConnectorResponse[] = storedRows.flatMap(
+    const connectorList: ConnectorWithRuntimeMethod[] = storedRows.flatMap(
       (row) => {
-        const type = connectorTypeSchema.safeParse(row.type);
-        if (
-          !type.success ||
-          !storedConnectorTypeIsVisible(type.data, featureStates)
-        ) {
+        if (!visibleConnectorRefs.has(row.type)) {
           return [];
         }
-        const authMethod = connectorAuthMethodIdSchema.safeParse(
-          row.authMethod,
-        );
-        if (
-          !authMethod.success ||
-          !getConnectorAuthMethod(type.data, authMethod.data)
-        ) {
+        const runtimeMethod = getConnectorRuntimeMethod({
+          snapshot,
+          connectorRef: row.type,
+          authMethodId: row.authMethod,
+          requireExecutable: true,
+        });
+        if (runtimeMethod === undefined) {
           return [];
         }
         return [
-          storedConnectorRowToResponse(row, type.data, authMethod.data, now),
+          {
+            response: storedConnectorRowToResponse(row, runtimeMethod, now),
+            runtimeMethod,
+          },
         ];
       },
     );
     const connectorProvidedBindings =
       connectorProvidedBindingsForStoredConnectors(connectorList);
 
-    const configuredTypes = getRuntimeAvailableConnectorTypes((name) => {
-      return optionalEnv(name);
-    }).filter((type) => {
-      return storedConnectorTypeIsVisible(type, featureStates);
-    });
-
     return {
-      connectors: connectorList,
-      configuredTypes,
+      connectors: connectorList.map((connector) => {
+        return connector.response;
+      }),
+      configuredTypes: [...configuredTypes],
       connectorProvidedBindings,
     };
   });
 }
 
 function connectorProvidedBindingsForStoredConnectors(
-  connectorList: readonly ExecutableConnectorResponse[],
+  connectorList: readonly ConnectorWithRuntimeMethod[],
 ): ConnectorProvidedBinding[] {
   const provided: ConnectorProvidedBinding[] = [];
   for (const connector of connectorList) {
-    if (connector.connectionStatus !== "connected") {
+    if (connector.response.connectionStatus !== "connected") {
       continue;
     }
-    const metadata = getConnectorAuthMethodRuntimeMetadata(
-      connector.type,
-      connector.authMethod,
+    const metadata = connectorAuthMethodRuntimeMetadata(
+      connector.runtimeMethod.method,
     );
-    if (!metadata) {
-      continue;
-    }
     for (const { envName, optional, source } of metadata.runtimeBindings) {
       switch (source.kind) {
         case "connector-secret": {
           provided.push({
-            connectorType: connector.type,
-            authMethod: connector.authMethod,
+            connectorType: connector.response.type,
+            authMethod: connector.response.authMethod,
             namespace: "secrets",
             name: envName,
             optional,
@@ -546,8 +529,8 @@ function connectorProvidedBindingsForStoredConnectors(
         }
         case "connector-variable": {
           provided.push({
-            connectorType: connector.type,
-            authMethod: connector.authMethod,
+            connectorType: connector.response.type,
+            authMethod: connector.response.authMethod,
             namespace: "vars",
             name: envName,
             optional,
@@ -567,7 +550,8 @@ function connectorProvidedBindingsForStoredConnectors(
 function storedConnectorByType(args: {
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorType;
+  readonly type: string;
+  readonly snapshot: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ConnectorResponse | null>> {
   return computed(async (get): Promise<ConnectorResponse | null> => {
     const db = get(db$);
@@ -598,21 +582,16 @@ function storedConnectorByType(args: {
 
     const oauthRow = oauthRows[0];
     if (oauthRow) {
-      const authMethod = connectorAuthMethodIdSchema.safeParse(
-        oauthRow.authMethod,
-      );
-      if (
-        !authMethod.success ||
-        !getConnectorAuthMethod(args.type, authMethod.data)
-      ) {
+      const runtimeMethod = getConnectorRuntimeMethod({
+        snapshot: args.snapshot,
+        connectorRef: args.type,
+        authMethodId: oauthRow.authMethod,
+        requireExecutable: true,
+      });
+      if (runtimeMethod === undefined) {
         return null;
       }
-      return storedConnectorRowToResponse(
-        oauthRow,
-        args.type,
-        authMethod.data,
-        nowDate(),
-      );
+      return storedConnectorRowToResponse(oauthRow, runtimeMethod, nowDate());
     }
 
     return null;
@@ -622,8 +601,9 @@ function storedConnectorByType(args: {
 export function zeroConnectorByType(args: {
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorType;
+  readonly type: string;
   readonly includeHiddenStoredConnector?: boolean;
+  readonly snapshot?: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ConnectorResponse | null>> {
   return computed(async (get): Promise<ConnectorResponse | null> => {
     const overrides = await get(
@@ -634,12 +614,20 @@ export function zeroConnectorByType(args: {
       orgId: args.orgId,
       overrides,
     });
-    const storedConnector = await get(storedConnectorByType(args));
+    const snapshot =
+      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
+    const storedConnector = await get(
+      storedConnectorByType({ ...args, snapshot }),
+    );
     if (storedConnector) {
-      if (
-        args.includeHiddenStoredConnector ||
-        storedConnectorTypeIsVisible(args.type, featureStates)
-      ) {
+      if (args.includeHiddenStoredConnector) {
+        return storedConnector;
+      }
+      const visibleConnectorRefs = await listConnectorRuntimeVisibleRefs({
+        snapshot,
+        featureStates,
+      });
+      if (visibleConnectorRefs.includes(args.type)) {
         return storedConnector;
       }
     }
@@ -651,13 +639,12 @@ async function loadPendingConnectorTokenRevoke(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
-  readonly method: TokenRevokeMethodRef;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
 }): Promise<PendingConnectorTokenRevoke | null> {
-  const revokeMetadata = getConnectorAuthMethodRevokeMetadata(
-    args.method.type,
-    args.method.authMethod,
+  const revokeMetadata = connectorAuthMethodRevokeMetadata(
+    args.runtimeMethod.method,
   );
   if (revokeMetadata?.kind !== "token-revoke") {
     return null;
@@ -666,7 +653,7 @@ async function loadPendingConnectorTokenRevoke(args: {
   const inputEntries = Object.entries(revokeMetadata.inputs);
   if (inputEntries.length === 0) {
     return {
-      ...args.method,
+      runtimeMethod: args.runtimeMethod,
       encryptedInputs: {},
       featureSwitchContext: args.featureSwitchContext,
     };
@@ -703,7 +690,7 @@ async function loadPendingConnectorTokenRevoke(args: {
   }
 
   return {
-    ...args.method,
+    runtimeMethod: args.runtimeMethod,
     encryptedInputs,
     featureSwitchContext: args.featureSwitchContext,
   };
@@ -723,47 +710,41 @@ async function decryptConnectorRevokeInputs(args: {
   return inputs;
 }
 
-function resolveTokenRevokeMethodRef(args: {
-  readonly type: ConnectorType;
+function resolveTokenRevokeRuntimeMethod(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly type: string;
   readonly authMethod: string;
-}): TokenRevokeMethodRef | null {
-  const parsedAuthMethod = connectorAuthMethodIdSchema.safeParse(
-    args.authMethod,
-  );
-  if (!parsedAuthMethod.success) {
-    return null;
-  }
-  const method: ConnectorAuthMethodRef = {
-    type: args.type,
-    authMethod: parsedAuthMethod.data,
-  };
-  return connectorAuthMethodRefHasRevokeKind(method, "token-revoke")
-    ? method
+}): ConnectorRuntimeMethod | null {
+  const runtimeMethod = getConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    connectorRef: args.type,
+    authMethodId: args.authMethod,
+    requireExecutable: true,
+  });
+  return runtimeMethod?.method.revoke.kind === "token-revoke"
+    ? runtimeMethod
     : null;
 }
 
-function resolveReplaceTokenRevokeMethodRef(args: {
-  readonly type: ConnectorType;
+function resolveReplaceTokenRevokeRuntimeMethod(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly type: string;
   readonly authMethod: string | null;
-}): TokenRevokeMethodRef | null {
+}): ConnectorRuntimeMethod | null {
   if (!args.authMethod) {
     return null;
   }
-  const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+  const tokenRevokeMethod = resolveTokenRevokeRuntimeMethod({
+    snapshot: args.snapshot,
     type: args.type,
     authMethod: args.authMethod,
   });
   if (!tokenRevokeMethod) {
     return null;
   }
-  const method = getConnectorAuthMethod(
-    tokenRevokeMethod.type,
-    tokenRevokeMethod.authMethod,
-  );
   if (
-    !method ||
-    method.revoke.kind !== "token-revoke" ||
-    method.revoke.revokePreviousOnReplace !== true
+    tokenRevokeMethod.method.revoke.kind !== "token-revoke" ||
+    tokenRevokeMethod.method.revoke.revokePreviousOnReplace !== true
   ) {
     return null;
   }
@@ -776,9 +757,10 @@ async function revokePendingConnectorToken(args: {
 }): Promise<void> {
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
-    revokeConnectorAuthMethodAccessToken({
-      type: args.pending.type,
-      authMethod: args.pending.authMethod,
+    revokeConnectorAuthMethodAccessTokenWithMethod({
+      connectorRef: args.pending.runtimeMethod.connectorRef,
+      authMethodId: args.pending.runtimeMethod.authMethodId,
+      method: args.pending.runtimeMethod.method,
       readEnv: optionalEnv,
       signal: args.signal,
       loadInputs: () => {
@@ -842,8 +824,9 @@ async function deleteManualGrantConnectorLocalStateForAuthMethods(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorType;
+  readonly type: string;
   readonly authMethods: readonly (string | null)[];
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly signal: AbortSignal;
 }): Promise<void> {
   const cleanupAuthMethods = new Set<string>();
@@ -855,14 +838,20 @@ async function deleteManualGrantConnectorLocalStateForAuthMethods(args: {
 
   for (const authMethod of cleanupAuthMethods) {
     args.signal.throwIfAborted();
+    const runtimeMethod = getConnectorRuntimeMethod({
+      snapshot: args.snapshot,
+      connectorRef: args.type,
+      authMethodId: authMethod,
+      requireExecutable: false,
+    });
     await deleteManualGrantConnectorLocalState({
       db: args.db,
       orgId: args.orgId,
       userId: args.userId,
-      fields: getConnectorManualGrantFieldNamesForAuthMethod(
-        args.type,
-        authMethod,
-      ),
+      fields:
+        runtimeMethod === undefined
+          ? null
+          : connectorAuthMethodManualGrantFieldNames(runtimeMethod.method),
       signal: args.signal,
     });
   }
@@ -874,11 +863,14 @@ export const deleteZeroConnectorLocalState$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorType;
+      readonly type: string;
+      readonly snapshot?: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
     const writeDb = set(writeDb$);
+    const snapshot =
+      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
@@ -916,17 +908,25 @@ export const deleteZeroConnectorLocalState$ = command(
         return { deleted: false, pendingTokenRevoke: null };
       }
 
+      const existingRuntimeMethod = getConnectorRuntimeMethod({
+        snapshot,
+        connectorRef: args.type,
+        authMethodId: existing.authMethod,
+        requireExecutable: false,
+      });
+
       let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-      const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+      const tokenRevokeRuntimeMethod = resolveTokenRevokeRuntimeMethod({
+        snapshot,
         type: args.type,
         authMethod: existing.authMethod,
       });
-      if (tokenRevokeMethod) {
+      if (tokenRevokeRuntimeMethod !== null) {
         pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
           db: tx,
           orgId: args.orgId,
           userId: args.userId,
-          method: tokenRevokeMethod,
+          runtimeMethod: tokenRevokeRuntimeMethod,
           featureSwitchContext,
           signal,
         });
@@ -939,13 +939,17 @@ export const deleteZeroConnectorLocalState$ = command(
       await deleteConnectorScopedSecretNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        names: getConnectorOwnedSecretNames(args.type, existing.authMethod),
+        names: connectorAuthMethodOwnedSecretNames(
+          existingRuntimeMethod?.method,
+        ),
         signal,
       });
       await deleteConnectorScopedVariableNames(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        names: getConnectorOwnedVariableNames(args.type, existing.authMethod),
+        names: connectorAuthMethodOwnedVariableNames(
+          existingRuntimeMethod?.method,
+        ),
         signal,
       });
 
@@ -1040,8 +1044,8 @@ async function upsertLocalConnectorRow(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ConnectorType;
-    readonly authMethod: ConnectorAuthMethodId;
+    readonly type: string;
+    readonly authMethod: string;
   },
 ): Promise<StoredConnectorRow> {
   const [row] = await db
@@ -1197,13 +1201,14 @@ async function cleanupExistingStoredConnectorForLocalConnect(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ConnectorType;
+    readonly type: string;
+    readonly snapshot: ConnectorRuntimeSnapshot;
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly signal: AbortSignal;
   },
 ): Promise<PendingConnectorTokenRevoke | null> {
   const [existing] = await db
-    .select({ id: connectors.id, authMethod: connectors.authMethod })
+    .select({ authMethod: connectors.authMethod })
     .from(connectors)
     .where(
       and(
@@ -1220,16 +1225,23 @@ async function cleanupExistingStoredConnectorForLocalConnect(
   }
 
   let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-  const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+  const existingRuntimeMethod = getConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    connectorRef: args.type,
+    authMethodId: existing.authMethod,
+    requireExecutable: false,
+  });
+  const tokenRevokeRuntimeMethod = resolveTokenRevokeRuntimeMethod({
+    snapshot: args.snapshot,
     type: args.type,
     authMethod: existing.authMethod,
   });
-  if (tokenRevokeMethod) {
+  if (tokenRevokeRuntimeMethod !== null) {
     pendingTokenRevoke = await loadPendingConnectorTokenRevoke({
       db,
       orgId: args.orgId,
       userId: args.userId,
-      method: tokenRevokeMethod,
+      runtimeMethod: tokenRevokeRuntimeMethod,
       featureSwitchContext: args.featureSwitchContext,
       signal: args.signal,
     });
@@ -1238,13 +1250,13 @@ async function cleanupExistingStoredConnectorForLocalConnect(
   await deleteConnectorScopedSecretNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: getConnectorOwnedSecretNames(args.type, existing.authMethod),
+    names: connectorAuthMethodOwnedSecretNames(existingRuntimeMethod?.method),
     signal: args.signal,
   });
   await deleteConnectorScopedVariableNames(db, {
     orgId: args.orgId,
     userId: args.userId,
-    names: getConnectorOwnedVariableNames(args.type, existing.authMethod),
+    names: connectorAuthMethodOwnedVariableNames(existingRuntimeMethod?.method),
     signal: args.signal,
   });
 
@@ -1257,15 +1269,14 @@ export const connectManualGrantConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorType;
-      readonly authMethod: ConnectorAuthMethodId;
+      readonly runtimeMethod: ConnectorRuntimeMethod;
+      readonly snapshot: ConnectorRuntimeSnapshot;
       readonly values: Readonly<Record<string, string>>;
     },
     signal: AbortSignal,
   ): Promise<ConnectManualGrantConnectorResult> => {
     const preparedResult = prepareManualGrantConnect(
-      args.type,
-      args.authMethod,
+      args.runtimeMethod,
       args.values,
     );
     if (!preparedResult.ok) {
@@ -1295,7 +1306,7 @@ export const connectManualGrantConnector$ = command(
       await lockConnectorState(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
+        type: args.runtimeMethod.connectorRef,
       });
       signal.throwIfAborted();
 
@@ -1304,7 +1315,8 @@ export const connectManualGrantConnector$ = command(
         {
           orgId: args.orgId,
           userId: args.userId,
-          type: args.type,
+          type: args.runtimeMethod.connectorRef,
+          snapshot: args.snapshot,
           featureSwitchContext,
           signal,
         },
@@ -1346,8 +1358,8 @@ export const connectManualGrantConnector$ = command(
       connectorRow = await upsertLocalConnectorRow(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
-        authMethod: args.authMethod,
+        type: args.runtimeMethod.connectorRef,
+        authMethod: args.runtimeMethod.authMethodId,
       });
       signal.throwIfAborted();
 
@@ -1384,8 +1396,7 @@ export const connectManualGrantConnector$ = command(
       status: "connected",
       connector: storedConnectorRowToResponse(
         connectorRow,
-        args.type,
-        args.authMethod,
+        args.runtimeMethod,
         nowDate(),
       ),
     };
@@ -1398,8 +1409,8 @@ export const connectNoAuthConnector$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorType;
-      readonly authMethod: ConnectorAuthMethodId;
+      readonly runtimeMethod: ConnectorRuntimeMethod;
+      readonly snapshot: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<ConnectNoAuthConnectorResult> => {
@@ -1417,7 +1428,7 @@ export const connectNoAuthConnector$ = command(
       await lockConnectorState(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
+        type: args.runtimeMethod.connectorRef,
       });
       signal.throwIfAborted();
 
@@ -1426,7 +1437,8 @@ export const connectNoAuthConnector$ = command(
         {
           orgId: args.orgId,
           userId: args.userId,
-          type: args.type,
+          type: args.runtimeMethod.connectorRef,
+          snapshot: args.snapshot,
           featureSwitchContext,
           signal,
         },
@@ -1435,8 +1447,8 @@ export const connectNoAuthConnector$ = command(
       connectorRow = await upsertLocalConnectorRow(tx, {
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
-        authMethod: args.authMethod,
+        type: args.runtimeMethod.connectorRef,
+        authMethod: args.runtimeMethod.authMethodId,
       });
       signal.throwIfAborted();
     });
@@ -1460,8 +1472,7 @@ export const connectNoAuthConnector$ = command(
       status: "connected",
       connector: storedConnectorRowToResponse(
         connectorRow,
-        args.type,
-        args.authMethod,
+        args.runtimeMethod,
         nowDate(),
       ),
     };
@@ -1528,17 +1539,10 @@ function connectorTokenExpiresAt(args: {
 }
 
 function connectorTokenOutputMetadataForAuthMethod(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
 }): ConnectorTokenOutputMetadata | undefined {
-  const method = getConnectorAuthMethod(args.type, args.authMethod);
-  const grantMetadata = getConnectorAuthMethodGrantMetadata(
-    args.type,
-    args.authMethod,
-  );
-  if (!method || !grantMetadata) {
-    return undefined;
-  }
+  const method = args.runtimeMethod.method;
+  const grantMetadata = connectorAuthMethodGrantMetadata(method);
 
   switch (method.grant.kind) {
     case "auth-code":
@@ -1551,8 +1555,7 @@ function connectorTokenOutputMetadataForAuthMethod(args: {
         }),
       );
       const outputRequirements = requiredConnectorTokenOutputRequirements({
-        type: args.type,
-        authMethod: args.authMethod,
+        method,
         outputTargets,
       });
       return {
@@ -1564,24 +1567,18 @@ function connectorTokenOutputMetadataForAuthMethod(args: {
     }
 
     case "manual":
-    case "managed": {
+    case "managed":
+    case "none": {
       return undefined;
     }
   }
 }
 
 function requiredConnectorTokenOutputRequirements(args: {
-  readonly type: ConnectorType;
-  readonly authMethod: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
 }): ConnectorTokenOutputRequirements {
-  const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
-    args.type,
-    args.authMethod,
-  );
-  if (!runtimeMetadata) {
-    return { requiredOutputNames: [], requiredExtraSecretNames: [] };
-  }
+  const runtimeMetadata = connectorAuthMethodRuntimeMetadata(args.method);
 
   const outputNameByTargetKey = new Map(
     Object.entries(args.outputTargets).map(([outputName, target]) => {
@@ -1631,7 +1628,7 @@ function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
 }
 
 function validateConnectorTokenOutputRequirements(args: {
-  readonly type: AuthGrantConnectorType;
+  readonly type: string;
   readonly outputs: ConnectorTokenOutputValues;
   readonly requiredOutputNames: readonly string[];
   readonly extraSecrets: readonly (readonly [string, string])[];
@@ -1664,10 +1661,9 @@ function validateConnectorTokenOutputRequirements(args: {
 }
 
 function allowedConnectorTokenSecretNames(
-  type: AuthGrantConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  method: ConnectorAuthMethodRuntimeConfig,
 ): Set<string> {
-  return new Set(getConnectorOwnedSecretNames(type, authMethod));
+  return new Set(connectorAuthMethodOwnedSecretNames(method));
 }
 
 function isPrimaryConnectorTokenSecret(args: {
@@ -1678,8 +1674,8 @@ function isPrimaryConnectorTokenSecret(args: {
 }
 
 function validateExtraConnectorTokenSecrets(args: {
-  readonly type: AuthGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly connectorRef: string;
+  readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly extraConnectorSecrets: Readonly<Record<string, string>> | undefined;
   readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
 }): readonly (readonly [string, string])[] {
@@ -1688,10 +1684,7 @@ function validateExtraConnectorTokenSecrets(args: {
     return [];
   }
 
-  const allowedSecretNames = allowedConnectorTokenSecretNames(
-    args.type,
-    args.authMethod,
-  );
+  const allowedSecretNames = allowedConnectorTokenSecretNames(args.method);
   const primaryOutputSecretNames = connectorOutputSecretNames(
     args.outputTargets,
   );
@@ -1703,12 +1696,12 @@ function validateExtraConnectorTokenSecrets(args: {
       })
     ) {
       throw new Error(
-        `${args.type} connector provider returned mapped token output ${name} in extra connector secrets`,
+        `${args.connectorRef} connector provider returned mapped token output ${name} in extra connector secrets`,
       );
     }
     if (!allowedSecretNames.has(name)) {
       throw new Error(
-        `${args.type} connector provider returned unsupported connector secret ${name}`,
+        `${args.connectorRef} connector provider returned unsupported connector secret ${name}`,
       );
     }
   }
@@ -1729,7 +1722,7 @@ function connectorOutputSecretNames(
 }
 
 async function encryptExtraConnectorTokenSecrets(args: {
-  readonly type: AuthGrantConnectorType;
+  readonly type: string;
   readonly extraSecrets: readonly (readonly [string, string])[];
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly signal: AbortSignal;
@@ -1750,7 +1743,7 @@ async function encryptExtraConnectorTokenSecrets(args: {
 }
 
 async function prepareConnectorTokenState(args: {
-  readonly type: AuthGrantConnectorType;
+  readonly type: string;
   readonly outputTargets: Readonly<Record<string, ConnectorOutputTarget>>;
   readonly requiredOutputNames: readonly string[];
   readonly requiredExtraSecretNames: readonly string[];
@@ -1877,7 +1870,7 @@ async function loadExistingConnectorAuthMethod(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: ConnectorType;
+    readonly type: string;
     readonly signal: AbortSignal;
   },
 ): Promise<string | null> {
@@ -1901,8 +1894,8 @@ async function upsertConnectorTokenConnectionRow(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: AuthGrantConnectorType;
-    readonly authMethod: ConnectorAuthMethodId;
+    readonly type: string;
+    readonly authMethod: string;
     readonly userInfo: ExternalUserInfo;
     readonly oauthScopes: readonly string[];
     readonly tokenExpiresAt: Date | null;
@@ -1965,31 +1958,31 @@ async function deleteObsoleteConnectorScopedStateForTokenConnect(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly type: AuthGrantConnectorType;
-    readonly authMethod: ConnectorAuthMethodId;
-    readonly existingAuthMethod: string | null;
+    readonly runtimeMethod: ConnectorRuntimeMethod;
+    readonly existingRuntimeMethod: ConnectorRuntimeMethod | null;
     readonly signal: AbortSignal;
   },
 ): Promise<void> {
-  if (!args.existingAuthMethod || args.existingAuthMethod === args.authMethod) {
+  if (
+    args.existingRuntimeMethod === null ||
+    args.existingRuntimeMethod.authMethodId === args.runtimeMethod.authMethodId
+  ) {
     return;
   }
 
   const targetSecretNames = new Set(
-    getConnectorOwnedSecretNames(args.type, args.authMethod),
+    connectorAuthMethodOwnedSecretNames(args.runtimeMethod.method),
   );
-  const obsoleteSecretNames = getConnectorOwnedSecretNames(
-    args.type,
-    args.existingAuthMethod,
+  const obsoleteSecretNames = connectorAuthMethodOwnedSecretNames(
+    args.existingRuntimeMethod.method,
   ).filter((name) => {
     return !targetSecretNames.has(name);
   });
   const targetVariableNames = new Set(
-    getConnectorOwnedVariableNames(args.type, args.authMethod),
+    connectorAuthMethodOwnedVariableNames(args.runtimeMethod.method),
   );
-  const obsoleteVariableNames = getConnectorOwnedVariableNames(
-    args.type,
-    args.existingAuthMethod,
+  const obsoleteVariableNames = connectorAuthMethodOwnedVariableNames(
+    args.existingRuntimeMethod.method,
   ).filter((name) => {
     return !targetVariableNames.has(name);
   });
@@ -2011,8 +2004,8 @@ async function commitConnectorTokenConnection(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: AuthGrantConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly connectorTokenState: PreparedConnectorTokenState;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly userInfo: ExternalUserInfo;
@@ -2026,18 +2019,27 @@ async function commitConnectorTokenConnection(args: {
   await lockConnectorState(args.db, {
     orgId: args.orgId,
     userId: args.userId,
-    type: args.type,
+    type: args.runtimeMethod.connectorRef,
   });
   args.signal.throwIfAborted();
 
   const existingAuthMethod = await loadExistingConnectorAuthMethod(args.db, {
     orgId: args.orgId,
     userId: args.userId,
-    type: args.type,
+    type: args.runtimeMethod.connectorRef,
     signal: args.signal,
   });
-  const replaceTokenRevokeMethod = resolveReplaceTokenRevokeMethodRef({
-    type: args.type,
+  const existingRuntimeMethod = existingAuthMethod
+    ? getConnectorRuntimeMethod({
+        snapshot: args.snapshot,
+        connectorRef: args.runtimeMethod.connectorRef,
+        authMethodId: existingAuthMethod,
+        requireExecutable: false,
+      })
+    : null;
+  const replaceTokenRevokeMethod = resolveReplaceTokenRevokeRuntimeMethod({
+    snapshot: args.snapshot,
+    type: args.runtimeMethod.connectorRef,
     authMethod: existingAuthMethod,
   });
   const pendingTokenRevoke = replaceTokenRevokeMethod
@@ -2045,7 +2047,7 @@ async function commitConnectorTokenConnection(args: {
         db: args.db,
         orgId: args.orgId,
         userId: args.userId,
-        method: replaceTokenRevokeMethod,
+        runtimeMethod: replaceTokenRevokeMethod,
         featureSwitchContext: args.featureSwitchContext,
         signal: args.signal,
       })
@@ -2063,8 +2065,8 @@ async function commitConnectorTokenConnection(args: {
   const connectorRow = await upsertConnectorTokenConnectionRow(args.db, {
     orgId: args.orgId,
     userId: args.userId,
-    type: args.type,
-    authMethod: args.authMethod,
+    type: args.runtimeMethod.connectorRef,
+    authMethod: args.runtimeMethod.authMethodId,
     userInfo: args.userInfo,
     oauthScopes: args.oauthScopes,
     tokenExpiresAt: args.tokenExpiresAt,
@@ -2074,17 +2076,17 @@ async function commitConnectorTokenConnection(args: {
   await deleteObsoleteConnectorScopedStateForTokenConnect(args.db, {
     orgId: args.orgId,
     userId: args.userId,
-    type: args.type,
-    authMethod: args.authMethod,
-    existingAuthMethod,
+    runtimeMethod: args.runtimeMethod,
+    existingRuntimeMethod: existingRuntimeMethod ?? null,
     signal: args.signal,
   });
   await deleteManualGrantConnectorLocalStateForAuthMethods({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
-    type: args.type,
-    authMethods: [existingAuthMethod, args.authMethod],
+    type: args.runtimeMethod.connectorRef,
+    authMethods: [existingAuthMethod, args.runtimeMethod.authMethodId],
+    snapshot: args.snapshot,
     signal: args.signal,
   });
 
@@ -2097,8 +2099,8 @@ export const upsertConnectorTokenConnection$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: AuthGrantConnectorType;
-      readonly authMethod: ConnectorAuthMethodId;
+      readonly runtimeMethod: ConnectorRuntimeMethod;
+      readonly snapshot: ConnectorRuntimeSnapshot;
       readonly outputs: ConnectorTokenOutputValues;
       readonly userInfo: ExternalUserInfo;
       readonly oauthScopes: readonly string[];
@@ -2112,12 +2114,11 @@ export const upsertConnectorTokenConnection$ = command(
   }> => {
     const writeDb = set(writeDb$);
     const outputMetadata = connectorTokenOutputMetadataForAuthMethod({
-      type: args.type,
-      authMethod: args.authMethod,
+      runtimeMethod: args.runtimeMethod,
     });
     if (!outputMetadata) {
       throw new Error(
-        `${args.type} connector auth method ${args.authMethod} does not expose token outputs`,
+        `${args.runtimeMethod.connectorRef} connector auth method ${args.runtimeMethod.authMethodId} does not expose token outputs`,
       );
     }
     const tokenExpiresAt = connectorTokenExpiresAt({
@@ -2125,8 +2126,8 @@ export const upsertConnectorTokenConnection$ = command(
       expiresIn: args.expiresIn,
     });
     const extraSecrets = validateExtraConnectorTokenSecrets({
-      type: args.type,
-      authMethod: args.authMethod,
+      connectorRef: args.runtimeMethod.connectorRef,
+      method: args.runtimeMethod.method,
       extraConnectorSecrets: args.extraConnectorSecrets,
       outputTargets: outputMetadata.outputTargets,
     });
@@ -2136,7 +2137,7 @@ export const upsertConnectorTokenConnection$ = command(
     signal.throwIfAborted();
 
     const connectorTokenState = await prepareConnectorTokenState({
-      type: args.type,
+      type: args.runtimeMethod.connectorRef,
       outputTargets: outputMetadata.outputTargets,
       requiredOutputNames: outputMetadata.requiredOutputNames,
       requiredExtraSecretNames: outputMetadata.requiredExtraSecretNames,
@@ -2153,8 +2154,8 @@ export const upsertConnectorTokenConnection$ = command(
         db: tx,
         orgId: args.orgId,
         userId: args.userId,
-        type: args.type,
-        authMethod: args.authMethod,
+        runtimeMethod: args.runtimeMethod,
+        snapshot: args.snapshot,
         connectorTokenState,
         featureSwitchContext,
         userInfo: args.userInfo,
@@ -2178,8 +2179,7 @@ export const upsertConnectorTokenConnection$ = command(
     return {
       connector: storedConnectorRowToResponse(
         connectionResult.connectorRow,
-        args.type,
-        args.authMethod,
+        args.runtimeMethod,
         nowDate(),
       ),
       created:
@@ -2192,18 +2192,28 @@ export const upsertConnectorTokenConnection$ = command(
 export function zeroConnectorScopeDiff(args: {
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorType;
+  readonly type: string;
+  readonly snapshot?: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ScopeDiffResponse | null>> {
   return computed(async (get): Promise<ScopeDiffResponse | null> => {
-    const connector = await get(zeroConnectorByType(args));
+    const snapshot =
+      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
+    const connector = await get(zeroConnectorByType({ ...args, snapshot }));
     if (!connector) {
       return null;
     }
-    return getConnectorAuthMethodScopeDiff(
-      args.type,
-      connector.authMethod,
-      connector.oauthScopes,
-    );
+    const runtimeMethod = getConnectorRuntimeMethod({
+      snapshot,
+      connectorRef: args.type,
+      authMethodId: connector.authMethod,
+      requireExecutable: true,
+    });
+    return runtimeMethod === undefined
+      ? null
+      : connectorAuthMethodScopeDiff(
+          runtimeMethod.method,
+          connector.oauthScopes,
+        );
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-share-x.service.ts
@@ -1,27 +1,25 @@
 import { command } from "ccstate";
 import { randomUUID } from "node:crypto";
-import { and, eq, inArray, sql } from "drizzle-orm";
 import type { ApiErrorKey } from "@vm0/api-contracts/contracts/errors";
-import { refreshXToken } from "@vm0/connectors/auth-providers/connectors/x/oauth";
-import { connectors } from "@vm0/db/schema/connector";
-import { secrets } from "@vm0/db/schema/secret";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { z } from "zod";
 
-import { env, optionalEnv } from "../../lib/env";
+import { env } from "../../lib/env";
 import { now } from "../../lib/time";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { safeJsonParse, safeUrlParse, tapError } from "../utils";
-import { lockConnectorState } from "./auth-state-lock.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import {
-  decryptStoredSecretValue,
-  encryptStoredSecretValue,
-} from "./crypto.utils";
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialConnection,
+  loadConnectorCredentialValues,
+  refreshConnectorCredentialAccess,
+  type ConnectorCredentialConnection,
+} from "./connector-credential-runtime.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 
 const X_CONNECTOR_TYPE = "x";
-const X_ACCESS_TOKEN_SECRET_NAME = "X_ACCESS_TOKEN";
-const X_REFRESH_TOKEN_SECRET_NAME = "X_REFRESH_TOKEN";
+const X_ACCESS_TOKEN_ENVIRONMENT_NAME = "X_TOKEN";
 const X_TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_X_ACCESS_TOKEN_EXPIRES_IN_MS = 2 * 60 * 60 * 1000;
 const DEFAULT_X_CAPTION = "Made with Zero";
@@ -58,25 +56,12 @@ interface XShareFailure {
 
 type XShareResult = XShareSuccess | XShareFailure;
 
-interface XConnectorRow {
-  readonly oauthScopes: string | null;
-  readonly needsReconnect: boolean;
-  readonly tokenExpiresAt: Date | null;
-}
-
 type XAccessTokenResult =
   | {
       readonly ok: true;
       readonly accessToken: string;
     }
   | XShareFailure;
-
-interface XSecretValues {
-  readonly accessToken: string | null;
-  readonly refreshToken: string | null;
-}
-
-const oauthScopesSchema = z.array(z.string());
 
 const xMediaUploadResponseSchema = z
   .object({
@@ -107,18 +92,6 @@ function xShareError(errorKey: ApiErrorKey, message: string): XShareFailure {
   return { ok: false, errorKey, message };
 }
 
-function parseOAuthScopes(value: string | null): readonly string[] {
-  if (!value) {
-    return [];
-  }
-  const raw = safeJsonParse(value);
-  if (raw === undefined) {
-    return [];
-  }
-  const parsed = oauthScopesSchema.safeParse(raw);
-  return parsed.success ? parsed.data : [];
-}
-
 function missingRequiredScopes(scopes: readonly string[]): readonly string[] {
   const scopeSet = new Set(scopes);
   return REQUIRED_X_SCOPES.filter((scope) => {
@@ -126,197 +99,57 @@ function missingRequiredScopes(scopes: readonly string[]): readonly string[] {
   });
 }
 
-async function readXConnectorRow(args: {
+async function resolveXAccessToken(args: {
+  readonly connector: ConnectorCredentialConnection;
   readonly db: ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
-}): Promise<XConnectorRow | null> {
-  const [row] = await args.db
-    .select({
-      oauthScopes: connectors.oauthScopes,
-      needsReconnect: connectors.needsReconnect,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-    })
-    .from(connectors)
-    .where(
-      and(
-        eq(connectors.orgId, args.orgId),
-        eq(connectors.userId, args.userId),
-        eq(connectors.type, X_CONNECTOR_TYPE),
-      ),
-    );
-  return row ?? null;
-}
-
-async function loadXSecretValues(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<XSecretValues> {
-  const rows = await args.db
-    .select({ name: secrets.name, encryptedValue: secrets.encryptedValue })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.orgId, args.orgId),
-        eq(secrets.userId, args.userId),
-        eq(secrets.type, "connector"),
-        inArray(secrets.name, [
-          X_ACCESS_TOKEN_SECRET_NAME,
-          X_REFRESH_TOKEN_SECRET_NAME,
-        ]),
-      ),
-    );
-
-  const values = new Map<string, string>();
-  for (const row of rows) {
-    values.set(row.name, await decryptStoredSecretValue(row.encryptedValue));
-  }
-
-  return {
-    accessToken: values.get(X_ACCESS_TOKEN_SECRET_NAME) ?? null,
-    refreshToken: values.get(X_REFRESH_TOKEN_SECRET_NAME) ?? null,
-  };
-}
-
-async function upsertConnectorSecret(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly name: string;
-  readonly value: string;
-}): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(args.value);
-  await args.db
-    .insert(secrets)
-    .values({
-      orgId: args.orgId,
-      userId: args.userId,
-      name: args.name,
-      encryptedValue,
-      description: null,
-      type: "connector",
-    })
-    .onConflictDoUpdate({
-      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
-      set: {
-        encryptedValue,
-        description: null,
-        updatedAt: sql`clock_timestamp()`,
-      },
-    });
-}
-
-async function refreshAndPersistXAccessToken(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly refreshToken: string;
   readonly signal: AbortSignal;
   readonly writeDb: Db;
 }): Promise<XAccessTokenResult> {
-  const clientId = optionalEnv("X_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("X_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return xShareError("PROVIDER_UNAVAILABLE", "X sharing is not configured");
-  }
-
-  const refreshed = await tapError(
-    refreshXToken(clientId, clientSecret, args.refreshToken, args.signal),
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    args.connector,
+    X_ACCESS_TOKEN_ENVIRONMENT_NAME,
   );
-  args.signal.throwIfAborted();
-  if (!refreshed) {
+  if (accessTokenValueRef === null) {
     return xShareError("CONFLICT", "Reconnect X to post images");
   }
-
-  const nextRefreshToken = refreshed.refreshToken ?? args.refreshToken;
-  const tokenExpiresAt = new Date(
-    now() +
-      (refreshed.expiresIn
-        ? refreshed.expiresIn * 1000
-        : DEFAULT_X_ACCESS_TOKEN_EXPIRES_IN_MS),
-  );
-
-  await args.writeDb.transaction(async (tx) => {
-    await lockConnectorState(tx, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: X_CONNECTOR_TYPE,
-    });
-    args.signal.throwIfAborted();
-
-    await upsertConnectorSecret({
-      db: tx,
-      orgId: args.orgId,
-      userId: args.userId,
-      name: X_ACCESS_TOKEN_SECRET_NAME,
-      value: refreshed.accessToken,
-    });
-    args.signal.throwIfAborted();
-
-    await upsertConnectorSecret({
-      db: tx,
-      orgId: args.orgId,
-      userId: args.userId,
-      name: X_REFRESH_TOKEN_SECRET_NAME,
-      value: nextRefreshToken,
-    });
-    args.signal.throwIfAborted();
-
-    await tx
-      .update(connectors)
-      .set({
-        tokenExpiresAt,
-        needsReconnect: false,
-        reconnectReason: null,
-        updatedAt: sql`clock_timestamp()`,
-      })
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.type, X_CONNECTOR_TYPE),
-        ),
-      );
-  });
-
-  return { ok: true, accessToken: refreshed.accessToken };
-}
-
-async function resolveXAccessToken(args: {
-  readonly connector: XConnectorRow;
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly signal: AbortSignal;
-  readonly writeDb: Db;
-}): Promise<XAccessTokenResult> {
-  const secretValues = await loadXSecretValues({
+  const values = await loadConnectorCredentialValues({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
+    valueRefs: [accessTokenValueRef],
   });
   args.signal.throwIfAborted();
 
   const tokenExpiresAtMs = args.connector.tokenExpiresAt?.getTime() ?? 0;
+  const accessToken = values.get(accessTokenValueRef);
   const accessTokenCurrent =
-    secretValues.accessToken &&
+    accessToken &&
     (tokenExpiresAtMs === 0 ||
       tokenExpiresAtMs > now() + X_TOKEN_REFRESH_SKEW_MS);
   if (accessTokenCurrent) {
-    return { ok: true, accessToken: secretValues.accessToken };
+    return { ok: true, accessToken };
   }
 
-  if (!secretValues.refreshToken) {
-    return xShareError("CONFLICT", "Reconnect X to post images");
-  }
-
-  return await refreshAndPersistXAccessToken({
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection: args.connector,
+    db: args.db,
     orgId: args.orgId,
     userId: args.userId,
-    refreshToken: secretValues.refreshToken,
+    runtimeEnvironmentName: X_ACCESS_TOKEN_ENVIRONMENT_NAME,
     signal: args.signal,
-    writeDb: args.writeDb,
+    persist: {
+      db: args.writeDb,
+      defaultExpiresInMs: DEFAULT_X_ACCESS_TOKEN_EXPIRES_IN_MS,
+    },
   });
+  if (refreshed.kind === "configuration-unavailable") {
+    return xShareError("PROVIDER_UNAVAILABLE", "X sharing is not configured");
+  }
+  return refreshed.kind === "ok"
+    ? { ok: true, accessToken: refreshed.accessToken }
+    : xShareError("CONFLICT", "Reconnect X to post images");
 }
 
 function normalizeImageContentType(contentTypeHeader: string | null): string {
@@ -553,22 +386,25 @@ export const shareImageToX$ = command(
   ): Promise<XShareResult> => {
     const db = get(db$);
     const writeDb = set(writeDb$);
-    const connector = await readXConnectorRow({
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+    const loaded = await loadConnectorCredentialConnection({
       db,
+      snapshot,
       orgId: args.orgId,
       userId: args.userId,
+      connectorRef: X_CONNECTOR_TYPE,
     });
     signal.throwIfAborted();
 
-    if (!connector) {
+    if (loaded.kind === "missing") {
       return xShareError("NOT_FOUND", "Connect X to post images");
     }
-    if (connector.needsReconnect) {
+    if (loaded.kind === "unavailable" || loaded.connection.needsReconnect) {
       return xShareError("CONFLICT", "Reconnect X to post images");
     }
-    const missingScopes = missingRequiredScopes(
-      parseOAuthScopes(connector.oauthScopes),
-    );
+    const connector = loaded.connection;
+    const missingScopes = missingRequiredScopes(connector.oauthScopes ?? []);
     if (missingScopes.length > 0) {
       return xShareError("CONFLICT", "Reconnect X to post images");
     }

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   zeroMailDraftSchema,
   zeroMailDraftStatusSchema,
@@ -10,27 +10,31 @@ import {
   type ZeroMailDraftStatus,
   type ZeroMailProvider,
 } from "@vm0/api-contracts/contracts/zero-mail";
-import { refreshGoogleToken } from "@vm0/connectors/auth-providers/oauth/google";
-import { hasRequiredConnectorAuthMethodScopes } from "@vm0/connectors/connector-utils";
+import { connectorAuthMethodHasRequiredScopes } from "@vm0/connectors/connector-utils";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { connectors } from "@vm0/db/schema/connector";
 import { mailDrafts } from "@vm0/db/schema/mail-draft";
-import { secrets } from "@vm0/db/schema/secret";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { z } from "zod";
 
-import { env, optionalEnv } from "../../lib/env";
+import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../external/time";
-import { settleIncludingAbort, tapError } from "../utils";
-import { lockConnectorState } from "./auth-state-lock.service";
+import { tapError } from "../utils";
 import {
-  decryptStoredSecretValue,
-  encryptStoredSecretValue,
-} from "./crypto.utils";
+  getConnectorRuntimeMethod,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import {
+  connectorCredentialRuntimeValueRef,
+  loadConnectorCredentialValues,
+  refreshConnectorCredentialAccess,
+  type ConnectorCredentialConnection,
+} from "./connector-credential-runtime.service";
 import { insertChatMessage } from "./zero-chat-message.service";
 
 const L = logger("api:zero-mail");
@@ -38,8 +42,7 @@ const L = logger("api:zero-mail");
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS = 60 * 60 * 1000;
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
-const GMAIL_ACCESS_TOKEN_SECRET = "GMAIL_ACCESS_TOKEN";
-const GMAIL_REFRESH_TOKEN_SECRET = "GMAIL_REFRESH_TOKEN";
+const GMAIL_ACCESS_TOKEN_ENV = "GMAIL_TOKEN";
 const oauthScopesSchema = z.array(z.string());
 
 const gmailDraftResourceSchema = z.object({
@@ -57,13 +60,11 @@ const gmailMessageResourceSchema = z.object({
   raw: z.string().optional(),
 });
 
-interface MailConnection {
-  readonly connectorId: string;
+interface MailConnection extends ConnectorCredentialConnection {
+  readonly connectorRef: "gmail";
   readonly externalEmail: string;
   readonly externalUsername: string | null;
-  readonly needsReconnect: boolean;
   readonly scopesReady: boolean;
-  readonly tokenExpiresAt: Date | null;
 }
 
 interface MailDraftResult {
@@ -174,6 +175,7 @@ function okResult(
 
 async function loadMailConnections(args: {
   readonly db: ReadonlyDb;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -181,9 +183,11 @@ async function loadMailConnections(args: {
   const rows = await args.db
     .select({
       connectorId: connectors.id,
+      connectorType: connectors.type,
       authMethod: connectors.authMethod,
       externalEmail: connectors.externalEmail,
       externalUsername: connectors.externalUsername,
+      externalId: connectors.externalId,
       needsReconnect: connectors.needsReconnect,
       oauthScopes: connectors.oauthScopes,
       tokenExpiresAt: connectors.tokenExpiresAt,
@@ -207,21 +211,34 @@ async function loadMailConnections(args: {
     );
 
   return rows.flatMap((row): MailConnection[] => {
-    if (!row.externalEmail) {
+    if (row.connectorType !== "gmail" || !row.externalEmail) {
       return [];
     }
+    const runtimeMethod = getConnectorRuntimeMethod({
+      snapshot: args.snapshot,
+      connectorRef: row.connectorType,
+      authMethodId: row.authMethod,
+      requireExecutable: true,
+    });
+    if (!runtimeMethod) {
+      return [];
+    }
+    const oauthScopes = row.oauthScopes
+      ? oauthScopesSchema.parse(JSON.parse(row.oauthScopes))
+      : null;
     return [
       {
         connectorId: row.connectorId,
+        connectorRef: row.connectorType,
+        runtimeMethod,
         externalEmail: row.externalEmail,
         externalUsername: row.externalUsername,
+        externalId: row.externalId,
         needsReconnect: row.needsReconnect,
-        scopesReady: hasRequiredConnectorAuthMethodScopes(
-          "gmail",
-          row.authMethod,
-          row.oauthScopes
-            ? oauthScopesSchema.parse(JSON.parse(row.oauthScopes))
-            : null,
+        oauthScopes,
+        scopesReady: connectorAuthMethodHasRequiredScopes(
+          runtimeMethod.method,
+          oauthScopes,
         ),
         tokenExpiresAt: row.tokenExpiresAt,
       },
@@ -324,137 +341,6 @@ async function loadOwnedMailDraft(args: {
   return await loadOwnedNewMailDraft(args);
 }
 
-async function upsertConnectorSecret(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly name: string;
-  readonly value: string;
-}): Promise<void> {
-  const encryptedValue = await encryptStoredSecretValue(args.value);
-  await args.db
-    .insert(secrets)
-    .values({
-      orgId: args.orgId,
-      userId: args.userId,
-      name: args.name,
-      encryptedValue,
-      description: null,
-      type: "connector",
-    })
-    .onConflictDoUpdate({
-      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
-      set: {
-        encryptedValue,
-        description: null,
-        updatedAt: sql`clock_timestamp()`,
-      },
-    });
-}
-
-async function loadConnectorTokens(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<{
-  readonly accessToken: string | null;
-  readonly refreshToken: string | null;
-}> {
-  const rows = await args.db
-    .select({ name: secrets.name, encryptedValue: secrets.encryptedValue })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.orgId, args.orgId),
-        eq(secrets.userId, args.userId),
-        eq(secrets.type, "connector"),
-        inArray(secrets.name, [
-          GMAIL_ACCESS_TOKEN_SECRET,
-          GMAIL_REFRESH_TOKEN_SECRET,
-        ]),
-      ),
-    );
-  const values = new Map<string, string>();
-  for (const row of rows) {
-    values.set(row.name, await decryptStoredSecretValue(row.encryptedValue));
-  }
-  return {
-    accessToken: values.get(GMAIL_ACCESS_TOKEN_SECRET) ?? null,
-    refreshToken: values.get(GMAIL_REFRESH_TOKEN_SECRET) ?? null,
-  };
-}
-
-async function refreshMailAccessToken(args: {
-  readonly connection: MailConnection;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly refreshToken: string;
-  readonly signal: AbortSignal;
-  readonly writeDb: Db;
-}): Promise<MailAccessTokenResult> {
-  const clientId = optionalEnv("GOOGLE_OAUTH_CLIENT_ID");
-  const clientSecret = optionalEnv("GOOGLE_OAUTH_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    return { kind: "error", message: "Gmail OAuth is not configured" };
-  }
-
-  const refreshResult = await settleIncludingAbort(
-    refreshGoogleToken(
-      "gmail",
-      clientId,
-      clientSecret,
-      args.refreshToken,
-      args.signal,
-    ),
-  );
-  if (!refreshResult.ok) {
-    L.warn("Gmail access token refresh failed", {
-      connectorId: args.connection.connectorId,
-      error: refreshResult.error,
-    });
-    return { kind: "error", message: "Reconnect Gmail before continuing" };
-  }
-  const refreshed = refreshResult.value;
-  const nextRefreshToken = refreshed.refreshToken ?? args.refreshToken;
-  const tokenExpiresAt = new Date(
-    nowDate().getTime() +
-      (refreshed.expiresIn
-        ? refreshed.expiresIn * 1000
-        : DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS),
-  );
-  await args.writeDb.transaction(async (tx) => {
-    await lockConnectorState(tx, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: "gmail",
-    });
-    await upsertConnectorSecret({
-      db: tx,
-      orgId: args.orgId,
-      userId: args.userId,
-      name: GMAIL_ACCESS_TOKEN_SECRET,
-      value: refreshed.accessToken,
-    });
-    await upsertConnectorSecret({
-      db: tx,
-      orgId: args.orgId,
-      userId: args.userId,
-      name: GMAIL_REFRESH_TOKEN_SECRET,
-      value: nextRefreshToken,
-    });
-    await tx
-      .update(connectors)
-      .set({
-        tokenExpiresAt,
-        needsReconnect: false,
-        reconnectReason: null,
-        updatedAt: sql`clock_timestamp()`,
-      })
-      .where(eq(connectors.id, args.connection.connectorId));
-  });
-  return { kind: "ok", accessToken: refreshed.accessToken };
-}
-
 async function resolveMailAccessToken(args: {
   readonly connection: MailConnection;
   readonly db: ReadonlyDb;
@@ -466,25 +352,48 @@ async function resolveMailAccessToken(args: {
   if (args.connection.needsReconnect || !args.connection.scopesReady) {
     return { kind: "error", message: "Reconnect Gmail before continuing" };
   }
-  const tokens = await loadConnectorTokens(args);
-  const expiresAt = args.connection.tokenExpiresAt?.getTime() ?? 0;
-  if (
-    tokens.accessToken &&
-    (expiresAt === 0 || expiresAt > nowDate().getTime() + TOKEN_REFRESH_SKEW_MS)
-  ) {
-    return { kind: "ok", accessToken: tokens.accessToken };
-  }
-  if (!tokens.refreshToken) {
+  const accessTokenValueRef = connectorCredentialRuntimeValueRef(
+    args.connection,
+    GMAIL_ACCESS_TOKEN_ENV,
+  );
+  if (accessTokenValueRef === null) {
     return { kind: "error", message: "Reconnect Gmail before continuing" };
   }
-  return await refreshMailAccessToken({
-    connection: args.connection,
+  const values = await loadConnectorCredentialValues({
+    db: args.db,
     orgId: args.orgId,
     userId: args.userId,
-    refreshToken: tokens.refreshToken,
-    signal: args.signal,
-    writeDb: args.writeDb,
+    valueRefs: [accessTokenValueRef],
   });
+  const expiresAt = args.connection.tokenExpiresAt?.getTime() ?? 0;
+  const accessToken = values.get(accessTokenValueRef);
+  if (
+    accessToken &&
+    (expiresAt === 0 || expiresAt > nowDate().getTime() + TOKEN_REFRESH_SKEW_MS)
+  ) {
+    return { kind: "ok", accessToken };
+  }
+  const refreshed = await refreshConnectorCredentialAccess({
+    connection: args.connection,
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    runtimeEnvironmentName: GMAIL_ACCESS_TOKEN_ENV,
+    signal: args.signal,
+    persist: {
+      db: args.writeDb,
+      defaultExpiresInMs: DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS,
+    },
+  });
+  if (refreshed.kind === "configuration-unavailable") {
+    return { kind: "error", message: "Gmail OAuth is not configured" };
+  }
+  return refreshed.kind === "ok"
+    ? { kind: "ok", accessToken: refreshed.accessToken }
+    : {
+        kind: "error",
+        message: "Reconnect Gmail before continuing",
+      };
 }
 
 function encodeHeader(value: string): string {
@@ -841,12 +750,14 @@ function responseDraft(args: {
 
 async function connectionForRow(args: {
   readonly db: ReadonlyDb;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly row: NewMailDraftRow;
 }): Promise<MailConnection | null> {
   const connections = await loadMailConnections({
     db: args.db,
+    snapshot: args.snapshot,
     orgId: args.orgId,
     userId: args.userId,
     agentId: args.row.agentId,
@@ -862,6 +773,7 @@ async function connectionForRow(args: {
 async function accessForRow(args: {
   readonly db: ReadonlyDb;
   readonly writeDb: Db;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly row: NewMailDraftRow;
@@ -981,6 +893,7 @@ async function updateNewRowFromDraft(args: {
 async function getNewDraft(args: {
   readonly db: ReadonlyDb;
   readonly writeDb: Db;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly row: NewMailDraftRow;
@@ -1089,6 +1002,8 @@ export const createZeroMailDraft$ = command(
       };
     }
     const db = get(db$);
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const threadAgentId = await ownedThreadAgentId({ db, ...args });
     signal.throwIfAborted();
     if (!threadAgentId || (args.agentId && threadAgentId !== args.agentId)) {
@@ -1097,6 +1012,7 @@ export const createZeroMailDraft$ = command(
     const connections = (
       await loadMailConnections({
         db,
+        snapshot,
         orgId: args.orgId,
         userId: args.userId,
         agentId: threadAgentId,
@@ -1190,9 +1106,12 @@ export const getZeroMailDraft$ = command(
     if (!row) {
       return { kind: "not_found", message: "Mail draft not found" };
     }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     return await getNewDraft({
       db,
       writeDb: set(writeDb$),
+      snapshot,
       orgId: args.orgId,
       userId: args.userId,
       row,
@@ -1225,9 +1144,12 @@ export const updateZeroMailDraft$ = command(
     if (row.status !== "draft") {
       return { kind: "conflict", message: "This mail draft cannot be edited" };
     }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const access = await accessForRow({
       db,
       writeDb: set(writeDb$),
+      snapshot,
       orgId: args.orgId,
       userId: args.userId,
       row,
@@ -1307,9 +1229,12 @@ export const deleteZeroMailDraft$ = command(
         message: "Only an active draft can be deleted",
       };
     }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const access = await accessForRow({
       db,
       writeDb: set(writeDb$),
+      snapshot,
       orgId: args.orgId,
       userId: args.userId,
       row,
@@ -1397,12 +1322,15 @@ export const deleteZeroMailDraftsForThread$ = command(
   ): Promise<void> => {
     const db = get(db$);
     const writeDb = set(writeDb$);
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     for (const row of args.drafts) {
       await tapError(
         (async () => {
           const access = await accessForRow({
             db,
             writeDb,
+            snapshot,
             orgId: args.orgId,
             userId: args.userId,
             row,
@@ -1442,6 +1370,7 @@ interface SendDraftFields {
 async function sendNewZeroMailDraft(args: {
   readonly db: ReadonlyDb;
   readonly writeDb: Db;
+  readonly snapshot: ConnectorRuntimeSnapshot;
   readonly orgId: string;
   readonly userId: string;
   readonly row: NewMailDraftRow;
@@ -1544,9 +1473,12 @@ export const sendZeroMailDraft$ = command(
     if (!row) {
       return { kind: "not_found", message: "Mail draft not found" };
     }
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     return await sendNewZeroMailDraft({
       db,
       writeDb: set(writeDb$),
+      snapshot,
       orgId: args.orgId,
       userId: args.userId,
       fields: args,

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -190,6 +190,7 @@ async function loadMailConnections(args: {
       externalId: connectors.externalId,
       needsReconnect: connectors.needsReconnect,
       oauthScopes: connectors.oauthScopes,
+      stateRevision: sql<string>`${connectors.updatedAt}::text`,
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
     .from(userConnectors)
@@ -236,6 +237,7 @@ async function loadMailConnections(args: {
         externalId: row.externalId,
         needsReconnect: row.needsReconnect,
         oauthScopes,
+        stateRevision: row.stateRevision,
         scopesReady: connectorAuthMethodHasRequiredScopes(
           runtimeMethod.method,
           oauthScopes,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import { resolveFirewallServerMetadataPolicies } from "@vm0/connectors/firewall-metadata/server";
@@ -568,7 +568,7 @@ async function resolveZeroRunPermissionPolicies(
     readonly orgId: string;
     readonly userId: string;
     readonly agent: ZeroAgentRunRecord;
-    readonly allowedConnectorTypes: readonly ConnectorType[];
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
     readonly checkedAt: Date;
   },
   signal: AbortSignal,
@@ -599,7 +599,7 @@ async function loadZeroRunWorkflowPermissionContext(
     readonly orgId: string;
     readonly userId: string;
     readonly agent: ZeroAgentRunRecord;
-    readonly allowedConnectorTypes: readonly ConnectorType[];
+    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
     readonly apiStartTime: number;
     readonly timing: ApiDispatchTimingCollector;
   },
@@ -875,7 +875,7 @@ async function loadZeroRunConnectorScopes(
   },
   signal: AbortSignal,
 ): Promise<{
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
 }> {
   const scope = await loadAgentConnectorScope(db, {
@@ -910,7 +910,7 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerAgentId: string | undefined;
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
@@ -990,7 +990,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
   readonly zeroMailEnabled: boolean;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
@@ -1050,7 +1050,7 @@ interface ZeroRunAfterPreCreateBase {
   readonly zeroMailEnabled: boolean;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
-  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -7,7 +7,6 @@ import {
   connectorCatalogRefSchema,
   type ConnectorCatalogRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
-import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { getAllFeatureStates } from "@vm0/core/feature-switch";
 import {
   zeroWorkflowAutomations,
@@ -57,7 +56,7 @@ type DetectWorkflowConnectorReadinessResult =
     };
 
 interface AutomationConnectorDependency {
-  readonly connectorRef: ConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly reason: string;
 }
 
@@ -134,7 +133,7 @@ async function loadAutomationConnectorDependencies(
     readonly userId: string;
     readonly workflowId: string;
   },
-): Promise<ReadonlyMap<ConnectorType, AutomationConnectorDependency>> {
+): Promise<ReadonlyMap<ConnectorCatalogRef, AutomationConnectorDependency>> {
   const automations = await db
     .select({ eventType: zeroWorkflowAutomations.eventType })
     .from(zeroWorkflowAutomations)
@@ -146,7 +145,10 @@ async function loadAutomationConnectorDependencies(
       ),
     );
 
-  const dependencies = new Map<ConnectorType, AutomationConnectorDependency>();
+  const dependencies = new Map<
+    ConnectorCatalogRef,
+    AutomationConnectorDependency
+  >();
   for (const automation of automations) {
     if (!automation.eventType) {
       continue;

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { connectorAuthMethodIdSchema } from "@vm0/connectors/connectors";
 import { initContract } from "./base";
+import { connectorCatalogAuthMethodIdSchema } from "./connector-identity";
 
 const c = initContract();
 
@@ -40,7 +40,7 @@ export const cliAuthTestConnectorContract = c.router({
     query: testEmailQuerySchema,
     body: z.object({
       connectorName: z.string(),
-      authMethod: connectorAuthMethodIdSchema,
+      authMethod: connectorCatalogAuthMethodIdSchema,
       accessToken: z.string(),
       refreshToken: z.string().min(1).optional(),
       expiresIn: z.number().int().optional(),

--- a/turbo/packages/connectors/src/connector-config.ts
+++ b/turbo/packages/connectors/src/connector-config.ts
@@ -277,7 +277,7 @@ interface ConnectorAuthMethodDisplayConfig {
   helpText?: string;
   /** When false, this auth method is unavailable for new connector actions. */
   visible?: boolean;
-  /** When set, this auth method is only available while the feature is enabled. */
+  /** Discovery/UI rollout filter; never an authorization or execution check. */
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */
   showExperimentalLabel?: boolean;

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1364,6 +1364,11 @@ export interface AvailableConnectorAuthMethodsOptions {
   readonly apiAuthMethodPolicy?: ApiAuthMethodPolicy;
 }
 
+/**
+ * Returns whether an auth method belongs in user-specific discovery output.
+ * Feature switches are UI rollout state, not execution authorization. Runtime
+ * callers must resolve the method contract without consulting this function.
+ */
 export function isConnectorAuthMethodAvailable(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -234,6 +234,14 @@ export function getConnectorManualGrantFieldNamesForAuthMethod(
   return fields ? manualGrantFieldNames(fields) : null;
 }
 
+export function connectorAuthMethodManualGrantFieldNames(
+  method: ConnectorAuthMethodRuntimeConfig,
+): ConnectorManualGrantFieldNames | null {
+  return method.grant.kind === "manual"
+    ? manualGrantFieldNames(method.grant.fields)
+    : null;
+}
+
 export function getConnectorManualGrantFieldNames(
   type: ConnectorType,
 ): ConnectorManualGrantFieldNames | null {
@@ -1075,6 +1083,12 @@ export function getConnectorAuthMethodOpenIdAuthCallbackOrigin(
   if (!grant) {
     return undefined;
   }
+  return connectorOpenIdAuthGrantCallbackOrigin(grant);
+}
+
+export function connectorOpenIdAuthGrantCallbackOrigin(
+  grant: ConnectorOpenIdAuthGrantConfig,
+): ConnectorBrowserAuthCallbackOrigin {
   return grant.callbackOrigin ?? "api";
 }
 
@@ -1096,6 +1110,12 @@ export function getConnectorAuthMethodAuthCodeCallbackOrigin(
   if (!grant) {
     return undefined;
   }
+  return connectorAuthCodeGrantCallbackOrigin(grant);
+}
+
+export function connectorAuthCodeGrantCallbackOrigin(
+  grant: ConnectorAuthCodeGrantConfig,
+): ConnectorAuthCodeCallbackOrigin {
   return grant.callbackOrigin ?? DEFAULT_AUTH_CODE_CALLBACK_ORIGIN;
 }
 
@@ -1808,14 +1828,14 @@ export function getConnectorOwnedVariableNames(
   );
 }
 
-function connectorAuthMethodOwnedSecretNames(
-  method: ConnectorAuthMethodConfig | undefined,
+export function connectorAuthMethodOwnedSecretNames(
+  method: ConnectorAuthMethodRuntimeConfig | undefined,
 ): string[] {
   return method ? [...method.storage.secrets] : [];
 }
 
-function connectorAuthMethodOwnedVariableNames(
-  method: ConnectorAuthMethodConfig | undefined,
+export function connectorAuthMethodOwnedVariableNames(
+  method: ConnectorAuthMethodRuntimeConfig | undefined,
 ): string[] {
   return method ? [...method.storage.variables] : [];
 }
@@ -2009,6 +2029,23 @@ export function getConnectorAuthMethodScopeDiff(
 ): ScopeDiff {
   return scopeDiff(
     getConnectorAuthMethodGrantScopes(connectorType, authMethod),
+    storedScopes,
+  );
+}
+
+export function connectorAuthMethodScopeDiff(
+  method: ConnectorAuthMethodRuntimeConfig,
+  storedScopes: string[] | null,
+): ScopeDiff {
+  return scopeDiff(connectorGrantScopes(method.grant), storedScopes);
+}
+
+export function connectorAuthMethodHasRequiredScopes(
+  method: ConnectorAuthMethodRuntimeConfig,
+  storedScopes: string[] | null,
+): boolean {
+  return hasRequiredGrantScopes(
+    connectorGrantScopes(method.grant),
     storedScopes,
   );
 }


### PR DESCRIPTION
## Summary

- add one immutable connector runtime snapshot selected from the static catalog or the accepted PostgreSQL-backed external catalog
- carry open connector and auth-method identities plus the exact runtime method through manual, OAuth, OpenID, device, external-code, refresh, revoke, webhook, CLI-test, and run credential paths
- require current compatibility and exact local provider registration for execution while allowing local cleanup of compatibility-filtered stored connections
- keep connector feature switches discovery-only; authored visibility gates only new actions, while in-flight and stored credentials remain compatibility/executability-driven
- reject authored-hidden new actions before capability checks while preserving unknown-method and wrong-grant error precedence
- keep shadow execution on static behavior and compare only sanitized catalog projections without duplicate provider side effects
- preserve static skill mounting until #21815 while allowing unknown external connector refs to materialize credentials in runs
- reject stale refresh persistence after connector replacement and ignore filtered sibling methods when selecting OAuth callback origin

## Boundaries

- production still defaults to `CONNECTOR_CATALOG_SOURCE_MODE=static`; this PR does not activate the external source
- external request paths read the accepted snapshot from PostgreSQL only and never fetch connector catalog objects from R2
- exact catalog skill mounting remains in #21815
- server-private firewall consumers remain in #21876
- runner firewall composition remains in #21816

## Validation

- `pnpm format`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/connectors exec vitest run --maxWorkers=4 --silent=passed-only` — 63 files, 1284 tests passed
- connector catalog lifecycle — 73 tests passed
- connector action and state-machine regression suite — 6 files, 169 tests passed
- run, webhook firewall, and workflow consumers — 5 files, 221 tests passed
- credential refresh consumers — 5 files, 23 tests passed

Closes #21814

Parent delivery: #19396
