### PR TITLE
refactor(runner): add generic workspace affinity resource classes

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -399,9 +399,12 @@ fn merge_held_session_state(existing: &mut HeldSessionState, mut incoming: HeldS
     existing
         .workspace_caches
         .append(&mut incoming.workspace_caches);
-    existing
-        .workspace_caches
-        .sort_unstable_by(|a, b| a.profile.cmp(&b.profile));
+    existing.workspace_caches.sort_unstable_by(|a, b| {
+        a.profile.cmp(&b.profile).then_with(|| {
+            b.workspace_affinity_version
+                .cmp(&a.workspace_affinity_version)
+        })
+    });
     existing
         .workspace_caches
         .dedup_by(|a, b| a.profile == b.profile);
@@ -566,6 +569,7 @@ mod tests {
     fn workspace_cache(profile: &str) -> WorkspaceCacheState {
         WorkspaceCacheState {
             profile: profile.to_owned(),
+            workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
         }
     }
 
@@ -1150,6 +1154,38 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].last_completed_at, "2026-06-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn merge_held_session_states_preserves_workspace_affinity_capability() {
+        let legacy = HeldSessionState {
+            session_id: "sess-capability".into(),
+            last_completed_at: "2026-06-01T00:00:00.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![WorkspaceCacheState {
+                profile: "vm0/default".into(),
+                workspace_affinity_version: None,
+            }],
+        };
+        let capable = HeldSessionState {
+            session_id: "sess-capability".into(),
+            last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
+        };
+
+        let merged = merge_held_session_states(
+            vec![legacy],
+            vec![capable],
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].workspace_caches.len(), 1);
+        assert_eq!(
+            merged[0].workspace_caches[0].workspace_affinity_version,
+            Some(crate::types::WORKSPACE_AFFINITY_VERSION)
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -37,7 +37,8 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::paths::short_digest;
 use crate::provider::{
-    ClaimedJob, JobCandidate, PreLocalAdmissionOutcome, SessionHistoryGenerationLocalAvailability,
+    ClaimedJob, JobCandidate, LocalAdmissionResourceKind, PreLocalAdmissionOutcome,
+    SessionAffinityLocalResource, SessionHistoryGenerationLocalAvailability,
     SessionHistoryGenerationRelationship,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -46,7 +47,10 @@ use crate::restored_session_identity::{
 };
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
-use crate::types::{ExecutionContext, HeldSessionState, SandboxReuseResult};
+use crate::types::{
+    ExecutionContext, HeldSessionState, SandboxReuseResult, SessionAffinityResource,
+    WORKSPACE_AFFINITY_VERSION,
+};
 
 pub(super) struct DiscoveredJob {
     pub(super) candidate: JobCandidate,
@@ -77,6 +81,13 @@ enum LocalAdmissionResource {
 }
 
 impl LocalAdmissionResource {
+    fn kind(&self) -> LocalAdmissionResourceKind {
+        match self {
+            Self::Fresh(_) => LocalAdmissionResourceKind::Fresh,
+            Self::Reusable(_) => LocalAdmissionResourceKind::ReusableSandbox,
+        }
+    }
+
     fn session_history_generation_relationship(
         &self,
         target_generation_run_id: Option<RunId>,
@@ -127,7 +138,7 @@ struct AdmittedClaim {
 
 struct PreparedAffinityCandidate {
     candidate: JobCandidate,
-    exact_generation_reservation: Option<Box<ReservedIdleSandbox>>,
+    resource: Option<LocalAdmissionResource>,
 }
 
 struct ReuseAdmissionRequest<'a> {
@@ -488,7 +499,7 @@ async fn claim_with_local_admission(
 ) -> Option<AdmittedClaim> {
     let PreparedAffinityCandidate {
         mut candidate,
-        exact_generation_reservation,
+        resource,
     } = prepare_affinity_protected_candidate(
         candidate,
         profile_name,
@@ -502,8 +513,8 @@ async fn claim_with_local_admission(
 
     // Reserve either the exact reusable sandbox or fresh capacity before
     // claiming so a losing claim can restore all local ownership.
-    let resource = match exact_generation_reservation {
-        Some(reservation) => LocalAdmissionResource::Reusable(reservation),
+    let resource = match resource {
+        Some(resource) => resource,
         None => {
             acquire_local_admission_resource(
                 &candidate,
@@ -516,6 +527,7 @@ async fn claim_with_local_admission(
             .await?
         }
     };
+    candidate.set_local_admission_resource(resource.kind());
 
     // Insert cancel token before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
@@ -623,10 +635,13 @@ async fn prepare_affinity_protected_candidate(
         )
         .await
         {
+            let mut candidate =
+                candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+            candidate
+                .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
             return Some(PreparedAffinityCandidate {
-                candidate: candidate
-                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
-                exact_generation_reservation: Some(Box::new(reservation)),
+                candidate,
+                resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
             });
         }
 
@@ -648,33 +663,123 @@ async fn prepare_affinity_protected_candidate(
         return Some(PreparedAffinityCandidate {
             candidate: candidate
                 .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected),
-            exact_generation_reservation: None,
+            resource: None,
         });
     }
     let Some(cli_agent_session_id) = candidate.cli_agent_session_id().map(str::to_owned) else {
+        if candidate.session_affinity_resource().is_some() {
+            let delay = candidate
+                .affinity_protection_remaining()
+                .unwrap_or_default();
+            info!(
+                run_id = %candidate.run_id(),
+                delay_ms = delay.as_millis(),
+                "resource-class affinity candidate missing session metadata, deferring claim"
+            );
+            ctx.spawn_ctx.provider.defer_poll_after(delay).await;
+            return None;
+        }
         return Some(PreparedAffinityCandidate {
             candidate: candidate
                 .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::MissingSessionMetadata),
-            exact_generation_reservation: None,
+            resource: None,
         });
     };
 
-    let has_reusable = ctx.idle_pool.lock().await.has_reusable(
-        &cli_agent_session_id,
-        profile_name,
-        device_rate_limits,
-    );
-    let held_session_states = current_local_held_session_states(ctx).await;
-    let has_fresh_affinity = ctx.budget.can_afford(job_vcpu, job_memory)
-        && held_session_states
-            .iter()
-            .any(|state| state.session_id == cli_agent_session_id);
-    if has_reusable || has_fresh_affinity {
-        return Some(PreparedAffinityCandidate {
-            candidate: candidate
-                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
-            exact_generation_reservation: None,
-        });
+    match candidate.session_affinity_resource() {
+        Some(SessionAffinityResource::ReusableSandbox) => {
+            if let Some(reservation) = reserve_reusable_idle(
+                &cli_agent_session_id,
+                profile_name,
+                device_rate_limits,
+                None,
+                ctx,
+            )
+            .await
+            {
+                let mut candidate = candidate
+                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                candidate.set_session_affinity_local_resource(
+                    SessionAffinityLocalResource::ReusableSandbox,
+                );
+                return Some(PreparedAffinityCandidate {
+                    candidate,
+                    resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
+                });
+            }
+        }
+        Some(SessionAffinityResource::WorkspaceCache) => {
+            if let Some(reservation) = reserve_reusable_idle(
+                &cli_agent_session_id,
+                profile_name,
+                device_rate_limits,
+                None,
+                ctx,
+            )
+            .await
+            {
+                let mut candidate = candidate
+                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                candidate.set_session_affinity_local_resource(
+                    SessionAffinityLocalResource::ReusableSandbox,
+                );
+                return Some(PreparedAffinityCandidate {
+                    candidate,
+                    resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
+                });
+            }
+
+            let held_session_states = current_local_held_session_states(ctx).await;
+            let has_capable_workspace = held_session_states.iter().any(|state| {
+                state.session_id == cli_agent_session_id
+                    && state.workspace_caches.iter().any(|workspace| {
+                        workspace.profile == profile_name
+                            && workspace.workspace_affinity_version
+                                == Some(WORKSPACE_AFFINITY_VERSION)
+                    })
+            });
+            if has_capable_workspace
+                && let Some(lease) =
+                    ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
+            {
+                let mut candidate = candidate
+                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                candidate.set_session_affinity_local_resource(
+                    SessionAffinityLocalResource::WorkspaceCache,
+                );
+                return Some(PreparedAffinityCandidate {
+                    candidate,
+                    resource: Some(LocalAdmissionResource::Fresh(lease)),
+                });
+            }
+        }
+        None => {
+            // Transitional fallback for API candidates without resource classes.
+            // Remove after the rollout gate tracked by #21871.
+            let has_reusable = ctx.idle_pool.lock().await.has_reusable(
+                &cli_agent_session_id,
+                profile_name,
+                device_rate_limits,
+            );
+            let held_session_states = current_local_held_session_states(ctx).await;
+            let has_fresh_affinity = ctx.budget.can_afford(job_vcpu, job_memory)
+                && held_session_states
+                    .iter()
+                    .any(|state| state.session_id == cli_agent_session_id);
+            if has_reusable || has_fresh_affinity {
+                let mut candidate = candidate
+                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                candidate.set_session_affinity_local_resource(if has_reusable {
+                    SessionAffinityLocalResource::ReusableSandbox
+                } else {
+                    SessionAffinityLocalResource::LegacySession
+                });
+                return Some(PreparedAffinityCandidate {
+                    candidate,
+                    resource: None,
+                });
+            }
+        }
     }
 
     let delay = candidate

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -36,7 +36,7 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::{HeldSessionState, WorkspaceCacheState};
+use crate::types::{HeldSessionState, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState};
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionRequest,
@@ -72,6 +72,7 @@ fn mark_workspace_cache_snapshot_promoted(
             reusable_sandbox: None,
             workspace_caches: vec![WorkspaceCacheState {
                 profile: profile_name.to_owned(),
+                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
             }],
         });
     }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1242,14 +1242,16 @@ async fn unknown_profile_skipped() {
 
 #[tokio::test(start_paused = true)]
 async fn duplicate_discovery_deduplicated() {
-    // Budget for 2 jobs — enough for the duplicate to pass the budget
-    // check and reach the cancel_tokens dedup logic.
+    // Budget for the running job plus one reusable idle sandbox.
     let gate = Arc::new(tokio::sync::Notify::new());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&gate),
     ));
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let session_id = "sess-duplicate-reservation";
+    seed_idle_pool(&idle_pool, &budget, session_id, "vm0/default", 2, 4096).await;
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -1261,17 +1263,19 @@ async fn duplicate_discovery_deduplicated() {
     let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
-    // Push the same run_id again (simulates duplicate discovery).
-    // Budget has room, but cancel_tokens already contains this run_id →
-    // the duplicate is rejected and budget is released.
+    // Push the same run_id again with reusable affinity. The duplicate first
+    // owns the idle reservation, then must restore it when cancel_tokens shows
+    // that the original run already owns local admission.
     env.handle
         .discover_tx
-        .send(crate::provider::JobCandidate::new(
-            run_id,
-            "vm0/default".into(),
-        ))
+        .send(reusable_affinity_protected_candidate(run_id, session_id))
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert_eq!(
+        idle_pool.lock().await.held_sessions(),
+        vec![session_id.to_string()],
+        "duplicate rejection should restore the reusable reservation"
+    );
 
     // Wait for the original job to complete.
     gate.notify_one();
@@ -1290,7 +1294,8 @@ async fn duplicate_discovery_deduplicated() {
             "duplicate discovery should not produce a second completion"
         );
     }
-    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
 
     shutdown(&env, run_handle).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -10,7 +10,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
-use crate::types::SandboxReuseResult;
+use crate::types::{SandboxReuseResult, SessionAffinityResource};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
@@ -20,6 +20,22 @@ fn affinity_protected_candidate(run_id: RunId, session_id: &str) -> crate::provi
         Some(session_id.to_string()),
         Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
     )
+}
+
+fn reusable_affinity_protected_candidate(
+    run_id: RunId,
+    session_id: &str,
+) -> crate::provider::JobCandidate {
+    affinity_protected_candidate(run_id, session_id)
+        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
+}
+
+fn workspace_affinity_protected_candidate(
+    run_id: RunId,
+    session_id: &str,
+) -> crate::provider::JobCandidate {
+    affinity_protected_candidate(run_id, session_id)
+        .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache))
 }
 
 fn generation_affinity_protected_candidate(
@@ -388,6 +404,48 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let session_id = "sess-generic-conflict-restore";
+    seed_idle_pool(&idle_pool, &budget, session_id, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(reusable_affinity_protected_candidate(run_id, session_id))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert_eq!(
+        idle_pool.lock().await.held_sessions(),
+        vec![session_id.to_string()],
+        "lost claim should restore the generic reusable reservation"
+    );
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    let candidates = env.handle.claim_candidates();
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("generic reusable candidate should reach claim");
+    assert_eq!(
+        candidate.session_affinity_local_resource(),
+        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
+    );
+    assert_eq!(
+        candidate.local_admission_resource(),
+        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn reusable_generation_parked_after_discovery_is_attributed_at_claim() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
@@ -470,7 +528,7 @@ async fn reusable_claim_without_generation_target_omits_local_availability() {
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, session_id))
+        .send(reusable_affinity_protected_candidate(run_id, session_id))
         .unwrap();
 
     let completion = env
@@ -491,6 +549,18 @@ async fn reusable_claim_without_generation_target_omits_local_availability() {
     assert_eq!(
         candidate.session_history_generation_local_availability(),
         None
+    );
+    assert_eq!(
+        candidate.session_affinity_resource(),
+        Some(SessionAffinityResource::ReusableSandbox)
+    );
+    assert_eq!(
+        candidate.session_affinity_local_resource(),
+        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
+    );
+    assert_eq!(
+        candidate.local_admission_resource(),
+        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
     );
 
     shutdown(&env, run_handle).await;
@@ -565,7 +635,10 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
     );
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, "sess-owned-elsewhere"))
+        .send(reusable_affinity_protected_candidate(
+            run_id,
+            "sess-owned-elsewhere",
+        ))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -762,7 +835,7 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     env.handle
         .discover_tx
         .send(
-            affinity_protected_candidate(run_id, "sess-held-local")
+            workspace_affinity_protected_candidate(run_id, "sess-held-local")
                 .with_history_generation_run_id(Some(RunId::new_v4()))
                 .with_history_generation_affinity_protected_until(Some(
                     "2000-01-01T00:00:00Z".to_string(),
@@ -785,6 +858,14 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     assert_eq!(
         claimed_candidate.pre_local_admission_outcome(),
         Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
+    );
+    assert_eq!(
+        claimed_candidate.session_affinity_local_resource(),
+        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
+    );
+    assert_eq!(
+        claimed_candidate.local_admission_resource(),
+        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
     );
     assert_eq!(
         claimed_candidate.session_history_generation_relationship(),
@@ -810,7 +891,7 @@ async fn expired_generation_protection_preserves_local_session_claim() {
 }
 
 #[tokio::test]
-async fn generation_protected_workspace_cache_defers_then_legacy_candidate_claims() {
+async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspace() {
     let session_id = "sess-cache-local";
     let image_size_bytes = 1024 * 1024;
     let mut profiles = test_profiles();
@@ -849,6 +930,25 @@ async fn generation_protected_workspace_cache_defers_then_legacy_candidate_claim
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
+    let reusable_protected_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        reusable_protected_run_id,
+        Some(context_with_session(reusable_protected_run_id, session_id)),
+    );
+    env.handle
+        .discover_tx
+        .send(reusable_affinity_protected_candidate(
+            reusable_protected_run_id,
+            session_id,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "workspace-only state must not satisfy reusable-sandbox selection"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+
     tokio::fs::remove_dir_all(&cache_entry_dir).await.unwrap();
     let generation_protected_run_id = RunId::new_v4();
     env.provider.set_claim_result(
@@ -871,14 +971,14 @@ async fn generation_protected_workspace_cache_defers_then_legacy_candidate_claim
         env.handle.claim_candidates().is_empty(),
         "workspace-cache state and fresh capacity must not impersonate an exact reusable generation"
     );
-    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(env.handle.deferred_poll_delays().len(), 2);
 
     let run_id = RunId::new_v4();
     env.provider
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, session_id))
+        .send(workspace_affinity_protected_candidate(run_id, session_id))
         .unwrap();
 
     let completion = env
@@ -900,9 +1000,21 @@ async fn generation_protected_workspace_cache_defers_then_legacy_candidate_claim
         Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
     );
     assert_eq!(
+        claimed_candidate.session_affinity_resource(),
+        Some(SessionAffinityResource::WorkspaceCache)
+    );
+    assert_eq!(
+        claimed_candidate.session_affinity_local_resource(),
+        Some(crate::provider::SessionAffinityLocalResource::WorkspaceCache)
+    );
+    assert_eq!(
+        claimed_candidate.local_admission_resource(),
+        Some(crate::provider::LocalAdmissionResourceKind::Fresh)
+    );
+    assert_eq!(
         env.handle.deferred_poll_delays().len(),
-        1,
-        "the legacy candidate should not add another deferral"
+        2,
+        "the workspace-selected candidate should not add another deferral"
     );
 
     shutdown(&env, run_handle).await;
@@ -952,7 +1064,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(affinity_protected_candidate(run_id, session_id))
+        .send(workspace_affinity_protected_candidate(run_id, session_id))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -963,7 +1075,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     assert_eq!(
         env.handle.deferred_poll_delays().len(),
         1,
-        "protected cache-only work should wait for the exact reusable holder"
+        "workspace-selected work should defer when fresh budget is unavailable"
     );
     assert_eq!(
         idle_pool.lock().await.held_sessions(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -25,8 +25,8 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    PreLocalAdmissionOutcome, SessionHistoryGenerationLocalAvailability,
-    SessionHistoryGenerationRelationship,
+    LocalAdmissionResourceKind, PreLocalAdmissionOutcome, SessionAffinityLocalResource,
+    SessionHistoryGenerationLocalAvailability, SessionHistoryGenerationRelationship,
 };
 use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
@@ -63,6 +63,12 @@ struct ClaimRequestTelemetry {
     main_loop_to_local_admission_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pre_local_admission_outcome: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_affinity_resource: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_affinity_local_resource: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_admission_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_history_generation_relationship: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -366,12 +372,14 @@ impl JobProvider for ApiProvider {
                     let history_generation_affinity_protected_until =
                         job.history_generation_affinity_protected_until;
                     let affinity_protected_until = job.affinity_protected_until;
+                    let session_affinity_resource = job.session_affinity_resource;
                     let profile = job
                         .experimental_profile
                         .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_affinity_metadata(cli_agent_session_id, affinity_protected_until)
+                        .with_session_affinity_resource(session_affinity_resource)
                         .with_history_generation_run_id(history_generation_run_id)
                         .with_history_generation_affinity_protected_until(
                             history_generation_affinity_protected_until,
@@ -848,6 +856,15 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             provider_discovery_to_main_loop_ms,
             main_loop_to_local_admission_ms,
             pre_local_admission_outcome,
+            session_affinity_resource: candidate
+                .session_affinity_resource()
+                .map(crate::types::SessionAffinityResource::as_str),
+            session_affinity_local_resource: candidate
+                .session_affinity_local_resource()
+                .map(SessionAffinityLocalResource::as_str),
+            local_admission_resource: candidate
+                .local_admission_resource()
+                .map(LocalAdmissionResourceKind::as_str),
             session_history_generation_relationship: candidate
                 .session_history_generation_relationship()
                 .map(SessionHistoryGenerationRelationship::as_str),
@@ -1648,6 +1665,9 @@ mod tests {
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
         )
         .with_discovery_source(JobDiscoverySource::Poll)
+        .with_session_affinity_resource(Some(
+            crate::types::SessionAffinityResource::ReusableSandbox,
+        ))
         .with_history_generation_run_id(Some(target_generation_run_id))
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
@@ -1657,6 +1677,9 @@ mod tests {
         candidate.set_session_history_generation_local_availability(
             SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod,
         );
+        candidate
+            .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
+        candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
@@ -1674,6 +1697,18 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert_eq!(
+            body["telemetry"]["sessionAffinityResource"],
+            "reusableSandbox"
+        );
+        assert_eq!(
+            body["telemetry"]["sessionAffinityLocalResource"],
+            "reusableSandbox"
+        );
+        assert_eq!(
+            body["telemetry"]["localAdmissionResource"],
+            "reusableSandbox"
+        );
         assert_eq!(
             body["telemetry"]["sessionHistoryGenerationRelationship"],
             "exact"
@@ -1925,7 +1960,8 @@ mod tests {
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
                         "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                        "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
+                        "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
+                        "sessionAffinityResource": "reusableSandbox"
                     }
                 }));
             })
@@ -1950,6 +1986,10 @@ mod tests {
         );
         assert!(discovered.is_affinity_protected());
         assert!(discovered.is_history_generation_affinity_protected());
+        assert_eq!(
+            discovered.session_affinity_resource(),
+            Some(crate::types::SessionAffinityResource::ReusableSandbox)
+        );
         assert_eq!(
             discovered.discovery_source(),
             Some(JobDiscoverySource::Poll)

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -32,6 +32,7 @@ use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::types::SessionAffinityResource;
 
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
@@ -687,6 +688,7 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.affinity_protected_until.map(str::to_owned),
                     )
                     .with_history_generation_run_id(notif.history_generation_run_id)
+                    .with_session_affinity_resource(notif.session_affinity_resource)
                     .with_history_generation_affinity_protected_until(
                         notif
                             .history_generation_affinity_protected_until
@@ -731,6 +733,7 @@ struct JobNotification<'a> {
     run_id: RunId,
     profile: Option<&'a str>,
     cli_agent_session_id: Option<&'a str>,
+    session_affinity_resource: Option<SessionAffinityResource>,
     history_generation_run_id: Option<RunId>,
     history_generation_affinity_protected_until: Option<&'a str>,
     affinity_protected_until: Option<&'a str>,
@@ -882,6 +885,22 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("affinityProtectedUntil")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
+    let session_affinity_resource = match msg.data.get("sessionAffinityResource") {
+        Some(value) if value.as_str() == Some("reusableSandbox") => {
+            Some(SessionAffinityResource::ReusableSandbox)
+        }
+        Some(value) if value.as_str() == Some("workspaceCache") => {
+            Some(SessionAffinityResource::WorkspaceCache)
+        }
+        Some(value) => {
+            warn!(
+                value = %value,
+                "ably: invalid session affinity resource, ignoring job notification"
+            );
+            return None;
+        }
+        None => None,
+    };
     let history_generation_affinity_protected_until = msg
         .data
         .get("historyGenerationAffinityProtectedUntil")
@@ -896,6 +915,7 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         run_id,
         profile,
         cli_agent_session_id,
+        session_affinity_resource,
         history_generation_run_id,
         history_generation_affinity_protected_until,
         affinity_protected_until,
@@ -1749,7 +1769,8 @@ mod tests {
                 "cliAgentSessionId": "sess-ably",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
+                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
+                "sessionAffinityResource": "workspaceCache"
             }),
         );
 
@@ -1765,6 +1786,10 @@ mod tests {
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert!(candidate.is_affinity_protected());
         assert!(candidate.is_history_generation_affinity_protected());
+        assert_eq!(
+            candidate.session_affinity_resource(),
+            Some(SessionAffinityResource::WorkspaceCache)
+        );
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }
@@ -2215,12 +2240,17 @@ mod tests {
                 "cliAgentSessionId": "sess-target",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
+                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
+                "sessionAffinityResource": "reusableSandbox"
             }),
         );
         let notif = parse_job_notification(&msg).unwrap();
         assert_eq!(notif.profile, Some("vm0/default"));
         assert_eq!(notif.cli_agent_session_id, Some("sess-target"));
+        assert_eq!(
+            notif.session_affinity_resource,
+            Some(SessionAffinityResource::ReusableSandbox)
+        );
         assert_eq!(
             notif.history_generation_run_id,
             Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
@@ -2233,6 +2263,20 @@ mod tests {
             notif.affinity_protected_until,
             Some("2999-01-01T00:00:00.000Z")
         );
+    }
+
+    #[test]
+    fn parse_job_notification_rejects_unknown_session_affinity_resource() {
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
+                "sessionAffinityResource": "futureResource"
+            }),
+        );
+
+        assert!(parse_job_notification(&msg).is_none());
     }
 
     #[test]

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -8,6 +8,7 @@ use tracing::warn;
 
 use super::{JobCandidate, JobDiscoverySource};
 use crate::ids::RunId;
+use crate::types::SessionAffinityResource;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
 
@@ -18,6 +19,7 @@ pub(super) struct DirectJobCandidate {
     discovered_at: StdInstant,
     enqueued_at: Option<StdInstant>,
     cli_agent_session_id: Option<String>,
+    session_affinity_resource: Option<SessionAffinityResource>,
     history_generation_run_id: Option<RunId>,
     history_generation_affinity_protected_until: Option<String>,
     affinity_protected_until: Option<String>,
@@ -64,6 +66,7 @@ impl DirectJobCandidate {
             discovered_at,
             enqueued_at: None,
             cli_agent_session_id,
+            session_affinity_resource: None,
             history_generation_run_id: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until,
@@ -102,6 +105,14 @@ impl DirectJobCandidate {
         self
     }
 
+    pub(super) fn with_session_affinity_resource(
+        mut self,
+        resource: Option<SessionAffinityResource>,
+    ) -> Self {
+        self.session_affinity_resource = resource;
+        self
+    }
+
     pub(super) fn with_history_generation_affinity_protected_until(
         mut self,
         protected_until: Option<String>,
@@ -120,6 +131,7 @@ impl DirectJobCandidate {
             .map(|enqueued_at| dequeued_at.saturating_duration_since(enqueued_at));
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
+            .with_session_affinity_resource(self.session_affinity_resource)
             .with_history_generation_run_id(self.history_generation_run_id)
             .with_history_generation_affinity_protected_until(
                 self.history_generation_affinity_protected_until,
@@ -143,6 +155,11 @@ impl DirectJobCandidate {
         }
         if candidate.affinity_protected_until.is_some() {
             self.affinity_protected_until = candidate.affinity_protected_until;
+        }
+        if self.session_affinity_resource.is_none()
+            || candidate.session_affinity_resource == Some(SessionAffinityResource::ReusableSandbox)
+        {
+            self.session_affinity_resource = candidate.session_affinity_resource;
         }
         if candidate
             .history_generation_affinity_protected_until
@@ -424,13 +441,16 @@ mod tests {
         let run_id = run_id(1);
 
         let inserted = inbox
-            .push(DirectJobCandidate::new_with_affinity_metadata(
-                run_id,
-                "vm0/default".to_string(),
-                first_discovered_at,
-                Some("sess-1".to_string()),
-                None,
-            ))
+            .push(
+                DirectJobCandidate::new_with_affinity_metadata(
+                    run_id,
+                    "vm0/default".to_string(),
+                    first_discovered_at,
+                    Some("sess-1".to_string()),
+                    None,
+                )
+                .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache)),
+            )
             .await;
         assert_eq!(
             inserted.snapshot(),
@@ -452,7 +472,8 @@ mod tests {
                 .with_history_generation_run_id(Some(history_generation_run_id))
                 .with_history_generation_affinity_protected_until(Some(
                     "2999-01-01T00:00:00.000Z".to_string(),
-                )),
+                ))
+                .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox)),
             )
             .await;
         assert!(matches!(
@@ -466,6 +487,23 @@ mod tests {
             }
         ));
 
+        let downgraded = inbox
+            .push(
+                DirectJobCandidate::new_with_affinity_metadata(
+                    run_id,
+                    "vm0/default".to_string(),
+                    second_discovered_at,
+                    None,
+                    None,
+                )
+                .with_session_affinity_resource(Some(SessionAffinityResource::WorkspaceCache)),
+            )
+            .await;
+        assert!(matches!(
+            downgraded,
+            DirectCandidateInsertOutcome::Updated { .. }
+        ));
+
         let candidate = inbox.try_pop().await.expect("direct candidate");
         assert_eq!(candidate.discovered_at(), first_discovered_at);
         assert!(candidate.enqueued_at().is_some());
@@ -477,6 +515,10 @@ mod tests {
         );
         assert!(candidate.is_affinity_protected());
         assert!(candidate.is_history_generation_affinity_protected());
+        assert_eq!(
+            candidate.session_affinity_resource(),
+            Some(SessionAffinityResource::ReusableSandbox)
+        );
         assert!(
             candidate
                 .direct_candidate_notification_to_enqueue_elapsed()

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource};
 
 /// Low-cardinality source that first discovered a job candidate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -58,6 +58,38 @@ impl PreLocalAdmissionOutcome {
             Self::NotProtected => "not_protected",
             Self::LocalHolder => "local_holder",
             Self::MissingSessionMetadata => "missing_session_metadata",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SessionAffinityLocalResource {
+    ReusableSandbox,
+    WorkspaceCache,
+    LegacySession,
+}
+
+impl SessionAffinityLocalResource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ReusableSandbox => "reusableSandbox",
+            Self::WorkspaceCache => "workspaceCache",
+            Self::LegacySession => "legacySession",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LocalAdmissionResourceKind {
+    ReusableSandbox,
+    Fresh,
+}
+
+impl LocalAdmissionResourceKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ReusableSandbox => "reusableSandbox",
+            Self::Fresh => "fresh",
         }
     }
 }
@@ -120,6 +152,9 @@ pub struct JobCandidate {
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
     cli_agent_session_id: Option<String>,
+    session_affinity_resource: Option<SessionAffinityResource>,
+    session_affinity_local_resource: Option<SessionAffinityLocalResource>,
+    local_admission_resource: Option<LocalAdmissionResourceKind>,
     history_generation_run_id: Option<RunId>,
     session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
     session_history_generation_local_availability:
@@ -156,6 +191,9 @@ impl JobCandidate {
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
             cli_agent_session_id: None,
+            session_affinity_resource: None,
+            session_affinity_local_resource: None,
+            local_admission_resource: None,
             history_generation_run_id: None,
             session_history_generation_relationship: None,
             session_history_generation_local_availability: None,
@@ -258,6 +296,18 @@ impl JobCandidate {
         self.cli_agent_session_id.as_deref()
     }
 
+    pub(crate) fn session_affinity_resource(&self) -> Option<SessionAffinityResource> {
+        self.session_affinity_resource
+    }
+
+    pub(crate) fn session_affinity_local_resource(&self) -> Option<SessionAffinityLocalResource> {
+        self.session_affinity_local_resource
+    }
+
+    pub(crate) fn local_admission_resource(&self) -> Option<LocalAdmissionResourceKind> {
+        self.local_admission_resource
+    }
+
     pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
         self.history_generation_run_id
     }
@@ -308,6 +358,14 @@ impl JobCandidate {
         self
     }
 
+    pub(crate) fn with_session_affinity_resource(
+        mut self,
+        resource: Option<SessionAffinityResource>,
+    ) -> Self {
+        self.session_affinity_resource = resource;
+        self
+    }
+
     pub(crate) fn with_history_generation_run_id(
         mut self,
         history_generation_run_id: Option<RunId>,
@@ -338,6 +396,17 @@ impl JobCandidate {
         availability: SessionHistoryGenerationLocalAvailability,
     ) {
         self.session_history_generation_local_availability = Some(availability);
+    }
+
+    pub(crate) fn set_session_affinity_local_resource(
+        &mut self,
+        resource: SessionAffinityLocalResource,
+    ) {
+        self.session_affinity_local_resource = Some(resource);
+    }
+
+    pub(crate) fn set_local_admission_resource(&mut self, resource: LocalAdmissionResourceKind) {
+        self.local_admission_resource = Some(resource);
     }
 
     pub(crate) fn with_discovery_source(mut self, source: JobDiscoverySource) -> Self {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -13,6 +13,7 @@ use crate::ids::RunId;
 pub(crate) const MAX_HELD_SESSION_STATES: usize = 1024;
 pub(crate) const MAX_WORKSPACE_CACHES_PER_SESSION: usize = 8;
 pub(crate) const MAX_WORKSPACE_CACHES_PER_HEARTBEAT: usize = 1024;
+pub(crate) const WORKSPACE_AFFINITY_VERSION: u8 = 1;
 
 fn is_false(value: &bool) -> bool {
     !*value
@@ -42,6 +43,24 @@ pub struct Job {
     pub history_generation_affinity_protected_until: Option<String>,
     #[serde(default)]
     pub affinity_protected_until: Option<String>,
+    #[serde(default)]
+    pub session_affinity_resource: Option<SessionAffinityResource>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionAffinityResource {
+    ReusableSandbox,
+    WorkspaceCache,
+}
+
+impl SessionAffinityResource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ReusableSandbox => "reusableSandbox",
+            Self::WorkspaceCache => "workspaceCache",
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1247,6 +1266,8 @@ pub struct ReusableSandboxState {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceCacheState {
     pub profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_affinity_version: Option<u8>,
 }
 
 /// Runner state snapshot sent to the server via heartbeat.
@@ -1353,7 +1374,8 @@ mod tests {
         let json = json!({
             "job": {
                 "runId": "550e8400-e29b-41d4-a716-446655440000",
-                "experimentalProfile": "browser"
+                "experimentalProfile": "browser",
+                "sessionAffinityResource": "workspaceCache"
             }
         });
         let resp: PollResponse = serde_json::from_value(json).unwrap();
@@ -1365,6 +1387,10 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(job.experimental_profile.as_deref(), Some("browser"));
+        assert_eq!(
+            job.session_affinity_resource,
+            Some(SessionAffinityResource::WorkspaceCache)
+        );
     }
 
     #[test]
@@ -1381,6 +1407,7 @@ mod tests {
         });
         let job: Job = serde_json::from_value(json).unwrap();
         assert!(job.experimental_profile.is_none());
+        assert!(job.session_affinity_resource.is_none());
     }
 
     #[test]
@@ -1969,6 +1996,7 @@ mod tests {
                 }),
                 workspace_caches: vec![WorkspaceCacheState {
                     profile: "vm0/large".into(),
+                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
                 }],
             }],
             mode: "running".into(),
@@ -1994,7 +2022,10 @@ mod tests {
                     "profile": "vm0/default",
                     "historyGenerationRunId": "11111111-1111-4111-8111-111111111111"
                 },
-                "workspaceCaches": [{ "profile": "vm0/large" }]
+                "workspaceCaches": [{
+                    "profile": "vm0/large",
+                    "workspaceAffinityVersion": 1
+                }]
             }])
         );
         assert_eq!(json["mode"], "running");

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -13,7 +13,7 @@ use crate::ids::RunId;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_SESSION, WorkspaceCacheState,
+    MAX_WORKSPACE_CACHES_PER_SESSION, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState,
 };
 
 use super::entry::is_cache_key_name;
@@ -640,6 +640,7 @@ impl SessionWorkspaceCache {
                     reusable_sandbox: None,
                     workspace_caches: vec![WorkspaceCacheState {
                         profile: metadata.profile_name,
+                        workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
                     }],
                 });
             }
@@ -1512,9 +1513,12 @@ pub(crate) fn cap_workspace_held_session_states(
     let mut states: Vec<HeldSessionState> = by_session
         .into_values()
         .map(|mut state| {
-            state
-                .workspace_caches
-                .sort_unstable_by(|a, b| a.profile.cmp(&b.profile));
+            state.workspace_caches.sort_unstable_by(|a, b| {
+                a.profile.cmp(&b.profile).then_with(|| {
+                    b.workspace_affinity_version
+                        .cmp(&a.workspace_affinity_version)
+                })
+            });
             state
                 .workspace_caches
                 .dedup_by(|a, b| a.profile == b.profile);

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -26,7 +26,7 @@ use crate::storage_fingerprints::StorageFingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind,
+    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind, WORKSPACE_AFFINITY_VERSION,
     WorkspaceCacheState as HeldWorkspaceCacheState,
 };
 use sha2::{Digest, Sha256};
@@ -1076,6 +1076,7 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
             reusable_sandbox: None,
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: TEST_PROFILE_NAME.to_owned(),
+                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
             }],
         })
         .collect();
@@ -1085,6 +1086,7 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
         reusable_sandbox: None,
         workspace_caches: vec![HeldWorkspaceCacheState {
             profile: TEST_PROFILE_NAME.to_owned(),
+            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
         }],
     });
 
@@ -1115,6 +1117,7 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
             reusable_sandbox: None,
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: format!("vm0/profile-{index:02}"),
+                workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
             }],
         })
         .collect();
@@ -1137,6 +1140,7 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
             workspace_caches: (0..8)
                 .map(|profile| HeldWorkspaceCacheState {
                     profile: format!("vm0/profile-{profile}"),
+                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
                 })
                 .collect(),
         })
@@ -1213,9 +1217,11 @@ async fn held_session_states_for_profiles_filters_and_aggregates_current_identit
             workspace_caches: vec![
                 HeldWorkspaceCacheState {
                     profile: "vm0/default".into(),
+                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
                 },
                 HeldWorkspaceCacheState {
                     profile: "vm0/large".into(),
+                    workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
                 },
             ],
         }]

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -1,4 +1,5 @@
 import Ably from "ably";
+import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
 import { env } from "../../lib/env";
@@ -277,6 +278,7 @@ export async function publishRunnerJobNotification(
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationAffinityProtectedUntil: string | null;
     readonly affinityProtectedUntil: string | null;
+    readonly sessionAffinityResource: SessionAffinityResource | null;
     readonly historyGenerationRunId: string | undefined;
   },
 ): Promise<boolean> {
@@ -291,6 +293,9 @@ export async function publishRunnerJobNotification(
           : {}),
         ...(metadata?.affinityProtectedUntil
           ? { affinityProtectedUntil: metadata.affinityProtectedUntil }
+          : {}),
+        ...(metadata?.sessionAffinityResource
+          ? { sessionAffinityResource: metadata.sessionAffinityResource }
           : {}),
         ...(metadata?.historyGenerationAffinityProtectedUntil
           ? {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -102,6 +102,12 @@ function historyGenerationAffinityProtectedUntil(
   return job?.historyGenerationAffinityProtectedUntil ?? null;
 }
 
+function sessionAffinityResource(
+  job: RunnerJob | null | undefined,
+): RunnerJob["sessionAffinityResource"] {
+  return job?.sessionAffinityResource;
+}
+
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_custom_connector_auth_refs",
@@ -2668,6 +2674,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         readonly profile: string;
         readonly historyGenerationRunId?: string;
       };
+      readonly workspaceCaches?: {
+        readonly profile: string;
+        readonly workspaceAffinityVersion?: 1;
+      }[];
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
         runnerId: affinityRunnerId,
@@ -2680,6 +2690,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
             ...(args.reusableSandbox
               ? { reusableSandbox: args.reusableSandbox }
               : {}),
+            workspaceCaches: args.workspaceCaches,
           },
         ],
         mode: args.mode,
@@ -2783,6 +2794,109 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(finalHeartbeatHolder.job),
     ).toBeNull();
+    expect(sessionAffinityResource(finalHeartbeatHolder.job)).toBeUndefined();
+
+    await heartbeatHolder({
+      admittableProfiles: ["vm0/default"],
+      workspaceCaches: [
+        { profile: "vm0/default", workspaceAffinityVersion: 1 },
+      ],
+    });
+    const capableWorkspaceHolder = await pollFollowUp(
+      "continue with a capable workspace holder",
+    );
+    expect(
+      sessionAffinityProtectedUntil(capableWorkspaceHolder.job),
+    ).toStrictEqual(expect.any(String));
+    expect(sessionAffinityResource(capableWorkspaceHolder.job)).toBe(
+      "workspaceCache",
+    );
+
+    const reusableRunnerId = randomUUID();
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: reusableRunnerId,
+      group: runnerGroup,
+      admittableProfiles: [],
+      heldSessionStates: [
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+    });
+    const reusableOverWorkspace = await pollFollowUp(
+      "prefer a reusable holder over a capable workspace holder",
+    );
+    expect(sessionAffinityResource(reusableOverWorkspace.job)).toBe(
+      "reusableSandbox",
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: reusableOverWorkspace.run.runId,
+        sessionAffinityResource: "reusableSandbox",
+      }),
+    );
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: reusableRunnerId,
+      group: runnerGroup,
+      admittableProfiles: [],
+      heldSessionStates: [],
+      mode: "stopping",
+    });
+
+    await heartbeatHolder({
+      admittableProfiles: ["vm0/default"],
+      workspaceCaches: [{ profile: "vm0/large", workspaceAffinityVersion: 1 }],
+    });
+    const mismatchedCapableWorkspace = await pollFollowUp(
+      "continue with a mismatched capable workspace",
+    );
+    expect(
+      sessionAffinityProtectedUntil(mismatchedCapableWorkspace.job),
+    ).toBeNull();
+    expect(
+      sessionAffinityResource(mismatchedCapableWorkspace.job),
+    ).toBeUndefined();
+
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: affinityRunnerId,
+      group: runnerGroup,
+      admittableProfiles: ["vm0/default"],
+      heldSessionStates: [
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+          workspaceCaches: [
+            { profile: "vm0/large", workspaceAffinityVersion: 1 },
+          ],
+        },
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+        },
+      ],
+    });
+    const duplicateLegacyParent = await pollFollowUp(
+      "continue with a duplicate legacy parent beside a capable mismatch",
+    );
+    expect(sessionAffinityProtectedUntil(duplicateLegacyParent.job)).toBeNull();
+    expect(sessionAffinityResource(duplicateLegacyParent.job)).toBeUndefined();
+
+    await heartbeatHolder({
+      admittableProfiles: ["vm0/default"],
+      workspaceCaches: [{ profile: "vm0/default" }],
+    });
+    const observationOnlyWorkspace = await pollFollowUp(
+      "continue with an observation-only workspace holder",
+    );
+    expect(
+      sessionAffinityProtectedUntil(observationOnlyWorkspace.job),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      sessionAffinityResource(observationOnlyWorkspace.job),
+    ).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -2797,6 +2911,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       sessionAffinityProtectedUntil(differentGenerationHolder.job),
     ).toStrictEqual(expect.any(String));
+    expect(sessionAffinityResource(differentGenerationHolder.job)).toBe(
+      "reusableSandbox",
+    );
     expect(
       historyGenerationAffinityProtectedUntil(differentGenerationHolder.job),
     ).toBeNull();
@@ -2817,6 +2934,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(exactGenerationHolder.job),
     ).toStrictEqual(expect.any(String));
+    expect(sessionAffinityResource(exactGenerationHolder.job)).toBe(
+      "reusableSandbox",
+    );
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -2946,6 +3066,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: protectedFollowUp.runId,
         historyGenerationRunId: first.runId,
         affinityProtectedUntil: new Date(queueInsertedAt + 2000).toISOString(),
+        sessionAffinityResource: "reusableSandbox",
         historyGenerationAffinityProtectedUntil: new Date(
           queueInsertedAt + 500,
         ).toISOString(),
@@ -2968,6 +3089,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(protectedPoll.body.job),
     ).toBe(new Date(queueInsertedAt + 500).toISOString());
+    expect(sessionAffinityResource(protectedPoll.body.job)).toBe(
+      "reusableSandbox",
+    );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
     expect(protectedClaim.prompt).toBe("continue affinity-protected session");
@@ -3009,6 +3133,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           profile: "vm0/default",
           notification_target: "broadcast",
           session_affinity: "protected",
+          session_affinity_resource: "reusableSandbox",
           history_generation_affinity: "protected",
         }),
       );
@@ -3125,6 +3250,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.affinityProtectedUntil).toStrictEqual(
       expect.any(String),
     );
+    expect(protectedPoll.body.job?.sessionAffinityResource).toBe(
+      "reusableSandbox",
+    );
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
 
     const olderGeneric = await api.createRun(actor, {
@@ -3208,6 +3336,102 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(expiredPriorityPoll.body.job?.runId).toBe(olderGeneric.runId);
 
     await api.requestCancelRun(actor, newerReusable.runId, [200]);
+    await api.requestCancelRun(actor, olderGeneric.runId, [200]);
+  });
+
+  it("prioritizes capable workspace work only for its matching runner", async () => {
+    const api = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "start workspace-priority session",
+      modelProvider: "anthropic-api-key",
+    });
+    const firstClaim = await api.claimRunnerJob(first.runId);
+    const cliAgentSessionId = `bdd-workspace-priority-${first.runId}`;
+    const history = `bdd workspace priority history ${first.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+
+    const workspaceRunnerId = randomUUID();
+    const priorityBase = now();
+    mockNow(priorityBase);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: workspaceRunnerId,
+      group: runnerGroup,
+      admittableProfiles: ["vm0/default"],
+      heldSessionStates: [
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+          workspaceCaches: [
+            { profile: "vm0/default", workspaceAffinityVersion: 1 },
+          ],
+        },
+      ],
+    });
+
+    const olderGeneric = await api.createRun(actor, {
+      agentId,
+      prompt: "older workspace-priority FIFO work",
+      modelProvider: "anthropic-api-key",
+    });
+    mockNow(priorityBase + 1);
+    const newerWorkspace = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "newer capable workspace work",
+      modelProvider: "anthropic-api-key",
+    });
+
+    const fifoPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (fifoPoll.status !== 200) {
+      throw new Error("Expected workspace FIFO poll to return 200");
+    }
+    expect(fifoPoll.body.job?.runId).toBe(olderGeneric.runId);
+
+    const workspacePoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: workspaceRunnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (workspacePoll.status !== 200) {
+      throw new Error("Expected workspace-priority poll to return 200");
+    }
+    expect(workspacePoll.body.job?.runId).toBe(newerWorkspace.runId);
+    expect(workspacePoll.body.job?.sessionAffinityResource).toBe(
+      "workspaceCache",
+    );
+
+    await api.requestCancelRun(actor, newerWorkspace.runId, [200]);
     await api.requestCancelRun(actor, olderGeneric.runId, [200]);
   });
 });
@@ -3469,6 +3693,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           profile: "vm0/default",
           notification_target: "broadcast",
           session_affinity: "no_session",
+          session_affinity_resource: "none",
           history_generation_affinity: "no_session",
         }),
       );
@@ -7952,6 +8177,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           discoverySource: "poll",
           jobDiscoveredToClaimRequestMs: 1234,
           localAdmissionToClaimRequestMs: 56,
+          sessionAffinityResource: "workspaceCache",
+          sessionAffinityLocalResource: "reusableSandbox",
+          localAdmissionResource: "reusableSandbox",
           pollDueToJobDiscoveredMs: 789,
           pollHttpRequestMs: 321,
           pollReason: "deferred",
@@ -8047,6 +8275,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         auth_type: "user",
         discovery_source: "poll",
         poll_reason: "deferred",
+        session_affinity_resource: "workspaceCache",
+        session_affinity_local_resource: "reusableSandbox",
+        local_admission_resource: "reusableSandbox",
       }),
     );
     expect(
@@ -8064,6 +8295,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         auth_type: "user",
         discovery_source: "poll",
         poll_reason: "deferred",
+        session_affinity_resource: "workspaceCache",
+        session_affinity_local_resource: "reusableSandbox",
+        local_admission_resource: "reusableSandbox",
       }),
     );
     for (const actionType of RUNNER_POLL_TIMING_ACTION_TYPES) {
@@ -8110,6 +8344,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           auth_type: "user",
           discovery_source: "poll",
           poll_reason: "deferred",
+          session_affinity_resource: "workspaceCache",
+          session_affinity_local_resource: "reusableSandbox",
+          local_admission_resource: "reusableSandbox",
         }),
       );
     }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -67,9 +67,10 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
-  runnerReusableSessionPollPriority,
+  runnerSessionAffinityPollPriority,
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
+  runnerSessionAffinityTelemetryResource,
 } from "../services/runner-session-affinity";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
@@ -334,7 +335,15 @@ function canonicalizeHeldSessionStates(
       ...(state.workspaceCaches
         ? {
             workspaceCaches: state.workspaceCaches.map((workspaceCache) => {
-              return { profile: workspaceCache.profile };
+              return {
+                profile: workspaceCache.profile,
+                ...(workspaceCache.workspaceAffinityVersion
+                  ? {
+                      workspaceAffinityVersion:
+                        workspaceCache.workspaceAffinityVersion,
+                    }
+                  : {}),
+              };
             }),
           }
         : {}),
@@ -424,6 +433,7 @@ function recordPollTimingMetrics(args: {
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
   readonly sessionAffinity: string;
+  readonly sessionAffinityResource: string;
   readonly historyGenerationAffinity: string;
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
@@ -436,6 +446,7 @@ function recordPollTimingMetrics(args: {
     profile: args.profile,
     auth_type: args.authType,
     session_affinity: args.sessionAffinity,
+    session_affinity_resource: args.sessionAffinityResource,
     history_generation_affinity: args.historyGenerationAffinity,
   };
   if (args.pollReason) {
@@ -476,6 +487,25 @@ function recordPollTimingMetrics(args: {
   ]);
 }
 
+function runnerPollPriorityOrder(args: {
+  readonly runnerId: string | undefined;
+  readonly runnerGroup: string;
+  readonly currentDate: Date;
+}): SQL<unknown>[] {
+  if (!args.runnerId) {
+    return [];
+  }
+  return [
+    desc(
+      runnerSessionAffinityPollPriority({
+        runnerId: args.runnerId,
+        runnerGroup: args.runnerGroup,
+        currentDate: args.currentDate,
+      }),
+    ),
+  ];
+}
+
 const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const pollRequestStartedAtMs = now();
   const auth = await set(runnerAuth$, get(authorization$), signal);
@@ -512,17 +542,11 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const db = set(writeDb$);
   const pendingJobLookupStartedAtMs = now();
   const currentDate = nowDate();
-  const reusableSessionPriorityOrder = body.data.runnerId
-    ? [
-        desc(
-          runnerReusableSessionPollPriority({
-            runnerId: body.data.runnerId,
-            runnerGroup: group,
-            currentDate,
-          }),
-        ),
-      ]
-    : [];
+  const sessionAffinityPriorityOrder = runnerPollPriorityOrder({
+    runnerId: body.data.runnerId,
+    runnerGroup: group,
+    currentDate,
+  });
   const [pendingJob] = await db
     .select({
       runId: runnerJobQueue.runId,
@@ -542,7 +566,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .where(and(...whereConditions))
     .orderBy(
-      ...reusableSessionPriorityOrder,
+      ...sessionAffinityPriorityOrder,
       runnerJobQueue.createdAt,
       runnerJobQueue.runId,
     )
@@ -583,6 +607,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
     sessionAffinity: affinity.status,
+    sessionAffinityResource: runnerSessionAffinityTelemetryResource(affinity),
     historyGenerationAffinity: affinity.historyGenerationStatus,
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
@@ -607,6 +632,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         historyGenerationAffinityProtectedUntil:
           affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
         affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
+        sessionAffinityResource: affinity.resource ?? undefined,
       },
     },
   };
@@ -1614,6 +1640,9 @@ interface ClaimTimingTelemetry {
   readonly providerDiscoveryToMainLoopMs?: number;
   readonly mainLoopToLocalAdmissionMs?: number;
   readonly preLocalAdmissionOutcome?: string;
+  readonly sessionAffinityResource?: string;
+  readonly sessionAffinityLocalResource?: string;
+  readonly localAdmissionResource?: string;
   readonly pollDueToJobDiscoveredMs?: number;
   readonly pollHttpRequestMs?: number;
   readonly pollReason?: string;
@@ -1667,6 +1696,9 @@ function scheduleSuccessfulClaimSideEffects(args: {
       args.telemetry?.providerDiscoveryToMainLoopMs,
     mainLoopToLocalAdmissionMs: args.telemetry?.mainLoopToLocalAdmissionMs,
     preLocalAdmissionOutcome: args.telemetry?.preLocalAdmissionOutcome,
+    sessionAffinityResource: args.telemetry?.sessionAffinityResource,
+    sessionAffinityLocalResource: args.telemetry?.sessionAffinityLocalResource,
+    localAdmissionResource: args.telemetry?.localAdmissionResource,
     discoverySource: args.telemetry?.discoverySource,
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
@@ -1693,6 +1725,9 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
   readonly preLocalAdmissionOutcome: string | undefined;
+  readonly sessionAffinityResource: string | undefined;
+  readonly sessionAffinityLocalResource: string | undefined;
+  readonly localAdmissionResource: string | undefined;
   readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
@@ -1729,6 +1764,9 @@ interface ClaimTimingMetricArgs {
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
   readonly preLocalAdmissionOutcome: string | undefined;
+  readonly sessionAffinityResource: string | undefined;
+  readonly sessionAffinityLocalResource: string | undefined;
+  readonly localAdmissionResource: string | undefined;
   readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
@@ -1829,6 +1867,16 @@ function claimTimingDimensions(
   }
   if (args.preLocalAdmissionOutcome) {
     dimensions.pre_local_admission_outcome = args.preLocalAdmissionOutcome;
+  }
+  if (args.sessionAffinityResource) {
+    dimensions.session_affinity_resource = args.sessionAffinityResource;
+  }
+  if (args.sessionAffinityLocalResource) {
+    dimensions.session_affinity_local_resource =
+      args.sessionAffinityLocalResource;
+  }
+  if (args.localAdmissionResource) {
+    dimensions.local_admission_resource = args.localAdmissionResource;
   }
   return dimensions;
 }

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -6,6 +6,7 @@ import type { Db } from "../external/db";
 import {
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
+  runnerSessionAffinityTelemetryResource,
 } from "./runner-session-affinity";
 import { tapError } from "../utils";
 
@@ -60,6 +61,7 @@ export async function notifyRunnerJob(
       historyGenerationAffinityProtectedUntil:
         affinity.historyGenerationProtectedUntil?.toISOString() ?? null,
       affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
+      sessionAffinityResource: affinity.resource,
       historyGenerationRunId: args.historyGenerationRunId,
     },
   );
@@ -70,6 +72,7 @@ export async function notifyRunnerJob(
     profile: args.profile,
     notification_target: "broadcast",
     session_affinity: affinity.status,
+    session_affinity_resource: runnerSessionAffinityTelemetryResource(affinity),
     history_generation_affinity: affinity.historyGenerationStatus,
   };
   // Queue-relative actions are cumulative boundaries. Affinity and publish

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,3 +1,4 @@
+import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import { and, eq, gt, sql, type SQL } from "drizzle-orm";
@@ -17,7 +18,99 @@ function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
   );
 }
 
-export function runnerReusableSessionPollPriority(args: {
+type SessionIdSqlValue = string | SQL<string | null>;
+type ProfileSqlValue = string | SQL<string>;
+type GenerationSqlValue = string | SQL<string | null>;
+
+function reusableSandboxCondition(args: {
+  readonly sessionId: SessionIdSqlValue;
+  readonly profile: ProfileSqlValue;
+  readonly historyGenerationRunId?: GenerationSqlValue;
+}): SQL<boolean> {
+  const reusableSandbox = args.historyGenerationRunId
+    ? sql`jsonb_build_object(
+        'profile', cast(${args.profile} as text),
+        'historyGenerationRunId', cast(${args.historyGenerationRunId} as text)
+      )`
+    : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
+  return sql<boolean>`${runnerState.heldSessionStates} @> jsonb_build_array(
+    jsonb_build_object(
+      'sessionId', cast(${args.sessionId} as text),
+      'reusableSandbox', ${reusableSandbox}
+    )
+  )`;
+}
+
+function capableWorkspaceCondition(args: {
+  readonly sessionId: SessionIdSqlValue;
+  readonly profile: ProfileSqlValue;
+}): SQL<boolean> {
+  return sql<boolean>`(
+    ${runnerState.heldSessionStates} @> jsonb_build_array(
+      jsonb_build_object(
+        'sessionId', cast(${args.sessionId} as text),
+        'workspaceCaches', jsonb_build_array(
+          jsonb_build_object(
+            'profile', cast(${args.profile} as text),
+            'workspaceAffinityVersion', 1
+          )
+        )
+      )
+    )
+    AND ${runnerState.admittableProfiles} @> jsonb_build_array(
+      cast(${args.profile} as text)
+    )
+  )`;
+}
+
+function legacySessionCondition(args: {
+  readonly sessionId: SessionIdSqlValue;
+  readonly profile: ProfileSqlValue;
+}): SQL<boolean> {
+  // Transitional fallback for runners without resource-class capabilities.
+  // Remove after the rollout gate tracked by #21871.
+  return sql<boolean>`(
+    ${runnerState.admittableProfiles} @> jsonb_build_array(
+      cast(${args.profile} as text)
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS session_state(value)
+      WHERE session_state.value->>'sessionId' = cast(${args.sessionId} as text)
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS capable_session(value)
+      CROSS JOIN LATERAL jsonb_array_elements(
+        coalesce(capable_session.value->'workspaceCaches', '[]'::jsonb)
+      ) AS workspace_cache(value)
+      WHERE capable_session.value->>'sessionId' = cast(${args.sessionId} as text)
+        AND workspace_cache.value @> '{"workspaceAffinityVersion": 1}'::jsonb
+    )
+  )`;
+}
+
+function runnerStateHas(args: {
+  readonly runnerId?: string;
+  readonly runnerGroup: string;
+  readonly freshAfter: Date;
+  readonly resourceCondition: SQL<boolean>;
+}): SQL<boolean> {
+  const runnerCondition = args.runnerId
+    ? sql`AND ${runnerState.runnerId} = ${args.runnerId}`
+    : sql``;
+  return sql<boolean>`EXISTS (
+    SELECT 1
+    FROM ${runnerState}
+    WHERE ${runnerState.runnerGroup} = ${args.runnerGroup}
+      ${runnerCondition}
+      AND ${runnerState.mode} = 'running'
+      AND ${runnerState.lastSeenAt} > ${args.freshAfter}
+      AND ${args.resourceCondition}
+  )`;
+}
+
+export function runnerSessionAffinityPollPriority(args: {
   readonly runnerId: string;
   readonly runnerGroup: string;
   readonly currentDate: Date;
@@ -33,46 +126,62 @@ export function runnerReusableSessionPollPriority(args: {
   const targetGenerationRunId = sql<
     string | null
   >`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
+  const sessionId = sql<string | null>`${runnerJobQueue.cliAgentSessionId}`;
+  const profile = sql<string>`${runnerJobQueue.profile}`;
+  const exactCondition = reusableSandboxCondition({
+    sessionId,
+    profile,
+    historyGenerationRunId: targetGenerationRunId,
+  });
+  const reusableCondition = reusableSandboxCondition({ sessionId, profile });
+  const workspaceCondition = capableWorkspaceCondition({ sessionId, profile });
+  const legacyCondition = legacySessionCondition({ sessionId, profile });
+  const global = (resourceCondition: SQL<boolean>) => {
+    return runnerStateHas({
+      runnerGroup: args.runnerGroup,
+      freshAfter,
+      resourceCondition,
+    });
+  };
+  const local = (resourceCondition: SQL<boolean>) => {
+    return runnerStateHas({
+      runnerId: args.runnerId,
+      runnerGroup: args.runnerGroup,
+      freshAfter,
+      resourceCondition,
+    });
+  };
+  const hasGlobalExact = global(exactCondition);
+  const hasLocalExact = local(exactCondition);
+  const hasGlobalReusable = global(reusableCondition);
+  const hasLocalReusable = local(reusableCondition);
+  const hasGlobalWorkspace = global(workspaceCondition);
+  const hasLocalWorkspace = local(workspaceCondition);
+  const hasGlobalLegacy = global(legacyCondition);
+  const hasLocalLegacy = local(legacyCondition);
   return sql<number>`CASE
     WHEN ${runnerJobQueue.createdAt} > ${generationProtectedAfter}
     AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
     AND ${targetGenerationRunId} IS NOT NULL
-    AND EXISTS (
-      SELECT 1
-      FROM ${runnerState}
-      WHERE ${runnerState.runnerId} = ${args.runnerId}
-        AND ${runnerState.runnerGroup} = ${args.runnerGroup}
-        AND ${runnerState.mode} = 'running'
-        AND ${runnerState.lastSeenAt} > ${freshAfter}
-        AND ${runnerState.heldSessionStates} @> jsonb_build_array(
-          jsonb_build_object(
-            'sessionId', ${runnerJobQueue.cliAgentSessionId},
-            'reusableSandbox', jsonb_build_object(
-              'profile', ${runnerJobQueue.profile},
-              'historyGenerationRunId', ${targetGenerationRunId}
-            )
-          )
-        )
-    )
-    THEN 2
+    AND ${hasGlobalExact}
+    THEN CASE WHEN ${hasLocalExact} THEN 5 ELSE 0 END
     WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
-    AND EXISTS (
-      SELECT 1
-      FROM ${runnerState}
-      WHERE ${runnerState.runnerId} = ${args.runnerId}
-        AND ${runnerState.runnerGroup} = ${args.runnerGroup}
-        AND ${runnerState.mode} = 'running'
-        AND ${runnerState.lastSeenAt} > ${freshAfter}
-        AND ${runnerState.heldSessionStates} @> jsonb_build_array(
-          jsonb_build_object(
-            'sessionId', ${runnerJobQueue.cliAgentSessionId},
-            'reusableSandbox', jsonb_build_object(
-              'profile', ${runnerJobQueue.profile}
-            )
-          )
-        )
-    )
-    THEN 1
+    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    AND ${hasGlobalReusable}
+    THEN CASE WHEN ${hasLocalReusable} THEN 4 ELSE 0 END
+    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
+    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    AND ${hasGlobalWorkspace}
+    THEN CASE
+      WHEN ${hasLocalReusable} THEN 4
+      WHEN ${hasLocalWorkspace} THEN 3
+      ELSE 0
+    END
+    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
+    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    AND ${hasGlobalLegacy}
+    AND ${hasLocalLegacy}
+    THEN 2
     ELSE 0
   END`;
 }
@@ -87,6 +196,7 @@ type RunnerSessionAffinityStatus =
 interface RunnerSessionAffinityProtection {
   readonly protectedUntil: Date | null;
   readonly status: RunnerSessionAffinityStatus;
+  readonly resource: SessionAffinityResource | null;
   readonly historyGenerationProtectedUntil: Date | null;
   readonly historyGenerationStatus: RunnerHistoryGenerationAffinityStatus;
 }
@@ -103,6 +213,7 @@ export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtect
   return {
     protectedUntil: null,
     status: "lookup_error",
+    resource: null,
     historyGenerationProtectedUntil: null,
     historyGenerationStatus: "lookup_error",
   };
@@ -131,6 +242,71 @@ function historyGenerationAffinityProtectedUntil(args: {
   );
 }
 
+interface RunnerSessionAffinityHolders {
+  readonly hasSessionHolder: boolean;
+  readonly hasExactGenerationHolder: boolean;
+  readonly resource: SessionAffinityResource | null;
+}
+
+async function runnerSessionAffinityHolders(args: {
+  readonly db: Pick<Db, "select">;
+  readonly runnerGroup: string;
+  readonly profile: string;
+  readonly cliAgentSessionId: string;
+  readonly historyGenerationRunId: string | undefined;
+  readonly freshAfter: Date;
+  readonly shouldLookUpExactGeneration: boolean;
+}): Promise<RunnerSessionAffinityHolders> {
+  const reusableCondition = reusableSandboxCondition({
+    sessionId: args.cliAgentSessionId,
+    profile: args.profile,
+  });
+  const workspaceCondition = capableWorkspaceCondition({
+    sessionId: args.cliAgentSessionId,
+    profile: args.profile,
+  });
+  const legacyCondition = legacySessionCondition({
+    sessionId: args.cliAgentSessionId,
+    profile: args.profile,
+  });
+  const exactGenerationCondition = args.shouldLookUpExactGeneration
+    ? reusableSandboxCondition({
+        sessionId: args.cliAgentSessionId,
+        profile: args.profile,
+        historyGenerationRunId: args.historyGenerationRunId,
+      })
+    : sql<boolean>`false`;
+  const [holders] = await args.db
+    .select({
+      hasReusableHolder: sql<boolean>`coalesce(bool_or(${reusableCondition}), false)`,
+      hasWorkspaceHolder: sql<boolean>`coalesce(bool_or(${workspaceCondition}), false)`,
+      hasLegacyHolder: sql<boolean>`coalesce(bool_or(${legacyCondition}), false)`,
+      hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationCondition}), false)`,
+    })
+    .from(runnerState)
+    .where(
+      and(
+        eq(runnerState.runnerGroup, args.runnerGroup),
+        eq(runnerState.mode, "running"),
+        gt(runnerState.lastSeenAt, args.freshAfter),
+      ),
+    );
+
+  const hasReusableHolder = holders?.hasReusableHolder ?? false;
+  const hasWorkspaceHolder = holders?.hasWorkspaceHolder ?? false;
+  const hasLegacyHolder = holders?.hasLegacyHolder ?? false;
+  return {
+    hasSessionHolder:
+      hasReusableHolder || hasWorkspaceHolder || hasLegacyHolder,
+    hasExactGenerationHolder: holders?.hasExactGenerationHolder ?? false,
+    resource: hasReusableHolder
+      ? "reusableSandbox"
+      : hasWorkspaceHolder
+        ? "workspaceCache"
+        : null,
+  };
+}
+
 export async function runnerSessionAffinityProtection(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerGroup: string;
@@ -150,6 +326,7 @@ export async function runnerSessionAffinityProtection(args: {
     return {
       protectedUntil: null,
       status: "no_session",
+      resource: null,
       historyGenerationProtectedUntil: null,
       historyGenerationStatus: "no_session",
     };
@@ -158,6 +335,7 @@ export async function runnerSessionAffinityProtection(args: {
     return {
       protectedUntil: null,
       status: "expired",
+      resource: null,
       historyGenerationProtectedUntil: null,
       historyGenerationStatus: args.historyGenerationRunId
         ? "expired"
@@ -166,72 +344,43 @@ export async function runnerSessionAffinityProtection(args: {
   }
 
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
-  const heldSessionProbe = JSON.stringify([
-    { sessionId: args.cliAgentSessionId },
-  ]);
-  const reusableSessionProbe = JSON.stringify([
-    {
-      sessionId: args.cliAgentSessionId,
-      reusableSandbox: { profile: args.profile },
-    },
-  ]);
   const shouldLookUpExactGeneration =
     historyGenerationProtectedUntil !== null &&
     historyGenerationProtectedUntil > args.currentDate;
-  const exactGenerationProbe = shouldLookUpExactGeneration
-    ? JSON.stringify([
-        {
-          sessionId: args.cliAgentSessionId,
-          reusableSandbox: {
-            profile: args.profile,
-            historyGenerationRunId: args.historyGenerationRunId,
-          },
-        },
-      ])
-    : null;
-  const admittableProfileProbe = JSON.stringify([args.profile]);
-  const sessionHolderCondition = sql<boolean>`(
-    (
-      ${runnerState.heldSessionStates} @> ${heldSessionProbe}::jsonb
-      AND ${runnerState.admittableProfiles} @> ${admittableProfileProbe}::jsonb
-    )
-    OR ${runnerState.heldSessionStates} @> ${reusableSessionProbe}::jsonb
-  )`;
-  const exactGenerationHolderCondition = exactGenerationProbe
-    ? sql<boolean>`${runnerState.heldSessionStates} @> ${exactGenerationProbe}::jsonb`
-    : sql<boolean>`false`;
-  const [holders] = await args.db
-    .select({
-      hasSessionHolder: sql<boolean>`coalesce(bool_or(${sessionHolderCondition}), false)`,
-      hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationHolderCondition}), false)`,
-    })
-    .from(runnerState)
-    .where(
-      and(
-        eq(runnerState.runnerGroup, args.runnerGroup),
-        eq(runnerState.mode, "running"),
-        gt(runnerState.lastSeenAt, freshAfter),
-        sessionHolderCondition,
-      ),
-    );
-
-  const hasSessionHolder = holders?.hasSessionHolder ?? false;
-  const hasExactGenerationHolder = holders?.hasExactGenerationHolder ?? false;
+  const holders = await runnerSessionAffinityHolders({
+    db: args.db,
+    runnerGroup: args.runnerGroup,
+    profile: args.profile,
+    cliAgentSessionId: args.cliAgentSessionId,
+    historyGenerationRunId: args.historyGenerationRunId,
+    freshAfter,
+    shouldLookUpExactGeneration,
+  });
   const historyGenerationStatus: RunnerHistoryGenerationAffinityStatus =
     !args.historyGenerationRunId
       ? "no_target"
       : !shouldLookUpExactGeneration
         ? "expired"
-        : hasExactGenerationHolder
+        : holders.hasExactGenerationHolder
           ? "protected"
           : "no_exact_holder";
 
   return {
-    protectedUntil: hasSessionHolder ? protectedUntil : null,
-    status: hasSessionHolder ? "protected" : "no_viable_holder",
-    historyGenerationProtectedUntil: hasExactGenerationHolder
+    protectedUntil: holders.hasSessionHolder ? protectedUntil : null,
+    status: holders.hasSessionHolder ? "protected" : "no_viable_holder",
+    resource: holders.resource,
+    historyGenerationProtectedUntil: holders.hasExactGenerationHolder
       ? historyGenerationProtectedUntil
       : null,
     historyGenerationStatus,
   };
+}
+
+export function runnerSessionAffinityTelemetryResource(
+  affinity: RunnerSessionAffinityProtection,
+): "reusableSandbox" | "workspaceCache" | "legacy" | "none" {
+  if (affinity.resource) {
+    return affinity.resource;
+  }
+  return affinity.status === "protected" ? "legacy" : "none";
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -361,11 +361,13 @@ describe("runner resume session contract", () => {
       checkpointId: null,
       historyGenerationRunId,
       historyGenerationAffinityProtectedUntil,
+      sessionAffinityResource: "reusableSandbox",
     });
     expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
     expect(job.historyGenerationAffinityProtectedUntil).toBe(
       historyGenerationAffinityProtectedUntil,
     );
+    expect(job.sessionAffinityResource).toBe("reusableSandbox");
 
     const heldSessionState = heldSessionStateSchema.parse({
       sessionId: "sess-123",
@@ -374,13 +376,16 @@ describe("runner resume session contract", () => {
         profile: "vm0/default",
         historyGenerationRunId,
       },
-      workspaceCaches: [{ profile: "vm0/default" }, { profile: "vm0/large" }],
+      workspaceCaches: [
+        { profile: "vm0/default", workspaceAffinityVersion: 1 },
+        { profile: "vm0/large" },
+      ],
     });
     expect(heldSessionState.reusableSandbox?.historyGenerationRunId).toBe(
       historyGenerationRunId,
     );
     expect(heldSessionState.workspaceCaches).toEqual([
-      { profile: "vm0/default" },
+      { profile: "vm0/default", workspaceAffinityVersion: 1 },
       { profile: "vm0/large" },
     ]);
   });
@@ -396,6 +401,7 @@ describe("runner resume session contract", () => {
       historyGenerationAffinityProtectedUntil: null,
     });
     expect(job.historyGenerationAffinityProtectedUntil).toBeNull();
+    expect(job.sessionAffinityResource).toBeUndefined();
 
     const heldSessionState = heldSessionStateSchema.parse({
       sessionId: "sess-legacy",
@@ -457,6 +463,15 @@ describe("runner resume session contract", () => {
         workspaceCaches: [
           ...workspaceCaches,
           { profile: "vm0/profile-over-cap" },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      heldSessionStateSchema.safeParse({
+        sessionId: "sess-invalid-capability",
+        lastCompletedAt: "2026-07-15T00:00:00.000Z",
+        workspaceCaches: [
+          { profile: "vm0/default", workspaceAffinityVersion: 2 },
         ],
       }).success,
     ).toBe(false);
@@ -629,6 +644,9 @@ describe("runner claim capability contract", () => {
         providerDiscoveryToMainLoopMs: 3,
         mainLoopToLocalAdmissionMs: 4,
         preLocalAdmissionOutcome: "local_holder",
+        sessionAffinityResource: "workspaceCache",
+        sessionAffinityLocalResource: "workspaceCache",
+        localAdmissionResource: "fresh",
         sessionHistoryGenerationRelationship: "exact",
       },
     });
@@ -664,6 +682,18 @@ describe("runner claim capability contract", () => {
 
   it("accepts old claim bodies without generation telemetry", () => {
     expect(runnersJobClaimContract.claim.body.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects non-enum affinity resource telemetry", () => {
+    const result = runnersJobClaimContract.claim.body.safeParse({
+      telemetry: {
+        sessionAffinityResource: "legacySession",
+        sessionAffinityLocalResource: "workspaceCache",
+        localAdmissionResource: "fresh",
+      },
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -68,6 +68,17 @@ export const runnerClaimPollReasonSchema = z.enum([
   "fast",
 ]);
 
+export const sessionAffinityResourceSchema = z.enum([
+  "reusableSandbox",
+  "workspaceCache",
+]);
+const sessionAffinityLocalResourceSchema = z.enum([
+  "reusableSandbox",
+  "workspaceCache",
+  "legacySession",
+]);
+const runnerLocalAdmissionResourceSchema = z.enum(["reusableSandbox", "fresh"]);
+
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
 const runnerPreLocalAdmissionOutcomeSchema = z.enum([
   "not_protected",
@@ -100,6 +111,9 @@ const runnerClaimTelemetrySchema = z.object({
   providerDiscoveryToMainLoopMs: z.number().int().nonnegative().optional(),
   mainLoopToLocalAdmissionMs: z.number().int().nonnegative().optional(),
   preLocalAdmissionOutcome: runnerPreLocalAdmissionOutcomeSchema.optional(),
+  sessionAffinityResource: sessionAffinityResourceSchema.optional(),
+  sessionAffinityLocalResource: sessionAffinityLocalResourceSchema.optional(),
+  localAdmissionResource: runnerLocalAdmissionResourceSchema.optional(),
   sessionHistoryGenerationRelationship:
     sessionHistoryGenerationRelationshipSchema.optional(),
   sessionHistoryGenerationLocalAvailability:
@@ -190,6 +204,7 @@ export const jobSchema = z.object({
     .datetime({ offset: true })
     .nullable()
     .optional(),
+  sessionAffinityResource: sessionAffinityResourceSchema.optional(),
 });
 
 export const heldSessionStateSchema = z.object({
@@ -207,6 +222,7 @@ export const heldSessionStateSchema = z.object({
     .array(
       z.object({
         profile: z.string(),
+        workspaceAffinityVersion: z.literal(1).optional(),
       }),
     )
     .max(8)
@@ -704,6 +720,9 @@ export type SessionHistoryGenerationRelationship = z.infer<
 >;
 export type SessionHistoryGenerationLocalAvailability = z.infer<
   typeof sessionHistoryGenerationLocalAvailabilitySchema
+>;
+export type SessionAffinityResource = z.infer<
+  typeof sessionAffinityResourceSchema
 >;
 
 export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -11,6 +11,7 @@ export interface RunnerHeldSessionState {
   };
   readonly workspaceCaches?: readonly {
     readonly profile: string;
+    readonly workspaceAffinityVersion?: 1;
   }[];
 }
 


### PR DESCRIPTION
## Summary

- classify generic session-affinity holders as `reusableSandbox`, capable `workspaceCache`, or temporary legacy state and carry the selected minimum class consistently through realtime and poll
- require an actual pre-claim idle reservation for reusable affinity, allow workspace-selected candidates to upgrade to reuse, and otherwise reserve fresh capacity only after matching a versioned local workspace observation
- publish `workspaceAffinityVersion: 1`, preserve it through heartbeat dedupe, and add fixed selected/local/admitted resource telemetry without identity-valued dimensions
- keep the server claim authoritative and workspace checkout optimistic, with existing rollback and post-claim fresh/remote fallback behavior

## Compatibility

- all wire and persisted JSONB fields are optional; there is no physical PostgreSQL migration or backfill
- old runner -> new API and new runner -> old API retain the absent-class legacy path during rollout
- strict ordering begins only after old claim-capable runners drain; the temporary compatibility branches are tracked for removal in #21871
- unknown resource classes fail closed in runner transports, while missing fields remain backward compatible

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner` (2,732 passed; 11 ignored; guest inventory passed)
- focused runner provider, admission, heartbeat, type, and workspace-cache tests
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=4 --silent=passed-only` (49 passed)
- focused API run-lifecycle affinity/priority/claim tests (4 passed)
- full API run-lifecycle file (109 passed; one unrelated marketing-tunnel assertion remains locally blocked by the development database's seeded managed key after `scripts/prepare.sh`)
- `cd turbo && pnpm knip`

Closes #21868

Parent context: #21861
