### PR TITLE
fix(chat): create mail draft signals outside render

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -25,6 +25,7 @@ function userMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
+    mailDraftResource: null,
   };
 }
 
@@ -44,6 +45,7 @@ function assistantMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
+    mailDraftResource: null,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -18,6 +18,7 @@ import { zeroClient$ } from "../api-client.ts";
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import { nowDate } from "../../lib/time.ts";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
+import type { MailDraftResource } from "./mail-draft.ts";
 
 export { chatThreads$ } from "../agent-chat.ts";
 
@@ -45,6 +46,10 @@ export type EnrichedChatMessage = PagedChatMessage & {
   blocks: BodyRenderBlock[];
   isQueued: boolean;
   isOptimisticRun: boolean;
+  mailDraftResource: {
+    readonly mailDraftId: string;
+    readonly mailDraft$: MailDraftResource;
+  } | null;
 };
 
 /** A group of consecutive messages with the same role. */

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -13,7 +13,6 @@ import type { WorkflowComposerSignals } from "../zero-page/tiptap-workflow-compo
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
-import type { MailDraftLoaderSignals } from "./mail-draft.ts";
 
 type RecommendedFollowup = NonNullable<
   Extract<PagedChatMessage, { role: "assistant" }>["recommendedFollowups"]
@@ -63,7 +62,6 @@ export interface ChatThreadSignals {
   threadTitleEmoji$: Computed<Promise<string | null>>;
   threadTitleText$: Computed<Promise<string>>;
   threadSettledInServer$: Computed<Promise<boolean>>;
-  mailDrafts: MailDraftLoaderSignals;
   // -- Composer model selection --------------------------------------------
   // Derived from the thread event projection; user edits register optimistic
   // model_selection_updated events and then persist through the thread API.

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -116,7 +116,10 @@ import type {
   ThinkingIndicatorMode,
 } from "./chat-thread-signals.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
-import { createMailDraftLoaderSignals } from "./mail-draft.ts";
+import {
+  createMailDraftLoaderSignals,
+  type MailDraftResource,
+} from "./mail-draft.ts";
 
 type ChatThreadRemote = ReturnType<typeof createRemoteChatThreadDataSource>;
 
@@ -904,7 +907,6 @@ function createAgentInfoSignals(
 // ---------------------------------------------------------------------------
 
 function createThreadUIState() {
-  const mailDrafts = createMailDraftLoaderSignals();
   // Timeline expansion
   const internalExpandedIds$ = state(new Set<string>());
 
@@ -957,7 +959,6 @@ function createThreadUIState() {
   );
 
   return {
-    mailDrafts,
     timelineExpandedIds$,
     toggleTimelineExpanded$,
     copiedMessageId$,
@@ -1233,9 +1234,12 @@ function setLatestUsageForRun(
 
 function createRenderedChatGroups(
   semanticMessages$: Computed<SemanticChatMessage[]>,
+  mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
 ) {
-  const transcriptMessages$ =
-    createTranscriptMessagesComputed(semanticMessages$);
+  const transcriptMessages$ = createTranscriptMessagesComputed(
+    semanticMessages$,
+    mailDraftById$,
+  );
 
   const allRenderedChatGroups$ = computed(
     async (get): Promise<GroupedChatMessageGroup[]> => {
@@ -1322,6 +1326,7 @@ function mergeServerMessages(
 function createWritePersistentMessages(
   threadId: string,
   persistentMessages$: PersistentChatMessages$,
+  registerMailDraftMessages$: Command<void, [readonly PagedChatMessage[]]>,
 ) {
   return command(
     async (
@@ -1343,6 +1348,7 @@ function createWritePersistentMessages(
       for (const _ of newlyCompletedRunIds) {
         captureTaskCompletedSuccessfully();
       }
+      set(registerMailDraftMessages$, msgs);
       set(persistentMessages$, (prev) => {
         return mergeServerMessages([prev, msgs]);
       });
@@ -1401,14 +1407,29 @@ function createRawMessagesComputed({
 
 function createTranscriptMessagesComputed(
   semanticMessages$: Computed<SemanticChatMessage[]>,
+  mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
 ): Computed<Promise<EnrichedChatMessage[]>> {
   return computed((get): Promise<EnrichedChatMessage[]> => {
+    const mailDraftById = get(mailDraftById$);
     return Promise.resolve(
       get(semanticMessages$).map((entry) => {
         const { message, isQueued, isOptimisticRun } = entry;
         const { blocks } = parseBodyRenderBlocks(message.content ?? "", {
           previews: message.role === "assistant",
         });
+        let mailDraftResource: EnrichedChatMessage["mailDraftResource"] = null;
+        if (message.mailDraftId !== undefined) {
+          const mailDraft$ = mailDraftById.get(message.mailDraftId);
+          if (mailDraft$ === undefined) {
+            throw new Error(
+              `Mail draft resource was not registered: ${message.mailDraftId}`,
+            );
+          }
+          mailDraftResource = {
+            mailDraftId: message.mailDraftId,
+            mailDraft$,
+          };
+        }
         if (message.role !== "assistant") {
           return {
             ...message,
@@ -1416,6 +1437,7 @@ function createTranscriptMessagesComputed(
             blocks: enrichBlocksWithTextPreviews(blocks),
             isQueued,
             isOptimisticRun,
+            mailDraftResource,
           };
         }
         return {
@@ -1424,6 +1446,7 @@ function createTranscriptMessagesComputed(
           blocks: enrichBlocksWithTextPreviews(blocks),
           isQueued,
           isOptimisticRun: false,
+          mailDraftResource,
         };
       }),
     );
@@ -2151,6 +2174,7 @@ function createActiveGoalObjectiveComputed(
 }
 
 function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
+  const mailDrafts = createMailDraftLoaderSignals();
   const persistentChatMessages$ = state<PagedChatMessage[]>([]);
   const hasReachedOldestMessage$ = state(false);
   const optimisticMessages$ = createOptimisticChatMessagesForThread(threadId);
@@ -2174,15 +2198,20 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
   // because goal markers are control rows, not transcript rows.
   const activeGoalObjective$ = createActiveGoalObjectiveComputed(rawMessages$);
 
-  const renderedMessages = createRenderedChatGroups(semanticMessages$);
+  const renderedMessages = createRenderedChatGroups(
+    semanticMessages$,
+    mailDrafts.mailDraftById$,
+  );
 
   const writePersistentMessages$ = createWritePersistentMessages(
     threadId,
     persistentChatMessages$,
+    mailDrafts.registerMailDraftMessages$,
   );
 
   const mergeIndexedDbMessages$ = command(
     ({ set }, messages: PagedChatMessage[]): void => {
+      set(mailDrafts.registerMailDraftMessages$, messages);
       set(persistentChatMessages$, (previous) => {
         return mergeServerMessages([messages, previous]);
       });

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -1,4 +1,5 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroMailContract,
   type ZeroMailDraft,
@@ -28,31 +29,59 @@ export const mailDraftOverrides$ = computed((get) => {
   return get(internalMailDraftOverrides$);
 });
 
+export type MailDraftResource = Computed<Promise<ZeroMailDraft>>;
+
 export interface MailDraftLoaderSignals {
-  readonly byId: (mailDraftId: string) => Computed<Promise<ZeroMailDraft>>;
+  readonly mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>;
+  readonly registerMailDraftMessages$: Command<
+    void,
+    [readonly PagedChatMessage[]]
+  >;
 }
 
 export function createMailDraftLoaderSignals(): MailDraftLoaderSignals {
-  const cache = new Map<string, Computed<Promise<ZeroMailDraft>>>();
-  return {
-    byId: (mailDraftId) => {
-      const existing = cache.get(mailDraftId);
-      if (existing) {
-        return existing;
-      }
-      const mailDraft$ = computed(async (get) => {
-        const response = await accept(
-          get(zeroClient$)(zeroMailContract).getDraft({
-            params: { mailDraftId },
-            fetchOptions: { signal: get(pageSignal$) },
+  const internalMailDraftById$ = state<ReadonlyMap<string, MailDraftResource>>(
+    new Map(),
+  );
+  const mailDraftById$ = computed((get) => {
+    return get(internalMailDraftById$);
+  });
+  const registerMailDraftMessages$ = command(
+    ({ get, set }, messages: readonly PagedChatMessage[]) => {
+      const current = get(internalMailDraftById$);
+      let next: Map<string, MailDraftResource> | undefined;
+      for (const message of messages) {
+        const { mailDraftId } = message;
+        if (
+          mailDraftId === undefined ||
+          current.has(mailDraftId) ||
+          next?.has(mailDraftId)
+        ) {
+          continue;
+        }
+        next ??= new Map(current);
+        next.set(
+          mailDraftId,
+          computed(async (get) => {
+            const response = await accept(
+              get(zeroClient$)(zeroMailContract).getDraft({
+                params: { mailDraftId },
+                fetchOptions: { signal: get(pageSignal$) },
+              }),
+              [200],
+            );
+            return response.body.mailDraft;
           }),
-          [200],
         );
-        return response.body.mailDraft;
-      });
-      cache.set(mailDraftId, mailDraft$);
-      return mailDraft$;
+      }
+      if (next !== undefined) {
+        set(internalMailDraftById$, next);
+      }
     },
+  );
+  return {
+    mailDraftById$,
+    registerMailDraftMessages$,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -203,9 +203,11 @@ describe("chat message action cards", () => {
     const messageId = "c0000000-0000-4000-a000-000000000011";
     const mailDraftId = "c0000000-0000-4000-a000-000000000012";
     const createdAt = "2026-07-14T10:00:00.000Z";
+    let draftRequests = 0;
     let sentBody: unknown = null;
 
     context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+      draftRequests += 1;
       return respond(200, {
         mailDraftId,
         mailDraft: {
@@ -301,6 +303,7 @@ describe("chat message action cards", () => {
     expect(within(card).getByRole("textbox", { name: "From" })).toHaveAttribute(
       "readonly",
     );
+    expect(draftRequests).toBe(1);
   });
 
   it("lets users authorize connectors and confirm permissions from assistant messages", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6610,7 +6610,6 @@ function PagedAssistantGroup({
       <PagedAssistantMessageItem
         key={message.id}
         message={message}
-        thread={thread}
         compactTop={compactTop}
       />
     );
@@ -6660,11 +6659,9 @@ function PagedAssistantGroup({
 
 function PagedAssistantMessageItem({
   message,
-  thread,
   compactTop = false,
 }: {
   message: EnrichedChatMessage;
-  thread: ChatThreadSignals;
   compactTop?: boolean;
 }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
@@ -6672,7 +6669,8 @@ function PagedAssistantMessageItem({
     openImageLightbox(url);
   };
 
-  if (message.mailDraftId) {
+  if (message.mailDraftResource) {
+    const { mailDraftId, mailDraft$ } = message.mailDraftResource;
     return (
       <div
         className={cn(
@@ -6681,9 +6679,9 @@ function PagedAssistantMessageItem({
         )}
       >
         <MailDraftCard
-          key={message.mailDraftId}
-          mailDraftId={message.mailDraftId}
-          mailDraft$={thread.mailDrafts.byId(message.mailDraftId)}
+          key={mailDraftId}
+          mailDraftId={mailDraftId}
+          mailDraft$={mailDraft$}
         />
       </div>
     );


### PR DESCRIPTION
## Summary

- keep mail draft data loading lazy while removing computed creation and cache mutation from React render
- register stable per-draft resources when remote or IndexedDB messages enter the thread pipeline
- attach the registered resource during transcript projection so the mail draft card only consumes an existing signal

## User impact

Mail draft cards keep the same loading, editing, cancel, and send behavior, but React rendering is now pure and safe under repeated or discarded renders.

## Verification

- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx -t 'renders a persistent mail draft and sends the reviewed fields'`
- `pnpm exec vitest run src/signals/chat-page/__tests__/run-group-folding.test.ts`
