### PR TITLE
test(api): await chat completion before same-family model switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2308,6 +2308,7 @@ describe("CHAT-02: run-level model overrides", () => {
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
 
     const second = await sendChatRun(actor, {
       agentId,


### PR DESCRIPTION
## Summary

- Wait for the first successful chat run’s terminal waitUntil work before sending the same-family model-switch follow-up.
- Keep the CLI session-resume assertion isolated from the completion-time queue-drain race that can claim the follow-up with the previous model.
- Leave production behavior unchanged.

## Verification

- npx --yes prettier@3.8.1 --check turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
- Full local Vitest was not run per the repository PR verification preference; PR CI will run the affected test suite.