### PR TITLE
refactor: reduce fallback slop in cli auth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -205,8 +205,8 @@ describe("AUTH-02: approval transitions and timezone", () => {
   });
 });
 
-describe("AUTH-02: no-org approval issues an org-less PAT", () => {
-  it("approves and exchanges for a session without an active organization", async () => {
+describe("AUTH-02: no-org approval cannot issue a PAT", () => {
+  it("reports missing authenticated identity instead of issuing an unusable token", async () => {
     const noOrgActor = bdd.user({ orgId: null });
 
     const started = await authDevice.startCliDevice();
@@ -217,20 +217,13 @@ describe("AUTH-02: no-org approval issues an org-less PAT", () => {
     );
     expect(approved.body).toStrictEqual({ success: true });
 
-    const token = await authDevice.requestCliToken(started.device_code, [200]);
-    if (token.status !== 200) {
-      throw new Error(`Expected CLI token exchange, got ${token.status}`);
-    }
-    expect(token.body.access_token).toMatch(/^vm0_pat_/);
-    expect(token.body.token_type).toBe("Bearer");
-    expect(token.body.expires_in).toBe(90 * 24 * 60 * 60);
-
-    // An org-less exchange issues a PAT with an empty org claim, which the
-    // CLI token verifier rejects (`orgId: z.string().min(1)`), so the only
-    // visible contract is the token-issuance response itself.
-    const reused = await authDevice.requestCliToken(started.device_code, [400]);
-    expectOAuthError(reused.body);
-    expect(reused.body.error).toBe("invalid_request");
+    const token = await authDevice.requestCliToken(started.device_code, [500]);
+    expectOAuthError(token.body);
+    expect(token.body).toStrictEqual({
+      error: "server_error",
+      error_description:
+        "Authenticated device code is missing user or organization identity",
+    });
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/cli-auth.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth.ts
@@ -135,11 +135,19 @@ const exchangeTokenInner$ = command(
         );
       }
       case "authenticated": {
+        if (!session.userId || !session.orgId) {
+          return oauthError(
+            500,
+            "server_error",
+            "Authenticated device code is missing user or organization identity",
+          );
+        }
+
         const issued = await set(
           issueCliToken$,
           {
-            userId: session.userId ?? "",
-            orgId: session.orgId ?? "",
+            userId: session.userId,
+            orgId: session.orgId,
             name: "CLI Device Flow Authentication",
           },
           signal,


### PR DESCRIPTION
## Summary

- Stops CLI device-token exchange from minting an unusable PAT when an authenticated device-code row is missing its user or organization identity.
- Returns an explicit OAuth `server_error` for the broken state and updates the no-organization regression case to cover the fail-fast behavior.

## Scan

- Timestamp: `2026-07-16T20:01:27.013Z`
- Base commit: `5b5901f21453723a299ab0c71d1a47ce3d14cf87`
- Files scanned: `4302`
- Scanner high-confidence production actionable matches: `236`
- Scanner suggested 5% budget: `12`
- Manual `actionable_total`: `1` underlying safe business-logic candidate after excluding intentional external-payload, UI-display, test, compatibility, and explicit-null contracts
- Adjusted `edit_budget`: `1`
- Candidates changed: `1`

Matches by category:

- `nullish`: 6149
- `nullish-chain`: 136
- `field-fallback-chain`: 110
- `optional-prop`: 6326
- `zod-optional`: 2348
- `zod-loose-optional`: 2
- `loose-record`: 1212
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 34
- `empty-fallback`: 717
- `string-fallback`: 773
- `null-undefined-fallback`: 1656
- `empty-catch`: 3
- `promise-catch-swallow`: 14
- `rust-unwrap-or`: 642
- `rust-ok-discard`: 143

## Files changed

- `turbo/apps/api/src/signals/routes/cli-auth.ts`: requires both persisted identity fields before issuing a CLI PAT. This is safe because CLI token verification already requires a non-empty organization claim; the removed fallback only produced a credential that could not be used.
- `turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts`: replaces the regression case that documented the unusable org-less token with an assertion for the explicit OAuth error.

## Verification

- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/cli-auth.ts apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts`
- `pnpm exec oxlint src/signals/routes/cli-auth.ts src/signals/routes/__tests__/cli-auth.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `git diff --check`
- Targeted Vitest was attempted, but the local PostgreSQL dependency was unavailable (`ECONNREFUSED`); the PR pipeline will run the database-backed regression test.

This workflow intentionally leaves the remaining candidates for later daily runs.
