### PR TITLE
fix(platform): stabilize connector form selectors across renders

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/connector-form-signals.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/connector-form-signals.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  connectorOAuthDeviceAuthStartOptionValuesFor$,
+  manualGrantFormValuesFor$,
+  setConnectorOAuthDeviceAuthStartOptionValue$,
+  setManualGrantFormValue$,
+} from "../zero-page/settings/connectors.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+describe("connector form signals", () => {
+  it("selects reactive form values while keeping connector keys isolated", () => {
+    const initialManualGrantFormValuesFor = context.store.get(
+      manualGrantFormValuesFor$,
+    );
+    expect(initialManualGrantFormValuesFor("connector-a")).toStrictEqual({});
+
+    context.store.set(
+      setManualGrantFormValue$,
+      "connector-a",
+      "token",
+      "manual-token",
+    );
+    const manualGrantFormValuesFor = context.store.get(
+      manualGrantFormValuesFor$,
+    );
+    expect(manualGrantFormValuesFor("connector-a")).toStrictEqual({
+      token: "manual-token",
+    });
+    expect(manualGrantFormValuesFor("connector-b")).toStrictEqual({});
+
+    const initialConnectorOAuthDeviceAuthStartOptionValuesFor =
+      context.store.get(connectorOAuthDeviceAuthStartOptionValuesFor$);
+    expect(
+      initialConnectorOAuthDeviceAuthStartOptionValuesFor(
+        "connector-a",
+        "device-auth-a",
+      ),
+    ).toStrictEqual({});
+
+    context.store.set(setConnectorOAuthDeviceAuthStartOptionValue$, {
+      type: "connector-a",
+      authMethod: "device-auth-a",
+      name: "region",
+      value: "us-west",
+    });
+    const connectorOAuthDeviceAuthStartOptionValuesFor = context.store.get(
+      connectorOAuthDeviceAuthStartOptionValuesFor$,
+    );
+    expect(
+      connectorOAuthDeviceAuthStartOptionValuesFor(
+        "connector-a",
+        "device-auth-a",
+      ),
+    ).toStrictEqual({
+      region: "us-west",
+    });
+    expect(
+      connectorOAuthDeviceAuthStartOptionValuesFor(
+        "connector-a",
+        "device-auth-b",
+      ),
+    ).toStrictEqual({});
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -816,18 +816,14 @@ function connectorOAuthDeviceAuthStartOptionsKey(
   return `${type}:${authMethod}`;
 }
 
-export const connectorOAuthDeviceAuthStartOptionValuesFor$ = (
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-) => {
-  return computed((get) => {
+export const connectorOAuthDeviceAuthStartOptionValuesFor$ = computed((get) => {
+  const values = get(connectorOAuthDeviceAuthStartOptionValues$);
+  return (type: ConnectorType, authMethod: ConnectorAuthMethodId) => {
     return (
-      get(connectorOAuthDeviceAuthStartOptionValues$)[
-        connectorOAuthDeviceAuthStartOptionsKey(type, authMethod)
-      ] ?? {}
+      values[connectorOAuthDeviceAuthStartOptionsKey(type, authMethod)] ?? {}
     );
-  });
-};
+  };
+});
 
 export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
   (
@@ -909,11 +905,12 @@ export const clearManualGrantForm$ = command(({ get, set }, type: string) => {
   set(manualGrantFormValues$, updated);
 });
 
-export const manualGrantFormValuesFor$ = (type: string) => {
-  return computed((get) => {
-    return get(manualGrantFormValues$)[type] ?? {};
-  });
-};
+export const manualGrantFormValuesFor$ = computed((get) => {
+  const values = get(manualGrantFormValues$);
+  return (type: string) => {
+    return values[type] ?? {};
+  };
+});
 
 export const setManualGrantFormSubmitting$ = command(
   ({ set }, value: string | null) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -261,7 +261,8 @@ function ManualGrantForm({
   const setFormValue = useSet(setManualGrantFormValue$);
   const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
-  const fieldValues = useGet(manualGrantFormValuesFor$(type));
+  const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
+  const fieldValues = manualGrantFormValuesFor(type);
 
   const allFilled = method.manualFields.every((field) => {
     return !field.required || hasTokenInputValue(fieldValues[field.id]);
@@ -606,11 +607,12 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
   );
   const startOptions =
     props.method.grantKind === "device-auth" ? props.method.startOptions : [];
-  const startOptionValues = useGet(
-    connectorOAuthDeviceAuthStartOptionValuesFor$(
-      props.item.type,
-      props.authMethod,
-    ),
+  const connectorOAuthDeviceAuthStartOptionValuesFor = useGet(
+    connectorOAuthDeviceAuthStartOptionValuesFor$,
+  );
+  const startOptionValues = connectorOAuthDeviceAuthStartOptionValuesFor(
+    props.item.type,
+    props.authMethod,
   );
   const effectiveStartOptionValues = {
     ...defaultDeviceAuthStartOptionValues(startOptions),

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -174,7 +174,8 @@ function ManualGrantForm({
   const setFormValue = useSet(setManualGrantFormValue$);
   const clearForm = useSet(clearManualGrantForm$);
   const pageSignal = useGet(pageSignal$);
-  const fieldValues = useGet(manualGrantFormValuesFor$(type));
+  const manualGrantFormValuesFor = useGet(manualGrantFormValuesFor$);
+  const fieldValues = manualGrantFormValuesFor(type);
   const submittingType = useGet(manualGrantFormSubmitting$);
   const setSubmitting = useSet(setManualGrantFormSubmitting$);
   const submitting = submittingType === type;


### PR DESCRIPTION
## Summary

- replace render-time connector form signal factories with package-scope computed selectors
- read manual-grant and OAuth device-auth values through stable atoms without keyed caches
- cover selector reactivity and connector/auth-method value isolation

## User impact

The two manual-grant consumers and the OAuth device-auth consumer now subscribe to stable ccstate atoms across React renders. This removes repeated `Computed` creation and subscription replacement without retaining one cached atom per connector type or auth method, while preserving reactive and isolated form values.

## Verification

- `npx -y pnpm@10.33.4 format`
- `npx -y pnpm@10.33.4 turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 npx -y pnpm@10.33.4 check-types`
- `npx -y pnpm@10.33.4 exec vitest run apps/platform/src/signals/__tests__/connector-form-signals.test.ts`
