### PR TITLE
fix(platform): dispatch app skeleton event after mount

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { resetSignal, setLoop } from "./utils.ts";
+import { onRef, resetSignal, setLoop } from "./utils.ts";
 import { getAvatarPresets } from "../views/zero-page/zero-avatars.ts";
 import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
 
@@ -8,6 +8,27 @@ import { captureFirstSkeletonHide$ } from "../lib/posthog.ts";
 // ---------------------------------------------------------------------------
 
 const internalVisible$ = state(true);
+
+const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
+const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
+  "vm0AppSkeletonVisibleEventQueued";
+
+export const appSkeletonVisibleEventRef$ = onRef(
+  command((_visitor, _element: HTMLDivElement, _signal: AbortSignal) => {
+    if (
+      document.documentElement.dataset[
+        APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
+      ] === "true"
+    ) {
+      return;
+    }
+    document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] =
+      "true";
+    queueMicrotask(() => {
+      window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
+    });
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Avatar – picked once at module load so remounts don't flicker

--- a/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
@@ -1,0 +1,44 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
+const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
+  "vm0AppSkeletonVisibleEventQueued";
+
+const context = testContext();
+
+describe("app skeleton", () => {
+  it("dispatches one visible event after the skeleton mounts", async () => {
+    delete document.documentElement.dataset[
+      APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
+    ];
+    context.signal.addEventListener("abort", () => {
+      delete document.documentElement.dataset[
+        APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
+      ];
+    });
+
+    let eventCount = 0;
+    let skeletonMountedAtDispatch = false;
+    window.addEventListener(
+      APP_SKELETON_VISIBLE_EVENT,
+      () => {
+        eventCount += 1;
+        skeletonMountedAtDispatch =
+          document.querySelector('[data-testid="app-skeleton"]') !== null;
+      },
+      { signal: context.signal },
+    );
+
+    detachedSetupPage({ context, path: "/_/skeleton" });
+
+    await screen.findAllByTestId("app-skeleton");
+    await waitFor(() => {
+      expect(eventCount).toBe(1);
+    });
+    expect(skeletonMountedAtDispatch).toBeTruthy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -1,27 +1,10 @@
-import { useGet } from "ccstate-react";
+import { useGet, useSet } from "ccstate-react";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import {
+  appSkeletonVisibleEventRef$,
   skeletonMessages$,
   skeletonAvatarConfig$,
 } from "../../signals/app-skeleton.ts";
-
-const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
-const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
-  "vm0AppSkeletonVisibleEventQueued";
-
-function queueSkeletonVisibleEvent(): void {
-  if (
-    document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] ===
-    "true"
-  ) {
-    return;
-  }
-  document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] =
-    "true";
-  queueMicrotask(() => {
-    window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
-  });
-}
 
 /** Static CSS — does not depend on message content. */
 const skeletonCSS = `
@@ -55,14 +38,12 @@ export function AppSkeleton({ visible = true }: { visible?: boolean }) {
   const skeletonConfig = useGet(skeletonAvatarConfig$);
   const { staticMsg, typewriterMsg, isFirst, cycle } =
     useGet(skeletonMessages$);
+  const visibleEventRef = useSet(appSkeletonVisibleEventRef$);
   const charCount = typewriterMsg.length;
-
-  if (visible) {
-    queueSkeletonVisibleEvent();
-  }
 
   return (
     <div
+      ref={visible ? visibleEventRef : undefined}
       data-testid="app-skeleton"
       aria-hidden={visible ? undefined : true}
       className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${


### PR DESCRIPTION
## Summary

- dispatch `vm0:app-skeleton-visible` from a ccstate `onRef` lifecycle after the visible skeleton DOM mounts
- keep the existing document dataset latch, microtask dispatch, event name, and marketing-script consumer contract
- cover mounted-DOM timing and one-shot dispatch through the real `/_/skeleton` page bootstrap

## User impact

Marketing attribution scripts are now scheduled only after the app skeleton has committed to the DOM. An interrupted or abandoned React render can no longer consume the document-level one-shot signal before anything is mounted.

## Verification

- `pnpm exec vitest run src/views/zero-page/__tests__/app-skeleton.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose`
- `pnpm check-types`
- `pnpm lint`
- Prettier 3.8.1 check on changed files
- `git diff --check`
