### PR TITLE
fix(platform): bind presentation thumbnail observer to slide list

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/presentation-html-slide-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-html-slide-list.ts
@@ -1,0 +1,74 @@
+import { command, type Command } from "ccstate";
+import { onRef } from "../utils.ts";
+
+interface PresentationSlideListDependencies {
+  readonly loadThumbnail: (frame: HTMLIFrameElement, slideId: string) => void;
+  readonly releaseThumbnail: (frame: HTMLIFrameElement) => void;
+}
+
+export interface PresentationSlideListSignals {
+  readonly setRootRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
+}
+
+export function createPresentationSlideListSignals(
+  dependencies: PresentationSlideListDependencies,
+): PresentationSlideListSignals {
+  const setRootRef$ = onRef(
+    command((_ctx, root: HTMLElement, signal: AbortSignal) => {
+      const frames = Array.from(
+        root.querySelectorAll<HTMLIFrameElement>(
+          "[data-slide-thumbnail-frame]",
+        ),
+      );
+      const observer =
+        typeof IntersectionObserver === "undefined"
+          ? null
+          : new IntersectionObserver(
+              (entries, currentObserver) => {
+                if (signal.aborted) {
+                  return;
+                }
+                for (const entry of entries) {
+                  if (
+                    !entry.isIntersecting ||
+                    !(entry.target instanceof HTMLIFrameElement)
+                  ) {
+                    continue;
+                  }
+                  const slideId = entry.target.dataset.slideThumbnailFrame;
+                  if (slideId) {
+                    dependencies.loadThumbnail(entry.target, slideId);
+                  }
+                  currentObserver.unobserve(entry.target);
+                }
+              },
+              { root, rootMargin: "480px" },
+            );
+
+      for (const frame of frames) {
+        const slideId = frame.dataset.slideThumbnailFrame;
+        if (!slideId) {
+          continue;
+        }
+        if (!observer || frame.dataset.slideThumbnailActive === "true") {
+          dependencies.loadThumbnail(frame, slideId);
+        } else {
+          observer.observe(frame);
+        }
+      }
+
+      signal.addEventListener(
+        "abort",
+        () => {
+          observer?.disconnect();
+          for (const frame of frames) {
+            dependencies.releaseThumbnail(frame);
+          }
+        },
+        { once: true },
+      );
+    }),
+  );
+
+  return { setRootRef$ };
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -808,12 +808,16 @@ function menuItemByText(text: string): HTMLElement {
   return item;
 }
 
-function mockIntersectionObserver(): { triggerAll: () => void } {
+function mockIntersectionObserver(): {
+  activeRoots: () => (Document | Element | null)[];
+  observedTargetCount: () => number;
+  triggerAll: () => void;
+} {
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     globalThis,
     "IntersectionObserver",
   );
-  const observers: { trigger: () => void }[] = [];
+  const observers: TestIntersectionObserver[] = [];
 
   class TestIntersectionObserver implements IntersectionObserver {
     readonly root: Element | Document | null;
@@ -855,6 +859,10 @@ function mockIntersectionObserver(): { triggerAll: () => void } {
       return [];
     }
 
+    observedTargetCount(): number {
+      return this.observedTargets.length;
+    }
+
     trigger(): void {
       const entries = this.observedTargets.map((target) => {
         return {
@@ -894,6 +902,16 @@ function mockIntersectionObserver(): { triggerAll: () => void } {
   );
 
   return {
+    activeRoots: () => {
+      return observers.flatMap((observer) => {
+        return observer.observedTargetCount() > 0 ? [observer.root] : [];
+      });
+    },
+    observedTargetCount: () => {
+      return observers.reduce((count, observer) => {
+        return count + observer.observedTargetCount();
+      }, 0);
+    },
     triggerAll: () => {
       for (const observer of observers) {
         observer.trigger();
@@ -4214,8 +4232,10 @@ ${openFencedHostedSiteUrl}`,
   });
 
   it("exits the presentation editor without publishing draft changes", async () => {
+    const thumbnailObserver = mockIntersectionObserver();
     const presentationUrl =
       "https://deck.sites.vm7.io/exit-without-saving.html";
+    const browser = context.mocks.browser.blobDownload();
     let redeployCount = 0;
 
     context.mocks.api(
@@ -4243,6 +4263,20 @@ ${openFencedHostedSiteUrl}`,
         "Open with launch metrics.",
       );
     });
+    const slideList = screen.getByTestId("presentation-editor-slide-list");
+    await waitFor(() => {
+      expect(thumbnailObserver.activeRoots()).toStrictEqual([slideList]);
+      expect(thumbnailObserver.observedTargetCount()).toBe(1);
+    });
+    const activeThumbnail = document.querySelector(
+      'iframe[data-slide-thumbnail-frame="slide-intro"]',
+    );
+    if (!(activeThumbnail instanceof HTMLIFrameElement)) {
+      throw new Error("Active presentation thumbnail frame not found");
+    }
+    const activeThumbnailUrl = activeThumbnail.dataset.vm0EditorObjectUrl;
+    expect(activeThumbnailUrl).toMatch(/^blob:/u);
+
     await fill(
       screen.getByLabelText("Speaker notes"),
       "Discard this local draft.",
@@ -4257,12 +4291,17 @@ ${openFencedHostedSiteUrl}`,
       ).toBeInTheDocument();
     });
     expect(redeployCount).toBe(0);
+    expect(thumbnailObserver.activeRoots()).toStrictEqual([slideList]);
+    expect(thumbnailObserver.observedTargetCount()).toBe(1);
 
     click(screen.getByText("Discard"));
     await waitFor(() => {
       expect(screen.queryByText("Presentation editor")).not.toBeInTheDocument();
     });
     expect(redeployCount).toBe(0);
+    expect(thumbnailObserver.activeRoots()).toStrictEqual([]);
+    expect(thumbnailObserver.observedTargetCount()).toBe(0);
+    expect(browser.revokedUrls).toContain(activeThumbnailUrl);
 
     click(screen.getByLabelText("Edit presentation"));
     await waitFor(() => {
@@ -4270,6 +4309,11 @@ ${openFencedHostedSiteUrl}`,
         "Open with launch metrics.",
       );
     });
+    const reopenedSlideList = screen.getByTestId(
+      "presentation-editor-slide-list",
+    );
+    expect(thumbnailObserver.activeRoots()).toStrictEqual([reopenedSlideList]);
+    expect(thumbnailObserver.observedTargetCount()).toBe(1);
 
     click(screen.getByLabelText("Close presentation editor"));
     await waitFor(() => {
@@ -4281,6 +4325,8 @@ ${openFencedHostedSiteUrl}`,
       }),
     ).not.toBeInTheDocument();
     expect(redeployCount).toBe(0);
+    expect(thumbnailObserver.activeRoots()).toStrictEqual([]);
+    expect(thumbnailObserver.observedTargetCount()).toBe(0);
   });
 
   it("edits and downloads a presentation artifact from the editor", async () => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -29,6 +29,10 @@ import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { refreshPresentationHtmlPreviews$ } from "../../signals/zero-page/presentation-html-cache-bust.ts";
 import { createPresentationDraftByUrlFactory } from "../../signals/zero-page/presentation-html-editor-draft.ts";
 import {
+  createPresentationSlideListSignals,
+  type PresentationSlideListSignals,
+} from "../../signals/zero-page/presentation-html-slide-list.ts";
+import {
   presentationEditorCloseDialogOpen$,
   setPresentationEditorCloseDialogOpen$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
@@ -79,6 +83,7 @@ interface PresentationEditorSession {
   readonly publishedSignatureRef: MutableValue<string>;
   readonly publishingRef: MutableValue<boolean>;
   readonly moveBlocksRef: MutableValue<readonly PresentationMoveBlock[]>;
+  readonly slideList: PresentationSlideListSignals;
   readonly slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
   readonly statusRef: MutableValue<HTMLDivElement | null>;
   readonly thumbnailUpdateFrameRef: MutableValue<number | null>;
@@ -90,10 +95,38 @@ function mutableValue<T>(current: T): MutableValue<T> {
 
 function createPresentationEditorSession(
   draft: PresentationEditDraft,
+  publicUrl: string,
 ): PresentationEditorSession {
+  const blocksRef = mutableValue<readonly PresentationEditBlock[]>(
+    draft.blocks,
+  );
+  const moveBlocksRef = mutableValue<readonly PresentationMoveBlock[]>(
+    draft.moveBlocks,
+  );
+  const slidesRef = mutableValue<readonly PresentationSlideDraft[]>(
+    draft.slides,
+  );
+  const slideList = createPresentationSlideListSignals({
+    loadThumbnail: (frame, slideId) => {
+      setSandboxedFrameHtml(
+        frame,
+        previewPresentationHtml({
+          activeSlideId: slideId,
+          html: buildPresentationEditorHtml({
+            blocks: blocksRef.current,
+            html: draft.html,
+            moveBlocks: moveBlocksRef.current,
+            slides: slidesRef.current,
+          }),
+          sourceUrl: publicUrl,
+        }),
+      );
+    },
+    releaseThumbnail: releaseSandboxedFrameHtml,
+  });
   return {
     activeSlideIdRef: mutableValue(draft.slides[0]?.id ?? ""),
-    blocksRef: mutableValue<readonly PresentationEditBlock[]>(draft.blocks),
+    blocksRef,
     busyRef: mutableValue<SVGSVGElement | null>(null),
     pendingThumbnailSlideIdRef: mutableValue<string | null>(null),
     previewFrameRef: mutableValue<HTMLIFrameElement | null>(null),
@@ -105,10 +138,9 @@ function createPresentationEditorSession(
       }),
     ),
     publishingRef: mutableValue(false),
-    moveBlocksRef: mutableValue<readonly PresentationMoveBlock[]>(
-      draft.moveBlocks,
-    ),
-    slidesRef: mutableValue<readonly PresentationSlideDraft[]>(draft.slides),
+    moveBlocksRef,
+    slideList,
+    slidesRef,
     statusRef: mutableValue<HTMLDivElement | null>(null),
     thumbnailUpdateFrameRef: mutableValue<number | null>(null),
   };
@@ -128,7 +160,7 @@ const presentationDraftByUrl = createPresentationDraftByUrlFactory<EditorDraft>(
     const draft = parsePresentationEditDraft(await response.text());
     return {
       ...draft,
-      editorSession: createPresentationEditorSession(draft),
+      editorSession: createPresentationEditorSession(draft, publicUrl),
       publicUrl,
     };
   },
@@ -141,15 +173,21 @@ const PREVIEW_CANVAS_HEIGHT = 1080;
 const PREVIEW_FIT_SCALE = 0.99;
 
 function setSandboxedFrameHtml(frame: HTMLIFrameElement, html: string): void {
-  const previousUrl = frame.dataset.vm0EditorObjectUrl;
-  if (previousUrl) {
-    URL.revokeObjectURL(previousUrl);
-  }
+  releaseSandboxedFrameHtml(frame);
   const url = URL.createObjectURL(
     new Blob([html], { type: "text/html;charset=utf-8" }),
   );
   frame.dataset.vm0EditorObjectUrl = url;
   frame.src = url;
+}
+
+function releaseSandboxedFrameHtml(frame: HTMLIFrameElement): void {
+  const url = frame.dataset.vm0EditorObjectUrl;
+  if (!url) {
+    return;
+  }
+  URL.revokeObjectURL(url);
+  delete frame.dataset.vm0EditorObjectUrl;
 }
 
 function revealPresentationPreviewSlide(
@@ -431,77 +469,19 @@ function PresentationEditorError({
 
 function SlideList({
   activeSlideId,
-  getSlideHtml,
   setActiveSlideId,
+  signals,
   slides,
 }: {
   activeSlideId: string;
-  getSlideHtml: (slideId: string) => string | null;
   setActiveSlideId: (id: string) => void;
+  signals: PresentationSlideListSignals;
   slides: readonly PresentationSlideDraft[];
 }) {
-  const rootRef = mutableValue<HTMLElement | null>(null);
-  const observerRef = mutableValue<IntersectionObserver | null>(null);
-  const observedFramesRef = mutableValue(new WeakSet<HTMLIFrameElement>());
-  const loadThumbnail = (frame: HTMLIFrameElement, slideId: string) => {
-    const html = getSlideHtml(slideId);
-    if (html) {
-      setSandboxedFrameHtml(frame, html);
-    }
-  };
-  const thumbnailObserver = () => {
-    if (typeof IntersectionObserver === "undefined") {
-      return null;
-    }
-    if (!observerRef.current) {
-      observerRef.current = new IntersectionObserver(
-        (entries) => {
-          for (const entry of entries) {
-            if (!(entry.target instanceof HTMLIFrameElement)) {
-              continue;
-            }
-            if (!entry.isIntersecting) {
-              continue;
-            }
-            const slideId = entry.target.dataset.slideThumbnailFrame;
-            if (slideId) {
-              loadThumbnail(entry.target, slideId);
-            }
-            observerRef.current?.unobserve(entry.target);
-          }
-        },
-        { root: rootRef.current, rootMargin: "480px" },
-      );
-    }
-    return observerRef.current;
-  };
-  const setThumbnailFrame = (
-    frame: HTMLIFrameElement | null,
-    slideId: string,
-    active: boolean,
-  ) => {
-    if (!frame) {
-      return;
-    }
-    if (active) {
-      loadThumbnail(frame, slideId);
-      return;
-    }
-    const observer = thumbnailObserver();
-    if (!observer) {
-      loadThumbnail(frame, slideId);
-      return;
-    }
-    if (!observedFramesRef.current.has(frame)) {
-      observedFramesRef.current.add(frame);
-      observer.observe(frame);
-    }
-  };
+  const setRootRef = useSet(signals.setRootRef$);
   return (
     <aside
-      ref={(node) => {
-        rootRef.current = node;
-      }}
+      ref={setRootRef}
       data-testid="presentation-editor-slide-list"
       className="min-h-0 overflow-x-auto overflow-y-hidden border-b border-border/60 bg-[#eeeeee] px-3 py-3 md:overflow-auto md:border-b-0 md:border-r md:px-5 md:py-6"
     >
@@ -526,11 +506,9 @@ function SlideList({
                 )}
               >
                 <iframe
-                  ref={(frame) => {
-                    setThumbnailFrame(frame, slide.id, active);
-                  }}
                   title={`Slide ${String(index + 1)} thumbnail`}
                   data-slide-thumbnail-frame={slide.id}
+                  data-slide-thumbnail-active={active ? "true" : "false"}
                   sandbox="allow-same-origin allow-scripts"
                   onLoad={revealPresentationPreviewSlide}
                   className="pointer-events-none origin-top-left border-0 bg-white"
@@ -1406,13 +1384,13 @@ function downloadEditedPptx(params: {
 
 function buildPresentationEditorHtml(params: {
   readonly blocks: readonly PresentationEditBlock[];
-  readonly draft: EditorDraft;
+  readonly html: string;
   readonly moveBlocks: readonly PresentationMoveBlock[];
   readonly slides: readonly PresentationSlideDraft[];
 }) {
   return patchPresentationHtml({
     blocks: params.blocks,
-    html: params.draft.html,
+    html: params.html,
     moveBlocks: params.moveBlocks,
     slides: params.slides,
   });
@@ -1615,7 +1593,6 @@ function PresentationEditorWorkspace({
   activeSlide,
   activeSlideId,
   blocksRef,
-  buildEditedHtml,
   movementEnabled,
   moveBlocksRef,
   markDirty,
@@ -1623,14 +1600,13 @@ function PresentationEditorWorkspace({
   previewHtml,
   queueSlideThumbnailUpdate,
   showSlide,
+  slideList,
   slidesRef,
   slides,
-  sourceUrl,
 }: {
   activeSlide: PresentationSlideDraft | undefined;
   activeSlideId: string;
   blocksRef: MutableValue<readonly PresentationEditBlock[]>;
-  buildEditedHtml: () => string;
   movementEnabled: boolean;
   moveBlocksRef: MutableValue<readonly PresentationMoveBlock[]>;
   markDirty: () => void;
@@ -1638,20 +1614,13 @@ function PresentationEditorWorkspace({
   previewHtml: string | null;
   queueSlideThumbnailUpdate: (slideId: string) => void;
   showSlide: (slideId: string) => void;
+  slideList: PresentationSlideListSignals;
   slidesRef: MutableValue<readonly PresentationSlideDraft[]>;
   slides: readonly PresentationSlideDraft[];
-  sourceUrl: string;
 }) {
   if (slides.length === 0 || !activeSlide) {
     return <UnsupportedPresentation />;
   }
-  const slidePreviewHtml = (slideId: string) => {
-    return previewPresentationHtml({
-      activeSlideId: slideId,
-      html: buildEditedHtml(),
-      sourceUrl,
-    });
-  };
 
   return (
     <div
@@ -1660,8 +1629,8 @@ function PresentationEditorWorkspace({
     >
       <SlideList
         activeSlideId={activeSlideId}
-        getSlideHtml={slidePreviewHtml}
         setActiveSlideId={showSlide}
+        signals={slideList}
         slides={slides}
       />
       <div
@@ -1858,7 +1827,7 @@ function createPresentationEditorController(
   const buildEditedHtml = () => {
     return buildPresentationEditorHtml({
       blocks: params.blocksRef.current,
-      draft: params.draft,
+      html: params.draft.html,
       moveBlocks: params.moveBlocksRef.current,
       slides: params.slidesRef.current,
     });
@@ -2080,6 +2049,7 @@ function PresentationEditorReady({
     publishedSignatureRef,
     publishingRef,
     moveBlocksRef,
+    slideList,
     slidesRef,
     statusRef,
     thumbnailUpdateFrameRef,
@@ -2154,7 +2124,6 @@ function PresentationEditorReady({
         activeSlide={controller.activeSlide}
         activeSlideId={controller.activeSlideId}
         blocksRef={blocksRef}
-        buildEditedHtml={controller.buildEditedHtml}
         movementEnabled={movementEnabled}
         moveBlocksRef={moveBlocksRef}
         markDirty={controller.markDirty}
@@ -2162,9 +2131,9 @@ function PresentationEditorReady({
         previewHtml={controller.previewHtml}
         queueSlideThumbnailUpdate={controller.queueSlideThumbnailUpdate}
         showSlide={controller.showSlide}
+        slideList={slideList}
         slidesRef={slidesRef}
         slides={controller.slides}
-        sourceUrl={draft.publicUrl}
       />
       <PresentationEditorCloseDialog
         open={closeDialogOpen}


### PR DESCRIPTION
## Summary

- move presentation thumbnail lazy loading into a per-editor ccstate signal bound directly to the SlideList root
- keep one `IntersectionObserver` rooted at the slide list across rerenders, then disconnect it during ref cleanup
- revoke thumbnail Blob URLs when frames are replaced or the editor unmounts
- cover the observer root, close-dialog rerender, editor teardown, reopen, and Blob URL cleanup in the page integration test

## User impact

Long presentations now preload thumbnails relative to the slide list instead of the viewport. Opening the close confirmation dialog or rerendering the editor no longer accumulates observers, frames, or thumbnail Blob URLs.

## Verification

- `corepack pnpm exec prettier --check apps/platform/src/signals/zero-page/presentation-html-slide-list.ts apps/platform/src/views/zero-page/presentation-html-editor.tsx apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `corepack pnpm -F @vm0/app exec oxlint ...` for the three changed files
- `corepack pnpm -F @vm0/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json ...` for the three changed files
- `corepack pnpm -F @vm0/app exec eslint ... --max-warnings 0` for the three changed files
- `corepack pnpm -F @vm0/app exec tsc -p tsconfig.production.json --noEmit`
- `corepack pnpm -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit`
- `corepack pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "exits the presentation editor without publishing draft changes"` (1 passed, 50 skipped)

Full Vitest was not run per repository PR guidance.
