### PR TITLE
refactor(platform): remove keyed caches from request computeds

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -31,29 +31,16 @@ export const defaultAgentId$ = computed(async (get) => {
 
 const internalAgentByIdReload$ = state(0);
 
-function createAgentByIdFactory(): (
-  id: string,
-) => Computed<Promise<ZeroAgentResponse>> {
-  const cache = new Map<string, Computed<Promise<ZeroAgentResponse>>>();
-  return (id: string) => {
-    const existing = cache.get(id);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = computed(async (get) => {
-      get(internalAgentByIdReload$);
-      const client = get(zeroClient$)(zeroAgentsByIdContract);
-      const result = await retryTransientLoad(() => {
-        return accept(client.get({ params: { id } }), [200]);
-      });
-      return result.body;
+export function agentById(id: string): Computed<Promise<ZeroAgentResponse>> {
+  return computed(async (get) => {
+    get(internalAgentByIdReload$);
+    const client = get(zeroClient$)(zeroAgentsByIdContract);
+    const result = await retryTransientLoad(() => {
+      return accept(client.get({ params: { id } }), [200]);
     });
-    cache.set(id, atom$);
-    return atom$;
-  };
+    return result.body;
+  });
 }
-
-export const agentById = createAgentByIdFactory();
 
 export const reloadAgentById$ = command(({ set }) => {
   set(internalAgentByIdReload$, (prev) => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -13,6 +13,8 @@ import type { WorkflowComposerSignals } from "../zero-page/tiptap-workflow-compo
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
+import type { HeaderAutomationSignals } from "./header-automation-menu.ts";
+import type { WorkflowQueueSignals } from "./workflow-queue.ts";
 
 type RecommendedFollowup = NonNullable<
   Extract<PagedChatMessage, { role: "assistant" }>["recommendedFollowups"]
@@ -110,6 +112,9 @@ export interface ChatThreadSignals {
   agentId$: Computed<Promise<string | null>>;
   agentDisplayName$: Computed<Promise<string | null>>;
   agentPinned$: Computed<Promise<boolean | null>>;
+  // -- Thread-owned automation resources -----------------------------------
+  headerAutomations: HeaderAutomationSignals;
+  workflowQueue: WorkflowQueueSignals;
   // -- Per-thread UI state --------------------------------------------------
   timelineExpandedIds$: Computed<Set<string>>;
   toggleTimelineExpanded$: Command<void, [string]>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -18,8 +18,8 @@ import {
   setLoop,
   withCleanup,
 } from "../utils.ts";
-import { reloadHeaderAutomationMenu$ } from "./header-automation-menu.ts";
-import { createWorkflowQueueChangedHandler as workflowQueueHandler } from "./workflow-queue.ts";
+import { createHeaderAutomationSignals } from "./header-automation-menu.ts";
+import { createWorkflowQueueSignals } from "./workflow-queue.ts";
 import {
   createScrollSignals,
   type PrependScrollCompensationToken,
@@ -33,6 +33,7 @@ import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
   shouldExcludeVisualAttachmentsForModel,
+  ATTACH_ONLY_PLACEHOLDER,
 } from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatMessage$,
@@ -83,6 +84,7 @@ import {
 import {
   enrichBlocksWithTextPreviews,
   parseBodyRenderBlocks,
+  type BodyRenderBlock,
 } from "./parse-body-blocks.ts";
 import { getChatThreadTitleParts } from "./chat-thread-title.ts";
 import {
@@ -105,6 +107,8 @@ import {
 } from "../zero-page/model-first-personal-oauth.ts";
 import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/codex-device-auth.ts";
+import { userPermissionGrantsByAgent } from "../permission-allow/permission-allow-signals.ts";
+import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 
 import type {
   ChatThreadSignals,
@@ -902,6 +906,18 @@ function createAgentInfoSignals(
   return { agentId$, agentDisplayName$, agentPinned$ };
 }
 
+function createThreadOwnedSignals(
+  threadId: string,
+  threadMeta$: Computed<Promise<ThreadMeta | null>>,
+) {
+  return {
+    ...createAgentInfoSignals(threadMeta$),
+    headerAutomations: createHeaderAutomationSignals(threadId),
+    workflowQueue: createWorkflowQueueSignals(threadId),
+    ...createThreadUIState(),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Sub-factory: per-thread UI state (timeline expansion, copy)
 // ---------------------------------------------------------------------------
@@ -1414,9 +1430,13 @@ function createTranscriptMessagesComputed(
     return Promise.resolve(
       get(semanticMessages$).map((entry) => {
         const { message, isQueued, isOptimisticRun } = entry;
-        const { blocks } = parseBodyRenderBlocks(message.content ?? "", {
+        const content = chatMessageBodyContent(message);
+        const { blocks } = parseBodyRenderBlocks(content, {
           previews: message.role === "assistant",
         });
+        const enrichedBlocks = enrichBlocksWithPermissionActionResources(
+          enrichBlocksWithTextPreviews(blocks),
+        );
         let mailDraftResource: EnrichedChatMessage["mailDraftResource"] = null;
         if (message.mailDraftId !== undefined) {
           const mailDraft$ = mailDraftById.get(message.mailDraftId);
@@ -1434,7 +1454,7 @@ function createTranscriptMessagesComputed(
           return {
             ...message,
             role: "user" as const,
-            blocks: enrichBlocksWithTextPreviews(blocks),
+            blocks: enrichedBlocks,
             isQueued,
             isOptimisticRun,
             mailDraftResource,
@@ -1443,13 +1463,51 @@ function createTranscriptMessagesComputed(
         return {
           ...message,
           role: "assistant" as const,
-          blocks: enrichBlocksWithTextPreviews(blocks),
+          blocks: enrichedBlocks,
           isQueued,
           isOptimisticRun: false,
           mailDraftResource,
         };
       }),
     );
+  });
+}
+
+function chatMessageBodyContent(message: PagedChatMessage): string {
+  if (message.role === "assistant") {
+    return message.content ?? "";
+  }
+  const content = (message.content ?? "").replace(
+    /\[Attached file: ([^\]]+)\]\(([^)]+)\)(?:\nDownload with: curl [^\n]*)?\n?/g,
+    "",
+  );
+  if (
+    message.attachFiles &&
+    message.attachFiles.length > 0 &&
+    content.trim() === ATTACH_ONLY_PLACEHOLDER
+  ) {
+    return "";
+  }
+  return content.trim();
+}
+
+function enrichBlocksWithPermissionActionResources(
+  blocks: BodyRenderBlock[],
+): BodyRenderBlock[] {
+  return blocks.map((block) => {
+    if (block.type !== "permission-action") {
+      return block;
+    }
+    return {
+      ...block,
+      resource: {
+        agent$: agentById(block.agentId),
+        grants$: userPermissionGrantsByAgent({ agentId: block.agentId }),
+        metadata$: firewallPermissionMetadataByConnector({
+          connectorRef: block.connectorRef,
+        }),
+      },
+    };
   });
 }
 
@@ -2417,6 +2475,10 @@ interface RunTrackingDeps {
   fetchUpdatedMessage$: Command<Promise<boolean>, [unknown, AbortSignal]>;
   reloadArtifacts$: Command<void, []>;
   autoScroll$: Command<void, []>;
+  automationSignals: Pick<
+    ChatThreadSignals,
+    "headerAutomations" | "workflowQueue"
+  >;
   dataSource: ChatThreadRemote;
 }
 
@@ -2611,6 +2673,7 @@ function createRunTracking({
   fetchUpdatedMessage$,
   reloadArtifacts$,
   autoScroll$,
+  automationSignals,
   dataSource,
 }: RunTrackingDeps) {
   const locallyMarkedReadAt$ = state<string | undefined>(undefined);
@@ -2692,8 +2755,7 @@ function createRunTracking({
     });
 
     const onAutomationsChanged$ = command(({ set }) => {
-      L.debug("onAutomationsChanged$ fired", { threadId });
-      set(reloadHeaderAutomationMenu$);
+      set(automationSignals.headerAutomations.reload$);
       return false;
     });
 
@@ -2709,7 +2771,6 @@ function createRunTracking({
       return false;
     });
 
-    L.debug("subscribeChatThread$ subscribeRealtime$ start", { threadId });
     const subscriptionScope = set(resetChatSubscriptionSignal$, signal);
     const subscriptionSignal = subscriptionScope.signal;
 
@@ -2728,7 +2789,8 @@ function createRunTracking({
               onAutomationsChanged$,
               onArtifactsChanged$,
               onWorkflowsChanged$,
-              onWorkflowQueueChanged$: workflowQueueHandler(threadId),
+              onWorkflowQueueChanged$:
+                automationSignals.workflowQueue.handleChanged$,
               onSubscribed$,
             },
           },
@@ -3887,8 +3949,7 @@ export function createChatThreadSignals(
   const { containerEl$, setContainerRef$ } = createContainerRef();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
-  const agentInfo = createAgentInfoSignals(threadMeta$);
-  const threadUi = createThreadUIState();
+  const threadOwned = createThreadOwnedSignals(threadId, threadMeta$);
   const messages = createChatThreadMessagePipeline({
     threadId,
     dataSource,
@@ -3911,6 +3972,7 @@ export function createChatThreadSignals(
     fetchUpdatedMessage$: messages.fetchUpdatedMessage$,
     reloadArtifacts$: artifact.reloadArtifacts$,
     autoScroll$: scrollSignals.autoScroll$,
+    automationSignals: threadOwned,
     dataSource,
   });
   const messageActions = createThreadMessageActions({
@@ -3952,8 +4014,7 @@ export function createChatThreadSignals(
     workflowComposer,
     composerFileInput$,
     setComposerFileInput$,
-    ...agentInfo,
-    ...threadUi,
+    ...threadOwned,
     focusInput$: workflowComposer.focus$,
     queueDraftSync$,
     latestChatMessageId$: messages.latestChatMessageId$,

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import {
   zeroWorkflowAutomationsContract,
@@ -12,13 +12,6 @@ import { zeroClient$ } from "../api-client.ts";
 import { userPreferences$ } from "../zero-page/settings/user-preferences.ts";
 import { listThreadWorkflowAutomations } from "../zero-page/workflow-automations-api.ts";
 
-const headerAutomationMenuReload$ = state(0);
-
-/** Bump to force the header automation menu to refetch (e.g. when it opens). */
-export const reloadHeaderAutomationMenu$ = command(({ get, set }) => {
-  set(headerAutomationMenuReload$, get(headerAutomationMenuReload$) + 1);
-});
-
 /** A workflow automation bound to a chat thread, projected for the header automation sidebar. */
 export interface HeaderWorkflowAutomationEntry {
   readonly id: string;
@@ -31,6 +24,44 @@ export interface HeaderWorkflowAutomationEntry {
   readonly summary: string;
   readonly timezone: string;
   readonly automation: ChatThreadWorkflowAutomation;
+}
+
+export interface HeaderAutomationSignals {
+  readonly automations$: Computed<
+    Promise<readonly HeaderWorkflowAutomationEntry[]>
+  >;
+  readonly reload$: Command<void, []>;
+  readonly updateSchedule$: Command<
+    Promise<void>,
+    [
+      {
+        readonly automationId: string;
+        readonly schedule: ZeroWorkflowSchedule;
+      },
+      AbortSignal,
+    ]
+  >;
+  readonly updateGmailNewMessage$: Command<
+    Promise<void>,
+    [
+      {
+        readonly automationId: string;
+        readonly eventConfig: GmailNewMessageEventConfig;
+      },
+      AbortSignal,
+    ]
+  >;
+  readonly updateGmailLabelApplied$: Command<
+    Promise<void>,
+    [
+      {
+        readonly automationId: string;
+        readonly eventConfig: GmailLabelAppliedEventConfig;
+      },
+      AbortSignal,
+    ]
+  >;
+  readonly runNow$: Command<Promise<void>, [string, AbortSignal]>;
 }
 
 function workflowAutomationSummary(
@@ -58,137 +89,136 @@ function workflowAutomationSummary(
 }
 
 /**
- * Workflow automations bound to a chat thread, for the header automation sidebar.
+ * Create the automation graph owned by one chat-thread signal instance.
  */
-function createHeaderWorkflowAutomationsFactory(): (
+export function createHeaderAutomationSignals(
   threadId: string,
-) => Computed<Promise<readonly HeaderWorkflowAutomationEntry[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly HeaderWorkflowAutomationEntry[]>>
-  >();
-  return (threadId: string) => {
-    const cached = cache.get(threadId);
-    if (cached) {
-      return cached;
-    }
-    const automations$ = computed(
-      async (get): Promise<readonly HeaderWorkflowAutomationEntry[]> => {
-        get(headerAutomationMenuReload$);
-        const automations = await listThreadWorkflowAutomations(
-          get(zeroClient$),
-          {
-            threadId,
-          },
-        );
-        const prefs = await get(userPreferences$);
-        const displayTz =
-          prefs?.timezone ??
-          new Intl.DateTimeFormat().resolvedOptions().timeZone;
-        return automations.map((automation) => {
-          return {
-            id: automation.id,
-            chatThreadId: automation.chatThreadId,
-            enabled: automation.enabled,
-            workflowId: automation.workflow.id,
-            workflowAgentId: automation.workflow.agentId,
-            workflowName: automation.workflow.name,
-            workflowDisplayName: automation.workflow.displayName,
-            summary: workflowAutomationSummary(automation),
-            timezone: displayTz,
-            automation,
-          };
-        });
+): HeaderAutomationSignals {
+  const reloadVersion$ = state(0);
+
+  const reload$ = command(({ set }) => {
+    set(reloadVersion$, (version) => {
+      return version + 1;
+    });
+  });
+
+  const automations$ = computed(
+    async (get): Promise<readonly HeaderWorkflowAutomationEntry[]> => {
+      get(reloadVersion$);
+      const automations = await listThreadWorkflowAutomations(
+        get(zeroClient$),
+        { threadId },
+      );
+      const prefs = await get(userPreferences$);
+      const displayTz =
+        prefs?.timezone ?? new Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return automations.map((automation) => {
+        return {
+          id: automation.id,
+          chatThreadId: automation.chatThreadId,
+          enabled: automation.enabled,
+          workflowId: automation.workflow.id,
+          workflowAgentId: automation.workflow.agentId,
+          workflowName: automation.workflow.name,
+          workflowDisplayName: automation.workflow.displayName,
+          summary: workflowAutomationSummary(automation),
+          timezone: displayTz,
+          automation,
+        };
+      });
+    },
+  );
+
+  const updateSchedule$ = command(
+    async (
+      { get, set },
+      params: {
+        readonly automationId: string;
+        readonly schedule: ZeroWorkflowSchedule;
       },
-    );
-    cache.set(threadId, automations$);
-    return automations$;
+      signal: AbortSignal,
+    ) => {
+      const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+      await accept(
+        client.update({
+          params: { id: params.automationId },
+          body: { schedule: params.schedule },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  const updateGmailNewMessage$ = command(
+    async (
+      { get, set },
+      params: {
+        readonly automationId: string;
+        readonly eventConfig: GmailNewMessageEventConfig;
+      },
+      signal: AbortSignal,
+    ) => {
+      const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+      await accept(
+        client.update({
+          params: { id: params.automationId },
+          body: { eventConfig: params.eventConfig },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  const updateGmailLabelApplied$ = command(
+    async (
+      { get, set },
+      params: {
+        readonly automationId: string;
+        readonly eventConfig: GmailLabelAppliedEventConfig;
+      },
+      signal: AbortSignal,
+    ) => {
+      const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+      await accept(
+        client.update({
+          params: { id: params.automationId },
+          body: { eventConfig: params.eventConfig },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  const runNow$ = command(
+    async ({ get, set }, automationId: string, signal: AbortSignal) => {
+      const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+      await accept(
+        client.run({
+          params: { id: automationId },
+          fetchOptions: { signal },
+        }),
+        [201],
+      );
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  return {
+    automations$,
+    reload$,
+    updateSchedule$,
+    updateGmailNewMessage$,
+    updateGmailLabelApplied$,
+    runNow$,
   };
 }
-
-export const headerWorkflowAutomationsForThread =
-  createHeaderWorkflowAutomationsFactory();
-
-export const updateHeaderWorkflowScheduleAutomation$ = command(
-  async (
-    { get, set },
-    params: {
-      readonly automationId: string;
-      readonly schedule: ZeroWorkflowSchedule;
-    },
-    signal: AbortSignal,
-  ) => {
-    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
-    await accept(
-      client.update({
-        params: { id: params.automationId },
-        body: { schedule: params.schedule },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(reloadHeaderAutomationMenu$);
-  },
-);
-
-export const updateHeaderWorkflowGmailNewMessageAutomation$ = command(
-  async (
-    { get, set },
-    params: {
-      readonly automationId: string;
-      readonly eventConfig: GmailNewMessageEventConfig;
-    },
-    signal: AbortSignal,
-  ) => {
-    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
-    await accept(
-      client.update({
-        params: { id: params.automationId },
-        body: { eventConfig: params.eventConfig },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(reloadHeaderAutomationMenu$);
-  },
-);
-
-export const runHeaderWorkflowAutomationNow$ = command(
-  async ({ get, set }, automationId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
-    await accept(
-      client.run({
-        params: { id: automationId },
-        fetchOptions: { signal },
-      }),
-      [201],
-    );
-    signal.throwIfAborted();
-    set(reloadHeaderAutomationMenu$);
-  },
-);
-
-export const updateHeaderWorkflowGmailLabelAppliedAutomation$ = command(
-  async (
-    { get, set },
-    params: {
-      readonly automationId: string;
-      readonly eventConfig: GmailLabelAppliedEventConfig;
-    },
-    signal: AbortSignal,
-  ) => {
-    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
-    await accept(
-      client.update({
-        params: { id: params.automationId },
-        body: { eventConfig: params.eventConfig },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(reloadHeaderAutomationMenu$);
-  },
-);

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -1,4 +1,10 @@
-import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { Computed } from "ccstate";
+import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type {
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import {
   resolvePlatformOriginForTarget,
   rewritePlatformHostname,
@@ -25,7 +31,16 @@ export type PermissionActionBlock = PermissionActionDescriptor & {
   type: "permission-action";
   id: string;
   href: string;
+  resource?: PermissionActionResource;
 };
+
+export interface PermissionActionResource {
+  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
+  readonly grants$: Computed<Promise<readonly UserPermissionGrantResponse[]>>;
+  readonly metadata$: Computed<
+    Promise<PublicConnectorCatalogPermissionDetail | null>
+  >;
+}
 
 function permissionActionHref(descriptor: PermissionActionDescriptor): string {
   const path = `/agents/${encodeURIComponent(descriptor.agentId)}/permissions`;

--- a/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
+++ b/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 
 import {
   zeroWorkflowQueueContract,
@@ -10,68 +10,62 @@ import { zeroClient$ } from "../api-client.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { openHeaderAutomationSidebar$ } from "./header-automation-sidebar.ts";
 
-const workflowQueueReload$ = state(0);
-
-/** Bump to force the workflow queue panel to refetch. */
-const reloadWorkflowQueue$ = command(({ get, set }) => {
-  set(workflowQueueReload$, get(workflowQueueReload$) + 1);
-});
-
-/**
- * The chat thread's workflow queue snapshot, or null when the WorkflowQueue
- * switch is off or the thread has no workflow queue (403/404 from the API).
- */
-function createWorkflowQueueFactory(): (
-  threadId: string,
-) => Computed<Promise<WorkflowQueueResponse | null>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<WorkflowQueueResponse | null>>
-  >();
-  return (threadId: string) => {
-    const cached = cache.get(threadId);
-    if (cached) {
-      return cached;
-    }
-    const queue$ = computed(
-      async (get): Promise<WorkflowQueueResponse | null> => {
-        get(workflowQueueReload$);
-        const switches = get(featureSwitch$);
-        if (!switches[FeatureSwitchKey.WorkflowQueue]) {
-          return null;
-        }
-        const client = get(zeroClient$)(zeroWorkflowQueueContract);
-        const response = await client.get({ params: { threadId } });
-        if (response.status !== 200) {
-          return null;
-        }
-        return response.body;
-      },
-    );
-    cache.set(threadId, queue$);
-    return queue$;
-  };
+export interface WorkflowQueueSignals {
+  readonly queue$: Computed<Promise<WorkflowQueueResponse | null>>;
+  readonly reload$: Command<void, []>;
+  readonly skipEvent$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly clear$: Command<Promise<void>, [AbortSignal]>;
+  readonly setPaused$: Command<Promise<void>, [boolean, AbortSignal]>;
+  readonly handleChanged$: Command<Promise<boolean>, [AbortSignal]>;
 }
 
-export const workflowQueueForThread = createWorkflowQueueFactory();
+/**
+ * Create the workflow queue graph owned by one chat-thread signal instance.
+ */
+export function createWorkflowQueueSignals(
+  threadId: string,
+): WorkflowQueueSignals {
+  const reloadVersion$ = state(0);
+  const lastPendingCount$ = state(0);
 
-export const skipWorkflowQueueEvent$ = command(
-  async ({ get, set }, eventId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroWorkflowQueueContract);
-    await accept(
-      client.skipEvent({
-        params: { id: eventId },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(reloadWorkflowQueue$);
-  },
-);
+  const reload$ = command(({ set }) => {
+    set(reloadVersion$, (version) => {
+      return version + 1;
+    });
+  });
 
-export const clearWorkflowQueue$ = command(
-  async ({ get, set }, threadId: string, signal: AbortSignal) => {
+  const queue$ = computed(
+    async (get): Promise<WorkflowQueueResponse | null> => {
+      get(reloadVersion$);
+      const switches = get(featureSwitch$);
+      if (!switches[FeatureSwitchKey.WorkflowQueue]) {
+        return null;
+      }
+      const client = get(zeroClient$)(zeroWorkflowQueueContract);
+      const response = await accept(
+        client.get({ params: { threadId } }),
+        [200, 403, 404],
+      );
+      return response.status === 200 ? response.body : null;
+    },
+  );
+
+  const skipEvent$ = command(
+    async ({ get, set }, eventId: string, signal: AbortSignal) => {
+      const client = get(zeroClient$)(zeroWorkflowQueueContract);
+      await accept(
+        client.skipEvent({
+          params: { id: eventId },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  const clear$ = command(async ({ get, set }, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroWorkflowQueueContract);
     await accept(
       client.clear({
@@ -81,62 +75,51 @@ export const clearWorkflowQueue$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(reloadWorkflowQueue$);
-  },
-);
-
-export const setWorkflowQueuePaused$ = command(
-  async (
-    { get, set },
-    args: { readonly threadId: string; readonly paused: boolean },
-    signal: AbortSignal,
-  ) => {
-    const client = get(zeroClient$)(zeroWorkflowQueueContract);
-    const request = args.paused
-      ? client.pause({
-          params: { threadId: args.threadId },
-          fetchOptions: { signal },
-        })
-      : client.resume({
-          params: { threadId: args.threadId },
-          fetchOptions: { signal },
-        });
-    await accept(request, [200]);
-    signal.throwIfAborted();
-    set(reloadWorkflowQueue$);
-  },
-);
-
-// Last observed pending count per thread, for the 0 -> >0 auto-expand edge.
-const lastPendingCounts$ = state<Readonly<Record<string, number>>>({});
-
-/**
- * Realtime `chatThreadWorkflowQueueChanged` handler: refetch the queue and
- * auto-expand the Automations panel only when the backlog transitions from
- * empty to non-empty, so it never fights a user who closed the panel.
- */
-const handleWorkflowQueueChanged$ = command(
-  async ({ get, set }, threadId: string, signal: AbortSignal) => {
-    set(reloadWorkflowQueue$);
-    const queue = await get(workflowQueueForThread(threadId));
-    signal.throwIfAborted();
-    if (!queue) {
-      return;
-    }
-    const pending = queue.pending.length;
-    const counts = get(lastPendingCounts$);
-    const previous = counts[threadId] ?? 0;
-    set(lastPendingCounts$, { ...counts, [threadId]: pending });
-    if (previous === 0 && pending > 0) {
-      set(openHeaderAutomationSidebar$, threadId);
-    }
-  },
-);
-
-/** Loop-style realtime handler bound to one thread, for the chat subscription. */
-export function createWorkflowQueueChangedHandler(threadId: string) {
-  return command(async ({ set }, signal: AbortSignal) => {
-    await set(handleWorkflowQueueChanged$, threadId, signal);
-    return false;
+    set(reload$);
   });
+
+  const setPaused$ = command(
+    async ({ get, set }, paused: boolean, signal: AbortSignal) => {
+      const client = get(zeroClient$)(zeroWorkflowQueueContract);
+      const request = paused
+        ? client.pause({
+            params: { threadId },
+            fetchOptions: { signal },
+          })
+        : client.resume({
+            params: { threadId },
+            fetchOptions: { signal },
+          });
+      await accept(request, [200]);
+      signal.throwIfAborted();
+      set(reload$);
+    },
+  );
+
+  const handleChanged$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+      set(reload$);
+      const queue = await get(queue$);
+      signal.throwIfAborted();
+      if (!queue) {
+        return false;
+      }
+      const pending = queue.pending.length;
+      const previous = get(lastPendingCount$);
+      set(lastPendingCount$, pending);
+      if (previous === 0 && pending > 0) {
+        set(openHeaderAutomationSidebar$, threadId);
+      }
+      return false;
+    },
+  );
+
+  return {
+    queue$,
+    reload$,
+    skipEvent$,
+    clear$,
+    setPaused$,
+    handleChanged$,
+  };
 }

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -13,66 +13,34 @@ interface FirewallPermissionMetadataParams {
   readonly connectorRef: string;
 }
 
-const FIREWALL_PERMISSION_METADATA_CACHE_LIMIT = 256;
-const MISSING_FIREWALL_PERMISSION_METADATA$ = computed(
-  (): Promise<PublicConnectorCatalogPermissionDetail | null> => {
-    return Promise.resolve(null);
-  },
-);
-
-function evictOldestCacheEntry<K, V>(cache: Map<K, V>): void {
-  const oldest = cache.keys().next();
-  if (!oldest.done) {
-    cache.delete(oldest.value);
-  }
-}
-
-function createFirewallPermissionMetadataFactory(): (
+export function firewallPermissionMetadataByConnector(
   params: FirewallPermissionMetadataParams,
-) => Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<PublicConnectorCatalogPermissionDetail | null>>
-  >();
-  return (params) => {
-    const key = params.connectorRef;
+): Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
+  const key = params.connectorRef;
+  return computed(async (get) => {
     if (key.length === 0 || key.length > CONNECTOR_REF_MAX_LENGTH) {
-      return MISSING_FIREWALL_PERMISSION_METADATA$;
+      return null;
     }
-    const existing = cache.get(key);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = computed(async (get) => {
-      get(connectorsReloadVersion$);
-      get(featureSwitch$);
+    get(connectorsReloadVersion$);
+    get(featureSwitch$);
 
-      const createClient = get(zeroClient$);
-      const client = createClient(zeroConnectorCatalogContract);
-      const result = await accept(
-        client.permissions({
-          params: { connectorRef: key },
-        }),
-        [200, 404],
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroConnectorCatalogContract);
+    const result = await accept(
+      client.permissions({
+        params: { connectorRef: key },
+      }),
+      [200, 404],
+    );
+    if (result.status === 404) {
+      return null;
+    }
+    const { permissions } = result.body;
+    if (permissions.connectorRef !== key) {
+      throw new Error(
+        `Permission metadata connectorRef mismatch: expected ${key}, got ${permissions.connectorRef}`,
       );
-      if (result.status === 404) {
-        return null;
-      }
-      const { permissions } = result.body;
-      if (permissions.connectorRef !== key) {
-        throw new Error(
-          `Permission metadata connectorRef mismatch: expected ${key}, got ${permissions.connectorRef}`,
-        );
-      }
-      return permissions;
-    });
-    if (cache.size >= FIREWALL_PERMISSION_METADATA_CACHE_LIMIT) {
-      evictOldestCacheEntry(cache);
     }
-    cache.set(key, atom$);
-    return atom$;
-  };
+    return permissions;
+  });
 }
-
-export const firewallPermissionMetadataByConnector =
-  createFirewallPermissionMetadataFactory();

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -15,7 +15,8 @@ import {
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
-import { agentById, reloadAgentById$ } from "../agent.ts";
+import { agentById, currentAgentId$, reloadAgentById$ } from "../agent.ts";
+import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 import { retryTransientLoad } from "../utils.ts";
 import { resolveActiveUserPermissionGrantPolicy } from "../user-permission-grants.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
@@ -110,33 +111,18 @@ interface UserPermissionGrantsByAgentParams {
   agentId: string;
 }
 
-function createUserPermissionGrantsFactory(): (
+export function userPermissionGrantsByAgent(
   params: UserPermissionGrantsByAgentParams,
-) => Computed<Promise<readonly UserPermissionGrantResponse[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly UserPermissionGrantResponse[]>>
-  >();
-  return (params) => {
-    const key = JSON.stringify(params);
-    const existing = cache.get(key);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = computed(async (get) => {
-      get(internalUserPermissionGrantsReload$);
-      const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-      const result = await retryTransientLoad(() => {
-        return accept(client.list({ query: params }), [200]);
-      });
-      return result.body;
+): Computed<Promise<readonly UserPermissionGrantResponse[]>> {
+  return computed(async (get) => {
+    get(internalUserPermissionGrantsReload$);
+    const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+    const result = await retryTransientLoad(() => {
+      return accept(client.list({ query: params }), [200]);
     });
-    cache.set(key, atom$);
-    return atom$;
-  };
+    return result.body;
+  });
 }
-
-export const userPermissionGrantsByAgent = createUserPermissionGrantsFactory();
 
 export const permissionAllowUserPermissionGrants$ = computed(async (get) => {
   const agentId = get(permissionAllowAgentId$);
@@ -145,6 +131,26 @@ export const permissionAllowUserPermissionGrants$ = computed(async (get) => {
   }
   return await get(userPermissionGrantsByAgent({ agentId }));
 });
+
+/** The current agent-detail route's permission grants. */
+export const currentAgentUserPermissionGrants$ = computed(async (get) => {
+  const agentId = get(currentAgentId$);
+  if (!agentId) {
+    return [];
+  }
+  return await get(userPermissionGrantsByAgent({ agentId }));
+});
+
+/** Firewall metadata selected by the permission-allow route. */
+export const permissionAllowFirewallPermissionMetadata$ = computed(
+  async (get) => {
+    const connectorRef = get(permissionAllowRef$);
+    if (!connectorRef) {
+      return null;
+    }
+    return await get(firewallPermissionMetadataByConnector({ connectorRef }));
+  },
+);
 
 export const applyUserPermissionGrants$ = command(
   async (

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import {
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
@@ -41,6 +41,7 @@ import {
   type RouteKey,
 } from "../route-paths.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { currentAgentId$ } from "../agent.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 import { onRejection } from "../utils.ts";
 import {
@@ -633,35 +634,19 @@ export const reloadWorkflows$ = command(({ set }) => {
   set(internalWorkflowConnectorReadiness$, null);
 });
 
-/**
- * Factory for a single agent's visible workflows (public ∪ the caller's own
- * private), scoped via the `agentId` query parameter.
- */
-function createAgentWorkflowsFactory(): (
-  agentId: string,
-) => Computed<Promise<readonly ZeroWorkflowSummary[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly ZeroWorkflowSummary[]>>
-  >();
-  return (agentId: string) => {
-    const existing = cache.get(agentId);
-    if (existing) {
-      return existing;
+/** The current agent detail route's visible workflows. */
+export const currentAgentVisibleWorkflows$ = computed(
+  async (get): Promise<readonly ZeroWorkflowSummary[]> => {
+    get(workflowReloadVersion$);
+    const agentId = get(currentAgentId$);
+    if (!agentId) {
+      return [];
     }
-    const atom$ = computed(async (get) => {
-      get(workflowReloadVersion$);
-      const client = get(zeroClient$)(zeroWorkflowsCollectionContract);
-      const result = await accept(client.list({ query: { agentId } }), [200]);
-      return result.body;
-    });
-    cache.set(agentId, atom$);
-    return atom$;
-  };
-}
-
-const agentWorkflows = createAgentWorkflowsFactory();
-export const agentVisibleWorkflows$ = agentWorkflows;
+    const client = get(zeroClient$)(zeroWorkflowsCollectionContract);
+    const result = await accept(client.list({ query: { agentId } }), [200]);
+    return result.body;
+  },
+);
 
 /**
  * The current chat agent's visible workflows, used by the slash-workflow
@@ -673,7 +658,10 @@ export const composerWorkflows$ = computed(
     if (!agentId) {
       return [];
     }
-    return get(agentWorkflows(agentId));
+    get(workflowReloadVersion$);
+    const client = get(zeroClient$)(zeroWorkflowsCollectionContract);
+    const result = await accept(client.list({ query: { agentId } }), [200]);
+    return result.body;
   },
 );
 
@@ -720,39 +708,22 @@ export const allWorkflowAutomationEntries$ = computed(
   },
 );
 
-/**
- * Factory for a single workflow's detail, addressed by its uuid.
- */
-function createWorkflowDetailFactory(): (
-  workflowId: string,
-) => Computed<Promise<ZeroWorkflowDetailResponse | null>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<ZeroWorkflowDetailResponse | null>>
-  >();
-  return (workflowId: string) => {
-    const existing = cache.get(workflowId);
-    if (existing) {
-      return existing;
+/** The workflow detail derived from the active route. */
+export const currentWorkflowDetail$ = computed(
+  async (get): Promise<ZeroWorkflowDetailResponse | null> => {
+    get(workflowReloadVersion$);
+    const workflowId = get(currentWorkflowId$);
+    if (!workflowId) {
+      return null;
     }
-    const atom$ = computed(async (get) => {
-      get(workflowReloadVersion$);
-      const client = get(zeroClient$)(zeroWorkflowsDetailContract);
-      const result = await accept(
-        client.get({ params: { workflowId } }),
-        [200, 404],
-      );
-      if (result.status === 404) {
-        return null;
-      }
-      return result.body;
-    });
-    cache.set(workflowId, atom$);
-    return atom$;
-  };
-}
-
-export const workflowDetail = createWorkflowDetailFactory();
+    const client = get(zeroClient$)(zeroWorkflowsDetailContract);
+    const result = await accept(
+      client.get({ params: { workflowId } }),
+      [200, 404],
+    );
+    return result.status === 404 ? null : result.body;
+  },
+);
 
 export const checkWorkflowConnectorReadiness$ = command(
   async ({ get, set }, workflowId: string, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -21,17 +21,6 @@ export const reloadAgentConnectorAuthorizations$ = command(({ set }) => {
   });
 });
 
-interface AgentConnectorAuthorizationsFactory {
-  (params: {
-    readonly agentId: string;
-    readonly missing: "null";
-  }): Computed<Promise<AgentConnectorAuthorizations | null>>;
-  (params: {
-    readonly agentId: string;
-    readonly missing?: "throw";
-  }): Computed<Promise<AgentConnectorAuthorizations>>;
-}
-
 function createAuthorizationsAtom(
   agentId: string,
   options: { readonly missing: "throw" },
@@ -59,85 +48,32 @@ function createAuthorizationsAtom(
   });
 }
 
-function createAgentConnectorAuthorizationsFactory(): AgentConnectorAuthorizationsFactory {
-  const authorizationsCache = new Map<
-    string,
-    Computed<Promise<AgentConnectorAuthorizations>>
-  >();
-  const nullableAuthorizationsCache = new Map<
-    string,
-    Computed<Promise<AgentConnectorAuthorizations | null>>
-  >();
-
-  const createAuthorizations = (
-    agentId: string,
-  ): Computed<Promise<AgentConnectorAuthorizations>> => {
-    const existing = authorizationsCache.get(agentId);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = createAuthorizationsAtom(agentId, { missing: "throw" });
-    authorizationsCache.set(agentId, atom$);
-    return atom$;
-  };
-
-  const createNullableAuthorizations = (
-    agentId: string,
-  ): Computed<Promise<AgentConnectorAuthorizations | null>> => {
-    const existing = nullableAuthorizationsCache.get(agentId);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = createAuthorizationsAtom(agentId, { missing: "null" });
-    nullableAuthorizationsCache.set(agentId, atom$);
-    return atom$;
-  };
-
-  function authorizations(params: {
-    readonly agentId: string;
-    readonly missing: "null";
-  }): Computed<Promise<AgentConnectorAuthorizations | null>>;
-  function authorizations(params: {
-    readonly agentId: string;
-    readonly missing?: "throw";
-  }): Computed<Promise<AgentConnectorAuthorizations>>;
-  function authorizations(params: {
-    readonly agentId: string;
-    readonly missing?: "throw" | "null";
-  }): Computed<Promise<AgentConnectorAuthorizations | null>> {
-    if (params.missing === "null") {
-      return createNullableAuthorizations(params.agentId);
-    }
-    return createAuthorizations(params.agentId);
+export function agentConnectorAuthorizations(params: {
+  readonly agentId: string;
+  readonly missing: "null";
+}): Computed<Promise<AgentConnectorAuthorizations | null>>;
+export function agentConnectorAuthorizations(params: {
+  readonly agentId: string;
+  readonly missing?: "throw";
+}): Computed<Promise<AgentConnectorAuthorizations>>;
+export function agentConnectorAuthorizations(params: {
+  readonly agentId: string;
+  readonly missing?: "throw" | "null";
+}): Computed<Promise<AgentConnectorAuthorizations | null>> {
+  if (params.missing === "null") {
+    return createAuthorizationsAtom(params.agentId, { missing: "null" });
   }
-
-  return authorizations;
+  return createAuthorizationsAtom(params.agentId, { missing: "throw" });
 }
 
-function createAgentConnectorAuthorizedFactory(): (params: {
+export function isAgentConnectorAuthorized(params: {
   readonly agentId: string;
   readonly connectorType: ConnectorCatalogRef;
-}) => Computed<Promise<boolean>> {
-  const cache = new Map<string, Computed<Promise<boolean>>>();
-  return (params) => {
-    const key = `${params.agentId}:${params.connectorType}`;
-    const existing = cache.get(key);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = computed(async (get): Promise<boolean> => {
-      const authorizations = await get(
-        agentConnectorAuthorizations({ agentId: params.agentId }),
-      );
-      return authorizations.enabledTypes.includes(params.connectorType);
-    });
-    cache.set(key, atom$);
-    return atom$;
-  };
+}): Computed<Promise<boolean>> {
+  return computed(async (get): Promise<boolean> => {
+    const authorizations = await get(
+      agentConnectorAuthorizations({ agentId: params.agentId }),
+    );
+    return authorizations.enabledTypes.includes(params.connectorType);
+  });
 }
-
-export const agentConnectorAuthorizations =
-  createAgentConnectorAuthorizationsFactory();
-
-export const isAgentConnectorAuthorized =
-  createAgentConnectorAuthorizedFactory();

--- a/turbo/apps/platform/src/signals/zero-page/presentation-html-editor-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-html-editor-draft.ts
@@ -1,28 +1,16 @@
 import { computed, type Computed } from "ccstate";
 import { pageSignal$ } from "../page-signal.ts";
+import { currentPresentationEditorUrl$ } from "./zero-artifact-sidebar.ts";
 
-export function createPresentationDraftByUrlFactory<T>(
+/** Create the draft resource owned by the active presentation editor route. */
+export function createCurrentPresentationDraft<T>(
   load: (url: string, signal: AbortSignal) => Promise<T>,
-): {
-  readonly get: (url: string) => Computed<Promise<T>>;
-  readonly invalidate: (url: string) => void;
-} {
-  const cache = new Map<string, Computed<Promise<T>>>();
-  const get = (url: string) => {
-    const existing = cache.get(url);
-    if (existing) {
-      return existing;
+): Computed<Promise<T>> {
+  return computed((get) => {
+    const url = get(currentPresentationEditorUrl$);
+    if (!url) {
+      throw new Error("Presentation editor URL is unavailable");
     }
-    const draft$ = computed((get) => {
-      return load(url, get(pageSignal$));
-    });
-    cache.set(url, draft$);
-    return draft$;
-  };
-  return {
-    get,
-    invalidate: (url: string) => {
-      cache.delete(url);
-    },
-  };
+    return load(url, get(pageSignal$));
+  });
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
@@ -12,6 +12,7 @@ import {
   reloadAgentConnectorAuthorizations$,
 } from "../agent-connector-authorizations.ts";
 import { settle, withCleanup } from "../../utils.ts";
+import { firewallPermissionMetadataByConnector } from "../../firewall-permission-metadata.ts";
 
 export interface ConnectorAgentAccessRow {
   readonly agent: TeamComposeItem;
@@ -22,10 +23,6 @@ export interface ConnectorAgentAccessRow {
 interface ConnectorAgentAuthorizationRow {
   readonly agent: TeamComposeItem;
   readonly enabledTypes: readonly ConnectorType[];
-}
-
-interface ConnectorAgentAccessRowsParams {
-  readonly connectorType: ConnectorType;
 }
 
 interface SetConnectorAgentAuthorizationParams {
@@ -116,93 +113,78 @@ export const connectorAgentAuthorizations$ = computed(
   },
 );
 
-function createConnectorAuthorizedAgentsFactory(): (
-  params: ConnectorAgentAccessRowsParams,
-) => Computed<Promise<readonly TeamComposeItem[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly TeamComposeItem[]>>
-  >();
-  return (params) => {
-    const existing = cache.get(params.connectorType);
-    if (existing) {
-      return existing;
+export const connectorAuthorizedAgentsByType$ = computed(
+  async (
+    get,
+  ): Promise<ReadonlyMap<ConnectorType, readonly TeamComposeItem[]>> => {
+    const authorizations = await get(connectorAgentAuthorizations$);
+    const agentsByType = new Map<ConnectorType, TeamComposeItem[]>();
+    for (const row of authorizations) {
+      for (const connectorType of row.enabledTypes) {
+        const agents = agentsByType.get(connectorType) ?? [];
+        agents.push(row.agent);
+        agentsByType.set(connectorType, agents);
+      }
     }
-    const atom$ = computed(async (get): Promise<readonly TeamComposeItem[]> => {
-      const authorizations = await get(connectorAgentAuthorizations$);
-      return authorizations
-        .filter((row) => {
-          return row.enabledTypes.includes(params.connectorType);
-        })
-        .map((row) => {
-          return row.agent;
-        });
-    });
-    cache.set(params.connectorType, atom$);
-    return atom$;
-  };
-}
+    return agentsByType;
+  },
+);
 
-function createConnectorAgentAccessRowsFactory(): (
-  params: ConnectorAgentAccessRowsParams,
-) => Computed<Promise<readonly ConnectorAgentAccessRow[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly ConnectorAgentAccessRow[]>>
-  >();
-  return (params) => {
-    const existing = cache.get(params.connectorType);
-    if (existing) {
-      return existing;
+export const managedConnectorAgentAccessRows$ = computed(
+  async (get): Promise<readonly ConnectorAgentAccessRow[]> => {
+    const connectorType = get(managedConnectorAccessType$);
+    if (!connectorType) {
+      return [];
     }
-    const atom$ = computed(
-      async (get): Promise<readonly ConnectorAgentAccessRow[]> => {
-        const authorizations = await get(connectorAgentAuthorizations$);
-        const rows = await Promise.all(
-          authorizations.map(
-            async ({
-              agent,
-              enabledTypes,
-            }): Promise<ConnectorAgentAccessRow | null> => {
-              const authorized = enabledTypes.includes(params.connectorType);
-              let grants: readonly UserPermissionGrantResponse[] = [];
-              if (authorized) {
-                const grantsResult = await settle(
-                  get(userPermissionGrantsByAgent({ agentId: agent.id })),
-                );
-                if (!grantsResult.ok) {
-                  if (
-                    grantsResult.error instanceof ApiError &&
-                    grantsResult.error.status === 404
-                  ) {
-                    return null;
-                  }
-                  throw grantsResult.error;
-                }
-                grants = grantsResult.value;
+    const authorizations = await get(connectorAgentAuthorizations$);
+    const rows = await Promise.all(
+      authorizations.map(
+        async ({
+          agent,
+          enabledTypes,
+        }): Promise<ConnectorAgentAccessRow | null> => {
+          const authorized = enabledTypes.includes(connectorType);
+          let grants: readonly UserPermissionGrantResponse[] = [];
+          if (authorized) {
+            const grantsResult = await settle(
+              get(userPermissionGrantsByAgent({ agentId: agent.id })),
+            );
+            if (!grantsResult.ok) {
+              if (
+                grantsResult.error instanceof ApiError &&
+                grantsResult.error.status === 404
+              ) {
+                return null;
               }
-              return {
-                agent,
-                authorized,
-                grants,
-              };
-            },
-          ),
-        );
-        return rows.filter((row): row is ConnectorAgentAccessRow => {
-          return row !== null;
-        });
-      },
+              throw grantsResult.error;
+            }
+            grants = grantsResult.value;
+          }
+          return {
+            agent,
+            authorized,
+            grants,
+          };
+        },
+      ),
     );
-    cache.set(params.connectorType, atom$);
-    return atom$;
-  };
-}
+    return rows.filter((row): row is ConnectorAgentAccessRow => {
+      return row !== null;
+    });
+  },
+);
 
-export const connectorAuthorizedAgents =
-  createConnectorAuthorizedAgentsFactory();
-
-export const connectorAgentAccessRows = createConnectorAgentAccessRowsFactory();
+export const managedConnectorFirewallPermissionMetadata$ = computed(
+  async (get) => {
+    const connectorType = get(managedConnectorAccessType$);
+    if (!connectorType) {
+      return null;
+    }
+    return await get(
+      firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
+    );
+  },
+);
 
 export const setConnectorAgentAuthorization$ = command(
   async (

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 
 // ---------------------------------------------------------------------------
 // JobPermissionsTab UI state
@@ -14,6 +15,16 @@ export const setPermConnectorType$ = command(
     set(internalConnectorType$, type);
   },
 );
+
+export const agentPermissionMetadata$ = computed(async (get) => {
+  const connectorType = get(permConnectorType$);
+  if (!connectorType) {
+    return null;
+  }
+  return await get(
+    firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
+  );
+});
 
 const internalPermSearch$ = state("");
 export const permSearch$ = computed((get) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
@@ -12,7 +12,7 @@ import {
 import { zeroActivityDetail$ } from "../../signals/activity-page/activity-signals.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { workflowDetail } from "../workflows-page/workflows-signals.ts";
+import { currentWorkflowDetail$ } from "../workflows-page/workflows-signals.ts";
 
 interface MobileBreadcrumb {
   section: string;
@@ -85,7 +85,7 @@ const workflowsBreadcrumb$ = computed(
     const params = get(pathParams$) as Params;
     const workflowId = getStringParam(params, "workflowId");
     if (workflowId) {
-      const detail = await get(workflowDetail(workflowId));
+      const detail = await get(currentWorkflowDetail$);
       if (detail) {
         return {
           section,

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -15,7 +15,6 @@ import type {
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
-import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
 import {
   findPermissionInMetadata,
   permissionAllowAction$,
@@ -26,6 +25,7 @@ import {
   permissionAllowPermission$,
   permissionAllowRef$,
   permissionAllowUserPermissionGrants$,
+  permissionAllowFirewallPermissionMetadata$,
   resolveUserPermissionGrantPolicy,
   type Permission,
   applyUserPermissionGrant$,
@@ -444,7 +444,7 @@ function PermissionAllowDoctorPage({
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
   const metadataLoadable = useLoadable(
-    firewallPermissionMetadataByConnector({ connectorRef: ref }),
+    permissionAllowFirewallPermissionMetadata$,
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
   const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -90,7 +90,7 @@ import { noConnectorImg } from "../zero-page/platform-assets.ts";
 import { JobCustomConnectorsSection } from "./job-custom-connectors-section.tsx";
 import {
   applyUserPermissionGrants$,
-  userPermissionGrantsByAgent,
+  currentAgentUserPermissionGrants$,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import {
   allConnectorTypes$,
@@ -100,13 +100,14 @@ import {
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import {
-  agentVisibleWorkflows$,
+  currentAgentVisibleWorkflows$,
   allWorkflowAutomationEntries$,
   copyWorkflow$,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   permConnectorType$,
+  agentPermissionMetadata$,
   setPermConnectorType$,
   permSearch$,
   setPermSearch$,
@@ -658,6 +659,7 @@ export function AgentPermissionsDrawer({
       targetKind={targetKind}
       connectorType={connectorType}
       connectorLabel={connectorLabel}
+      metadata$={agentPermissionMetadata$}
       displayName={displayName}
       initialPolicies={initialPolicies}
       initialGrants={initialGrants}
@@ -694,11 +696,7 @@ function JobPermissionsTab({
   const deauthorizeFn = useSet(deauthorizeAgentConnector$);
   const saveConnectors = useSet(saveAgentConnectors$);
   const pageSignal = useGet(pageSignal$);
-  const userGrantsLoadable = useLoadable(
-    userPermissionGrantsByAgent({
-      agentId,
-    }),
-  );
+  const userGrantsLoadable = useLoadable(currentAgentUserPermissionGrants$);
   const userGrants =
     userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
   useUserPermissionGrantExpiryTick(userGrants);
@@ -867,8 +865,8 @@ function JobInstructionsTab() {
   );
 }
 
-function AgentWorkflowsTab({ agentId }: { readonly agentId: string }) {
-  const workflowsLoadable = useLastLoadable(agentVisibleWorkflows$(agentId));
+function AgentWorkflowsTab() {
+  const workflowsLoadable = useLastLoadable(currentAgentVisibleWorkflows$);
   const automationEntriesLoadable = useLastLoadable(
     allWorkflowAutomationEntries$,
   );
@@ -1016,7 +1014,7 @@ function AgentProfileSettings({
   onDelete: () => Promise<void>;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const workflowsLoadable = useLastLoadable(agentVisibleWorkflows$(agentId));
+  const workflowsLoadable = useLastLoadable(currentAgentVisibleWorkflows$);
   const agentsLoadable = useLoadable(agents$);
   const [, copyWorkflow] = useLoadableSet(copyWorkflow$);
 
@@ -1103,7 +1101,7 @@ function AgentTabContent({
       return <JobPermissionsTab agentId={agentId} displayName={displayName} />;
     }
     case "workflows": {
-      return <AgentWorkflowsTab agentId={agentId} />;
+      return <AgentWorkflowsTab />;
     }
     case "profile": {
       return (

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -151,7 +151,7 @@ import {
   workflowAutomationPickerCategory$,
   workflowAutomationPickerOpen$,
   workflowFileDraft$,
-  workflowDetail,
+  currentWorkflowDetail$,
   type WorkflowCopyFormState,
   type WorkflowCronFields,
   type WorkflowCronFrequency,
@@ -353,15 +353,11 @@ export function WorkflowDetailPage() {
     return null;
   }
 
-  return <WorkflowDetailContent workflowId={workflowId} />;
+  return <WorkflowDetailContent />;
 }
 
-function WorkflowDetailContent({
-  workflowId,
-}: {
-  readonly workflowId: string;
-}) {
-  const detail$ = workflowDetail(workflowId);
+function WorkflowDetailContent() {
+  const detail$ = currentWorkflowDetail$;
   const detailLoadable = useLoadable(detail$);
   const lastResolvedDetail = useLastResolved(detail$);
   const detail =

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -22,11 +22,11 @@ import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/co
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { firewallPermissionMetadataByConnector } from "../../../../signals/firewall-permission-metadata.ts";
 import { applyUserPermissionGrants$ } from "../../../../signals/permission-allow/permission-allow-signals.ts";
 import { activeUserPermissionGrantSnapshot } from "../../../../signals/user-permission-grants.ts";
 import {
-  connectorAgentAccessRows,
+  managedConnectorAgentAccessRows$,
+  managedConnectorFirewallPermissionMetadata$,
   connectorAccessManagementPermissionAgentId$,
   connectorAccessManagementSavingAgentId$,
   connectorAccessManagementSearch$,
@@ -340,6 +340,7 @@ function AgentPermissionDialog({
       agentId={row.agent.id}
       connectorType={connectorType}
       connectorLabel={connectorLabel}
+      metadata$={managedConnectorFirewallPermissionMetadata$}
       displayName={agentName(row.agent)}
       initialPolicies={initialPolicies}
       initialGrants={activeSnapshot.grants}
@@ -368,11 +369,9 @@ export function ConnectorAccessManagementDialog({
   connectorLabel,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
-  const rowsLoadable = useLastLoadable(
-    connectorAgentAccessRows({ connectorType }),
-  );
+  const rowsLoadable = useLastLoadable(managedConnectorAgentAccessRows$);
   const metadataLoadable = useLastLoadable(
-    firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
+    managedConnectorFirewallPermissionMetadata$,
   );
   const pageSignal = useGet(pageSignal$);
   const search = useGet(connectorAccessManagementSearch$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1,6 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import type { ReactNode } from "react";
+import type { Computed } from "ccstate";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -94,7 +95,6 @@ import {
 } from "./permission-policy-toggle.tsx";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { firewallPermissionMetadataByConnector } from "../../../../signals/firewall-permission-metadata.ts";
 
 interface ConnectorPermission {
   name: string;
@@ -106,6 +106,7 @@ interface PermissionsDrawerProps {
   targetKind?: "agent" | "workflow";
   connectorType: ConnectorType;
   connectorLabel: string;
+  metadata$: Computed<Promise<PublicConnectorCatalogPermissionDetail | null>>;
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
@@ -1544,11 +1545,7 @@ function PermissionsContent({
   readonly surface: PermissionsSurface;
   readonly onClose: () => void;
 }) {
-  const metadataLoadable = useLoadable(
-    firewallPermissionMetadataByConnector({
-      connectorRef: props.connectorType,
-    }),
-  );
+  const metadataLoadable = useLoadable(props.metadata$);
   const loadedMetadata =
     metadataLoadable.state === "hasData" ? metadataLoadable.data : null;
   const loadedInitialState = loadedMetadata

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -27,7 +27,7 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { refreshPresentationHtmlPreviews$ } from "../../signals/zero-page/presentation-html-cache-bust.ts";
-import { createPresentationDraftByUrlFactory } from "../../signals/zero-page/presentation-html-editor-draft.ts";
+import { createCurrentPresentationDraft } from "../../signals/zero-page/presentation-html-editor-draft.ts";
 import {
   createPresentationSlideListSignals,
   type PresentationSlideListSignals,
@@ -146,7 +146,7 @@ function createPresentationEditorSession(
   };
 }
 
-const presentationDraftByUrl = createPresentationDraftByUrlFactory<EditorDraft>(
+const currentPresentationDraft$ = createCurrentPresentationDraft<EditorDraft>(
   async (url, signal) => {
     const publicUrl = publicAttachmentUrl(url);
     const response = await fetch(readableAttachmentResourceUrl(publicUrl), {
@@ -1540,7 +1540,6 @@ async function ensurePresentationRedeployed(params: {
   readonly refreshPresentationHtmlPreviews: () => void;
   readonly setPublishing: (publishing: boolean) => void;
   readonly setStatus: (value: string) => void;
-  readonly sourceUrl: string;
 }): Promise<boolean> {
   const signature = params.currentSignature();
   if (signature === params.publishedSignatureRef.current) {
@@ -1555,8 +1554,6 @@ async function ensurePresentationRedeployed(params: {
       publicUrl: params.draft.publicUrl,
       signal: params.pageSignal,
     });
-    presentationDraftByUrl.invalidate(params.sourceUrl);
-    presentationDraftByUrl.invalidate(params.draft.publicUrl);
     params.refreshPresentationHtmlPreviews();
     params.publishedSignatureRef.current = signature;
     toast.success("Presentation updated");
@@ -1890,7 +1887,6 @@ function createPresentationEditorController(
       refreshPresentationHtmlPreviews: params.refreshPresentationHtmlPreviews,
       setPublishing,
       setStatus,
-      sourceUrl: params.sourceUrl,
     });
   };
   const fillEmptySpeakerNotes = () => {
@@ -1945,7 +1941,6 @@ function createPresentationEditorCloseActions(params: {
   readonly onClose: () => void;
   readonly publishingRef: MutableValue<boolean>;
   readonly setCloseDialogOpen: (open: boolean) => void;
-  readonly sourceUrl: string;
 }) {
   const requestClose = () => {
     if (!params.controller.hasUnsavedChanges()) {
@@ -1955,8 +1950,6 @@ function createPresentationEditorCloseActions(params: {
     params.setCloseDialogOpen(true);
   };
   const exitWithoutSaving = () => {
-    presentationDraftByUrl.invalidate(params.sourceUrl);
-    presentationDraftByUrl.invalidate(params.draft.publicUrl);
     params.setCloseDialogOpen(false);
     params.onClose();
   };
@@ -2080,7 +2073,6 @@ function PresentationEditorReady({
     onClose,
     publishingRef,
     setCloseDialogOpen,
-    sourceUrl,
   });
 
   return (
@@ -2151,7 +2143,7 @@ export function PresentationHtmlEditor({
 }: PresentationHtmlEditorProps) {
   const filename = attachmentFilenameFromUrl(url);
   const title = fallbackHtmlPreviewTitle(filename, url);
-  const loadable = useLoadable(presentationDraftByUrl.get(url));
+  const loadable = useLoadable(currentPresentationDraft$);
   const features = useGet(featureSwitch$);
   const movementFeatureEnabled = Boolean(
     features?.[FeatureSwitchKey.PresentationElementDragging],

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -134,10 +134,7 @@ function MobileAutomationButtonLeaf() {
   }
 
   return (
-    <AutomationMenuButton
-      threadId={thread.threadId}
-      ariaLabel="Open mobile automations"
-    />
+    <AutomationMenuButton thread={thread} ariaLabel="Open mobile automations" />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -128,8 +128,6 @@ import { MailDraftCard } from "./mail-draft-card.tsx";
 import {
   classifyChatAttachment,
   contentTypeForBodyPreviewKind,
-  enrichBlocksWithTextPreviews,
-  parseBodyRenderBlocks,
   type BodyRenderBlock,
 } from "../../signals/chat-page/parse-body-blocks.ts";
 import {
@@ -150,7 +148,10 @@ import {
   type RunGroupFold,
   type RunGroupFolding,
 } from "../../signals/chat-page/run-group-folding.ts";
-import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
+import type {
+  PermissionActionBlock,
+  PermissionActionResource,
+} from "../../signals/chat-page/permission-action-block.ts";
 import type { ComputerUseAuthorizationBlock } from "../../signals/chat-page/computer-use-authorization-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
@@ -196,14 +197,9 @@ import {
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import {
-  headerWorkflowAutomationsForThread,
-  runHeaderWorkflowAutomationNow$,
-  reloadHeaderAutomationMenu$,
-  updateHeaderWorkflowGmailLabelAppliedAutomation$,
-  updateHeaderWorkflowGmailNewMessageAutomation$,
-  updateHeaderWorkflowScheduleAutomation$,
-  type HeaderWorkflowAutomationEntry,
+import type {
+  HeaderAutomationSignals,
+  HeaderWorkflowAutomationEntry,
 } from "../../signals/chat-page/header-automation-menu.ts";
 import { pauseChatThreadGoal$ } from "../../signals/chat-page/chat-goal.ts";
 import {
@@ -213,12 +209,6 @@ import {
   openHeaderAutomationSidebar$,
   setEditingHeaderWorkflowAutomationId$,
 } from "../../signals/chat-page/header-automation-sidebar.ts";
-import {
-  clearWorkflowQueue$,
-  setWorkflowQueuePaused$,
-  skipWorkflowQueueEvent$,
-  workflowQueueForThread,
-} from "../../signals/chat-page/workflow-queue.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import {
   closeChatThreadEmojiMenu$,
@@ -294,14 +284,11 @@ import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { setBillingSubPage$ } from "../../signals/zero-page/settings/workspace-settings-state.ts";
 import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
-import { agentById } from "../../signals/agent.ts";
 import {
   applyUserPermissionGrant$,
   findPermissionInMetadata,
   resolveUserPermissionGrantPolicy,
-  userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
-import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
 import {
   billingStatusAsync$,
   type CreditCheckoutSelection,
@@ -369,25 +356,25 @@ function ArtifactsButtonInner({ thread }: { thread: ChatThreadSignals }) {
 // Loads automations and only renders once this thread has at least one linked
 // automation.
 export function AutomationMenuButton({
-  threadId,
+  thread,
   ariaLabel = "Automations",
 }: {
-  threadId: string;
+  thread: ChatThreadSignals;
   ariaLabel?: string;
 }) {
-  const reloadAutomations = useSet(reloadHeaderAutomationMenu$);
+  const reloadAutomations = useSet(thread.headerAutomations.reload$);
   const openAutomationSidebar = useSet(openHeaderAutomationSidebar$);
   const openThreadId = useGet(currentHeaderAutomationThreadId$);
-  const workflowAutomations$ = headerWorkflowAutomationsForThread(threadId);
+  const workflowAutomations$ = thread.headerAutomations.automations$;
   const workflowAutomationsLoadable = useLastLoadable(workflowAutomations$);
   const lastResolvedAutomations = useLastResolved(workflowAutomations$);
   const workflowAutomations =
     workflowAutomationsLoadable.state === "hasData"
       ? workflowAutomationsLoadable.data
       : (lastResolvedAutomations ?? []);
-  const queue = useLastResolved(workflowQueueForThread(threadId));
+  const queue = useLastResolved(thread.workflowQueue.queue$);
   const pendingCount = queue?.pending.length ?? 0;
-  const open = openThreadId === threadId;
+  const open = openThreadId === thread.threadId;
 
   // Show the opener when the thread has a workflow automation.
   // Goals live in the composer, so a goal-only thread has nothing here.
@@ -411,7 +398,7 @@ export function AutomationMenuButton({
             aria-pressed={open}
             onClick={() => {
               reloadAutomations();
-              openAutomationSidebar(threadId);
+              openAutomationSidebar(thread.threadId);
             }}
           >
             <IconClock size={18} />
@@ -476,7 +463,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
-        <AutomationMenuButton threadId={thread.threadId} />
+        <AutomationMenuButton thread={thread} />
         <ArtifactsButton thread={thread} />
       </div>
     </header>
@@ -1804,15 +1791,15 @@ function headerWorkflowAutomationRows(
 
 function HeaderWorkflowAutomationCard({
   automation,
+  headerAutomations,
 }: {
   automation: HeaderWorkflowAutomationEntry;
+  headerAutomations: HeaderAutomationSignals;
 }) {
   const pageSignal = useGet(pageSignal$);
   const editingAutomationId = useGet(currentEditingHeaderWorkflowAutomationId$);
   const setEditingAutomationId = useSet(setEditingHeaderWorkflowAutomationId$);
-  const [runningLoadable, runNow] = useLoadableSet(
-    runHeaderWorkflowAutomationNow$,
-  );
+  const [runningLoadable, runNow] = useLoadableSet(headerAutomations.runNow$);
   const running = runningLoadable.state === "loading";
   const title =
     automation.workflowDisplayName?.trim() || automation.workflowName;
@@ -1883,6 +1870,7 @@ function HeaderWorkflowAutomationCard({
       />
       <HeaderWorkflowAutomationEditDialog
         automation={automation.automation}
+        headerAutomations={headerAutomations}
         displayTimezone={automation.timezone}
         open={editing}
         onOpenChange={(open) => {
@@ -1895,11 +1883,13 @@ function HeaderWorkflowAutomationCard({
 
 function HeaderWorkflowAutomationEditDialog({
   automation,
+  headerAutomations,
   displayTimezone,
   open,
   onOpenChange,
 }: {
   readonly automation: ChatThreadWorkflowAutomation;
+  readonly headerAutomations: HeaderAutomationSignals;
   readonly displayTimezone: string;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
@@ -1923,6 +1913,7 @@ function HeaderWorkflowAutomationEditDialog({
         {automation.kind === "schedule" ? (
           <HeaderScheduleAutomationEditForm
             automation={automation}
+            headerAutomations={headerAutomations}
             displayTimezone={displayTimezone}
             onDone={() => {
               onOpenChange(false);
@@ -1933,6 +1924,7 @@ function HeaderWorkflowAutomationEditDialog({
         automation.eventType === "gmail-new-message" ? (
           <HeaderGmailNewMessageAutomationEditForm
             automation={automation}
+            headerAutomations={headerAutomations}
             onDone={() => {
               onOpenChange(false);
             }}
@@ -1942,6 +1934,7 @@ function HeaderWorkflowAutomationEditDialog({
         automation.eventType === "gmail-label-applied" ? (
           <HeaderGmailLabelAutomationEditForm
             automation={automation}
+            headerAutomations={headerAutomations}
             onDone={() => {
               onOpenChange(false);
             }}
@@ -2005,6 +1998,7 @@ function scheduleFromHeaderAutomationForm(
 
 function HeaderScheduleAutomationEditForm({
   automation,
+  headerAutomations,
   displayTimezone,
   onDone,
 }: {
@@ -2012,12 +2006,13 @@ function HeaderScheduleAutomationEditForm({
     ChatThreadWorkflowAutomation,
     { kind: "schedule" }
   >;
+  readonly headerAutomations: HeaderAutomationSignals;
   readonly displayTimezone: string;
   readonly onDone: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
   const [updateLoadable, updateAutomation] = useLoadableSet(
-    updateHeaderWorkflowScheduleAutomation$,
+    headerAutomations.updateSchedule$,
   );
   const saving = updateLoadable.state === "loading";
   const schedule = automation.schedule;
@@ -2134,17 +2129,19 @@ function HeaderIntervalField({
 
 function HeaderGmailNewMessageAutomationEditForm({
   automation,
+  headerAutomations,
   onDone,
 }: {
   readonly automation: Extract<
     ChatThreadWorkflowAutomation,
     { eventType: "gmail-new-message" }
   >;
+  readonly headerAutomations: HeaderAutomationSignals;
   readonly onDone: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
   const [updateLoadable, updateAutomation] = useLoadableSet(
-    updateHeaderWorkflowGmailNewMessageAutomation$,
+    headerAutomations.updateGmailNewMessage$,
   );
   const saving = updateLoadable.state === "loading";
 
@@ -2225,17 +2222,19 @@ function HeaderGmailNewMessageAutomationEditForm({
 
 function HeaderGmailLabelAutomationEditForm({
   automation,
+  headerAutomations,
   onDone,
 }: {
   readonly automation: Extract<
     ChatThreadWorkflowAutomation,
     { eventType: "gmail-label-applied" }
   >;
+  readonly headerAutomations: HeaderAutomationSignals;
   readonly onDone: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
   const [updateLoadable, updateAutomation] = useLoadableSet(
-    updateHeaderWorkflowGmailLabelAppliedAutomation$,
+    headerAutomations.updateGmailLabelApplied$,
   );
   const saving = updateLoadable.state === "loading";
 
@@ -2292,12 +2291,12 @@ function HeaderGmailLabelAutomationEditForm({
     </form>
   );
 }
-function HeaderWorkflowQueueSection({ threadId }: { threadId: string }) {
-  const queue = useLastResolved(workflowQueueForThread(threadId));
+function HeaderWorkflowQueueSection({ thread }: { thread: ChatThreadSignals }) {
+  const queue = useLastResolved(thread.workflowQueue.queue$);
   const pageSignal = useGet(pageSignal$);
-  const skipEvent = useSet(skipWorkflowQueueEvent$);
-  const clearQueue = useSet(clearWorkflowQueue$);
-  const setPaused = useSet(setWorkflowQueuePaused$);
+  const skipEvent = useSet(thread.workflowQueue.skipEvent$);
+  const clearQueue = useSet(thread.workflowQueue.clear$);
+  const setPaused = useSet(thread.workflowQueue.setPaused$);
 
   if (!queue) {
     return null;
@@ -2327,10 +2326,7 @@ function HeaderWorkflowQueueSection({ threadId }: { threadId: string }) {
           className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           aria-label={paused ? "Resume queue" : "Pause queue"}
           onClick={() => {
-            detach(
-              setPaused({ threadId, paused: !paused }, pageSignal),
-              Reason.DomCallback,
-            );
+            detach(setPaused(!paused, pageSignal), Reason.DomCallback);
           }}
         >
           {paused ? (
@@ -2345,7 +2341,7 @@ function HeaderWorkflowQueueSection({ threadId }: { threadId: string }) {
             type="button"
             className="inline-flex h-6 items-center rounded-md px-1.5 text-xs text-muted-foreground hover:bg-muted/60 hover:text-destructive"
             onClick={() => {
-              detach(clearQueue(threadId, pageSignal), Reason.DomCallback);
+              detach(clearQueue(pageSignal), Reason.DomCallback);
             }}
           >
             Clear queue ({queue.pending.length})
@@ -2412,8 +2408,8 @@ function HeaderWorkflowQueueSection({ threadId }: { threadId: string }) {
   );
 }
 
-function HeaderAutomationSidebar({ threadId }: { threadId: string }) {
-  const workflowAutomations$ = headerWorkflowAutomationsForThread(threadId);
+function HeaderAutomationSidebar({ thread }: { thread: ChatThreadSignals }) {
+  const workflowAutomations$ = thread.headerAutomations.automations$;
   const workflowAutomationsLoadable = useLastLoadable(workflowAutomations$);
   const lastResolvedAutomations = useLastResolved(workflowAutomations$);
   const close = useSet(closeHeaderAutomationSidebar$);
@@ -2458,7 +2454,7 @@ function HeaderAutomationSidebar({ threadId }: { threadId: string }) {
           </div>
         ) : (
           <div className="grid gap-6">
-            <HeaderWorkflowQueueSection threadId={threadId} />
+            <HeaderWorkflowQueueSection thread={thread} />
             {workflowAutomations.length > 0 ? (
               <div className="grid gap-3">
                 {workflowAutomations.map((automation) => {
@@ -2466,6 +2462,7 @@ function HeaderAutomationSidebar({ threadId }: { threadId: string }) {
                     <HeaderWorkflowAutomationCard
                       key={automation.id}
                       automation={automation}
+                      headerAutomations={thread.headerAutomations}
                     />
                   );
                 })}
@@ -2648,13 +2645,16 @@ export function ZeroChatThreadPage() {
   const artifactRef = useGet(currentArtifactRef$);
   const artifactInboxThreadId = useGet(currentArtifactInboxThreadId$);
   const automationPanelThreadId = useGet(currentHeaderAutomationThreadId$);
+  const automationPanelThread = [leftThread, rightThread].find((thread) => {
+    return thread?.threadId === automationPanelThreadId;
+  });
   const presentationEditorUrl = useGet(currentPresentationEditorUrl$);
   const closePresentationEditor = useSet(closePresentationEditor$);
   const artifactFullscreen = useGet(artifactFullscreen$);
   const activePresentationEditorUrl = presentationEditorUrl;
   const artifactPanelOpen =
     artifactRef !== null || artifactInboxThreadId !== null;
-  const automationPanelOpen = automationPanelThreadId !== null;
+  const automationPanelOpen = automationPanelThread !== undefined;
   const rightPanelOpen = artifactPanelOpen || automationPanelOpen;
   const { style: artifactPanelStyle, transition: artifactTransition } =
     artifactPanelLayout(
@@ -2717,8 +2717,8 @@ export function ZeroChatThreadPage() {
           )}
           aria-hidden={!rightPanelOpen}
         >
-          {automationPanelOpen && automationPanelThreadId ? (
-            <HeaderAutomationSidebar threadId={automationPanelThreadId} />
+          {automationPanelThread ? (
+            <HeaderAutomationSidebar thread={automationPanelThread} />
           ) : artifactPanelOpen ? (
             <ChatArtifactInboxSlot
               artifactRef={artifactRef}
@@ -5418,11 +5418,13 @@ function PermissionActionCardContent({
 
 function PermissionActionCardForTarget({
   block,
+  resource,
   hasTarget,
   targetLoadableState,
   userGrantsLoadable,
 }: {
   block: PermissionActionBlock;
+  resource: PermissionActionResource;
   hasTarget: boolean;
   targetLoadableState: string;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
@@ -5436,11 +5438,7 @@ function PermissionActionCardForTarget({
     expiresInByScope[durationScope] ??
     block.expiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
-  const permissionMetadataLoadable = useLoadable(
-    firewallPermissionMetadataByConnector({
-      connectorRef: block.connectorRef,
-    }),
-  );
+  const permissionMetadataLoadable = useLoadable(resource.metadata$);
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
   const savedGrant =
     grantLoadable.state === "hasData" ? grantLoadable.data : null;
@@ -5503,21 +5501,20 @@ function PermissionActionCardForTarget({
   );
 }
 
-function AgentPermissionActionCard({
+function AgentPermissionActionCardWithResource({
   block,
+  resource,
 }: {
   block: PermissionActionBlock;
+  resource: PermissionActionResource;
 }) {
-  const agentLoadable = useLastLoadable(agentById(block.agentId));
-  const userGrantsLoadable = useLoadable(
-    userPermissionGrantsByAgent({
-      agentId: block.agentId,
-    }),
-  );
+  const agentLoadable = useLastLoadable(resource.agent$);
+  const userGrantsLoadable = useLoadable(resource.grants$);
   const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
   return (
     <PermissionActionCardForTarget
       block={block}
+      resource={resource}
       hasTarget={Boolean(agent)}
       targetLoadableState={agentLoadable.state}
       userGrantsLoadable={userGrantsLoadable}
@@ -5526,7 +5523,15 @@ function AgentPermissionActionCard({
 }
 
 function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
-  return <AgentPermissionActionCard block={block} />;
+  if (!block.resource) {
+    return null;
+  }
+  return (
+    <AgentPermissionActionCardWithResource
+      block={block}
+      resource={block.resource}
+    />
+  );
 }
 
 function ChatConnectorActionConnectModal() {
@@ -6448,18 +6453,13 @@ function PagedUserMessage({
   // over from messages sent before #10243 split the flows. Use the structured
   // source when it's present and fall back to inline parsing otherwise.
   const { cleanContent, parsed } = parseInlineAttachments(content);
-  // `ATTACH_ONLY_PLACEHOLDER` is the server-side placeholder stored when the
-  // user sent only files with no typed text — strip it so the bubble shows
-  // just the attachments.
-  const strippedContent =
+  const copyText =
     message.attachFiles &&
     message.attachFiles.length > 0 &&
     cleanContent.trim() === ATTACH_ONLY_PLACEHOLDER
       ? ""
       : cleanContent;
-  const bodyBlocks = enrichBlocksWithTextPreviews(
-    parseBodyRenderBlocks(strippedContent, { previews: false }).blocks,
-  );
+  const bodyBlocks = message.blocks;
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openLightbox = (url: string) => {
@@ -6470,7 +6470,6 @@ function PagedUserMessage({
   const copyMessage = useSet(thread.copyMessage$);
   const allAttachments = resolveAttachments(message, parsed);
   const clipboardAttachments = clipboardAttachmentsFromMessage(message, parsed);
-  const copyText = strippedContent;
   const canCopy = copyText.trim().length > 0 || clipboardAttachments.length > 0;
 
   const handleCopy = () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -77,7 +77,7 @@ import { ConnectorPermissionDialog } from "./components/settings/connector-permi
 import { ConnectorAccessManagementDialog } from "./components/settings/connector-access-management-dialog.tsx";
 import {
   closeConnectorAccessManagement$,
-  connectorAuthorizedAgents,
+  connectorAuthorizedAgentsByType$,
   managedConnectorAccessType$,
   setManagedConnectorAccessType$,
 } from "../../signals/zero-page/settings/connector-access-management.ts";
@@ -555,11 +555,14 @@ function ConnectorAccessButton({
   readonly connectorLabel: string;
   readonly onClick: () => void;
 }) {
-  const agentsLoadable = useLastLoadable(
-    connectorAuthorizedAgents({ connectorType }),
+  const agentsByTypeLoadable = useLastLoadable(
+    connectorAuthorizedAgentsByType$,
   );
-  const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
-  const loading = agentsLoadable.state === "loading";
+  const agents =
+    agentsByTypeLoadable.state === "hasData"
+      ? (agentsByTypeLoadable.data.get(connectorType) ?? [])
+      : [];
+  const loading = agentsByTypeLoadable.state === "loading";
   const visibleNames = agents
     .slice(0, CONNECTOR_CARD_AGENT_NAME_LIMIT)
     .map((agent) => {


### PR DESCRIPTION
## Summary

- move workflow queue and header automation resources into each `ChatThreadSignals` owner, including their reload and mutation commands
- derive workflow detail, agent workflows and grants, connector access, permission metadata, and presentation drafts from the active route, dialog, or editor owner
- make reusable request factories uncached, including agent lookup and connector authorization factories, and create chat permission-action resources in the thread message projection instead of React render
- preserve reload-counter invalidation while allowing duplicate idempotent requests across independent owners

## User impact

Historical thread IDs, agent IDs, workflow IDs, connector refs, and presentation URLs no longer accumulate request `Computed` values and resolved payloads in module-level maps for the lifetime of the SPA. Existing UI behavior and mutation reload patterns remain unchanged.

The text-attachment preview cache and self-deleting permission-expiry timer cache are intentionally outside this PR because they have different ownership and lifecycle semantics.

## Verification

- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app lint`
- targeted Vitest coverage for workflow queue, chat permission actions, permission allow, team navigation, workflow detail, connectors, automation editing, presentation editor, and legacy attachment rendering
- 157 targeted tests passed; one connector scope-review test timed out only in the combined parallel run and passed on its isolated rerun
- after rebasing onto latest `main`, team navigation passed 22/22 and presentation editor passed 2/2
