### PR TITLE
docs: document react and ccstate cache lifecycle anti-patterns

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -54,6 +54,8 @@ review "authentication changes"     # Review by description
 4. **Review Each Commit Against Bad Smells**
    - Read the bad smell documentation from `docs/bad-smell.md`
    - For testing-related changes, read testing spec from `docs/testing.md`
+   - For React, ccstate, cache, Store, ref, or resource-lifecycle changes, read
+     `docs/cache.md`
    - For each commit, analyze code changes against all code quality issues
    - Create individual review file: `codereviews/YYYYMMDD/review-{short-hash}.md`
 
@@ -69,6 +71,15 @@ review "authentication changes"     # Review by description
    - Evaluate test quality and completeness
    - Check for fake timers, partial mocks, implementation detail testing
    - Verify mocks are reset through the package's standard centralized cleanup
+
+   **React, ccstate, Cache, and Resource Lifecycles** (refer to `docs/cache.md`)
+   - Keep React render pure and do not allocate signal identities during render
+   - Reject unbounded lifetime caches and state whose owner outlives its domain
+   - Avoid duplicate mutable sources of truth and parallel state machines
+   - Verify callback-ref stability and preserve `onRef` cleanup returns
+   - Require symmetric teardown for listeners, timers, observers, object URLs,
+     editors, subscriptions, and async work
+   - Inspect helper, chaining, and nested-callback shapes that can evade lint
 
    **Error Handling (Bad Smell #3)**
    - Identify unnecessary try/catch blocks
@@ -546,6 +557,8 @@ codereviews/
 ## References
 
 - Bad smell documentation: `docs/bad-smell.md` (non-testing patterns)
+- React and ccstate cache practices: `docs/cache.md` (state ownership, retention,
+  refs, and resource lifecycles)
 - Testing spec: `docs/testing.md` (comprehensive testing patterns and anti-patterns)
 - Project principles: `CLAUDE.md`
 - Conventional commits: https://www.conventionalcommits.org/

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,169 @@
+# React and ccstate Cache and Lifecycle Practices
+
+This document defines the React, ccstate, cache, and resource-lifecycle
+anti-patterns to check during implementation and code review. It complements
+the ccstate patterns in `.claude/skills/ccstate/SKILL.md` and the React
+measurement guidance in `docs/react-commit.md`.
+
+Do not classify a match from syntax alone. For each candidate, trace the
+component, signal definition, callers, owner, identity key, invalidation path,
+and teardown path before deciding that it is a defect.
+
+## RC-1: Render-Phase Side Effects
+
+React render must stay pure. A component must not execute commands, write to a
+Store, mutate `document`, `window`, or `globalThis`, schedule timers or
+microtasks, register events, or create external resources while rendering.
+
+These effects can run again when React restarts, replays, or abandons work. Put
+them behind an event, an effect with symmetric cleanup, or an owning signal
+lifecycle instead.
+
+## RC-2: Render-Time Signal Allocation
+
+Do not call a signal factory or create a new `state`, `computed`, or `command`
+from component render. Each render can then produce a new atom identity,
+recompute the graph, and replace subscriptions even when the domain identity
+did not change.
+
+Create scoped signal groups at the lifecycle boundary that owns them. A
+package-scope `computed` may select a factory result from a stable domain
+identity because ccstate memoizes the result until its dependencies change.
+
+## RC-3: Unbounded Lifetime Caches
+
+Do not retain domain-scoped values in a package- or process-lifetime keyed
+cache unless the domain is bounded and the cache has an explicit lifetime.
+Suspicious storage includes:
+
+- module-level `Map`, `Set`, or `WeakMap` instances;
+- function properties or factory closures that outlive the instance they
+  create;
+- `globalThis` registries;
+- caches of `Computed`, Promise, DOM, editor, subscription, or resource
+  objects;
+- keys such as thread, agent, workflow, route, URL, or user identity that can
+  grow throughout a session.
+
+A `WeakMap` is not automatically safe: it only weakens its key. Keys that stay
+reachable elsewhere still retain their entries, and cached values can retain
+the rest of the object graph. Trace every strong path instead of inferring a
+bound from the container type.
+
+ccstate `computed` already memoizes its last result while dependencies remain
+unchanged. Do not add a manual cache merely to duplicate that behavior.
+
+## RC-4: Owner and Lifetime Mismatch
+
+State belongs to the narrowest lifecycle that owns it. Thread, route, agent,
+dialog, connector, and editor-session state must not default to a root Store or
+module singleton when multiple identities can exist or when the data should be
+released before application shutdown.
+
+Check that every scoped state group has:
+
+- an explicit domain identity;
+- isolation from simultaneous instances;
+- an invalidation or replacement rule;
+- a release path tied to its real owner.
+
+## RC-5: Duplicate Mutable Sources of Truth
+
+Do not copy a complete server object into a second mutable Store and then keep
+both versions synchronized. Derived values should remain computed from the
+authoritative source; genuinely local edits should be modeled as an explicitly
+scoped draft.
+
+A draft must carry the identity it edits, such as agent, thread, connector, or
+editor session. React effects and ref callbacks must not become synchronization
+bridges between two mutable state systems.
+
+## RC-6: Parallel Editors, Drafts, or State Machines
+
+Do not maintain separate implementations of the same editor, draft, or state
+machine for one product behavior. Parallel paths drift in keyboard shortcuts,
+IME behavior, validation, submission, reset, and cleanup semantics even when
+their visible UI starts out equivalent.
+
+Shared behavior should have one lifecycle and one state transition model.
+Presentation differences may adapt that model without duplicating it.
+
+## RC-7: Unstable Callback Refs and Lost Cleanup
+
+An inline callback ref changes identity on every render, so React can detach
+and attach it repeatedly. It is a defect when those transitions write state,
+register listeners, start timers, attach observers or subscriptions, or
+navigate without a matching cleanup path.
+
+For ccstate DOM refs, use `onRef` and pass the stable `useSet(onRef(...))`
+result directly:
+
+```tsx
+const setElement = useSet(setElement$);
+return <div ref={setElement} />;
+```
+
+Do not wrap it in an inline arrow. The wrapper discards the React-compatible
+cleanup function returned by `onRef`.
+
+## RC-8: Asymmetric Resource Lifecycles
+
+Every acquired resource needs teardown owned by the same lifecycle. Verify the
+pairing for:
+
+- `addEventListener` / `removeEventListener`;
+- timer creation / clearing;
+- observer creation / `disconnect`;
+- object URL creation / `revokeObjectURL`;
+- editor or external object creation / `destroy`, `dispose`, or equivalent;
+- subscription creation / unsubscribe;
+- async work / abort and awaited completion.
+
+Long-running ccstate work must receive an `AbortSignal` whose owner will abort
+it. A reset signal used only for mutual exclusion is not enough for a polling
+loop that may never be started again. Do not use `detach()` to conceal a
+missing owner or abort path.
+
+## RC-9: Lint Coverage Gaps
+
+Lint passing is not proof that render and lifecycle behavior is correct. Review
+patterns that can hide an effect from a syntax-based rule, including:
+
+- chained calls such as `useSet(command$)(...)`;
+- render-time side effects hidden inside a helper;
+- nested callbacks that a rule incorrectly treats as outside render;
+- wrappers that discard the cleanup return from `onRef`;
+- accessor aliases or closures that let ccstate `get` or `set` escape a
+  command callback.
+
+Treat a gap as both a code finding and a potential lint-rule coverage finding.
+Do not weaken or suppress the rule.
+
+## Avoiding False Positives
+
+The following patterns are not defects by themselves:
+
+- a stable callback ref returned by `useSet`;
+- `onRef` paired with its provided `AbortSignal` and cleanup;
+- a signal factory owned by a clear domain lifecycle with teardown;
+- normal ccstate `computed` memoization;
+- a cache with a proven finite domain or hard capacity plus explicit
+  invalidation and release.
+
+When the owner, bound, or teardown cannot be proved, record the item as needing
+confirmation rather than asserting a leak.
+
+## Review Evidence
+
+Every confirmed finding should record:
+
+- file and line;
+- the shortest trigger path;
+- the state or resource's real owner;
+- the identity or key that controls retention;
+- the missing or incorrect invalidation and teardown path;
+- user or engineering impact;
+- confidence and any evidence still missing.
+
+Merge findings with the same root cause instead of reporting every call site
+separately.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,27 @@
+# Engineering Documentation Index
+
+Use this index to locate the repository's authoritative engineering guidance
+before implementation or review. Read the documents relevant to the changed
+surface; the index does not replace their detailed rules.
+
+## Code Review
+
+- [Bad code smells](./bad-smell.md): production-code quality rules.
+- [React and ccstate cache and lifecycle practices](./cache.md): render purity,
+  state ownership, cache retention, refs, and resource teardown.
+- [Testing](./testing.md): testing strategy, patterns, and anti-patterns.
+- [Deployment compatibility](./deployment-compatibility.md): compatibility
+  requirements for independently deployed components and persisted state.
+
+## Specialized Guidance
+
+- [React commit analysis](./react-commit.md): measuring and attributing React
+  work without confusing executions, scheduler events, or DOM mutations with
+  commits.
+- [CLI design](./cli-design-guideline.md): command behavior and interface
+  conventions.
+- [Resource model](./resource-model.md): resource relationships and ownership.
+- [Architecture](./architecture.md): system structure and boundaries.
+- [Development workflow](./dev-workflow.md): the repository development and
+  review flow.
+- [Testing catalog](./testing/anti-patterns.md): detailed testing anti-patterns.


### PR DESCRIPTION
## Summary

- add `docs/cache.md` with the React and ccstate render, identity, cache,
  ownership, draft, ref, resource-lifecycle, and lint-gap anti-patterns used by
  the daily scan
- add `docs/docs.md` as the engineering documentation index for implementation
  and review workflows
- make the repository code-quality review guidance require `docs/cache.md` for
  relevant changes

The new guidance also records false-positive controls and the evidence needed
before reporting a lifecycle or retention defect.

The external `daily-react-ccstate-antipattern-report` and `pr-review` workflows
have been updated separately to use `docs/docs.md`, with a fallback while the
new index is not yet present on `main`.

## Verification

- `npx --yes prettier@3.8.1 --check docs/cache.md docs/docs.md`
- `git diff --check`
- verified every relative link in `docs/docs.md` resolves in the repository
- tests not run (documentation-only change)
