### PR TITLE
fix(platform): release workspace logo previews with settings modal

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -86,6 +86,11 @@ interface ImageDimensionsMockValue {
 
 type ImageDimensionsMockResult = ImageDimensionsMockValue | null;
 
+interface ImageDimensionsMock {
+  readonly createdUrls: string[];
+  readonly revokedUrls: string[];
+}
+
 interface Bb0BluetoothRequestDeviceOptions {
   readonly acceptAllDevices?: boolean;
   readonly filters?: readonly {
@@ -290,8 +295,8 @@ export function createTestMocks(getSignal: () => AbortSignal) {
         results:
           | ImageDimensionsMockResult
           | readonly ImageDimensionsMockResult[],
-      ): void => {
-        mockImageDimensions(getSignal(), results);
+      ): ImageDimensionsMock => {
+        return mockImageDimensions(getSignal(), results);
       },
       webBluetoothSupport: (): void => {
         mockSupportedWebBluetooth(getSignal());
@@ -697,8 +702,10 @@ function mockVoiceInput(
 function mockImageDimensions(
   signal: AbortSignal,
   results: ImageDimensionsMockResult | readonly ImageDimensionsMockResult[],
-): void {
+): ImageDimensionsMock {
   const pendingResults = Array.isArray(results) ? [...results] : [results];
+  const createdUrls: string[] = [];
+  const revokedUrls: string[] = [];
   let objectUrlIndex = 0;
 
   class TestImage extends EventTarget {
@@ -725,13 +732,17 @@ function mockImageDimensions(
     "createObjectURL",
     (_object: Blob | MediaSource) => {
       objectUrlIndex += 1;
-      return `blob:mock-image-${objectUrlIndex}`;
+      const url = `blob:mock-image-${objectUrlIndex}`;
+      createdUrls.push(url);
+      return url;
     },
   );
   const revokeObjectUrlDescriptor = defineWindowProperty(
     URL,
     "revokeObjectURL",
-    (_url: string) => {},
+    (url: string) => {
+      revokedUrls.push(url);
+    },
   );
   const imageDescriptor = defineWindowProperty(
     window,
@@ -744,6 +755,8 @@ function mockImageDimensions(
     restoreWindowProperty(URL, "revokeObjectURL", revokeObjectUrlDescriptor);
     restoreWindowProperty(window, "Image", imageDescriptor);
   });
+
+  return { createdUrls, revokedUrls };
 }
 
 function mockSupportedWebBluetooth(signal: AbortSignal): void {

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -4,6 +4,7 @@ import {
   type AudioInputQuotaResponse,
 } from "@vm0/api-contracts/contracts/zero-voice-io-quota";
 import { fetch$ } from "../fetch.ts";
+import { pageSignal$ } from "../page-signal.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setBillingSubPage$ } from "../zero-page/settings/workspace-settings-state.ts";
 import { openSettingsDialogAt$ } from "../zero-page/settings/settings-dialog.ts";
@@ -445,13 +446,14 @@ const refreshAudioInputQuota$ = command(({ set }) => {
 });
 
 export const openAudioInputQuotaRecovery$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
+    signal.throwIfAborted();
     toast.error(AUDIO_INPUT_QUOTA_TOAST, {
       id: AUDIO_INPUT_QUOTA_TOAST_ID,
     });
     set(refreshAudioInputQuota$);
     set(setBillingSubPage$, true);
-    await set(openSettingsDialogAt$, "billing", signal);
+    await set(openSettingsDialogAt$, "billing", get(pageSignal$));
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -23,12 +23,20 @@ export const setupHomePage$ = command(
     const params = get(searchParams$);
     const prompt = params.get("prompt");
     const queue = params.get("queue");
+    const settings = params.get("settings");
+    const billingView = params.get("billingView");
     const forwardParams = new URLSearchParams();
     if (prompt) {
       forwardParams.set("prompt", prompt);
     }
     if (queue) {
       forwardParams.set("queue", queue);
+    }
+    if (settings) {
+      forwardParams.set("settings", settings);
+    }
+    if (billingView) {
+      forwardParams.set("billingView", billingView);
     }
     set(detachedNavigateTo$, "/agents/:agentId/chat", {
       pathParams: { agentId: homeAgentId },

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -1,6 +1,9 @@
 import { command } from "ccstate";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
-import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
+import {
+  checkUnifiedSettingsParam$,
+  handoffSettingsDialogSession$,
+} from "./settings/settings-dialog.ts";
 import { homeAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 
@@ -37,6 +40,9 @@ export const setupHomePage$ = command(
     }
     if (billingView) {
       forwardParams.set("billingView", billingView);
+    }
+    if (settings) {
+      set(handoffSettingsDialogSession$);
     }
     set(detachedNavigateTo$, "/agents/:agentId/chat", {
       pathParams: { agentId: homeAgentId },

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -5,7 +5,9 @@ import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
+import { resetSignal } from "../../utils.ts";
 import {
+  clearPendingLogo$,
   initProfileName$,
   setBillingScrollTarget$,
   setBillingSubPage$,
@@ -43,6 +45,8 @@ export function isAdminOnlySettingsSection(section: SettingsSection): boolean {
 }
 
 const internalSettingsDialogOpen$ = state(false);
+const internalSettingsDialogSignal$ = state<AbortSignal | null>(null);
+const resetSettingsDialogSignal$ = resetSignal();
 const internalExternalProfileModalOpen$ = state(false);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
@@ -52,6 +56,8 @@ const pendingAccountMenuSettingsSection$ = state<{
 export const settingsDialogOpen$ = computed((get) => {
   return get(internalSettingsDialogOpen$);
 });
+
+export { internalSettingsDialogSignal$ as settingsDialogSignal$ };
 
 export const externalProfileModalOpen$ = computed((get) => {
   return get(internalExternalProfileModalOpen$);
@@ -118,29 +124,53 @@ export const openSettingsBillingPlans$ = command(({ get, set }) => {
   set(updateSearchParams$, params);
 });
 
+const clearSettingsDialogSession$ = command(({ set }) => {
+  set(internalSettingsDialogSignal$, null);
+  set(internalSettingsDialogOpen$, false);
+  set(clearPendingLogo$);
+});
+
+export const closeSettingsModal$ = command(({ get, set }) => {
+  set(resetSettingsDialogSignal$);
+  set(clearSettingsDialogSession$);
+
+  const params = new URLSearchParams(get(searchParams$));
+  if (params.has("settings") || params.has("billingView")) {
+    params.delete("settings");
+    params.delete("billingView");
+    set(updateSearchParams$, params);
+  }
+});
+
 export const setSettingsDialogOpen$ = command(
-  async ({ get, set }, open: boolean, signal: AbortSignal) => {
-    set(internalSettingsDialogOpen$, open);
-    if (open) {
-      await set(initProfileName$, signal);
-      signal.throwIfAborted();
-      set(reloadBillingStatus$);
-      const params = new URLSearchParams(get(searchParams$));
-      const section = get(internalActiveSection$);
-      if (section === "model") {
-        set(reloadPersonalModelProviders$);
-      }
-      if (params.get("settings") !== section) {
-        params.set("settings", section);
-        set(updateSearchParams$, params);
-      }
-    } else {
-      const params = new URLSearchParams(get(searchParams$));
-      if (params.has("settings") || params.has("billingView")) {
-        params.delete("settings");
-        params.delete("billingView");
-        set(updateSearchParams$, params);
-      }
+  async ({ get, set }, open: boolean, pageSignal: AbortSignal) => {
+    if (!open) {
+      set(closeSettingsModal$);
+      return;
+    }
+
+    const modalSignal = set(resetSettingsDialogSignal$, pageSignal);
+    modalSignal.addEventListener(
+      "abort",
+      () => {
+        set(clearSettingsDialogSession$);
+      },
+      { once: true },
+    );
+    set(internalSettingsDialogSignal$, modalSignal);
+    set(internalSettingsDialogOpen$, true);
+    await set(initProfileName$, modalSignal);
+    pageSignal.throwIfAborted();
+    modalSignal.throwIfAborted();
+    set(reloadBillingStatus$);
+    const params = new URLSearchParams(get(searchParams$));
+    const section = get(internalActiveSection$);
+    if (section === "model") {
+      set(reloadPersonalModelProviders$);
+    }
+    if (params.get("settings") !== section) {
+      params.set("settings", section);
+      set(updateSearchParams$, params);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -47,6 +47,9 @@ export function isAdminOnlySettingsSection(section: SettingsSection): boolean {
 const internalSettingsDialogOpen$ = state(false);
 const internalSettingsDialogSignal$ = state<AbortSignal | null>(null);
 const resetSettingsDialogSignal$ = resetSignal();
+const internalSettingsDialogSessionActive$ = state(false);
+const internalSettingsDialogInitialized$ = state(false);
+const internalSettingsDialogHandoffPending$ = state(false);
 const internalExternalProfileModalOpen$ = state(false);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
@@ -124,10 +127,28 @@ export const openSettingsBillingPlans$ = command(({ get, set }) => {
   set(updateSearchParams$, params);
 });
 
-const clearSettingsDialogSession$ = command(({ set }) => {
+const releaseSettingsDialogSession$ = command(({ get, set }) => {
   set(internalSettingsDialogSignal$, null);
-  set(internalSettingsDialogOpen$, false);
+  set(internalSettingsDialogSessionActive$, false);
   set(clearPendingLogo$);
+
+  const handoffPending = get(internalSettingsDialogHandoffPending$);
+  set(internalSettingsDialogHandoffPending$, false);
+  if (!handoffPending) {
+    set(internalSettingsDialogOpen$, false);
+    set(internalSettingsDialogInitialized$, false);
+  }
+});
+
+const clearSettingsDialogSession$ = command(({ set }) => {
+  set(releaseSettingsDialogSession$);
+  set(internalSettingsDialogOpen$, false);
+  set(internalSettingsDialogInitialized$, false);
+  set(internalSettingsDialogHandoffPending$, false);
+});
+
+export const handoffSettingsDialogSession$ = command(({ set }) => {
+  set(internalSettingsDialogHandoffPending$, true);
 });
 
 export const closeSettingsModal$ = command(({ get, set }) => {
@@ -149,20 +170,30 @@ export const setSettingsDialogOpen$ = command(
       return;
     }
 
+    if (get(internalSettingsDialogSessionActive$)) {
+      set(setSettingsActiveSection$, get(internalActiveSection$));
+      return;
+    }
+
+    const dialogInitialized = get(internalSettingsDialogInitialized$);
     const modalSignal = set(resetSettingsDialogSignal$, pageSignal);
     modalSignal.addEventListener(
       "abort",
       () => {
-        set(clearSettingsDialogSession$);
+        set(releaseSettingsDialogSession$);
       },
       { once: true },
     );
     set(internalSettingsDialogSignal$, modalSignal);
+    set(internalSettingsDialogSessionActive$, true);
     set(internalSettingsDialogOpen$, true);
-    await set(initProfileName$, modalSignal);
-    pageSignal.throwIfAborted();
-    modalSignal.throwIfAborted();
-    set(reloadBillingStatus$);
+    if (!dialogInitialized) {
+      await set(initProfileName$, modalSignal);
+      pageSignal.throwIfAborted();
+      modalSignal.throwIfAborted();
+      set(reloadBillingStatus$);
+      set(internalSettingsDialogInitialized$, true);
+    }
     const params = new URLSearchParams(get(searchParams$));
     const section = get(internalActiveSection$);
     if (section === "model") {

--- a/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
@@ -67,21 +67,32 @@ export const pendingLogoFile$ = computed((get) => {
   return get(internalPendingLogoFile$);
 });
 
-export const setPendingLogoFile$ = command(({ set }, value: File | null) => {
-  set(internalPendingLogoFile$, value);
-});
-
 const internalPendingLogoPreview$ = state<string | null>(null);
 
 export const pendingLogoPreview$ = computed((get) => {
   return get(internalPendingLogoPreview$);
 });
 
-export const setPendingLogoPreview$ = command(
-  ({ set }, value: string | null) => {
-    set(internalPendingLogoPreview$, value);
+export const setPendingLogo$ = command(
+  ({ set }, file: File, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    const preview = URL.createObjectURL(file);
+    signal.addEventListener(
+      "abort",
+      () => {
+        URL.revokeObjectURL(preview);
+      },
+      { once: true },
+    );
+    set(internalPendingLogoFile$, file);
+    set(internalPendingLogoPreview$, preview);
   },
 );
+
+export const clearPendingLogo$ = command(({ set }) => {
+  set(internalPendingLogoFile$, null);
+  set(internalPendingLogoPreview$, null);
+});
 
 const internalFileInputEl$ = state<HTMLInputElement | null>(null);
 
@@ -109,17 +120,13 @@ export const setLogoLoaded$ = command(({ set }, value: boolean) => {
 });
 
 export const initProfileName$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const org = await get(org$);
-    const preview = get(internalPendingLogoPreview$);
-    if (preview) {
-      URL.revokeObjectURL(preview);
-    }
+    signal.throwIfAborted();
     set(internalProfileName$, org?.name ?? "");
     set(internalProfileSlug$, org?.slug ?? "");
     set(internalProfileLogoUrl$, null);
-    set(internalPendingLogoFile$, null);
-    set(internalPendingLogoPreview$, null);
+    set(clearPendingLogo$);
     set(internalLogoLoaded$, false);
   },
 );
@@ -376,12 +383,7 @@ export const saveOrgProfile$ = command(
     }
 
     signal.throwIfAborted();
-    const preview = get(internalPendingLogoPreview$);
-    if (preview) {
-      URL.revokeObjectURL(preview);
-    }
-    set(internalPendingLogoFile$, null);
-    set(internalPendingLogoPreview$, null);
+    set(clearPendingLogo$);
     set(refreshOrg$);
     const clerk = await get(clerk$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -177,6 +177,54 @@ describe("organization general settings", () => {
     });
   });
 
+  it("releases workspace logo previews when settings close", async () => {
+    const user = userEvent.setup({ delay: null });
+    const imageDimensions = context.mocks.browser.imageDimensions([
+      { width: 512, height: 512 },
+      { width: 512, height: 512 },
+    ]);
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Acme",
+      slug: "acme",
+      role: "admin",
+    });
+
+    await openGeneralTab();
+
+    const uploadInput = screen.getByLabelText("Upload logo");
+    await user.upload(
+      uploadInput,
+      new File(["first"], "first-logo.png", { type: "image/png" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+        "src",
+        "blob:mock-image-2",
+      );
+    });
+
+    await user.upload(
+      uploadInput,
+      new File(["second"], "second-logo.png", { type: "image/png" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "acme" })).toHaveAttribute(
+        "src",
+        "blob:mock-image-4",
+      );
+    });
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect([...imageDimensions.revokedUrls].sort()).toStrictEqual(
+        [...imageDimensions.createdUrls].sort(),
+      );
+    });
+  });
+
   it("rejects workspace logos outside the supported dimensions", async () => {
     const user = userEvent.setup({ delay: null });
     context.mocks.browser.imageDimensions([

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -18,18 +18,18 @@ import {
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { OrgResponse } from "@vm0/api-contracts/contracts/orgs";
 import { org$, isOrgAdmin$ } from "../../../../signals/org.ts";
-import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
+import { settingsDialogSignal$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import {
+  clearPendingLogo$,
   profileName$,
   setProfileName$,
   profileSlug$,
   setProfileSlug$,
   profileLogoUrl$,
   pendingLogoFile$,
-  setPendingLogoFile$,
   pendingLogoPreview$,
-  setPendingLogoPreview$,
+  setPendingLogo$,
   fileInputEl$,
   setFileInputEl$,
   logoLoaded$,
@@ -69,15 +69,14 @@ function ProfileSection({
   const logoUrl = useGet(profileLogoUrl$);
 
   const pendingLogoFile = useGet(pendingLogoFile$);
-  const setPendingLogoFile = useSet(setPendingLogoFile$);
-
   const pendingLogoPreview = useGet(pendingLogoPreview$);
-  const setPendingLogoPreview = useSet(setPendingLogoPreview$);
+  const setPendingLogo = useSet(setPendingLogo$);
+  const clearPendingLogo = useSet(clearPendingLogo$);
 
   const fileInputEl = useGet(fileInputEl$);
   const setFileInputEl = useSet(setFileInputEl$);
 
-  const pageSignal = useGet(pageSignal$);
+  const modalSignal = useGet(settingsDialogSignal$);
 
   const logoLoaded = useGet(logoLoaded$);
   const setLogoLoaded = useSet(setLogoLoaded$);
@@ -87,7 +86,11 @@ function ProfileSection({
   const hasChanges = hasNameChange || hasSlugChange || !!pendingLogoFile;
 
   const handleFileSelect = async (file: File) => {
+    if (!modalSignal) {
+      return;
+    }
     const dimensions = await readImageDimensions(file);
+    modalSignal.throwIfAborted();
     if (!dimensions) {
       toast.error("Could not read image file");
       return;
@@ -105,22 +108,17 @@ function ProfileSection({
       );
       return;
     }
-    setPendingLogoFile(file);
-    setPendingLogoPreview(URL.createObjectURL(file));
+    setPendingLogo(file, modalSignal);
   };
 
   const handleDiscard = () => {
     setName(org.name ?? "");
     setSlug(org.slug ?? "");
-    if (pendingLogoPreview) {
-      URL.revokeObjectURL(pendingLogoPreview);
-    }
-    setPendingLogoFile(null);
-    setPendingLogoPreview(null);
+    clearPendingLogo();
   };
 
   const handleSave = async () => {
-    if (!hasChanges || saving) {
+    if (!hasChanges || saving || !modalSignal) {
       return;
     }
     await saveProfile(
@@ -129,16 +127,16 @@ function ProfileSection({
         slug,
         logoFile: pendingLogoFile,
       },
-      pageSignal,
+      modalSignal,
     );
   };
 
   const handleLogoLoad = () => {
-    if (logoLoaded) {
+    if (logoLoaded || !modalSignal) {
       return;
     }
     setLogoLoaded(true);
-    detach(loadOrgLogo(pageSignal), Reason.DomCallback);
+    detach(loadOrgLogo(modalSignal), Reason.DomCallback);
   };
 
   return (
@@ -292,7 +290,7 @@ function DangerZoneSection({
   isAdmin: boolean;
 }) {
   const canLeave = !isAdmin;
-  const pageSignal = useGet(pageSignal$);
+  const modalSignal = useGet(settingsDialogSignal$);
   const [leaveLoadable, leave] = useLoadableSet(leaveOrg$);
   const [deleteLoadable, deleteWorkspace] = useLoadableSet(deleteOrg$);
   const leaving = leaveLoadable.state === "loading";
@@ -302,17 +300,17 @@ function DangerZoneSection({
   const setDeleteConfirm = useSet(setDeleteConfirm$);
 
   const handleLeave = async () => {
-    if (leaving) {
+    if (leaving || !modalSignal) {
       return;
     }
-    await leave(pageSignal);
+    await leave(modalSignal);
   };
 
   const handleDelete = async () => {
-    if (deleting || deleteConfirm !== org.slug) {
+    if (deleting || deleteConfirm !== org.slug || !modalSignal) {
       return;
     }
-    await deleteWorkspace(org.slug, pageSignal);
+    await deleteWorkspace(org.slug, modalSignal);
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import {
   IconBrandGithub,
   IconBrandSlack,
@@ -41,9 +41,7 @@ import {
   teamMemberUsageAsync$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
-import { setSettingsDialogOpen$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
-import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { detach, Reason } from "../../../../signals/utils.ts";
+import { closeSettingsModal$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { nowDate } from "../../../../lib/time.ts";
 import { Link } from "../../../router/link.tsx";
 import { MemberUsageTable } from "../org-manage/org-usage-tab.tsx";
@@ -267,8 +265,7 @@ function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
 }
 
 function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
-  const closeSettings = useSet(setSettingsDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
+  const closeSettings = useSet(closeSettingsModal$);
   const { label, Icon } = SOURCE_META[row.source];
   const title = row.title && row.title.length > 0 ? row.title : "Untitled";
 
@@ -276,7 +273,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
       return;
     }
-    detach(closeSettings(false, pageSignal), Reason.DomCallback);
+    closeSettings();
   };
   const credits = formatCredits(row.credits);
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -28,9 +28,9 @@ import { mobileBreadcrumb$ } from "../../signals/zero-page/zero-mobile-breadcrum
 import { Link } from "../router/link.tsx";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
+  closeSettingsModal$,
   openSettingsDialogAt$,
   settingsDialogOpen$,
-  setSettingsDialogOpen$,
 } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -203,14 +203,15 @@ function MobileTopBar() {
 
 function SettingsDialogMount() {
   const dialogOpen = useGet(settingsDialogOpen$);
-  const setDialogOpen = useSet(setSettingsDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
+  const closeSettingsModal = useSet(closeSettingsModal$);
 
   return (
     <SettingsDialog
       open={dialogOpen}
       onOpenChange={(open) => {
-        detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
+        if (!open) {
+          closeSettingsModal();
+        }
       }}
     />
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -1,11 +1,9 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { detach, Reason } from "../../signals/utils.ts";
-import { pageSignal$ } from "../../signals/page-signal.ts";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
+  closeSettingsModal$,
   settingsDialogOpen$,
-  setSettingsDialogOpen$,
 } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { SettingsDialog } from "./components/settings/settings-dialog.tsx";
 import { AccountDropdown } from "./zero-sidebar.tsx";
@@ -14,15 +12,16 @@ import { Link } from "../router/link.tsx";
 export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const onAccountAction = useSet(handleZeroAccountAction$);
   const dialogOpen = useGet(settingsDialogOpen$);
-  const setDialogOpen = useSet(setSettingsDialogOpen$);
-  const pageSignal = useGet(pageSignal$);
+  const closeSettingsModal = useSet(closeSettingsModal$);
 
   return (
     <div className="zero-app zero-viewport-shell flex w-full bg-background">
       <SettingsDialog
         open={dialogOpen}
         onOpenChange={(open) => {
-          detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
+          if (!open) {
+            closeSettingsModal();
+          }
         }}
       />
       <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">


### PR DESCRIPTION
## Summary

- give each Settings dialog session its own resettable abort signal and route every close path through `closeSettingsModal$`
- bind workspace profile work and every generated logo preview URL to that dialog signal, preventing late image validation writes and releasing all previews when the dialog closes
- hand off initialized Settings state across the home-to-agent redirect while rebinding the modal to the destination page signal
- keep voice-input quota recovery bound to the page lifecycle so recording cleanup cannot immediately close the billing dialog

## User impact

Repeated workspace logo selections no longer retain stale Blob URLs after Settings closes, in-flight Settings work is cancelled with the modal session, and voice quota recovery remains visible after transcription cleanup.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx src/views/zero-page/__tests__/settings-dialog.test.tsx src/views/zero-page/__tests__/org-general-tab.test.tsx --maxWorkers=1 --silent=passed-only` (18 tests passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "opens billing recovery" --maxWorkers=1 --silent=passed-only` (3 tests passed)
- `pnpm -F @vm0/app check-types`
- targeted Prettier, Oxlint, type-aware Oxlint, and ESLint on changed files
