### PR TITLE
feat(platform): render @-mentioned chat threads as atomic chips in the composer

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/chat-thread-mention.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-thread-mention.test.ts
@@ -27,14 +27,14 @@ describe("serializeChatThreadMention", () => {
 
 describe("splitChatThreadMentionSegments", () => {
   it("keeps plain text as a single text segment", () => {
-    expect(splitChatThreadMentionSegments("hello world")).toEqual([
+    expect(splitChatThreadMentionSegments("hello world")).toStrictEqual([
       { type: "text", text: "hello world" },
     ]);
   });
 
   it("splits mentions and surrounding text", () => {
     const line = `see [Weekly sync](/chats/${THREAD_ID}) for details`;
-    expect(splitChatThreadMentionSegments(line)).toEqual([
+    expect(splitChatThreadMentionSegments(line)).toStrictEqual([
       { type: "text", text: "see " },
       { type: "mention", threadId: THREAD_ID, title: "Weekly sync" },
       { type: "text", text: " for details" },
@@ -43,28 +43,28 @@ describe("splitChatThreadMentionSegments", () => {
 
   it("unescapes backslash-escaped characters in the title", () => {
     const line = serializeChatThreadMention(THREAD_ID, String.raw`a[b]c\d`);
-    expect(splitChatThreadMentionSegments(line)).toEqual([
+    expect(splitChatThreadMentionSegments(line)).toStrictEqual([
       { type: "mention", threadId: THREAD_ID, title: String.raw`a[b]c\d` },
     ]);
   });
 
   it("ignores links that are not chat thread paths", () => {
     const line = "[docs](https://example.com) and [x](/agents/abc)";
-    expect(splitChatThreadMentionSegments(line)).toEqual([
+    expect(splitChatThreadMentionSegments(line)).toStrictEqual([
       { type: "text", text: line },
     ]);
   });
 
   it("ignores chat links without a valid uuid", () => {
     const line = "[x](/chats/not-a-uuid)";
-    expect(splitChatThreadMentionSegments(line)).toEqual([
+    expect(splitChatThreadMentionSegments(line)).toStrictEqual([
       { type: "text", text: line },
     ]);
   });
 
   it("ignores links with an empty title", () => {
     const line = `[](/chats/${THREAD_ID})`;
-    expect(splitChatThreadMentionSegments(line)).toEqual([
+    expect(splitChatThreadMentionSegments(line)).toStrictEqual([
       { type: "text", text: line },
     ]);
   });
@@ -96,7 +96,7 @@ describe("chat thread mention in the workflow composer", () => {
       threadId: THREAD_ID,
       title: "Weekly sync",
     });
-    expect(mention.isAtom).toBe(true);
+    expect(mention.isAtom).toBeTruthy();
   });
 
   it("round-trips the mention between the doc and the draft string", () => {

--- a/turbo/apps/platform/src/signals/__tests__/chat-thread-mention.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-thread-mention.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "./test-helpers.ts";
+import {
+  serializeChatThreadMention,
+  splitChatThreadMentionSegments,
+} from "../zero-page/chat-thread-suggestion-domain.ts";
+import { createDraftSignals } from "../zero-page/chat-draft.ts";
+import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
+
+const context = testContext();
+
+const THREAD_ID = "1fe7f3cc-40b9-49f2-8f86-5f07d8d8dfd8";
+
+describe("serializeChatThreadMention", () => {
+  it("serializes a title as a markdown link to the chat thread", () => {
+    expect(serializeChatThreadMention(THREAD_ID, "Weekly sync")).toBe(
+      `[Weekly sync](/chats/${THREAD_ID})`,
+    );
+  });
+
+  it("backslash-escapes backslashes and square brackets in the title", () => {
+    expect(serializeChatThreadMention(THREAD_ID, String.raw`a[b]c\d`)).toBe(
+      String.raw`[a\[b\]c\\d](/chats/${THREAD_ID})`,
+    );
+  });
+});
+
+describe("splitChatThreadMentionSegments", () => {
+  it("keeps plain text as a single text segment", () => {
+    expect(splitChatThreadMentionSegments("hello world")).toEqual([
+      { type: "text", text: "hello world" },
+    ]);
+  });
+
+  it("splits mentions and surrounding text", () => {
+    const line = `see [Weekly sync](/chats/${THREAD_ID}) for details`;
+    expect(splitChatThreadMentionSegments(line)).toEqual([
+      { type: "text", text: "see " },
+      { type: "mention", threadId: THREAD_ID, title: "Weekly sync" },
+      { type: "text", text: " for details" },
+    ]);
+  });
+
+  it("unescapes backslash-escaped characters in the title", () => {
+    const line = serializeChatThreadMention(THREAD_ID, String.raw`a[b]c\d`);
+    expect(splitChatThreadMentionSegments(line)).toEqual([
+      { type: "mention", threadId: THREAD_ID, title: String.raw`a[b]c\d` },
+    ]);
+  });
+
+  it("ignores links that are not chat thread paths", () => {
+    const line = "[docs](https://example.com) and [x](/agents/abc)";
+    expect(splitChatThreadMentionSegments(line)).toEqual([
+      { type: "text", text: line },
+    ]);
+  });
+
+  it("ignores chat links without a valid uuid", () => {
+    const line = "[x](/chats/not-a-uuid)";
+    expect(splitChatThreadMentionSegments(line)).toEqual([
+      { type: "text", text: line },
+    ]);
+  });
+
+  it("ignores links with an empty title", () => {
+    const line = `[](/chats/${THREAD_ID})`;
+    expect(splitChatThreadMentionSegments(line)).toEqual([
+      { type: "text", text: line },
+    ]);
+  });
+});
+
+describe("chat thread mention in the workflow composer", () => {
+  function mountComposer() {
+    const draft = createDraftSignals();
+    const composer = createWorkflowComposerSignals(draft);
+    const element = document.createElement("div");
+    document.body.append(element);
+    const cleanup = context.store.set(composer.setContainerRef$, element);
+    context.signal.addEventListener("abort", () => {
+      cleanup?.();
+      element.remove();
+    });
+    return { draft, composer };
+  }
+
+  it("restores a draft mention as an atomic chip node", () => {
+    const { draft, composer } = mountComposer();
+    const input = `check [Weekly sync](/chats/${THREAD_ID}) please`;
+    context.store.set(draft.setInput$, input);
+
+    const paragraph = composer.editor.state.doc.child(0);
+    const mention = paragraph.child(1);
+    expect(mention.type.name).toBe("chatThreadMention");
+    expect(mention.attrs).toMatchObject({
+      threadId: THREAD_ID,
+      title: "Weekly sync",
+    });
+    expect(mention.isAtom).toBe(true);
+  });
+
+  it("round-trips the mention between the doc and the draft string", () => {
+    const { draft, composer } = mountComposer();
+    const input = `check [a\\[b\\]](/chats/${THREAD_ID}) please`;
+    context.store.set(draft.setInput$, input);
+
+    expect(
+      composer.editor.getText({
+        blockSeparator: "\n",
+        textSerializers: {
+          hardBreak: () => {
+            return "\n";
+          },
+        },
+      }),
+    ).toBe(input);
+    // A second sync with the same string must not rebuild the document.
+    const doc = composer.editor.state.doc;
+    context.store.set(draft.setInput$, input);
+    expect(composer.editor.state.doc).toBe(doc);
+  });
+
+  it("renders the mention chip with the thread title", () => {
+    const { draft, composer } = mountComposer();
+    context.store.set(draft.setInput$, `[Weekly sync](/chats/${THREAD_ID})`);
+
+    const chip = composer.editor.view.dom.querySelector(
+      `span[data-chat-thread-mention="${THREAD_ID}"]`,
+    );
+    expect(chip?.textContent).toBe("Weekly sync");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
@@ -33,7 +33,7 @@ export function serializeChatThreadMention(
   threadId: string,
   title: string,
 ): string {
-  const escapedTitle = title.replace(/[\\[\]]/g, "\\$&");
+  const escapedTitle = title.replace(/[\\[\]]/g, String.raw`\$&`);
   return `[${escapedTitle}](/chats/${threadId})`;
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-thread-suggestion-domain.ts
@@ -9,6 +9,57 @@ export interface ComposerChatThreadSuggestion {
   readonly title: string;
 }
 
+export interface ChatThreadMentionTextSegment {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export interface ChatThreadMentionSegment {
+  readonly type: "mention";
+  readonly threadId: string;
+  readonly title: string;
+}
+
+export type ChatThreadLineSegment =
+  | ChatThreadMentionTextSegment
+  | ChatThreadMentionSegment;
+
+// Matches `[title](/chats/<uuid>)` where the title backslash-escapes
+// `\`, `[` and `]` (the characters escaped by serializeChatThreadMention).
+const CHAT_THREAD_MENTION_PATTERN =
+  /\[((?:\\[\\[\]]|[^[\]\\])+)\]\(\/chats\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)/g;
+
+export function serializeChatThreadMention(
+  threadId: string,
+  title: string,
+): string {
+  const escapedTitle = title.replace(/[\\[\]]/g, "\\$&");
+  return `[${escapedTitle}](/chats/${threadId})`;
+}
+
+export function splitChatThreadMentionSegments(
+  line: string,
+): readonly ChatThreadLineSegment[] {
+  const segments: ChatThreadLineSegment[] = [];
+  let lastIndex = 0;
+  for (const match of line.matchAll(CHAT_THREAD_MENTION_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ type: "text", text: line.slice(lastIndex, index) });
+    }
+    segments.push({
+      type: "mention",
+      threadId: match[2] ?? "",
+      title: (match[1] ?? "").replace(/\\([\\[\]])/g, "$1"),
+    });
+    lastIndex = index + match[0].length;
+  }
+  if (lastIndex < line.length) {
+    segments.push({ type: "text", text: line.slice(lastIndex) });
+  }
+  return segments;
+}
+
 export function findActiveChatThreadSuggestionRange(
   value: string,
   caretIndex: number,

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -148,7 +148,7 @@ const ChatThreadMentionNode = Node.create({
         tag: "span[data-chat-thread-mention]",
         getAttrs: (element) => {
           return {
-            threadId: element.getAttribute("data-chat-thread-mention") ?? "",
+            threadId: element.dataset.chatThreadMention ?? "",
             title: element.textContent ?? "",
           };
         },

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -20,6 +20,8 @@ import {
 } from "./chat-feedback.ts";
 import {
   findActiveChatThreadSuggestionRange,
+  serializeChatThreadMention,
+  splitChatThreadMentionSegments,
   type ChatThreadSuggestionRange,
   type ComposerChatThreadSuggestion,
 } from "./chat-thread-suggestion-domain.ts";
@@ -104,6 +106,70 @@ export interface WorkflowComposerEventHandlers {
 }
 
 const FEEDBACK_ITEM_NODE_NAME = "feedbackItem";
+const CHAT_THREAD_MENTION_NODE_NAME = "chatThreadMention";
+const CHAT_THREAD_MENTION_CLASS =
+  "rounded bg-primary/10 px-1 text-primary whitespace-nowrap";
+
+interface ChatThreadMentionAttributes {
+  readonly threadId: string;
+  readonly title: string;
+}
+
+function chatThreadMentionAttributes(
+  node: ProseMirrorNode,
+): ChatThreadMentionAttributes {
+  const threadId: unknown = node.attrs.threadId;
+  const title: unknown = node.attrs.title;
+  if (typeof threadId !== "string" || typeof title !== "string") {
+    throw new Error("Chat thread mention node attributes are invalid");
+  }
+  return { threadId, title };
+}
+
+function chatThreadMentionText(node: ProseMirrorNode): string {
+  const { threadId, title } = chatThreadMentionAttributes(node);
+  return serializeChatThreadMention(threadId, title);
+}
+
+const ChatThreadMentionNode = Node.create({
+  name: CHAT_THREAD_MENTION_NODE_NAME,
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return {
+      threadId: { default: "" },
+      title: { default: "" },
+    };
+  },
+  parseHTML() {
+    return [
+      {
+        tag: "span[data-chat-thread-mention]",
+        getAttrs: (element) => {
+          return {
+            threadId: element.getAttribute("data-chat-thread-mention") ?? "",
+            title: element.textContent ?? "",
+          };
+        },
+      },
+    ];
+  },
+  renderHTML({ node }) {
+    const { threadId, title } = chatThreadMentionAttributes(node);
+    return [
+      "span",
+      {
+        "data-chat-thread-mention": threadId,
+        class: CHAT_THREAD_MENTION_CLASS,
+      },
+      title,
+    ];
+  },
+  renderText({ node }) {
+    return chatThreadMentionText(node);
+  },
+});
 
 interface FeedbackItemNodeAttributes {
   readonly feedbackId: number;
@@ -330,9 +396,20 @@ function feedbackItemsFromWorkflowComposer(
 
 function valueToWorkflowComposerDoc(value: string): JSONContent {
   const content: JSONContent[] = value.split("\n").map((line) => {
-    return line.length > 0
-      ? { type: "paragraph", content: [{ type: "text", text: line }] }
-      : { type: "paragraph" };
+    if (line.length === 0) {
+      return { type: "paragraph" };
+    }
+    const inlineContent = splitChatThreadMentionSegments(line).map(
+      (segment): JSONContent => {
+        return segment.type === "text"
+          ? { type: "text", text: segment.text }
+          : {
+              type: CHAT_THREAD_MENTION_NODE_NAME,
+              attrs: { threadId: segment.threadId, title: segment.title },
+            };
+      },
+    );
+    return { type: "paragraph", content: inlineContent };
   });
   return { type: "doc", content };
 }
@@ -344,6 +421,9 @@ function workflowComposerDocToString(editor: Editor): string {
       hardBreak: () => {
         return "\n";
       },
+      [CHAT_THREAD_MENTION_NODE_NAME]: ({ node }) => {
+        return chatThreadMentionText(node);
+      },
     },
   });
 }
@@ -351,6 +431,9 @@ function workflowComposerDocToString(editor: Editor): string {
 function caretStringIndex(editor: Editor): number {
   const head = editor.state.selection.head;
   return editor.state.doc.textBetween(0, head, "\n", (leafNode) => {
+    if (leafNode.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
+      return chatThreadMentionText(leafNode);
+    }
     return leafNode.type.name === "hardBreak" ? "\n" : "";
   }).length;
 }
@@ -494,6 +577,7 @@ function createWorkflowEditor(runtime: WorkflowComposerRuntime): Editor {
     extensions: [
       STARTER_KIT,
       createFeedbackItemNode(runtime),
+      ChatThreadMentionNode,
       WorkflowHighlight,
     ],
     content: valueToWorkflowComposerDoc(""),
@@ -686,15 +770,22 @@ function createInsertChatThreadCommand(
     const input = get(draft.input$);
     const head = editor.state.selection.head;
     const from = head - (range.end - range.start);
-    const token = `/chats/${chatThread.id}`;
-    const suffix = input.slice(range.end).startsWith(" ") ? "" : " ";
+    const content: JSONContent[] = [
+      {
+        type: CHAT_THREAD_MENTION_NODE_NAME,
+        attrs: { threadId: chatThread.id, title: chatThread.title },
+      },
+    ];
+    if (!input.slice(range.end).startsWith(" ")) {
+      content.push({ type: "text", text: " " });
+    }
     editor
       .chain()
       .focus()
-      .insertContentAt({ from, to: head }, [
-        { type: "text", text: `${token}${suffix}` },
-      ])
-      .setTextSelection(from + token.length + 1)
+      .insertContentAt({ from, to: head }, content)
+      // The mention node occupies a single document position; place the
+      // caret after the node and the following space.
+      .setTextSelection(from + 2)
       .run();
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1121,7 +1121,7 @@ describe("chat composer models", () => {
     expect(highlightedWorkflow).toHaveClass("text-primary");
   });
 
-  it("inserts a current-agent chat thread URL from @ suggestions", async () => {
+  it("inserts a current-agent chat thread mention chip from @ suggestions", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
@@ -1161,10 +1161,12 @@ describe("chat composer models", () => {
     await user.keyboard("{Enter}next");
 
     await waitFor(() => {
-      expect(editor).toHaveTextContent(
-        `Review /chats/${SUGGESTED_THREAD_ID} next`,
-      );
+      expect(editor).toHaveTextContent("Review Project Alpha next");
     });
+    const chip = editor.querySelector(
+      `span[data-chat-thread-mention="${SUGGESTED_THREAD_ID}"]`,
+    );
+    expect(chip).toHaveTextContent("Project Alpha");
   });
 
   it("hides @ suggestions when no titled thread matches", async () => {


### PR DESCRIPTION
## Summary

When picking a chat thread from the composer's `@` suggestion menu, the composer now inserts an **atomic inline mention chip** showing the thread title, instead of the plain text `/chats/<uuid>`. The chip behaves as a single unit (one Backspace deletes it, the caret skips over it) and serializes to a standard CommonMark link `[title](/chats/<uuid>)` in the draft string, so the agent now receives the thread title in addition to the path.

### User-visible impact
- `@`-selecting a thread shows a styled chip with the thread title in the input instead of a raw `/chats/<uuid>` path.
- The chip is atomic: whole-unit deletion/selection, caret cannot enter it.
- The message sent to the agent becomes `[title](/chats/<uuid>)` — backward compatible for consumers matching the `/chats/<uuid>` path, with title info added.
- Drafts persist and restore losslessly; a manually typed/pasted `[title](/chats/<uuid>)` link also upgrades to a chip.

### Implementation
- `draft.input$` (string) remains the single source of truth; the Tiptap doc is a view of it. New `chatThreadMention` node (`inline`, `atom`, attrs `{threadId, title}`) rendered via `renderHTML` (no NodeView, no React).
- Pure domain functions `serializeChatThreadMention` / `splitChatThreadMentionSegments` in `chat-thread-suggestion-domain.ts` handle the lossless string↔doc round-trip. Titles backslash-escape `\`, `[`, `]` (same character set prosemirror-markdown escapes); parsing only recognizes `/chats/<uuid>` destinations, other links stay plain text.
- `valueToWorkflowComposerDoc`, `workflowComposerDocToString`, and `caretStringIndex` all serialize the node identically, keeping string offsets (@-detection regex, caret index) consistent. Round-trip stability is what keeps the `doc.eq` short-circuit in `setWorkflowComposerDocument` effective on every keystroke.
- Title is a snapshot at insert time (renames don't retroactively update chips). The `/workflow` token highlight is unchanged. Feature remains gated by the existing `ComposerChatThreadSuggestions` switch (the suggestion menu is the only entry point).

### Verification
- New tests: domain serialize/parse/escaping cases plus editor-level tests (mount via ccstate store, no React) covering chip creation from a draft string, lossless round-trip, doc identity stability on repeated sync, and chip DOM rendering — 11 passed.
- Updated the existing `@` suggestion integration test to assert the chip instead of the raw URL — passes.
- `tsc --noEmit`, `eslint`, and `prettier` clean on touched files. Full vitest/dev-server verification left to the PR pipeline per repo practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)