### PR TITLE
refactor(platform): cache chat blocks and share permission card signals

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -158,6 +158,30 @@ export async function publishChatThreadAutomationsChangedSafely(
 }
 
 /**
+ * Notify the user's chat threads that their connector permission grants
+ * changed (allowed or denied from any client: chat permission card,
+ * permission-allow page, or settings dialog). Chat threads subscribe to this
+ * topic and invalidate all rendered permission cards at once — grants are few
+ * and re-fetching them is cheap, so a single user-level signal beats
+ * per-permission topics. Payload is intentionally empty.
+ *
+ * Best-effort: a failed publish must not fail the grant mutation that
+ * triggers it.
+ */
+export async function publishConnectorPermissionUpdatedSafely(
+  userId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], "connectorPermissionUpdated"),
+    (error) => {
+      L.warn("Failed to publish connector permission updated signal", {
+        error,
+      });
+    },
+  );
+}
+
+/**
  * Notify a chat thread's UI that its visible workflow set changed. The slash
  * workflow composer subscribes to this topic and refetches the authoritative
  * agent-scoped workflow list.

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -24,7 +24,10 @@ import type {
 
 import { notFound } from "../../lib/error";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { publishNetworkPolicyRefreshToRunnerGroup } from "../external/realtime";
+import {
+  publishConnectorPermissionUpdatedSafely,
+  publishNetworkPolicyRefreshToRunnerGroup,
+} from "../external/realtime";
 import { nowDate } from "../external/time";
 import {
   defaultFirewallPolicyForPermissionIndex,
@@ -709,6 +712,8 @@ export const applyUserPermissionGrants$ = command(
     if ("status" in rows) {
       return rows;
     }
+    await publishConnectorPermissionUpdatedSafely(args.userId);
+    signal.throwIfAborted();
     const responseScope = applyPermissionGrantResponseScope(args);
 
     return {

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -6,6 +6,7 @@ import {
 } from "./chat-thread-list-reload.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
+import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
 import { setupRealtime$ } from "./realtime.ts";
 import { setupBillingRealtime$ } from "./zero-page/billing.ts";
 
@@ -23,6 +24,7 @@ export const setupAuthenticatedDaemons$ = command(
       set(subscribeThreadListChanged$, signal),
       set(subscribeChatThreadReadCursorUpdated$, signal),
       set(subscribeEventDrivenChatThreads$, signal),
+      set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),
       set(reloadFeatureSwitch$, signal),
     ]);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -11,6 +11,7 @@ import type { ChatClipboardPayload } from "../zero-page/clipboard.ts";
 import type { DraftSignals } from "../zero-page/chat-draft.ts";
 import type { WorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
+import type { PermissionCardSignals } from "./permission-card-signals.ts";
 import type { GroupedChatMessageGroup } from "./chat-message.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 import type { HeaderAutomationSignals } from "./header-automation-menu.ts";
@@ -131,6 +132,12 @@ export interface ChatThreadSignals {
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
+  // Signals backing rendered permission action cards, keyed by the card's
+  // normalized permission URL. Populated when persistent messages are written;
+  // cards look up their signals at render time.
+  permissionCardSignalsByUrl$: Computed<
+    ReadonlyMap<string, PermissionCardSignals>
+  >;
   visibleRenderedChatGroups$: Computed<Promise<GroupedChatMessageGroup[]>>;
   visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
   messageImageGroups$: Computed<Promise<MessageImageGroupProjection[]>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -107,8 +107,8 @@ import {
 } from "../zero-page/model-first-personal-oauth.ts";
 import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/codex-device-auth.ts";
-import { userPermissionGrantsByAgent } from "../permission-allow/permission-allow-signals.ts";
-import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
+import { createPermissionCardRegistry } from "./permission-card-signals.ts";
+import type { PermissionActionBlock } from "./permission-action-block.ts";
 
 import type {
   ChatThreadSignals,
@@ -1251,10 +1251,12 @@ function setLatestUsageForRun(
 function createRenderedChatGroups(
   semanticMessages$: Computed<SemanticChatMessage[]>,
   mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
+  messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ) {
   const transcriptMessages$ = createTranscriptMessagesComputed(
     semanticMessages$,
     mailDraftById$,
+    messageBlocksById$,
   );
 
   const allRenderedChatGroups$ = computed(
@@ -1339,10 +1341,89 @@ function mergeServerMessages(
   return Array.from(byId.values()).sort(compareServerMessageOrder);
 }
 
+function parseMessageBodyBlocks(message: PagedChatMessage): BodyRenderBlock[] {
+  const content = chatMessageBodyContent(message);
+  const { blocks } = parseBodyRenderBlocks(content, {
+    previews: message.role === "assistant",
+  });
+  return enrichBlocksWithTextPreviews(blocks);
+}
+
+/**
+ * Whether the message's blocks must not be cached under its own id. Interrupt
+ * control rows are projected onto a synthetic "Run cancelled" assistant
+ * message that reuses the same id (see createInterruptedAssistantProjection),
+ * so a cache entry parsed from the control row's content would be wrong.
+ * Other control markers are filtered from the transcript entirely, so parsing
+ * them is wasted work; a cache miss falls back to parsing on read.
+ */
+function skipsMessageBlocksCache(message: PagedChatMessage): boolean {
+  return (
+    isInterruptControlMessage(message) ||
+    isRecallControlMessage(message) ||
+    isQueueMarkerMessage(message) ||
+    isGoalMarkerMessage(message)
+  );
+}
+
+interface MessageBlocksRegistrySignals {
+  readonly messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>;
+  readonly registerMessageBlocks$: Command<void, [readonly PagedChatMessage[]]>;
+}
+
+/**
+ * Parses message bodies into render blocks once, at persistent-message write
+ * time, instead of re-parsing the whole transcript on every evaluation of the
+ * transcript computed. Permission action URLs found during parsing are
+ * registered with the thread's permission card registry so cards read stable
+ * signals keyed by URL.
+ */
+function createMessageBlocksRegistry(
+  registerPermissionCardBlocks$: Command<
+    void,
+    [readonly PermissionActionBlock[]]
+  >,
+): MessageBlocksRegistrySignals {
+  const internalBlocksById$ = state<ReadonlyMap<string, BodyRenderBlock[]>>(
+    new Map(),
+  );
+  const messageBlocksById$ = computed((get) => {
+    return get(internalBlocksById$);
+  });
+  const registerMessageBlocks$ = command(
+    ({ get, set }, messages: readonly PagedChatMessage[]) => {
+      if (messages.length === 0) {
+        return;
+      }
+      const current = get(internalBlocksById$);
+      const next = new Map(current);
+      const permissionBlocks: PermissionActionBlock[] = [];
+      for (const message of messages) {
+        if (skipsMessageBlocksCache(message)) {
+          continue;
+        }
+        const blocks = parseMessageBodyBlocks(message);
+        next.set(message.id, blocks);
+        for (const block of blocks) {
+          if (block.type === "permission-action") {
+            permissionBlocks.push(block);
+          }
+        }
+      }
+      set(internalBlocksById$, next);
+      if (permissionBlocks.length > 0) {
+        set(registerPermissionCardBlocks$, permissionBlocks);
+      }
+    },
+  );
+  return { messageBlocksById$, registerMessageBlocks$ };
+}
+
 function createWritePersistentMessages(
   threadId: string,
   persistentMessages$: PersistentChatMessages$,
   registerMailDraftMessages$: Command<void, [readonly PagedChatMessage[]]>,
+  registerMessageBlocks$: Command<void, [readonly PagedChatMessage[]]>,
 ) {
   return command(
     async (
@@ -1365,6 +1446,7 @@ function createWritePersistentMessages(
         captureTaskCompletedSuccessfully();
       }
       set(registerMailDraftMessages$, msgs);
+      set(registerMessageBlocks$, msgs);
       set(persistentMessages$, (prev) => {
         return mergeServerMessages([prev, msgs]);
       });
@@ -1424,19 +1506,20 @@ function createRawMessagesComputed({
 function createTranscriptMessagesComputed(
   semanticMessages$: Computed<SemanticChatMessage[]>,
   mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
+  messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ): Computed<Promise<EnrichedChatMessage[]>> {
   return computed((get): Promise<EnrichedChatMessage[]> => {
     const mailDraftById = get(mailDraftById$);
+    const blocksById = get(messageBlocksById$);
     return Promise.resolve(
       get(semanticMessages$).map((entry) => {
         const { message, isQueued, isOptimisticRun } = entry;
-        const content = chatMessageBodyContent(message);
-        const { blocks } = parseBodyRenderBlocks(content, {
-          previews: message.role === "assistant",
-        });
-        const enrichedBlocks = enrichBlocksWithPermissionActionResources(
-          enrichBlocksWithTextPreviews(blocks),
-        );
+        // Persistent messages have their blocks registered at write time.
+        // Optimistic messages and synthetic projections (e.g. the "Run
+        // cancelled" interrupt projection) are not registered — they are few
+        // and short-lived, so parse them on read.
+        const enrichedBlocks =
+          blocksById.get(message.id) ?? parseMessageBodyBlocks(message);
         let mailDraftResource: EnrichedChatMessage["mailDraftResource"] = null;
         if (message.mailDraftId !== undefined) {
           const mailDraft$ = mailDraftById.get(message.mailDraftId);
@@ -1489,26 +1572,6 @@ function chatMessageBodyContent(message: PagedChatMessage): string {
     return "";
   }
   return content.trim();
-}
-
-function enrichBlocksWithPermissionActionResources(
-  blocks: BodyRenderBlock[],
-): BodyRenderBlock[] {
-  return blocks.map((block) => {
-    if (block.type !== "permission-action") {
-      return block;
-    }
-    return {
-      ...block,
-      resource: {
-        agent$: agentById(block.agentId),
-        grants$: userPermissionGrantsByAgent({ agentId: block.agentId }),
-        metadata$: firewallPermissionMetadataByConnector({
-          connectorRef: block.connectorRef,
-        }),
-      },
-    };
-  });
 }
 
 interface SemanticChatMessage {
@@ -2236,6 +2299,10 @@ function createActiveGoalObjectiveComputed(
 
 function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
   const mailDrafts = createMailDraftLoaderSignals();
+  const permissionCards = createPermissionCardRegistry();
+  const messageBlocks = createMessageBlocksRegistry(
+    permissionCards.registerPermissionCardBlocks$,
+  );
   const persistentChatMessages$ = state<PagedChatMessage[]>([]);
   const hasReachedOldestMessage$ = state(false);
   const optimisticMessages$ = createOptimisticChatMessagesForThread(threadId);
@@ -2262,17 +2329,20 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
   const renderedMessages = createRenderedChatGroups(
     semanticMessages$,
     mailDrafts.mailDraftById$,
+    messageBlocks.messageBlocksById$,
   );
 
   const writePersistentMessages$ = createWritePersistentMessages(
     threadId,
     persistentChatMessages$,
     mailDrafts.registerMailDraftMessages$,
+    messageBlocks.registerMessageBlocks$,
   );
 
   const mergeIndexedDbMessages$ = command(
     ({ set }, messages: PagedChatMessage[]): void => {
       set(mailDrafts.registerMailDraftMessages$, messages);
+      set(messageBlocks.registerMessageBlocks$, messages);
       set(persistentChatMessages$, (previous) => {
         return mergeServerMessages([messages, previous]);
       });
@@ -2329,6 +2399,7 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
     latestChatMessageId$,
     latestRunFinishCreatedAt$,
     latestAssistantTextCreatedAt$,
+    permissionCardSignalsByUrl$: permissionCards.permissionCardSignalsByUrl$,
     ...semanticSignals,
     ...renderedMessages,
     rawMessages$,
@@ -4023,6 +4094,7 @@ export function createChatThreadSignals(
     latestChatMessageId$: messages.latestChatMessageId$,
     latestRunFinishCreatedAt$: messages.latestRunFinishCreatedAt$,
     latestAssistantTextCreatedAt$: messages.latestAssistantTextCreatedAt$,
+    permissionCardSignalsByUrl$: messages.permissionCardSignalsByUrl$,
     visibleRenderedChatGroups$: messages.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: messages.visibleRenderedChatGroupsReady$,
     messageImageGroups$: messages.messageImageGroups$,

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -1,10 +1,4 @@
-import type { Computed } from "ccstate";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
-import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import type {
-  UserPermissionGrantExpiresIn,
-  UserPermissionGrantResponse,
-} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import {
   resolvePlatformOriginForTarget,
   rewritePlatformHostname,
@@ -27,20 +21,16 @@ export interface PermissionActionDescriptor {
   originalUrl: string;
 }
 
+/**
+ * Pure data parsed from a permission URL in a message body. The reactive
+ * resources backing the rendered card live in the thread-scoped permission
+ * card registry (see permission-card-signals.ts), keyed by `href`.
+ */
 export type PermissionActionBlock = PermissionActionDescriptor & {
   type: "permission-action";
   id: string;
   href: string;
-  resource?: PermissionActionResource;
 };
-
-export interface PermissionActionResource {
-  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
-  readonly grants$: Computed<Promise<readonly UserPermissionGrantResponse[]>>;
-  readonly metadata$: Computed<
-    Promise<PublicConnectorCatalogPermissionDetail | null>
-  >;
-}
 
 function permissionActionHref(descriptor: PermissionActionDescriptor): string {
   const path = `/agents/${encodeURIComponent(descriptor.agentId)}/permissions`;

--- a/turbo/apps/platform/src/signals/chat-page/permission-card-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-card-signals.ts
@@ -1,0 +1,76 @@
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
+import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { agentById } from "../agent.ts";
+import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
+import { userPermissionGrantsByAgent } from "../permission-allow/permission-allow-signals.ts";
+import type { PermissionActionBlock } from "./permission-action-block.ts";
+
+/**
+ * Reactive resources backing one rendered permission action card. Created once
+ * per normalized permission URL (`PermissionActionBlock.href`) and held by the
+ * thread-scoped registry, so card components keep stable signal identities
+ * across transcript re-evaluations.
+ */
+export interface PermissionCardSignals {
+  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
+  readonly grants$: Computed<Promise<readonly UserPermissionGrantResponse[]>>;
+  readonly metadata$: Computed<
+    Promise<PublicConnectorCatalogPermissionDetail | null>
+  >;
+}
+
+export interface PermissionCardRegistrySignals {
+  readonly permissionCardSignalsByUrl$: Computed<
+    ReadonlyMap<string, PermissionCardSignals>
+  >;
+  readonly registerPermissionCardBlocks$: Command<
+    void,
+    [readonly PermissionActionBlock[]]
+  >;
+}
+
+/**
+ * Thread-scoped registry of permission card signals keyed by normalized
+ * permission URL. Entries are inserted by `registerPermissionCardBlocks$` when
+ * persistent messages are written; the registry intentionally never removes
+ * entries because a URL's signals are immutable for the thread's lifetime.
+ */
+export function createPermissionCardRegistry(): PermissionCardRegistrySignals {
+  const internalSignalsByUrl$ = state<
+    ReadonlyMap<string, PermissionCardSignals>
+  >(new Map());
+
+  const permissionCardSignalsByUrl$ = computed((get) => {
+    return get(internalSignalsByUrl$);
+  });
+
+  const registerPermissionCardBlocks$ = command(
+    ({ get, set }, blocks: readonly PermissionActionBlock[]) => {
+      const current = get(internalSignalsByUrl$);
+      let next: Map<string, PermissionCardSignals> | undefined;
+      for (const block of blocks) {
+        if (current.has(block.href) || next?.has(block.href)) {
+          continue;
+        }
+        next ??= new Map(current);
+        next.set(block.href, {
+          agent$: agentById(block.agentId),
+          grants$: userPermissionGrantsByAgent({ agentId: block.agentId }),
+          metadata$: firewallPermissionMetadataByConnector({
+            connectorRef: block.connectorRef,
+          }),
+        });
+      }
+      if (next !== undefined) {
+        set(internalSignalsByUrl$, next);
+      }
+    },
+  );
+
+  return {
+    permissionCardSignalsByUrl$,
+    registerPermissionCardBlocks$,
+  };
+}

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -17,6 +17,7 @@ import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, currentAgentId$, reloadAgentById$ } from "../agent.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 import { retryTransientLoad } from "../utils.ts";
 import { resolveActiveUserPermissionGrantPolicy } from "../user-permission-grants.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
@@ -98,6 +99,25 @@ export function findPermissionInMetadata(
 // ---------------------------------------------------------------------------
 
 const internalUserPermissionGrantsReload$ = state(0);
+
+export const subscribePermissionUpdate$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const onPermissionUpdated$ = command(({ set }) => {
+      set(internalUserPermissionGrantsReload$, (version) => {
+        return version + 1;
+      });
+      return false;
+    });
+    await set(
+      setAblyLoop$,
+      {
+        topic: "connectorPermissionUpdated",
+        loopCommand$: onPermissionUpdated$,
+      },
+      signal,
+    );
+  },
+);
 
 export function resolveUserPermissionGrantPolicy(
   grants: readonly UserPermissionGrantResponse[],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -21,6 +21,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
+import { triggerAblyEvent, hasSubscription } from "../../../mocks/ably.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
@@ -958,6 +959,76 @@ describe("chat message action cards", () => {
       within(permissionCard).queryByLabelText("Permission duration"),
     ).not.toBeInTheDocument();
     expect(applyRequests).toBe(0);
+  });
+
+  it("reloads permission cards when a connectorPermissionUpdated event arrives", async () => {
+    mockNow();
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    let grantAllowed = false;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(
+        200,
+        grantAllowed
+          ? [
+              {
+                agentId: AGENT_ID,
+                connectorRef: "youtube",
+                permission: "videos.write",
+                action: "allow" as const,
+                expiresAt: isoFromNowMs(24 * 60 * 60 * 1000),
+                createdAt: "2026-06-09T11:00:00Z",
+                updatedAt: "2026-06-09T11:01:00Z",
+              },
+            ]
+          : [],
+      );
+    });
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-updated-event`,
+      threadTitle: "Permission updated event",
+      chatMessages: [
+        {
+          id: "msg-user-permission-updated-event",
+          role: "user",
+          content: "Upload the video",
+          runId: "run-permission-updated-event",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-updated-event-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-updated-event",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-updated-event`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitForButtonByText("Confirm", permissionCard);
+    expect(
+      within(permissionCard).queryByText("Already allowed"),
+    ).not.toBeInTheDocument();
+
+    // The authenticated bootstrap owns one user-level subscription shared by
+    // every permission-grant reader, including all open chat threads.
+    await waitFor(() => {
+      expect(hasSubscription("connectorPermissionUpdated")).toBeTruthy();
+    });
+    grantAllowed = true;
+    triggerAblyEvent("connectorPermissionUpdated");
+
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Already allowed"),
+      ).toBeInTheDocument();
+    });
+    expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
   });
 
   it("renders custom connector proposal links as configure cards", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7,6 +7,7 @@ import type {
   UIEvent as ReactUIEvent,
 } from "react";
 import { createPortal } from "react-dom";
+import type { Computed } from "ccstate";
 import {
   useGet,
   useSet,
@@ -148,10 +149,8 @@ import {
   type RunGroupFold,
   type RunGroupFolding,
 } from "../../signals/chat-page/run-group-folding.ts";
-import type {
-  PermissionActionBlock,
-  PermissionActionResource,
-} from "../../signals/chat-page/permission-action-block.ts";
+import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
+import type { PermissionCardSignals } from "../../signals/chat-page/permission-card-signals.ts";
 import type { ComputerUseAuthorizationBlock } from "../../signals/chat-page/computer-use-authorization-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
@@ -4719,12 +4718,16 @@ function BodyContentBlocks({
   hardBreaks,
   escapeMarkdownHtml = false,
   markdownMediaPreview = true,
+  permissionCardSignalsByUrl$,
 }: {
   blocks: BodyRenderBlock[];
   openLightbox: (url: string) => void;
   hardBreaks: boolean;
   escapeMarkdownHtml?: boolean;
   markdownMediaPreview?: boolean;
+  permissionCardSignalsByUrl$: Computed<
+    ReadonlyMap<string, PermissionCardSignals>
+  >;
 }) {
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
 
@@ -4757,7 +4760,13 @@ function BodyContentBlocks({
         }
 
         if (block.type === "permission-action") {
-          return <PermissionActionCard key={block.id} block={block} />;
+          return (
+            <PermissionActionCard
+              key={block.id}
+              block={block}
+              permissionCardSignalsByUrl$={permissionCardSignalsByUrl$}
+            />
+          );
         }
 
         if (block.type === "computer-use-authorization") {
@@ -5423,7 +5432,7 @@ function PermissionActionCardForTarget({
   userGrantsLoadable,
 }: {
   block: PermissionActionBlock;
-  resource: PermissionActionResource;
+  resource: PermissionCardSignals;
   hasTarget: boolean;
   targetLoadableState: string;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
@@ -5501,7 +5510,7 @@ function AgentPermissionActionCardWithResource({
   resource,
 }: {
   block: PermissionActionBlock;
-  resource: PermissionActionResource;
+  resource: PermissionCardSignals;
 }) {
   const agentLoadable = useLastLoadable(resource.agent$);
   const userGrantsLoadable = useLoadable(resource.grants$);
@@ -5517,15 +5526,24 @@ function AgentPermissionActionCardWithResource({
   );
 }
 
-function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
-  if (!block.resource) {
+function PermissionActionCard({
+  block,
+  permissionCardSignalsByUrl$,
+}: {
+  block: PermissionActionBlock;
+  permissionCardSignalsByUrl$: Computed<
+    ReadonlyMap<string, PermissionCardSignals>
+  >;
+}) {
+  const signalsByUrl = useGet(permissionCardSignalsByUrl$);
+  const signals = signalsByUrl.get(block.href);
+  if (!signals) {
+    // The block's URL was not registered (e.g. an optimistic message that
+    // never reached the persistent-message write path) — nothing to render.
     return null;
   }
   return (
-    <AgentPermissionActionCardWithResource
-      block={block}
-      resource={block.resource}
-    />
+    <AgentPermissionActionCardWithResource block={block} resource={signals} />
   );
 }
 
@@ -6392,10 +6410,14 @@ function GoalUserMessage({
   message,
   bodyBlocks,
   openLightbox,
+  permissionCardSignalsByUrl$,
 }: {
   message: EnrichedChatMessage & { role: "user" };
   bodyBlocks: BodyRenderBlock[];
   openLightbox: (url: string) => void;
+  permissionCardSignalsByUrl$: Computed<
+    ReadonlyMap<string, PermissionCardSignals>
+  >;
 }) {
   const objectiveBrief = message.goalSnapshot?.objectiveBrief?.trim();
   return (
@@ -6425,6 +6447,7 @@ function GoalUserMessage({
                   hardBreaks
                   escapeMarkdownHtml
                   markdownMediaPreview={false}
+                  permissionCardSignalsByUrl$={permissionCardSignalsByUrl$}
                 />
               </div>
             </div>
@@ -6491,6 +6514,7 @@ function PagedUserMessage({
         message={message}
         bodyBlocks={bodyBlocks}
         openLightbox={openLightbox}
+        permissionCardSignalsByUrl$={thread.permissionCardSignalsByUrl$}
       />
     );
   }
@@ -6516,6 +6540,9 @@ function PagedUserMessage({
                   hardBreaks
                   escapeMarkdownHtml
                   markdownMediaPreview={false}
+                  permissionCardSignalsByUrl$={
+                    thread.permissionCardSignalsByUrl$
+                  }
                 />
               </div>
             </div>
@@ -6574,6 +6601,7 @@ function PagedAssistantGroup({
       <PagedAssistantMessageItem
         key={message.id}
         message={message}
+        thread={thread}
         compactTop={compactTop}
       />
     );
@@ -6623,9 +6651,11 @@ function PagedAssistantGroup({
 
 function PagedAssistantMessageItem({
   message,
+  thread,
   compactTop = false,
 }: {
   message: EnrichedChatMessage;
+  thread: ChatThreadSignals;
   compactTop?: boolean;
 }) {
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
@@ -6678,6 +6708,7 @@ function PagedAssistantMessageItem({
             blocks={blocks}
             openLightbox={openLightbox}
             hardBreaks={false}
+            permissionCardSignalsByUrl$={thread.permissionCardSignalsByUrl$}
           />
         ) : null}
       </div>


### PR DESCRIPTION
## Summary

Chat message render blocks were created inside the transcript computed. Any persistent-message adjustment re-parsed the full transcript and recreated permission-card signal identities, causing mounted cards to resubscribe. Permission cards also stayed stale when grants changed from another surface.

This PR makes render-block parsing write-driven and permission-grant invalidation user-scoped:

- **Parse persistent messages at write time** — `writePersistentMessages$` and `mergeIndexedDbMessages$` register parsed blocks in a thread-owned `Map<messageId, blocks>`, so transcript computation reuses stable blocks.
- **Keep stable permission-card signals** — permission URLs are registered in a thread-owned `Map<href, PermissionCardSignals>`. Rendering resolves `agent$`, `grants$`, and `metadata$` by normalized URL instead of allocating resources during transcript computation.
- **Share one permission-update subscription** — the grants apply route publishes `connectorPermissionUpdated` on the user channel. Authenticated bootstrap starts one `subscribePermissionUpdate$` daemon, which bumps the module-private grants reload counter used by every `userPermissionGrantsByAgent` computed. Multiple chat threads and other permission readers therefore refresh together without exposing a reload command or subscribing per thread.

## Notes

- Interrupt, recall, queue, and goal control rows are not registered. Optimistic messages and synthetic projections use the existing parse-on-read cache-miss path.
- The URL registry shares signal identities within a thread and is released with that thread.
- Hosted-site and text-preview blocks also benefit from write-time parsing. A dedicated preview-signals registry remains outside this PR.

## Verification

- `@vm0/app` lint: passed
- `@vm0/app` production and test TypeScript checks: passed
- `chat-message-action-cards.test.tsx`: 20 tests passed, including external permission-update refresh
- Full Vitest suite and deployment checks are left to the PR pipeline
