### PR TITLE
test(api): deflake artifact dedupe chat test by flushing run-1 completion side effects

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2310,6 +2310,9 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     await chat.completeUploadWithBearer(bearer1, { id: sharedId }, [200]);
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(run1.runId, claim1.sandboxHeaders);
+    // Run 1's completion drains the thread queue via waitUntil side effects;
+    // flush them so the drain cannot claim run 2's queued message first.
+    await flushWaitUntilForTest();
 
     // Run 2 in the same thread re-completes the shared upload: the later
     // run owns the deduplicated URL.


### PR DESCRIPTION
## Summary

Fixes the flaky `chat-threads.bdd.test.ts` → CHAT-03 → `dedupes artifact urls and filters hosted-site runs` test, which failed twice on main within two days with identical signatures:

- [run 29544458431 / job 87773592740](https://github.com/vm0-ai/vm0/actions/runs/29544458431/job/87773592740) (merge queue, PR #21891 — unrelated docs change)
- [run 29533075740 / job 87738033087](https://github.com/vm0-ai/vm0/actions/runs/29533075740/job/87738033087) (main, `ec7ead2c`)

Both failed at the second `sendChatRun` (line 2316) with `Expected the entitled chat send to create a run`, i.e. the send returned **201 with `runId: null`** — the message was queued instead of dispatching a run.

## Root cause

The agent-complete webhook commits the run's terminal status **before** responding, but dispatches its side effects — including the chat-thread queue drain / auto-send of queued messages (`dispatchCompleteSideEffects$` → `autoSendQueuedMessageForThread`) — via `waitUntil(...)` **after** the 200 response (`webhooks-agent-complete.ts`).

This test sent the second message immediately after `completeChatRunOk(run1)`. With the queue-first send flow, that send enqueues the message, then checks for an active run and self-dispatches. If run 1's still-in-flight drain reads the queue first, it claims the new message's queue item and creates the run itself; the send then either observes the drain-created active run (`wait` branch) or finds its queue item already consumed (`drain` branch) — both return 201 with `runId: null`, and the test throws.

Whether the test or the drain wins is pure event-loop timing, hence the flakiness. The product behavior is correct in both interleavings (the message does become a run via auto-send); only the test's assumption of synchronous dispatch was wrong.

## Fix

Add `await flushWaitUntilForTest()` after `completeChatRunOk(run1)`, forcing the completion side effects to drain an empty queue before the second send. The send then always self-dispatches. This matches the barrier pattern already used by every other same-thread complete-then-send test in this file (`:691`, `:711`, `:1703`, `:1734`, `:2813`, `:2905`); this call site was the only one missing it.

## Verification

Not run locally (test-only change; per repo convention the PR pipeline runs the API suite). The change is a 3-line addition inside a single BDD test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)