### PR TITLE
docs(sandbox-fc): document outbound tcp proxy routing

### DIFF
--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -20,7 +20,9 @@ pub struct FirecrackerConfig {
     pub base_dir: PathBuf,
     /// Profile name (e.g., "vm0/default") used for per-profile isolation.
     pub profile: String,
-    /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.
+    /// Host proxy port for outbound TCP redirects. When `dns_port` is also set,
+    /// those redirects exclude TCP 53 and 853: TCP 53 is redirected to
+    /// `dns_port`, while TCP 853 is blocked.
     pub proxy_port: Option<u16>,
     /// Port of the DNS proxy. When set, iptables rules redirect DNS queries through it.
     pub dns_port: Option<u16>,

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -760,8 +760,11 @@ pub(super) fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)>
 // Namespace creation
 // ---------------------------------------------------------------------------
 
-/// Create a single namespace with full connectivity, optionally adding proxy
-/// REDIRECT rules for HTTP/HTTPS traffic.
+/// Create a single namespace with full connectivity, optionally adding a proxy
+/// REDIRECT rule for outbound TCP traffic.
+///
+/// When DNS proxying is enabled, the general proxy redirect excludes TCP 53
+/// and 853: TCP 53 is redirected to the DNS proxy, while TCP 853 is blocked.
 ///
 /// This is a free function (no `&self`) so it can be spawned on a `JoinSet`.
 pub(super) async fn create_single_namespace(

--- a/crates/sandbox-fc/src/network/pool/types.rs
+++ b/crates/sandbox-fc/src/network/pool/types.rs
@@ -138,7 +138,9 @@ impl Drop for NetnsLease {
 /// When both proxy and DNS ports are set, callers must start the DNS service
 /// and call [`super::NetnsPool::activate_dns_readiness`] before acquiring.
 pub struct NetnsPoolConfig {
-    /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
+    /// Host proxy port for outbound TCP redirects. When `dns_port` is also set,
+    /// those redirects exclude TCP 53 and 853: TCP 53 is redirected to
+    /// `dns_port`, while TCP 853 is blocked.
     pub proxy_port: Option<u16>,
     /// DNS proxy port for DNS query redirect. Only meaningful with `proxy_port`.
     pub dns_port: Option<u16>,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,10 +249,14 @@ profiles:
 - Guest fixed IP: `192.168.241.2` (same across VMs, isolated by namespace)
 - NAT/MASQUERADE: Guest traffic routed through namespace to external network
 
-**HTTP Proxy**: mitmproxy (dynamically allocated port)
+**Transparent TCP Proxy**: mitmproxy (dynamically allocated port)
 
-- Intercepts all HTTP/HTTPS traffic
-- Logs requests/responses to per-run JSONL files
+- Redirects outbound TCP through mitmproxy
+- Intercepts HTTP/HTTPS; non-HTTP TCP uses raw TCP passthrough
+- When DNS proxying is enabled, UDP/TCP 53 is redirected to dnsmasq and TCP 853
+  is blocked; TCP 53 and 853 are excluded from the general mitmproxy redirect
+- Logs HTTP requests/responses and raw TCP connection metadata to per-run JSONL
+  files
 - CA certificate injected into VM trust store
 - Proxy registry: `{base_dir}/proxy-registry.json` (flock-based coordination)
 


### PR DESCRIPTION
## Summary

- document that proxy namespaces redirect outbound TCP rather than only HTTP/HTTPS
- describe how configured DNS excludes TCP 53 and 853 from the general proxy path
- update the network architecture with HTTP/HTTPS interception, raw TCP passthrough, and DNS-specific routing

## Scope

Documentation only. This PR does not change iptables rules, proxy or DNS behavior, public configuration shapes, tests, persisted data, or deployment compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `git diff --check`
- pre-commit Rust formatting, workspace Clippy, workspace Rustdoc, and repository file checks

Existing runner E2E coverage already verifies raw TCP passthrough and DNS routing; it was not rerun because executable behavior is unchanged.

Closes #21923
