### PR TITLE
fix(runner): scope interception certificates to tls sni

### DIFF
--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -518,6 +518,8 @@ pub(crate) async fn spawn_mitmdump(
         .arg("--set")
         .arg(format!("confdir={}", config.ca_dir.display()))
         .arg("--set")
+        .arg("upstream_cert=false")
+        .arg("--set")
         .arg(format!(
             "vm0_proxy_registry_path={}",
             config.registry_path.display()
@@ -1050,7 +1052,7 @@ PY
     }
 
     #[tokio::test]
-    async fn spawn_mitmdump_passes_usage_state_id_option() {
+    async fn spawn_mitmdump_passes_runner_options_and_preserves_ca() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         crate::ca::ensure(&home).await.unwrap();
@@ -1090,6 +1092,10 @@ PY
         assert!(
             std::fs::read(home.ca_dir().join(crate::ca::CA_CERT)).unwrap() == original_cert,
             "proxy preparation must not rotate the standalone identity"
+        );
+        assert!(
+            args.lines().any(|arg| arg == "upstream_cert=false"),
+            "mitmdump args should scope generated certificates to TLS SNI; got:\n{args}",
         );
         assert!(
             args.lines()


### PR DESCRIPTION
## Summary

- launch runner mitmdump with `upstream_cert=false` so generated interception
  leaves advertise the TLS SNI instead of copied upstream wildcard or sibling
  SANs
- preserve upstream certificate verification, HTTP/2, strict
  `authority_mismatch` handling, and the existing runner CA
- extend the runner process integration test to lock the production option and
  retain its CA-preservation assertions

## Why

Mitmproxy's default upstream certificate sniffing can copy a wildcard into the
client-facing interception leaf. Chromium may then coalesce a sibling origin
onto that HTTP/2 connection even though the runner intentionally requires HTTP
authority to match the connection's original SNI. Scoping the generated leaf
prevents that invalid pooling decision before a rejected request is sent.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` — 2733 passed, 11 ignored
- repository pre-commit and commit-message hooks
- checksum-verified mitmdump 12.2.2 real TLS proxy handshake:
  - default leaf DNS names: `*.github.com`, `github.com`, `api.github.com`
  - scoped leaf DNS names: `api.github.com`
  - SNI validation passed and sibling validation failed
  - the CA SHA-256 fingerprint remained unchanged across both process starts

## Compatibility and exclusions

- no CA regeneration or persisted-data migration
- no API, runner protocol, registry, or firewall format change
- no 421 response, relaxed authority validation, HTTP/2 disablement, custom TLS
  hook, HTTP/3 change, or telemetry change
- old runners continue draining with their existing process options; new
  mitmdump processes use the scoped certificates

Closes #21920
