### PR TITLE
refactor(mitm-addon): split websocket tests by responsibility

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
@@ -1,0 +1,323 @@
+"""Tests for model-provider WebSocket terminal lifecycle behavior."""
+
+import json
+from pathlib import Path
+
+import pytest
+from mitmproxy import http
+from mitmproxy.flow import Error
+from mitmproxy.test import tutils
+
+import mitm_addon
+import usage
+from tests.model_provider_flow_helpers import (
+    make_openai_responses_websocket_request_flow,
+    make_openai_responses_websocket_response_headers,
+)
+from tests.model_provider_websocket_helpers import feed_websocket_server_message
+from tests.pending_helpers import assert_pending
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+
+
+def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
+    firewall_name = "model-provider:openai-api-key"
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            run_id="run-abc-123",
+            sandbox_marker="tok-xyz",
+            firewall_name=firewall_name,
+            api_entry={
+                "base": "https://api.openai.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "responses", "rules": ["GET /v1/responses"]}],
+            },
+            network_policy={
+                "allow": ["responses"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            billable_firewalls=[firewall_name],
+            vm_fields={
+                "cliAgentType": "codex",
+                "modelUsageProvider": "gpt-5.5",
+            },
+        ),
+    )
+
+
+class TestModelProviderWebSocketLifecycle:
+    """Tests for HTTP upgrade and terminal in-flight lifecycle behavior."""
+
+    async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        usage_webhook_server,
+        sync_usage_executor,
+    ):
+        """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+
+        flow = make_openai_responses_websocket_request_flow(real_flow)
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            usage.write_pending_snapshot(flush_request_id="before-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="before-response",
+            )
+
+            flow.response = tutils.tresp(
+                status_code=101,
+                headers=make_openai_responses_websocket_response_headers(),
+            )
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="after-response",
+            )
+
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_1",
+                            "model": "gpt-5.5",
+                            "usage": {
+                                "input_tokens": 50,
+                                "output_tokens": 20,
+                                "input_tokens_details": {"cached_tokens": 10},
+                            },
+                        },
+                    }
+                ).encode(),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        events = usage_webhook_server.usage_events()
+        assert len(events) == 3
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 40,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+        }
+        observation_events = usage_webhook_server.model_usage_observation_events()
+        assert len(observation_events) == len(events)
+        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
+        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
+        usage.write_pending_snapshot(flush_request_id="after-websocket-end")
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-websocket-end",
+        )
+
+    async def test_non_websocket_switching_protocols_response_releases_usage_flow(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+    ):
+        """A non-WebSocket 101 response is terminal and must not wait for websocket_end()."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.openai.com",
+            path="/v1/responses",
+            method="GET",
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path)),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            usage.write_pending_snapshot(flush_request_id="before-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="before-response",
+            )
+
+            flow.response = tutils.tresp(
+                status_code=101,
+                headers=http.Headers(upgrade="h2c"),
+            )
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-response",
+        )
+
+    @pytest.mark.parametrize(
+        "response_headers",
+        [
+            pytest.param(
+                make_openai_responses_websocket_response_headers(upgrade="h2c"),
+                id="non-websocket-upgrade",
+            ),
+            pytest.param(
+                make_openai_responses_websocket_response_headers(connection=None),
+                id="missing-connection-upgrade",
+            ),
+            pytest.param(
+                make_openai_responses_websocket_response_headers(accept="wrong"),
+                id="wrong-accept",
+            ),
+        ],
+    )
+    async def test_invalid_websocket_switching_protocols_response_releases_usage_flow(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        response_headers: http.Headers,
+    ):
+        """A malformed 101 WebSocket response must not wait for websocket_end()."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+
+        flow = make_openai_responses_websocket_request_flow(real_flow)
+
+        with (
+            mitm_ctx(registry_path=str(reg_path)),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            usage.write_pending_snapshot(flush_request_id="before-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="before-response",
+            )
+
+            flow.response = tutils.tresp(status_code=101, headers=response_headers)
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-response",
+        )
+
+    async def test_model_websocket_error_releases_usage_flow_after_upgrade(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        usage_webhook_server,
+        sync_usage_executor,
+    ):
+        """A WebSocket connection error after HTTP 101 is terminal for usage tracking."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+
+        flow = make_openai_responses_websocket_request_flow(real_flow)
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+            fake_firewall_headers(),
+        ):
+            await mitm_addon.request(flow)
+            flow.response = tutils.tresp(
+                status_code=101,
+                headers=make_openai_responses_websocket_response_headers(),
+            )
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+            assert_pending(
+                pending_path,
+                flows=1,
+                buffered=0,
+                reports=0,
+                flush_request_id="after-response",
+            )
+
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_error",
+                            "model": "gpt-5.5",
+                            "usage": {
+                                "input_tokens": 10,
+                                "output_tokens": 4,
+                            },
+                        },
+                    }
+                ).encode(),
+            )
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+
+        events = usage_webhook_server.usage_events()
+        assert len(events) == 2
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert by_category == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        observation_events = usage_webhook_server.model_usage_observation_events()
+        assert len(observation_events) == len(events)
+        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
+        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
+        usage.write_pending_snapshot(flush_request_id="after-error")
+        assert_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-error",
+        )

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_retention.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_retention.py
@@ -1,0 +1,229 @@
+"""Tests for model-provider WebSocket message retention and cleanup."""
+
+import pytest
+from mitmproxy.flow import Error
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import usage
+from tests.model_provider_flow_helpers import (
+    make_openai_responses_websocket_flow,
+    model_provider_usage_sources,
+)
+from tests.model_provider_websocket_helpers import (
+    ScheduledWebSocketTrim,
+    append_websocket_message,
+    capture_deferred_websocket_trims,
+    openai_websocket_usage_frame,
+    run_deferred_websocket_trims,
+)
+
+
+@pytest.fixture
+def deferred_websocket_trim_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[ScheduledWebSocketTrim]:
+    return capture_deferred_websocket_trims(monkeypatch)
+
+
+def _sum_quantities_by_category(events: list[dict]) -> dict[str, int]:
+    quantities: dict[str, int] = {}
+    for event in events:
+        category = event["category"]
+        quantities[category] = quantities.get(category, 0) + event["quantity"]
+    return quantities
+
+
+class TestModelProviderWebSocketRetentionWithUsageDelivery:
+    """Retention and cleanup tests that also verify delivered usage."""
+
+    @pytest.fixture(autouse=True)
+    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
+        self._usage_webhook_api = usage_webhook_api
+
+    def test_model_websocket_deferred_trim_keeps_latest_server_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        old_client = append_websocket_message(flow, from_client=True, content=b"client-old")
+        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_server = append_websocket_message(
+            flow,
+            from_client=False,
+            content=openai_websocket_usage_frame("resp_ws_latest"),
+        )
+        assert flow.websocket is not None
+        messages = flow.websocket.messages
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert messages == [old_client, old_server, latest_server]
+        assert model_provider_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket.messages is messages
+        assert flow.websocket.messages == [latest_server]
+
+    def test_model_websocket_deferred_trim_coalesces_and_keeps_latest_at_callback(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        first_server = append_websocket_message(
+            flow,
+            from_client=False,
+            content=openai_websocket_usage_frame(
+                "resp_ws_first",
+                input_tokens=1,
+                output_tokens=1,
+            ),
+        )
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
+
+            latest_server = append_websocket_message(
+                flow,
+                from_client=False,
+                content=openai_websocket_usage_frame("resp_ws_latest"),
+            )
+            mitm_addon.websocket_message(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert len(deferred_websocket_trim_scheduler) == 1
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [first_server, latest_server]
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket.messages == [latest_server]
+        assert model_provider_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 11,
+            "tokens.output": 5,
+        }
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+
+    def test_model_websocket_end_clears_final_retained_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        append_websocket_message(
+            flow,
+            from_client=False,
+            content=openai_websocket_usage_frame("resp_ws_1"),
+        )
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+        assert "model_websocket_usage_enabled" not in flow.metadata
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []
+
+    def test_model_websocket_error_clears_final_retained_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        flow.error = Error("connection reset by peer")
+        append_websocket_message(
+            flow,
+            from_client=False,
+            content=openai_websocket_usage_frame("resp_ws_1"),
+        )
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+        assert "model_websocket_usage_enabled" not in flow.metadata
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []
+
+
+class TestModelProviderWebSocketRetention:
+    """Retention tests without usage delivery."""
+
+    def test_model_websocket_deferred_trim_keeps_latest_client_message(
+        self,
+        tmp_path,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
+        latest_client = append_websocket_message(
+            flow,
+            from_client=True,
+            content=openai_websocket_usage_frame("resp_ws_client"),
+        )
+
+        mitm_addon.websocket_message(flow)
+
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+        assert model_provider_usage_sources(flow) == {}
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [latest_client]
+        assert old_server not in flow.websocket.messages
+
+    def test_non_model_websocket_message_retention_is_unchanged(
+        self,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = real_flow(with_response=False, host="example.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        first = append_websocket_message(flow, from_client=True, content=b"client")
+        second = append_websocket_message(flow, from_client=False, content=b"server")
+
+        mitm_addon.websocket_message(flow)
+
+        assert deferred_websocket_trim_scheduler == []
+        assert flow.websocket is not None
+        assert flow.websocket.messages == [first, second]

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import pytest
 from mitmproxy import http
-from mitmproxy.flow import Error
-from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
@@ -15,22 +13,16 @@ import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
-    make_openai_responses_websocket_request_flow,
-    make_openai_responses_websocket_response_headers,
     model_provider_usage_sources,
 )
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
-    append_websocket_message,
     capture_deferred_websocket_trims,
     feed_websocket_server_message,
     feed_websocket_server_text_message,
     openai_websocket_usage_frame,
-    run_deferred_websocket_trims,
     set_websocket_message,
 )
-from tests.pending_helpers import assert_pending
-from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 
 @pytest.fixture(autouse=True)
@@ -38,35 +30,6 @@ def deferred_websocket_trim_scheduler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> list[ScheduledWebSocketTrim]:
     return capture_deferred_websocket_trims(monkeypatch)
-
-
-def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
-    firewall_name = "model-provider:openai-api-key"
-    return _write_registry(
-        tmp_path,
-        vm_info=_single_firewall_vm(
-            tmp_path,
-            run_id="run-abc-123",
-            sandbox_marker="tok-xyz",
-            firewall_name=firewall_name,
-            api_entry={
-                "base": "https://api.openai.com",
-                "auth": {"headers": {"Authorization": "Bearer token"}},
-                "permissions": [{"name": "responses", "rules": ["GET /v1/responses"]}],
-            },
-            network_policy={
-                "allow": ["responses"],
-                "deny": [],
-                "ask": [],
-                "unknownPolicy": "deny",
-            },
-            billable_firewalls=[firewall_name],
-            vm_fields={
-                "cliAgentType": "codex",
-                "modelUsageProvider": "gpt-5.5",
-            },
-        ),
-    )
 
 
 def _sum_quantities_by_category(events: list[dict]) -> dict[str, int]:
@@ -102,91 +65,8 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
     ).encode()
 
 
-class TestModelProviderWebSocketUsage:
-    """Tests for model-provider WebSocket usage reporting."""
-
-    @pytest.fixture(autouse=True)
-    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
-        self._usage_webhook_api = usage_webhook_api
-
-    def _run_response(self, flow: http.HTTPFlow):
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.response(flow)
-            usage.flush_usage_events(trigger="test")
-        return webhook
-
-    def _run_error(self, flow: http.HTTPFlow):
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.error(flow)
-            usage.flush_usage_events(trigger="test")
-        return webhook
-
-    def _run_websocket_end(self, flow: http.HTTPFlow):
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-        return webhook
-
-    def _run_websocket_messages_and_end(self, flow: http.HTTPFlow, *messages: bytes):
-        with self._usage_webhook_api() as webhook:
-            for message in messages:
-                feed_websocket_server_message(flow, message)
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-        return webhook
-
-    def _run_websocket_message_and_end(self, flow: http.HTTPFlow):
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-        return webhook
-
-    def test_full_pipeline_model_websocket_reports_usage(self, tmp_path, real_flow):
-        """Codex Responses WebSocket frames should bill like SSE events."""
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        assert flow.metadata["model_websocket_usage_enabled"] is True
-        assert "model_json_usage_finish" not in flow.metadata
-        assert "model_sse_usage_finish" not in flow.metadata
-        assert metadata_keys.STREAM_BUFFER not in flow.metadata
-        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
-
-        set_websocket_message(
-            flow,
-            from_client=False,
-            content=json.dumps(
-                {
-                    "type": "response.completed",
-                    "response": {
-                        "id": "resp_ws_1",
-                        "model": "gpt-5.5",
-                        "usage": {
-                            "input_tokens": 50,
-                            "output_tokens": 20,
-                            "input_tokens_details": {
-                                "cached_tokens": 10,
-                                "cache_write_tokens": 15,
-                            },
-                        },
-                    },
-                }
-            ).encode(),
-        )
-
-        webhook = self._run_websocket_message_and_end(flow)
-
-        events = webhook.usage_events()
-        by_category = _sum_quantities_by_category(events)
-        assert len(events) == len(by_category)
-        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert model_provider_usage_sources(flow) == {}
-        assert by_category == {
-            "tokens.input": 25,
-            "tokens.output": 20,
-            "tokens.cache_read": 10,
-            "tokens.cache_creation": 15,
-        }
+class TestModelProviderWebSocketUsageSourceRelease:
+    """Tests for sources that cannot be delivered to the usage webhook."""
 
     def test_model_websocket_missing_context_releases_positive_source(
         self, tmp_path, real_flow, mitm_ctx
@@ -289,6 +169,75 @@ class TestModelProviderWebSocketUsage:
 
         assert model_provider_usage_sources(flow) == {}
         assert not jsonl_exists_after_flush(proxy_log)
+
+
+class TestModelProviderWebSocketUsage:
+    """Tests for model-provider WebSocket usage reporting."""
+
+    @pytest.fixture(autouse=True)
+    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
+        self._usage_webhook_api = usage_webhook_api
+
+    def _run_websocket_messages_and_end(self, flow: http.HTTPFlow, *messages: bytes):
+        with self._usage_webhook_api() as webhook:
+            for message in messages:
+                feed_websocket_server_message(flow, message)
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def _run_websocket_message_and_end(self, flow: http.HTTPFlow):
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def test_full_pipeline_model_websocket_reports_usage(self, tmp_path, real_flow):
+        """Codex Responses WebSocket frames should bill like SSE events."""
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        assert flow.metadata["model_websocket_usage_enabled"] is True
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+
+        set_websocket_message(
+            flow,
+            from_client=False,
+            content=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 50,
+                            "output_tokens": 20,
+                            "input_tokens_details": {
+                                "cached_tokens": 10,
+                                "cache_write_tokens": 15,
+                            },
+                        },
+                    },
+                }
+            ).encode(),
+        )
+
+        webhook = self._run_websocket_message_and_end(flow)
+
+        events = webhook.usage_events()
+        by_category = _sum_quantities_by_category(events)
+        assert len(events) == len(by_category)
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+        assert model_provider_usage_sources(flow) == {}
+        assert by_category == {
+            "tokens.input": 25,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+            "tokens.cache_creation": 15,
+        }
 
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
@@ -833,277 +782,6 @@ class TestModelProviderWebSocketUsage:
         assert observations_by_category == by_category
         assert model_provider_usage_sources(flow) == {}
 
-    async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
-        self,
-        tmp_path,
-        real_flow,
-        mitm_ctx,
-        fake_firewall_headers,
-        usage_webhook_server,
-    ):
-        """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
-        reg_path = _write_openai_model_websocket_registry(tmp_path)
-
-        flow = make_openai_responses_websocket_request_flow(real_flow)
-
-        with (
-            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
-            fake_firewall_headers(),
-        ):
-            await mitm_addon.request(flow)
-            usage.write_pending_snapshot(flush_request_id="before-response")
-            assert_pending(
-                pending_path,
-                flows=1,
-                buffered=0,
-                reports=0,
-                flush_request_id="before-response",
-            )
-
-            flow.response = tutils.tresp(
-                status_code=101,
-                headers=make_openai_responses_websocket_response_headers(),
-            )
-            mitm_addon.responseheaders(flow)
-            mitm_addon.response(flow)
-            usage.write_pending_snapshot(flush_request_id="after-response")
-            assert_pending(
-                pending_path,
-                flows=1,
-                buffered=0,
-                reports=0,
-                flush_request_id="after-response",
-            )
-
-            feed_websocket_server_message(
-                flow,
-                json.dumps(
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": "resp_ws_1",
-                            "model": "gpt-5.5",
-                            "usage": {
-                                "input_tokens": 50,
-                                "output_tokens": 20,
-                                "input_tokens_details": {"cached_tokens": 10},
-                            },
-                        },
-                    }
-                ).encode(),
-            )
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-
-        events = usage_webhook_server.usage_events()
-        assert len(events) == 3
-        by_category = {event["category"]: event["quantity"] for event in events}
-        assert by_category == {
-            "tokens.input": 40,
-            "tokens.output": 20,
-            "tokens.cache_read": 10,
-        }
-        observation_events = usage_webhook_server.model_usage_observation_events()
-        assert len(observation_events) == len(events)
-        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
-        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
-        usage.write_pending_snapshot(flush_request_id="after-websocket-end")
-        assert_pending(
-            pending_path,
-            flows=0,
-            buffered=0,
-            reports=0,
-            flush_request_id="after-websocket-end",
-        )
-
-    async def test_non_websocket_switching_protocols_response_releases_usage_flow(
-        self,
-        tmp_path,
-        real_flow,
-        mitm_ctx,
-        fake_firewall_headers,
-        usage_webhook_server,
-    ):
-        """A non-WebSocket 101 response is terminal and must not wait for websocket_end()."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
-        reg_path = _write_openai_model_websocket_registry(tmp_path)
-
-        flow = real_flow(
-            with_response=False,
-            client_ip="10.200.0.5",
-            host="api.openai.com",
-            path="/v1/responses",
-            method="GET",
-        )
-
-        with (
-            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
-            fake_firewall_headers(),
-        ):
-            await mitm_addon.request(flow)
-            usage.write_pending_snapshot(flush_request_id="before-response")
-            assert_pending(
-                pending_path,
-                flows=1,
-                buffered=0,
-                reports=0,
-                flush_request_id="before-response",
-            )
-
-            flow.response = tutils.tresp(
-                status_code=101,
-                headers=http.Headers(upgrade="h2c"),
-            )
-            mitm_addon.responseheaders(flow)
-            mitm_addon.response(flow)
-            usage.write_pending_snapshot(flush_request_id="after-response")
-
-        assert_pending(
-            pending_path,
-            flows=0,
-            buffered=0,
-            reports=0,
-            flush_request_id="after-response",
-        )
-
-    @pytest.mark.parametrize(
-        "response_headers",
-        [
-            pytest.param(
-                make_openai_responses_websocket_response_headers(upgrade="h2c"),
-                id="non-websocket-upgrade",
-            ),
-            pytest.param(
-                make_openai_responses_websocket_response_headers(connection=None),
-                id="missing-connection-upgrade",
-            ),
-            pytest.param(
-                make_openai_responses_websocket_response_headers(accept="wrong"),
-                id="wrong-accept",
-            ),
-        ],
-    )
-    async def test_invalid_websocket_switching_protocols_response_releases_usage_flow(
-        self,
-        tmp_path,
-        real_flow,
-        mitm_ctx,
-        fake_firewall_headers,
-        usage_webhook_server,
-        response_headers: http.Headers,
-    ):
-        """A malformed 101 WebSocket response must not wait for websocket_end()."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
-        reg_path = _write_openai_model_websocket_registry(tmp_path)
-
-        flow = make_openai_responses_websocket_request_flow(real_flow)
-
-        with (
-            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
-            fake_firewall_headers(),
-        ):
-            await mitm_addon.request(flow)
-            usage.write_pending_snapshot(flush_request_id="before-response")
-            assert_pending(
-                pending_path,
-                flows=1,
-                buffered=0,
-                reports=0,
-                flush_request_id="before-response",
-            )
-
-            flow.response = tutils.tresp(status_code=101, headers=response_headers)
-            mitm_addon.responseheaders(flow)
-            mitm_addon.response(flow)
-            usage.write_pending_snapshot(flush_request_id="after-response")
-
-        assert_pending(
-            pending_path,
-            flows=0,
-            buffered=0,
-            reports=0,
-            flush_request_id="after-response",
-        )
-
-    async def test_model_websocket_error_releases_usage_flow_after_upgrade(
-        self,
-        tmp_path,
-        real_flow,
-        mitm_ctx,
-        fake_firewall_headers,
-        usage_webhook_server,
-    ):
-        """A WebSocket connection error after HTTP 101 is terminal for usage tracking."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
-        reg_path = _write_openai_model_websocket_registry(tmp_path)
-
-        flow = make_openai_responses_websocket_request_flow(real_flow)
-
-        with (
-            mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
-            fake_firewall_headers(),
-        ):
-            await mitm_addon.request(flow)
-            flow.response = tutils.tresp(
-                status_code=101,
-                headers=make_openai_responses_websocket_response_headers(),
-            )
-            mitm_addon.responseheaders(flow)
-            mitm_addon.response(flow)
-            usage.write_pending_snapshot(flush_request_id="after-response")
-            assert_pending(
-                pending_path,
-                flows=1,
-                buffered=0,
-                reports=0,
-                flush_request_id="after-response",
-            )
-
-            feed_websocket_server_message(
-                flow,
-                json.dumps(
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": "resp_ws_error",
-                            "model": "gpt-5.5",
-                            "usage": {
-                                "input_tokens": 10,
-                                "output_tokens": 4,
-                            },
-                        },
-                    }
-                ).encode(),
-            )
-            flow.error = Error("connection reset by peer")
-            mitm_addon.error(flow)
-            usage.flush_usage_events(trigger="test")
-
-        events = usage_webhook_server.usage_events()
-        assert len(events) == 2
-        by_category = {event["category"]: event["quantity"] for event in events}
-        assert by_category == {
-            "tokens.input": 10,
-            "tokens.output": 4,
-        }
-        observation_events = usage_webhook_server.model_usage_observation_events()
-        assert len(observation_events) == len(events)
-        assert {event["category"]: event["quantity"] for event in observation_events} == by_category
-        assert {event["model"] for event in observation_events} == {"gpt-5.5"}
-        usage.write_pending_snapshot(flush_request_id="after-error")
-        assert_pending(
-            pending_path,
-            flows=0,
-            buffered=0,
-            reports=0,
-            flush_request_id="after-error",
-        )
-
     def test_full_pipeline_model_websocket_zero_frame_preserves_billed_usage_and_id(
         self, tmp_path, real_flow
     ):
@@ -1177,186 +855,3 @@ class TestModelProviderWebSocketUsage:
         assert webhook.request_count == 0
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert model_provider_usage_sources(flow) == {}
-
-    def test_model_websocket_deferred_trim_keeps_latest_server_message(
-        self,
-        tmp_path,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        old_client = append_websocket_message(flow, from_client=True, content=b"client-old")
-        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
-        latest_server = append_websocket_message(
-            flow,
-            from_client=False,
-            content=openai_websocket_usage_frame("resp_ws_latest"),
-        )
-        assert flow.websocket is not None
-        messages = flow.websocket.messages
-
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            usage.flush_usage_events(trigger="test")
-
-        assert messages == [old_client, old_server, latest_server]
-        assert model_provider_usage_sources(flow) == {}
-        assert _sum_quantities_by_category(webhook.usage_events()) == {
-            "tokens.input": 10,
-            "tokens.output": 4,
-        }
-        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert len(deferred_websocket_trim_scheduler) == 1
-
-        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
-
-        assert flow.websocket.messages is messages
-        assert flow.websocket.messages == [latest_server]
-
-    def test_model_websocket_deferred_trim_keeps_latest_client_message(
-        self,
-        tmp_path,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
-        latest_client = append_websocket_message(
-            flow,
-            from_client=True,
-            content=openai_websocket_usage_frame("resp_ws_client"),
-        )
-
-        mitm_addon.websocket_message(flow)
-
-        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-        assert model_provider_usage_sources(flow) == {}
-        assert len(deferred_websocket_trim_scheduler) == 1
-
-        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
-
-        assert flow.websocket is not None
-        assert flow.websocket.messages == [latest_client]
-        assert old_server not in flow.websocket.messages
-
-    def test_model_websocket_deferred_trim_coalesces_and_keeps_latest_at_callback(
-        self,
-        tmp_path,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        first_server = append_websocket_message(
-            flow,
-            from_client=False,
-            content=openai_websocket_usage_frame(
-                "resp_ws_first",
-                input_tokens=1,
-                output_tokens=1,
-            ),
-        )
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            assert len(deferred_websocket_trim_scheduler) == 1
-
-            latest_server = append_websocket_message(
-                flow,
-                from_client=False,
-                content=openai_websocket_usage_frame("resp_ws_latest"),
-            )
-            mitm_addon.websocket_message(flow)
-            usage.flush_usage_events(trigger="test")
-
-        assert len(deferred_websocket_trim_scheduler) == 1
-        assert flow.websocket is not None
-        assert flow.websocket.messages == [first_server, latest_server]
-
-        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
-
-        assert flow.websocket.messages == [latest_server]
-        assert model_provider_usage_sources(flow) == {}
-        assert _sum_quantities_by_category(webhook.usage_events()) == {
-            "tokens.input": 11,
-            "tokens.output": 5,
-        }
-        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
-
-    def test_non_model_websocket_message_retention_is_unchanged(
-        self,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = real_flow(with_response=False, host="example.com")
-        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
-        first = append_websocket_message(flow, from_client=True, content=b"client")
-        second = append_websocket_message(flow, from_client=False, content=b"server")
-
-        mitm_addon.websocket_message(flow)
-
-        assert deferred_websocket_trim_scheduler == []
-        assert flow.websocket is not None
-        assert flow.websocket.messages == [first, second]
-
-    def test_model_websocket_end_clears_final_retained_message(
-        self,
-        tmp_path,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        append_websocket_message(
-            flow,
-            from_client=False,
-            content=openai_websocket_usage_frame("resp_ws_1"),
-        )
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            assert len(deferred_websocket_trim_scheduler) == 1
-            mitm_addon.websocket_end(flow)
-            usage.flush_usage_events(trigger="test")
-
-        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
-            "tokens.input": 10,
-            "tokens.output": 4,
-        }
-        assert flow.websocket is not None
-        assert flow.websocket.messages == []
-        assert "model_websocket_usage_enabled" not in flow.metadata
-
-        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
-        assert flow.websocket.messages == []
-
-    def test_model_websocket_error_clears_final_retained_message(
-        self,
-        tmp_path,
-        real_flow,
-        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
-    ):
-        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-        mitm_addon.responseheaders(flow)
-        flow.error = Error("connection reset by peer")
-        append_websocket_message(
-            flow,
-            from_client=False,
-            content=openai_websocket_usage_frame("resp_ws_1"),
-        )
-        with self._usage_webhook_api() as webhook:
-            mitm_addon.websocket_message(flow)
-            assert len(deferred_websocket_trim_scheduler) == 1
-            mitm_addon.error(flow)
-            usage.flush_usage_events(trigger="test")
-
-        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
-            "tokens.input": 10,
-            "tokens.output": 4,
-        }
-        assert flow.websocket is not None
-        assert flow.websocket.messages == []
-        assert "model_websocket_usage_enabled" not in flow.metadata
-
-        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
-        assert flow.websocket.messages == []

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -26,93 +26,95 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 
 ## Test Files
 
-| File | Tests |
-|------|-------|
-| `test_addon_configuration.py` | Addon option registration and configuration updates |
-| `test_builtin_host_policy_contract.py` | Cross-stage malformed built-in host policy contracts |
-| `test_request_handler_passthrough.py` | Request pass-through, auto-allow, and browser user-agent passthrough decisions |
-| `test_request_handler_authority_validation.py` | HTTPS authority validation before firewall auth |
-| `test_request_handler_firewall_dispatch.py` | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |
-| `test_request_handler_public_destination.py` | Request-hook public destination validation and revalidation |
-| `test_request_handler_connector_diagnostics.py` | Request-hook connector diagnostics and inactive built-in connector diagnostics |
-| `test_request_handler_auth_base_body.py` | Request-hook auth-base body admission and cleanup |
-| `test_request_handler_usage_tracking.py` | Request-hook billable usage tracking lifecycle |
-| `test_response_headers_handler.py` | Response-header hook stream setup |
-| `test_response_handler_connector_diagnostics.py` | Response-hook connector diagnostic replacement and streaming lifecycle |
-| `test_response_handler_logging.py` | Response-hook network/proxy logging, size accounting, and body capture |
-| `test_response_handler_auth_recovery.py` | Response-hook 401 firewall-auth cache invalidation and refresh recovery |
-| `test_response_handler_cleanup.py` | Response-hook terminal request/response stream-state cleanup |
-| `test_error_handler.py` | Error hook logging and usage cleanup |
-| `test_done_hook.py` | Shutdown hook usage flush and executor cleanup |
-| `test_runner_usage_flush_signal.py` | Runner-triggered usage and JSONL flush requests |
-| `test_tls_clienthello_hook.py` | TLS clienthello admission behavior |
-| `test_tcp_hooks.py` | TCP start, logging, message drain, end, and error hooks |
-| `test_registry_loading.py` | Registry loading, parsing, unavailable-state, and cache behavior |
-| `test_registry_auth_cache_eviction.py` | Registry-driven auth-cache ownership and eviction behavior |
-| `test_registry_context.py` | VM lookup and public compiled context API behavior |
-| `test_registry_builtin_cache.py` | Registry built-in firewall resolution and compiled-core cache behavior |
-| `test_registry_builtin_base_url_vars.py` | Registry built-in base URL variable resolution and validation |
-| `test_registry_context_state.py` | Registry compiled context reload, unavailable-state, and malformed-shape behavior |
-| `test_matching_path.py` | Low-level firewall path matching |
-| `test_matching_host.py` | Low-level firewall host matching |
-| `test_matching_path_prefix.py` | Low-level firewall path-prefix matching |
-| `test_matching_base_url_static.py` | Static firewall base URL matching and authority normalization |
-| `test_matching_base_url_parameterized.py` | Parameterized firewall base URL matching |
-| `test_matching_mixed_segments.py` | Mixed parameter-segment matcher regressions |
-| `test_matching_anthropic_firewall_scope.py` | Anthropic firewall scope matching regressions |
-| `test_firewall_request_matching.py` | Raw firewall request matching through the compiled matcher |
-| `test_firewall_request_base_matching.py` | Request-layer firewall base URL matching through raw firewall config |
-| `test_firewall_request_rel_path.py` | Request-layer `rel_path` propagation through raw firewall config |
-| `test_firewall_network_policy_decisions.py` | Request-layer network policy decision behavior |
-| `test_compiled_firewall_base_path_matching.py` | Compiled firewall base path, rule path, segment boundary, and path syntax matching |
-| `test_compiled_firewall_host_base_matching.py` | Compiled firewall host-parameterized base matching |
-| `test_compiled_firewall_authority_normalization.py` | Compiled firewall runtime URL, authority, and port normalization |
-| `test_compiled_firewall_idna_matching.py` | Compiled firewall IDNA authority matching and compatibility-alias rejection |
-| `test_compiled_firewall_unknown_policy.py` | Compiled firewall unknown-policy and unsafe-path behavior |
-| `test_compiled_firewall_base_specificity_precedence.py` | Compiled firewall base specificity precedence |
-| `test_compiled_firewall_cross_firewall_precedence.py` | Compiled firewall cross-firewall and permission ordering precedence |
-| `test_compiled_firewall_malformed_auth.py` | Compiled firewall malformed auth config behavior |
-| `test_compiled_firewall_malformed_base.py` | Compiled firewall malformed base and base-scope behavior |
-| `test_compiled_firewall_malformed_permissions.py` | Compiled firewall malformed permission behavior |
-| `test_compiled_firewall_malformed_policies.py` | Compiled firewall malformed policy and payload-shape behavior |
-| `test_compiled_firewall_malformed_precedence.py` | Compiled firewall malformed config and malformed network-policy precedence |
-| `test_compiled_firewall_malformed_rules.py` | Compiled firewall malformed rule and rule-shape behavior |
-| `test_compiled_firewall_permission_aggregation.py` | Compiled firewall denied-permission aggregation and deduplication |
-| `test_compiled_firewall_rule_specificity_precedence.py` | Compiled firewall rule ordering and rule specificity precedence |
-| `test_firewall_auth.py` | Firewall auth header resolution, fetching, forwarding, and cleanup |
-| `test_auth_base_forwarder.py` | Low-level auth.base forwarding, header filtering, and cleanup |
-| `test_firewall_rewrite_success.py` | Firewall auth URL rewrite success behavior |
-| `test_firewall_rewrite_forwarding.py` | Firewall auth URL rewrite forwarding behavior |
-| `test_firewall_rewrite_safety.py` | Firewall auth URL rewrite fail-closed and safety behavior |
-| `test_auth_query_injection.py` | Firewall auth query injection and query rewrite behavior |
-| `test_url_utils.py` | Rewrite URL, path, query, and auth-base URL utility cases |
-| `test_url_utils_trusted_authority.py` | Trusted request authority success and URL reconstruction |
-| `test_url_utils_trusted_authority_rejection.py` | Trusted request authority rejection matrices |
-| `test_auth_cache.py` | Firewall auth cache behavior |
-| `test_body_capture_decompression.py` | Capture-level body decompression integration |
-| `test_body_capture_encoding.py` | Body capture text detection, encoding, and UTF-8 truncation helpers |
-| `test_body_capture_fields.py` | Ordinary request/response body capture fields |
-| `test_body_capture_headers.py` | Captured network-log header sanitization |
-| `test_body_capture_stream_buffer.py` | Body capture stream-buffer contracts |
-| `test_body_decoding.py` | Shared body decoding, streaming decode, codec limits, and decompression errors |
-| `test_anthropic_messages.py` | Anthropic Messages SSE and JSON usage extraction |
-| `test_openai_responses_event_json.py` | OpenAI Responses event JSON usage extraction and merge behavior |
-| `test_openai_responses_json.py` | OpenAI Responses non-SSE JSON usage extraction |
-| `test_openai_responses_sse.py` | OpenAI Responses SSE usage extraction |
-| `test_response_streaming.py` | Response streaming parser setup |
-| `test_model_provider_json_fallback.py` | Model provider buffered JSON fallback usage pipeline |
-| `test_model_provider_json_streaming.py` | Model provider streaming JSON response usage pipeline |
-| `test_model_provider_sse_usage.py` | Model provider SSE usage pipeline |
-| `test_model_provider_websocket_usage.py` | Model provider WebSocket usage reporting pipeline |
-| `test_model_provider_websocket_metadata.py` | Model provider WebSocket usage metadata parsing |
-| `test_model_provider_usage.py` | Model provider usage reporter |
-| `x_connector_usage/` | Direct X connector usage billing, write refinement, unparseable fallback, and skip gates |
-| `test_connector_usage.py` | Connector usage reporter and stream-path detection |
-| `test_usage_idempotency.py` | Usage event idempotency key helpers |
-| `test_usage_reporting_idempotency.py` | Hook-level usage reporting idempotency |
-| `test_webhook_delivery_admission.py` | Usage webhook delivery admission, capacity, pending counter, and executor fallback behavior |
-| `test_webhook_http_delivery.py` | Usage webhook HTTP delivery, retry, request, and log behavior |
-| `test_counters.py` | Usage pending counters |
+| File                                                    | Tests                                                                                                                |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `test_addon_configuration.py`                           | Addon option registration and configuration updates                                                                  |
+| `test_builtin_host_policy_contract.py`                  | Cross-stage malformed built-in host policy contracts                                                                 |
+| `test_request_handler_passthrough.py`                   | Request pass-through, auto-allow, and browser user-agent passthrough decisions                                       |
+| `test_request_handler_authority_validation.py`          | HTTPS authority validation before firewall auth                                                                      |
+| `test_request_handler_firewall_dispatch.py`             | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |
+| `test_request_handler_public_destination.py`            | Request-hook public destination validation and revalidation                                                          |
+| `test_request_handler_connector_diagnostics.py`         | Request-hook connector diagnostics and inactive built-in connector diagnostics                                       |
+| `test_request_handler_auth_base_body.py`                | Request-hook auth-base body admission and cleanup                                                                    |
+| `test_request_handler_usage_tracking.py`                | Request-hook billable usage tracking lifecycle                                                                       |
+| `test_response_headers_handler.py`                      | Response-header hook stream setup                                                                                    |
+| `test_response_handler_connector_diagnostics.py`        | Response-hook connector diagnostic replacement and streaming lifecycle                                               |
+| `test_response_handler_logging.py`                      | Response-hook network/proxy logging, size accounting, and body capture                                               |
+| `test_response_handler_auth_recovery.py`                | Response-hook 401 firewall-auth cache invalidation and refresh recovery                                              |
+| `test_response_handler_cleanup.py`                      | Response-hook terminal request/response stream-state cleanup                                                         |
+| `test_error_handler.py`                                 | Error hook logging and usage cleanup                                                                                 |
+| `test_done_hook.py`                                     | Shutdown hook usage flush and executor cleanup                                                                       |
+| `test_runner_usage_flush_signal.py`                     | Runner-triggered usage and JSONL flush requests                                                                      |
+| `test_tls_clienthello_hook.py`                          | TLS clienthello admission behavior                                                                                   |
+| `test_tcp_hooks.py`                                     | TCP start, logging, message drain, end, and error hooks                                                              |
+| `test_registry_loading.py`                              | Registry loading, parsing, unavailable-state, and cache behavior                                                     |
+| `test_registry_auth_cache_eviction.py`                  | Registry-driven auth-cache ownership and eviction behavior                                                           |
+| `test_registry_context.py`                              | VM lookup and public compiled context API behavior                                                                   |
+| `test_registry_builtin_cache.py`                        | Registry built-in firewall resolution and compiled-core cache behavior                                               |
+| `test_registry_builtin_base_url_vars.py`                | Registry built-in base URL variable resolution and validation                                                        |
+| `test_registry_context_state.py`                        | Registry compiled context reload, unavailable-state, and malformed-shape behavior                                    |
+| `test_matching_path.py`                                 | Low-level firewall path matching                                                                                     |
+| `test_matching_host.py`                                 | Low-level firewall host matching                                                                                     |
+| `test_matching_path_prefix.py`                          | Low-level firewall path-prefix matching                                                                              |
+| `test_matching_base_url_static.py`                      | Static firewall base URL matching and authority normalization                                                        |
+| `test_matching_base_url_parameterized.py`               | Parameterized firewall base URL matching                                                                             |
+| `test_matching_mixed_segments.py`                       | Mixed parameter-segment matcher regressions                                                                          |
+| `test_matching_anthropic_firewall_scope.py`             | Anthropic firewall scope matching regressions                                                                        |
+| `test_firewall_request_matching.py`                     | Raw firewall request matching through the compiled matcher                                                           |
+| `test_firewall_request_base_matching.py`                | Request-layer firewall base URL matching through raw firewall config                                                 |
+| `test_firewall_request_rel_path.py`                     | Request-layer `rel_path` propagation through raw firewall config                                                     |
+| `test_firewall_network_policy_decisions.py`             | Request-layer network policy decision behavior                                                                       |
+| `test_compiled_firewall_base_path_matching.py`          | Compiled firewall base path, rule path, segment boundary, and path syntax matching                                   |
+| `test_compiled_firewall_host_base_matching.py`          | Compiled firewall host-parameterized base matching                                                                   |
+| `test_compiled_firewall_authority_normalization.py`     | Compiled firewall runtime URL, authority, and port normalization                                                     |
+| `test_compiled_firewall_idna_matching.py`               | Compiled firewall IDNA authority matching and compatibility-alias rejection                                          |
+| `test_compiled_firewall_unknown_policy.py`              | Compiled firewall unknown-policy and unsafe-path behavior                                                            |
+| `test_compiled_firewall_base_specificity_precedence.py` | Compiled firewall base specificity precedence                                                                        |
+| `test_compiled_firewall_cross_firewall_precedence.py`   | Compiled firewall cross-firewall and permission ordering precedence                                                  |
+| `test_compiled_firewall_malformed_auth.py`              | Compiled firewall malformed auth config behavior                                                                     |
+| `test_compiled_firewall_malformed_base.py`              | Compiled firewall malformed base and base-scope behavior                                                             |
+| `test_compiled_firewall_malformed_permissions.py`       | Compiled firewall malformed permission behavior                                                                      |
+| `test_compiled_firewall_malformed_policies.py`          | Compiled firewall malformed policy and payload-shape behavior                                                        |
+| `test_compiled_firewall_malformed_precedence.py`        | Compiled firewall malformed config and malformed network-policy precedence                                           |
+| `test_compiled_firewall_malformed_rules.py`             | Compiled firewall malformed rule and rule-shape behavior                                                             |
+| `test_compiled_firewall_permission_aggregation.py`      | Compiled firewall denied-permission aggregation and deduplication                                                    |
+| `test_compiled_firewall_rule_specificity_precedence.py` | Compiled firewall rule ordering and rule specificity precedence                                                      |
+| `test_firewall_auth.py`                                 | Firewall auth header resolution, fetching, forwarding, and cleanup                                                   |
+| `test_auth_base_forwarder.py`                           | Low-level auth.base forwarding, header filtering, and cleanup                                                        |
+| `test_firewall_rewrite_success.py`                      | Firewall auth URL rewrite success behavior                                                                           |
+| `test_firewall_rewrite_forwarding.py`                   | Firewall auth URL rewrite forwarding behavior                                                                        |
+| `test_firewall_rewrite_safety.py`                       | Firewall auth URL rewrite fail-closed and safety behavior                                                            |
+| `test_auth_query_injection.py`                          | Firewall auth query injection and query rewrite behavior                                                             |
+| `test_url_utils.py`                                     | Rewrite URL, path, query, and auth-base URL utility cases                                                            |
+| `test_url_utils_trusted_authority.py`                   | Trusted request authority success and URL reconstruction                                                             |
+| `test_url_utils_trusted_authority_rejection.py`         | Trusted request authority rejection matrices                                                                         |
+| `test_auth_cache.py`                                    | Firewall auth cache behavior                                                                                         |
+| `test_body_capture_decompression.py`                    | Capture-level body decompression integration                                                                         |
+| `test_body_capture_encoding.py`                         | Body capture text detection, encoding, and UTF-8 truncation helpers                                                  |
+| `test_body_capture_fields.py`                           | Ordinary request/response body capture fields                                                                        |
+| `test_body_capture_headers.py`                          | Captured network-log header sanitization                                                                             |
+| `test_body_capture_stream_buffer.py`                    | Body capture stream-buffer contracts                                                                                 |
+| `test_body_decoding.py`                                 | Shared body decoding, streaming decode, codec limits, and decompression errors                                       |
+| `test_anthropic_messages.py`                            | Anthropic Messages SSE and JSON usage extraction                                                                     |
+| `test_openai_responses_event_json.py`                   | OpenAI Responses event JSON usage extraction and merge behavior                                                      |
+| `test_openai_responses_json.py`                         | OpenAI Responses non-SSE JSON usage extraction                                                                       |
+| `test_openai_responses_sse.py`                          | OpenAI Responses SSE usage extraction                                                                                |
+| `test_response_streaming.py`                            | Response streaming parser setup                                                                                      |
+| `test_model_provider_json_fallback.py`                  | Model provider buffered JSON fallback usage pipeline                                                                 |
+| `test_model_provider_json_streaming.py`                 | Model provider streaming JSON response usage pipeline                                                                |
+| `test_model_provider_sse_usage.py`                      | Model provider SSE usage pipeline                                                                                    |
+| `test_model_provider_websocket_usage.py`                | Model provider WebSocket usage reporting and source reconciliation                                                   |
+| `test_model_provider_websocket_lifecycle.py`            | Model provider WebSocket HTTP upgrade and terminal usage lifecycle                                                   |
+| `test_model_provider_websocket_retention.py`            | Model provider WebSocket message retention and cleanup                                                               |
+| `test_model_provider_websocket_metadata.py`             | Model provider WebSocket usage metadata parsing                                                                      |
+| `test_model_provider_usage.py`                          | Model provider usage reporter                                                                                        |
+| `x_connector_usage/`                                    | Direct X connector usage billing, write refinement, unparseable fallback, and skip gates                             |
+| `test_connector_usage.py`                               | Connector usage reporter and stream-path detection                                                                   |
+| `test_usage_idempotency.py`                             | Usage event idempotency key helpers                                                                                  |
+| `test_usage_reporting_idempotency.py`                   | Hook-level usage reporting idempotency                                                                               |
+| `test_webhook_delivery_admission.py`                    | Usage webhook delivery admission, capacity, pending counter, and executor fallback behavior                          |
+| `test_webhook_http_delivery.py`                         | Usage webhook HTTP delivery, retry, request, and log behavior                                                        |
+| `test_counters.py`                                      | Usage pending counters                                                                                               |
 
 ## Patterns
 


### PR DESCRIPTION
## Summary

- split model-provider WebSocket tests into focused usage, lifecycle, and retention modules
- scope webhook delivery and deferred callback fixtures to the tests that exercise them
- remove three unused lifecycle test helpers while preserving all 32 test definitions and 35 parameter cases
- update the mitm-addon testing guide's test-file index for the new module boundaries

## Scope

This is a test-only refactor plus its directly affected test documentation. It does not change production code, runtime behavior, schemas, APIs, protocols, deployment compatibility, or shared WebSocket helper interfaces.

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright`
- `.venv/bin/pytest tests/test_model_provider_websocket_usage.py tests/test_model_provider_websocket_lifecycle.py tests/test_model_provider_websocket_retention.py tests/test_model_provider_websocket_metadata.py tests/test_deferred_scheduler.py` (40 passed)
- `.venv/bin/pytest` (4,043 passed)
- `pnpm exec prettier --check ../docs/testing/mitm-addon-testing.md`

Closes #21924
