### PR TITLE
test(mitm-addon): assert duplicate content-length admission

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -356,6 +356,9 @@ async def test_auth_base_requestheaders_accepts_matching_duplicate_content_lengt
         mitm_addon.requestheaders(flow)
 
     assert flow.response is None
+    assert flow.error is None
+    assert flow.live is True
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
 
 
 @pytest.mark.parametrize("method", ["GET", "HEAD"])


### PR DESCRIPTION
## Summary

- prove matching duplicate `Content-Length` fields leave the request flow admitted
- assert the flow has no error, remains live, and records no framing error
- preserve the existing conflicting duplicate rejection coverage

## Scope

- test-only change
- no production parsing, auth resolution, or upstream forwarding behavior changes

## Testing

- `.venv/bin/ruff format --check tests/test_request_handler_auth_base_body.py`
- `.venv/bin/ruff check tests/test_request_handler_auth_base_body.py`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/pytest -q tests/test_request_handler_auth_base_body.py` (`25 passed`)

Closes #21930
