### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,14 +113,14 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.211"
+CLAUDE_CODE_VERSION="2.1.212"
 CODEX_CLI_VERSION="0.144.5"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.3"
-AGENT_BROWSER_VERSION="0.32.0"
+AGENT_BROWSER_VERSION="0.32.1"
 PNPM_VERSION="11.13.1"
-CHROMIUM_VERSION="150.0.7871.114-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260712T033608Z"
+CHROMIUM_VERSION="150.0.7871.124-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260716T075414Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Claude Code from 2.1.211 to 2.1.212.
- Update agent-browser from 0.32.0 to 0.32.1.
- Update Chromium from 150.0.7871.114-1~deb12u1 to 150.0.7871.124-1~deb12u1.
- Move the Debian security snapshot from 20260712T033608Z to 20260716T075414Z so the updated Chromium packages are reproducible on amd64 and arm64.

## Verification

- bash -n crates/runner/scripts/build-template.sh
- git diff --check
- Confirmed the selected Debian security snapshot publishes Chromium 150.0.7871.124-1~deb12u1 for amd64 and arm64.