### PR TITLE
chore(rust): update aws-sdk-s3, cfg_aliases, and tokio

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.138.0"
+version = "1.138.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c29be98554a0deea25d4eaca131240a224dcbcaf20357e35cc432e17b721ab5"
+checksum = "8fa59420755799fec8aac71f562aa37ba82263f5b1926bba8b5d3465d2f7a73f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -724,9 +724,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -3361,9 +3361,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
## Summary

Updates the Rust workspace lockfile to the latest versions allowed by the existing dependency constraints:

- `aws-sdk-s3`: `1.138.0` → `1.138.1`
- `cfg_aliases`: `0.2.1` → `0.2.2`
- `tokio`: `1.52.3` → `1.52.4`

All direct Rust dependency requirements were checked against their latest stable crates.io releases and are current.

## Dependencies not updated

- `generic-array`: `0.14.7` remains locked even though `0.14.9` is available. The transitive dependency `crypto-common v0.1.7` requires exactly `generic-array = "=0.14.7"`, so Cargo cannot select `0.14.9`.

## Manual version bumps

None. No direct dependency was blocked by a safe minor or patch constraint.

## Verification

- `cargo update --verbose`: passed; no further compatible updates were available.
- `cargo test --workspace`: could not complete in the automation runtime. The initial build exhausted the root filesystem while compiling `aws-lc-sys`. After moving generated artifacts to the 2 GiB tmpfs, disabling test debug info, disabling incremental compilation, and reducing build parallelism to one job, the `runner` test binary compilation was terminated with `SIGKILL` under the 4 GiB memory limit.
- `cargo test --workspace --exclude runner`: also could not complete because linking the `guest-agent` integration test `heartbeat_panic_reap_sigkill` exhausted the 2 GiB tmpfs.

No Rust assertion or dependency-related compilation failure was observed; both failures were runtime resource limits during compilation/linking.