### PR TITLE
fix(mitm-addon): avoid stale bytecode in tld snapshot checks

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import argparse
 import difflib
 import http.client
-import importlib.util
 import re
+import runpy
 import ssl
 import sys
 import tempfile
@@ -14,7 +14,6 @@ import urllib.error
 import urllib.request
 from http import HTTPStatus
 from pathlib import Path
-from types import ModuleType
 from typing import NamedTuple
 
 SOURCE_HOST = "data.iana.org"
@@ -152,19 +151,10 @@ def render_module(version: str, tlds: tuple[str, ...]) -> str:
     return "\n".join(lines)
 
 
-def load_generated_module() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("x_tlds_generated", OUTPUT_PATH)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"could not load module spec for {OUTPUT_PATH}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
 def read_existing_snapshot() -> tuple[str, tuple[str, ...]]:
-    module = load_generated_module()
-    version = getattr(module, "IANA_TLD_VERSION", None)
-    tlds = getattr(module, "IANA_TLDS", None)
+    namespace = runpy.run_path(str(OUTPUT_PATH), run_name="x_tlds_generated")
+    version = namespace.get("IANA_TLD_VERSION")
+    tlds = namespace.get("IANA_TLDS")
     if not isinstance(version, str) or not version:
         raise ValueError("generated module has invalid IANA_TLD_VERSION")
     if not isinstance(tlds, frozenset) or not all(isinstance(tld, str) for tld in tlds):

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -319,7 +319,7 @@ def test_snapshot_has_version_and_expected_stable_entries():
     assert {"ai", "com", "dev", "museum", "xn--q9jyb4c"} <= IANA_TLDS
 
 
-def test_read_existing_snapshot_ignores_stale_timestamp_bytecode(tmp_path, monkeypatch):
+def test_check_cli_ignores_stale_timestamp_bytecode(tmp_path, monkeypatch, capsys):
     output = tmp_path / "x_tlds.py"
     initial = update_x_tlds.render_module("111", ("aaa",))
     updated = update_x_tlds.render_module("222", ("bbb",))
@@ -340,8 +340,13 @@ def test_read_existing_snapshot_ignores_stale_timestamp_bytecode(tmp_path, monke
     output.write_text(updated, encoding="utf-8")
     os.utime(output, ns=(timestamp_ns, timestamp_ns))
     monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT), "--check"])
 
-    assert update_x_tlds.read_existing_snapshot() == ("222", ("bbb",))
+    assert update_x_tlds.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == f"{output} is canonical for IANA TLD version 222\n"
+    assert captured.err == ""
 
 
 def test_compare_snapshot_to_source_accepts_version_only_drift():

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import http.client
 import io
+import os
+import py_compile
 import subprocess
 import sys
 import urllib.error
@@ -315,6 +317,31 @@ def test_update_cli_reports_missing_source_file_without_replacing_output(
 def test_snapshot_has_version_and_expected_stable_entries():
     assert IANA_TLD_VERSION
     assert {"ai", "com", "dev", "museum", "xn--q9jyb4c"} <= IANA_TLDS
+
+
+def test_read_existing_snapshot_ignores_stale_timestamp_bytecode(tmp_path, monkeypatch):
+    output = tmp_path / "x_tlds.py"
+    initial = update_x_tlds.render_module("111", ("aaa",))
+    updated = update_x_tlds.render_module("222", ("bbb",))
+    timestamp_ns = 1_700_000_000_000_000_000
+
+    assert len(initial.encode()) == len(updated.encode())
+
+    output.write_text(initial, encoding="utf-8")
+    os.utime(output, ns=(timestamp_ns, timestamp_ns))
+    bytecode = py_compile.compile(
+        str(output),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
+    )
+    assert bytecode is not None
+    assert Path(bytecode).is_file()
+
+    output.write_text(updated, encoding="utf-8")
+    os.utime(output, ns=(timestamp_ns, timestamp_ns))
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.read_existing_snapshot() == ("222", ("bbb",))
 
 
 def test_compare_snapshot_to_source_accepts_version_only_drift():


### PR DESCRIPTION
## Summary

- execute the generated TLD snapshot from its current source path so maintenance checks
  cannot reuse a stale sibling bytecode cache
- preserve the existing generated-module format, runtime import, value validation, and
  check diagnostics
- add a deterministic regression that seeds timestamp-based bytecode before an equal-size,
  equal-timestamp source rewrite

## Scope

This changes only the TLD snapshot maintenance loader and its regression coverage. It
does not change the checked-in TLD data, X billing runtime behavior, CLI arguments,
output text, packaging, APIs, or persisted state.

## Validation

- `python3 -m pytest tests/test_update_x_tlds.py -v` — 33 passed
- `ruff format .` — 239 files left unchanged
- `ruff check .` — passed
- `basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `python3 -m pytest tests/ -v` — 4044 passed

Closes #21932
