### PR TITLE
refactor(platform): share mail draft signals within chat threads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -25,7 +25,7 @@ function userMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
-    mailDraftResource: null,
+    mailDraftSignals: null,
   };
 }
 
@@ -45,7 +45,7 @@ function assistantMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
-    mailDraftResource: null,
+    mailDraftSignals: null,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -25,7 +25,7 @@ function userMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
-    mailDraftSignals: null,
+    mailDraftCard: null,
   };
 }
 
@@ -45,7 +45,7 @@ function assistantMessage(params: {
     blocks: [],
     isQueued: false,
     isOptimisticRun: false,
-    mailDraftSignals: null,
+    mailDraftCard: null,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -18,7 +18,7 @@ import { zeroClient$ } from "../api-client.ts";
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import { nowDate } from "../../lib/time.ts";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
-import type { MailDraftSignals } from "./mail-draft.ts";
+import type { MailDraftCard } from "./mail-draft.ts";
 
 export { chatThreads$ } from "../agent-chat.ts";
 
@@ -46,7 +46,7 @@ export type EnrichedChatMessage = PagedChatMessage & {
   blocks: BodyRenderBlock[];
   isQueued: boolean;
   isOptimisticRun: boolean;
-  mailDraftSignals: MailDraftSignals | null;
+  mailDraftCard: MailDraftCard | null;
 };
 
 /** A group of consecutive messages with the same role. */

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -18,7 +18,7 @@ import { zeroClient$ } from "../api-client.ts";
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import { nowDate } from "../../lib/time.ts";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
-import type { MailDraftResource } from "./mail-draft.ts";
+import type { MailDraftSignals } from "./mail-draft.ts";
 
 export { chatThreads$ } from "../agent-chat.ts";
 
@@ -46,10 +46,7 @@ export type EnrichedChatMessage = PagedChatMessage & {
   blocks: BodyRenderBlock[];
   isQueued: boolean;
   isOptimisticRun: boolean;
-  mailDraftResource: {
-    readonly mailDraftId: string;
-    readonly mailDraft$: MailDraftResource;
-  } | null;
+  mailDraftSignals: MailDraftSignals | null;
 };
 
 /** A group of consecutive messages with the same role. */

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -121,8 +121,8 @@ import type {
 } from "./chat-thread-signals.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
 import {
-  createMailDraftLoaderSignals,
-  type MailDraftResource,
+  createMailDraftRegistry,
+  type MailDraftSignals,
 } from "./mail-draft.ts";
 
 type ChatThreadRemote = ReturnType<typeof createRemoteChatThreadDataSource>;
@@ -1250,12 +1250,12 @@ function setLatestUsageForRun(
 
 function createRenderedChatGroups(
   semanticMessages$: Computed<SemanticChatMessage[]>,
-  mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
+  mailDraftSignalsById$: Computed<ReadonlyMap<string, MailDraftSignals>>,
   messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ) {
   const transcriptMessages$ = createTranscriptMessagesComputed(
     semanticMessages$,
-    mailDraftById$,
+    mailDraftSignalsById$,
     messageBlocksById$,
   );
 
@@ -1505,11 +1505,11 @@ function createRawMessagesComputed({
 
 function createTranscriptMessagesComputed(
   semanticMessages$: Computed<SemanticChatMessage[]>,
-  mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>,
+  mailDraftSignalsById$: Computed<ReadonlyMap<string, MailDraftSignals>>,
   messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ): Computed<Promise<EnrichedChatMessage[]>> {
   return computed((get): Promise<EnrichedChatMessage[]> => {
-    const mailDraftById = get(mailDraftById$);
+    const mailDraftSignalsById = get(mailDraftSignalsById$);
     const blocksById = get(messageBlocksById$);
     return Promise.resolve(
       get(semanticMessages$).map((entry) => {
@@ -1520,18 +1520,15 @@ function createTranscriptMessagesComputed(
         // and short-lived, so parse them on read.
         const enrichedBlocks =
           blocksById.get(message.id) ?? parseMessageBodyBlocks(message);
-        let mailDraftResource: EnrichedChatMessage["mailDraftResource"] = null;
+        let mailDraftSignals: EnrichedChatMessage["mailDraftSignals"] = null;
         if (message.mailDraftId !== undefined) {
-          const mailDraft$ = mailDraftById.get(message.mailDraftId);
-          if (mailDraft$ === undefined) {
+          mailDraftSignals =
+            mailDraftSignalsById.get(message.mailDraftId) ?? null;
+          if (mailDraftSignals === null) {
             throw new Error(
-              `Mail draft resource was not registered: ${message.mailDraftId}`,
+              `Mail draft signals were not registered: ${message.mailDraftId}`,
             );
           }
-          mailDraftResource = {
-            mailDraftId: message.mailDraftId,
-            mailDraft$,
-          };
         }
         if (message.role !== "assistant") {
           return {
@@ -1540,7 +1537,7 @@ function createTranscriptMessagesComputed(
             blocks: enrichedBlocks,
             isQueued,
             isOptimisticRun,
-            mailDraftResource,
+            mailDraftSignals,
           };
         }
         return {
@@ -1549,7 +1546,7 @@ function createTranscriptMessagesComputed(
           blocks: enrichedBlocks,
           isQueued,
           isOptimisticRun: false,
-          mailDraftResource,
+          mailDraftSignals,
         };
       }),
     );
@@ -2298,7 +2295,7 @@ function createActiveGoalObjectiveComputed(
 }
 
 function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
-  const mailDrafts = createMailDraftLoaderSignals();
+  const mailDrafts = createMailDraftRegistry();
   const permissionCards = createPermissionCardRegistry();
   const messageBlocks = createMessageBlocksRegistry(
     permissionCards.registerPermissionCardBlocks$,
@@ -2328,7 +2325,7 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
 
   const renderedMessages = createRenderedChatGroups(
     semanticMessages$,
-    mailDrafts.mailDraftById$,
+    mailDrafts.mailDraftSignalsById$,
     messageBlocks.messageBlocksById$,
   );
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -121,7 +121,7 @@ import type {
 } from "./chat-thread-signals.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
 import {
-  createMailDraftRegistry,
+  createMailDraftCardRegistry,
   type MailDraftSignals,
 } from "./mail-draft.ts";
 
@@ -1250,12 +1250,12 @@ function setLatestUsageForRun(
 
 function createRenderedChatGroups(
   semanticMessages$: Computed<SemanticChatMessage[]>,
-  mailDraftSignalsById$: Computed<ReadonlyMap<string, MailDraftSignals>>,
+  mailDraftCardSignals$: Computed<ReadonlyMap<string, MailDraftSignals>>,
   messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ) {
   const transcriptMessages$ = createTranscriptMessagesComputed(
     semanticMessages$,
-    mailDraftSignalsById$,
+    mailDraftCardSignals$,
     messageBlocksById$,
   );
 
@@ -1505,11 +1505,11 @@ function createRawMessagesComputed({
 
 function createTranscriptMessagesComputed(
   semanticMessages$: Computed<SemanticChatMessage[]>,
-  mailDraftSignalsById$: Computed<ReadonlyMap<string, MailDraftSignals>>,
+  mailDraftCardSignals$: Computed<ReadonlyMap<string, MailDraftSignals>>,
   messageBlocksById$: Computed<ReadonlyMap<string, BodyRenderBlock[]>>,
 ): Computed<Promise<EnrichedChatMessage[]>> {
   return computed((get): Promise<EnrichedChatMessage[]> => {
-    const mailDraftSignalsById = get(mailDraftSignalsById$);
+    const mailDraftCardSignals = get(mailDraftCardSignals$);
     const blocksById = get(messageBlocksById$);
     return Promise.resolve(
       get(semanticMessages$).map((entry) => {
@@ -1520,15 +1520,19 @@ function createTranscriptMessagesComputed(
         // and short-lived, so parse them on read.
         const enrichedBlocks =
           blocksById.get(message.id) ?? parseMessageBodyBlocks(message);
-        let mailDraftSignals: EnrichedChatMessage["mailDraftSignals"] = null;
+        let mailDraftCard: EnrichedChatMessage["mailDraftCard"] = null;
         if (message.mailDraftId !== undefined) {
-          mailDraftSignals =
-            mailDraftSignalsById.get(message.mailDraftId) ?? null;
-          if (mailDraftSignals === null) {
+          const signals = mailDraftCardSignals.get(message.mailDraftId);
+          if (signals === undefined) {
             throw new Error(
               `Mail draft signals were not registered: ${message.mailDraftId}`,
             );
           }
+          mailDraftCard = {
+            type: "mail-draft",
+            resourceKey: message.mailDraftId,
+            signals,
+          };
         }
         if (message.role !== "assistant") {
           return {
@@ -1537,7 +1541,7 @@ function createTranscriptMessagesComputed(
             blocks: enrichedBlocks,
             isQueued,
             isOptimisticRun,
-            mailDraftSignals,
+            mailDraftCard,
           };
         }
         return {
@@ -1546,7 +1550,7 @@ function createTranscriptMessagesComputed(
           blocks: enrichedBlocks,
           isQueued,
           isOptimisticRun: false,
-          mailDraftSignals,
+          mailDraftCard,
         };
       }),
     );
@@ -2295,7 +2299,7 @@ function createActiveGoalObjectiveComputed(
 }
 
 function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
-  const mailDrafts = createMailDraftRegistry();
+  const mailDraftCards = createMailDraftCardRegistry();
   const permissionCards = createPermissionCardRegistry();
   const messageBlocks = createMessageBlocksRegistry(
     permissionCards.registerPermissionCardBlocks$,
@@ -2325,20 +2329,20 @@ function createPagedMessages(threadId: string, dataSource: ChatThreadRemote) {
 
   const renderedMessages = createRenderedChatGroups(
     semanticMessages$,
-    mailDrafts.mailDraftSignalsById$,
+    mailDraftCards.mailDraftCardSignals$,
     messageBlocks.messageBlocksById$,
   );
 
   const writePersistentMessages$ = createWritePersistentMessages(
     threadId,
     persistentChatMessages$,
-    mailDrafts.registerMailDraftMessages$,
+    mailDraftCards.registerMailDraftMessages$,
     messageBlocks.registerMessageBlocks$,
   );
 
   const mergeIndexedDbMessages$ = command(
     ({ set }, messages: PagedChatMessage[]): void => {
-      set(mailDrafts.registerMailDraftMessages$, messages);
+      set(mailDraftCards.registerMailDraftMessages$, messages);
       set(messageBlocks.registerMessageBlocks$, messages);
       set(persistentChatMessages$, (previous) => {
         return mergeServerMessages([messages, previous]);

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -15,41 +15,160 @@ export interface MailDraftFields {
   readonly body: string;
 }
 
-interface MailDraftCommandArgs {
+export interface MailDraftSignals {
   readonly mailDraftId: string;
+  readonly serverDraft$: Computed<Promise<ZeroMailDraft>>;
+  readonly mutationDraft$: Computed<ZeroMailDraft | undefined>;
+  readonly update$: Command<
+    Promise<ZeroMailDraft>,
+    [MailDraftFields, AbortSignal]
+  >;
+  readonly cancel$: Command<Promise<ZeroMailDraft>, [AbortSignal]>;
+  readonly send$: Command<
+    Promise<ZeroMailDraft>,
+    [MailDraftFields, AbortSignal]
+  >;
 }
 
-interface SaveMailDraftCommandArgs extends MailDraftCommandArgs {
-  readonly fields: MailDraftFields;
-}
-
-const internalMailDraftOverrides$ = state<Record<string, ZeroMailDraft>>({});
-
-export const mailDraftOverrides$ = computed((get) => {
-  return get(internalMailDraftOverrides$);
-});
-
-export type MailDraftResource = Computed<Promise<ZeroMailDraft>>;
-
-export interface MailDraftLoaderSignals {
-  readonly mailDraftById$: Computed<ReadonlyMap<string, MailDraftResource>>;
+export interface MailDraftRegistrySignals {
+  readonly mailDraftSignalsById$: Computed<
+    ReadonlyMap<string, MailDraftSignals>
+  >;
   readonly registerMailDraftMessages$: Command<
     void,
     [readonly PagedChatMessage[]]
   >;
 }
 
-export function createMailDraftLoaderSignals(): MailDraftLoaderSignals {
-  const internalMailDraftById$ = state<ReadonlyMap<string, MailDraftResource>>(
+export function newestMailDraft(
+  first: ZeroMailDraft,
+  second: ZeroMailDraft,
+): ZeroMailDraft {
+  return Date.parse(second.updatedAt) >= Date.parse(first.updatedAt)
+    ? second
+    : first;
+}
+
+function createMailDraftSignals(mailDraftId: string): MailDraftSignals {
+  const internalMutationDraft$ = state<ZeroMailDraft | undefined>(undefined);
+  const serverDraft$ = computed(async (get): Promise<ZeroMailDraft> => {
+    const response = await accept(
+      get(zeroClient$)(zeroMailContract).getDraft({
+        params: { mailDraftId },
+        fetchOptions: { signal: get(pageSignal$) },
+      }),
+      [200],
+    );
+    return response.body.mailDraft;
+  });
+  const mutationDraft$ = computed((get) => {
+    return get(internalMutationDraft$);
+  });
+
+  const update$ = command(
+    async (
+      { get, set },
+      fields: MailDraftFields,
+      signal: AbortSignal,
+    ): Promise<ZeroMailDraft> => {
+      const client = get(zeroClient$)(zeroMailContract);
+      const response = await accept(
+        client.updateDraft({
+          params: { mailDraftId },
+          body: {
+            to: [...fields.to],
+            subject: fields.subject,
+            body: fields.body,
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(internalMutationDraft$, (current) => {
+        return current === undefined
+          ? response.body.mailDraft
+          : newestMailDraft(current, response.body.mailDraft);
+      });
+      return response.body.mailDraft;
+    },
+  );
+
+  const cancel$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<ZeroMailDraft> => {
+      const client = get(zeroClient$)(zeroMailContract);
+      const response = await accept(
+        client.cancelDraft({
+          params: { mailDraftId },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(internalMutationDraft$, (current) => {
+        return current === undefined
+          ? response.body.mailDraft
+          : newestMailDraft(current, response.body.mailDraft);
+      });
+      return response.body.mailDraft;
+    },
+  );
+
+  const send$ = command(
+    async (
+      { get, set },
+      fields: MailDraftFields,
+      signal: AbortSignal,
+    ): Promise<ZeroMailDraft> => {
+      const client = get(zeroClient$)(zeroMailContract);
+      const response = await accept(
+        client.sendDraft({
+          params: { mailDraftId },
+          body: {
+            to: [...fields.to],
+            subject: fields.subject,
+            body: fields.body,
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      set(internalMutationDraft$, (current) => {
+        return current === undefined
+          ? response.body.mailDraft
+          : newestMailDraft(current, response.body.mailDraft);
+      });
+      return response.body.mailDraft;
+    },
+  );
+
+  return {
+    mailDraftId,
+    serverDraft$,
+    mutationDraft$,
+    update$,
+    cancel$,
+    send$,
+  };
+}
+
+/**
+ * Thread-scoped registry of mail draft signals keyed by draft ID. Persistent
+ * messages register their draft before entering the transcript, so every card
+ * for the same draft reuses one signals object for the thread's lifetime.
+ */
+export function createMailDraftRegistry(): MailDraftRegistrySignals {
+  const internalSignalsById$ = state<ReadonlyMap<string, MailDraftSignals>>(
     new Map(),
   );
-  const mailDraftById$ = computed((get) => {
-    return get(internalMailDraftById$);
+  const mailDraftSignalsById$ = computed((get) => {
+    return get(internalSignalsById$);
   });
   const registerMailDraftMessages$ = command(
     ({ get, set }, messages: readonly PagedChatMessage[]) => {
-      const current = get(internalMailDraftById$);
-      let next: Map<string, MailDraftResource> | undefined;
+      const current = get(internalSignalsById$);
+      let next: Map<string, MailDraftSignals> | undefined;
       for (const message of messages) {
         const { mailDraftId } = message;
         if (
@@ -60,109 +179,15 @@ export function createMailDraftLoaderSignals(): MailDraftLoaderSignals {
           continue;
         }
         next ??= new Map(current);
-        next.set(
-          mailDraftId,
-          computed(async (get) => {
-            const response = await accept(
-              get(zeroClient$)(zeroMailContract).getDraft({
-                params: { mailDraftId },
-                fetchOptions: { signal: get(pageSignal$) },
-              }),
-              [200],
-            );
-            return response.body.mailDraft;
-          }),
-        );
+        next.set(mailDraftId, createMailDraftSignals(mailDraftId));
       }
       if (next !== undefined) {
-        set(internalMailDraftById$, next);
+        set(internalSignalsById$, next);
       }
     },
   );
   return {
-    mailDraftById$,
+    mailDraftSignalsById$,
     registerMailDraftMessages$,
   };
 }
-
-export const updateMailDraft$ = command(
-  async (
-    { get, set },
-    args: SaveMailDraftCommandArgs,
-    signal: AbortSignal,
-  ): Promise<ZeroMailDraft> => {
-    const client = get(zeroClient$)(zeroMailContract);
-    const response = await accept(
-      client.updateDraft({
-        params: {
-          mailDraftId: args.mailDraftId,
-        },
-        body: {
-          to: [...args.fields.to],
-          subject: args.fields.subject,
-          body: args.fields.body,
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(internalMailDraftOverrides$, (current) => {
-      return { ...current, [args.mailDraftId]: response.body.mailDraft };
-    });
-    return response.body.mailDraft;
-  },
-);
-
-export const cancelMailDraft$ = command(
-  async (
-    { get, set },
-    args: MailDraftCommandArgs,
-    signal: AbortSignal,
-  ): Promise<ZeroMailDraft> => {
-    const client = get(zeroClient$)(zeroMailContract);
-    const response = await accept(
-      client.cancelDraft({
-        params: {
-          mailDraftId: args.mailDraftId,
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(internalMailDraftOverrides$, (current) => {
-      return { ...current, [args.mailDraftId]: response.body.mailDraft };
-    });
-    return response.body.mailDraft;
-  },
-);
-
-export const sendMailDraft$ = command(
-  async (
-    { get, set },
-    args: SaveMailDraftCommandArgs,
-    signal: AbortSignal,
-  ): Promise<ZeroMailDraft> => {
-    const client = get(zeroClient$)(zeroMailContract);
-    const response = await accept(
-      client.sendDraft({
-        params: {
-          mailDraftId: args.mailDraftId,
-        },
-        body: {
-          to: [...args.fields.to],
-          subject: args.fields.subject,
-          body: args.fields.body,
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    set(internalMailDraftOverrides$, (current) => {
-      return { ...current, [args.mailDraftId]: response.body.mailDraft };
-    });
-    return response.body.mailDraft;
-  },
-);

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -16,7 +16,6 @@ export interface MailDraftFields {
 }
 
 export interface MailDraftSignals {
-  readonly mailDraftId: string;
   readonly serverDraft$: Computed<Promise<ZeroMailDraft>>;
   readonly mutationDraft$: Computed<ZeroMailDraft | undefined>;
   readonly update$: Command<
@@ -30,8 +29,14 @@ export interface MailDraftSignals {
   >;
 }
 
-export interface MailDraftRegistrySignals {
-  readonly mailDraftSignalsById$: Computed<
+export interface MailDraftCard {
+  readonly type: "mail-draft";
+  readonly resourceKey: string;
+  readonly signals: MailDraftSignals;
+}
+
+export interface MailDraftCardRegistrySignals {
+  readonly mailDraftCardSignals$: Computed<
     ReadonlyMap<string, MailDraftSignals>
   >;
   readonly registerMailDraftMessages$: Command<
@@ -144,7 +149,6 @@ function createMailDraftSignals(mailDraftId: string): MailDraftSignals {
   );
 
   return {
-    mailDraftId,
     serverDraft$,
     mutationDraft$,
     update$,
@@ -158,36 +162,36 @@ function createMailDraftSignals(mailDraftId: string): MailDraftSignals {
  * messages register their draft before entering the transcript, so every card
  * for the same draft reuses one signals object for the thread's lifetime.
  */
-export function createMailDraftRegistry(): MailDraftRegistrySignals {
-  const internalSignalsById$ = state<ReadonlyMap<string, MailDraftSignals>>(
-    new Map(),
-  );
-  const mailDraftSignalsById$ = computed((get) => {
-    return get(internalSignalsById$);
+export function createMailDraftCardRegistry(): MailDraftCardRegistrySignals {
+  const internalSignalsByResourceKey$ = state<
+    ReadonlyMap<string, MailDraftSignals>
+  >(new Map());
+  const mailDraftCardSignals$ = computed((get) => {
+    return get(internalSignalsByResourceKey$);
   });
   const registerMailDraftMessages$ = command(
     ({ get, set }, messages: readonly PagedChatMessage[]) => {
-      const current = get(internalSignalsById$);
+      const current = get(internalSignalsByResourceKey$);
       let next: Map<string, MailDraftSignals> | undefined;
       for (const message of messages) {
-        const { mailDraftId } = message;
+        const resourceKey = message.mailDraftId;
         if (
-          mailDraftId === undefined ||
-          current.has(mailDraftId) ||
-          next?.has(mailDraftId)
+          resourceKey === undefined ||
+          current.has(resourceKey) ||
+          next?.has(resourceKey)
         ) {
           continue;
         }
         next ??= new Map(current);
-        next.set(mailDraftId, createMailDraftSignals(mailDraftId));
+        next.set(resourceKey, createMailDraftSignals(resourceKey));
       }
       if (next !== undefined) {
-        set(internalSignalsById$, next);
+        set(internalSignalsByResourceKey$, next);
       }
     },
   );
   return {
-    mailDraftSignalsById$,
+    mailDraftCardSignals$,
     registerMailDraftMessages$,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   detachedSetupPage,
+  fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
@@ -198,13 +199,16 @@ async function confirmPermissionAction(
 }
 
 describe("chat message action cards", () => {
-  it("renders a persistent mail draft and sends the reviewed fields", async () => {
+  it("keeps one mail draft consistent across persistent messages", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000010";
     const messageId = "c0000000-0000-4000-a000-000000000011";
+    const secondMessageId = "c0000000-0000-4000-a000-000000000013";
     const mailDraftId = "c0000000-0000-4000-a000-000000000012";
+    const runId = "d0000000-0000-4000-a000-000000000020";
     const createdAt = "2026-07-14T10:00:00.000Z";
     let draftRequests = 0;
+    let savedBody: unknown = null;
     let sentBody: unknown = null;
 
     context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
@@ -225,6 +229,7 @@ describe("chat message action cards", () => {
       });
     });
     context.mocks.api(zeroMailContract.updateDraft, ({ body, respond }) => {
+      savedBody = body;
       return respond(200, {
         mailDraftId,
         mailDraft: {
@@ -262,10 +267,20 @@ describe("chat message action cards", () => {
           id: messageId,
           role: "assistant",
           content: null,
+          runId,
           createdAt,
           mailDraftId,
         },
+        {
+          id: secondMessageId,
+          role: "assistant",
+          content: null,
+          runId,
+          createdAt: "2026-07-14T10:00:01.000Z",
+          mailDraftId,
+        },
       ],
+      activeRunIds: [runId],
     });
 
     detachedSetupPage({
@@ -274,36 +289,68 @@ describe("chat message action cards", () => {
       featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
     });
 
-    const from = await screen.findByRole("textbox", { name: "From" });
-    const card = from.closest<HTMLElement>("[data-mail-draft-card]");
-    if (!card) {
-      throw new Error("Mail draft card not found");
+    await waitFor(() => {
+      expect(screen.getAllByRole("textbox", { name: "From" })).toHaveLength(2);
+    });
+    const fromFields = screen.getAllByRole("textbox", { name: "From" });
+    const cards = fromFields.map((from) => {
+      const card = from.closest<HTMLElement>("[data-mail-draft-card]");
+      if (!card) {
+        throw new Error("Mail draft card not found");
+      }
+      return card;
+    });
+    const [firstCard, secondCard] = cards;
+    if (!firstCard || !secondCard) {
+      throw new Error("Expected two mail draft cards");
     }
-    expect(from).toHaveValue("sender@example.com");
-    expect(within(card).getByRole("textbox", { name: "To" })).toHaveValue(
+    expect(fromFields[0]).toHaveValue("sender@example.com");
+    expect(within(firstCard).getByRole("textbox", { name: "To" })).toHaveValue(
       "recipient@example.com",
     );
-    expect(within(card).getByRole("textbox", { name: "Subject" })).toHaveValue(
-      "Hello",
-    );
-    expect(within(card).getByRole("textbox", { name: "Message" })).toHaveValue(
-      "Mail body",
-    );
+    expect(
+      within(firstCard).getByRole("textbox", { name: "Subject" }),
+    ).toHaveValue("Hello");
+    expect(
+      within(firstCard).getByRole("textbox", { name: "Message" }),
+    ).toHaveValue("Mail body");
 
-    await user.click(buttonByText("Send", card));
+    const firstSubject = within(firstCard).getByRole("textbox", {
+      name: "Subject",
+    });
+    await fill(firstSubject, "Shared subject");
+    firstSubject.blur();
+
+    await waitFor(() => {
+      expect(savedBody).toStrictEqual({
+        to: ["recipient@example.com"],
+        subject: "Shared subject",
+        body: "Mail body",
+      });
+      expect(
+        within(secondCard).getByRole("textbox", { name: "Subject" }),
+      ).toHaveValue("Shared subject");
+    });
+
+    await user.click(buttonByText("Send", secondCard));
 
     await waitFor(() => {
       expect(sentBody).toStrictEqual({
         to: ["recipient@example.com"],
-        subject: "Hello",
+        subject: "Shared subject",
         body: "Mail body",
       });
-      expect(within(card).getByText("Sent")).toBeInTheDocument();
+      expect(within(firstCard).getByText("Sent")).toBeInTheDocument();
+      expect(within(secondCard).getByText("Sent")).toBeInTheDocument();
     });
-    expect(queryButtonByText("Send", card)).toBeNull();
-    expect(within(card).getByRole("textbox", { name: "From" })).toHaveAttribute(
-      "readonly",
-    );
+    expect(queryButtonByText("Send", firstCard)).toBeNull();
+    expect(queryButtonByText("Send", secondCard)).toBeNull();
+    expect(
+      within(firstCard).getByRole("textbox", { name: "From" }),
+    ).toHaveAttribute("readonly");
+    expect(
+      within(secondCard).getByRole("textbox", { name: "From" }),
+    ).toHaveAttribute("readonly");
     expect(draftRequests).toBe(1);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -13,24 +13,20 @@ import type {
   ZeroMailDraft,
   ZeroMailDraftStatus,
 } from "@vm0/api-contracts/contracts/zero-mail";
-import type { Computed } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Button, Input, cn } from "@vm0/ui";
 
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  cancelMailDraft$,
-  mailDraftOverrides$,
-  sendMailDraft$,
-  updateMailDraft$,
+  newestMailDraft,
   type MailDraftFields,
+  type MailDraftSignals,
 } from "../../signals/chat-page/mail-draft.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
 interface MailDraftCardProps {
-  readonly mailDraftId: string;
-  readonly mailDraft$: Computed<Promise<ZeroMailDraft>>;
+  readonly signals: MailDraftSignals;
 }
 
 interface DraftStatusCopy {
@@ -83,18 +79,6 @@ function statusCopy(status: ZeroMailDraftStatus): DraftStatusCopy {
       };
     }
   }
-}
-
-function newestDraft(
-  serverDraft: ZeroMailDraft,
-  localDraft: ZeroMailDraft | undefined,
-): ZeroMailDraft {
-  if (!localDraft) {
-    return serverDraft;
-  }
-  return Date.parse(localDraft.updatedAt) >= Date.parse(serverDraft.updatedAt)
-    ? localDraft
-    : serverDraft;
 }
 
 function fieldsFromForm(form: HTMLFormElement): MailDraftFields {
@@ -288,18 +272,16 @@ function MailDraftActions({
 }
 
 function ReadyMailDraftCard({
-  mailDraftId,
-  serverMailDraft,
+  signals,
+  mailDraft,
 }: {
-  readonly mailDraftId: string;
-  readonly serverMailDraft: ZeroMailDraft;
+  readonly signals: MailDraftSignals;
+  readonly mailDraft: ZeroMailDraft;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const localDraft = useGet(mailDraftOverrides$)[mailDraftId];
-  const mailDraft = newestDraft(serverMailDraft, localDraft);
-  const [updateLoadable, updateDraft] = useLoadableSet(updateMailDraft$);
-  const [cancelLoadable, cancelDraft] = useLoadableSet(cancelMailDraft$);
-  const [sendLoadable, sendDraft] = useLoadableSet(sendMailDraft$);
+  const [updateLoadable, updateDraft] = useLoadableSet(signals.update$);
+  const [cancelLoadable, cancelDraft] = useLoadableSet(signals.cancel$);
+  const [sendLoadable, sendDraft] = useLoadableSet(signals.send$);
   const editable =
     mailDraft.status === "draft" || mailDraft.status === "failed";
   const updatePending = updateLoadable.state === "loading";
@@ -325,25 +307,19 @@ function ReadyMailDraftCard({
     ) {
       return;
     }
-    detach(
-      updateDraft({ mailDraftId, fields: fieldsFromForm(form) }, pageSignal),
-      Reason.DomCallback,
-    );
+    detach(updateDraft(fieldsFromForm(form), pageSignal), Reason.DomCallback);
   };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     detach(
-      sendDraft(
-        { mailDraftId, fields: fieldsFromForm(event.currentTarget) },
-        pageSignal,
-      ),
+      sendDraft(fieldsFromForm(event.currentTarget), pageSignal),
       Reason.DomCallback,
     );
   };
 
   const onCancel = () => {
-    detach(cancelDraft({ mailDraftId }, pageSignal), Reason.DomCallback);
+    detach(cancelDraft(pageSignal), Reason.DomCallback);
   };
 
   return (
@@ -375,8 +351,9 @@ function ReadyMailDraftCard({
   );
 }
 
-function EnabledMailDraftCard({ mailDraftId, mailDraft$ }: MailDraftCardProps) {
-  const mailDraftLoadable = useLoadable(mailDraft$);
+function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
+  const mailDraftLoadable = useLoadable(signals.serverDraft$);
+  const mutationDraft = useGet(signals.mutationDraft$);
   if (mailDraftLoadable.state === "loading") {
     return (
       <section
@@ -401,8 +378,12 @@ function EnabledMailDraftCard({ mailDraftId, mailDraft$ }: MailDraftCardProps) {
   }
   return (
     <ReadyMailDraftCard
-      mailDraftId={mailDraftId}
-      serverMailDraft={mailDraftLoadable.data}
+      signals={signals}
+      mailDraft={
+        mutationDraft === undefined
+          ? mailDraftLoadable.data
+          : newestMailDraft(mailDraftLoadable.data, mutationDraft)
+      }
     />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6616,8 +6616,9 @@ function PagedAssistantMessageItem({
     openImageLightbox(url);
   };
 
-  if (message.mailDraftResource) {
-    const { mailDraftId, mailDraft$ } = message.mailDraftResource;
+  const mailDraftSignals = message.mailDraftSignals;
+  if (mailDraftSignals) {
+    const { mailDraftId } = mailDraftSignals;
     return (
       <div
         className={cn(
@@ -6625,11 +6626,7 @@ function PagedAssistantMessageItem({
           compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
         )}
       >
-        <MailDraftCard
-          key={mailDraftId}
-          mailDraftId={mailDraftId}
-          mailDraft$={mailDraft$}
-        />
+        <MailDraftCard key={mailDraftId} signals={mailDraftSignals} />
       </div>
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6616,9 +6616,8 @@ function PagedAssistantMessageItem({
     openImageLightbox(url);
   };
 
-  const mailDraftSignals = message.mailDraftSignals;
-  if (mailDraftSignals) {
-    const { mailDraftId } = mailDraftSignals;
+  const { mailDraftCard } = message;
+  if (mailDraftCard) {
     return (
       <div
         className={cn(
@@ -6626,7 +6625,10 @@ function PagedAssistantMessageItem({
           compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
         )}
       >
-        <MailDraftCard key={mailDraftId} signals={mailDraftSignals} />
+        <MailDraftCard
+          key={mailDraftCard.resourceKey}
+          signals={mailDraftCard.signals}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- replace the root-wide mail draft override and global mutation commands with an independent, thread-owned mail draft card registry keyed by the draft resource identity
- represent each mail draft occurrence as `{ type, resourceKey, signals }`, reusing the same stable `MailDraftSignals` object for the same `mailDraftId` across messages
- create and register signals before transcript rendering so React only dispatches the card and consumes its existing signals object
- keep fetch, update, cancel, and send state inside the shared draft signals so it is released with the thread

## User impact

Mail draft cards that reference the same draft now stay consistent across messages. Editing, cancelling, or sending from one card updates every card for that draft without retaining draft responses in the root store or notifying unrelated cards.

This follows the same thread-scoped resource-signals model used by chat artifact and action cards: one registry per card type, get-or-create by resource identity, a direct signals reference on the render resource, and no signal creation or registry lookup in React.

## Verification

- platform production and test TypeScript checks
- targeted Vitest: `chat-message-action-cards.test.tsx` and `run-group-folding.test.ts` (28 passed)
- platform static asset check, oxlint, type-aware oxlint, and ESLint on changed files
- Prettier 3.8.1 on all changed files
