### PR TITLE
refactor: derive connector action completion from server state

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -10,10 +10,7 @@ import {
   connectors$,
   type ConnectorCatalogDisplayMetadata,
 } from "../external/connectors.ts";
-import {
-  justConnectedTypes$,
-  setSelectedConnectorType$,
-} from "../zero-page/settings/connectors.ts";
+import { setSelectedConnectorType$ } from "../zero-page/settings/connectors.ts";
 import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-type.ts";
 import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authorizations.ts";
 import { jsonParseBase64UrlOr } from "../utils.ts";
@@ -50,11 +47,7 @@ export type CustomConnectorActionBlock = CustomConnectorActionDescriptor & {
   id: string;
 };
 
-type ActiveChatConnectorAction = ConnectorActionDescriptor & {
-  markComplete$: Command<void, []>;
-};
-
-const activeChatConnectorActionState$ = state<ActiveChatConnectorAction | null>(
+const activeChatConnectorActionState$ = state<ConnectorActionDescriptor | null>(
   null,
 );
 
@@ -65,15 +58,6 @@ export const activeChatConnectorAction$ = computed((get) => {
 export const closeChatConnectorActionConnectDialog$ = command(({ set }) => {
   set(activeChatConnectorActionState$, null);
   set(setSelectedConnectorType$, null);
-});
-
-export const completeChatConnectorActionConnect$ = command(({ get, set }) => {
-  const active = get(activeChatConnectorActionState$);
-  if (!active) {
-    return;
-  }
-  set(active.markComplete$);
-  set(closeChatConnectorActionConnectDialog$);
 });
 
 const CONNECTOR_AUTHORIZE_BASE_URL = "https://app.vm0.ai";
@@ -150,14 +134,6 @@ export function createConnectorActionBlock(
   id: string,
   descriptor: ConnectorActionDescriptor,
 ): ConnectorActionBlock {
-  const connectedOverride$ = state(false);
-  const authorizedOverride$ = state(false);
-
-  const markComplete$ = command(({ set }) => {
-    set(connectedOverride$, true);
-    set(authorizedOverride$, true);
-  });
-
   const displayMetadata$ = computed(async (get) => {
     const metadataByRef = await get(connectorCatalogDisplayMetadataByRef$);
     return metadataByRef.get(descriptor.connectorRef) ?? null;
@@ -169,20 +145,11 @@ export function createConnectorActionBlock(
   });
 
   const connected$ = computed(async (get): Promise<boolean> => {
-    if (
-      get(connectedOverride$) ||
-      get(justConnectedTypes$).has(descriptor.connectorRef)
-    ) {
-      return true;
-    }
     const statusByRef = await get(connectorCatalogStatusByRef$);
     return statusByRef.get(descriptor.connectorRef)?.connected ?? false;
   });
 
   const authorized$ = computed(async (get): Promise<boolean> => {
-    if (get(authorizedOverride$)) {
-      return true;
-    }
     return await get(
       isAgentConnectorAuthorized({
         agentId: descriptor.agentId,
@@ -221,7 +188,6 @@ export function createConnectorActionBlock(
         signal,
       );
       signal.throwIfAborted();
-      set(markComplete$);
       return;
     }
 
@@ -229,7 +195,6 @@ export function createConnectorActionBlock(
     signal.throwIfAborted();
     set(activeChatConnectorActionState$, {
       ...descriptor,
-      markComplete$,
     });
     set(setSelectedConnectorType$, descriptor.connectorRef);
   });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -62,6 +62,7 @@ import {
 import { setAblyLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { resetPermissionDialog$ } from "./permission-dialog.ts";
+import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
 import { sanitizeTokenInputRecord } from "./token-input.ts";
 import { IN_VITEST } from "../../../env.ts";
 
@@ -935,6 +936,9 @@ const finishConnectorConnection$ = command(
     });
     if (options.reloadConnectors !== false) {
       set(reloadConnectors$);
+    }
+    if (options.agentId) {
+      set(reloadAgentConnectorAuthorizations$);
     }
 
     const hidden = new Set(get(hiddenConnectorTypes$));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1,4 +1,5 @@
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import { zeroConnectorManualGrantContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
   zeroConnectorCatalogContract,
@@ -642,34 +643,64 @@ describe("chat message action cards", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
-  it("keeps catalog-visible connectors actionable without a bundled type", async () => {
+  it("completes catalog-visible connectors without a bundled type", async () => {
     const user = userEvent.setup({ delay: null });
     const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/future-connector/authorize?agentId=${AGENT_ID}`;
-    mockConnectorCatalogStatus([
-      publicConnectorStatusItem({
-        connectorRef: "future-connector",
-        label: "Catalog Future Connector",
-        description: "Catalog future connector help text",
-        authMethods: [
-          {
-            id: "partner-token",
-            label: "Partner token",
-            description: null,
-            grantKind: "manual",
-            manualFields: [
+    let connected = false;
+    let authorized = false;
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            connectorRef: "future-connector",
+            label: "Catalog Future Connector",
+            description: "Catalog future connector help text",
+            connected,
+            connectionStatus: connected ? "connected" : "not-connected",
+            authMethods: [
               {
-                id: "apiKey",
-                label: "API key",
-                required: true,
-                placeholder: null,
-                inputType: "password",
+                id: "partner-token",
+                label: "Partner token",
+                description: null,
+                grantKind: "manual",
+                manualFields: [
+                  {
+                    id: "apiKey",
+                    label: "API key",
+                    required: true,
+                    placeholder: "future-api-key",
+                    inputType: "password",
+                  },
+                ],
+                startOptions: [],
               },
             ],
-            startOptions: [],
-          },
+          }),
         ],
-      }),
-    ]);
+      });
+    });
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        enabledTypes: authorized ? ["future-connector"] : [],
+      });
+    });
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("future-connector");
+        expect(body.agentId).toBe(AGENT_ID);
+        expect(body.authorizeAgent).toBeTruthy();
+        connected = true;
+        authorized = true;
+        return respond(
+          200,
+          connectedConnector({
+            type: "future-connector",
+            authMethod: body.authMethod,
+          }),
+        );
+      },
+    );
     mockChatLifecycle(context, {
       threadId: `${THREAD_ID}-future-connector`,
       threadTitle: "Future connector",
@@ -706,7 +737,27 @@ describe("chat message action cards", () => {
     const connectButton = buttonByText("Connect", connectorCard);
     expect(connectButton).toBeEnabled();
     await user.click(connectButton);
-    expect((await screen.findAllByText("API key")).length).toBeGreaterThan(0);
+    const apiKeyInputs =
+      await screen.findAllByPlaceholderText("future-api-key");
+    const apiKeyInput = apiKeyInputs.at(-1);
+    if (!apiKeyInput) {
+      throw new Error("Future connector API key input not found");
+    }
+    await user.type(apiKeyInput, "future-token");
+    const currentApiKeyInput = screen
+      .getAllByPlaceholderText("future-api-key")
+      .at(-1);
+    const saveButton = currentApiKeyInput
+      ?.closest("form")
+      ?.querySelector<HTMLElement>('button[type="submit"]');
+    if (!saveButton) {
+      throw new Error("Future connector save button not found");
+    }
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(within(connectorCard).getByText("Connected")).toBeInTheDocument();
+    });
   });
 
   it("fails closed when permission action metadata is hidden", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -134,7 +134,6 @@ import {
 import {
   activeChatConnectorAction$,
   closeChatConnectorActionConnectDialog$,
-  completeChatConnectorActionConnect$,
   type CustomConnectorActionBlock,
   type ConnectorActionBlock,
 } from "../../signals/chat-page/connector-action-block.ts";
@@ -4782,10 +4781,14 @@ function BodyContentBlocks({
 function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
   const pageSignal = useGet(pageSignal$);
   const available = useLastResolved(block.available$) ?? false;
-  const complete = useLastResolved(block.complete$) ?? false;
+  const completeLoadable = useLoadable(block.complete$);
+  const complete =
+    completeLoadable.state === "hasData" && completeLoadable.data;
   const displayMetadata = useLastResolved(block.displayMetadata$);
   const [activateLoadable, activate] = useLoadableSet(block.activate$);
-  const activating = activateLoadable.state === "loading";
+  const loading =
+    completeLoadable.state === "loading" ||
+    activateLoadable.state === "loading";
   if (!available || !displayMetadata) {
     return null;
   }
@@ -4810,13 +4813,13 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
       </div>
       <button
         type="button"
-        disabled={complete || activating}
+        disabled={complete || loading}
         onClick={() => {
           detach(activate(pageSignal), Reason.DomCallback);
         }}
         className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
       >
-        {activating && <IconLoader2 size={15} className="animate-spin" />}
+        {loading && <IconLoader2 size={15} className="animate-spin" />}
         {complete ? "Connected" : "Connect"}
       </button>
     </div>
@@ -5503,21 +5506,12 @@ function PermissionActionCard({
 function ChatConnectorActionConnectModal() {
   const active = useGet(activeChatConnectorAction$);
   const close = useSet(closeChatConnectorActionConnectDialog$);
-  const complete = useSet(completeChatConnectorActionConnect$);
 
   if (!active) {
     return null;
   }
 
-  return (
-    <ConnectModal
-      agentId={active.agentId}
-      onClose={close}
-      onSuccess={() => {
-        complete();
-      }}
-    />
-  );
+  return <ConnectModal agentId={active.agentId} onClose={close} />;
 }
 
 function isImageFilename(filename: string): boolean {


### PR DESCRIPTION
## Summary

- Remove per-action connected and authorized override state from chat connector action blocks.
- Use loadables to represent connector action read and write lifecycles in the card UI.
- Refresh targeted agent authorization data when connector setup finishes so the final Connected state comes from authoritative connector and authorization reads.
- Extend the page-level action-card flow to complete a catalog-only manual connector and verify the card reaches Connected.

## User impact

Connector action cards remain disabled with a loading indicator while connection and authorization data refresh, then reflect the server-authored result without forcing a local completed state.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (13/13 tasks passed)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx` (20/20 tests passed)
- `pnpm knip --workspace @vm0/app`