### PR TITLE
fix(runner): validate brotli tails at decode limit

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [
+    "Brotli>=1.2.0",
     "basedpyright>=1.39",
     "mitmproxy>=10.0",
     "pytest>=7.0",
@@ -17,6 +18,7 @@ dev = [
     "wsproto>=1.2",
 ]
 test = [
+    "Brotli>=1.2.0",
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
     "mitmproxy>=10.0",

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -23,10 +23,10 @@ from body_limits import (
     STREAM_DECODE_CHUNK_LIMIT,
 )
 
-# Python's brotli binding has no max-output API, and one process() call can
-# still transiently emit multi-MB output. Keep small compressed inputs on tiny
-# chunks to preserve the best-effort high-compression guard, but scale up for
-# larger inputs to avoid thousands of Python-to-C calls.
+# Brotli 1.2's output_buffer_limit is a soft allocation threshold, not a hard
+# returned-byte cap. Keep small compressed inputs on tiny chunks as a second
+# high-compression guard, but scale up for larger inputs to avoid thousands of
+# Python-to-C calls.
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
@@ -233,11 +233,10 @@ def decompress_body(
     - zstd: hard cap via ``ZstdDecompressor.stream_reader(data).read(max_output)``;
       zstd reads incrementally so total memory is bounded by
       ``max_output`` plus library internal buffers.
-    - br: bounded accumulator over small compressed input chunks.  The
-      Python ``brotli`` bindings expose no max-output API, so ``process`` may
-      still transiently emit a multi-MB chunk, but decoding stops once
-      ``max_output`` bytes have been accumulated instead of materialising the
-      full response before slicing.
+    - br: exact accumulator cap over adaptive compressed-input chunks.
+      Brotli 1.2's ``output_buffer_limit`` keeps transient output near the
+      remaining budget, plus library allocation blocks; returned chunks may
+      exceed that soft threshold and are sliced to the exact cap.
 
     Returns the original data unchanged when the encoding is missing,
     ``identity``, unrecognised, or invalid before any compressed member
@@ -336,7 +335,10 @@ def _decode_body_bounded(
 
 
 def _decompress_brotli_bounded_with_status(
-    data: bytes, max_output: int
+    data: bytes,
+    max_output: int,
+    *,
+    validate_complete_input: bool,
 ) -> tuple[bytes, bool, bool]:
     if max_output <= 0:
         return b"", False, bool(data)
@@ -354,27 +356,29 @@ def _decompress_brotli_bounded_with_status(
     out = bytearray()
     for offset in range(0, len(data), chunk_size):
         chunk = data[offset : offset + chunk_size]
-        decoded = dec.process(chunk)
-        if not decoded:
-            continue
-
         remaining = max_output - len(out)
-        if remaining <= 0:
-            return bytes(out), dec.is_finished(), True
+        # The binding may return more than this soft threshold because it fills
+        # allocation blocks before checking. Using one probe byte beyond the
+        # remaining budget means a paused decoder has already proven overflow;
+        # non-overflow results consume the complete input chunk, so another
+        # nonempty chunk remains safe without an empty-input drain loop.
+        decoded = dec.process(chunk, output_buffer_limit=remaining + 1)
         if len(decoded) > remaining:
             out.extend(decoded[:remaining])
             return bytes(out), dec.is_finished(), True
-        if len(decoded) == remaining:
-            out.extend(decoded)
-            finished = dec.is_finished()
-            return bytes(out), finished, not finished
         out.extend(decoded)
+        if not validate_complete_input and len(out) == max_output:
+            return bytes(out), dec.is_finished(), False
 
     return bytes(out), dec.is_finished(), False
 
 
 def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
-    body, _finished, _limited = _decompress_brotli_bounded_with_status(data, max_output)
+    body, _finished, _limited = _decompress_brotli_bounded_with_status(
+        data,
+        max_output,
+        validate_complete_input=False,
+    )
     return body
 
 
@@ -477,7 +481,11 @@ def _decode_supported_body_with_complete_status(
         return _decompress_zlib_json_usage_body(data, encoding, max_output)
     if encoding == "br":
         try:
-            body, finished, limited = _decompress_brotli_bounded_with_status(data, max_output)
+            body, finished, limited = _decompress_brotli_bounded_with_status(
+                data,
+                max_output,
+                validate_complete_input=True,
+            )
         except brotli.error as exc:
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime

--- a/crates/runner/mitm-addon/tests/body_decode_helpers.py
+++ b/crates/runner/mitm-addon/tests/body_decode_helpers.py
@@ -5,16 +5,25 @@ import brotli
 
 def track_brotli_decompressor(monkeypatch):
     real_decompressor = brotli.Decompressor
-    stats = {"calls": 0, "max_input": 0, "max_output": 0}
+    stats = {
+        "calls": 0,
+        "max_input": 0,
+        "max_output": 0,
+        "max_output_buffer_limit": 0,
+    }
 
     class CountingDecompressor:
         def __init__(self):
             self._inner = real_decompressor()
 
-        def process(self, chunk: bytes) -> bytes:
-            out = self._inner.process(chunk)
+        def process(self, chunk: bytes, output_buffer_limit: int = 0) -> bytes:
             stats["calls"] += 1
             stats["max_input"] = max(stats["max_input"], len(chunk))
+            stats["max_output_buffer_limit"] = max(
+                stats["max_output_buffer_limit"],
+                output_buffer_limit,
+            )
+            out = self._inner.process(chunk, output_buffer_limit=output_buffer_limit)
             stats["max_output"] = max(stats["max_output"], len(out))
             return out
 

--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -155,7 +155,8 @@ class TestDecompression:
         assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
         assert stats["max_input"] < len(compressed)
         assert stats["max_input"] <= 16
-        assert stats["max_output"] < len(original)
+        assert stats["max_output_buffer_limit"] == BODY_CAPTURE_LIMIT + 2
+        assert stats["max_output"] < BODY_CAPTURE_LIMIT * 4
 
     def test_zstd_decompressed(self, real_flow):
         original = b'{"result": "hello world"}'

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -263,9 +263,9 @@ class TestDecompressBody:
     ``LARGE_RESPONSE_DECOMPRESS_LIMIT``) for JSON parsing.
 
     Focus: verify the documented ``max_output`` cap is enforced during
-    decompression (not only via after-the-fact slicing) for codecs with
-    hard output-limit APIs.  Brotli's Python binding is best-effort; the
-    high-compression capture regression is covered in ``TestDecompression``.
+    decompression (not only via after-the-fact slicing). Brotli uses a soft
+    output threshold plus exact accumulator slicing; its high-compression
+    regression is covered in ``TestDecompression``.
     """
 
     def test_gzip_respects_max_output(self, headers):
@@ -482,6 +482,74 @@ class TestDecodeRequestBodyForNetworkLogCapture:
 
 class TestDecompressJsonUsageBody:
     """Direct tests for strict JSON usage decompression."""
+
+    def test_brotli_exact_limit_consumes_later_frame_trailer(self, headers, monkeypatch):
+        body = pseudo_random_ascii(13)
+        compressed = brotli.compress(body)
+        assert len(compressed) == 17
+
+        boundary_decoder = brotli.Decompressor()
+        assert boundary_decoder.process(compressed[:16]) == body
+        assert not boundary_decoder.is_finished()
+
+        stats = track_brotli_decompressor(monkeypatch)
+        hdrs = headers(("Content-Encoding", "br"))
+        decoded, error = decompress_json_usage_body(
+            compressed,
+            hdrs,
+            max_output=len(body),
+        )
+        assert stats["calls"] == 2
+        assert stats["max_input"] == 16
+
+        truncated, truncated_error = decompress_json_usage_body(
+            compressed[:-1],
+            hdrs,
+            max_output=len(body),
+        )
+
+        assert decoded == body
+        assert error is None
+        assert truncated == body
+        assert truncated_error == "incomplete compressed body"
+
+    def test_brotli_exact_limit_validates_later_wire_input(self, headers, monkeypatch):
+        body = pseudo_random_ascii(12)
+        compressed = brotli.compress(body)
+        assert len(compressed) == 16
+        malformed = compressed + b"trailing garbage"
+
+        stats = track_brotli_decompressor(monkeypatch)
+        hdrs = headers(("Content-Encoding", "br"))
+        decoded, error = decompress_json_usage_body(
+            malformed,
+            hdrs,
+            max_output=len(body),
+        )
+
+        assert stats["calls"] == 2
+        assert stats["max_input"] == 16
+        assert decoded == b""
+        assert error == "invalid compressed body"
+        assert (
+            decode_request_body_for_network_log_capture(
+                malformed,
+                hdrs,
+                max_output=len(body),
+            )
+            is None
+        )
+        assert decompress_body(malformed, hdrs, max_output=len(body)) == body
+
+    def test_brotli_single_frame_exceeding_limit_returns_error(self, headers):
+        body = pseudo_random_ascii(33)
+        compressed = brotli.compress(body)
+        hdrs = headers(("Content-Encoding", "br"))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=32)
+
+        assert decoded == body[:32]
+        assert error == "decoded body limit exceeded"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_zlib_exact_limit_accepts_empty_trailing_members(self, headers, encoding):


### PR DESCRIPTION
## Summary

- keep strict Brotli decoding active after an exact decoded-output fill so
  later frame trailers finish normally and later garbage is rejected
- use Brotli 1.2's soft output threshold with a one-byte overflow probe while
  preserving best-effort response-capture cap termination
- declare the Brotli 1.2 requirement and add real-codec regressions for strict
  usage, request capture, true overflow, and high-ratio transient output

## Compatibility

- no database schema, migration, persisted-data, or backfill changes
- no API, queue payload, runner protocol, or cross-service contract changes
- Brotli streaming remains disabled; safe response negotiation and the
  one-shot fallback architecture remain in place

## Validation

- `.venv/bin/python -m pip install -e ".[dev]"`
- `.venv/bin/python -m pip check`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_body_decoding.py tests/test_body_capture_decompression.py -v`
  (104 passed)
- `.venv/bin/python -m pytest tests/ -v` (4,046 passed)
- pre-commit Ruff, Cargo fmt, Cargo doc, and Clippy hooks passed

Closes #21931
