### PR TITLE
perf(api): avoid redundant zero plan admission read

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -171,7 +171,6 @@ const RUNNER_CLAIM_POLL_TIMING_ACTION_TYPES = [
 ] as const;
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
-  "api_dispatch_check_org_tier",
   "api_dispatch_check_run_admission",
   "api_dispatch_prepare_run_context",
   "api_dispatch_prepare_context_feature_switches",
@@ -1015,6 +1014,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectNoApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES,
@@ -1145,6 +1145,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_check_org_tier"],
+      "top_level",
+    );
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
@@ -3041,6 +3047,8 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       description: "Covers the pro-suspend admission branch.",
       visibility: "private",
     });
+    const byokPrompt = `suspended BYOK ${randomUUID()}`;
+    const vm0Prompt = `suspended VM0 ${randomUUID()}`;
     await seedOrgMetadata({
       orgId: actor.orgId,
       tier: "pro-suspend",
@@ -3051,7 +3059,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       actor,
       {
         agentId: agent.agentId,
-        prompt: "should be rejected",
+        prompt: byokPrompt,
         modelProvider: "anthropic-api-key",
       },
       [402],
@@ -3064,13 +3072,26 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       actor,
       {
         agentId: agent.agentId,
-        prompt: "should be rejected",
+        prompt: vm0Prompt,
         modelProvider: "vm0",
       },
       [402],
     );
     expectApiError(vm0Rejected.body);
     expect(vm0Rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((run) => {
+        return run.prompt === byokPrompt || run.prompt === vm0Prompt;
+      }),
+    ).toHaveLength(0);
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).toHaveLength(0);
+    expect(queue.body.concurrency.active).toBe(0);
   });
 
   it("does not require queued payload encryption while capacity is available", async () => {
@@ -3853,7 +3874,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
   });
 
-  it("uses staff entitlement capabilities for run admission", async () => {
+  it("enforces staff entitlement status at final run admission", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const actor = bdd.user({ orgId: STAFF_ORG_ID });
@@ -3896,8 +3917,57 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       prompt: "staff entitlement BYOK run",
       modelProvider: "anthropic-api-key",
     });
-
+    expectNoApiDispatchActions(apiDispatchTimingEventsForRun(run.runId), [
+      "api_dispatch_check_org_tier",
+    ]);
     await api.requestCancelRun(actor, run.runId, [200]);
+
+    await upsertOrgPlanEntitlementFixture({
+      orgId: STAFF_ORG_ID,
+      status: "suspended",
+      supportByok: true,
+      restrictedVm0Models: false,
+    });
+
+    const byokPrompt = `staff suspended BYOK ${randomUUID()}`;
+    const vm0Prompt = `staff suspended VM0 ${randomUUID()}`;
+    const byokRejected = await api.requestCreateRun(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: byokPrompt,
+        modelProvider: "anthropic-api-key",
+      },
+      [402],
+    );
+    expectApiError(byokRejected.body);
+    expect(byokRejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    const vm0Rejected = await api.requestCreateRun(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: vm0Prompt,
+        modelProvider: "vm0",
+      },
+      [402],
+    );
+    expectApiError(vm0Rejected.body);
+    expect(vm0Rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((candidate) => {
+        return (
+          candidate.prompt === byokPrompt || candidate.prompt === vm0Prompt
+        );
+      }),
+    ).toHaveLength(0);
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).toHaveLength(0);
+    expect(queue.body.concurrency.active).toBe(0);
   });
 
   it("defaults limited-free runs to Luna, allows Terra and VM0 Model, and rejects Sol", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1121,7 +1121,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [prompt, agentId]);
   });
 
-  it("emits api dispatch timing for direct create route runs", async () => {
+  it("retains direct plan admission and emits direct create timing", async () => {
     const api = createRunsApi(context);
     const { actor } = await entitledRunActor();
     const prompt = "direct route api dispatch timing should not leak prompt";
@@ -1198,6 +1198,33 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ]);
 
     await api.requestCancelRun(actor, created.runId, [200]);
+
+    if (!actor.orgId) {
+      throw new Error("Expected suspended direct-run actor to have an org");
+    }
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    const suspendedPrompt = `suspended direct ${randomUUID()}`;
+    const rejected = await api.requestDirectRun(
+      actor,
+      { agentComposeVersionId: headVersionId, prompt: suspendedPrompt },
+      [402],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((run) => {
+        return run.prompt === suspendedPrompt;
+      }),
+    ).toHaveLength(0);
   });
 
   it("emits bucketed storage manifest shape dimensions without leaking storage identifiers", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -183,7 +183,7 @@ import {
 } from "./org-concurrency-entitlements.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 import {
-  checkOrgModelRunAdmission,
+  checkOrgPlanRunAdmission,
   checkOrgCreditsForRunAdmission,
   checkResolvedOrgCreditsForRunAdmission,
   resolveOrgCreditAvailability,
@@ -4001,7 +4001,7 @@ async function checkFinalRunAdmission(
   const capabilities = await loadOrgPlanCapabilities(db, args.orgId);
   args.signal.throwIfAborted();
   return (
-    checkOrgModelRunAdmission({
+    checkOrgPlanRunAdmission({
       capabilities,
       modelProviderType: args.modelProviderType,
       selectedModel: args.selectedModel,
@@ -7403,6 +7403,7 @@ interface PreparedAgentRun {
 interface PrepareAgentRunArgs {
   readonly args: CreateAgentRunArgs;
   readonly timing: ApiDispatchTimingCollector;
+  readonly checkOrgPlanStatusBeforeContext: boolean;
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
 }
 
@@ -7436,16 +7437,18 @@ export const prepareAgentRun$ = command(
   ): Promise<PreparedAgentRun | CreateRunErrorResult> => {
     const { args, timing } = input;
     const db = set(writeDb$);
-    const tierGate = await timing.measure(
-      "api_dispatch_check_org_tier",
-      "top_level",
-      async () => {
-        return await checkOrgRunPlanStatus(db, { orgId: args.orgId });
-      },
-    );
-    signal.throwIfAborted();
-    if (tierGate) {
-      return tierGate;
+    if (input.checkOrgPlanStatusBeforeContext) {
+      const tierGate = await timing.measure(
+        "api_dispatch_check_org_tier",
+        "top_level",
+        async () => {
+          return await checkOrgRunPlanStatus(db, { orgId: args.orgId });
+        },
+      );
+      signal.throwIfAborted();
+      if (tierGate) {
+        return tierGate;
+      }
     }
 
     const context = await timing.measure(
@@ -7550,7 +7553,11 @@ export const createAgentRun$ = command(
       "top_level",
       args.apiStartTime,
     );
-    const prepared = await set(prepareAgentRun$, { args, timing }, signal);
+    const prepared = await set(
+      prepareAgentRun$,
+      { args, timing, checkOrgPlanStatusBeforeContext: true },
+      signal,
+    );
     if (isRouteError(prepared)) {
       return prepared;
     }

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -23,9 +23,9 @@ interface OrgCreditAvailability {
   readonly spendableCredits: number;
 }
 
-type OrgModelAdmissionCapabilities = Pick<
+type OrgPlanRunAdmissionCapabilities = Pick<
   OrgPlanCapabilities,
-  "supportByok" | "restrictedVm0Models"
+  "status" | "supportByok" | "restrictedVm0Models"
 >;
 
 export async function resolveOrgCreditAvailability(params: {
@@ -94,16 +94,13 @@ export async function checkResolvedOrgCreditsForRunAdmission(params: {
   if (!availability) {
     return insufficientCredits();
   }
-  const modelAdmission = checkOrgModelRunAdmission({
+  const planAdmission = checkOrgPlanRunAdmission({
     capabilities: availability,
     modelProviderType: params.modelProviderType,
     selectedModel: params.selectedModel,
   });
-  if (modelAdmission) {
-    return modelAdmission;
-  }
-  if (availability.status !== "active") {
-    return insufficientCredits();
+  if (planAdmission) {
+    return planAdmission;
   }
 
   if (params.modelProviderType !== "vm0") {
@@ -123,14 +120,14 @@ export async function checkResolvedOrgCreditsForRunAdmission(params: {
     : insufficientCredits();
 }
 
-export function checkOrgModelRunAdmission(params: {
-  readonly capabilities: OrgModelAdmissionCapabilities | null;
+export function checkOrgPlanRunAdmission(params: {
+  readonly capabilities: OrgPlanRunAdmissionCapabilities | null;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel: string | null | undefined;
 }): ReturnType<typeof insufficientCredits> | undefined {
   const { capabilities } = params;
-  if (!capabilities) {
-    return undefined;
+  if (!capabilities || capabilities.status !== "active") {
+    return insufficientCredits();
   }
   return (!capabilities.supportByok && params.modelProviderType !== "vm0") ||
     (capabilities.restrictedVm0Models &&

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -1063,6 +1063,7 @@ const createAgentRunAfterZeroPreCreate$ = command(
       {
         args: createAgentRunArgs,
         timing: input.timing,
+        checkOrgPlanStatusBeforeContext: false,
         preloadedFeatureSwitchContext: input.featureSwitchContext,
       },
       signal,


### PR DESCRIPTION
## Summary

- skip the standalone early org-plan status read for Zero run creation
- make final run admission enforce org-plan status together with VM0/BYOK model capabilities
- retain the early plan-status gate for direct agent-run creation
- verify active-path timing and ensure suspended rejections leave no run, queue, or concurrency state

## Compatibility

- no schema, migration, persisted-data, public API, queue payload, or runner protocol changes
- direct run creation keeps its existing early rejection behavior
- Zero run creation still rejects suspended plans before durable run state is created

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (105 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- pre-commit full-repository Knip and TypeScript checks

Closes #21938

Parent delivery issue: #21674
