### PR TITLE
fix: rename vm0 model to auto

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -84,7 +84,7 @@ CLAUDE_CODE_VERSION_URL=https://storage.googleapis.com/claude-code-dist-86c565f3
 # Required: OpenAI (voice-chat ephemeral token minting, STT, TTS)
 OPENAI_API_KEY=op://Development/openai/OPENAI_API_KEY
 
-# Optional: VM0 Model proxy authentication (required to run vm0-model)
+# Optional: Auto proxy authentication (required to run vm0-model)
 VM0_MODEL_PROXY_TOKEN=op://Development/vm0/VM0_MODEL_PROXY_TOKEN
 VM0_MODEL_PROXY_HOST=
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3900,7 +3900,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("defaults limited-free runs to Luna, allows Terra and VM0 Model, and rejects Sol", async () => {
+  it("defaults limited-free runs to Luna, allows Terra and Auto, and rejects Sol", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
@@ -3991,13 +3991,13 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       actor,
       {
         agentId,
-        prompt: "limited-free VM0 Model run",
+        prompt: "limited-free Auto run",
         model: vm0Model,
       },
       [201],
     );
     if (vm0Sent.status !== 201 || vm0Sent.body.runId === null) {
-      throw new Error("Expected VM0 Model to create a limited-free run");
+      throw new Error("Expected Auto to create a limited-free run");
     }
     await api.heartbeatRunner(runnerGroup);
     const vm0Claim = await api.claimRunnerJob(vm0Sent.body.runId);
@@ -4150,7 +4150,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       [201],
     );
     if (sent.status !== 201 || sent.body.runId === null) {
-      throw new Error("Expected VM0 Model chat send to create a run");
+      throw new Error("Expected Auto chat send to create a run");
     }
 
     await api.heartbeatRunner(runnerGroup);
@@ -4165,7 +4165,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(claim.environment?.OPENAI_API_KEY).not.toBe("vm0-model-proxy-token");
     expect(claim.codexRuntimeConfig).toMatchObject({
       providerId: "vm0-model",
-      name: "VM0 Model",
+      name: "Auto",
       baseUrl: proxyBaseUrl,
       envKey: "OPENAI_API_KEY",
       wireApi: "responses",
@@ -4199,7 +4199,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       [200],
     );
     if (resolved.status !== 200) {
-      throw new Error("Expected VM0 Model firewall auth to resolve");
+      throw new Error("Expected Auto firewall auth to resolve");
     }
     expect(resolved.body.headers).toStrictEqual({
       Authorization: "Bearer vm0-model-proxy-token",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2446,7 +2446,7 @@ describe("chat composer models", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("keeps VM0 Model available when VM0 models and BYOK are restricted", async () => {
+  it("keeps Auto available when VM0 models and BYOK are restricted", async () => {
     const user = userEvent.setup({ delay: null });
     mockBillingCapabilities({ supportByok: false, restrictedVm0Models: true });
     context.mocks.data.orgModelPolicies([
@@ -2461,7 +2461,7 @@ describe("chat composer models", () => {
       buildModelPolicy({
         id: "00000000-0000-4000-a000-000000000704",
         model: "vm0-model",
-        modelLabel: "VM0 Model",
+        modelLabel: "Auto",
         defaultProviderType: "vm0",
         credentialScope: "org",
       }),
@@ -2472,9 +2472,9 @@ describe("chat composer models", () => {
 
     await expectComposerModel("Kimi K2.7 Code");
     await user.click(screen.getByRole("combobox", { name: "Kimi K2.7 Code" }));
-    await user.click(await screen.findByRole("option", { name: /VM0 Model/u }));
+    await user.click(await screen.findByRole("option", { name: /Auto/u }));
 
-    await expectComposerModel("VM0 Model");
+    await expectComposerModel("Auto");
     expect(
       screen.queryByRole("heading", { name: "Compare plans" }),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -300,7 +300,7 @@ function dialogContaining(element: HTMLElement): HTMLElement {
 }
 
 describe("organization model providers settings", () => {
-  it("only offers VM0 Model when its feature switch is enabled", async () => {
+  it("only offers Auto when its feature switch is enabled", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);
     context.mocks.data.orgModelPolicies([]);
@@ -311,18 +311,18 @@ describe("organization model providers settings", () => {
     click(within(dialog).getByRole("combobox"));
 
     expect(
-      screen.queryByRole("option", { name: "VM0 Model" }),
+      screen.queryByRole("option", { name: "Auto" }),
     ).not.toBeInTheDocument();
   });
 
-  it("shows the VM0 Model description without provider routing choices", async () => {
+  it("shows the Auto description without provider routing choices", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);
     context.mocks.data.orgModelPolicies([]);
     await openProvidersTab({ vm0ModelEnabled: true });
 
     click(buttonByText("Add model"));
-    await selectDialogModel("VM0 Model");
+    await selectDialogModel("Auto");
 
     const dialog = screen.getByRole("dialog", { name: "Add model" });
     expect(
@@ -336,7 +336,7 @@ describe("organization model providers settings", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("lets limited-free-1 workspaces add VM0 Model without upgrading", async () => {
+  it("lets limited-free-1 workspaces add Auto without upgrading", async () => {
     mockAdminOrg();
     mockBillingCapabilities({
       supportByok: false,
@@ -354,7 +354,7 @@ describe("organization model providers settings", () => {
     await openProvidersTab({ vm0ModelEnabled: true });
 
     click(buttonByText("Add model"));
-    await selectDialogModel("VM0 Model");
+    await selectDialogModel("Auto");
 
     const dialog = screen.getByRole("dialog", { name: "Add model" });
     expect(buttonByText("Add model", dialog)).toBeInTheDocument();
@@ -364,7 +364,7 @@ describe("organization model providers settings", () => {
     const vm0ModelRow = await screen.findByTestId(
       "org-model-policy-row-vm0-model",
     );
-    expect(within(vm0ModelRow).getByText("VM0 Model")).toBeInTheDocument();
+    expect(within(vm0ModelRow).getByText("Auto")).toBeInTheDocument();
   });
 
   it("opens a workspace API key model route form", async () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -202,7 +202,7 @@ describe("model-first canonical catalog", () => {
   });
 
   it("surfaces display labels for canonical models", () => {
-    expect(getCanonicalModelDisplayName("vm0-model")).toBe("VM0 Model");
+    expect(getCanonicalModelDisplayName("vm0-model")).toBe("Auto");
     expect(getCanonicalModelDisplayName("claude-opus-4-8")).toBe(
       "Claude Opus 4.8",
     );

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -62,7 +62,7 @@ export interface Vm0ModelProviderConfig {
 }
 
 /**
- * VM0 Model uses the public Responses shape while keeping both credentials in
+ * Auto uses the public Responses shape while keeping both credentials in
  * firewall auth. Codex sees only the canonical OPENAI_API_KEY placeholder; the
  * firewall injects the proxy credential as Authorization and a managed OpenAI
  * credential in the internal upstream header consumed by the proxy.

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -155,7 +155,7 @@ export function getVm0ModelCodexRuntimeConfig(
 ): ModelProviderCodexRuntimeConfig {
   return {
     providerId: "vm0-model",
-    name: "VM0 Model",
+    name: "Auto",
     baseUrl,
     envKey: "OPENAI_API_KEY",
     wireApi: "responses",
@@ -164,7 +164,7 @@ export function getVm0ModelCodexRuntimeConfig(
       models: [
         {
           slug: "vm0-model",
-          display_name: "VM0 Model",
+          display_name: "Auto",
           description: "Automatically routes each task to a VM0 model.",
           default_reasoning_level: null,
           supported_reasoning_levels: [],
@@ -303,7 +303,7 @@ export interface DefaultOrgModelPolicySeed {
 }
 
 const SUPPORTED_RUN_MODEL_LABELS: Record<SupportedRunModel, string> = {
-  "vm0-model": "VM0 Model",
+  "vm0-model": "Auto",
   "claude-fable-5": "Claude Fable 5",
   "claude-opus-4-8": "Claude Opus 4.8",
   "claude-opus-4-7": "Claude Opus 4.7",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -308,7 +308,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.Vm0Model]: {
     maintainer: "yuma@vm0.ai",
-    description: "Show VM0 Model in the workspace Add model selector.",
+    description: "Show Auto in the workspace Add model selector.",
     enabled: false,
   },
   [FeatureSwitchKey.RealAgentInPreview]: {

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -6,7 +6,7 @@
 	}
 }
 
-# Public dev tunnel ingress. Keep VM0 Model on the same www authority as the
+# Public dev tunnel ingress. Keep Auto on the same www authority as the
 # API while routing only its internal proxy path to vm0-marketing.
 :3043 {
 	handle /api/internal/vm0-model/v1/* {

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -91,7 +91,7 @@ The `Caddyfile` defines:
 | api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)   |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443 |
 
-The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043. Caddy sends the VM0 Model proxy path to vm0-marketing and preserves the
+The public `tunnel-*-www.vm7.ai` development tunnel points to Caddy on port 3043. Caddy sends the Auto proxy path to vm0-marketing and preserves the
 API as the fallback for every other path.
 
 ## Scripts


### PR DESCRIPTION
## Summary

- Rename the managed `vm0-model` display label from `VM0 Model` to `Auto` in the canonical model catalog and Codex runtime configuration.
- Update the workspace model selector, chat composer fixtures, feature-switch copy, proxy documentation, and related assertions to use the new name.
- Preserve the internal `vm0-model` identifier and leave historical changelogs and applied migrations unchanged.

## User impact

Users now see `Auto` everywhere the managed routing model is presented in workspace settings and chat model selection.

## Verification

- API contracts: 178 targeted tests passed.
- Platform: 99 targeted tests passed.
- Lint passed for `@vm0/api-contracts`, `@vm0/core`, `@vm0/app`, and `api`.
- Type checking passed for `@vm0/api-contracts`, `@vm0/core`, `@vm0/app`, and `api`.
- Prettier and `git diff --check` passed.
- The two targeted API integration tests were attempted but could not reach the local PostgreSQL instance (`ECONNREFUSED`); the PR pipeline will run them with the repository test environment.