### PR TITLE
perf(runner): attribute generation-specific workspace sidecars

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -396,18 +396,25 @@ fn merge_held_session_state(existing: &mut HeldSessionState, mut incoming: HeldS
     if existing.reusable_sandbox.is_none() {
         existing.reusable_sandbox = incoming.reusable_sandbox;
     }
+    for incoming_workspace in incoming.workspace_caches.drain(..) {
+        match existing
+            .workspace_caches
+            .iter_mut()
+            .find(|workspace| workspace.profile == incoming_workspace.profile)
+        {
+            Some(existing_workspace)
+                if incoming_workspace.workspace_affinity_version
+                    >= existing_workspace.workspace_affinity_version =>
+            {
+                *existing_workspace = incoming_workspace;
+            }
+            Some(_) => {}
+            None => existing.workspace_caches.push(incoming_workspace),
+        }
+    }
     existing
         .workspace_caches
-        .append(&mut incoming.workspace_caches);
-    existing.workspace_caches.sort_unstable_by(|a, b| {
-        a.profile.cmp(&b.profile).then_with(|| {
-            b.workspace_affinity_version
-                .cmp(&a.workspace_affinity_version)
-        })
-    });
-    existing
-        .workspace_caches
-        .dedup_by(|a, b| a.profile == b.profile);
+        .sort_unstable_by(|a, b| a.profile.cmp(&b.profile));
     existing
         .workspace_caches
         .truncate(MAX_WORKSPACE_CACHES_PER_SESSION);
@@ -526,7 +533,9 @@ mod tests {
     use crate::ids::RunId;
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
-    use crate::types::WorkspaceCacheState;
+    use crate::types::{
+        SessionHistorySizeBucket, WorkspaceCacheState, WorkspaceSessionHistorySidecarState,
+    };
     use crate::workspace_image_cache::{
         WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
@@ -570,6 +579,18 @@ mod tests {
         WorkspaceCacheState {
             profile: profile.to_owned(),
             workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
+            session_history_sidecar: None,
+        }
+    }
+
+    fn workspace_cache_with_sidecar(profile: &str, run_id: RunId) -> WorkspaceCacheState {
+        WorkspaceCacheState {
+            profile: profile.to_owned(),
+            workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
+            session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
+                history_generation_run_id: Some(run_id),
+                raw_size_bucket: SessionHistorySizeBucket::LessThan64Kib,
+            }),
         }
     }
 
@@ -1060,6 +1081,36 @@ mod tests {
         assert_eq!(states, vec![original]);
     }
 
+    #[test]
+    fn held_session_snapshot_concurrent_promotion_clears_stale_sidecar_attribution() {
+        let snapshot = HeldSessionStateSnapshot::new();
+        let run_id = RunId::new_v4();
+        let observed = HeldSessionState {
+            session_id: "sess-shared".into(),
+            last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache_with_sidecar("vm0/default", run_id)],
+        };
+        refresh_snapshot(&snapshot, vec![observed.clone()]);
+
+        let refresh = snapshot.begin_workspace_cache_refresh();
+        snapshot.upsert_workspace_cache_state(HeldSessionState {
+            session_id: "sess-shared".into(),
+            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            reusable_sandbox: None,
+            workspace_caches: vec![workspace_cache("vm0/default")],
+        });
+        let refreshed = snapshot.finish_workspace_cache_refresh(refresh, vec![observed]);
+
+        assert_eq!(refreshed.len(), 1);
+        assert_eq!(refreshed[0].workspace_caches.len(), 1);
+        assert!(
+            refreshed[0].workspace_caches[0]
+                .session_history_sidecar
+                .is_none()
+        );
+    }
+
     fn timestamp_for_index(index: usize) -> String {
         format!("2026-06-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
     }
@@ -1165,6 +1216,7 @@ mod tests {
             workspace_caches: vec![WorkspaceCacheState {
                 profile: "vm0/default".into(),
                 workspace_affinity_version: None,
+                session_history_sidecar: None,
             }],
         };
         let capable = HeldSessionState {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -39,7 +39,7 @@ use crate::paths::short_digest;
 use crate::provider::{
     ClaimedJob, JobCandidate, LocalAdmissionResourceKind, PreLocalAdmissionOutcome,
     SessionAffinityLocalResource, SessionHistoryGenerationLocalAvailability,
-    SessionHistoryGenerationRelationship,
+    SessionHistoryGenerationRelationship, WorkspaceSessionHistorySidecarRelationship,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
@@ -49,7 +49,7 @@ use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{
     ExecutionContext, HeldSessionState, SandboxReuseResult, SessionAffinityResource,
-    WORKSPACE_AFFINITY_VERSION,
+    SessionHistorySizeBucket, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState,
 };
 
 pub(super) struct DiscoveredJob {
@@ -730,15 +730,15 @@ async fn prepare_affinity_protected_candidate(
             }
 
             let held_session_states = current_local_held_session_states(ctx).await;
-            let has_capable_workspace = held_session_states.iter().any(|state| {
-                state.session_id == cli_agent_session_id
-                    && state.workspace_caches.iter().any(|workspace| {
-                        workspace.profile == profile_name
-                            && workspace.workspace_affinity_version
-                                == Some(WORKSPACE_AFFINITY_VERSION)
-                    })
-            });
-            if has_capable_workspace
+            let capable_workspace = held_session_states
+                .iter()
+                .filter(|state| state.session_id == cli_agent_session_id)
+                .flat_map(|state| &state.workspace_caches)
+                .find(|workspace| {
+                    workspace.profile == profile_name
+                        && workspace.workspace_affinity_version == Some(WORKSPACE_AFFINITY_VERSION)
+                });
+            if let Some(capable_workspace) = capable_workspace
                 && let Some(lease) =
                     ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
             {
@@ -746,6 +746,14 @@ async fn prepare_affinity_protected_candidate(
                     .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
                 candidate.set_session_affinity_local_resource(
                     SessionAffinityLocalResource::WorkspaceCache,
+                );
+                let (relationship, raw_size_bucket) = workspace_sidecar_observation(
+                    capable_workspace,
+                    candidate.history_generation_run_id(),
+                );
+                candidate.set_workspace_session_history_sidecar_observation(
+                    relationship,
+                    raw_size_bucket,
                 );
                 return Some(PreparedAffinityCandidate {
                     candidate,
@@ -794,6 +802,35 @@ async fn prepare_affinity_protected_candidate(
     );
     ctx.spawn_ctx.provider.defer_poll_after(delay).await;
     None
+}
+
+fn workspace_sidecar_observation(
+    workspace: &WorkspaceCacheState,
+    target_generation_run_id: Option<RunId>,
+) -> (
+    WorkspaceSessionHistorySidecarRelationship,
+    Option<SessionHistorySizeBucket>,
+) {
+    let Some(target_generation_run_id) = target_generation_run_id else {
+        return (
+            WorkspaceSessionHistorySidecarRelationship::NoTarget,
+            workspace
+                .session_history_sidecar
+                .as_ref()
+                .map(|sidecar| sidecar.raw_size_bucket),
+        );
+    };
+    let Some(sidecar) = workspace.session_history_sidecar.as_ref() else {
+        return (WorkspaceSessionHistorySidecarRelationship::Absent, None);
+    };
+    let relationship = match sidecar.history_generation_run_id {
+        Some(generation_run_id) if generation_run_id == target_generation_run_id => {
+            WorkspaceSessionHistorySidecarRelationship::Exact
+        }
+        Some(_) => WorkspaceSessionHistorySidecarRelationship::Different,
+        None => WorkspaceSessionHistorySidecarRelationship::Legacy,
+    };
+    (relationship, Some(sidecar.raw_size_bucket))
 }
 
 fn diagnostic_session_fingerprint(session_id: &str) -> String {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -73,6 +73,7 @@ fn mark_workspace_cache_snapshot_promoted(
             workspace_caches: vec![WorkspaceCacheState {
                 profile: profile_name.to_owned(),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                session_history_sidecar: None,
             }],
         });
     }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,16 +1,17 @@
 use super::super::super::*;
 use super::super::support::{
-    TestParkedIdleCandidateSpec, assert_run_exits_within, context_with_session, minimal_context,
-    mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool,
-    seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
-    seed_idle_pool_with_timing, seed_workspace_cache_state, shutdown, test_profiles,
-    wait_budget_count, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
+    TestParkedIdleCandidateSpec, TestWorkspaceSidecar, assert_run_exits_within,
+    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
+    push_job, seed_idle_pool, seed_idle_pool_with_history_generation,
+    seed_idle_pool_with_overrides, seed_idle_pool_with_timing, seed_workspace_cache_state,
+    shutdown, test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
+    wait_discover_entered,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
-use crate::types::{SandboxReuseResult, SessionAffinityResource};
+use crate::types::{SandboxReuseResult, SessionAffinityResource, SessionHistorySizeBucket};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
@@ -909,6 +910,7 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         session_id,
         "vm0/default",
         image_size_bytes,
+        None,
     )
     .await;
     let cache_key = crate::paths::scoped_session_workspace_cache_key(
@@ -978,7 +980,10 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
     env.handle
         .discover_tx
-        .send(workspace_affinity_protected_candidate(run_id, session_id))
+        .send(
+            workspace_affinity_protected_candidate(run_id, session_id)
+                .with_history_generation_run_id(Some(RunId::new_v4())),
+        )
         .unwrap();
 
     let completion = env
@@ -1012,12 +1017,147 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         Some(crate::provider::LocalAdmissionResourceKind::Fresh)
     );
     assert_eq!(
+        claimed_candidate.workspace_session_history_sidecar_relationship(),
+        Some(crate::provider::WorkspaceSessionHistorySidecarRelationship::Absent)
+    );
+    assert_eq!(
+        claimed_candidate.workspace_session_history_sidecar_raw_size_bucket(),
+        None
+    );
+    assert_eq!(
         env.handle.deferred_poll_delays().len(),
         2,
         "the workspace-selected candidate should not add another deferral"
     );
 
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn workspace_selected_claim_records_observed_sidecar_relationship() {
+    #[derive(Clone, Copy, Debug)]
+    enum Case {
+        Exact,
+        Different,
+        Legacy,
+        Absent,
+        NoTarget,
+    }
+
+    for case in [
+        Case::Exact,
+        Case::Different,
+        Case::Legacy,
+        Case::Absent,
+        Case::NoTarget,
+    ] {
+        let session_id = format!("sess-cache-sidecar-{case:?}").to_ascii_lowercase();
+        let image_size_bytes = 1024 * 1024;
+        let producing_run_id = RunId::new_v4();
+        let (sidecar, target_generation_run_id, expected_relationship, expected_bucket) = match case
+        {
+            Case::Exact => (
+                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
+                Some(producing_run_id),
+                crate::provider::WorkspaceSessionHistorySidecarRelationship::Exact,
+                Some(SessionHistorySizeBucket::LessThan64Kib),
+            ),
+            Case::Different => (
+                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
+                Some(RunId::new_v4()),
+                crate::provider::WorkspaceSessionHistorySidecarRelationship::Different,
+                Some(SessionHistorySizeBucket::LessThan64Kib),
+            ),
+            Case::Legacy => (
+                Some(TestWorkspaceSidecar::Legacy),
+                Some(RunId::new_v4()),
+                crate::provider::WorkspaceSessionHistorySidecarRelationship::Legacy,
+                Some(SessionHistorySizeBucket::LessThan64Kib),
+            ),
+            Case::Absent => (
+                None,
+                Some(RunId::new_v4()),
+                crate::provider::WorkspaceSessionHistorySidecarRelationship::Absent,
+                None,
+            ),
+            Case::NoTarget => (
+                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
+                None,
+                crate::provider::WorkspaceSessionHistorySidecarRelationship::NoTarget,
+                Some(SessionHistorySizeBucket::LessThan64Kib),
+            ),
+        };
+
+        let mut profiles = test_profiles();
+        profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
+        let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+        let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+        let workspace_cache = SessionWorkspaceCache::shared(
+            runner_paths.clone(),
+            &config.paths.home,
+            &config.runner.group,
+        );
+        seed_workspace_cache_state(
+            &workspace_cache,
+            &runner_paths,
+            &session_id,
+            "vm0/default",
+            image_size_bytes,
+            sidecar,
+        )
+        .await;
+        Arc::get_mut(&mut config.exec_config)
+            .unwrap()
+            .workspace_cache = Some(workspace_cache);
+        let run_handle = tokio::spawn(run(config));
+        wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+        let run_id = RunId::new_v4();
+        env.provider
+            .set_claim_result(run_id, Some(context_with_session(run_id, &session_id)));
+        env.handle
+            .discover_tx
+            .send(
+                workspace_affinity_protected_candidate(run_id, &session_id)
+                    .with_history_generation_run_id(target_generation_run_id),
+            )
+            .unwrap();
+        assert!(
+            env.handle
+                .wait_completion(run_id, Duration::from_secs(5))
+                .await
+                .is_some(),
+            "case {case:?} should claim and complete"
+        );
+
+        let claim_candidates = env.handle.claim_candidates();
+        let claimed_candidate = claim_candidates
+            .iter()
+            .find(|candidate| candidate.run_id() == run_id)
+            .expect("claim should record the workspace-selected candidate");
+        assert_eq!(
+            claimed_candidate.session_affinity_local_resource(),
+            Some(crate::provider::SessionAffinityLocalResource::WorkspaceCache),
+            "case: {case:?}"
+        );
+        assert_eq!(
+            claimed_candidate.local_admission_resource(),
+            Some(crate::provider::LocalAdmissionResourceKind::Fresh),
+            "case: {case:?}"
+        );
+        assert_eq!(
+            claimed_candidate.workspace_session_history_sidecar_relationship(),
+            Some(expected_relationship),
+            "case: {case:?}"
+        );
+        assert_eq!(
+            claimed_candidate.workspace_session_history_sidecar_raw_size_bucket(),
+            expected_bucket,
+            "case: {case:?}"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
 }
 
 #[tokio::test]
@@ -1039,6 +1179,7 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
         session_id,
         "vm0/default",
         image_size_bytes,
+        None,
     )
     .await;
     Arc::get_mut(&mut config.exec_config)

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -6,13 +6,17 @@ use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
+use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::types::ResumeSessionHistoryRefKind;
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
+    WorkspaceSessionHistorySidecarRepresentation,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
+use sha2::{Digest, Sha256};
 
 fn make_synthetic_parked_candidate(
     session_id: &str,
@@ -237,8 +241,12 @@ pub(in super::super) async fn seed_workspace_cache_state(
     session_id: &str,
     profile_name: &str,
     image_size_bytes: u64,
+    sidecar: Option<TestWorkspaceSidecar>,
 ) {
-    let run_id = RunId::new_v4();
+    let run_id = match sidecar {
+        Some(TestWorkspaceSidecar::Attributed(run_id)) => run_id,
+        Some(TestWorkspaceSidecar::Legacy) | None => RunId::new_v4(),
+    };
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -260,18 +268,83 @@ pub(in super::super) async fn seed_workspace_cache_state(
     let file = tokio::fs::File::create(&active_image).await.unwrap();
     file.set_len(image_size_bytes).await.unwrap();
     drop(file);
-    assert!(
-        lease
-            .promote(
-                run_id,
-                None,
-                WorkspaceCacheTerminalStatus::Success,
-                TEST_SESSION_LAST_COMPLETED_AT.into(),
-                &StorageFingerprints::default(),
-            )
-            .await
-            .unwrap()
+    let Some(sidecar) = sidecar else {
+        assert!(
+            lease
+                .promote(
+                    run_id,
+                    None,
+                    WorkspaceCacheTerminalStatus::Success,
+                    TEST_SESSION_LAST_COMPLETED_AT.into(),
+                    &StorageFingerprints::default(),
+                )
+                .await
+                .unwrap()
+        );
+        return;
+    };
+
+    let history = br#"{"type":"message","content":"main-loop-sidecar"}"#;
+    let restored_session_identity = RestoredSessionIdentity::new(
+        RestoredSessionFramework::ClaudeCode,
+        session_id,
+        ResumeSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        Some(history.len() as u64),
     );
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: None,
+            restored_session_identity: Some(&restored_session_identity),
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: TEST_SESSION_LAST_COMPLETED_AT.into(),
+            storage_fingerprints: StorageFingerprints::default(),
+        })
+        .expect("workspace image should be promotable");
+    let guard = promotion
+        .try_acquire_session_history_sidecar_entry_guard()
+        .await
+        .expect("sidecar entry guard should be available");
+    let tmp_path = guard.session_history_sidecar_tmp_path();
+    let entry_dir = tmp_path
+        .parent()
+        .expect("sidecar temporary path should have a cache entry parent")
+        .to_path_buf();
+    tokio::fs::create_dir_all(&entry_dir).await.unwrap();
+    tokio::fs::write(&tmp_path, history).await.unwrap();
+    let source = guard.session_history_sidecar_source(
+        tmp_path,
+        WorkspaceSessionHistorySidecarRepresentation::Raw,
+        history.len() as u64,
+    );
+    assert_eq!(
+        guard
+            .promote_with_session_history_sidecar(&promotion, &source)
+            .await
+            .unwrap(),
+        WorkspaceImagePromotionOutcome::Promoted
+    );
+
+    if sidecar == TestWorkspaceSidecar::Legacy {
+        let metadata_path = entry_dir.join("session-history.metadata.json");
+        let mut metadata: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(&metadata_path).await.unwrap()).unwrap();
+        metadata
+            .as_object_mut()
+            .unwrap()
+            .remove("historyGenerationRunId");
+        tokio::fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
+            .await
+            .unwrap();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in super::super) enum TestWorkspaceSidecar {
+    Attributed(RunId),
+    Legacy,
 }
 
 pub(in super::super) async fn seed_idle_pool_expired(

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -9,7 +9,7 @@ pub(super) use self::env::{
     mock_run_config_with_overrides, mock_run_config_with_runtime, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
-    TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
+    TestParkedIdleCandidateSpec, TestWorkspaceSidecar, WorkspacePromotionSeedSpec, seed_idle_pool,
     seed_idle_pool_expired, seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
     seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
     seed_workspace_cache_state,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -74,6 +74,10 @@ struct ClaimRequestTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     session_history_generation_local_availability: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_session_history_sidecar_relationship: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_session_history_sidecar_raw_size_bucket: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_http_request_ms: Option<u64>,
@@ -871,6 +875,12 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             session_history_generation_local_availability: candidate
                 .session_history_generation_local_availability()
                 .map(SessionHistoryGenerationLocalAvailability::as_str),
+            workspace_session_history_sidecar_relationship: candidate
+                .workspace_session_history_sidecar_relationship()
+                .map(crate::provider::WorkspaceSessionHistorySidecarRelationship::as_str),
+            workspace_session_history_sidecar_raw_size_bucket: candidate
+                .workspace_session_history_sidecar_raw_size_bucket()
+                .map(crate::types::SessionHistorySizeBucket::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1677,6 +1687,10 @@ mod tests {
         candidate.set_session_history_generation_local_availability(
             SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod,
         );
+        candidate.set_workspace_session_history_sidecar_observation(
+            crate::provider::WorkspaceSessionHistorySidecarRelationship::Different,
+            Some(crate::types::SessionHistorySizeBucket::From256KibTo1Mib),
+        );
         candidate
             .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
         candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
@@ -1717,11 +1731,24 @@ mod tests {
             body["telemetry"]["sessionHistoryGenerationLocalAvailability"],
             "parked_before_discovery_ge_heartbeat_period"
         );
+        assert_eq!(
+            body["telemetry"]["workspaceSessionHistorySidecarRelationship"],
+            "different"
+        );
+        assert_eq!(
+            body["telemetry"]["workspaceSessionHistorySidecarRawSizeBucket"],
+            "256_kib_1_mib"
+        );
         assert!(
             !body
                 .to_string()
                 .contains(&target_generation_run_id.to_string())
         );
+        assert!(!body.to_string().contains("rawSizeBytes"));
+        assert!(!body.to_string().contains("sessionId"));
+        assert!(!body.to_string().contains("historyHash"));
+        assert!(!body.to_string().contains("cacheKey"));
+        assert!(!body.to_string().contains("path"));
         assert!(body.get("capabilities").is_none());
     }
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -27,7 +27,10 @@ use std::time::{Duration, Instant};
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource};
+use crate::types::{
+    ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource,
+    SessionHistorySizeBucket,
+};
 
 /// Low-cardinality source that first discovered a job candidate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -132,6 +135,27 @@ impl SessionHistoryGenerationLocalAvailability {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WorkspaceSessionHistorySidecarRelationship {
+    Exact,
+    Different,
+    Legacy,
+    Absent,
+    NoTarget,
+}
+
+impl WorkspaceSessionHistorySidecarRelationship {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Different => "different",
+            Self::Legacy => "legacy",
+            Self::Absent => "absent",
+            Self::NoTarget => "no_target",
+        }
+    }
+}
+
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -159,6 +183,9 @@ pub struct JobCandidate {
     session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
     session_history_generation_local_availability:
         Option<SessionHistoryGenerationLocalAvailability>,
+    workspace_session_history_sidecar_relationship:
+        Option<WorkspaceSessionHistorySidecarRelationship>,
+    workspace_session_history_sidecar_raw_size_bucket: Option<SessionHistorySizeBucket>,
     history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
@@ -197,6 +224,8 @@ impl JobCandidate {
             history_generation_run_id: None,
             session_history_generation_relationship: None,
             session_history_generation_local_availability: None,
+            workspace_session_history_sidecar_relationship: None,
+            workspace_session_history_sidecar_raw_size_bucket: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
         }
@@ -324,6 +353,18 @@ impl JobCandidate {
         self.session_history_generation_local_availability
     }
 
+    pub(crate) fn workspace_session_history_sidecar_relationship(
+        &self,
+    ) -> Option<WorkspaceSessionHistorySidecarRelationship> {
+        self.workspace_session_history_sidecar_relationship
+    }
+
+    pub(crate) fn workspace_session_history_sidecar_raw_size_bucket(
+        &self,
+    ) -> Option<SessionHistorySizeBucket> {
+        self.workspace_session_history_sidecar_raw_size_bucket
+    }
+
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
         protection_remaining(self.affinity_protected_until)
     }
@@ -396,6 +437,15 @@ impl JobCandidate {
         availability: SessionHistoryGenerationLocalAvailability,
     ) {
         self.session_history_generation_local_availability = Some(availability);
+    }
+
+    pub(crate) fn set_workspace_session_history_sidecar_observation(
+        &mut self,
+        relationship: WorkspaceSessionHistorySidecarRelationship,
+        raw_size_bucket: Option<SessionHistorySizeBucket>,
+    ) {
+        self.workspace_session_history_sidecar_relationship = Some(relationship);
+        self.workspace_session_history_sidecar_raw_size_bucket = raw_size_bucket;
     }
 
     pub(crate) fn set_session_affinity_local_resource(

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -15,6 +15,7 @@ use crate::http::HttpClient;
 use crate::ids::RunId;
 use crate::types::{
     ResumeSessionHistoryDownloadSource, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
+    SessionHistorySizeBucket,
 };
 
 /// How long before we auto-flush pending ops (matching TS: 30s).
@@ -22,13 +23,6 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 
 /// Timeout for telemetry HTTP requests (shorter than default API timeout).
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
-
-const SIZE_64_KIB: u64 = 64 * 1024;
-const SIZE_256_KIB: u64 = 256 * 1024;
-const SIZE_1_MIB: u64 = 1024 * 1024;
-const SIZE_4_MIB: u64 = 4 * SIZE_1_MIB;
-const SIZE_16_MIB: u64 = 16 * SIZE_1_MIB;
-const SIZE_64_MIB: u64 = 64 * SIZE_1_MIB;
 
 /// Per-job telemetry collector. Buffers sandbox operations and flushes them
 /// periodically (auto on 30 s threshold) and at job end.
@@ -603,72 +597,36 @@ const fn session_history_download_source_value(
     }
 }
 
-#[derive(Clone, Copy)]
-enum SessionHistorySizeBucket {
-    LessThan64Kib,
-    From64To256Kib,
-    From256KibTo1Mib,
-    From1To4Mib,
-    From4To16Mib,
-    From16To64Mib,
-    From64To128Mib,
-}
-
-impl SessionHistorySizeBucket {
-    const fn from_size(size: u64) -> Self {
-        if size < SIZE_64_KIB {
-            Self::LessThan64Kib
-        } else if size < SIZE_256_KIB {
-            Self::From64To256Kib
-        } else if size < SIZE_1_MIB {
-            Self::From256KibTo1Mib
-        } else if size < SIZE_4_MIB {
-            Self::From1To4Mib
-        } else if size < SIZE_16_MIB {
-            Self::From4To16Mib
-        } else if size < SIZE_64_MIB {
-            Self::From16To64Mib
-        } else {
-            Self::From64To128Mib
-        }
-    }
-
-    const fn value(self) -> &'static str {
-        match self {
-            Self::LessThan64Kib => "lt_64_kib",
-            Self::From64To256Kib => "64_256_kib",
-            Self::From256KibTo1Mib => "256_kib_1_mib",
-            Self::From1To4Mib => "1_4_mib",
-            Self::From4To16Mib => "4_16_mib",
-            Self::From16To64Mib => "16_64_mib",
-            Self::From64To128Mib => "64_128_mib",
-        }
-    }
-
-    const fn requested_larger_prefix_extension_action_type(self) -> &'static str {
-        match self {
-            Self::LessThan64Kib => "session_history_requested_larger_prefix_extension_lt_64_kib",
-            Self::From64To256Kib => "session_history_requested_larger_prefix_extension_64_256_kib",
-            Self::From256KibTo1Mib => {
-                "session_history_requested_larger_prefix_extension_256_kib_1_mib"
-            }
-            Self::From1To4Mib => "session_history_requested_larger_prefix_extension_1_4_mib",
-            Self::From4To16Mib => "session_history_requested_larger_prefix_extension_4_16_mib",
-            Self::From16To64Mib => "session_history_requested_larger_prefix_extension_16_64_mib",
-            Self::From64To128Mib => "session_history_requested_larger_prefix_extension_64_128_mib",
-        }
-    }
-}
-
 const fn size_bucket(size: u64) -> &'static str {
-    SessionHistorySizeBucket::from_size(size).value()
+    SessionHistorySizeBucket::from_size(size).as_str()
 }
 
 pub(crate) const fn session_history_prefix_extension_action_type(
     raw_extension_size: u64,
 ) -> &'static str {
-    SessionHistorySizeBucket::from_size(raw_extension_size)
-        .requested_larger_prefix_extension_action_type()
+    match SessionHistorySizeBucket::from_size(raw_extension_size) {
+        SessionHistorySizeBucket::LessThan64Kib => {
+            "session_history_requested_larger_prefix_extension_lt_64_kib"
+        }
+        SessionHistorySizeBucket::From64To256Kib => {
+            "session_history_requested_larger_prefix_extension_64_256_kib"
+        }
+        SessionHistorySizeBucket::From256KibTo1Mib => {
+            "session_history_requested_larger_prefix_extension_256_kib_1_mib"
+        }
+        SessionHistorySizeBucket::From1To4Mib => {
+            "session_history_requested_larger_prefix_extension_1_4_mib"
+        }
+        SessionHistorySizeBucket::From4To16Mib => {
+            "session_history_requested_larger_prefix_extension_4_16_mib"
+        }
+        SessionHistorySizeBucket::From16To64Mib => {
+            "session_history_requested_larger_prefix_extension_16_64_mib"
+        }
+        SessionHistorySizeBucket::From64To128Mib => {
+            "session_history_requested_larger_prefix_extension_64_128_mib"
+        }
+    }
 }
 
 fn compression_ratio_bucket(
@@ -831,6 +789,12 @@ mod tests {
 
     #[test]
     fn session_history_size_bucket_boundaries_keep_stable_labels_and_actions() {
+        const SIZE_64_KIB: u64 = 64 * 1024;
+        const SIZE_256_KIB: u64 = 256 * 1024;
+        const SIZE_1_MIB: u64 = 1024 * 1024;
+        const SIZE_4_MIB: u64 = 4 * SIZE_1_MIB;
+        const SIZE_16_MIB: u64 = 16 * SIZE_1_MIB;
+        const SIZE_64_MIB: u64 = 64 * SIZE_1_MIB;
         let cases = [
             (
                 0,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1262,12 +1262,79 @@ pub struct ReusableSandboxState {
     pub history_generation_run_id: Option<RunId>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SessionHistorySizeBucket {
+    #[serde(rename = "lt_64_kib")]
+    LessThan64Kib,
+    #[serde(rename = "64_256_kib")]
+    From64To256Kib,
+    #[serde(rename = "256_kib_1_mib")]
+    From256KibTo1Mib,
+    #[serde(rename = "1_4_mib")]
+    From1To4Mib,
+    #[serde(rename = "4_16_mib")]
+    From4To16Mib,
+    #[serde(rename = "16_64_mib")]
+    From16To64Mib,
+    #[serde(rename = "64_128_mib")]
+    From64To128Mib,
+}
+
+impl SessionHistorySizeBucket {
+    pub const fn from_size(size: u64) -> Self {
+        const SIZE_64_KIB: u64 = 64 * 1024;
+        const SIZE_256_KIB: u64 = 256 * 1024;
+        const SIZE_1_MIB: u64 = 1024 * 1024;
+        const SIZE_4_MIB: u64 = 4 * SIZE_1_MIB;
+        const SIZE_16_MIB: u64 = 16 * SIZE_1_MIB;
+        const SIZE_64_MIB: u64 = 64 * SIZE_1_MIB;
+
+        if size < SIZE_64_KIB {
+            Self::LessThan64Kib
+        } else if size < SIZE_256_KIB {
+            Self::From64To256Kib
+        } else if size < SIZE_1_MIB {
+            Self::From256KibTo1Mib
+        } else if size < SIZE_4_MIB {
+            Self::From1To4Mib
+        } else if size < SIZE_16_MIB {
+            Self::From4To16Mib
+        } else if size < SIZE_64_MIB {
+            Self::From16To64Mib
+        } else {
+            Self::From64To128Mib
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LessThan64Kib => "lt_64_kib",
+            Self::From64To256Kib => "64_256_kib",
+            Self::From256KibTo1Mib => "256_kib_1_mib",
+            Self::From1To4Mib => "1_4_mib",
+            Self::From4To16Mib => "4_16_mib",
+            Self::From16To64Mib => "16_64_mib",
+            Self::From64To128Mib => "64_128_mib",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSessionHistorySidecarState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_generation_run_id: Option<RunId>,
+    pub raw_size_bucket: SessionHistorySizeBucket,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceCacheState {
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_affinity_version: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_history_sidecar: Option<WorkspaceSessionHistorySidecarState>,
 }
 
 /// Runner state snapshot sent to the server via heartbeat.
@@ -1997,6 +2064,12 @@ mod tests {
                 workspace_caches: vec![WorkspaceCacheState {
                     profile: "vm0/large".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
+                        history_generation_run_id: Some(
+                            "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                        ),
+                        raw_size_bucket: SessionHistorySizeBucket::From64To256Kib,
+                    }),
                 }],
             }],
             mode: "running".into(),
@@ -2024,7 +2097,11 @@ mod tests {
                 },
                 "workspaceCaches": [{
                     "profile": "vm0/large",
-                    "workspaceAffinityVersion": 1
+                    "workspaceAffinityVersion": 1,
+                    "sessionHistorySidecar": {
+                        "historyGenerationRunId": "22222222-2222-4222-8222-222222222222",
+                        "rawSizeBucket": "64_256_kib"
+                    }
                 }]
             }])
         );

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -634,6 +634,10 @@ impl SessionWorkspaceCache {
                 )
                 .await
             {
+                let session_history_sidecar = self
+                    .observe_session_history_sidecar(cache_key, &metadata.session_id)
+                    .await
+                    .ok();
                 states.push(HeldSessionState {
                     session_id: metadata.session_id,
                     last_completed_at: metadata.last_completed_at,
@@ -641,6 +645,7 @@ impl SessionWorkspaceCache {
                     workspace_caches: vec![WorkspaceCacheState {
                         profile: metadata.profile_name,
                         workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                        session_history_sidecar,
                     }],
                 });
             }
@@ -1490,42 +1495,69 @@ impl WorkspaceSessionHistorySidecarEntryGuard {
 pub(crate) fn cap_workspace_held_session_states(
     states: Vec<HeldSessionState>,
 ) -> Vec<HeldSessionState> {
-    let mut by_session = BTreeMap::<String, HeldSessionState>::new();
-    for mut state in states {
-        match by_session.get_mut(&state.session_id) {
-            Some(existing) => {
-                if state.last_completed_at > existing.last_completed_at {
-                    existing.last_completed_at = state.last_completed_at;
+    struct ObservedSessionState {
+        last_completed_at: String,
+        reusable_sandbox: Option<crate::types::ReusableSandboxState>,
+        workspace_caches: BTreeMap<String, (String, WorkspaceCacheState)>,
+    }
+
+    let mut by_session = BTreeMap::<String, ObservedSessionState>::new();
+    for state in states {
+        let session = by_session
+            .entry(state.session_id.clone())
+            .or_insert_with(|| ObservedSessionState {
+                last_completed_at: state.last_completed_at.clone(),
+                reusable_sandbox: state.reusable_sandbox.clone(),
+                workspace_caches: BTreeMap::new(),
+            });
+        if state.last_completed_at > session.last_completed_at {
+            session.last_completed_at = state.last_completed_at.clone();
+        }
+        if session.reusable_sandbox.is_none() {
+            session.reusable_sandbox = state.reusable_sandbox;
+        }
+        for workspace_cache in state.workspace_caches {
+            match session
+                .workspace_caches
+                .entry(workspace_cache.profile.clone())
+            {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert((state.last_completed_at.clone(), workspace_cache));
                 }
-                if existing.reusable_sandbox.is_none() {
-                    existing.reusable_sandbox = state.reusable_sandbox;
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    let (existing_completed_at, existing) = entry.get_mut();
+                    let capability_order = workspace_cache
+                        .workspace_affinity_version
+                        .cmp(&existing.workspace_affinity_version);
+                    if capability_order.is_gt()
+                        || (capability_order.is_eq()
+                            && state.last_completed_at > *existing_completed_at)
+                    {
+                        *existing_completed_at = state.last_completed_at.clone();
+                        *existing = workspace_cache;
+                    } else if capability_order.is_eq()
+                        && state.last_completed_at == *existing_completed_at
+                        && workspace_cache != *existing
+                    {
+                        existing.session_history_sidecar = None;
+                    }
                 }
-                existing
-                    .workspace_caches
-                    .append(&mut state.workspace_caches);
-            }
-            None => {
-                by_session.insert(state.session_id.clone(), state);
             }
         }
     }
 
     let mut states: Vec<HeldSessionState> = by_session
-        .into_values()
-        .map(|mut state| {
-            state.workspace_caches.sort_unstable_by(|a, b| {
-                a.profile.cmp(&b.profile).then_with(|| {
-                    b.workspace_affinity_version
-                        .cmp(&a.workspace_affinity_version)
-                })
-            });
-            state
+        .into_iter()
+        .map(|(session_id, state)| HeldSessionState {
+            session_id,
+            last_completed_at: state.last_completed_at,
+            reusable_sandbox: state.reusable_sandbox,
+            workspace_caches: state
                 .workspace_caches
-                .dedup_by(|a, b| a.profile == b.profile);
-            state
-                .workspace_caches
-                .truncate(MAX_WORKSPACE_CACHES_PER_SESSION);
-            state
+                .into_values()
+                .map(|(_, workspace_cache)| workspace_cache)
+                .take(MAX_WORKSPACE_CACHES_PER_SESSION)
+                .collect(),
         })
         .collect();
     states.sort_unstable_by(|a, b| {

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -1,13 +1,17 @@
 use std::path::Path;
 
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryRefKind, SESSION_HISTORY_SIDECAR_MAX_BYTES,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::fs;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::ids::RunId;
 use crate::restored_session_identity::{RestoredSessionIdentity, RestoredSessionIdentityFields};
+use crate::types::{SessionHistorySizeBucket, WorkspaceSessionHistorySidecarState};
 
 use super::fs::{
     allocated_bytes, ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
@@ -22,10 +26,19 @@ use super::{SessionWorkspaceCache, entry::CacheEntryPaths};
 
 const SESSION_HISTORY_SIDECAR_FORMAT_VERSION: u8 = 1;
 
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WorkspaceSessionHistorySidecarMetadata {
     version: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    history_generation_run_id: Option<RunId>,
     framework: FinalSessionHistoryFramework,
     session_id_hash: String,
     history_ref_kind: FinalSessionHistoryRefKind,
@@ -39,6 +52,7 @@ struct WorkspaceSessionHistorySidecarMetadata {
 
 impl WorkspaceSessionHistorySidecarMetadata {
     fn from_source(
+        history_generation_run_id: RunId,
         source: &WorkspaceSessionHistorySidecarPromotionSource,
         body_metadata: &std::fs::Metadata,
     ) -> Option<Self> {
@@ -51,6 +65,7 @@ impl WorkspaceSessionHistorySidecarMetadata {
         } = source.restored_session_identity.cache_fields()?;
         Some(Self {
             version: SESSION_HISTORY_SIDECAR_FORMAT_VERSION,
+            history_generation_run_id: Some(history_generation_run_id),
             framework,
             session_id_hash: session_id_hash.to_owned(),
             history_ref_kind,
@@ -97,6 +112,59 @@ impl WorkspaceSessionHistorySidecarMetadata {
             _ => Err(WorkspaceSessionHistorySidecarMiss::UnsupportedFormat),
         }
     }
+
+    fn observe(
+        &self,
+        workspace_session_id: &str,
+    ) -> Result<WorkspaceSessionHistorySidecarState, WorkspaceSessionHistorySidecarMiss> {
+        if self.version != SESSION_HISTORY_SIDECAR_FORMAT_VERSION
+            || self.encoded_size == 0
+            || self.encoded_size > SESSION_HISTORY_SIDECAR_MAX_BYTES
+            || !(1..=RESUME_SESSION_HISTORY_MAX_BYTES).contains(&self.history_size_bytes)
+            || !is_sha256_hex(&self.session_id_hash)
+            || !is_sha256_hex(&self.history_hash)
+        {
+            return Err(WorkspaceSessionHistorySidecarMiss::InvalidMetadata);
+        }
+        match (self.framework, self.representation) {
+            (_, WorkspaceSessionHistorySidecarRepresentation::Raw)
+                if self.encoded_size == self.history_size_bytes => {}
+            (
+                FinalSessionHistoryFramework::Codex,
+                WorkspaceSessionHistorySidecarRepresentation::CodexZstd,
+            ) => {}
+            _ => return Err(WorkspaceSessionHistorySidecarMiss::UnsupportedFormat),
+        }
+        let normalized_session_id = match self.framework {
+            FinalSessionHistoryFramework::ClaudeCode => workspace_session_id.to_owned(),
+            FinalSessionHistoryFramework::Codex => {
+                guest_contracts::codex_thread_id::canonical_codex_thread_id(workspace_session_id)
+                    .ok_or(WorkspaceSessionHistorySidecarMiss::IdentityMismatch)?
+            }
+        };
+        let expected_session_id_hash =
+            hex::encode(Sha256::digest(normalized_session_id.as_bytes()));
+        if self.session_id_hash != expected_session_id_hash {
+            return Err(WorkspaceSessionHistorySidecarMiss::IdentityMismatch);
+        }
+        Ok(WorkspaceSessionHistorySidecarState {
+            history_generation_run_id: self.history_generation_run_id,
+            raw_size_bucket: SessionHistorySizeBucket::from_size(self.history_size_bytes),
+        })
+    }
+
+    fn validate_body_metadata(
+        &self,
+        body_metadata: &std::fs::Metadata,
+    ) -> Result<(), WorkspaceSessionHistorySidecarMiss> {
+        if !body_metadata.is_file()
+            || WorkspaceImageFileIdentity::from_metadata(body_metadata) != self.body_file
+            || body_metadata.len() != self.encoded_size
+        {
+            return Err(WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch);
+        }
+        Ok(())
+    }
 }
 
 impl SessionWorkspaceCache {
@@ -119,12 +187,7 @@ impl SessionWorkspaceCache {
                     WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch
                 }
             })?;
-        if !body_metadata.is_file()
-            || WorkspaceImageFileIdentity::from_metadata(&body_metadata) != metadata.body_file
-            || body_metadata.len() != metadata.encoded_size
-        {
-            return Err(WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch);
-        }
+        metadata.validate_body_metadata(&body_metadata)?;
         Ok(WorkspaceSessionHistorySidecar {
             path: paths.session_history_sidecar().to_path_buf(),
             representation: metadata.representation,
@@ -132,10 +195,33 @@ impl SessionWorkspaceCache {
         })
     }
 
+    pub(super) async fn observe_session_history_sidecar(
+        &self,
+        cache_key: &str,
+        workspace_session_id: &str,
+    ) -> Result<WorkspaceSessionHistorySidecarState, WorkspaceSessionHistorySidecarMiss> {
+        let paths = self.entry_paths(cache_key);
+        let metadata = self
+            .read_session_history_sidecar_metadata(paths.session_history_sidecar_metadata())
+            .await?;
+        let state = metadata.observe(workspace_session_id)?;
+        let body_metadata = fs::symlink_metadata(paths.session_history_sidecar())
+            .await
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    WorkspaceSessionHistorySidecarMiss::BodyMissing
+                } else {
+                    WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch
+                }
+            })?;
+        metadata.validate_body_metadata(&body_metadata)?;
+        Ok(state)
+    }
+
     pub(super) async fn publish_session_history_sidecar(
         &self,
         cache_key: &str,
-        run_id: crate::ids::RunId,
+        run_id: RunId,
         source: Option<&WorkspaceSessionHistorySidecarPromotionSource>,
     ) -> RunnerResult<()> {
         let paths = self.entry_paths(cache_key);
@@ -180,7 +266,7 @@ impl SessionWorkspaceCache {
     async fn publish_session_history_sidecar_source(
         &self,
         cache_key: &str,
-        run_id: crate::ids::RunId,
+        run_id: RunId,
         paths: &CacheEntryPaths,
         source: &WorkspaceSessionHistorySidecarPromotionSource,
     ) -> RunnerResult<()> {
@@ -195,7 +281,7 @@ impl SessionWorkspaceCache {
             return Ok(());
         }
         let Some(sidecar_metadata) =
-            WorkspaceSessionHistorySidecarMetadata::from_source(source, &tmp_metadata)
+            WorkspaceSessionHistorySidecarMetadata::from_source(run_id, source, &tmp_metadata)
         else {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             self.prune_session_history_sidecar(cache_key).await?;

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -26,8 +26,9 @@ use crate::storage_fingerprints::StorageFingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind, WORKSPACE_AFFINITY_VERSION,
-    WorkspaceCacheState as HeldWorkspaceCacheState,
+    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind, SessionHistorySizeBucket,
+    WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState as HeldWorkspaceCacheState,
+    WorkspaceSessionHistorySidecarState,
 };
 use sha2::{Digest, Sha256};
 use tokio::fs;
@@ -1077,6 +1078,7 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: TEST_PROFILE_NAME.to_owned(),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                session_history_sidecar: None,
             }],
         })
         .collect();
@@ -1087,6 +1089,7 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
         workspace_caches: vec![HeldWorkspaceCacheState {
             profile: TEST_PROFILE_NAME.to_owned(),
             workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+            session_history_sidecar: None,
         }],
     });
 
@@ -1118,6 +1121,7 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: format!("vm0/profile-{index:02}"),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                session_history_sidecar: None,
             }],
         })
         .collect();
@@ -1141,6 +1145,7 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
                 .map(|profile| HeldWorkspaceCacheState {
                     profile: format!("vm0/profile-{profile}"),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    session_history_sidecar: None,
                 })
                 .collect(),
         })
@@ -1159,6 +1164,47 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
         !capped.iter().any(|state| state.session_id == "sess-0000"),
         "oldest session should be dropped at the global workspace cap"
     );
+}
+
+#[test]
+fn cap_workspace_held_session_states_clears_ambiguous_equal_timestamp_sidecars() {
+    let run_id = RunId::new_v4();
+    let attributed = HeldSessionState {
+        session_id: "sess-ambiguous".into(),
+        last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+        reusable_sandbox: None,
+        workspace_caches: vec![HeldWorkspaceCacheState {
+            profile: TEST_PROFILE_NAME.to_owned(),
+            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+            session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
+                history_generation_run_id: Some(run_id),
+                raw_size_bucket: SessionHistorySizeBucket::LessThan64Kib,
+            }),
+        }],
+    };
+    let absent = HeldSessionState {
+        session_id: "sess-ambiguous".into(),
+        last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+        reusable_sandbox: None,
+        workspace_caches: vec![HeldWorkspaceCacheState {
+            profile: TEST_PROFILE_NAME.to_owned(),
+            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+            session_history_sidecar: None,
+        }],
+    };
+
+    for states in [
+        vec![attributed.clone(), absent.clone()],
+        vec![absent.clone(), attributed.clone()],
+    ] {
+        let capped = cap_workspace_held_session_states(states);
+        assert_eq!(capped.len(), 1);
+        assert!(
+            capped[0].workspace_caches[0]
+                .session_history_sidecar
+                .is_none()
+        );
+    }
 }
 
 #[tokio::test]
@@ -1218,10 +1264,12 @@ async fn held_session_states_for_profiles_filters_and_aggregates_current_identit
                 HeldWorkspaceCacheState {
                     profile: "vm0/default".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    session_history_sidecar: None,
                 },
                 HeldWorkspaceCacheState {
                     profile: "vm0/large".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
+                    session_history_sidecar: None,
                 },
             ],
         }]
@@ -1669,6 +1717,22 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+    let metadata_path = paths
+        .session_workspace_cache_entry_dir(&cache_key)
+        .join("session-history.metadata.json");
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
+    assert_eq!(metadata["historyGenerationRunId"], run_id.to_string());
+    let held_states = cache.held_session_states().await;
+    let observed_sidecar = held_states[0].workspace_caches[0]
+        .session_history_sidecar
+        .as_ref()
+        .unwrap();
+    assert_eq!(observed_sidecar.history_generation_run_id, Some(run_id));
+    assert_eq!(
+        observed_sidecar.raw_size_bucket,
+        SessionHistorySizeBucket::LessThan64Kib
+    );
     let sidecar = cache
         .probe_session_history_sidecar(&cache_key, &identity)
         .await
@@ -1680,6 +1744,199 @@ async fn session_history_sidecar_publish_and_probe_hit() {
     );
     assert_eq!(sidecar.encoded_size, history.len() as u64);
     assert_eq!(fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn legacy_session_history_sidecar_remains_restoreable_and_observable() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-legacy";
+    let history = br#"{"type":"message","content":"legacy"}"#;
+    let cache_key = write_current_cache_entry(
+        &cache,
+        run_id,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let identity =
+        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+    let metadata_path = paths
+        .session_workspace_cache_entry_dir(&cache_key)
+        .join("session-history.metadata.json");
+    let mut metadata: serde_json::Value =
+        serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
+    metadata
+        .as_object_mut()
+        .unwrap()
+        .remove("historyGenerationRunId");
+    fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
+        .await
+        .unwrap();
+
+    let held_states = cache.held_session_states().await;
+    let observed_sidecar = held_states[0].workspace_caches[0]
+        .session_history_sidecar
+        .as_ref()
+        .unwrap();
+    assert_eq!(observed_sidecar.history_generation_run_id, None);
+    assert_eq!(
+        observed_sidecar.raw_size_bucket,
+        SessionHistorySizeBucket::LessThan64Kib
+    );
+    assert!(
+        cache
+            .probe_session_history_sidecar(&cache_key, &identity)
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn session_history_sidecar_observation_does_not_read_body() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-unreadable";
+    let history = br#"{"type":"message","content":"unreadable"}"#;
+    let cache_key = write_current_cache_entry(
+        &cache,
+        run_id,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+    let body_path = paths
+        .session_workspace_cache_entry_dir(&cache_key)
+        .join("session-history.blob");
+    let mut permissions = fs::metadata(&body_path).await.unwrap().permissions();
+    permissions.set_mode(0o0);
+    fs::set_permissions(&body_path, permissions).await.unwrap();
+
+    let held_states = cache.held_session_states().await;
+    assert!(
+        held_states[0].workspace_caches[0]
+            .session_history_sidecar
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn invalid_session_history_sidecars_are_not_advertised() {
+    #[derive(Clone, Copy, Debug)]
+    enum InvalidSidecarCase {
+        MissingMetadata,
+        MalformedMetadata,
+        UnsupportedRepresentation,
+        MetadataSymlink,
+        MissingBody,
+        BodySymlink,
+        SessionMismatch,
+        InvalidHash,
+        InvalidSize,
+    }
+
+    for case in [
+        InvalidSidecarCase::MissingMetadata,
+        InvalidSidecarCase::MalformedMetadata,
+        InvalidSidecarCase::UnsupportedRepresentation,
+        InvalidSidecarCase::MetadataSymlink,
+        InvalidSidecarCase::MissingBody,
+        InvalidSidecarCase::BodySymlink,
+        InvalidSidecarCase::SessionMismatch,
+        InvalidSidecarCase::InvalidHash,
+        InvalidSidecarCase::InvalidSize,
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let session_id = "sess-sidecar-invalid-observation";
+        let history = br#"{"type":"message","content":"invalid"}"#;
+        let cache_key = write_current_cache_entry(
+            &cache,
+            run_id,
+            session_id,
+            CANONICAL_WORKING_DIR,
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+        let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
+        let metadata_path = entry_dir.join("session-history.metadata.json");
+        let body_path = entry_dir.join("session-history.blob");
+
+        match case {
+            InvalidSidecarCase::MissingMetadata => {
+                fs::remove_file(&metadata_path).await.unwrap();
+            }
+            InvalidSidecarCase::MalformedMetadata => {
+                fs::write(&metadata_path, b"not-json").await.unwrap();
+            }
+            InvalidSidecarCase::UnsupportedRepresentation
+            | InvalidSidecarCase::SessionMismatch
+            | InvalidSidecarCase::InvalidHash
+            | InvalidSidecarCase::InvalidSize => {
+                let mut metadata: serde_json::Value =
+                    serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
+                match case {
+                    InvalidSidecarCase::UnsupportedRepresentation => {
+                        metadata["representation"] = "codex-zstd".into();
+                    }
+                    InvalidSidecarCase::SessionMismatch => {
+                        metadata["sessionIdHash"] =
+                            hex::encode(Sha256::digest(b"another-session")).into();
+                    }
+                    InvalidSidecarCase::InvalidHash => {
+                        metadata["historyHash"] = "not-a-sha256-hash".into();
+                    }
+                    InvalidSidecarCase::InvalidSize => {
+                        metadata["historySizeBytes"] = 0.into();
+                    }
+                    unexpected => {
+                        panic!("unexpected grouped invalid sidecar case: {unexpected:?}")
+                    }
+                }
+                fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
+                    .await
+                    .unwrap();
+            }
+            InvalidSidecarCase::MetadataSymlink => {
+                let target = entry_dir.join("session-history.metadata.target.json");
+                fs::rename(&metadata_path, &target).await.unwrap();
+                symlink(&target, &metadata_path).unwrap();
+            }
+            InvalidSidecarCase::MissingBody => {
+                fs::remove_file(&body_path).await.unwrap();
+            }
+            InvalidSidecarCase::BodySymlink => {
+                let target = entry_dir.join("session-history.target.blob");
+                fs::rename(&body_path, &target).await.unwrap();
+                symlink(&target, &body_path).unwrap();
+            }
+        }
+
+        let held_states = cache.held_session_states().await;
+        assert_eq!(held_states.len(), 1, "case: {case:?}");
+        assert!(
+            held_states[0].workspace_caches[0]
+                .session_history_sidecar
+                .is_none(),
+            "case: {case:?}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -1795,6 +2052,12 @@ async fn session_history_sidecar_probe_rejects_mismatched_body_identity() {
             .await
             .unwrap_err(),
         WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch
+    );
+    let held_states = cache.held_session_states().await;
+    assert!(
+        held_states[0].workspace_caches[0]
+            .session_history_sidecar
+            .is_none()
     );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2529,20 +2529,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "reusableSandbox",
     );
 
-    await heartbeatHolder({
-      admittableProfiles: ["vm0/default"],
-      workspaceCaches: [
-        {
-          profile: "vm0/default",
-          workspaceAffinityVersion: 1,
-          sessionHistorySidecar: {
-            historyGenerationRunId: first.runId,
-            rawSizeBucket: "64_256_kib",
-          },
-        },
-      ],
-    });
     const sidecarVariantRunners = [
+      {
+        runnerId: randomUUID(),
+        sessionHistorySidecar: {
+          historyGenerationRunId: first.runId,
+          rawSizeBucket: "64_256_kib" as const,
+        },
+      },
       {
         runnerId: randomUUID(),
         sessionHistorySidecar: {
@@ -2582,6 +2576,22 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         ],
       });
     }
+    const reusableWithCompetingWorkspaceSidecars = await pollFollowUp(
+      "observe workspace sidecars while reusable sandbox remains preferred",
+    );
+    expect(
+      sessionAffinityProtectedUntil(reusableWithCompetingWorkspaceSidecars.job),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      historyGenerationAffinityProtectedUntil(
+        reusableWithCompetingWorkspaceSidecars.job,
+      ),
+    ).toStrictEqual(expect.any(String));
+    expect(
+      sessionAffinityResource(reusableWithCompetingWorkspaceSidecars.job),
+    ).toBe("reusableSandbox");
+
+    await heartbeatHolder({ admittableProfiles: [], mode: "stopping" });
     const competingWorkspaceSidecars = await pollFollowUp(
       "observe competing workspace sidecars without routing by them",
     );
@@ -2591,24 +2601,32 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       historyGenerationAffinityProtectedUntil(competingWorkspaceSidecars.job),
     ).toBeNull();
-    for (const actionType of [
-      "runner_notification_affinity_lookup",
-      "runner_poll_pending_job_lookup",
+    for (const { runId, resource } of [
+      {
+        runId: reusableWithCompetingWorkspaceSidecars.run.runId,
+        resource: "reusableSandbox",
+      },
+      {
+        runId: competingWorkspaceSidecars.run.runId,
+        resource: "workspaceCache",
+      },
     ]) {
-      const events = sandboxOperationEventsForRunByAction(
-        competingWorkspaceSidecars.run.runId,
-        actionType,
-      );
-      expect(events).toHaveLength(1);
-      expect(events[0]).toStrictEqual(
-        expect.objectContaining({
-          session_affinity_resource: "workspaceCache",
-          workspace_sidecar_exact_holder: "true",
-          workspace_sidecar_different_holder: "true",
-          workspace_sidecar_legacy_holder: "true",
-          workspace_sidecar_absent_holder: "true",
-        }),
-      );
+      for (const actionType of [
+        "runner_notification_affinity_lookup",
+        "runner_poll_pending_job_lookup",
+      ]) {
+        const events = sandboxOperationEventsForRunByAction(runId, actionType);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toStrictEqual(
+          expect.objectContaining({
+            session_affinity_resource: resource,
+            workspace_sidecar_exact_holder: "true",
+            workspace_sidecar_different_holder: "true",
+            workspace_sidecar_legacy_holder: "true",
+            workspace_sidecar_absent_holder: "true",
+          }),
+        );
+      }
     }
     for (const variant of sidecarVariantRunners) {
       await api.requestHeartbeatRunner(true, [200], {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13,7 +13,10 @@ import {
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import type { Job as RunnerJob } from "@vm0/api-contracts/contracts/runners";
+import type {
+  Job as RunnerJob,
+  SessionHistorySizeBucket,
+} from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -2261,6 +2264,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       readonly workspaceCaches?: {
         readonly profile: string;
         readonly workspaceAffinityVersion?: 1;
+        readonly sessionHistorySidecar?: {
+          readonly historyGenerationRunId?: string;
+          readonly rawSizeBucket: SessionHistorySizeBucket;
+        };
       }[];
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
@@ -2521,6 +2528,97 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sessionAffinityResource(exactGenerationHolder.job)).toBe(
       "reusableSandbox",
     );
+
+    await heartbeatHolder({
+      admittableProfiles: ["vm0/default"],
+      workspaceCaches: [
+        {
+          profile: "vm0/default",
+          workspaceAffinityVersion: 1,
+          sessionHistorySidecar: {
+            historyGenerationRunId: first.runId,
+            rawSizeBucket: "64_256_kib",
+          },
+        },
+      ],
+    });
+    const sidecarVariantRunners = [
+      {
+        runnerId: randomUUID(),
+        sessionHistorySidecar: {
+          historyGenerationRunId: randomUUID(),
+          rawSizeBucket: "256_kib_1_mib" as const,
+        },
+      },
+      {
+        runnerId: randomUUID(),
+        sessionHistorySidecar: {
+          rawSizeBucket: "1_4_mib" as const,
+        },
+      },
+      { runnerId: randomUUID(), sessionHistorySidecar: undefined },
+    ];
+    for (const variant of sidecarVariantRunners) {
+      await api.requestHeartbeatRunner(true, [200], {
+        runnerId: variant.runnerId,
+        group: runnerGroup,
+        admittableProfiles: ["vm0/default"],
+        heldSessionStates: [
+          {
+            sessionId: cliAgentSessionId,
+            lastCompletedAt: nowDate().toISOString(),
+            workspaceCaches: [
+              {
+                profile: "vm0/default",
+                workspaceAffinityVersion: 1,
+                ...(variant.sessionHistorySidecar
+                  ? {
+                      sessionHistorySidecar: variant.sessionHistorySidecar,
+                    }
+                  : {}),
+              },
+            ],
+          },
+        ],
+      });
+    }
+    const competingWorkspaceSidecars = await pollFollowUp(
+      "observe competing workspace sidecars without routing by them",
+    );
+    expect(sessionAffinityResource(competingWorkspaceSidecars.job)).toBe(
+      "workspaceCache",
+    );
+    expect(
+      historyGenerationAffinityProtectedUntil(competingWorkspaceSidecars.job),
+    ).toBeNull();
+    for (const actionType of [
+      "runner_notification_affinity_lookup",
+      "runner_poll_pending_job_lookup",
+    ]) {
+      const events = sandboxOperationEventsForRunByAction(
+        competingWorkspaceSidecars.run.runId,
+        actionType,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          session_affinity_resource: "workspaceCache",
+          workspace_sidecar_exact_holder: "true",
+          workspace_sidecar_different_holder: "true",
+          workspace_sidecar_legacy_holder: "true",
+          workspace_sidecar_absent_holder: "true",
+        }),
+      );
+    }
+    for (const variant of sidecarVariantRunners) {
+      await api.requestHeartbeatRunner(true, [200], {
+        runnerId: variant.runnerId,
+        group: runnerGroup,
+        admittableProfiles: [],
+        heldSessionStates: [],
+        mode: "stopping",
+      });
+    }
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -7508,6 +7606,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           sessionHistoryGenerationRelationship: "different",
           sessionHistoryGenerationLocalAvailability:
             "parked_before_discovery_lt_heartbeat_period",
+          workspaceSessionHistorySidecarRelationship: "different",
+          workspaceSessionHistorySidecarRawSizeBucket: "256_kib_1_mib",
         },
       },
     );
@@ -7521,6 +7621,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         telemetry: {
           sessionHistoryGenerationRelationship: "exact",
           sessionHistoryGenerationLocalAvailability: "parked_after_discovery",
+          workspaceSessionHistorySidecarRelationship: "exact",
+          workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
         },
       },
     );
@@ -7540,6 +7642,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         telemetry: {
           sessionHistoryGenerationRelationship: "exact",
           sessionHistoryGenerationLocalAvailability: "parked_after_discovery",
+          workspaceSessionHistorySidecarRelationship: "exact",
+          workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
         },
       },
     );
@@ -7555,6 +7659,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         generation_relationship: "different",
         generation_local_availability:
           "parked_before_discovery_lt_heartbeat_period",
+        workspace_sidecar_relationship: "different",
+        workspace_sidecar_raw_size_bucket: "256_kib_1_mib",
         claim_outcome: "accepted",
         auth_type: "official-runner",
         runner_group: runnerGroup,
@@ -7565,6 +7671,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         duration_ms: 0,
         generation_relationship: "exact",
         generation_local_availability: "parked_after_discovery",
+        workspace_sidecar_relationship: "exact",
+        workspace_sidecar_raw_size_bucket: "64_256_kib",
         claim_outcome: "unavailable",
         auth_type: "official-runner",
       }),
@@ -7576,6 +7684,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(event).not.toHaveProperty("parked_at");
       expect(event).not.toHaveProperty("discovered_at");
       expect(event).not.toHaveProperty("generation_local_availability_ms");
+      expect(event).not.toHaveProperty("workspace_sidecar_generation_run_id");
+      expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bytes");
       expect(JSON.stringify(event)).not.toContain(actorRunnerKey.token);
     }
 
@@ -7696,6 +7806,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           sessionHistoryGenerationRelationship: "exact",
           sessionHistoryGenerationLocalAvailability:
             "parked_before_discovery_ge_heartbeat_period",
+          workspaceSessionHistorySidecarRelationship: "legacy",
+          workspaceSessionHistorySidecarRawSizeBucket: "1_4_mib",
         },
       },
     );
@@ -7712,6 +7824,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         generation_relationship: "exact",
         generation_local_availability:
           "parked_before_discovery_ge_heartbeat_period",
+        workspace_sidecar_relationship: "legacy",
+        workspace_sidecar_raw_size_bucket: "1_4_mib",
         claim_outcome: "preclaim_error",
         auth_type: "official-runner",
         runner_group: runnerGroup,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -13,7 +13,9 @@ import {
   type SessionHistoryDownloadSource,
   type SessionHistoryGenerationLocalAvailability,
   type SessionHistoryGenerationRelationship,
+  type SessionHistorySizeBucket,
   type StoredExecutionContext,
+  type WorkspaceSessionHistorySidecarRelationship,
 } from "@vm0/api-contracts/contracts/runners";
 import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
@@ -71,6 +73,7 @@ import {
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
   runnerSessionAffinityTelemetryResource,
+  runnerWorkspaceSidecarTelemetryDimensions,
 } from "../services/runner-session-affinity";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
@@ -343,6 +346,22 @@ function canonicalizeHeldSessionStates(
                         workspaceCache.workspaceAffinityVersion,
                     }
                   : {}),
+                ...(workspaceCache.sessionHistorySidecar
+                  ? {
+                      sessionHistorySidecar: {
+                        ...(workspaceCache.sessionHistorySidecar
+                          .historyGenerationRunId
+                          ? {
+                              historyGenerationRunId:
+                                workspaceCache.sessionHistorySidecar
+                                  .historyGenerationRunId,
+                            }
+                          : {}),
+                        rawSizeBucket:
+                          workspaceCache.sessionHistorySidecar.rawSizeBucket,
+                      },
+                    }
+                  : {}),
               };
             }),
           }
@@ -435,6 +454,7 @@ function recordPollTimingMetrics(args: {
   readonly sessionAffinity: string;
   readonly sessionAffinityResource: string;
   readonly historyGenerationAffinity: string;
+  readonly workspaceSidecarDimensions: Readonly<Record<string, string>>;
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
   readonly pendingJobLookupStartedAtMs: number;
@@ -448,6 +468,7 @@ function recordPollTimingMetrics(args: {
     session_affinity: args.sessionAffinity,
     session_affinity_resource: args.sessionAffinityResource,
     history_generation_affinity: args.historyGenerationAffinity,
+    ...args.workspaceSidecarDimensions,
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -609,6 +630,8 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     sessionAffinity: affinity.status,
     sessionAffinityResource: runnerSessionAffinityTelemetryResource(affinity),
     historyGenerationAffinity: affinity.historyGenerationStatus,
+    workspaceSidecarDimensions:
+      runnerWorkspaceSidecarTelemetryDimensions(affinity),
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
     pendingJobLookupStartedAtMs,
@@ -686,6 +709,10 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
   readonly localAvailability:
     | SessionHistoryGenerationLocalAvailability
     | undefined;
+  readonly workspaceSidecarRelationship:
+    | WorkspaceSessionHistorySidecarRelationship
+    | undefined;
+  readonly workspaceSidecarRawSizeBucket: SessionHistorySizeBucket | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly runnerGroup?: string;
@@ -701,6 +728,14 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
   };
   if (args.localAvailability) {
     dimensions.generation_local_availability = args.localAvailability;
+  }
+  if (args.workspaceSidecarRelationship) {
+    dimensions.workspace_sidecar_relationship =
+      args.workspaceSidecarRelationship;
+  }
+  if (args.workspaceSidecarRawSizeBucket) {
+    dimensions.workspace_sidecar_raw_size_bucket =
+      args.workspaceSidecarRawSizeBucket;
   }
   if (args.runnerGroup) {
     dimensions.runner_group = args.runnerGroup;
@@ -726,6 +761,10 @@ function recordSessionHistoryGenerationClaimAttemptForJob(args: {
   readonly localAvailability:
     | SessionHistoryGenerationLocalAvailability
     | undefined;
+  readonly workspaceSidecarRelationship:
+    | WorkspaceSessionHistorySidecarRelationship
+    | undefined;
+  readonly workspaceSidecarRawSizeBucket: SessionHistorySizeBucket | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly job: ClaimableJob["job"];
@@ -734,6 +773,8 @@ function recordSessionHistoryGenerationClaimAttemptForJob(args: {
     runId: args.runId,
     relationship: args.relationship,
     localAvailability: args.localAvailability,
+    workspaceSidecarRelationship: args.workspaceSidecarRelationship,
+    workspaceSidecarRawSizeBucket: args.workspaceSidecarRawSizeBucket,
     outcome: args.outcome,
     authType: args.authType,
     runnerGroup: args.job.runnerGroup,
@@ -2046,6 +2087,12 @@ const claimAuthorizedJob$ = command(
       readonly generationLocalAvailability:
         | SessionHistoryGenerationLocalAvailability
         | undefined;
+      readonly workspaceSidecarRelationship:
+        | WorkspaceSessionHistorySidecarRelationship
+        | undefined;
+      readonly workspaceSidecarRawSizeBucket:
+        | SessionHistorySizeBucket
+        | undefined;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;
       readonly claimRouteTiming: ClaimRouteTimingCollector;
@@ -2059,6 +2106,8 @@ const claimAuthorizedJob$ = command(
         runId,
         relationship: args.generationRelationship,
         localAvailability: args.generationLocalAvailability,
+        workspaceSidecarRelationship: args.workspaceSidecarRelationship,
+        workspaceSidecarRawSizeBucket: args.workspaceSidecarRawSizeBucket,
         outcome,
         authType: args.authType,
         job: jobWithRun.job,
@@ -2174,6 +2223,10 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     body.data.telemetry?.sessionHistoryGenerationRelationship;
   const generationLocalAvailability =
     body.data.telemetry?.sessionHistoryGenerationLocalAvailability;
+  const workspaceSidecarRelationship =
+    body.data.telemetry?.workspaceSessionHistorySidecarRelationship;
+  const workspaceSidecarRawSizeBucket =
+    body.data.telemetry?.workspaceSessionHistorySidecarRawSizeBucket;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -2189,6 +2242,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         runId,
         relationship: generationRelationship,
         localAvailability: generationLocalAvailability,
+        workspaceSidecarRelationship,
+        workspaceSidecarRawSizeBucket,
         outcome: "unavailable",
         authType: auth.type,
       });
@@ -2212,6 +2267,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     jobWithRun,
     generationRelationship,
     generationLocalAvailability,
+    workspaceSidecarRelationship,
+    workspaceSidecarRawSizeBucket,
     telemetry: body.data.telemetry,
     claimRequestStartedAtMs,
     claimRouteTiming,

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -7,6 +7,7 @@ import {
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
   runnerSessionAffinityTelemetryResource,
+  runnerWorkspaceSidecarTelemetryDimensions,
 } from "./runner-session-affinity";
 import { tapError } from "../utils";
 
@@ -74,6 +75,7 @@ export async function notifyRunnerJob(
     session_affinity: affinity.status,
     session_affinity_resource: runnerSessionAffinityTelemetryResource(affinity),
     history_generation_affinity: affinity.historyGenerationStatus,
+    ...runnerWorkspaceSidecarTelemetryDimensions(affinity),
   };
   // Queue-relative actions are cumulative boundaries. Affinity and publish
   // durations are nested children and must not be added to those boundaries.

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -199,6 +199,14 @@ interface RunnerSessionAffinityProtection {
   readonly resource: SessionAffinityResource | null;
   readonly historyGenerationProtectedUntil: Date | null;
   readonly historyGenerationStatus: RunnerHistoryGenerationAffinityStatus;
+  readonly workspaceSidecarAvailability?: RunnerWorkspaceSidecarAvailability;
+}
+
+interface RunnerWorkspaceSidecarAvailability {
+  readonly exact: boolean;
+  readonly different: boolean;
+  readonly legacy: boolean;
+  readonly absent: boolean;
 }
 
 type RunnerHistoryGenerationAffinityStatus =
@@ -216,6 +224,21 @@ export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtect
     resource: null,
     historyGenerationProtectedUntil: null,
     historyGenerationStatus: "lookup_error",
+  };
+}
+
+export function runnerWorkspaceSidecarTelemetryDimensions(
+  affinity: RunnerSessionAffinityProtection,
+): Record<string, string> {
+  const availability = affinity.workspaceSidecarAvailability;
+  if (!availability) {
+    return {};
+  }
+  return {
+    workspace_sidecar_exact_holder: String(availability.exact),
+    workspace_sidecar_different_holder: String(availability.different),
+    workspace_sidecar_legacy_holder: String(availability.legacy),
+    workspace_sidecar_absent_holder: String(availability.absent),
   };
 }
 
@@ -246,6 +269,48 @@ interface RunnerSessionAffinityHolders {
   readonly hasSessionHolder: boolean;
   readonly hasExactGenerationHolder: boolean;
   readonly resource: SessionAffinityResource | null;
+  readonly workspaceSidecarAvailability?: RunnerWorkspaceSidecarAvailability;
+}
+
+const WORKSPACE_SIDECAR_EXACT_BIT = 1;
+const WORKSPACE_SIDECAR_DIFFERENT_BIT = 2;
+const WORKSPACE_SIDECAR_LEGACY_BIT = 4;
+const WORKSPACE_SIDECAR_ABSENT_BIT = 8;
+
+function workspaceSidecarAvailabilityMask(args: {
+  readonly sessionId: string;
+  readonly profile: string;
+  readonly historyGenerationRunId: string | undefined;
+}): SQL<number> {
+  if (!args.historyGenerationRunId) {
+    return sql<number>`0`;
+  }
+  return sql<number>`CASE
+    WHEN ${runnerState.admittableProfiles} @> jsonb_build_array(
+      cast(${args.profile} as text)
+    )
+    THEN coalesce((
+      SELECT bit_or(
+        CASE
+          WHEN jsonb_typeof(workspace_cache.value->'sessionHistorySidecar') IS DISTINCT FROM 'object'
+            THEN cast(${WORKSPACE_SIDECAR_ABSENT_BIT} as integer)
+          WHEN workspace_cache.value->'sessionHistorySidecar'->>'historyGenerationRunId' IS NULL
+            THEN cast(${WORKSPACE_SIDECAR_LEGACY_BIT} as integer)
+          WHEN workspace_cache.value->'sessionHistorySidecar'->>'historyGenerationRunId' = cast(${args.historyGenerationRunId} as text)
+            THEN cast(${WORKSPACE_SIDECAR_EXACT_BIT} as integer)
+          ELSE cast(${WORKSPACE_SIDECAR_DIFFERENT_BIT} as integer)
+        END
+      )
+      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS session_state(value)
+      CROSS JOIN LATERAL jsonb_array_elements(
+        coalesce(session_state.value->'workspaceCaches', '[]'::jsonb)
+      ) AS workspace_cache(value)
+      WHERE session_state.value->>'sessionId' = cast(${args.sessionId} as text)
+        AND workspace_cache.value->>'profile' = cast(${args.profile} as text)
+        AND workspace_cache.value @> '{"workspaceAffinityVersion": 1}'::jsonb
+    ), 0::integer)
+    ELSE 0::integer
+  END`;
 }
 
 async function runnerSessionAffinityHolders(args: {
@@ -276,12 +341,18 @@ async function runnerSessionAffinityHolders(args: {
         historyGenerationRunId: args.historyGenerationRunId,
       })
     : sql<boolean>`false`;
+  const workspaceSidecarMask = workspaceSidecarAvailabilityMask({
+    sessionId: args.cliAgentSessionId,
+    profile: args.profile,
+    historyGenerationRunId: args.historyGenerationRunId,
+  });
   const [holders] = await args.db
     .select({
       hasReusableHolder: sql<boolean>`coalesce(bool_or(${reusableCondition}), false)`,
       hasWorkspaceHolder: sql<boolean>`coalesce(bool_or(${workspaceCondition}), false)`,
       hasLegacyHolder: sql<boolean>`coalesce(bool_or(${legacyCondition}), false)`,
       hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationCondition}), false)`,
+      workspaceSidecarMask: sql<number>`coalesce(bit_or((${workspaceSidecarMask})::integer), 0)`,
     })
     .from(runnerState)
     .where(
@@ -295,6 +366,7 @@ async function runnerSessionAffinityHolders(args: {
   const hasReusableHolder = holders?.hasReusableHolder ?? false;
   const hasWorkspaceHolder = holders?.hasWorkspaceHolder ?? false;
   const hasLegacyHolder = holders?.hasLegacyHolder ?? false;
+  const observedWorkspaceSidecarMask = holders?.workspaceSidecarMask ?? 0;
   return {
     hasSessionHolder:
       hasReusableHolder || hasWorkspaceHolder || hasLegacyHolder,
@@ -304,6 +376,25 @@ async function runnerSessionAffinityHolders(args: {
       : hasWorkspaceHolder
         ? "workspaceCache"
         : null,
+    ...(args.historyGenerationRunId
+      ? {
+          workspaceSidecarAvailability: {
+            exact:
+              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_EXACT_BIT) !==
+              0,
+            different:
+              (observedWorkspaceSidecarMask &
+                WORKSPACE_SIDECAR_DIFFERENT_BIT) !==
+              0,
+            legacy:
+              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_LEGACY_BIT) !==
+              0,
+            absent:
+              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_ABSENT_BIT) !==
+              0,
+          },
+        }
+      : {}),
   };
 }
 
@@ -373,6 +464,7 @@ export async function runnerSessionAffinityProtection(args: {
       ? historyGenerationProtectedUntil
       : null,
     historyGenerationStatus,
+    workspaceSidecarAvailability: holders.workspaceSidecarAvailability,
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -377,7 +377,14 @@ describe("runner resume session contract", () => {
         historyGenerationRunId,
       },
       workspaceCaches: [
-        { profile: "vm0/default", workspaceAffinityVersion: 1 },
+        {
+          profile: "vm0/default",
+          workspaceAffinityVersion: 1,
+          sessionHistorySidecar: {
+            historyGenerationRunId,
+            rawSizeBucket: "64_256_kib",
+          },
+        },
         { profile: "vm0/large" },
       ],
     });
@@ -385,7 +392,14 @@ describe("runner resume session contract", () => {
       historyGenerationRunId,
     );
     expect(heldSessionState.workspaceCaches).toEqual([
-      { profile: "vm0/default", workspaceAffinityVersion: 1 },
+      {
+        profile: "vm0/default",
+        workspaceAffinityVersion: 1,
+        sessionHistorySidecar: {
+          historyGenerationRunId,
+          rawSizeBucket: "64_256_kib",
+        },
+      },
       { profile: "vm0/large" },
     ]);
   });
@@ -648,6 +662,8 @@ describe("runner claim capability contract", () => {
         sessionAffinityLocalResource: "workspaceCache",
         localAdmissionResource: "fresh",
         sessionHistoryGenerationRelationship: "exact",
+        workspaceSessionHistorySidecarRelationship: "exact",
+        workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
       },
     });
 
@@ -678,6 +694,26 @@ describe("runner claim capability contract", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("rejects dynamic workspace sidecar telemetry values", () => {
+    expect(
+      runnersJobClaimContract.claim.body.safeParse({
+        telemetry: {
+          sessionHistoryGenerationRelationship: "fresh",
+          workspaceSessionHistorySidecarRelationship:
+            "exact-for-11111111-1111-4111-8111-111111111111",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersJobClaimContract.claim.body.safeParse({
+        telemetry: {
+          sessionHistoryGenerationRelationship: "fresh",
+          workspaceSessionHistorySidecarRawSizeBucket: "exact_123_bytes",
+        },
+      }).success,
+    ).toBe(false);
   });
 
   it("accepts old claim bodies without generation telemetry", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -44,6 +44,15 @@ export const sessionHistoryDownloadSourceSchema = z.enum([
   SESSION_HISTORY_DOWNLOAD_SOURCE_CONFIGURED_PUBLIC_ENDPOINT,
   SESSION_HISTORY_DOWNLOAD_SOURCE_DEFAULT_R2_ENDPOINT,
 ]);
+export const sessionHistorySizeBucketSchema = z.enum([
+  "lt_64_kib",
+  "64_256_kib",
+  "256_kib_1_mib",
+  "1_4_mib",
+  "4_16_mib",
+  "16_64_mib",
+  "64_128_mib",
+]);
 
 export function elapsedSinceApiStartMs(
   apiStartTimeMs: number | undefined,
@@ -97,6 +106,13 @@ export const sessionHistoryGenerationLocalAvailabilitySchema = z.enum([
   "parked_before_discovery_lt_heartbeat_period",
   "parked_before_discovery_ge_heartbeat_period",
 ]);
+export const workspaceSessionHistorySidecarRelationshipSchema = z.enum([
+  "exact",
+  "different",
+  "legacy",
+  "absent",
+  "no_target",
+]);
 
 const runnerClaimTelemetrySchema = z.object({
   discoverySource: runnerClaimDiscoverySourceSchema.optional(),
@@ -118,6 +134,10 @@ const runnerClaimTelemetrySchema = z.object({
     sessionHistoryGenerationRelationshipSchema.optional(),
   sessionHistoryGenerationLocalAvailability:
     sessionHistoryGenerationLocalAvailabilitySchema.optional(),
+  workspaceSessionHistorySidecarRelationship:
+    workspaceSessionHistorySidecarRelationshipSchema.optional(),
+  workspaceSessionHistorySidecarRawSizeBucket:
+    sessionHistorySizeBucketSchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),
@@ -223,6 +243,12 @@ export const heldSessionStateSchema = z.object({
       z.object({
         profile: z.string(),
         workspaceAffinityVersion: z.literal(1).optional(),
+        sessionHistorySidecar: z
+          .object({
+            historyGenerationRunId: z.uuid().optional(),
+            rawSizeBucket: sessionHistorySizeBucketSchema,
+          })
+          .optional(),
       }),
     )
     .max(8)
@@ -720,6 +746,12 @@ export type SessionHistoryGenerationRelationship = z.infer<
 >;
 export type SessionHistoryGenerationLocalAvailability = z.infer<
   typeof sessionHistoryGenerationLocalAvailabilitySchema
+>;
+export type SessionHistorySizeBucket = z.infer<
+  typeof sessionHistorySizeBucketSchema
+>;
+export type WorkspaceSessionHistorySidecarRelationship = z.infer<
+  typeof workspaceSessionHistorySidecarRelationshipSchema
 >;
 export type SessionAffinityResource = z.infer<
   typeof sessionAffinityResourceSchema

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -6,6 +6,7 @@ import {
   RESUME_SESSION_HISTORY_MAX_BYTES,
   sessionHistoryDownloadSourceSchema,
   sessionHistoryEncodingSchema,
+  sessionHistorySizeBucketSchema,
   secretConnectorMetadataMapSchema,
 } from "./runners";
 import { eventSequenceNumberSchema, networkLogEntrySchema } from "./runs";
@@ -680,16 +681,6 @@ const metricDataSchema = z.object({
   disk_used: z.number(),
   disk_total: z.number(),
 });
-
-const sessionHistorySizeBucketSchema = z.enum([
-  "lt_64_kib",
-  "64_256_kib",
-  "256_kib_1_mib",
-  "1_4_mib",
-  "4_16_mib",
-  "16_64_mib",
-  "64_128_mib",
-]);
 
 const sessionHistoryCompressionRatioBucketSchema = z.enum([
   "identity",

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -1,3 +1,5 @@
+import type { SessionHistorySizeBucket } from "@vm0/api-contracts/contracts/runners";
+
 export type RunnerAdmittableProfiles = string[];
 
 export interface RunnerHeldSessionState {
@@ -12,6 +14,10 @@ export interface RunnerHeldSessionState {
   readonly workspaceCaches?: readonly {
     readonly profile: string;
     readonly workspaceAffinityVersion?: 1;
+    readonly sessionHistorySidecar?: {
+      readonly historyGenerationRunId?: string;
+      readonly rawSizeBucket: SessionHistorySizeBucket;
+    };
   }[];
 }
 


### PR DESCRIPTION
## Summary

- Attribute each valid workspace session-history sidecar to its producing history generation and a bounded raw-size bucket.
- Carry exact/different/legacy/absent holder facts through runner heartbeats and API aggregation, and correlate them with the runner's post-claim result.
- Preserve legacy metadata and old runner/API payloads while keeping routing, admission, polling, deadlines, claim, checkout, and restore behavior unchanged.

## Compatibility and data model

- No physical database schema migration or backfill is required; the new fields are optional members of existing JSONB and wire contracts.
- Existing sidecar metadata remains valid and restoreable, but is reported as legacy-unattributed rather than exact.
- New API versions accept old runner heartbeats, and new runners accept API responses without the optional observation fields.
- Heartbeat observation performs bounded metadata and file-identity validation under the cache-entry lock without reading, decompressing, or hashing the sidecar body.

## Validation

- `cargo test -p runner`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo fmt --all -- --check`
- scoped Turbo lint and type checks for API, API contracts, and DB
- API-contract runner tests and focused API run-lifecycle integration scenarios
- `pnpm knip`
- Rust contract generation, with no generated drift

An additional full local run-lifecycle file run passed 104 of 105 scenarios; the remaining unrelated scenario selected a pre-existing VM0 model key from the persistent development database instead of its fixed test fixture. The affected sidecar scenarios pass in isolation after applying current migrations.

Closes #21869

Parent: #21861
