### PR TITLE
fix(vsock-guest): roll back partial cgroup creation

### DIFF
--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -101,16 +101,35 @@ impl SupervisedProcessContainment {
 
 impl CgroupGuard {
     fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
+        Self::create_in(Path::new(SUPERVISED_CGROUP_BASE_PATH), sequence)
+    }
+
+    fn create_in(base_path: &Path, sequence: u32) -> Result<Self, ProcessContainmentError> {
         let started = Instant::now();
         let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
         let group_name = format!("exec-{}-{sequence}-{id}", std::process::id());
-        let group_path = Path::new(SUPERVISED_CGROUP_BASE_PATH).join(&group_name);
+        let group_path = base_path.join(&group_name);
         fs::create_dir(&group_path)
             .map_err(|error| ProcessContainmentError::new("create cgroup", error))?;
-        let placement = OpenOptions::new()
+        let placement = match OpenOptions::new()
             .write(true)
             .open(group_path.join(CGROUP_PROCS_FILE))
-            .map_err(|error| ProcessContainmentError::new("open cgroup.procs", error))?;
+        {
+            Ok(placement) => placement,
+            Err(source) => {
+                let error = ProcessContainmentError::new("open cgroup.procs", source);
+                if let Err(rollback_error) = remove_empty_cgroup(&group_path) {
+                    log(
+                        "ERROR",
+                        &format!(
+                            "supervised process containment creation rollback failed group={group_name} original_stage={} original_error={} rollback_stage={} rollback_error={}",
+                            error.stage, error.source, rollback_error.stage, rollback_error.source
+                        ),
+                    );
+                }
+                return Err(error);
+            }
+        };
 
         Ok(Self {
             group_name,
@@ -429,6 +448,20 @@ mod tests {
         assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));
         assert_eq!(parse_populated("frozen 0\n"), None);
         assert_eq!(parse_populated("populated 2\n"), None);
+    }
+
+    #[test]
+    fn failed_placement_open_removes_created_cgroup() {
+        let base = tempfile::tempdir().unwrap();
+
+        let error = match CgroupGuard::create_in(base.path(), 7) {
+            Ok(_) => panic!("placement open unexpectedly succeeded"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.stage, "open cgroup.procs");
+        assert_eq!(error.source.kind(), io::ErrorKind::NotFound);
+        assert!(fs::read_dir(base.path()).unwrap().next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- roll back a newly created supervised cgroup when opening its placement file fails
- preserve the original initialization error while logging rollback failure as secondary diagnostics
- cover the failure with a deterministic real-filesystem regression

## Scope

- successful cgroup creation and post-construction cleanup are unchanged
- no API, protocol, schema, persisted-data, dependency, or workflow changes
- the later ownership-transfer failure tracked by #21951 remains separate

## Validation

- `cargo test -p vsock-guest process_containment::tests::failed_placement_open_removes_created_cgroup`
- `cargo test -p vsock-guest --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets -- -D warnings`
- `cargo doc -p vsock-guest --no-deps`

Closes #21953
