### PR TITLE
fix: hide artifacts page from non-staff organizations

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,7 +15,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ArtifactPreviewImage, {})).toBe(
       true,
     );
-    expect(isFeatureEnabled(FeatureSwitchKey.Artifacts, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -35,6 +34,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.HtmlArtifactCommentEditing, {}),
     ).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.Artifacts, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.WebsiteTemplates, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.AgentDetailWorkflowsTab, {})).toBe(
       false,
@@ -180,7 +180,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactPreviewImage]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -440,7 +440,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Show the Artifacts manage page for generated artifacts in the current organization.",
-    enabled: true,
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ArtifactFavorites]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

- disable the `Artifacts` feature switch by default
- retain the staff organization allowlist for internal access while the blank page is investigated
- update feature-switch coverage for staff and non-staff organizations

## User impact

After deployment, non-staff users no longer see the Artifacts navigation entry. Direct visits to `/artifacts` redirect to the home route. Staff organizations retain access for investigation.

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests passed)

Full local Vitest was not run per repository PR verification guidance; the PR pipeline will run broader checks.