### PR TITLE
fix(vsock-guest): roll back cgroup setup failures

### DIFF
--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -849,7 +849,7 @@ fn run_exec_operation_worker<S>(
         effective_env,
         request.sudo,
         pipe_stdin,
-        process_containment.as_ref(),
+        process_containment,
     ) {
         Ok(spawned) => spawned,
         Err(e) => {
@@ -862,7 +862,11 @@ fn run_exec_operation_worker<S>(
         }
     };
 
-    let SpawnedShellCommand { child, env_script } = spawned;
+    let SpawnedShellCommand {
+        child,
+        env_script,
+        process_containment,
+    } = spawned;
     let _env_script = env_script;
     let mut setup = ExecSetup::new(child, process_containment);
 

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -30,6 +30,8 @@ pub(crate) struct SupervisedProcessContainment {
 enum ContainmentBackend {
     Cgroup(CgroupGuard),
     TestNoop,
+    #[cfg(test)]
+    TestDirectory(PathBuf),
 }
 
 struct CgroupGuard {
@@ -88,6 +90,8 @@ impl SupervisedProcessContainment {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.configure_command(command),
             ContainmentBackend::TestNoop => Ok(()),
+            #[cfg(test)]
+            ContainmentBackend::TestDirectory(_) => Ok(()),
         }
     }
 
@@ -95,22 +99,44 @@ impl SupervisedProcessContainment {
         match self.backend {
             ContainmentBackend::Cgroup(guard) => guard.cleanup(),
             ContainmentBackend::TestNoop => Ok(()),
+            #[cfg(test)]
+            ContainmentBackend::TestDirectory(group_path) => fs::remove_dir(group_path)
+                .map_err(|error| ProcessContainmentError::new("remove test cgroup", error)),
         }
     }
 }
 
 impl CgroupGuard {
     fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
+        Self::create_in(Path::new(SUPERVISED_CGROUP_BASE_PATH), sequence)
+    }
+
+    fn create_in(base_path: &Path, sequence: u32) -> Result<Self, ProcessContainmentError> {
         let started = Instant::now();
         let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
         let group_name = format!("exec-{}-{sequence}-{id}", std::process::id());
-        let group_path = Path::new(SUPERVISED_CGROUP_BASE_PATH).join(&group_name);
+        let group_path = base_path.join(&group_name);
         fs::create_dir(&group_path)
             .map_err(|error| ProcessContainmentError::new("create cgroup", error))?;
-        let placement = OpenOptions::new()
+        let placement = match OpenOptions::new()
             .write(true)
             .open(group_path.join(CGROUP_PROCS_FILE))
-            .map_err(|error| ProcessContainmentError::new("open cgroup.procs", error))?;
+        {
+            Ok(placement) => placement,
+            Err(source) => {
+                let original = ProcessContainmentError::new("open cgroup.procs", source);
+                if let Err(rollback) = remove_empty_cgroup(&group_path) {
+                    log(
+                        "ERROR",
+                        &format!(
+                            "supervised process containment creation rollback failed group={group_name} original_stage={} original_error={} rollback_stage={} rollback_error={}",
+                            original.stage, original.source, rollback.stage, rollback.source
+                        ),
+                    );
+                }
+                return Err(original);
+            }
+        };
 
         Ok(Self {
             group_name,
@@ -446,6 +472,68 @@ mod tests {
         let mut content = String::new();
         placement.read_to_string(&mut content).unwrap();
         assert_eq!(content, "0");
+    }
+
+    #[test]
+    fn partial_creation_failure_removes_operation_cgroup() {
+        let base = tempfile::tempdir().unwrap();
+
+        let result = CgroupGuard::create_in(base.path(), 17);
+        let Err(error) = result else {
+            panic!("placement-file open unexpectedly succeeded");
+        };
+
+        assert_eq!(error.stage, "open cgroup.procs");
+        assert!(fs::read_dir(base.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn spawn_failure_removes_owned_operation_cgroup() {
+        let base = tempfile::tempdir().unwrap();
+        let group_path = base.path().join("exec-spawn-failure");
+        fs::create_dir(&group_path).unwrap();
+        let containment = SupervisedProcessContainment {
+            backend: ContainmentBackend::TestDirectory(group_path.clone()),
+        };
+
+        let result = crate::shell_command::spawn_shell_command_with_pipes(
+            "bad\0command",
+            &[],
+            false,
+            false,
+            Some(containment),
+        );
+        let Err(error) = result else {
+            panic!("invalid command unexpectedly spawned");
+        };
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(!group_path.exists());
+    }
+
+    #[test]
+    fn spawn_failure_preserves_primary_error_when_cleanup_fails() {
+        let base = tempfile::tempdir().unwrap();
+        let group_path = base.path().join("exec-cleanup-failure");
+        fs::create_dir(&group_path).unwrap();
+        fs::write(group_path.join("blocker"), b"keep directory non-empty").unwrap();
+        let containment = SupervisedProcessContainment {
+            backend: ContainmentBackend::TestDirectory(group_path.clone()),
+        };
+
+        let result = crate::shell_command::spawn_shell_command_with_pipes(
+            "bad\0command",
+            &[],
+            false,
+            false,
+            Some(containment),
+        );
+        let Err(error) = result else {
+            panic!("invalid command unexpectedly spawned");
+        };
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(group_path.is_dir());
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -484,6 +484,7 @@ mod tests {
         };
 
         assert_eq!(error.stage, "open cgroup.procs");
+        assert_eq!(error.source.kind(), io::ErrorKind::NotFound);
         assert!(fs::read_dir(base.path()).unwrap().next().is_none());
     }
 

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -32,6 +32,9 @@
 //! spawned operation. Callers must retain the guard while the shell wrapper may
 //! still need to open the script; dropping it too early can remove the script
 //! before bash reads it.
+//! `SpawnedShellCommand` also returns supervised process-containment ownership
+//! only after a successful spawn. Setup failures clean that containment before
+//! returning the original spawn error.
 
 use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::io::{self, Read, Write};
@@ -154,6 +157,7 @@ pub(crate) struct PreparedShellCommand {
 pub(crate) struct SpawnedShellCommand {
     pub(crate) child: Child,
     pub(crate) env_script: Option<EnvScriptGuard>,
+    pub(crate) process_containment: Option<SupervisedProcessContainment>,
 }
 
 fn effective_uid() -> libc::uid_t {
@@ -553,25 +557,41 @@ pub(crate) fn spawn_shell_command_with_pipes(
     env: &[(&str, &str)],
     sudo: bool,
     pipe_stdin: bool,
-    process_containment: Option<&SupervisedProcessContainment>,
+    process_containment: Option<SupervisedProcessContainment>,
 ) -> io::Result<SpawnedShellCommand> {
-    let PreparedShellCommand {
-        mut command,
-        env_script,
-    } = build_shell_command_with_env(command, env, sudo)?;
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    if pipe_stdin {
-        command.stdin(Stdio::piped());
+    let spawn_result = (|| -> io::Result<(Child, Option<EnvScriptGuard>)> {
+        let PreparedShellCommand {
+            mut command,
+            env_script,
+        } = build_shell_command_with_env(command, env, sudo)?;
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        if pipe_stdin {
+            command.stdin(Stdio::piped());
+        }
+        if let Some(process_containment) = process_containment.as_ref() {
+            process_containment
+                .configure_command(&mut command)
+                .map_err(|error| {
+                    io::Error::other(format!("process containment setup failed: {error}"))
+                })?;
+        }
+        let child = crate::process::spawn_in_own_process_group(&mut command)?;
+        Ok((child, env_script))
+    })();
+
+    match spawn_result {
+        Ok((child, env_script)) => Ok(SpawnedShellCommand {
+            child,
+            env_script,
+            process_containment,
+        }),
+        Err(error) => {
+            if let Some(process_containment) = process_containment {
+                let _ = process_containment.cleanup();
+            }
+            Err(error)
+        }
     }
-    if let Some(process_containment) = process_containment {
-        process_containment
-            .configure_command(&mut command)
-            .map_err(|error| {
-                io::Error::other(format!("process containment setup failed: {error}"))
-            })?;
-    }
-    let child = crate::process::spawn_in_own_process_group(&mut command)?;
-    Ok(SpawnedShellCommand { child, env_script })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- roll back a newly created supervised-operation cgroup when opening `cgroup.procs` fails
- transfer containment ownership through shell setup so every pre-spawn and spawn failure cleans the cgroup
- preserve the primary setup error while retaining production cleanup-failure diagnostics
- cover partial creation, spawn rollback, cleanup failure, and VM reuse cleanup behavior

## Scope

This changes only guest-side supervised process containment ownership and rollback. It does not change schemas, APIs, queue payloads, runner protocols, or unsupervised command behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test reuse_preparation_helper prepare_for_reuse_rejects_stale_operation_cgroup`
- pre-commit workspace Rust format, Clippy, and documentation hooks
- `git diff --check`

Closes #21951
Closes #21953
