### PR TITLE
fix: chat composer grows with content instead of scrolling internally

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -47,7 +47,10 @@ import {
 } from "./template-preview-runtime.ts";
 
 const EDITOR_CONTENT_CLASS =
-  "w-full max-h-[200px] overflow-y-auto whitespace-pre-wrap " +
+  // The editor grows with its content instead of scrolling inside a fixed
+  // 200px box: a nested scroll region felt cramped once queued references and
+  // typed text stacked up. Overflow is delegated to the surrounding page.
+  "w-full whitespace-pre-wrap " +
   "break-words px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground " +
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";


### PR DESCRIPTION
## What & why

Fixes #21978. The web chat composer showed an **internal scrollbar** instead of growing with its content: once a workflow was selected and queued references + typed text stacked up, the editor hit a fixed height and scrolled inside a cramped nested box.

![before](https://zero-composer-scroll-bug-715f6d07-a73a4001.sites.vm0.io/composer-bug.png)

## Root cause

The scroll lived on the TipTap editor content class, not the queued-messages strip (they share an identical `max-h-[200px] overflow-y-auto` string, which made the original triage point at the wrong line):

- `turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts` — `EDITOR_CONTENT_CLASS` carried `max-h-[200px] overflow-y-auto`, applied to the ProseMirror content on both the desktop and compact/mobile editors.

## Change

Drop `max-h-[200px] overflow-y-auto` from `EDITOR_CONTENT_CLASS` (option A, agreed with @Lunarivibe): the editor now grows naturally with its content and overflow is delegated to the surrounding scroll container. `min-h-[96px]` (and the mobile `min-h-[44px]`) are unchanged.

## Why this is safe for both surfaces

Both composer host layouts already provide an outer scroll region, so past a reasonable height the page/footer scrolls rather than the editor:

- **Home / new chat** (`agent-chat-page.tsx`) — composer sits inside `<main class="flex-1 min-h-0 overflow-y-auto">`.
- **Chat thread** (`zero-chat-thread-page.tsx`) — composer footer wraps it in `<div class="overflow-y-auto [scrollbar-gutter:stable]">`.

## Verification

Static, single-class change; relying on the PR pipeline for lint/type/tests. No local dev server per team convention.
