### PR TITLE
fix(runner): delegate service signals to systemd

### DIFF
--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -460,8 +460,8 @@ async fn signal_resume_after_restart_policy_restored(
     ops: &mut impl ServiceResumeOps,
 ) -> RunnerResult<()> {
     match ops.signal_resume(unit).await {
-        Ok(ServiceSignalOutcome::Sent { pid }) => {
-            info!(unit = %unit.unit_name(), pid, "sent SIGUSR2 (resume)");
+        Ok(ServiceSignalOutcome::Sent) => {
+            info!(unit = %unit.unit_name(), "sent SIGUSR2 (resume)");
             Ok(())
         }
         Ok(ServiceSignalOutcome::AlreadyGone) => {
@@ -550,8 +550,7 @@ async fn drain_with_ops(
     }
 
     if should_signal {
-        // `is_unit_active` above can race against the runner exiting on its own:
-        // by the time we read MainPID or call `kill`, the process may be gone.
+        // `is_unit_active` above can race against the runner exiting on its own.
         // Both outcomes ("live, signal delivered" and "already gone") must still
         // run `systemctl disable` below so the unit does not auto-start at the
         // next boot.
@@ -560,8 +559,8 @@ async fn drain_with_ops(
                 rollback_drain_restart_override(unit, ops, "signal_drain").await;
                 return Err(e);
             }
-            Ok(ServiceSignalOutcome::Sent { pid }) => {
-                info!(unit = %unit.unit_name(), pid, "sent SIGUSR1 (drain)");
+            Ok(ServiceSignalOutcome::Sent) => {
+                info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain)");
             }
             Ok(ServiceSignalOutcome::AlreadyGone) => {
                 info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
@@ -1335,7 +1334,7 @@ profiles:
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
                 signal_error: false,
-                signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
+                signal_outcome: ServiceSignalOutcome::Sent,
                 disable_error: false,
             }
         }
@@ -1350,7 +1349,7 @@ profiles:
                 removed_restart_override: true,
                 reload_errors: VecDeque::new(),
                 signal_error: false,
-                signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
+                signal_outcome: ServiceSignalOutcome::Sent,
             }
         }
     }

--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -1,52 +1,256 @@
+use std::process::ExitStatus;
+
 use crate::error::{RunnerError, RunnerResult};
 
-use super::systemctl::get_service_pid;
+use super::diagnostic::status_field_preview;
+use super::systemctl::has_service_main_process;
 use super::target::RunnerServiceUnit;
 
-/// Outcome of attempting to signal a systemd unit's main process.
+/// Outcome of asking systemd to signal a unit's main process.
 ///
-/// The `AlreadyGone` variant collapses two distinct races into a single
-/// state so callers can encode one policy instead of two:
-///
-/// 1. `systemctl show` read `MainPID=0` — the runner either exited, systemd
-///    is mid-transition and has cleared MainPID, or the unit was explicitly
-///    reported as not found after a prior active-state check.
-/// 2. MainPID resolved to a live value but `kill(2)` returned `ESRCH`
-///    because the process exited in the ~µs window before signal delivery.
-///
-/// Failed or malformed MainPID lookups are not `AlreadyGone`; they propagate
-/// as errors because the signal may still be needed.
-///
-/// Either way the signal was not delivered, and the cause is the same:
-/// the runner is no longer around to receive it. `Sent` carries the PID
-/// so callers can keep the pre-refactor `info!(…, pid, …)` structured
-/// field in their journald logs.
+/// `AlreadyGone` means the delivery command failed and a follow-up systemd
+/// query proved that the unit no longer has a main process. Callers retain
+/// their distinct policies for that race: drain continues boot-enablement
+/// cleanup, while resume rejects an inactive runner.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ServiceSignalOutcome {
-    Sent { pid: u32 },
+    Sent,
     AlreadyGone,
 }
 
-/// Send `sig` to the main process of `unit`, tolerating the race between
-/// MainPID lookup and signal delivery.
+/// Ask systemd to send `signal` to the current main process of `unit`.
 ///
-/// Callers decide the policy for `AlreadyGone`: `drain` continues to
-/// `systemctl disable` (the unit file must still be rewritten so the
-/// service does not restart on reboot), while `resume` surfaces an error
-/// matching its preflight "not active" branch — a runner that has exited
-/// cannot be resumed.
+/// Systemd owns the unit's process identity, so resolving and signaling the
+/// target inside the manager avoids a caller-side numeric PID reuse race.
 pub(super) async fn signal_service_main(
     unit: &RunnerServiceUnit,
-    sig: nix::sys::signal::Signal,
+    signal: nix::sys::signal::Signal,
 ) -> RunnerResult<ServiceSignalOutcome> {
-    let Some(pid) = get_service_pid(unit).await? else {
-        return Ok(ServiceSignalOutcome::AlreadyGone);
-    };
-    let raw_pid =
-        i32::try_from(pid).map_err(|_| RunnerError::Internal(format!("PID {pid} out of range")))?;
-    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(raw_pid), sig) {
-        Ok(()) => Ok(ServiceSignalOutcome::Sent { pid }),
-        Err(nix::errno::Errno::ESRCH) => Ok(ServiceSignalOutcome::AlreadyGone),
-        Err(e) => Err(RunnerError::Internal(format!("{sig:?} to PID {pid}: {e}"))),
+    let signal_arg = format!("--signal={}", signal.as_str());
+    let output = tokio::process::Command::new("systemctl")
+        .args([
+            "kill",
+            "--kill-whom=main",
+            signal_arg.as_str(),
+            unit.service_name(),
+        ])
+        .output()
+        .await
+        .map_err(|e| {
+            RunnerError::Internal(format!(
+                "spawn systemctl kill for {}: {e}",
+                unit.service_name()
+            ))
+        })?;
+
+    if output.status.success() {
+        return Ok(ServiceSignalOutcome::Sent);
+    }
+
+    let signal_error = systemctl_kill_error(unit, signal, output.status, &output.stderr);
+    match has_service_main_process(unit).await {
+        Ok(false) => Ok(ServiceSignalOutcome::AlreadyGone),
+        Ok(true) | Err(_) => Err(signal_error),
+    }
+}
+
+fn systemctl_kill_error(
+    unit: &RunnerServiceUnit,
+    signal: nix::sys::signal::Signal,
+    status: ExitStatus,
+    stderr: &[u8],
+) -> RunnerError {
+    let stderr = String::from_utf8_lossy(stderr);
+    let stderr = stderr.trim();
+    let command = format!(
+        "systemctl kill --kill-whom=main --signal={} {}",
+        signal.as_str(),
+        unit.service_name()
+    );
+    if stderr.is_empty() {
+        RunnerError::Internal(format!("{command} exited with {status}"))
+    } else {
+        RunnerError::Internal(format!(
+            "{command} exited with {status}: stderr={:?}",
+            status_field_preview(stderr)
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+    const SCENARIO_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_SCENARIO";
+    const SIGNAL_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_NAME";
+    const INVOCATIONS_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_INVOCATIONS";
+    const CHILD_TEST: &str = "cmd::service::signal::tests::signal_service_main_systemctl_child";
+    const FAKE_SYSTEMCTL: &str = r#"#!/bin/sh
+printf '%s\n' "$*" >> "$VM0_RUN_SERVICE_SIGNAL_INVOCATIONS"
+
+if [ "$1" = "kill" ]; then
+  case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
+    success-*) exit 0 ;;
+    absent|live|recheck-failed)
+      printf '%s\n' 'signal delivery failed' >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [ "$1" = "show" ]; then
+  case "$VM0_RUN_SERVICE_SIGNAL_SCENARIO" in
+    absent)
+      printf '%s\n' 'LoadState=loaded' 'MainPID=0'
+      exit 0
+      ;;
+    live)
+      printf '%s\n' 'LoadState=loaded' 'MainPID=123'
+      exit 0
+      ;;
+    recheck-failed)
+      printf '%s\n' 'state lookup failed' >&2
+      exit 1
+      ;;
+  esac
+fi
+
+printf '%s\n' "unexpected fake systemctl invocation: $*" >&2
+exit 2
+"#;
+
+    #[tokio::test]
+    async fn signal_service_main_uses_systemd_main_scope_for_both_signals() {
+        for (scenario, signal) in [
+            ("success-sigusr1", nix::sys::signal::Signal::SIGUSR1),
+            ("success-sigusr2", nix::sys::signal::Signal::SIGUSR2),
+        ] {
+            let invocations = run_signal_scenario(scenario, signal).await;
+
+            assert_eq!(invocations, vec![expected_kill_invocation(signal)]);
+        }
+    }
+
+    #[tokio::test]
+    async fn signal_service_main_returns_already_gone_when_recheck_proves_absence() {
+        let signal = nix::sys::signal::Signal::SIGUSR1;
+        let invocations = run_signal_scenario("absent", signal).await;
+
+        assert_eq!(
+            invocations,
+            vec![expected_kill_invocation(signal), expected_show_invocation()]
+        );
+    }
+
+    #[tokio::test]
+    async fn signal_service_main_preserves_failure_when_main_process_is_present() {
+        let signal = nix::sys::signal::Signal::SIGUSR2;
+        let invocations = run_signal_scenario("live", signal).await;
+
+        assert_eq!(
+            invocations,
+            vec![expected_kill_invocation(signal), expected_show_invocation()]
+        );
+    }
+
+    #[tokio::test]
+    async fn signal_service_main_preserves_failure_when_recheck_fails() {
+        let signal = nix::sys::signal::Signal::SIGUSR1;
+        let invocations = run_signal_scenario("recheck-failed", signal).await;
+
+        assert_eq!(
+            invocations,
+            vec![expected_kill_invocation(signal), expected_show_invocation()]
+        );
+    }
+
+    async fn run_signal_scenario(scenario: &str, signal: nix::sys::signal::Signal) -> Vec<String> {
+        let dir = tempfile::tempdir().unwrap();
+        let fake_systemctl = dir.path().join("systemctl");
+        std::fs::write(&fake_systemctl, FAKE_SYSTEMCTL).unwrap();
+        let mut permissions = std::fs::metadata(&fake_systemctl).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_systemctl, permissions).unwrap();
+
+        let invocations_path = dir.path().join("invocations");
+        let path = utf8_path(dir.path());
+        let invocations = utf8_path(&invocations_path);
+        run_ignored_child_test(
+            CHILD_TEST,
+            (SCENARIO_ENV, scenario),
+            &[
+                ("PATH", Some(path)),
+                (SIGNAL_ENV, Some(signal.as_str())),
+                (INVOCATIONS_ENV, Some(invocations)),
+            ],
+            Duration::from_secs(10),
+        )
+        .await;
+
+        std::fs::read_to_string(invocations_path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn utf8_path(path: &Path) -> &str {
+        path.to_str().expect("temporary path must be UTF-8")
+    }
+
+    fn expected_kill_invocation(signal: nix::sys::signal::Signal) -> String {
+        format!(
+            "kill --kill-whom=main --signal={} vm0-runner-test.service",
+            signal.as_str()
+        )
+    }
+
+    fn expected_show_invocation() -> String {
+        "show vm0-runner-test.service --property=LoadState --property=MainPID".to_string()
+    }
+
+    #[tokio::test]
+    #[ignore = "spawned by signal service main systemctl tests"]
+    async fn signal_service_main_systemctl_child() {
+        let Ok(scenario) = std::env::var(SCENARIO_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((SCENARIO_ENV, &scenario)) {
+            return;
+        }
+
+        let signal = match std::env::var(SIGNAL_ENV).as_deref() {
+            Ok("SIGUSR1") => nix::sys::signal::Signal::SIGUSR1,
+            Ok("SIGUSR2") => nix::sys::signal::Signal::SIGUSR2,
+            value => panic!("unexpected signal scenario value: {value:?}"),
+        };
+        let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+        let result = signal_service_main(&unit, signal).await;
+
+        match scenario.as_str() {
+            "success-sigusr1" | "success-sigusr2" => {
+                assert_eq!(result.unwrap(), ServiceSignalOutcome::Sent);
+            }
+            "absent" => {
+                assert_eq!(result.unwrap(), ServiceSignalOutcome::AlreadyGone);
+            }
+            "live" | "recheck-failed" => {
+                let error = result.unwrap_err().to_string();
+                assert!(
+                    error.contains("signal delivery failed"),
+                    "unexpected error: {error}"
+                );
+                assert!(
+                    !error.contains("state lookup failed"),
+                    "recheck error replaced original failure: {error}"
+                );
+            }
+            unexpected => panic!("unexpected service signal scenario: {unexpected}"),
+        }
     }
 }

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -431,13 +431,19 @@ pub(super) async fn is_unit_enabled_bounded(
     unit_enabled_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
 }
 
-/// Get the main PID of a systemd unit.
-pub(super) async fn get_service_pid(unit: &RunnerServiceUnit) -> RunnerResult<Option<u32>> {
+/// Check whether systemd currently reports a main process for a unit.
+pub(super) async fn has_service_main_process(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
     let svc = unit.service_name();
     let properties = ["LoadState", "MainPID"];
     let output = run_systemctl_show(svc, &properties).await?;
     let values = parse_systemctl_show_output(svc, &properties, &output)?;
-    service_pid_from_systemctl_show(svc, &properties, &output.status, &values, &output.stderr)
+    service_main_process_present_from_systemctl_show(
+        svc,
+        &properties,
+        &output.status,
+        &values,
+        &output.stderr,
+    )
 }
 
 /// Get the effective systemd Restart policy of a service unit.
@@ -652,13 +658,13 @@ fn service_unit_state_from_systemctl_show(
     })
 }
 
-fn service_pid_from_systemctl_show(
+fn service_main_process_present_from_systemctl_show(
     svc: &str,
     properties: &[&str],
     status: &ExitStatus,
     values: &BTreeMap<String, String>,
     stderr: &[u8],
-) -> RunnerResult<Option<u32>> {
+) -> RunnerResult<bool> {
     let load_state = required_systemctl_property(svc, values, "LoadState")?;
     let pid_str = required_systemctl_property(svc, values, "MainPID")?;
     let pid = match parse_main_pid(svc, pid_str) {
@@ -670,7 +676,7 @@ fn service_pid_from_systemctl_show(
     };
     let missing_unit = load_state == "not-found" && pid.is_none();
     ensure_systemctl_show_status(svc, properties, status, stderr, missing_unit)?;
-    Ok(pid)
+    Ok(pid.is_some())
 }
 
 fn parse_main_pid(svc: &str, value: &str) -> RunnerResult<Option<u32>> {
@@ -1512,7 +1518,7 @@ mod tests {
     }
 
     #[test]
-    fn service_pid_from_systemctl_show_returns_pid_on_success() {
+    fn service_main_process_present_from_systemctl_show_returns_true_on_success() {
         use std::os::unix::process::ExitStatusExt;
 
         let properties = ["LoadState", "MainPID"];
@@ -1524,21 +1530,20 @@ mod tests {
         .unwrap();
         let status = ExitStatus::from_raw(0);
 
-        assert_eq!(
-            service_pid_from_systemctl_show(
+        assert!(
+            service_main_process_present_from_systemctl_show(
                 "vm0-runner-test.service",
                 &properties,
                 &status,
                 &values,
                 b"",
             )
-            .unwrap(),
-            Some(123)
+            .unwrap()
         );
     }
 
     #[test]
-    fn service_pid_from_systemctl_show_allows_not_found_zero_on_failed_status() {
+    fn service_main_process_present_from_systemctl_show_allows_not_found_zero_on_failed_status() {
         use std::os::unix::process::ExitStatusExt;
 
         let properties = ["LoadState", "MainPID"];
@@ -1550,16 +1555,15 @@ mod tests {
         .unwrap();
         let status = ExitStatus::from_raw(0x100);
 
-        assert_eq!(
-            service_pid_from_systemctl_show(
+        assert!(
+            !service_main_process_present_from_systemctl_show(
                 "vm0-runner-test.service",
                 &properties,
                 &status,
                 &values,
                 b"Unit not found\n",
             )
-            .unwrap(),
-            None
+            .unwrap()
         );
     }
 
@@ -1642,7 +1646,7 @@ mod tests {
     }
 
     #[test]
-    fn service_pid_from_systemctl_show_rejects_nonzero_loaded_zero() {
+    fn service_main_process_present_from_systemctl_show_rejects_nonzero_loaded_zero() {
         use std::os::unix::process::ExitStatusExt;
 
         let properties = ["LoadState", "MainPID"];
@@ -1653,7 +1657,7 @@ mod tests {
         )
         .unwrap();
         let status = ExitStatus::from_raw(0x100);
-        let err = service_pid_from_systemctl_show(
+        let err = service_main_process_present_from_systemctl_show(
             "vm0-runner-test.service",
             &properties,
             &status,
@@ -1667,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn service_pid_from_systemctl_show_rejects_malformed_pid_on_failed_status() {
+    fn service_main_process_present_from_systemctl_show_rejects_malformed_pid_on_failed_status() {
         use std::os::unix::process::ExitStatusExt;
 
         let properties = ["LoadState", "MainPID"];
@@ -1678,7 +1682,7 @@ mod tests {
         )
         .unwrap();
         let status = ExitStatus::from_raw(0x100);
-        let err = service_pid_from_systemctl_show(
+        let err = service_main_process_present_from_systemctl_show(
             "vm0-runner-test.service",
             &properties,
             &status,


### PR DESCRIPTION
## Summary

- delegate drain and resume signal delivery to systemd's current unit main process
- classify a failed delivery as already gone only when a follow-up systemd query proves there is no main process
- remove unverified PID diagnostics and add isolated subprocess-boundary coverage for both lifecycle signals and failure policies

## Scope

- preserves the existing drain restart override, disable, resume rollback, and enablement ordering
- does not change database schemas, persisted state, APIs, queue payloads, runner protocols, or feature switches

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- applicable repository pre-commit hooks

Closes #21954
