### PR TITLE
docs(mitm-addon): clarify jsonl flush completion semantics

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -76,7 +76,13 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
 
 
 def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
-    """Wait until all writes accepted so far for ``log_path`` are completed."""
+    """Wait until writes accepted so far for ``log_path`` have been processed.
+
+    Processing includes append attempts that fail. Those failures are reported
+    through mitmproxy warnings and do not affect the return value. Return
+    ``False`` only when a configured timeout expires with accepted writes still
+    pending; ``True`` does not confirm that every line was persisted.
+    """
     if not log_path:
         return True
 
@@ -101,7 +107,12 @@ def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
 
 
 def flush_all_logs() -> None:
-    """Wait until all writes accepted so far for every path are completed."""
+    """Wait until writes accepted so far for every path have been processed.
+
+    Processing includes append attempts that fail. Those failures are reported
+    through mitmproxy warnings, and returning does not confirm that every line
+    was persisted.
+    """
     with _condition:
         targets = dict(_accepted_by_path)
         for path in targets:

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -47,12 +47,23 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
 
 
 def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
-    """Flush accepted JSONL writes for a path."""
+    """Wait until accepted JSONL writes for a path have been processed.
+
+    Failed append attempts count as processed and are reported through mitmproxy
+    warnings without affecting the result. ``False`` only means a configured
+    timeout expired with accepted writes still pending; ``True`` does not
+    confirm that every line was persisted.
+    """
     return jsonl_writer.flush_log_path(log_path, timeout=timeout)
 
 
 def flush_all_logs() -> None:
-    """Flush accepted JSONL writes for all paths."""
+    """Wait until accepted JSONL writes for all paths have been processed.
+
+    Failed append attempts count as processed and are reported through mitmproxy
+    warnings; completion of this call does not confirm that every line was
+    persisted.
+    """
     jsonl_writer.flush_all_logs()
 
 


### PR DESCRIPTION
## Summary

- define JSONL flush completion as processing accepted writes until they are no longer pending
- clarify that failed append attempts count as processed and are reported through mitmproxy warnings
- document that the path-flush boolean reports timeout status, not persistence or durability
- keep the low-level writer and `logging_utils` wrapper contracts consistent

## Scope

This PR changes docstrings only. It does not change runtime behavior, function signatures, schemas, persisted data, APIs, queue behavior, timeouts, warnings, runner acknowledgement files, Rust/Python protocols, or deployment compatibility.

## Validation

- `.venv/bin/ruff format --check src/jsonl_writer.py src/logging_utils.py`
- `.venv/bin/ruff check src/jsonl_writer.py src/logging_utils.py`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/pytest tests/test_jsonl_writer.py tests/test_logging_utils.py tests/test_runner_usage_flush_signal.py` (70 passed)

Closes #21963
