### PR TITLE
docs(sandbox-fc): document snapshot completion marker contract

### DIFF
--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -7,6 +7,17 @@ use crate::paths::SnapshotOutputPaths;
 
 use super::SnapshotError;
 
+/// Exact versioned payload written to [`SnapshotOutputPaths::complete_marker`].
+///
+/// Writers must use the full byte sequence verbatim, including the trailing
+/// line feed (`\n`), after all required snapshot artifacts are present as
+/// regular files and the output directory has been synced. Readers must compare
+/// the full sequence without trimming or reconstructing it.
+///
+/// The marker is the snapshot publication commit signal, not standalone proof
+/// of completeness: [`crate::FirecrackerSnapshotProvider`] also validates the
+/// required artifact files. Changing `v1` or any other byte is a compatibility
+/// change for independently deployed readers and writers.
 pub const SNAPSHOT_COMPLETE_MARKER_CONTENT: &[u8] = b"snapshot-complete-v1\n";
 
 pub(super) fn snapshot_artifact_paths(output: &SnapshotOutputPaths) -> [PathBuf; 4] {


### PR DESCRIPTION
## Summary

- document the exact versioned snapshot completion-marker payload at its public constant
- call out the required trailing line feed and verbatim reader/writer comparison
- distinguish the publication commit signal from required artifact validation
- record that changing `v1` or any other byte is a cross-version compatibility change

## Scope

Documentation only. This PR does not change marker bytes, public APIs, publication or validation behavior, runtime performance, persistence, security, or deployment ordering. Existing tests already cover the documented behavior, so no test cases were added.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc` (723 passed)
- pre-commit hooks, including workspace Rust documentation, passed

Closes #21956
