### PR TITLE
fix: fall back to attached card for auto-recharge

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -150,6 +150,9 @@ export interface ApiTestMocks {
     readonly fetchFile: AsyncMock;
   };
   readonly stripe: {
+    readonly paymentMethods: {
+      readonly list: AsyncMock;
+    };
     readonly invoices: {
       readonly list: AsyncMock;
       readonly create: AsyncMock;
@@ -303,6 +306,9 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   };
 
   const stripe = {
+    paymentMethods: {
+      list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
     invoices: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -705,6 +711,9 @@ vi.mock("stripe", async (importOriginal) => {
   const MockStripe = Object.assign(
     vi.fn(() => {
       return {
+        paymentMethods: {
+          list: apiTestMocks.stripe.paymentMethods.list,
+        },
         invoices: {
           list: apiTestMocks.stripe.invoices.list,
           create: apiTestMocks.stripe.invoices.create,
@@ -955,6 +964,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.slack.views.open.mockReset();
   apiTestMocks.slack.users.info.mockReset();
   apiTestMocks.slack.fetchFile.mockReset();
+  apiTestMocks.stripe.paymentMethods.list.mockReset();
+  apiTestMocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
   apiTestMocks.stripe.invoices.list.mockReset();
   apiTestMocks.stripe.invoices.create.mockReset();
   apiTestMocks.stripe.invoices.finalizeInvoice.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts
@@ -256,6 +256,51 @@ describe("PUT /api/zero/billing/auto-recharge", () => {
     expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(invoiceId);
   });
 
+  it("uses an attached card when no default payment method is configured", async () => {
+    const { admin, entitlement } = await createProActor();
+    const status = await billingApi.readBillingStatus(admin);
+    const threshold = status.credits + 1000;
+    const amount = threshold + 5000;
+    const invoiceId = acceptAutoRechargeStripeInvoice(entitlement.customerId);
+
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: entitlement.customerId,
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: entitlement.subscriptionId,
+      default_payment_method: null,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({
+      data: [{ id: "pm_attached_card" }],
+    });
+
+    await billingApi.updateAutoRecharge(
+      admin,
+      { enabled: true, threshold, amount },
+      [200],
+    );
+
+    expect(context.mocks.stripe.paymentMethods.list).toHaveBeenCalledWith({
+      customer: entitlement.customerId,
+      type: "card",
+      limit: 1,
+    });
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: entitlement.customerId,
+        default_payment_method: "pm_attached_card",
+        metadata: expect.objectContaining({
+          type: "auto_recharge",
+          orgId: admin.orgId,
+          creditsAmount: String(amount),
+        }),
+      }),
+    );
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(invoiceId);
+  });
+
   it("disables auto-recharge after a public recharge trigger", async () => {
     const { admin, entitlement } = await createProActor();
     const status = await billingApi.readBillingStatus(admin);

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -68,9 +68,22 @@ async function resolvePaymentMethod(
     }
   }
 
-  L.warn("No payment method found on customer or subscription", {
-    stripeCustomerId: org.stripeCustomerId,
+  const paymentMethods = await stripe.paymentMethods.list({
+    customer: org.stripeCustomerId,
+    type: "card",
+    limit: 1,
   });
+  const attachedPm = paymentMethods.data[0]?.id;
+  if (attachedPm) {
+    return attachedPm;
+  }
+
+  L.warn(
+    "No payment method found on customer, subscription, or attached cards",
+    {
+      stripeCustomerId: org.stripeCustomerId,
+    },
+  );
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Fall back to one attached card when the Stripe customer and subscription have no default payment method.
- Restrict the fallback lookup to card payment methods and pass the selected ID to the auto-recharge invoice.
- Extend the centralized Stripe test mock and add API integration coverage for the fallback path.

## Verification

- `pnpm prettier --check apps/api/src/signals/services/zero-credit-recharge.service.ts apps/api/src/__tests__/mocks.ts apps/api/src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts` — passed
- `pnpm -F api lint` — passed
- `pnpm -F api check-types` — passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts` — blocked by the local PostgreSQL test database missing the required `vector` extension; CI should run the integration test in the standard environment
