### PR TITLE
fix(api): spend usage allowance before credits for all billable usage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -601,8 +601,14 @@ describe("Usage Allowance", () => {
   });
 
   it("does not apply newly created allowance to older runs", async () => {
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const runCreatedAt = nowDate();
+    mockNow(runCreatedAt);
     const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 100 });
     const run = await createVm0Run(actor, agentId, "run before entitlement");
+    mockNow(addHours(runCreatedAt, 1));
     await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 100,
       weeklyWindowUnits: 200,
@@ -689,10 +695,16 @@ describe("Usage Allowance", () => {
   });
 
   it("denies billable firewall auth when the run has no allowance window", async () => {
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const runCreatedAt = nowDate();
+    mockNow(runCreatedAt);
     const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 100 });
     const api = createRunsApi(context);
     // The run predates the entitlement, so it has no allowance windows.
     const run = await createVm0Run(actor, agentId, "run without windows");
+    mockNow(addHours(runCreatedAt, 1));
     await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 2,
       weeklyWindowUnits: 2,

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -528,9 +528,7 @@ describe("Usage Allowance", () => {
     expect(denied.body.error.code).toBe("INSUFFICIENT_CREDITS");
   });
 
-  it("does not backfill allowance windows during usage settlement", async () => {
-    // A non-vm0 run never activates allowance windows, so settlement must
-    // charge org credits in full even though an active entitlement exists.
+  it("backfills allowance windows during non-vm0 usage settlement", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const actor = bdd.user();
@@ -555,7 +553,7 @@ describe("Usage Allowance", () => {
     });
     const run = await api.createRun(actor, {
       agentId: agent.agentId,
-      prompt: "non-vm0 run bypasses allowance",
+      prompt: "non-vm0 run uses allowance",
       modelProvider: "anthropic-api-key",
     });
     const provider = usageProvider();
@@ -568,11 +566,11 @@ describe("Usage Allowance", () => {
 
     await processUsageEvents();
 
-    await expect(readOrgCredits(actor)).resolves.toBe(20);
+    await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
   });
 
-  it("does not apply allowance to non-vm0 runs inside active allowance windows", async () => {
+  it("applies allowance to non-vm0 runs inside active allowance windows", async () => {
     const { actor, agentId } = await vm0AllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
@@ -598,7 +596,7 @@ describe("Usage Allowance", () => {
 
     await processUsageEvents();
 
-    await expect(readOrgCredits(actor)).resolves.toBe(20);
+    await expect(readOrgCredits(actor)).resolves.toBe(100);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -10,7 +10,7 @@ import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { now } from "../../external/time";
+import { now, nowDate } from "../../external/time";
 import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
@@ -26,6 +26,10 @@ import {
 } from "../../../test-fixtures/system-config-seeds";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { seedCompose$, seedRun$ } from "./helpers/zero-usage-insight";
+import {
+  generatedStripeCustomerId,
+  postUsageAllowanceInvoicePaid,
+} from "./helpers/stripe-billing-webhook";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -679,6 +683,40 @@ describe("POST /api/zero/image-io/generate", () => {
         code: "INSUFFICIENT_CREDITS",
       },
     });
+  });
+
+  it("admits image generation when allowance remains", async () => {
+    const fixture = await seedImageFixture({ credits: 0, withPricing: true });
+    const effectiveAt = nowDate();
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      customerId: generatedStripeCustomerId(),
+      subscriptionId: `sub_image_allowance_${randomUUID()}`,
+      effectiveAt,
+      expiresAt: new Date(effectiveAt.getTime() + 365 * 24 * 60 * 60 * 1000),
+      shortWindowSeconds: 5 * 60 * 60,
+      shortWindowUnits: 100,
+      weeklyWindowSeconds: 7 * 24 * 60 * 60,
+      weeklyWindowUnits: 200,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    server.use(
+      http.post(FAL_GPT_IMAGE_1_URL, () => {
+        return HttpResponse.json(falQueueHandle("allowance-image-request"));
+      }),
+    );
+
+    const response = await createImageIoTestApp().request(
+      "/api/zero/image-io/generate",
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ prompt: "a cat covered by allowance" }),
+      },
+    );
+
+    expect(response.status).toBe(202);
   });
 
   it("returns 503 when image pricing is not configured", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
@@ -25,7 +25,7 @@ import {
 import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { now } from "../../external/time";
+import { now, nowDate } from "../../external/time";
 import type { RouteEntry } from "../../route-entry";
 import { createDeferredPromise } from "../../utils";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
@@ -36,6 +36,10 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  generatedStripeCustomerId,
+  postUsageAllowanceInvoicePaid,
+} from "./helpers/stripe-billing-webhook";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -420,6 +424,61 @@ describe("zero web-search route", () => {
     expectApiError(response.body);
     expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
     expect(providerRequests).toBe(0);
+  });
+
+  it("uses allowance for runless searches when org credits are exhausted", async () => {
+    const actor = await webSearchEnabledActor();
+    if (!actor.orgId) {
+      throw new Error(
+        "Zero Web Search test actor must belong to an organization",
+      );
+    }
+    configureProvider();
+    await seedWebSearchPricing();
+    await bootstrapOnboarding(actor);
+    await setActorCredits(actor, 0);
+    const effectiveAt = nowDate();
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customerId: generatedStripeCustomerId(),
+      subscriptionId: `sub_web_search_allowance_${randomUUID()}`,
+      effectiveAt,
+      expiresAt: new Date(effectiveAt.getTime() + 365 * 24 * 60 * 60 * 1000),
+      shortWindowSeconds: 5 * 60 * 60,
+      shortWindowUnits: 100,
+      weeklyWindowSeconds: 7 * 24 * 60 * 60,
+      weeklyWindowUnits: 200,
+    });
+    server.use(
+      http.post(PERPLEXITY_SEARCH_URL, () => {
+        return HttpResponse.json(providerResponse());
+      }),
+    );
+
+    const response = await accept(
+      client()(zeroWebSearchContract).search({
+        headers: authenticate(actor),
+        body: defaultRequest(),
+      }),
+      [200],
+    );
+    const status = await accept(
+      client()(zeroBillingStatusContract).get({
+        headers: authenticate(actor),
+      }),
+      [200],
+    );
+
+    expect(response.body.creditsCharged).toBe(0);
+    expect(status.body.credits).toBe(0);
+    expect(
+      Object.fromEntries(
+        status.body.usageAllowance?.windows.map((window) => {
+          return [window.kind, window.consumedUnits];
+        }) ?? [],
+      ),
+    ).toStrictEqual({ short: 5, weekly: 5 });
   });
 
   it("translates filtered searches and records successful usage", async () => {

--- a/turbo/apps/api/src/signals/services/billable-operation-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/billable-operation-admission.service.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 
 import { writeDb$ } from "../external/db";
+import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { resolveOrgCreditAvailability } from "./zero-run-admission.service";
 
 export const checkBillableOperationCredits$ = command(
@@ -16,10 +17,18 @@ export const checkBillableOperationCredits$ = command(
     });
     signal.throwIfAborted();
 
-    return (
-      availability !== null &&
-      availability.status === "active" &&
-      availability.spendableCredits > 0
+    if (!availability || availability.status !== "active") {
+      return false;
+    }
+    if (availability.spendableCredits > 0) {
+      return true;
+    }
+
+    const allowance = await resolveUsageAllowanceAvailability(
+      writeDb,
+      args.orgId,
     );
+    signal.throwIfAborted();
+    return (allowance?.remainingUnits ?? 0) > 0;
   },
 );

--- a/turbo/apps/api/src/signals/services/usage-allowance.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-allowance.service.ts
@@ -4,7 +4,6 @@ import {
   usageAllowanceAllocations,
 } from "@vm0/db/schema/org-usage-allowance";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   and,
   asc,
@@ -81,15 +80,21 @@ interface UsageAllowanceEventInput {
   readonly usageEventId: string;
   readonly runId: string | null;
   readonly grossUnits: number;
+  readonly occurredAt: Date;
 }
 
 interface UsageAllowanceCandidate {
   readonly usageEventId: string;
-  readonly runId: string;
+  readonly runId: string | null;
   readonly grossUnits: number;
+  readonly occurredAt: Date;
 }
 
-interface UsageAllowanceWindowState {
+interface AnchoredUsageAllowanceCandidate extends UsageAllowanceCandidate {
+  readonly allowanceAt: Date;
+}
+
+interface UsageAllowanceWindowState extends UsageAllowanceWindow {
   readonly id: string;
   readonly unitLimit: number;
   consumedUnits: number;
@@ -98,14 +103,9 @@ interface UsageAllowanceWindowState {
   readonly expiresAt: Date;
 }
 
-interface MutableUsageAllowanceWindows {
-  readonly shortWindow: UsageAllowanceWindowState;
-  readonly weeklyWindow: UsageAllowanceWindowState;
-}
-
 interface NewUsageAllowanceAllocation {
   readonly usageEventId: string;
-  readonly runId: string;
+  readonly runId: string | null;
   readonly shortWindowId: string;
   readonly weeklyWindowId: string;
   readonly unitsApplied: number;
@@ -137,6 +137,16 @@ function windowUnitLimit(
 
 function addSeconds(date: Date, seconds: number): Date {
   return new Date(date.getTime() + seconds * 1000);
+}
+
+function entitlementCoversAt(
+  entitlement: UsageAllowanceEntitlement,
+  at: Date,
+): boolean {
+  return (
+    entitlement.effectiveAt <= at &&
+    (!entitlement.expiresAt || at < entitlement.expiresAt)
+  );
 }
 
 function remainingUnits(
@@ -340,7 +350,7 @@ async function loadActiveUsageAllowanceEntitlement(
   return await refreshUsageAllowanceEntitlementFromStripe(tx, row, currentTime);
 }
 
-async function loadVm0RunCreatedAt(
+async function loadRunCreatedAt(
   tx: UsageAllowanceStore,
   args: {
     readonly orgId: string;
@@ -350,14 +360,7 @@ async function loadVm0RunCreatedAt(
   const [row] = await tx
     .select({ createdAt: agentRuns.createdAt })
     .from(agentRuns)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .where(
-      and(
-        eq(agentRuns.orgId, args.orgId),
-        eq(agentRuns.id, args.runId),
-        eq(zeroRuns.modelProvider, "vm0"),
-      ),
-    )
+    .where(and(eq(agentRuns.orgId, args.orgId), eq(agentRuns.id, args.runId)))
     .limit(1);
   return row?.createdAt ?? null;
 }
@@ -449,9 +452,9 @@ async function insertWindow(
     readonly entitlement: UsageAllowanceEntitlement;
     readonly kind: UsageAllowanceWindowKind;
     readonly startsAt: Date;
-    readonly createdByRunId: string;
+    readonly createdByRunId: string | null;
   },
-): Promise<UsageAllowanceWindow> {
+): Promise<UsageAllowanceWindowState> {
   const [window] = await tx
     .insert(orgUsageAllowanceWindows)
     .values({
@@ -472,11 +475,13 @@ async function insertWindow(
       kind: orgUsageAllowanceWindows.kind,
       unitLimit: orgUsageAllowanceWindows.unitLimit,
       consumedUnits: orgUsageAllowanceWindows.consumedUnits,
+      startsAt: orgUsageAllowanceWindows.startsAt,
+      expiresAt: orgUsageAllowanceWindows.expiresAt,
     });
   if (!window) {
     throw new Error("Usage allowance window insert returned no row");
   }
-  return window;
+  return { ...window, initialConsumedUnits: window.consumedUnits };
 }
 
 async function ensureWindowForRun(
@@ -514,7 +519,7 @@ async function ensureWindowsForRun(
   },
 ): Promise<UsageAllowanceWindows | null> {
   const entitlement = await loadActiveUsageAllowanceEntitlement(tx, args.orgId);
-  if (!entitlement) {
+  if (!entitlement || !entitlementCoversAt(entitlement, args.runCreatedAt)) {
     return null;
   }
 
@@ -533,27 +538,22 @@ async function ensureWindowsForRun(
   return { shortWindow, weeklyWindow };
 }
 
-async function loadExistingWindowsForRun(
+async function loadExistingWindowsAt(
   tx: UsageAllowanceStore,
   args: {
     readonly orgId: string;
-    readonly runId: string;
+    readonly at: Date;
   },
 ): Promise<UsageAllowanceWindows | null> {
-  const runCreatedAt = await loadVm0RunCreatedAt(tx, args);
-  if (!runCreatedAt) {
-    return null;
-  }
-
   const shortWindow = await lockIssuedWindowAt(tx, {
     orgId: args.orgId,
     kind: "short",
-    at: runCreatedAt,
+    at: args.at,
   });
   const weeklyWindow = await lockIssuedWindowAt(tx, {
     orgId: args.orgId,
     kind: "weekly",
-    at: runCreatedAt,
+    at: args.at,
   });
 
   return shortWindow && weeklyWindow ? { shortWindow, weeklyWindow } : null;
@@ -636,7 +636,17 @@ export async function resolveUsageAllowanceAvailabilityForRun(
 ): Promise<UsageAllowanceAvailability | null> {
   return await db.transaction(async (tx) => {
     await lockUsageAllowanceOrg(tx, args.orgId);
-    const windows = await loadExistingWindowsForRun(tx, args);
+    const runCreatedAt = await loadRunCreatedAt(tx, args);
+    if (!runCreatedAt) {
+      return null;
+    }
+    const existingWindows = await loadExistingWindowsAt(tx, {
+      orgId: args.orgId,
+      at: runCreatedAt,
+    });
+    const windows =
+      existingWindows ??
+      (await ensureWindowsForRun(tx, { ...args, runCreatedAt }));
     return windows ? availabilityFromWindows(windows) : null;
   });
 }
@@ -665,7 +675,7 @@ async function loadExistingUsageAllowanceAllocations(
   );
 }
 
-async function loadVm0RunCreatedAts(
+async function loadRunCreatedAts(
   tx: UsageAllowanceStore,
   args: {
     readonly orgId: string;
@@ -679,11 +689,9 @@ async function loadVm0RunCreatedAts(
   const rows = await tx
     .select({ id: agentRuns.id, createdAt: agentRuns.createdAt })
     .from(agentRuns)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .where(
       and(
         eq(agentRuns.orgId, args.orgId),
-        eq(zeroRuns.modelProvider, "vm0"),
         sql`${agentRuns.id} = ANY(${sql.param([...args.runIds])}::uuid[])`,
       ),
     );
@@ -694,21 +702,37 @@ async function loadVm0RunCreatedAts(
   );
 }
 
-async function lockIssuedWindowsForRuns(
+async function lockIssuedWindowsForTimes(
   tx: UsageAllowanceStore,
   args: {
     readonly orgId: string;
     readonly kind: UsageAllowanceWindowKind;
-    readonly runIds: readonly string[];
+    readonly times: readonly Date[];
   },
 ): Promise<UsageAllowanceWindowState[]> {
-  if (args.runIds.length === 0) {
+  if (args.times.length === 0) {
     return [];
   }
+
+  const earliestAt = new Date(
+    Math.min(
+      ...args.times.map((at) => {
+        return at.getTime();
+      }),
+    ),
+  );
+  const latestAt = new Date(
+    Math.max(
+      ...args.times.map((at) => {
+        return at.getTime();
+      }),
+    ),
+  );
 
   const windows = await tx
     .select({
       id: orgUsageAllowanceWindows.id,
+      kind: orgUsageAllowanceWindows.kind,
       unitLimit: orgUsageAllowanceWindows.unitLimit,
       consumedUnits: orgUsageAllowanceWindows.consumedUnits,
       startsAt: orgUsageAllowanceWindows.startsAt,
@@ -719,16 +743,8 @@ async function lockIssuedWindowsForRuns(
       and(
         eq(orgUsageAllowanceWindows.orgId, args.orgId),
         eq(orgUsageAllowanceWindows.kind, args.kind),
-        sql`EXISTS (
-          SELECT 1
-          FROM ${agentRuns}
-          INNER JOIN ${zeroRuns} ON ${zeroRuns.id} = ${agentRuns.id}
-          WHERE ${agentRuns.orgId} = ${args.orgId}
-            AND ${zeroRuns.modelProvider} = 'vm0'
-            AND ${agentRuns.id} = ANY(${sql.param([...args.runIds])}::uuid[])
-            AND ${orgUsageAllowanceWindows.startsAt} <= ${agentRuns.createdAt}
-            AND ${orgUsageAllowanceWindows.expiresAt} > ${agentRuns.createdAt}
-        )`,
+        lte(orgUsageAllowanceWindows.startsAt, latestAt),
+        gt(orgUsageAllowanceWindows.expiresAt, earliestAt),
       ),
     )
     .orderBy(asc(orgUsageAllowanceWindows.id))
@@ -847,6 +863,143 @@ async function insertUsageAllowanceAllocations(
   `);
 }
 
+async function anchorUsageAllowanceCandidates(
+  tx: UsageAllowanceStore,
+  args: {
+    readonly orgId: string;
+    readonly candidates: readonly UsageAllowanceCandidate[];
+  },
+): Promise<AnchoredUsageAllowanceCandidate[]> {
+  const runIds = [
+    ...new Set(
+      args.candidates.flatMap((candidate) => {
+        return candidate.runId ? [candidate.runId] : [];
+      }),
+    ),
+  ];
+  const runCreatedAtById = await loadRunCreatedAts(tx, {
+    orgId: args.orgId,
+    runIds,
+  });
+  const anchoredCandidates: AnchoredUsageAllowanceCandidate[] = [];
+  for (const candidate of args.candidates) {
+    const allowanceAt = candidate.runId
+      ? runCreatedAtById.get(candidate.runId)
+      : candidate.occurredAt;
+    if (allowanceAt) {
+      anchoredCandidates.push({ ...candidate, allowanceAt });
+    }
+  }
+  return anchoredCandidates;
+}
+
+async function ensureIssuedWindowsForKind(
+  tx: UsageAllowanceStore,
+  args: {
+    readonly entitlement: UsageAllowanceEntitlement;
+    readonly kind: UsageAllowanceWindowKind;
+    readonly candidates: readonly AnchoredUsageAllowanceCandidate[];
+    readonly windows: UsageAllowanceWindowState[];
+  },
+): Promise<void> {
+  for (const candidate of args.candidates) {
+    if (
+      !latestIssuedWindowAt(args.windows, candidate.allowanceAt) &&
+      entitlementCoversAt(args.entitlement, candidate.allowanceAt)
+    ) {
+      args.windows.push(
+        await insertWindow(tx, {
+          entitlement: args.entitlement,
+          kind: args.kind,
+          startsAt: candidate.allowanceAt,
+          createdByRunId: candidate.runId,
+        }),
+      );
+    }
+  }
+}
+
+async function ensureIssuedWindowsForCandidates(
+  tx: UsageAllowanceStore,
+  args: {
+    readonly orgId: string;
+    readonly candidates: readonly AnchoredUsageAllowanceCandidate[];
+    readonly shortWindows: UsageAllowanceWindowState[];
+    readonly weeklyWindows: UsageAllowanceWindowState[];
+  },
+): Promise<void> {
+  const missingWindows = args.candidates.some((candidate) => {
+    return (
+      !latestIssuedWindowAt(args.shortWindows, candidate.allowanceAt) ||
+      !latestIssuedWindowAt(args.weeklyWindows, candidate.allowanceAt)
+    );
+  });
+  if (!missingWindows) {
+    return;
+  }
+  const entitlement = await loadActiveUsageAllowanceEntitlement(tx, args.orgId);
+  if (!entitlement) {
+    return;
+  }
+  const candidatesByAllowanceTime = [...args.candidates].sort((a, b) => {
+    return a.allowanceAt.getTime() - b.allowanceAt.getTime();
+  });
+  await ensureIssuedWindowsForKind(tx, {
+    entitlement,
+    kind: "short",
+    candidates: candidatesByAllowanceTime,
+    windows: args.shortWindows,
+  });
+  await ensureIssuedWindowsForKind(tx, {
+    entitlement,
+    kind: "weekly",
+    candidates: candidatesByAllowanceTime,
+    windows: args.weeklyWindows,
+  });
+}
+
+function allocateUsageAllowanceToCandidates(args: {
+  readonly candidates: readonly AnchoredUsageAllowanceCandidate[];
+  readonly shortWindows: UsageAllowanceWindowState[];
+  readonly weeklyWindows: UsageAllowanceWindowState[];
+  readonly allowanceByUsageEvent: Map<string, number>;
+}): NewUsageAllowanceAllocation[] {
+  const allocations: NewUsageAllowanceAllocation[] = [];
+  for (const candidate of args.candidates) {
+    const shortWindow = latestIssuedWindowAt(
+      args.shortWindows,
+      candidate.allowanceAt,
+    );
+    const weeklyWindow = latestIssuedWindowAt(
+      args.weeklyWindows,
+      candidate.allowanceAt,
+    );
+    if (!shortWindow || !weeklyWindow) {
+      continue;
+    }
+    const unitsApplied = Math.min(
+      candidate.grossUnits,
+      remainingUnits(shortWindow),
+      remainingUnits(weeklyWindow),
+    );
+    if (unitsApplied <= 0) {
+      continue;
+    }
+
+    shortWindow.consumedUnits += unitsApplied;
+    weeklyWindow.consumedUnits += unitsApplied;
+    args.allowanceByUsageEvent.set(candidate.usageEventId, unitsApplied);
+    allocations.push({
+      usageEventId: candidate.usageEventId,
+      runId: candidate.runId,
+      shortWindowId: shortWindow.id,
+      weeklyWindowId: weeklyWindow.id,
+      unitsApplied,
+    });
+  }
+  return allocations;
+}
+
 export async function applyUsageAllowanceToUsageEventsInLockedTransaction(
   tx: UsageAllowanceStore,
   args: {
@@ -856,11 +1009,12 @@ export async function applyUsageAllowanceToUsageEventsInLockedTransaction(
 ): Promise<ReadonlyMap<string, number>> {
   const candidates: UsageAllowanceCandidate[] = [];
   for (const event of args.events) {
-    if (event.grossUnits > 0 && event.runId) {
+    if (event.grossUnits > 0) {
       candidates.push({
         usageEventId: event.usageEventId,
         runId: event.runId,
         grossUnits: event.grossUnits,
+        occurredAt: event.occurredAt,
       });
     }
   }
@@ -871,70 +1025,42 @@ export async function applyUsageAllowanceToUsageEventsInLockedTransaction(
       return candidate.usageEventId;
     }),
   );
-  const unresolvedRunIds = [
-    ...new Set(
-      candidates.flatMap((candidate) => {
-        return allowanceByUsageEvent.has(candidate.usageEventId)
-          ? []
-          : [candidate.runId];
-      }),
-    ),
-  ];
-  const runCreatedAtById = await loadVm0RunCreatedAts(tx, {
-    orgId: args.orgId,
-    runIds: unresolvedRunIds,
+  const unresolvedCandidates = candidates.filter((candidate) => {
+    return !allowanceByUsageEvent.has(candidate.usageEventId);
   });
-  const eligibleRunIds = [...runCreatedAtById.keys()];
+  const anchoredCandidates = await anchorUsageAllowanceCandidates(tx, {
+    orgId: args.orgId,
+    candidates: unresolvedCandidates,
+  });
+  const allowanceTimes = anchoredCandidates.map((candidate) => {
+    return candidate.allowanceAt;
+  });
 
   // Preserve the existing short-before-weekly row-lock order.
-  const shortWindows = await lockIssuedWindowsForRuns(tx, {
+  const shortWindows = await lockIssuedWindowsForTimes(tx, {
     orgId: args.orgId,
     kind: "short",
-    runIds: eligibleRunIds,
+    times: allowanceTimes,
   });
-  const weeklyWindows = await lockIssuedWindowsForRuns(tx, {
+  const weeklyWindows = await lockIssuedWindowsForTimes(tx, {
     orgId: args.orgId,
     kind: "weekly",
-    runIds: eligibleRunIds,
+    times: allowanceTimes,
   });
-  const windowsByRunId = new Map<string, MutableUsageAllowanceWindows>();
-  for (const [runId, runCreatedAt] of runCreatedAtById) {
-    const shortWindow = latestIssuedWindowAt(shortWindows, runCreatedAt);
-    const weeklyWindow = latestIssuedWindowAt(weeklyWindows, runCreatedAt);
-    if (shortWindow && weeklyWindow) {
-      windowsByRunId.set(runId, { shortWindow, weeklyWindow });
-    }
-  }
 
-  const newAllocations: NewUsageAllowanceAllocation[] = [];
-  for (const candidate of candidates) {
-    if (allowanceByUsageEvent.has(candidate.usageEventId)) {
-      continue;
-    }
-    const windows = windowsByRunId.get(candidate.runId);
-    if (!windows) {
-      continue;
-    }
-    const unitsApplied = Math.min(
-      candidate.grossUnits,
-      remainingUnits(windows.shortWindow),
-      remainingUnits(windows.weeklyWindow),
-    );
-    if (unitsApplied <= 0) {
-      continue;
-    }
+  await ensureIssuedWindowsForCandidates(tx, {
+    orgId: args.orgId,
+    candidates: anchoredCandidates,
+    shortWindows,
+    weeklyWindows,
+  });
 
-    windows.shortWindow.consumedUnits += unitsApplied;
-    windows.weeklyWindow.consumedUnits += unitsApplied;
-    allowanceByUsageEvent.set(candidate.usageEventId, unitsApplied);
-    newAllocations.push({
-      usageEventId: candidate.usageEventId,
-      runId: candidate.runId,
-      shortWindowId: windows.shortWindow.id,
-      weeklyWindowId: windows.weeklyWindow.id,
-      unitsApplied,
-    });
-  }
+  const newAllocations = allocateUsageAllowanceToCandidates({
+    candidates: anchoredCandidates,
+    shortWindows,
+    weeklyWindows,
+    allowanceByUsageEvent,
+  });
 
   await persistUsageAllowanceWindowConsumption(tx, [
     ...shortWindows,

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -307,6 +307,7 @@ async function processOrgUsageEventsInTransaction(
           usageEventId: event.record.id,
           runId: event.record.runId,
           grossUnits: event.grossCredits,
+          occurredAt: event.record.createdAt,
         };
       }),
     });

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -4,12 +4,13 @@ import { randomUUID } from "node:crypto";
 import { command, computed, type Computed } from "ccstate";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
+import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { putS3Object } from "../external/s3";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
@@ -498,11 +499,6 @@ interface FalImageQueueHandle {
   readonly requestId: string | undefined;
   readonly statusUrl: string;
   readonly responseUrl: string;
-}
-
-interface CreditCheckRow extends Record<string, unknown> {
-  readonly credits: string | null;
-  readonly unsettled_expired: string | null;
 }
 
 function errorBody(message: string, code: string): ErrorBody {
@@ -1213,34 +1209,7 @@ export const checkImageCredits$ = command(
     args: { readonly orgId: string },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const writeDb = set(writeDb$);
-    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
-      WITH org AS (
-        SELECT credits FROM org_metadata
-        WHERE org_id = ${args.orgId}
-        LIMIT 1
-      ),
-      expired AS (
-        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-        FROM credit_expires_record
-        WHERE org_id = ${args.orgId}
-          AND expires_at <= now()
-          AND remaining > 0
-      )
-      SELECT
-        (SELECT credits FROM org) AS credits,
-        (SELECT total FROM expired) AS unsettled_expired
-    `);
-    signal.throwIfAborted();
-
-    const row = rows[0];
-    if (!row || row.credits === null) {
-      return false;
-    }
-
-    const credits = Number(row.credits);
-    const unsettledExpired = Number(row.unsettled_expired ?? 0);
-    return credits - unsettledExpired > 0;
+    return await set(checkBillableOperationCredits$, args, signal);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -6,6 +6,7 @@ import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
+import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 
 interface CreditCheckRow extends Record<string, unknown> {
@@ -132,10 +133,25 @@ export const checkManagedCredits$ = command(
     const credits = BigInt(row.credits);
     const unsettledExpired = BigInt(row.unsettled_expired ?? "0");
     const quantity = args.resource.quantity ?? 1;
-    return credits - unsettledExpired >=
-      estimatedCredits(row.unit_price, row.unit_size, quantity)
-      ? null
-      : insufficientCredits();
+    const requiredCredits = estimatedCredits(
+      row.unit_price,
+      row.unit_size,
+      quantity,
+    );
+    const spendableCredits = credits - unsettledExpired;
+    if (spendableCredits >= requiredCredits) {
+      return null;
+    }
+
+    const allowance = await resolveUsageAllowanceAvailability(
+      writeDb,
+      args.orgId,
+    );
+    signal.throwIfAborted();
+    const spendableUnits =
+      (spendableCredits > 0n ? spendableCredits : 0n) +
+      BigInt(allowance?.remainingUnits ?? 0);
+    return spendableUnits >= requiredCredits ? null : insufficientCredits();
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -4,12 +4,13 @@ import { randomUUID } from "node:crypto";
 import { command, computed, type Computed } from "ccstate";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
+import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { putS3Object } from "../external/s3";
 import { safeJsonParse, safeSync, tapError } from "../utils";
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
@@ -437,11 +438,6 @@ interface RecordedVideo {
   readonly generateAudio: boolean;
   readonly sourceUrl: string;
   readonly requestId: string | undefined;
-}
-
-interface CreditCheckRow extends Record<string, unknown> {
-  readonly credits: string | null;
-  readonly unsettled_expired: string | null;
 }
 
 type BytePlusContent =
@@ -1076,34 +1072,7 @@ export const checkVideoCredits$ = command(
     args: { readonly orgId: string },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const writeDb = set(writeDb$);
-    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
-      WITH org AS (
-        SELECT credits FROM org_metadata
-        WHERE org_id = ${args.orgId}
-        LIMIT 1
-      ),
-      expired AS (
-        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-        FROM credit_expires_record
-        WHERE org_id = ${args.orgId}
-          AND expires_at <= now()
-          AND remaining > 0
-      )
-      SELECT
-        (SELECT credits FROM org) AS credits,
-        (SELECT total FROM expired) AS unsettled_expired
-    `);
-    signal.throwIfAborted();
-
-    const row = rows[0];
-    if (!row || row.credits === null) {
-      return false;
-    }
-
-    const credits = Number(row.credits);
-    const unsettledExpired = Number(row.unsettled_expired ?? 0);
-    return credits - unsettledExpired > 0;
+    return await set(checkBillableOperationCredits$, args, signal);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -11,6 +11,7 @@ import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
+import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { nowDate } from "../external/time";
 import { putS3Object } from "../external/s3";
 import { tapError } from "../utils";
@@ -130,11 +131,6 @@ interface RecordedSpeech {
   readonly creditsCharged: number;
   readonly model: string;
   readonly voice: string;
-}
-
-interface CreditCheckRow extends Record<string, unknown> {
-  readonly credits: string | null;
-  readonly unsettled_expired: string | null;
 }
 
 interface WavFormat {
@@ -814,34 +810,7 @@ export const checkSpeechCredits$ = command(
     args: { readonly orgId: string },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    const writeDb = set(writeDb$);
-    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
-      WITH org AS (
-        SELECT credits FROM org_metadata
-        WHERE org_id = ${args.orgId}
-        LIMIT 1
-      ),
-      expired AS (
-        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-        FROM credit_expires_record
-        WHERE org_id = ${args.orgId}
-          AND expires_at <= now()
-          AND remaining > 0
-      )
-      SELECT
-        (SELECT credits FROM org) AS credits,
-        (SELECT total FROM expired) AS unsettled_expired
-    `);
-    signal.throwIfAborted();
-
-    const row = rows[0];
-    if (!row || row.credits === null) {
-      return false;
-    }
-
-    const credits = Number(row.credits);
-    const unsettledExpired = Number(row.unsettled_expired ?? 0);
-    return credits - unsettledExpired > 0;
+    return await set(checkBillableOperationCredits$, args, signal);
   },
 );
 


### PR DESCRIPTION
## Summary

- apply organization usage allowance before legacy credits for every priced usage event, including non-vm0 runs and usage without a run
- lazily create short and weekly windows at the run start or runless usage time while preserving existing window binding and allowance allocation audit rows
- include remaining allowance in admission checks for managed search/maps/scrape, built-in image/video/voice, generic billable operations, and billable firewall access
- add API integration coverage for non-vm0 connector usage, runless web search settlement, and image generation admission with zero org credits

## User-visible impact

Organizations with an active usage allowance now consume that allowance before Pay as You Go credits across billable product usage. Usage reporting continues to show gross usage; only the funding source changes.

## Correctness and compatibility

- retains the existing `credit_<org>` advisory lock and short-before-weekly row-lock order
- keeps run-scoped usage bound to the run creation time and uses the usage timestamp only when no run exists
- retains fallback to org credits after either allowance window is exhausted
- changes no schema, public API, queue payload, runner protocol, or frontend contract

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm knip --workspace api`
- targeted API integration tests were invoked locally, but the local test PostgreSQL service was unavailable (`ECONNREFUSED`); PR CI will run them with the test database
