### PR TITLE
fix: update stripe customer default card after payment

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1589,7 +1589,7 @@ jobs:
           fi
           stripe listen \
             --api-key "$STRIPE_SECRET_KEY" \
-            --events checkout.session.completed,invoice.paid,customer.subscription.updated,customer.subscription.deleted \
+            --events checkout.session.completed,payment_intent.succeeded,invoice.paid,customer.subscription.updated,customer.subscription.deleted \
             --forward-to "$forward_url" \
             > /tmp/stripe-listen.log 2>&1 &
           stripe_pid="$!"

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -164,6 +164,9 @@ export interface ApiTestMocks {
       readonly create: AsyncMock;
       readonly update: AsyncMock;
     };
+    readonly paymentMethods: {
+      readonly retrieve: AsyncMock;
+    };
     readonly subscriptions: {
       readonly list: AsyncMock;
       readonly retrieve: AsyncMock;
@@ -316,6 +319,9 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    },
+    paymentMethods: {
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     subscriptions: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -719,6 +725,9 @@ vi.mock("stripe", async (importOriginal) => {
           create: apiTestMocks.stripe.customers.create,
           update: apiTestMocks.stripe.customers.update,
         },
+        paymentMethods: {
+          retrieve: apiTestMocks.stripe.paymentMethods.retrieve,
+        },
         subscriptions: {
           list: apiTestMocks.stripe.subscriptions.list,
           retrieve: apiTestMocks.stripe.subscriptions.retrieve,
@@ -963,6 +972,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.customers.retrieve.mockReset();
   apiTestMocks.stripe.customers.create.mockReset();
   apiTestMocks.stripe.customers.update.mockReset();
+  apiTestMocks.stripe.paymentMethods.retrieve.mockReset();
   apiTestMocks.stripe.subscriptions.list.mockReset();
   apiTestMocks.stripe.subscriptions.list.mockResolvedValue({ data: [] });
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -152,6 +152,7 @@ export interface ApiTestMocks {
   readonly stripe: {
     readonly paymentMethods: {
       readonly list: AsyncMock;
+      readonly retrieve: AsyncMock;
     };
     readonly invoices: {
       readonly list: AsyncMock;
@@ -166,9 +167,6 @@ export interface ApiTestMocks {
       readonly retrieve: AsyncMock;
       readonly create: AsyncMock;
       readonly update: AsyncMock;
-    };
-    readonly paymentMethods: {
-      readonly retrieve: AsyncMock;
     };
     readonly subscriptions: {
       readonly list: AsyncMock;
@@ -311,6 +309,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const stripe = {
     paymentMethods: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     invoices: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -325,9 +324,6 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
-    },
-    paymentMethods: {
-      retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     subscriptions: {
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -719,6 +715,7 @@ vi.mock("stripe", async (importOriginal) => {
       return {
         paymentMethods: {
           list: apiTestMocks.stripe.paymentMethods.list,
+          retrieve: apiTestMocks.stripe.paymentMethods.retrieve,
         },
         invoices: {
           list: apiTestMocks.stripe.invoices.list,
@@ -733,9 +730,6 @@ vi.mock("stripe", async (importOriginal) => {
           retrieve: apiTestMocks.stripe.customers.retrieve,
           create: apiTestMocks.stripe.customers.create,
           update: apiTestMocks.stripe.customers.update,
-        },
-        paymentMethods: {
-          retrieve: apiTestMocks.stripe.paymentMethods.retrieve,
         },
         subscriptions: {
           list: apiTestMocks.stripe.subscriptions.list,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1831,6 +1831,60 @@ describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in t
 });
 
 describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
+  it("uses each successful card payment as the customer default", async () => {
+    api.configureStripeBillingEnv();
+    const customerId = `cus_bdd_default_${randomUUID().slice(0, 8)}`;
+    const cardPaymentMethodId = `pm_bdd_card_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.paymentMethods.retrieve.mockResolvedValueOnce({
+      id: cardPaymentMethodId,
+      type: "card",
+      customer: customerId,
+    });
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "payment_intent.succeeded",
+        object: {
+          id: `pi_bdd_card_${randomUUID().slice(0, 8)}`,
+          customer: customerId,
+          payment_method: cardPaymentMethodId,
+          metadata: {},
+        },
+      }),
+      [200],
+    );
+
+    expect(context.mocks.stripe.customers.update).toHaveBeenCalledWith(
+      customerId,
+      {
+        invoice_settings: {
+          default_payment_method: cardPaymentMethodId,
+        },
+      },
+    );
+
+    context.mocks.stripe.customers.update.mockClear();
+    const bankPaymentMethodId = `pm_bdd_bank_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.paymentMethods.retrieve.mockResolvedValueOnce({
+      id: bankPaymentMethodId,
+      type: "us_bank_account",
+      customer: customerId,
+    });
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "payment_intent.succeeded",
+        object: {
+          id: `pi_bdd_bank_${randomUUID().slice(0, 8)}`,
+          customer: customerId,
+          payment_method: bankPaymentMethodId,
+          metadata: {},
+        },
+      }),
+      [200],
+    );
+    expect(context.mocks.stripe.customers.update).not.toHaveBeenCalled();
+  });
+
   it("grants and renews Atom invoice-backed Team entitlements", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);
@@ -4088,6 +4142,25 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       vm0_environment: "preview",
       job_ref: "pr-bdd-456",
     };
+    const paymentMethodId = `pm_bdd_preview_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.retrieve.mockResolvedValueOnce({
+      id: granted.customerId,
+      deleted: false,
+      metadata: mismatchedMetadata,
+    });
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "payment_intent.succeeded",
+        object: {
+          id: `pi_bdd_preview_skip_${randomUUID().slice(0, 8)}`,
+          customer: granted.customerId,
+          payment_method: paymentMethodId,
+          metadata: {},
+        },
+      }),
+      [200],
+    );
+    expect(context.mocks.stripe.customers.update).not.toHaveBeenCalled();
     await api.postStripeEvent(
       stripeEvent({
         type: "invoice.paid",
@@ -4156,6 +4229,35 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       [200],
     );
     expect((await billing.readBillingStatus(actor)).credits).toBe(40_000);
+
+    context.mocks.stripe.customers.retrieve.mockResolvedValueOnce({
+      id: granted.customerId,
+      deleted: false,
+      metadata: { vm0_environment: "preview", job_ref: "pr-bdd-123" },
+    });
+    context.mocks.stripe.paymentMethods.retrieve.mockResolvedValueOnce({
+      id: paymentMethodId,
+      type: "card",
+      customer: granted.customerId,
+    });
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "payment_intent.succeeded",
+        object: {
+          id: `pi_bdd_preview_match_${randomUUID().slice(0, 8)}`,
+          customer: granted.customerId,
+          payment_method: paymentMethodId,
+          metadata: {},
+        },
+      }),
+      [200],
+    );
+    expect(context.mocks.stripe.customers.update).toHaveBeenCalledWith(
+      granted.customerId,
+      {
+        invoice_settings: { default_payment_method: paymentMethodId },
+      },
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
@@ -188,6 +188,14 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
         discounts: [{ coupon: COUPON_ID }],
         success_url: SUCCESS_URL,
         cancel_url: CANCEL_URL,
+        payment_intent_data: {
+          setup_future_usage: "off_session",
+          metadata: {
+            orgId: fixture.orgId,
+            campaignKey: CAMPAIGN,
+            purpose: "one_time_purchase",
+          },
+        },
         metadata: {
           orgId: fixture.orgId,
           campaignKey: CAMPAIGN,

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -925,6 +925,74 @@ function shouldHandleStripePreviewEvent(event: Stripe.Event): boolean {
   });
 }
 
+function stripeObjectId(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "object" || value === null || !("id" in value)) {
+    return null;
+  }
+  return typeof value.id === "string" ? value.id : null;
+}
+
+async function paymentIntentMatchesCurrentStripePreview(
+  stripe: ReturnType<typeof getStripeClient>,
+  paymentIntent: Stripe.PaymentIntent,
+  customerId: string,
+): Promise<boolean> {
+  if (isCurrentStripePreviewMetadata(paymentIntent.metadata)) {
+    return true;
+  }
+
+  const customer = await stripe.customers.retrieve(customerId);
+  if ("deleted" in customer && customer.deleted) {
+    return false;
+  }
+  return isCurrentStripePreviewMetadata(customer.metadata);
+}
+
+async function handlePaymentIntentSucceeded(
+  paymentIntent: Stripe.PaymentIntent,
+): Promise<void> {
+  const customerId = stripeObjectId(paymentIntent.customer);
+  const paymentMethodId = stripeObjectId(paymentIntent.payment_method);
+  if (!customerId || !paymentMethodId) {
+    return;
+  }
+
+  const stripe = getStripeClient();
+  if (
+    !(await paymentIntentMatchesCurrentStripePreview(
+      stripe,
+      paymentIntent,
+      customerId,
+    ))
+  ) {
+    return;
+  }
+
+  const paymentMethod = await stripe.paymentMethods.retrieve(paymentMethodId);
+  if (
+    paymentMethod.type !== "card" ||
+    stripeObjectId(paymentMethod.customer) !== customerId
+  ) {
+    return;
+  }
+
+  await stripe.customers.update(customerId, {
+    invoice_settings: { default_payment_method: paymentMethodId },
+  });
+}
+
+function addBillingChangedOrgIds(
+  target: Set<string>,
+  orgIds: Iterable<string>,
+): void {
+  for (const orgId of orgIds) {
+    target.add(orgId);
+  }
+}
+
 async function grantOrgCredits(
   tx: WriteTx,
   orgId: string,
@@ -3596,14 +3664,17 @@ export const handleStripeWebhookEvent$ = command(
     }
 
     switch (event.type) {
+      case "payment_intent.succeeded": {
+        await handlePaymentIntentSucceeded(event.data.object);
+        signal.throwIfAborted();
+        break;
+      }
       case "checkout.session.completed":
       case "checkout.session.async_payment_succeeded": {
         const result = await handleCheckoutCompleted(db, event.data.object);
         signal.throwIfAborted();
         drainOrgId = result.drainOrgId;
-        for (const orgId of result.orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, result.orgIds);
         break;
       }
       case "invoice.paid": {
@@ -3626,9 +3697,7 @@ export const handleStripeWebhookEvent$ = command(
           event.data.object,
         );
         signal.throwIfAborted();
-        for (const orgId of orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       case "customer.subscription.updated": {
@@ -3638,17 +3707,13 @@ export const handleStripeWebhookEvent$ = command(
           event.data.previous_attributes,
         );
         signal.throwIfAborted();
-        for (const orgId of orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       case "customer.subscription.deleted": {
         const orgIds = await handleSubscriptionDeleted(db, event.data.object);
         signal.throwIfAborted();
-        for (const orgId of orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       case "subscription_schedule.released": {
@@ -3657,9 +3722,7 @@ export const handleStripeWebhookEvent$ = command(
           event.data.object,
         );
         signal.throwIfAborted();
-        for (const orgId of orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       case "subscription_schedule.canceled":
@@ -3669,9 +3732,7 @@ export const handleStripeWebhookEvent$ = command(
           event.data.object,
         );
         signal.throwIfAborted();
-        for (const orgId of orgIds) {
-          billingChangedOrgIds.add(orgId);
-        }
+        addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       default: {

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -336,6 +336,12 @@ const createOneTimeCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const stripe = getStripeClient();
+    const metadata = {
+      orgId: args.orgId,
+      campaignKey: args.campaignKey,
+      purpose: "one_time_purchase",
+      ...stripePreviewMetadata(),
+    };
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
       customer: customerId,
@@ -343,12 +349,11 @@ const createOneTimeCheckoutSession$ = command(
       discounts: [{ coupon: campaign.couponId }],
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
-      metadata: {
-        orgId: args.orgId,
-        campaignKey: args.campaignKey,
-        purpose: "one_time_purchase",
-        ...stripePreviewMetadata(),
+      payment_intent_data: {
+        setup_future_usage: "off_session",
+        metadata,
       },
+      metadata,
     });
     signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary

- Handle `payment_intent.succeeded` by setting the successful attached card as the Stripe Customer's `invoice_settings.default_payment_method`.
- Ignore non-card payment methods, missing/unattached payment methods, and payment methods owned by another Customer.
- Preserve Stripe preview isolation by accepting PaymentIntent metadata or the associated Customer metadata for the current preview job.
- Save one-time Checkout cards for off-session reuse so they can become the Customer default, and add the new event to the preview Stripe listener.

## User impact

After a successful card payment, future invoices and automatic credit recharges use that proven card as the Customer default. Zero-dollar and non-card payments do not change the default.

## Verification

- `pnpm exec prettier --check` on all changed files
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- Targeted webhook test: 1 passed, 40 skipped
- The broader route integration test run requires a local PostgreSQL instance, which is unavailable in this environment; the PR pipeline will run the integration coverage.

## Deployment note

The production Stripe webhook endpoint must deliver `payment_intent.succeeded` events unless it is already configured to receive all events. The preview Stripe listener is updated by this PR.
