### PR TITLE
fix(mitm-addon): detect unbound metadata key access

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -39,6 +39,11 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
     "setdefault",
 }
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
+_DIRECT_UNBOUND_METADATA_KEY_CALL_ARGUMENTS = {
+    ("dict", "__getitem__"): (0, 1),
+    ("dict", "get"): (0, 1),
+    ("operator", "getitem"): (0, 1),
+}
 
 
 @dataclass
@@ -71,6 +76,23 @@ def _metadata_match_pattern_alias_names(pattern: ast.pattern) -> set[str]:
             names.update(_metadata_match_pattern_alias_names(child_pattern))
         return names
     return set()
+
+
+def _direct_unbound_metadata_key_arguments(node: ast.Call) -> tuple[ast.AST, ast.AST] | None:
+    if not isinstance(node.func, ast.Attribute) or not isinstance(node.func.value, ast.Name):
+        return None
+    argument_indexes = _DIRECT_UNBOUND_METADATA_KEY_CALL_ARGUMENTS.get(
+        (node.func.value.id, node.func.attr)
+    )
+    if argument_indexes is None:
+        return None
+    mapping_index, key_index = argument_indexes
+    last_required_index = max(argument_indexes)
+    if len(node.args) <= last_required_index or any(
+        isinstance(argument, ast.Starred) for argument in node.args[: last_required_index + 1]
+    ):
+        return None
+    return node.args[mapping_index], node.args[key_index]
 
 
 class _MetadataKeyVisitor(ast.NodeVisitor):
@@ -665,6 +687,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                     key_name = _REGISTERED_METADATA_KEYS.get(keyword.arg)
                     if key_name is not None:
                         self._add_violation(_violation(self.path, keyword, key_name))
+        direct_unbound_arguments = _direct_unbound_metadata_key_arguments(node)
+        if direct_unbound_arguments is not None:
+            mapping_arg, key_arg = direct_unbound_arguments
+            if self._is_metadata_alias_value(mapping_arg):
+                self._add_violations(_metadata_key_expression_violations(self.path, key_arg))
         self.visit(node.func)
         for argument in node.args:
             self.visit(argument)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/unbound_calls.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/unbound_calls.base.py.txt
@@ -1,0 +1,19 @@
+import operator
+
+dict.__getitem__(flow.metadata, "vm_run_id")
+dict.get(flow.metadata, "firewall_name")
+operator.getitem(flow.metadata, "firewall_action")
+
+meta = flow.metadata
+dict.__getitem__(meta, "firewall_error")
+dict.get(meta, "firewall_base", None)
+operator.getitem(meta, "firewall_permission")
+
+dict.__getitem__(flow.metadata, metadata_keys.VM_RUN_ID)
+dict.get(flow.metadata, metadata_keys.FIREWALL_NAME)
+operator.getitem(flow.metadata, metadata_keys.FIREWALL_ACTION)
+
+external = {"vm_run_id": "external"}
+dict.__getitem__(external, "vm_run_id")
+dict.get(external, "firewall_name")
+operator.getitem(external, "firewall_action")

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/unbound_calls.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/unbound_calls.expected.txt
@@ -1,0 +1,6 @@
+unbound_calls.py:3: use metadata_keys.VM_RUN_ID for flow.metadata access
+unbound_calls.py:4: use metadata_keys.FIREWALL_NAME for flow.metadata access
+unbound_calls.py:5: use metadata_keys.FIREWALL_ACTION for flow.metadata access
+unbound_calls.py:8: use metadata_keys.FIREWALL_ERROR for flow.metadata access
+unbound_calls.py:9: use metadata_keys.FIREWALL_BASE for flow.metadata access
+unbound_calls.py:10: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -137,6 +137,17 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     )
 
 
+def test_registered_flow_metadata_guard_flags_direct_unbound_mapping_reads(tmp_path):
+    source_path = tmp_path / "unbound_calls.py"
+    _write_python_source(source_path, "unbound_calls.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "unbound_calls.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_flags_literals_after_dynamic_star_args(tmp_path):
     source_path = tmp_path / "dynamic_star_args.py"
     _write_python_source(source_path, "dynamic_star_args.base.py.txt")


### PR DESCRIPTION
## Summary

- recognize direct `dict.__getitem__`, `dict.get`, and `operator.getitem` calls against tracked flow metadata
- reuse existing metadata alias tracking and registered-key diagnostics through an explicit call-shape table
- add focused integration fixtures for raw keys, registry constants, tracked aliases, and unrelated mappings

## Scope

This intentionally covers only directly qualified helpers with direct positional mapping and key arguments. Callable aliases, starred argument reconstruction, import provenance, and general Python symbol resolution remain outside this repository contract guard.

## Validation

- `.venv/bin/python -m pytest tests/test_flow_metadata_key_contract.py` — 15 passed
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .` — 0 errors, 0 warnings
- `.venv/bin/python -m pytest tests/` — 4,048 passed

Closes #21966
