### PR TITLE
perf(runner): reuse firewall auth identities

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -9,7 +9,7 @@ import asyncio
 import hashlib
 import json
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from mitmproxy import http
@@ -67,6 +67,24 @@ _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
 _FIREWALL_AUTH_IDENTITY_VERSION = 1
+_FIREWALL_AUTH_IDENTITY_CACHE_KEY = "_firewallAuthIdentityCache"
+
+
+@dataclass(frozen=True)
+class _FirewallAuthIdentityCacheEntry:
+    """One resolved API identity retained for its VM snapshot lifetime."""
+
+    api_entry: dict = field(repr=False)
+    auth_identity: str
+
+
+@dataclass
+class _FirewallAuthIdentityCache:
+    """Lazy auth identities owned by one published VM registry snapshot."""
+
+    entries: dict[tuple[int, str, str], _FirewallAuthIdentityCacheEntry] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(frozen=True)
@@ -143,7 +161,9 @@ def _build_firewall_auth_context(
     auth_cache_key = FirewallAuthCacheKey(
         run_id=run_id,
         api_id=api_id,
-        auth_identity=_build_firewall_auth_identity(
+        auth_identity=_cached_firewall_auth_identity(
+            vm_info=vm_info,
+            api_entry=api_entry,
             firewall_name=allow.name,
             firewall_base=firewall_base,
             auth_request=auth_request,
@@ -175,6 +195,36 @@ def _build_firewall_auth_identity(
     }
     canonical_json = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(canonical_json).hexdigest()
+
+
+def _cached_firewall_auth_identity(
+    *,
+    vm_info: dict,
+    api_entry: dict,
+    firewall_name: str,
+    firewall_base: str,
+    auth_request: FirewallAuthRequest,
+) -> str:
+    cache = vm_info.get(_FIREWALL_AUTH_IDENTITY_CACHE_KEY)
+    if not isinstance(cache, _FirewallAuthIdentityCache):
+        cache = _FirewallAuthIdentityCache()
+        vm_info[_FIREWALL_AUTH_IDENTITY_CACHE_KEY] = cache
+
+    key = (id(api_entry), firewall_name, firewall_base)
+    entry = cache.entries.get(key)
+    if entry is not None and entry.api_entry is api_entry:
+        return entry.auth_identity
+
+    auth_identity = _build_firewall_auth_identity(
+        firewall_name=firewall_name,
+        firewall_base=firewall_base,
+        auth_request=auth_request,
+    )
+    cache.entries[key] = _FirewallAuthIdentityCacheEntry(
+        api_entry=api_entry,
+        auth_identity=auth_identity,
+    )
+    return auth_identity
 
 
 def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) -> bool:

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -955,6 +955,110 @@ class TestHandleFirewallRequest:
         assert second_cache_key.api_id == "run-1:0"
         assert first_cache_key.auth_identity != second_cache_key.auth_identity
 
+    @pytest.mark.parametrize(
+        "changed_input",
+        [
+            "firewall-name",
+            "firewall-base",
+            "auth-headers",
+            "auth-base",
+            "auth-query",
+            "auth-aws-sigv4",
+            "encrypted-secrets",
+            "secret-connector-map",
+            "secret-connector-metadata-map",
+            "vars",
+            "billable",
+            "sandbox-token",
+        ],
+    )
+    async def test_auth_cache_identity_distinguishes_all_auth_inputs(
+        self, real_flow, mitm_ctx, tmp_path, changed_input
+    ):
+        default_auth = {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}
+        changed_auth = default_auth
+        first_name = "github"
+        second_name = first_name
+        first_base = "https://api.github.com"
+        second_base = first_base
+        first_vm_info = _vm_info(tmp_path, run_id="run-1")
+        second_vm_info = _vm_info(tmp_path, run_id="run-1")
+
+        if changed_input == "firewall-name":
+            second_name = "github-enterprise"
+        elif changed_input == "firewall-base":
+            second_base = "https://api.github.com/v1"
+        elif changed_input == "auth-headers":
+            changed_auth = {"headers": {"Authorization": "Bearer ${{ secrets.OTHER_TOKEN }}"}}
+        elif changed_input == "auth-base":
+            changed_auth = {
+                **default_auth,
+                "base": "${{ secrets.WEBHOOK_URL }}",
+            }
+        elif changed_input == "auth-query":
+            changed_auth = {
+                **default_auth,
+                "query": {"api_key": "${{ secrets.QUERY_KEY }}"},
+            }
+        elif changed_input == "auth-aws-sigv4":
+            changed_auth = {
+                **default_auth,
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                },
+            }
+        elif changed_input == "encrypted-secrets":
+            second_vm_info["encryptedSecrets"] = "encrypted-updated"
+        elif changed_input == "secret-connector-map":
+            second_vm_info["secretConnectorMap"] = {"GITHUB_TOKEN": "github"}
+        elif changed_input == "secret-connector-metadata-map":
+            second_vm_info["secretConnectorMetadataMap"] = {"GITHUB_TOKEN": {"kind": "oauth"}}
+        elif changed_input == "vars":
+            second_vm_info["vars"] = {"TEAM": "vm0"}
+        elif changed_input == "billable":
+            second_vm_info["billableFirewalls"] = [second_name]
+        elif changed_input == "sandbox-token":
+            second_vm_info["sandboxToken"] = "sandbox-token-updated"
+        else:
+            raise AssertionError(f"Unhandled auth identity input: {changed_input}")
+
+        first_api_entry = _api_entry(
+            base=first_base,
+            api_id="run-1:0",
+            auth_config=default_auth,
+        )
+        second_api_entry = _api_entry(
+            base=second_base,
+            api_id="run-1:0",
+            auth_config=changed_auth,
+        )
+        first_flow = _firewall_flow(real_flow, run_id="run-1")
+        second_flow = _firewall_flow(real_flow, run_id="run-1")
+        mock_get_firewall_headers = AsyncMock(return_value=_token_meta())
+
+        with (
+            patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(
+                first_flow,
+                _allow(first_api_entry, name=first_name),
+                first_vm_info,
+            )
+            await auth.handle_firewall_request(
+                second_flow,
+                _allow(second_api_entry, name=second_name),
+                second_vm_info,
+            )
+
+        assert mock_get_firewall_headers.await_count == 2
+        first_cache_key = first_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        second_cache_key = second_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        assert first_cache_key.run_id == second_cache_key.run_id == "run-1"
+        assert first_cache_key.api_id == second_cache_key.api_id == "run-1:0"
+        assert first_cache_key.auth_identity != second_cache_key.auth_identity
+
     async def test_standard_auth_filters_unsafe_resolved_headers(
         self, real_flow, headers, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -9,6 +9,8 @@ from mitmproxy import connection
 
 import auth
 import connector_intent
+import firewall_auth_cache as auth_cache
+import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import upstream_destination_binding
@@ -21,6 +23,15 @@ from tests.request_handler_helpers import (
     _write_github_firewall_registry,
     _write_registry,
 )
+from tests.requestheaders_helpers import await_requestheaders_result
+
+
+def _resolved_firewall_auth() -> auth_client.FirewallAuthSuccess:
+    return auth_client.FirewallAuthSuccess(
+        payload=auth_client.FirewallAuthPayload(
+            headers={"Authorization": "Bearer resolved"},
+        )
+    )
 
 
 async def test_firewall_match_calls_handler(
@@ -44,6 +55,144 @@ async def test_firewall_match_calls_handler(
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "full-access"
+
+
+async def test_repeated_firewall_requests_reuse_snapshot_auth_identity(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={
+            "_firewallAuthIdentityCache": {
+                "entries": {"forged": {"authIdentity": "caller-controlled"}}
+            }
+        },
+    )
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(2)
+    ]
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+        patch.object(
+            auth,
+            "_build_firewall_auth_identity",
+            wraps=auth._build_firewall_auth_identity,
+        ) as build_identity,
+    ):
+        for flow in flows:
+            await mitm_addon.request(flow)
+
+    first_key = flows[0].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    second_key = flows[1].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    assert first_key == second_key
+    assert first_key.auth_identity != "caller-controlled"
+    assert build_identity.call_count == 1
+    auth_fetch.assert_awaited_once()
+    assert flows[0].metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert flows[1].metadata[metadata_keys.AUTH_CACHE_HIT] is True
+    assert flows[0].request.headers["Authorization"] == "Bearer resolved"
+    assert flows[1].request.headers["Authorization"] == "Bearer resolved"
+
+
+async def test_requestheaders_and_request_share_snapshot_auth_identity(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    streamed_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    normal_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+        patch.object(
+            auth,
+            "_build_firewall_auth_identity",
+            wraps=auth._build_firewall_auth_identity,
+        ) as build_identity,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(streamed_flow)
+        await await_requestheaders_result(requestheaders_result)
+        await mitm_addon.request(streamed_flow)
+        await mitm_addon.request(normal_flow)
+
+    streamed_key = streamed_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    normal_key = normal_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    assert streamed_key == normal_key
+    assert build_identity.call_count == 1
+    auth_fetch.assert_awaited_once()
+    assert streamed_flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert normal_flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
+    assert streamed_flow.request.headers["Authorization"] == "Bearer resolved"
+    assert normal_flow.request.headers["Authorization"] == "Bearer resolved"
+
+
+async def test_registry_reload_recomputes_firewall_auth_identity(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    first_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    second_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+        patch.object(
+            auth,
+            "_build_firewall_auth_identity",
+            wraps=auth._build_firewall_auth_identity,
+        ) as build_identity,
+    ):
+        await mitm_addon.request(first_flow)
+        _write_github_firewall_registry(
+            tmp_path,
+            vm_fields={"encryptedSecrets": "iv:tag:data-updated"},
+        )
+        await mitm_addon.request(second_flow)
+
+    first_key = first_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    second_key = second_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    assert first_key.run_id == second_key.run_id == "run-conn-1"
+    assert first_key.api_id == second_key.api_id == "run-conn-1:0"
+    assert first_key.auth_identity != second_key.auth_identity
+    assert build_identity.call_count == 2
+    assert auth_fetch.await_count == 2
 
 
 @pytest.mark.parametrize("reverse", [False, True])


### PR DESCRIPTION
## Summary

- cache each existing content-derived firewall auth identity in private runtime state owned by the published VM registry snapshot
- reuse the digest across normal request auth and requestheaders streaming auth for the exact resolved API context
- replace caller-controlled registry values under the private cache key and recompute after registry snapshot replacement
- cover every auth identity input so cache, in-flight, refresh, and cooldown state remain isolated across configuration changes

## Scope

- keeps the auth identity algorithm, version, and full `FirewallAuthCacheKey` unchanged
- keeps `FirewallAuthRequest` request-local and leaves `firewall_auth_cache.py` lifecycle behavior unchanged
- intentionally retains one identity derivation on the first use of each API in a new registry snapshot
- does not change persisted data, runner protocols, API contracts, or deployment sequencing

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_firewall_auth.py tests/test_request_handler_firewall_dispatch.py -q` (233 passed)
- `.venv/bin/python -m pytest tests/ -q` (4062 passed)
- `PATH=/workspaces/vm1/crates/runner/mitm-addon/.venv/bin:$PATH lefthook run pre-commit`

Closes #21964
