### PR TITLE
docs(api-contracts): document route url invariants

### DIFF
--- a/crates/api-contracts/src/route.rs
+++ b/crates/api-contracts/src/route.rs
@@ -32,17 +32,28 @@ impl Method {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Route {
     pub method: Method,
+    /// Path for this route.
+    ///
+    /// The path must begin with `/` before calling [`Route::url`].
     pub path: &'static str,
 }
 
 impl Route {
     /// Create a generated API route descriptor.
+    ///
+    /// `path` must begin with `/` before calling [`Self::url`].
     #[must_use]
     pub const fn new(method: Method, path: &'static str) -> Self {
         Self { method, path }
     }
 
-    /// Build an absolute URL for this route from a base API URL.
+    /// Build a URL by appending this route's path to a base API URL.
+    ///
+    /// If `base_url` is empty, returns the route path unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this route's path does not begin with `/`.
     #[must_use]
     pub fn url(self, base_url: &str) -> String {
         url_from_base_and_path(base_url, self.path)
@@ -68,17 +79,28 @@ impl RouteTemplate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedRoute {
     pub method: Method,
+    /// Concrete path for this route.
+    ///
+    /// The path must begin with `/` before calling [`ResolvedRoute::url`].
     pub path: String,
 }
 
 impl ResolvedRoute {
     /// Create a generated route descriptor with path params applied.
+    ///
+    /// `path` must begin with `/` before calling [`Self::url`].
     #[must_use]
     pub fn new(method: Method, path: String) -> Self {
         Self { method, path }
     }
 
-    /// Build an absolute URL for this resolved route from a base API URL.
+    /// Build a URL by appending this route's path to a base API URL.
+    ///
+    /// If `base_url` is empty, returns the route path unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this route's path does not begin with `/`.
     #[must_use]
     pub fn url(&self, base_url: &str) -> String {
         url_from_base_and_path(base_url, &self.path)

--- a/crates/api-contracts/tests/routes.rs
+++ b/crates/api-contracts/tests/routes.rs
@@ -1,4 +1,4 @@
-use api_contracts::{Method, RouteTemplate, generated::routes};
+use api_contracts::{Method, ResolvedRoute, RouteTemplate, generated::routes};
 
 #[test]
 fn exposes_generated_webhook_route_constants() {
@@ -101,12 +101,25 @@ fn generated_routes_build_resolved_routes_with_params() {
         resolved.url("https://api.vm0.dev/"),
         "https://api.vm0.dev/api/runners/jobs/550e8400-e29b-41d4-a716-446655440000/claim"
     );
+    assert_eq!(
+        resolved.url(""),
+        "/api/runners/jobs/550e8400-e29b-41d4-a716-446655440000/claim",
+        "empty base URL must preserve the path-only behavior"
+    );
 }
 
 #[test]
 #[should_panic(expected = "api route path must start with '/'")]
-fn generated_route_urls_reject_paths_without_leading_slash() {
+fn route_urls_reject_paths_without_leading_slash() {
     let route = api_contracts::Route::new(Method::Post, "api/runners/poll");
+
+    let _ = route.url("https://api.vm0.dev");
+}
+
+#[test]
+#[should_panic(expected = "api route path must start with '/'")]
+fn resolved_route_urls_reject_paths_without_leading_slash() {
+    let route = ResolvedRoute::new(Method::Post, "api/runners/poll".to_owned());
 
     let _ = route.url("https://api.vm0.dev");
 }


### PR DESCRIPTION
## Summary

- document the leading-slash requirement on `Route` and `ResolvedRoute` path fields and constructors
- describe URL composition, empty-base path-only results, and invalid-path panics on both public helpers
- add integration coverage for the previously implicit `ResolvedRoute` empty-base and panic behavior

## Compatibility

- no runtime behavior, public signature, generated binding, persisted data, or protocol changes
- `RouteTemplate` and generated route files remain unchanged

## Validation

- `cd crates && cargo fmt -p api-contracts -- --check`
- `cd crates && cargo clippy -p api-contracts --all-targets --all-features`
- `cd crates && cargo doc -p api-contracts --all-features --no-deps`
- `cd crates && cargo test -p api-contracts`
- `cd turbo && pnpm -F @vm0/api-contracts generate:rust`
- `git diff --exit-code -- crates/api-contracts/src/generated`
- pre-commit Rust formatting, Clippy, and workspace documentation hooks

Closes #21995
