### PR TITLE
docs(python): document tcp message byte accounting

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1423,7 +1423,11 @@ def tcp_start(flow: tcp.TCPFlow) -> None:
 
 
 def tcp_message(flow: tcp.TCPFlow) -> None:
-    """Schedule bounded retention cleanup for registered TCP flows."""
+    """Preserve byte totals while bounding registered TCP message retention.
+
+    The hook coalesces message events into a deferred drain, which records request and response
+    byte totals before clearing retained messages.
+    """
     tcp_logging.message(flow)
 
 

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -43,7 +43,11 @@ def start(flow: tcp.TCPFlow, *, registry_path: str) -> None:
 
 
 def message(flow: tcp.TCPFlow) -> None:
-    """Schedule bounded retention cleanup for registered TCP flows."""
+    """Preserve byte totals while bounding registered TCP message retention.
+
+    The hook coalesces message events into a deferred drain, which records request and response
+    byte totals before clearing retained messages.
+    """
     _schedule_tcp_message_drain(flow)
 
 


### PR DESCRIPTION
## Summary

- document that registered TCP message drains preserve request and response byte totals before clearing retained messages
- explain that deferred drain scheduling coalesces message events while bounding retention
- keep the registered mitmproxy hook and TCP logging owner docstrings aligned

## Scope

Documentation only. This PR does not change runtime behavior, tests, APIs, schemas, persisted data, queue payloads, or protocols.

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_tcp_hooks.py tests/test_deferred_scheduler.py` — 18 passed
- `.venv/bin/python -m pytest tests/` — 4049 passed
- `git diff --check`

Closes #21998
