### PR TITLE
fix(agent): prefer workspace directory in runtime prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7377,6 +7377,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain("# Agent Tools");
     for (const toolHint of [
       "zero web download-file -h",
+      "Prefer the workspace directory (`/home/user/workspace`) for file operations and project work",
       "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime",
       "`agent-browser` provides rendered-page inspection and interaction",
       "Local dev servers are useful for agent-side verification",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -252,6 +252,7 @@ function buildIntegrationToolsPrompt(
   zeroMailEnabled: boolean,
 ): readonly string[] {
   const localFileContext = [
+    "Prefer the workspace directory (`/home/user/workspace`) for file operations and project work.",
     "Local filesystem paths are only visible to the agent runtime. Users cannot open local paths directly.",
     "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime; users cannot rely on them as a way to view the result directly.",
     "Local dev servers are useful for agent-side verification, but they are not by themselves a user-facing deliverable.",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 
+import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -252,7 +253,7 @@ function buildIntegrationToolsPrompt(
   zeroMailEnabled: boolean,
 ): readonly string[] {
   const localFileContext = [
-    "Prefer the workspace directory (`/home/user/workspace`) for file operations and project work.",
+    `Prefer the workspace directory (\`${CANONICAL_WORKING_DIR}\`) for file operations and project work.`,
     "Local filesystem paths are only visible to the agent runtime. Users cannot open local paths directly.",
     "Localhost URLs, local dev server ports, and processes started inside the agent runtime are generally only reachable inside that runtime; users cannot rely on them as a way to view the result directly.",
     "Local dev servers are useful for agent-side verification, but they are not by themselves a user-facing deliverable.",


### PR DESCRIPTION
## Summary

- tell agents to prefer `/home/user/workspace` for file operations and project work
- derive the prompt path from the shared `CANONICAL_WORKING_DIR` runtime contract
- place the guidance in the shared local-file context so it applies across all integration trigger sources
- cover the prompt text in the existing runner-context integration test

## User-visible impact

Agents now receive explicit guidance to keep project and file work in the persistent workspace directory by default, while retaining the existing flexibility to use other filesystem locations when appropriate.

## Verification

- `pnpm format` — passed
- `pnpm turbo run lint --log-order grouped` — passed (12/12 workspaces)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm check-types` — passed (13/13 workspaces)
- `pnpm -F @vm0/db db:migrate` with local PostgreSQL 16 and pgvector — passed
- targeted `run-lifecycle.bdd.test.ts` case — prompt assertion was not reached because the local runner-queue claim returned 404; the same test passed in the prior PR CI run, and the follow-up changes only replace the path literal with its canonical constant
- full validation delegated to the updated PR pipeline per repository guidance
