### PR TITLE
fix(mitm-addon): preserve explicit port zero in http network logs

### DIFF
--- a/crates/runner/mitm-addon/src/http_network_log.py
+++ b/crates/runner/mitm-addon/src/http_network_log.py
@@ -23,8 +23,11 @@ def fallback_host_port(flow: http.HTTPFlow, original_url: str) -> tuple[str, int
     try:
         parsed_url = urllib.parse.urlparse(original_url)
         host = parsed_url.hostname or flow.request.pretty_host
-        port = parsed_url.port or (
-            _HTTPS_DEFAULT_PORT if parsed_url.scheme == "https" else _HTTP_DEFAULT_PORT
+        parsed_port = parsed_url.port
+        port = (
+            (_HTTPS_DEFAULT_PORT if parsed_url.scheme == "https" else _HTTP_DEFAULT_PORT)
+            if parsed_port is None
+            else parsed_port
         )
     except ValueError:
         host = flow.request.pretty_host

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -497,6 +497,24 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
+    def test_error_logs_explicit_zero_original_url_port(self, tmp_path, real_flow, mitm_ctx):
+        flow = real_flow(with_response=False, host="request.example.com", port=9443)
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://target.example.com:0/path"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.error = Error("connection reset by peer")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
+        assert entry["host"] == "target.example.com"
+        assert entry["port"] == 0
+        assert entry["url"] == "https://target.example.com:0/path"
+        assert entry["error"] == "connection reset by peer"
+
     def test_error_logs_legacy_target_when_original_url_port_is_invalid(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -192,6 +192,36 @@ def test_network_log_target_url_strips_query_and_fragment(
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
 
+@pytest.mark.parametrize(
+    ("original_url", "expected_port"),
+    [
+        ("http://target.example.com:0/path", 0),
+        ("https://target.example.com:0/path", 0),
+        ("http://target.example.com/path", 80),
+        ("https://target.example.com/path", 443),
+    ],
+)
+def test_logs_explicit_or_default_original_url_port(
+    tmp_path, real_flow, mitm_ctx, original_url, expected_port
+):
+    flow = real_flow(with_response=False, host="request.example.com", port=9443)
+    log_path = str(tmp_path / "network.jsonl")
+
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(Path(log_path))
+    assert entry["host"] == "target.example.com"
+    assert entry["port"] == expected_port
+    assert entry["url"] == original_url
+
+
 def test_logs_legacy_target_when_original_url_port_is_invalid(tmp_path, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
     log_path = str(tmp_path / "network.jsonl")


### PR DESCRIPTION
## Summary

- preserve an explicit URL port of `0` in HTTP network-log target metadata
- apply scheme defaults only when the parsed URL omits its port, while retaining malformed-port fallback behavior
- cover HTTP and HTTPS zero/default behavior through response logging and verify the shared correction through connection-error logging

## User impact

Failed or invalid requests that explicitly target port zero are now recorded with the requested destination port instead of appearing to target standard HTTP or HTTPS ports. This keeps audit and debugging metadata faithful to the original endpoint.

## Scope

- no API, schema, migration, dependency, protocol, or deployment changes
- no change to positive explicit ports, omitted-port defaults, or malformed/out-of-range port fallback

## Verification

- `python3 -m pytest tests/test_response_handler_logging.py tests/test_error_handler.py -v` — 74 passed
- `ruff check .` — passed
- `ruff format --check .` — 241 files already formatted
- `basedpyright -p .` — 0 errors, 0 warnings
- `python3 -m pytest tests/ -v` — 4,055 passed

Closes #22002
