### PR TITLE
test(mitm-addon): cover protocol-relative url fallback

### DIFF
--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -128,16 +128,6 @@ class TestLogProxyEntry:
                 id="protocol-relative",
             ),
             pytest.param(
-                "https://user:pass@[invalid/path?token=secret#fragment",
-                "https://[invalid/path",
-                id="urlsplit-value-error-absolute",
-            ),
-            pytest.param(
-                "//user:pass@[invalid/path?token=secret#fragment",
-                "//[invalid/path",
-                id="urlsplit-value-error-protocol-relative",
-            ),
-            pytest.param(
                 "https:////user:pass@example.com/path?token=secret#fragment",
                 "https://example.com/path",
                 id="extra-slashes",

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -128,6 +128,16 @@ class TestLogProxyEntry:
                 id="protocol-relative",
             ),
             pytest.param(
+                "https://user:pass@[invalid/path?token=secret#fragment",
+                "https://[invalid/path",
+                id="urlsplit-value-error-absolute",
+            ),
+            pytest.param(
+                "//user:pass@[invalid/path?token=secret#fragment",
+                "//[invalid/path",
+                id="urlsplit-value-error-protocol-relative",
+            ),
+            pytest.param(
                 "https:////user:pass@example.com/path?token=secret#fragment",
                 "https://example.com/path",
                 id="extra-slashes",

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -151,6 +151,10 @@ def test_response_log_includes_firewall_auth_metadata(tmp_path, real_flow, mitm_
             "https://[invalid.example.com/path",
         ),
         (
+            "//user:pass@[invalid.example.com/path?access_token=secret#fragment",
+            "//[invalid.example.com/path",
+        ),
+        (
             "https://user:pass@target.example.com:9443/path?access_token=secret#fragment",
             "https://target.example.com:9443/path",
         ),


### PR DESCRIPTION
## Summary

- add the missing protocol-relative unmatched-bracket case to the existing response-handler network-log sanitizer matrix
- verify persisted JSONL keeps the `//` form and remaining authority/path text while removing userinfo, query data, and the fragment
- retain the established absolute exception cases and avoid mocks or production sanitizer changes

## Implementation

The response-handler matrix already covered natural `urlsplit()` failures for absolute malformed authorities. This change adds only the distinct protocol-relative fallback arm at the same end-to-end persistence boundary.

## Verification

- `python3 -m pytest tests/test_response_handler_logging.py::test_network_log_target_url_strips_query_and_fragment -v` — 7 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — 241 files already formatted
- `python3 -m basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `python3 -m pytest tests/ -v` — 4,051 passed

Closes #22000
