### PR TITLE
fix(vsock): replace descendant process-group cleanup with exec cgroups

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -421,19 +421,59 @@ OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- echo hello-from-
 echo "$OUTPUT" | grep -q "hello-from-exec" || fail "expected 'hello-from-exec', got: $OUTPUT"
 echo "PASS: basic exec"
 
-# Test 3: exit code propagation
+# Test 3: one-shot exec owns detached descendants, including through the
+# production non-sudo `su` boundary.
+echo "--- Test: one-shot process containment ---"
+ONE_SHOT_COMMAND=$(cat <<'SCRIPT'
+set -eu
+identity=/tmp/vm0-one-shot-containment.identity
+rm -f "$identity"
+setsid python3 -c 'import os, pathlib, signal, time; p=pathlib.Path("/tmp/vm0-one-shot-containment.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); signal.signal(signal.SIGTERM, signal.SIG_IGN); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >/dev/null 2>&1 &
+for _ in $(seq 1 100); do
+  [ -s "$identity" ] && break
+  sleep 0.01
+done
+test -s "$identity"
+SCRIPT
+)
+sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$ONE_SHOT_COMMAND" \
+  || fail "one-shot descendant setup failed"
+VERIFY_ONE_SHOT_COMMAND=$(cat <<'SCRIPT'
+set -eu
+identity=/tmp/vm0-one-shot-containment.identity
+read -r pid start_time < "$identity"
+if [ -r "/proc/$pid/stat" ]; then
+  current_start=$(awk '{print $22}' "/proc/$pid/stat")
+  [ "$current_start" != "$start_time" ] || {
+    echo "one-shot descendant is still alive: pid=$pid" >&2
+    exit 1
+  }
+fi
+base=/sys/fs/cgroup/vm0-exec
+relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
+own_group=${relative##*/}
+test -n "$own_group"
+test -d "$base/$own_group"
+test -z "$(find "$base" -mindepth 1 -maxdepth 1 -type d ! -name "$own_group" -print -quit)"
+SCRIPT
+)
+sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$VERIFY_ONE_SHOT_COMMAND" \
+  || fail "one-shot descendant or cgroup leaf survived cleanup"
+echo "PASS: one-shot process containment"
+
+# Test 4: exit code propagation
 echo "--- Test: exit code propagation ---"
 sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- false && fail "expected non-zero exit"
 echo "PASS: exit code propagation"
 
-# Test 4: prefix matching
+# Test 5: prefix matching
 echo "--- Test: prefix matching ---"
 PREFIX=$(echo "$SANDBOX_ID" | cut -c1-8)
 OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$PREFIX" -- hostname)
 [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
 echo "PASS: prefix matching"
 
-# Test 5: argv boundary preservation — regression guard for #9019.
+# Test 6: argv boundary preservation — regression guard for #9019.
 # NOTE: each assertion relies on the surrounding bash (this
 # heredoc, running on the metal runner) to tokenise quoted
 # arguments and pass them to runner as separate argv entries.
@@ -477,7 +517,7 @@ OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- echo "roo
 [ "$OUTPUT" = "root with space" ] || fail "--sudo quoting: got '$OUTPUT'"
 echo "PASS: argv boundary preservation"
 
-# Test 6: verify pre-installed language runtimes and databases
+# Test 7: verify pre-installed language runtimes and databases
 echo "--- Test: runtime availability ---"
 for cmd in \
   "node --version" \
@@ -540,7 +580,7 @@ sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c '
 echo "  PostgreSQL start/stop: ok"
 echo "PASS: runtime availability"
 
-# Test 7: verify /etc/environment is loaded for both user and root
+# Test 8: verify /etc/environment is loaded for both user and root
 # [sync:etc-environment] Keep in sync with: crates/runner/scripts/customize-rootfs.sh
 echo "--- Test: environment variables ---"
 EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -571,7 +611,7 @@ check_env "user" ""
 check_env "root" "--sudo"
 echo "PASS: environment variables"
 
-# Test 8: verify HTTPS works through proxy for each runtime
+# Test 9: verify HTTPS works through proxy for each runtime
 # All traffic goes through mitmproxy, so TLS must trust the proxy CA.
 echo "--- Test: HTTPS through proxy ---"
 TLS_URL="https://www.vm0.ai"
@@ -609,7 +649,7 @@ sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "cd /tmp && printf 
 echo "  HTTPS go: ok"
 echo "PASS: HTTPS through proxy"
 
-# Test 9: verify DNS resolution works inside sandbox
+# Test 10: verify DNS resolution works inside sandbox
 # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
 echo "--- Test: DNS resolution ---"
 OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- getent hosts localhost 2>&1) \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -422,12 +422,21 @@ echo "$OUTPUT" | grep -q "hello-from-exec" || fail "expected 'hello-from-exec', 
 echo "PASS: basic exec"
 
 # Test 3: one-shot exec owns detached descendants, including through the
-# production non-sudo `su` boundary.
+# production non-sudo `su` boundary. The long-running job above can own another
+# valid leaf concurrently, so record and verify this exec's exact leaf.
 echo "--- Test: one-shot process containment ---"
 ONE_SHOT_COMMAND=$(cat <<'SCRIPT'
 set -eu
 identity=/tmp/vm0-one-shot-containment.identity
-rm -f "$identity"
+group_file=/tmp/vm0-one-shot-containment.group
+rm -f "$identity" "$group_file"
+relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
+own_group=${relative##*/}
+case "$own_group" in
+  exec-*) ;;
+  *) echo "unexpected one-shot cgroup: $relative" >&2; exit 1 ;;
+esac
+printf '%s\n' "$own_group" > "$group_file"
 setsid python3 -c 'import os, pathlib, signal, time; p=pathlib.Path("/tmp/vm0-one-shot-containment.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); signal.signal(signal.SIGTERM, signal.SIG_IGN); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >/dev/null 2>&1 &
 for _ in $(seq 1 100); do
   [ -s "$identity" ] && break
@@ -441,6 +450,7 @@ sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$ONE_SHOT_COMMAND"
 VERIFY_ONE_SHOT_COMMAND=$(cat <<'SCRIPT'
 set -eu
 identity=/tmp/vm0-one-shot-containment.identity
+group_file=/tmp/vm0-one-shot-containment.group
 read -r pid start_time < "$identity"
 if [ -r "/proc/$pid/stat" ]; then
   current_start=$(awk '{print $22}' "/proc/$pid/stat")
@@ -454,7 +464,19 @@ relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
 own_group=${relative##*/}
 test -n "$own_group"
 test -d "$base/$own_group"
-test -z "$(find "$base" -mindepth 1 -maxdepth 1 -type d ! -name "$own_group" -print -quit)"
+old_group=$(cat "$group_file")
+case "$old_group" in
+  exec-*) ;;
+  *) echo "unexpected recorded one-shot cgroup: $old_group" >&2; exit 1 ;;
+esac
+[ "$old_group" != "$own_group" ] || {
+  echo "one-shot cgroup was reused: $old_group" >&2
+  exit 1
+}
+[ ! -e "$base/$old_group" ] || {
+  echo "one-shot cgroup leaf survived cleanup: $old_group" >&2
+  exit 1
+}
 SCRIPT
 )
 sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$VERIFY_ONE_SHOT_COMMAND" \

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -452,12 +452,18 @@ set -eu
 identity=/tmp/vm0-one-shot-containment.identity
 group_file=/tmp/vm0-one-shot-containment.group
 read -r pid start_time < "$identity"
-if [ -r "/proc/$pid/stat" ]; then
-  current_start=$(awk '{print $22}' "/proc/$pid/stat")
-  [ "$current_start" != "$start_time" ] || {
-    echo "one-shot descendant is still alive: pid=$pid" >&2
-    exit 1
-  }
+if current_identity=$(awk '{sub(/^.*\) /, ""); print $1, $20}' "/proc/$pid/stat" 2>/dev/null); then
+  current_state=${current_identity%% *}
+  current_start=${current_identity#* }
+  case "$current_state" in
+    Z|X|x) ;;
+    *)
+      [ "$current_start" != "$start_time" ] || {
+        echo "one-shot descendant is still running: pid=$pid" >&2
+        exit 1
+      }
+      ;;
+  esac
 fi
 base=/sys/fs/cgroup/vm0-exec
 relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -158,26 +158,14 @@ LEAK_LINE=$(printf '%s\n' "$LOGS" \
   | grep -F 'cgroup_kill_used=true' \
   | head -1) \
   || fail "missing populated cleanup that used cgroup.kill"
-HEALTHY_LINE=$(printf '%s\n' "$LOGS" \
-  | grep -F 'exec process containment cleaned' \
-  | grep -F 'descendants_observed=false' \
-  | grep -F 'cgroup_kill_used=false' \
-  | head -1) \
-  || fail "missing healthy cleanup that skipped grace and kill"
 
 LEAK_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$LEAK_LINE")
-HEALTHY_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$HEALTHY_LINE")
-HEALTHY_CREATE_US=$(sed -n 's/.*create_us=\([0-9][0-9]*\).*/\1/p' <<<"$HEALTHY_LINE")
 [ -n "$LEAK_CLEANUP_MS" ] || fail "missing leaked cleanup latency"
-[ -n "$HEALTHY_CLEANUP_MS" ] || fail "missing healthy cleanup latency"
-[ -n "$HEALTHY_CREATE_US" ] || fail "missing healthy creation latency"
 [ "$LEAK_CLEANUP_MS" -le 2000 ] \
   || fail "leaked cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
-[ "$HEALTHY_CLEANUP_MS" -lt 500 ] \
-  || fail "healthy cleanup unexpectedly entered a wait: ${HEALTHY_CLEANUP_MS}ms"
 
 echo "PASS: detached user/root descendants were reclaimed"
-echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy create ${HEALTHY_CREATE_US}us; healthy cleanup ${HEALTHY_CLEANUP_MS}ms"
+echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"
 
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 wait_for_unit_inactive

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -116,12 +116,18 @@ test -f "$marker/vm-reuse-marker"
 
 for identity in "$marker/user.identity" "$marker/root.identity"; do
   read -r pid start_time < "$identity"
-  if [ -r "/proc/$pid/stat" ]; then
-    current_start=$(awk '{print $22}' "/proc/$pid/stat")
-    [ "$current_start" != "$start_time" ] || {
-      echo "recorded descendant is still alive: $identity pid=$pid" >&2
-      exit 1
-    }
+  if current_identity=$(awk '{sub(/^.*\) /, ""); print $1, $20}' "/proc/$pid/stat" 2>/dev/null); then
+    current_state=${current_identity%% *}
+    current_start=${current_identity#* }
+    case "$current_state" in
+      Z|X|x) ;;
+      *)
+        [ "$current_start" != "$start_time" ] || {
+          echo "recorded descendant is still running: $identity pid=$pid" >&2
+          exit 1
+        }
+        ;;
+    esac
   fi
 done
 

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -111,7 +111,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
 VERIFY_PROMPT=$(cat <<'PROMPT'
 set -eu
 marker=/tmp/vm0-process-containment
-base=/sys/fs/cgroup/vm0-supervised
+base=/sys/fs/cgroup/vm0-exec
 test -f "$marker/vm-reuse-marker"
 
 for identity in "$marker/user.identity" "$marker/root.identity"; do
@@ -153,13 +153,13 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
   || fail "failed to read runner logs"
 LEAK_LINE=$(printf '%s\n' "$LOGS" \
-  | grep -F 'supervised process containment cleaned' \
+  | grep -F 'exec process containment cleaned' \
   | grep -F 'descendants_observed=true' \
   | grep -F 'cgroup_kill_used=true' \
   | head -1) \
   || fail "missing populated cleanup that used cgroup.kill"
 HEALTHY_LINE=$(printf '%s\n' "$LOGS" \
-  | grep -F 'supervised process containment cleaned' \
+  | grep -F 'exec process containment cleaned' \
   | grep -F 'descendants_observed=false' \
   | grep -F 'cgroup_kill_used=false' \
   | head -1) \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -765,7 +765,7 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-cancel.sh
 
-      - name: Test supervised process containment
+      - name: Test exec process containment
         id: process_containment
         timeout-minutes: 5
         continue-on-error: true

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -3,9 +3,11 @@
 use std::ffi::{CString, OsStr, OsString};
 use std::io::{self, Read};
 use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
-use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH};
+use guest_contracts::process_containment::{
+    CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
+};
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
@@ -21,6 +23,9 @@ const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
 #[cfg(debug_assertions)]
 const TEST_CONTAINMENT_ROOT_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_ROOT";
+#[cfg(debug_assertions)]
+const TEST_CONTAINMENT_CURRENT_GROUP_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP";
+const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
 
 /// Failure returned by the reuse-preparation helper.
 #[derive(Debug)]
@@ -31,7 +36,7 @@ pub enum ReusePreparationError {
     Inspection(io::Error),
     /// Stale runtime entries could not be safely removed.
     Cleanup(io::Error),
-    /// Exec process containment could not be proven healthy and empty.
+    /// Exec process containment could not be proven ready for reuse.
     Containment(io::Error),
 }
 
@@ -175,6 +180,7 @@ struct ProcessContainmentPaths {
 
 fn verify_process_containment() -> io::Result<()> {
     let paths = process_containment_paths();
+    let current_group = current_process_cgroup_name()?;
     if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.mount)? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -217,22 +223,101 @@ fn verify_process_containment() -> io::Result<()> {
         ));
     }
 
+    let base_procs = std::fs::read_to_string(paths.base.join(CGROUP_PROCS_FILE))?;
+    if !base_procs.trim().is_empty() {
+        return Err(io::Error::other(
+            "exec cgroup base contains direct processes",
+        ));
+    }
+
+    let mut current_group_found = false;
     for entry in std::fs::read_dir(&paths.base)? {
         let entry = entry?;
-        if entry.file_type()?.is_dir() {
+        let file_type = entry.file_type()?;
+        if entry.file_name() == current_group {
+            if !file_type.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "current exec operation cgroup is not a directory",
+                ));
+            }
+            current_group_found = true;
+        } else if file_type.is_dir() {
             return Err(io::Error::other("stale exec operation cgroup remains"));
         }
+    }
+    if !current_group_found {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "current exec operation cgroup is missing",
+        ));
     }
 
     let events = std::fs::read_to_string(paths.base.join(CGROUP_EVENTS_FILE))?;
     match parse_populated(&events) {
-        Some(false) => Ok(()),
-        Some(true) => Err(io::Error::other("exec cgroup remains populated")),
+        Some(true) => Ok(()),
+        Some(false) => Err(io::Error::other(
+            "exec cgroup does not contain the current operation",
+        )),
         None => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "cgroup.events is missing valid populated state",
         )),
     }
+}
+
+fn current_process_cgroup_name() -> io::Result<OsString> {
+    #[cfg(debug_assertions)]
+    if let Some(cgroup_path) = std::env::var_os(TEST_CONTAINMENT_CURRENT_GROUP_ENV) {
+        return current_group_name_from_path(Path::new(&cgroup_path));
+    }
+
+    let content = std::fs::read_to_string(PROC_SELF_CGROUP)?;
+    let cgroup_path = content
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "current unified cgroup path is missing",
+            )
+        })?;
+    current_group_name_from_path(Path::new(cgroup_path))
+}
+
+fn current_group_name_from_path(cgroup_path: &Path) -> io::Result<OsString> {
+    let relative_base = Path::new(EXEC_CGROUP_BASE_PATH)
+        .strip_prefix(CGROUP_V2_MOUNT_PATH)
+        .map_err(|_| io::Error::other("exec cgroup base is outside the cgroup v2 mount"))?;
+    let relative_path = cgroup_path.strip_prefix(Path::new("/")).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "current unified cgroup path is not absolute",
+        )
+    })?;
+    let group_path = relative_path.strip_prefix(relative_base).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "current process is outside the exec cgroup base",
+        )
+    })?;
+    let mut components = group_path.components();
+    let group = match (components.next(), components.next()) {
+        (Some(Component::Normal(group)), None)
+            if group
+                .as_bytes()
+                .starts_with(EXEC_CGROUP_NAME_PREFIX.as_bytes()) =>
+        {
+            group.to_os_string()
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "current process is not in an exec operation leaf",
+            ));
+        }
+    };
+    Ok(group)
 }
 
 fn process_containment_paths() -> ProcessContainmentPaths {

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
-use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, SUPERVISED_CGROUP_BASE_PATH};
+use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH};
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INSPECTION_FAILED, REUSE_PREPARATION_EXIT_INVALID_REQUEST,
@@ -31,7 +31,7 @@ pub enum ReusePreparationError {
     Inspection(io::Error),
     /// Stale runtime entries could not be safely removed.
     Cleanup(io::Error),
-    /// Supervised process containment could not be proven healthy and empty.
+    /// Exec process containment could not be proven healthy and empty.
     Containment(io::Error),
 }
 
@@ -186,13 +186,13 @@ fn verify_process_containment() -> io::Result<()> {
     if !base_metadata.is_dir() || base_metadata.file_type().is_symlink() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "supervised cgroup base is not a directory",
+            "exec cgroup base is not a directory",
         ));
     }
     if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.base)? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "supervised cgroup base is not on cgroup v2",
+            "exec cgroup base is not on cgroup v2",
         ));
     }
     for filename in [
@@ -204,7 +204,7 @@ fn verify_process_containment() -> io::Result<()> {
         if !std::fs::metadata(paths.base.join(filename))?.is_file() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("supervised cgroup core file is invalid: {filename}"),
+                format!("exec cgroup core file is invalid: {filename}"),
             ));
         }
     }
@@ -213,23 +213,21 @@ fn verify_process_containment() -> io::Result<()> {
     if !subtree_control.trim().is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "resource controllers are enabled for the supervised cgroup",
+            "resource controllers are enabled for the exec cgroup",
         ));
     }
 
     for entry in std::fs::read_dir(&paths.base)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
-            return Err(io::Error::other(
-                "stale supervised operation cgroup remains",
-            ));
+            return Err(io::Error::other("stale exec operation cgroup remains"));
         }
     }
 
     let events = std::fs::read_to_string(paths.base.join(CGROUP_EVENTS_FILE))?;
     match parse_populated(&events) {
         Some(false) => Ok(()),
-        Some(true) => Err(io::Error::other("supervised cgroup remains populated")),
+        Some(true) => Err(io::Error::other("exec cgroup remains populated")),
         None => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "cgroup.events is missing valid populated state",
@@ -241,7 +239,7 @@ fn process_containment_paths() -> ProcessContainmentPaths {
     #[cfg(debug_assertions)]
     if let Some(root) = std::env::var_os(TEST_CONTAINMENT_ROOT_ENV) {
         let mount = PathBuf::from(root);
-        let base = mount.join("vm0-supervised");
+        let base = mount.join("vm0-exec");
         return ProcessContainmentPaths {
             mount,
             base,
@@ -251,7 +249,7 @@ fn process_containment_paths() -> ProcessContainmentPaths {
 
     ProcessContainmentPaths {
         mount: PathBuf::from(CGROUP_V2_MOUNT_PATH),
-        base: PathBuf::from(SUPERVISED_CGROUP_BASE_PATH),
+        base: PathBuf::from(EXEC_CGROUP_BASE_PATH),
         require_cgroup2_filesystem: true,
     }
 }

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -229,7 +229,7 @@ fn prepare_for_reuse_rejects_stale_operation_cgroup() -> TestResult {
 }
 
 #[test]
-fn prepare_for_reuse_rejects_populated_supervised_cgroup() -> TestResult {
+fn prepare_for_reuse_rejects_populated_exec_cgroup() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
     std::fs::write(containment.base.join("cgroup.events"), b"populated 1\n")?;
@@ -271,7 +271,7 @@ impl ContainmentFixture {
     fn new() -> TestResult<Self> {
         let directory = tempfile::tempdir()?;
         let root = directory.path().join("cgroup");
-        let base = root.join("vm0-supervised");
+        let base = root.join("vm0-exec");
         std::fs::create_dir_all(&base)?;
         for (filename, content) in [
             ("cgroup.procs", ""),

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -229,12 +229,56 @@ fn prepare_for_reuse_rejects_stale_operation_cgroup() -> TestResult {
 }
 
 #[test]
-fn prepare_for_reuse_rejects_populated_exec_cgroup() -> TestResult {
+fn prepare_for_reuse_rejects_missing_current_operation_cgroup() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
-    std::fs::write(containment.base.join("cgroup.events"), b"populated 1\n")?;
+    std::fs::remove_dir(containment.base.join("exec-current"))?;
 
     let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_unpopulated_exec_cgroup() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(containment.base.join("cgroup.events"), b"populated 0\n")?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_direct_processes_in_exec_base() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(containment.base.join("cgroup.procs"), b"42\n")?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_current_process_outside_exec_base() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+
+    let output = run_helper_with_current_group(&request, &containment, "/outside/exec-current")?;
 
     assert_eq!(
         output.status.code(),
@@ -273,9 +317,10 @@ impl ContainmentFixture {
         let root = directory.path().join("cgroup");
         let base = root.join("vm0-exec");
         std::fs::create_dir_all(&base)?;
+        std::fs::create_dir(base.join("exec-current"))?;
         for (filename, content) in [
             ("cgroup.procs", ""),
-            ("cgroup.events", "populated 0\nfrozen 0\n"),
+            ("cgroup.events", "populated 1\nfrozen 0\n"),
             ("cgroup.kill", ""),
             ("cgroup.subtree_control", ""),
         ] {
@@ -311,9 +356,18 @@ fn run_helper_with_containment(
     request: &ReusePreparationRequest,
     containment: &ContainmentFixture,
 ) -> Result<Output, Box<dyn std::error::Error>> {
+    run_helper_with_current_group(request, containment, "/vm0-exec/exec-current")
+}
+
+fn run_helper_with_current_group(
+    request: &ReusePreparationRequest,
+    containment: &ContainmentFixture,
+    current_group: &str,
+) -> Result<Output, Box<dyn std::error::Error>> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
         .env_clear()
         .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
+        .env("VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP", current_group)
         .arg("prepare-for-reuse")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -336,6 +390,10 @@ fn run_helper_with_bind_mount(
     let mut child = Command::new("/usr/bin/unshare")
         .env_clear()
         .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
+        .env(
+            "VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP",
+            "/vm0-exec/exec-current",
+        )
         .env("VM0_MOUNT_SOURCE", mount_source)
         .env("VM0_MOUNT_TARGET", mount_target)
         .env("VM0_HELPER", env!("CARGO_BIN_EXE_guest-agent"))

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -5,3 +5,6 @@ pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
 
 /// Cgroup containing all active exec-operation child cgroups.
 pub const EXEC_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-exec";
+
+/// Prefix for each per-operation cgroup directly below the exec cgroup base.
+pub const EXEC_CGROUP_NAME_PREFIX: &str = "exec-";

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -3,5 +3,5 @@
 /// Canonical cgroup v2 mount inside the guest.
 pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
 
-/// Cgroup containing all active supervised-operation child cgroups.
-pub const SUPERVISED_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-supervised";
+/// Cgroup containing all active exec-operation child cgroups.
+pub const EXEC_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-exec";

--- a/crates/guest-contracts/src/reuse_preparation.rs
+++ b/crates/guest-contracts/src/reuse_preparation.rs
@@ -10,7 +10,7 @@ pub const REUSE_PREPARATION_EXIT_INVALID_REQUEST: i32 = 2;
 pub const REUSE_PREPARATION_EXIT_INSPECTION_FAILED: i32 = 3;
 /// Stale runner-owned runtime state could not be safely removed.
 pub const REUSE_PREPARATION_EXIT_CLEANUP_FAILED: i32 = 4;
-/// Supervised process containment could not be proven healthy and empty.
+/// Exec process containment could not be proven ready for reuse.
 pub const REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED: i32 = 5;
 
 /// Runtime directories that must remain available after reuse preparation.

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, SUPERVISED_CGROUP_BASE_PATH};
+use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH};
 
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
@@ -157,10 +157,10 @@ fn initialize_process_containment() -> Result<(), InitError> {
         source,
     })?;
 
-    let base = Path::new(SUPERVISED_CGROUP_BASE_PATH);
+    let base = Path::new(EXEC_CGROUP_BASE_PATH);
     create_dir_all(base)?;
     verify_process_containment_base(base)?;
-    eprintln!("[guest-init] Supervised process containment initialized");
+    eprintln!("[guest-init] Exec process containment initialized");
     Ok(())
 }
 
@@ -202,7 +202,7 @@ fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
         })?;
     if !subtree_control.trim().is_empty() {
         return Err(InitError::InvalidProcessContainment(
-            "resource controllers are enabled for the supervised subtree".into(),
+            "resource controllers are enabled for the exec subtree".into(),
         ));
     }
     Ok(())

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -22,6 +22,7 @@ use crate::handlers::{
     MessageOutcome, decode_write_file_message, decode_write_files_message, handle_basic_message,
 };
 use crate::log::log;
+use crate::process_containment::verify_exec_process_containment_empty;
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
 use crate::writer::GuestWriter;
 
@@ -209,7 +210,16 @@ fn handle_quiesce_operations(
     }
 
     match operation_state.enter_quiescing() {
-        QuiesceResult::Quiesced => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),
+        // Quiescing atomically fences new guest operations. Once pending is
+        // zero, this is the final race-free boundary before the VM is parked.
+        QuiesceResult::Quiesced => match verify_exec_process_containment_empty() {
+            Ok(()) => send_empty_response(MSG_OPERATIONS_QUIESCED, seq, writer),
+            Err(error) => send_error_response(
+                seq,
+                &format!("guest process containment is not empty: {error}"),
+                writer,
+            ),
+        },
         QuiesceResult::Busy { pending } => send_error_response(
             seq,
             &format!("guest operations still pending: {pending}"),

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -468,10 +468,13 @@ impl ExecSetup {
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
         kill_and_reap_child(child);
-        let _ =
+        let containment_result =
             cleanup_process_containment(process_containment, ProcessContainmentCleanupMode::Forced);
         join_stdin_writer_after_kill(stdin_writer);
-        completion.wait_failed(diagnostic);
+        let containment_error = containment_result.as_ref().err().map(ToString::to_string);
+        let diagnostic =
+            append_containment_cleanup_failure(diagnostic, containment_error.as_deref());
+        completion.wait_failed(&diagnostic);
     }
 
     fn abort_exec_started_send_failed(self, completion: &ExecCompletion<'_>) {
@@ -528,11 +531,14 @@ impl ExecSetupWithStdout {
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
         kill_and_reap_child(child);
-        let _ =
+        let containment_result =
             cleanup_process_containment(process_containment, ProcessContainmentCleanupMode::Forced);
         join_stdin_writer_after_kill(stdin_writer);
         let _ = stdout_handle.join();
-        completion.wait_failed(diagnostic);
+        let containment_error = containment_result.as_ref().err().map(ToString::to_string);
+        let diagnostic =
+            append_containment_cleanup_failure(diagnostic, containment_error.as_deref());
+        completion.wait_failed(&diagnostic);
     }
 
     fn into_running(
@@ -697,16 +703,7 @@ fn resolve_exec_result(
     lifecycle: ExecOperationLifecycle,
     containment_error: Option<&str>,
 ) -> (ExecTermination, String) {
-    if lifecycle == ExecOperationLifecycle::OneShot
-        && let Some(error) = containment_error
-    {
-        return (
-            ExecTermination::WaitFailed,
-            format!("Failed to clean process containment: {error}"),
-        );
-    }
-
-    match outcome {
+    let (termination, diagnostic) = match outcome {
         WaitOutcome::Exited(status) => (
             ExecTermination::Exited {
                 exit_code: extract_exit_code(status),
@@ -719,6 +716,24 @@ fn resolve_exec_result(
             ExecTermination::WaitFailed,
             format!("Failed to wait: {msg}"),
         ),
+    };
+    if lifecycle == ExecOperationLifecycle::OneShot && containment_error.is_some() {
+        return (
+            ExecTermination::WaitFailed,
+            append_containment_cleanup_failure(&diagnostic, containment_error),
+        );
+    }
+    (termination, diagnostic)
+}
+
+fn append_containment_cleanup_failure(diagnostic: &str, containment_error: Option<&str>) -> String {
+    let Some(error) = containment_error else {
+        return diagnostic.to_string();
+    };
+    if diagnostic.is_empty() {
+        format!("Failed to clean process containment: {error}")
+    } else {
+        format!("{diagnostic}; failed to clean process containment: {error}")
     }
 }
 
@@ -1697,6 +1712,20 @@ mod tests {
 
         assert_eq!(termination, ExecTermination::WaitFailed);
         assert!(diagnostic.contains("Failed to clean process containment"));
+        assert!(diagnostic.contains("wait for cgroup.kill"));
+    }
+
+    #[test]
+    fn one_shot_containment_failure_preserves_wait_diagnostic() {
+        let (termination, diagnostic) = resolve_exec_result(
+            WaitOutcome::WaitFailed("wait observer failed".to_string()),
+            ExecOperationLifecycle::OneShot,
+            Some("wait for cgroup.kill: timed out"),
+        );
+
+        assert_eq!(termination, ExecTermination::WaitFailed);
+        assert!(diagnostic.contains("Failed to wait: wait observer failed"));
+        assert!(diagnostic.contains("failed to clean process containment"));
         assert!(diagnostic.contains("wait for cgroup.kill"));
     }
 

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -18,11 +18,10 @@ use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancel
 use crate::error::to_io_error;
 use crate::exec_control::ExecControlGuard;
 use crate::log::log;
-use crate::process::{
-    ProcessTreeKillTarget, extract_exit_code, kill_and_reap_child_with_target,
-    process_tree_kill_target, refresh_process_tree_kill_target,
+use crate::process::{extract_exit_code, kill_and_reap_child};
+use crate::process_containment::{
+    ExecProcessContainment, ProcessContainmentCleanupMode, ProcessContainmentError,
 };
-use crate::process_containment::SupervisedProcessContainment;
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
     SpawnedShellCommand, format_env_diagnostics, spawn_shell_command_with_pipes,
@@ -31,7 +30,7 @@ use crate::shell_command::{
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
     DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
-    wait_with_kill_timeout_or_cancelled_either_with_target,
+    wait_with_kill_timeout_or_cancelled_either,
 };
 use crate::writer::GuestWriter;
 
@@ -395,8 +394,7 @@ impl ExecCompletion<'_> {
 
 struct ExecSetup {
     child: Child,
-    kill_target: ProcessTreeKillTarget,
-    process_containment: Option<SupervisedProcessContainment>,
+    process_containment: ExecProcessContainment,
     stdin_writer: Option<StdinWriter>,
     drain_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
@@ -404,13 +402,11 @@ struct ExecSetup {
 }
 
 impl ExecSetup {
-    fn new(child: Child, process_containment: Option<SupervisedProcessContainment>) -> Self {
-        let kill_target = process_tree_kill_target(child.id());
+    fn new(child: Child, process_containment: ExecProcessContainment) -> Self {
         let drain_cancel = Arc::new(AtomicBool::new(false));
         let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
         Self {
             child,
-            kill_target,
             process_containment,
             stdin_writer: None,
             drain_cancel,
@@ -463,7 +459,6 @@ impl ExecSetup {
     ) {
         let ExecSetup {
             child,
-            kill_target,
             process_containment,
             stdin_writer,
             drain_cancel,
@@ -472,8 +467,9 @@ impl ExecSetup {
         } = self;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        kill_and_reap_child_with_target(child, kill_target);
-        cleanup_process_containment(process_containment);
+        kill_and_reap_child(child);
+        let _ =
+            cleanup_process_containment(process_containment, ProcessContainmentCleanupMode::Forced);
         join_stdin_writer_after_kill(stdin_writer);
         completion.wait_failed(diagnostic);
     }
@@ -482,15 +478,15 @@ impl ExecSetup {
         debug_assert!(self.stdin_writer.is_none());
         let ExecSetup {
             child,
-            kill_target,
             process_containment,
             stdin_writer: _,
             drain_cancel: _,
             drain_done_tx: _,
             drain_done_rx: _,
         } = self;
-        kill_and_reap_child_with_target(child, kill_target);
-        cleanup_process_containment(process_containment);
+        kill_and_reap_child(child);
+        let _ =
+            cleanup_process_containment(process_containment, ProcessContainmentCleanupMode::Forced);
         completion.release_without_result();
     }
 }
@@ -523,7 +519,6 @@ impl ExecSetupWithStdout {
         } = self;
         let ExecSetup {
             child,
-            kill_target,
             process_containment,
             stdin_writer,
             drain_cancel,
@@ -532,8 +527,9 @@ impl ExecSetupWithStdout {
         } = setup;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        kill_and_reap_child_with_target(child, kill_target);
-        cleanup_process_containment(process_containment);
+        kill_and_reap_child(child);
+        let _ =
+            cleanup_process_containment(process_containment, ProcessContainmentCleanupMode::Forced);
         join_stdin_writer_after_kill(stdin_writer);
         let _ = stdout_handle.join();
         completion.wait_failed(diagnostic);
@@ -551,7 +547,6 @@ impl ExecSetupWithStdout {
         } = self;
         let ExecSetup {
             child,
-            kill_target,
             process_containment,
             stdin_writer,
             drain_cancel,
@@ -562,7 +557,6 @@ impl ExecSetupWithStdout {
 
         RunningExec {
             child,
-            kill_target,
             process_containment,
             stdin_writer,
             stdout_handle,
@@ -577,8 +571,7 @@ impl ExecSetupWithStdout {
 
 struct RunningExec {
     child: Child,
-    kill_target: ProcessTreeKillTarget,
-    process_containment: Option<SupervisedProcessContainment>,
+    process_containment: ExecProcessContainment,
     stdin_writer: Option<StdinWriter>,
     stdout_handle: JoinHandle<()>,
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
@@ -598,7 +591,6 @@ impl RunningExec {
     ) {
         let RunningExec {
             child,
-            mut kill_target,
             process_containment,
             stdin_writer,
             stdout_handle,
@@ -609,7 +601,6 @@ impl RunningExec {
             drain_done_rx,
         } = self;
 
-        refresh_process_tree_kill_target(&mut kill_target);
         let prepare_stdin_writer_for_pre_reap = || {
             let Some(writer) = stdin_writer.as_ref() else {
                 return false;
@@ -621,20 +612,25 @@ impl RunningExec {
                 false
             }
         };
-        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
+        let outcome = wait_with_kill_timeout_or_cancelled_either(
             child,
-            kill_target,
             request.timeout.wait_timeout_ms(),
             connection_cancel,
             exec_cancel,
             prepare_stdin_writer_for_pre_reap,
         );
+        if let Some(writer) = stdin_writer.as_ref()
+            && matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty))
+        {
+            request_stdin_writer_cancel(writer);
+        }
+        let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome);
+        let containment_result = cleanup_process_containment(process_containment, cleanup_mode);
         join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
-        let containment_clean = cleanup_process_containment(process_containment);
         if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
             || connection_cancel.load(Ordering::Acquire)
             || exec_cancel.load(Ordering::Acquire)
-            || !containment_clean
+            || containment_result.is_err()
         {
             exec_cancel.store(true, Ordering::Release);
             drain_cancel.store(true, Ordering::Release);
@@ -657,20 +653,9 @@ impl RunningExec {
         let stdout_result = stdout_result_rx.recv().unwrap_or_default();
         let stderr_result = stderr_result_rx.recv().unwrap_or_default();
 
-        let (termination, diagnostic) = match outcome {
-            WaitOutcome::Exited(status) => (
-                ExecTermination::Exited {
-                    exit_code: extract_exit_code(status),
-                },
-                String::new(),
-            ),
-            WaitOutcome::TimedOut => (ExecTermination::TimedOut, String::new()),
-            WaitOutcome::Cancelled => (ExecTermination::Cancelled, String::new()),
-            WaitOutcome::WaitFailed(msg) => (
-                ExecTermination::WaitFailed,
-                format!("Failed to wait: {msg}"),
-            ),
-        };
+        let containment_error = containment_result.as_ref().err().map(ToString::to_string);
+        let (termination, diagnostic) =
+            resolve_exec_result(outcome, request.lifecycle, containment_error.as_deref());
 
         log_exec_terminal_if_notable(
             request,
@@ -690,11 +675,50 @@ impl RunningExec {
     }
 }
 
-fn cleanup_process_containment(process_containment: Option<SupervisedProcessContainment>) -> bool {
-    process_containment
-        .map(SupervisedProcessContainment::cleanup)
-        .transpose()
-        .is_ok()
+fn cleanup_mode_for_wait_outcome(outcome: &WaitOutcome) -> ProcessContainmentCleanupMode {
+    match outcome {
+        WaitOutcome::Exited(_) => ProcessContainmentCleanupMode::Graceful,
+        WaitOutcome::TimedOut | WaitOutcome::Cancelled | WaitOutcome::WaitFailed(_) => {
+            ProcessContainmentCleanupMode::Forced
+        }
+    }
+}
+
+fn resolve_exec_result(
+    outcome: WaitOutcome,
+    lifecycle: ExecOperationLifecycle,
+    containment_error: Option<&str>,
+) -> (ExecTermination, String) {
+    if lifecycle == ExecOperationLifecycle::OneShot
+        && let Some(error) = containment_error
+    {
+        return (
+            ExecTermination::WaitFailed,
+            format!("Failed to clean process containment: {error}"),
+        );
+    }
+
+    match outcome {
+        WaitOutcome::Exited(status) => (
+            ExecTermination::Exited {
+                exit_code: extract_exit_code(status),
+            },
+            String::new(),
+        ),
+        WaitOutcome::TimedOut => (ExecTermination::TimedOut, String::new()),
+        WaitOutcome::Cancelled => (ExecTermination::Cancelled, String::new()),
+        WaitOutcome::WaitFailed(msg) => (
+            ExecTermination::WaitFailed,
+            format!("Failed to wait: {msg}"),
+        ),
+    }
+}
+
+fn cleanup_process_containment(
+    process_containment: ExecProcessContainment,
+    mode: ProcessContainmentCleanupMode,
+) -> Result<(), ProcessContainmentError> {
+    process_containment.cleanup(mode)
 }
 
 pub(crate) fn start_exec_operation(
@@ -831,18 +855,14 @@ fn run_exec_operation_worker<S>(
     } else {
         env_refs.as_slice()
     };
-    let process_containment = if request.lifecycle == ExecOperationLifecycle::Supervised {
-        match SupervisedProcessContainment::create(request.seq) {
-            Ok(process_containment) => Some(process_containment),
-            Err(error) => {
-                completion.start_failed(&format!(
-                    "Failed to initialize supervised process containment: {error}"
-                ));
-                return;
-            }
+    let process_containment = match ExecProcessContainment::create(request.seq) {
+        Ok(process_containment) => process_containment,
+        Err(error) => {
+            completion.start_failed(&format!(
+                "Failed to initialize exec process containment: {error}"
+            ));
+            return;
         }
-    } else {
-        None
     };
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
@@ -1560,6 +1580,7 @@ mod tests {
     use std::net::Shutdown;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::os::unix::net::UnixStream;
+    use std::process::Command;
     use std::time::Duration;
 
     fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
@@ -1627,6 +1648,52 @@ mod tests {
             ExecTermination::TimedOut,
             &[124]
         ));
+    }
+
+    #[test]
+    fn wait_outcome_selects_containment_cleanup_mode() {
+        let status = Command::new("true").status().unwrap();
+        assert_eq!(
+            cleanup_mode_for_wait_outcome(&WaitOutcome::Exited(status)),
+            ProcessContainmentCleanupMode::Graceful
+        );
+        assert_eq!(
+            cleanup_mode_for_wait_outcome(&WaitOutcome::TimedOut),
+            ProcessContainmentCleanupMode::Forced
+        );
+        assert_eq!(
+            cleanup_mode_for_wait_outcome(&WaitOutcome::Cancelled),
+            ProcessContainmentCleanupMode::Forced
+        );
+        assert_eq!(
+            cleanup_mode_for_wait_outcome(&WaitOutcome::WaitFailed("wait failed".to_string())),
+            ProcessContainmentCleanupMode::Forced
+        );
+    }
+
+    #[test]
+    fn one_shot_containment_failure_overrides_terminal_result() {
+        let (termination, diagnostic) = resolve_exec_result(
+            WaitOutcome::TimedOut,
+            ExecOperationLifecycle::OneShot,
+            Some("wait for cgroup.kill: timed out"),
+        );
+
+        assert_eq!(termination, ExecTermination::WaitFailed);
+        assert!(diagnostic.contains("Failed to clean process containment"));
+        assert!(diagnostic.contains("wait for cgroup.kill"));
+    }
+
+    #[test]
+    fn supervised_containment_failure_preserves_terminal_result() {
+        let (termination, diagnostic) = resolve_exec_result(
+            WaitOutcome::TimedOut,
+            ExecOperationLifecycle::Supervised,
+            Some("wait for cgroup.kill: timed out"),
+        );
+
+        assert_eq!(termination, ExecTermination::TimedOut);
+        assert!(diagnostic.is_empty());
     }
 
     #[test]

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -624,7 +624,9 @@ impl RunningExec {
         {
             request_stdin_writer_cancel(writer);
         }
-        let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome);
+        let cancellation_observed =
+            connection_cancel.load(Ordering::Acquire) || exec_cancel.load(Ordering::Acquire);
+        let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome, cancellation_observed);
         let containment_result = cleanup_process_containment(process_containment, cleanup_mode);
         join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
         if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
@@ -675,7 +677,13 @@ impl RunningExec {
     }
 }
 
-fn cleanup_mode_for_wait_outcome(outcome: &WaitOutcome) -> ProcessContainmentCleanupMode {
+fn cleanup_mode_for_wait_outcome(
+    outcome: &WaitOutcome,
+    cancellation_observed: bool,
+) -> ProcessContainmentCleanupMode {
+    if cancellation_observed {
+        return ProcessContainmentCleanupMode::Forced;
+    }
     match outcome {
         WaitOutcome::Exited(_) => ProcessContainmentCleanupMode::Graceful,
         WaitOutcome::TimedOut | WaitOutcome::Cancelled | WaitOutcome::WaitFailed(_) => {
@@ -1654,19 +1662,27 @@ mod tests {
     fn wait_outcome_selects_containment_cleanup_mode() {
         let status = Command::new("true").status().unwrap();
         assert_eq!(
-            cleanup_mode_for_wait_outcome(&WaitOutcome::Exited(status)),
+            cleanup_mode_for_wait_outcome(&WaitOutcome::Exited(status), false),
             ProcessContainmentCleanupMode::Graceful
         );
         assert_eq!(
-            cleanup_mode_for_wait_outcome(&WaitOutcome::TimedOut),
+            cleanup_mode_for_wait_outcome(&WaitOutcome::TimedOut, false),
             ProcessContainmentCleanupMode::Forced
         );
         assert_eq!(
-            cleanup_mode_for_wait_outcome(&WaitOutcome::Cancelled),
+            cleanup_mode_for_wait_outcome(&WaitOutcome::Cancelled, false),
             ProcessContainmentCleanupMode::Forced
         );
         assert_eq!(
-            cleanup_mode_for_wait_outcome(&WaitOutcome::WaitFailed("wait failed".to_string())),
+            cleanup_mode_for_wait_outcome(
+                &WaitOutcome::WaitFailed("wait failed".to_string()),
+                false,
+            ),
+            ProcessContainmentCleanupMode::Forced
+        );
+        let status = Command::new("true").status().unwrap();
+        assert_eq!(
+            cleanup_mode_for_wait_outcome(&WaitOutcome::Exited(status), true),
             ProcessContainmentCleanupMode::Forced
         );
     }

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -248,7 +248,7 @@ mod tests {
         target_command.arg("60").process_group(0);
         let target = target_command.spawn().unwrap();
 
-        let unrelated = Command::new("setsid")
+        let mut unrelated = Command::new("setsid")
             .arg("sleep")
             .arg("60")
             .stdout(Stdio::null())
@@ -259,12 +259,19 @@ mod tests {
 
         kill_and_reap_child(target);
 
+        let unrelated_exit = wait_for_pidfd_exit(&unrelated_pidfd, Duration::from_millis(100));
+        let cleanup = kill_pidfd_and_wait(&unrelated_pidfd);
+        if cleanup.is_err() {
+            let _ = unrelated.kill();
+        }
+        let wait = unrelated.wait();
+
+        cleanup.unwrap();
+        wait.unwrap();
         assert!(
-            !wait_for_pidfd_exit(&unrelated_pidfd, Duration::from_millis(100)).unwrap(),
-            "direct child group cleanup must not signal an unrelated group"
+            matches!(unrelated_exit, Ok(false)),
+            "direct child group cleanup must not signal an unrelated group: {unrelated_exit:?}"
         );
-        kill_pidfd_and_wait(&unrelated_pidfd).unwrap();
-        let _ = unrelated.wait_with_output();
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -3,7 +3,7 @@ use std::process::{Child, Command, ExitStatus};
 
 use crate::log::log;
 
-/// Extract exit code from ExitStatus, mapping signals to 128 + signal number
+/// Extract exit code from ExitStatus, mapping signals to 128 + signal number.
 #[cfg(unix)]
 pub(crate) fn extract_exit_code(status: ExitStatus) -> i32 {
     use std::os::unix::process::ExitStatusExt;
@@ -33,23 +33,6 @@ pub(crate) fn spawn_in_own_process_group(command: &mut Command) -> io::Result<Ch
     }
 }
 
-/// Parse ppid and pgid from a `/proc/[pid]/stat` line.
-///
-/// Format: `"pid (comm) state ppid pgid session ..."` — the comm field can
-/// contain spaces and parentheses, so we locate the LAST `)` first.
-fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
-    let close_paren = stat.rfind(')')?;
-    if close_paren + 2 >= stat.len() {
-        return None;
-    }
-    let remainder = &stat[close_paren + 2..]; // skip ") "
-    let mut fields = remainder.split_whitespace();
-    fields.next()?; // state
-    let ppid = fields.next()?.parse().ok()?;
-    let pgid = fields.next()?.parse().ok()?;
-    Some((ppid, pgid))
-}
-
 pub(crate) fn process_signal_pid(pid: u32) -> Option<libc::pid_t> {
     let pid = libc::pid_t::try_from(pid).ok()?;
     (pid > 0).then_some(pid)
@@ -60,162 +43,43 @@ fn process_group_signal_pid(pgid: u32) -> Option<libc::pid_t> {
     (pgid > 1).then_some(-pgid)
 }
 
-fn signalable_child_pgid(child_id: u32, pgid: u32) -> Option<u32> {
-    (pgid != child_id && process_group_signal_pid(pgid).is_some()).then_some(pgid)
-}
-
-/// Find the process-group ID of a direct child of `parent_pid`.
-///
-/// In release builds, commands are wrapped in `su - user -c "..."`.
-/// `su` forks internally and the child calls `setsid()`, creating a new
-/// session and process group. `kill(-parent_pid, SIGKILL)` only reaches
-/// the `su` process's group — the child's group (where the actual command
-/// runs) is missed.
-///
-/// This function scans `/proc` to find that child and returns its distinct PGID
-/// so the timeout killer can send SIGKILL to both process groups. Same-group
-/// children are skipped because `kill(-parent_pid, SIGKILL)` already reaches
-/// them, and a later refresh can still capture a child that calls `setsid()`.
-///
-/// Must be called BEFORE killing the parent, because once the parent dies
-/// the child's PPID changes to 1 (init).
-fn find_child_pgid(parent_pid: u32) -> Option<u32> {
-    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
-        let name = entry.file_name();
-        let Ok(pid) = name.to_string_lossy().parse::<u32>() else {
-            continue;
-        };
-        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
-            continue;
-        };
-
-        let Some((ppid, pgid)) = parse_stat_ppid_pgid(&stat) else {
-            continue;
-        };
-
-        if ppid == parent_pid
-            && let Some(pgid) = signalable_child_pgid(parent_pid, pgid)
-        {
-            return Some(pgid);
-        }
-    }
-    None
-}
-
-pub(crate) struct ProcessTreeKillTarget {
-    child_id: u32,
-    child_pgid: Option<u32>,
-}
-
-impl ProcessTreeKillTarget {
-    pub(crate) fn child_id(&self) -> u32 {
-        self.child_id
-    }
-
-    fn child_pgid_to_signal(&self) -> Option<u32> {
-        self.child_pgid
-            .and_then(|pgid| signalable_child_pgid(self.child_id, pgid))
-    }
-}
-
-/// Snapshot process-tree kill targets while the direct child is still alive.
-///
-/// This preserves the process group created by `su - user` even if the direct
-/// child exits before a later cleanup path needs to signal lingering
-/// descendants that still hold stdio pipes.
-pub(crate) fn process_tree_kill_target(child_id: u32) -> ProcessTreeKillTarget {
-    ProcessTreeKillTarget {
-        child_id,
-        child_pgid: find_child_pgid(child_id),
-    }
-}
-
-/// Refresh a snapshotted process-tree target while the direct child may still
-/// have a distinct child session visible in `/proc`.
-pub(crate) fn refresh_process_tree_kill_target(target: &mut ProcessTreeKillTarget) {
-    if target.child_pgid_to_signal().is_none() {
-        target.child_pgid = find_child_pgid(target.child_id);
-    }
-}
-
-/// Kill a previously snapshotted process tree target.
+/// Kill the direct child's process group while its identity is still owned.
 ///
 /// # Safety
 ///
-/// `target.child_id` must come from a PID returned by `Command::spawn()`, and
-/// that direct child must not have been reaped since the target was captured.
-pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> bool {
-    // Kill the direct child's process group (the su wrapper).
-    let mut signalled = false;
-    if let Some(signal_pid) = process_group_signal_pid(target.child_id) {
+/// `child_id` must come from a direct child returned by `Command::spawn()`, and
+/// that child must not have been reaped. Keeping the child unreaped prevents
+/// its PID, and therefore its process-group ID, from being reused.
+pub(crate) unsafe fn kill_owned_child_process_group(child_id: u32) -> bool {
+    if let Some(signal_pid) = process_group_signal_pid(child_id) {
         let ret = unsafe { libc::kill(signal_pid, libc::SIGKILL) };
-        signalled = ret == 0;
         if ret != 0 {
-            let err = std::io::Error::last_os_error();
+            let err = io::Error::last_os_error();
             log(
                 "WARN",
-                &format!(
-                    "process-tree kill(-{}, SIGKILL) failed: {err}",
-                    target.child_id
-                ),
+                &format!("child-group kill(-{child_id}, SIGKILL) failed: {err}"),
             );
         }
+        ret == 0
     } else {
         log(
             "WARN",
-            &format!(
-                "process-tree kill skipped invalid process group id {}",
-                target.child_id
-            ),
+            &format!("child-group kill skipped invalid process group id {child_id}"),
         );
+        false
     }
-
-    // Kill the session/process group created by su's child after setsid().
-    // Skip if the child is in the same group (no setsid happened, e.g. debug builds).
-    // Guard pgid > 1: kill(0, sig) targets the caller's group, and kill(-1, sig)
-    // broadcasts to every process the caller may signal.
-    if let Some(pgid) = target.child_pgid_to_signal() {
-        let Some(signal_pid) = process_group_signal_pid(pgid) else {
-            return signalled;
-        };
-        let ret = unsafe { libc::kill(signal_pid, libc::SIGKILL) };
-        if ret == 0 {
-            signalled = true;
-        } else {
-            let err = std::io::Error::last_os_error();
-            log(
-                "WARN",
-                &format!("process-tree kill(-{pgid}, SIGKILL) for su child group failed: {err}"),
-            );
-        }
-    }
-
-    signalled
 }
 
-/// Kill the process tree for a spawned child and reap the direct child.
-pub(crate) fn kill_and_reap_child(child: Child) {
+/// Kill the direct child's process group and reap the direct child.
+pub(crate) fn kill_and_reap_child(mut child: Child) {
     let child_id = child.id();
-    let target = process_tree_kill_target(child_id);
-    kill_and_reap_child_with_target(child, target);
-}
-
-/// Kill a process tree using a previously snapshotted target and reap the
-/// direct child.
-pub(crate) fn kill_and_reap_child_with_target(mut child: Child, mut target: ProcessTreeKillTarget) {
-    // Signal before waiting. The direct child may already be a zombie while
-    // descendants still live in its process group; reaping first would release
-    // the child PID and lose the stable PGID we need for group cleanup.
     // SAFETY: child_id comes from a live `Child` returned by Command::spawn.
-    refresh_process_tree_kill_target(&mut target);
-    let child_id = target.child_id;
-    let tree_killed = unsafe { kill_process_tree_target(target) };
+    let group_killed = unsafe { kill_owned_child_process_group(child_id) };
     let child_killed = child.kill().is_ok();
-    let killed = tree_killed || child_killed;
-    if !killed {
+    if !group_killed && !child_killed {
         log(
             "WARN",
-            &format!("failed to signal process tree for child pid={child_id}"),
+            &format!("failed to signal child process group for pid={child_id}"),
         );
     }
 
@@ -228,7 +92,7 @@ pub(crate) fn kill_and_reap_child_with_target(mut child: Child, mut target: Proc
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -271,21 +135,6 @@ mod tests {
         path.exists()
     }
 
-    fn read_pid_file<T: std::str::FromStr>(path: &Path) -> Option<T> {
-        std::fs::read_to_string(path).ok()?.trim().parse().ok()
-    }
-
-    fn wait_for_pid_file<T: std::str::FromStr>(path: &Path, timeout: Duration) -> Option<T> {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            if let Some(pid) = read_pid_file(path) {
-                return Some(pid);
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        read_pid_file(path)
-    }
-
     #[test]
     fn extract_exit_code_success() {
         let status = Command::new("true").status().unwrap();
@@ -310,111 +159,10 @@ mod tests {
 
     #[test]
     fn extract_exit_code_signal_kill() {
-        // Kill a process with SIGKILL and verify 128 + 9 = 137
         let mut child = Command::new("sleep").arg("60").spawn().unwrap();
         unsafe { libc::kill(child.id() as i32, libc::SIGKILL) };
         let status = child.wait().unwrap();
         assert_eq!(extract_exit_code(status), 137);
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_normal() {
-        let stat = "42 (bash) S 10 42 42 0 -1 4194560 100 0 0 0 0 0 0 0 20 0 1 0 100 0 0\n";
-        assert_eq!(parse_stat_ppid_pgid(stat), Some((10, 42)));
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_comm_with_spaces() {
-        // comm can contain spaces and parens
-        let stat = "99 (Web Content (123)) S 50 99 99 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0\n";
-        assert_eq!(parse_stat_ppid_pgid(stat), Some((50, 99)));
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_setsid_child() {
-        // After setsid(): pgid (77) differs from parent's pgid
-        let stat = "77 (su) S 42 77 77 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0\n";
-        assert_eq!(parse_stat_ppid_pgid(stat), Some((42, 77)));
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_empty() {
-        assert_eq!(parse_stat_ppid_pgid(""), None);
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_truncated() {
-        // Only has closing paren, no fields after
-        assert_eq!(parse_stat_ppid_pgid("1 (x)"), None);
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_not_enough_fields() {
-        // Has state but no ppid/pgid
-        assert_eq!(parse_stat_ppid_pgid("1 (x) S\n"), None);
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_empty_comm() {
-        let stat = "1 () S 10 42 42 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n";
-        assert_eq!(parse_stat_ppid_pgid(stat), Some((10, 42)));
-    }
-
-    #[test]
-    fn parse_stat_ppid_pgid_no_closing_paren() {
-        assert_eq!(parse_stat_ppid_pgid("1 bash S 10 42 42"), None);
-    }
-
-    #[test]
-    fn child_pgid_to_signal_skips_reserved_and_self_targets() {
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: None
-            }
-            .child_pgid_to_signal(),
-            None
-        );
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: Some(0)
-            }
-            .child_pgid_to_signal(),
-            None
-        );
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: Some(1)
-            }
-            .child_pgid_to_signal(),
-            None
-        );
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: Some(42)
-            }
-            .child_pgid_to_signal(),
-            None
-        );
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: Some(43)
-            }
-            .child_pgid_to_signal(),
-            Some(43)
-        );
-        assert_eq!(
-            ProcessTreeKillTarget {
-                child_id: 42,
-                child_pgid: Some(i32::MAX as u32 + 1)
-            }
-            .child_pgid_to_signal(),
-            None
-        );
     }
 
     #[test]
@@ -464,7 +212,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn kill_and_reap_child_kills_group_after_direct_child_exits() {
+    fn kill_and_reap_child_kills_direct_child_group() {
         use std::io::{BufRead, BufReader};
         use std::os::unix::process::CommandExt;
 
@@ -489,6 +237,34 @@ mod tests {
             let _ = unsafe { libc::kill(background_pid, libc::SIGKILL) };
             panic!("background pid {background_pid} should have been killed");
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn direct_child_group_kill_does_not_signal_unrelated_group() {
+        use std::os::unix::process::CommandExt;
+
+        let mut target_command = Command::new("sleep");
+        target_command.arg("60").process_group(0);
+        let target = target_command.spawn().unwrap();
+
+        let unrelated = Command::new("setsid")
+            .arg("sleep")
+            .arg("60")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let unrelated_pidfd = open_pidfd(unrelated.id() as libc::pid_t).unwrap();
+
+        kill_and_reap_child(target);
+
+        assert!(
+            !wait_for_pidfd_exit(&unrelated_pidfd, Duration::from_millis(100)).unwrap(),
+            "direct child group cleanup must not signal an unrelated group"
+        );
+        kill_pidfd_and_wait(&unrelated_pidfd).unwrap();
+        let _ = unrelated.wait_with_output();
     }
 
     #[cfg(target_os = "linux")]
@@ -563,293 +339,6 @@ mod tests {
                 let cleanup = kill_pidfd_and_wait(&background_pidfd);
                 panic!(
                     "failed to wait for background pid {background_pid} exit: {e}; cleanup={cleanup:?}"
-                );
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn snapshotted_process_tree_target_kills_setsid_child_before_parent_reap() {
-        use std::io::{BufRead, BufReader, Write};
-        use std::os::unix::process::CommandExt;
-
-        let (dir, _guard) = temp_dir("snapshot-target");
-        let fifo = dir.join("parent-fifo");
-        let child_pid_path = dir.join("setsid-child-pid");
-
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "mkfifo \"$FIFO\"; \
-                 setsid sh -c 'printf %s \"$$\" > \"$CHILD_PID\"; printf \"ready\\n\"; sleep 60' & \
-                 read _ < \"$FIFO\"",
-            )
-            .env("FIFO", &fifo)
-            .env("CHILD_PID", &child_pid_path)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null());
-        command.process_group(0);
-
-        let mut child = Some(command.spawn().unwrap());
-        let stdout = child.as_mut().unwrap().stdout.take().unwrap();
-        let mut ready = String::new();
-        if let Err(e) = BufReader::new(stdout).read_line(&mut ready) {
-            kill_spawned_child(&mut child);
-            panic!("failed to read setsid child ready marker: {e}");
-        }
-        if ready != "ready\n" {
-            kill_spawned_child(&mut child);
-            panic!("setsid child should publish ready marker, got {ready:?}");
-        }
-        let child_pid_text = match std::fs::read_to_string(&child_pid_path) {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to read setsid child pid: {e}");
-            }
-        };
-        let child_pid: libc::pid_t = match child_pid_text.trim().parse() {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to parse setsid child pid {child_pid_text:?}: {e}");
-            }
-        };
-        if child_pid <= 0 {
-            kill_spawned_child(&mut child);
-            panic!("setsid child pid should be positive, got {child_pid}");
-        }
-        let child_pidfd = match open_pidfd(child_pid) {
-            Ok(pidfd) => pidfd,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to open pidfd for setsid child pid {child_pid}: {e}");
-            }
-        };
-
-        let target = process_tree_kill_target(child.as_ref().unwrap().id());
-        {
-            let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
-                Ok(writer) => writer,
-                Err(e) => {
-                    kill_spawned_child(&mut child);
-                    kill_pidfd_and_wait(&child_pidfd).unwrap_or_else(|cleanup| {
-                        panic!("fifo open failed: {e}; cleanup={cleanup}")
-                    });
-                    panic!("failed to open parent fifo: {e}");
-                }
-            };
-            if let Err(e) = writeln!(fifo_writer, "done") {
-                kill_spawned_child(&mut child);
-                kill_pidfd_and_wait(&child_pidfd)
-                    .unwrap_or_else(|cleanup| panic!("fifo write failed: {e}; cleanup={cleanup}"));
-                panic!("failed to release parent fifo: {e}");
-            }
-        }
-        let direct_child_id = child.as_ref().unwrap().id();
-        // SAFETY: zeroed siginfo_t is valid for waitid to fill.
-        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
-        // SAFETY: direct_child_id belongs to the test-owned direct child.
-        // WNOWAIT proves it exited without releasing its PID before signaling.
-        let waitid_result = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                direct_child_id as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOWAIT,
-            )
-        };
-        if waitid_result != 0 {
-            let waitid_error = std::io::Error::last_os_error();
-            kill_spawned_child(&mut child);
-            kill_pidfd_and_wait(&child_pidfd).unwrap_or_else(|cleanup| {
-                panic!("waitid failed: {waitid_error}; cleanup={cleanup}")
-            });
-            panic!("failed to observe parent shell exit: {waitid_error}");
-        }
-
-        // SAFETY: `target` came from the spawned shell, and WNOWAIT kept its
-        // direct-child identity owned and unreaped.
-        if !unsafe { kill_process_tree_target(target) } {
-            kill_spawned_child(&mut child);
-            kill_pidfd_and_wait(&child_pidfd)
-                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-            panic!("snapshotted target should signal at least one process group");
-        }
-
-        let status = match child.take().unwrap().wait() {
-            Ok(status) => status,
-            Err(e) => {
-                kill_pidfd_and_wait(&child_pidfd)
-                    .unwrap_or_else(|cleanup| panic!("parent wait failed: {e}; cleanup={cleanup}"));
-                panic!("failed to wait for parent shell: {e}");
-            }
-        };
-        if !status.success() {
-            kill_pidfd_and_wait(&child_pidfd)
-                .unwrap_or_else(|cleanup| panic!("parent exited with {status}; cleanup={cleanup}"));
-            panic!("parent shell should exit successfully, got {status}");
-        }
-
-        match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
-            Ok(true) => {}
-            Ok(false) => {
-                kill_pidfd_and_wait(&child_pidfd)
-                    .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-                panic!(
-                    "snapshotted target should terminate reparented setsid child pid {child_pid}"
-                );
-            }
-            Err(e) => {
-                let cleanup = kill_pidfd_and_wait(&child_pidfd);
-                panic!(
-                    "failed to wait for setsid child pid {child_pid} exit: {e}; cleanup={cleanup:?}"
-                );
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn refresh_process_tree_target_retries_same_group_child_pgid() {
-        use std::io::Write;
-        use std::os::unix::process::CommandExt;
-
-        let (dir, _guard) = temp_dir("refresh-same-group");
-        let fifo = dir.join("child-fifo");
-        let child_ready = dir.join("child-ready");
-        let direct_pid_path = dir.join("direct-child-pid");
-        let setsid_child_pid_path = dir.join("setsid-child-pid");
-        let child_script = dir.join("child.sh");
-        let parent_script = dir.join("parent.sh");
-
-        std::fs::write(
-            &child_script,
-            r#"#!/bin/sh
-exec 3<> "$FIFO"
-touch "$CHILD_READY"
-read _ <&3
-exec 3>&-
-exec setsid sh -c 'printf %s "$$" > "$SETSID_CHILD_PID"; sleep 60'
-"#,
-        )
-        .unwrap();
-        std::fs::write(
-            &parent_script,
-            r#"#!/bin/sh
-mkfifo "$FIFO"
-sh "$CHILD_SCRIPT" &
-echo $! > "$DIRECT_PID"
-wait
-"#,
-        )
-        .unwrap();
-
-        let mut command = Command::new("sh");
-        command
-            .arg(&parent_script)
-            .env("FIFO", &fifo)
-            .env("CHILD_READY", &child_ready)
-            .env("DIRECT_PID", &direct_pid_path)
-            .env("SETSID_CHILD_PID", &setsid_child_pid_path)
-            .env("CHILD_SCRIPT", &child_script)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
-        command.process_group(0);
-
-        let mut child = Some(command.spawn().unwrap());
-        let direct_pid: u32 = match wait_for_pid_file(&direct_pid_path, Duration::from_secs(2)) {
-            Some(pid) => pid,
-            None => {
-                kill_spawned_child(&mut child);
-                panic!("parent should publish same-group child pid before snapshot");
-            }
-        };
-        if !wait_for_path(&child_ready, Duration::from_secs(2)) {
-            kill_spawned_child(&mut child);
-            panic!("same-group child should block on fifo before snapshot");
-        }
-        let parent_pid = child.as_ref().unwrap().id();
-        let direct_stat = match std::fs::read_to_string(format!("/proc/{direct_pid}/stat")) {
-            Ok(stat) => stat,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to read direct child stat: {e}");
-            }
-        };
-        let direct_target = parse_stat_ppid_pgid(&direct_stat);
-        if direct_target != Some((parent_pid, parent_pid)) {
-            kill_spawned_child(&mut child);
-            panic!(
-                "direct child should initially share the parent process group, got {direct_target:?}"
-            );
-        }
-
-        let mut target = process_tree_kill_target(parent_pid);
-        {
-            let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
-                Ok(writer) => writer,
-                Err(e) => {
-                    kill_spawned_child(&mut child);
-                    panic!("failed to open child fifo: {e}");
-                }
-            };
-            if let Err(e) = writeln!(fifo_writer, "go") {
-                kill_spawned_child(&mut child);
-                panic!("failed to release child fifo: {e}");
-            }
-        }
-
-        let setsid_child_pid: libc::pid_t =
-            match wait_for_pid_file(&setsid_child_pid_path, Duration::from_secs(2)) {
-                Some(pid) => pid,
-                None => {
-                    kill_spawned_child(&mut child);
-                    panic!("setsid child should publish its pid before kill");
-                }
-            };
-        if setsid_child_pid <= 0 {
-            kill_spawned_child(&mut child);
-            panic!("setsid child pid should be positive, got {setsid_child_pid}");
-        }
-        let setsid_child_pidfd = match open_pidfd(setsid_child_pid) {
-            Ok(pidfd) => pidfd,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                // SAFETY: best-effort cleanup of a test-owned process.
-                let _ = unsafe { libc::kill(setsid_child_pid, libc::SIGKILL) };
-                panic!("failed to open pidfd for setsid child pid {setsid_child_pid}: {e}");
-            }
-        };
-
-        refresh_process_tree_kill_target(&mut target);
-        if !unsafe { kill_process_tree_target(target) } {
-            kill_spawned_child(&mut child);
-            kill_pidfd_and_wait(&setsid_child_pidfd)
-                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-            panic!("refreshed target should signal at least one process group");
-        }
-        if let Err(e) = child.take().unwrap().wait() {
-            kill_pidfd_and_wait(&setsid_child_pidfd)
-                .unwrap_or_else(|cleanup| panic!("parent wait failed: {e}; cleanup={cleanup}"));
-            panic!("failed to wait for killed parent shell: {e}");
-        }
-
-        match wait_for_pidfd_exit(&setsid_child_pidfd, Duration::from_secs(2)) {
-            Ok(true) => {}
-            Ok(false) => {
-                kill_pidfd_and_wait(&setsid_child_pidfd)
-                    .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-                panic!(
-                    "refresh should replace same-group child pgid and kill setsid child pid {setsid_child_pid}"
-                );
-            }
-            Err(e) => {
-                let cleanup = kill_pidfd_and_wait(&setsid_child_pidfd);
-                panic!(
-                    "failed to wait for setsid child pid {setsid_child_pid} exit: {e}; cleanup={cleanup:?}"
                 );
             }
         }

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -222,16 +222,15 @@ fn cleanup_cgroup(
 ) -> Result<CleanupReport, ProcessContainmentError> {
     let descendants_observed = match read_populated(group_path) {
         Ok(populated) => populated,
-        Err(error) if mode == ProcessContainmentCleanupMode::Forced => {
+        Err(error) => {
             log(
                 "WARN",
                 &format!(
-                    "exec process containment forced cleanup could not read populated state error={error}"
+                    "exec process containment cleanup could not read initial populated state mode={mode:?} error={error}"
                 ),
             );
             true
         }
-        Err(error) => return Err(error),
     };
     let mut cgroup_kill_used = false;
     let mut initial_members = 0;
@@ -252,10 +251,33 @@ fn cleanup_cgroup(
             }
         }
 
-        let _ = wait_until_empty(group_path, TERM_GRACE)?;
+        if let Err(error) = wait_until_empty(group_path, TERM_GRACE) {
+            log(
+                "WARN",
+                &format!(
+                    "exec process containment graceful wait could not read populated state error={error}"
+                ),
+            );
+        }
     }
 
-    if mode == ProcessContainmentCleanupMode::Forced || read_populated(group_path)? {
+    let remains_populated = if mode == ProcessContainmentCleanupMode::Forced {
+        true
+    } else {
+        match read_populated(group_path) {
+            Ok(populated) => populated,
+            Err(error) => {
+                log(
+                    "WARN",
+                    &format!(
+                        "exec process containment cleanup could not confirm empty state before cgroup.kill error={error}"
+                    ),
+                );
+                true
+            }
+        }
+    };
+    if remains_populated {
         fs::write(group_path.join(CGROUP_KILL_FILE), b"1")
             .map_err(|error| ProcessContainmentError::new("write cgroup.kill", error))?;
         cgroup_kill_used = true;
@@ -492,6 +514,19 @@ mod tests {
         fs::write(&kill_path, b"").unwrap();
 
         let error = cleanup_cgroup(group.path(), ProcessContainmentCleanupMode::Forced)
+            .expect_err("missing cgroup.events should leave cleanup unproven");
+
+        assert_eq!(error.stage, "read cgroup.events");
+        assert_eq!(fs::read(&kill_path).unwrap(), b"1");
+    }
+
+    #[test]
+    fn graceful_cleanup_attempts_cgroup_kill_when_events_are_unreadable() {
+        let group = tempfile::tempdir().unwrap();
+        let kill_path = group.path().join(CGROUP_KILL_FILE);
+        fs::write(&kill_path, b"").unwrap();
+
+        let error = cleanup_cgroup(group.path(), ProcessContainmentCleanupMode::Graceful)
             .expect_err("missing cgroup.events should leave cleanup unproven");
 
         assert_eq!(error.stage, "read cgroup.events");

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -76,9 +76,7 @@ impl ExecProcessContainment {
         // Host-side debug integration tests have no guest cgroup hierarchy.
         // A real guest, including a debug build, gets the hierarchy from
         // guest-init before vsock-guest starts and therefore uses cgroups.
-        if cfg!(feature = "test-support")
-            || (cfg!(debug_assertions) && !Path::new(EXEC_CGROUP_BASE_PATH).is_dir())
-        {
+        if use_test_noop_backend() {
             return Ok(Self {
                 backend: ContainmentBackend::TestNoop,
             });
@@ -113,6 +111,47 @@ impl ExecProcessContainment {
                 .map_err(|error| ProcessContainmentError::new("remove test cgroup", error)),
         }
     }
+}
+
+pub(crate) fn verify_exec_process_containment_empty() -> Result<(), ProcessContainmentError> {
+    if use_test_noop_backend() {
+        return Ok(());
+    }
+    verify_exec_process_containment_empty_in(Path::new(EXEC_CGROUP_BASE_PATH))
+}
+
+fn use_test_noop_backend() -> bool {
+    cfg!(feature = "test-support")
+        || (cfg!(debug_assertions) && !Path::new(EXEC_CGROUP_BASE_PATH).is_dir())
+}
+
+fn verify_exec_process_containment_empty_in(
+    base_path: &Path,
+) -> Result<(), ProcessContainmentError> {
+    for entry in fs::read_dir(base_path)
+        .map_err(|error| ProcessContainmentError::new("read exec cgroup base", error))?
+    {
+        let entry =
+            entry.map_err(|error| ProcessContainmentError::new("read exec cgroup entry", error))?;
+        if entry
+            .file_type()
+            .map_err(|error| ProcessContainmentError::new("inspect exec cgroup entry", error))?
+            .is_dir()
+        {
+            return Err(ProcessContainmentError::new(
+                "verify exec cgroup empty",
+                io::Error::other("exec operation cgroup remains after quiesce"),
+            ));
+        }
+    }
+
+    if read_populated(base_path)? {
+        return Err(ProcessContainmentError::new(
+            "verify exec cgroup empty",
+            io::Error::other("exec cgroup remains populated after quiesce"),
+        ));
+    }
+    Ok(())
 }
 
 impl CgroupGuard {
@@ -512,6 +551,37 @@ mod tests {
         assert_eq!(parse_populated("populated 1\nfrozen 0\n"), Some(true));
         assert_eq!(parse_populated("frozen 0\n"), None);
         assert_eq!(parse_populated("populated 2\n"), None);
+    }
+
+    #[test]
+    fn quiesce_accepts_empty_exec_cgroup_base() {
+        let base = tempfile::tempdir().unwrap();
+        fs::write(base.path().join(CGROUP_EVENTS_FILE), b"populated 0\n").unwrap();
+
+        verify_exec_process_containment_empty_in(base.path()).unwrap();
+    }
+
+    #[test]
+    fn quiesce_rejects_stale_exec_cgroup_leaf() {
+        let base = tempfile::tempdir().unwrap();
+        fs::write(base.path().join(CGROUP_EVENTS_FILE), b"populated 0\n").unwrap();
+        fs::create_dir(base.path().join("exec-stale")).unwrap();
+
+        let error = verify_exec_process_containment_empty_in(base.path())
+            .expect_err("stale operation leaf must reject quiesce");
+
+        assert_eq!(error.stage, "verify exec cgroup empty");
+    }
+
+    #[test]
+    fn quiesce_rejects_populated_exec_cgroup_base() {
+        let base = tempfile::tempdir().unwrap();
+        fs::write(base.path().join(CGROUP_EVENTS_FILE), b"populated 1\n").unwrap();
+
+        let error = verify_exec_process_containment_empty_in(base.path())
+            .expect_err("populated containment must reject quiesce");
+
+        assert_eq!(error.stage, "verify exec cgroup empty");
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use guest_contracts::process_containment::SUPERVISED_CGROUP_BASE_PATH;
+use guest_contracts::process_containment::EXEC_CGROUP_BASE_PATH;
 
 use crate::log::log;
 
@@ -23,8 +23,14 @@ const REMOVE_TIMEOUT: Duration = Duration::from_millis(250);
 
 static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(1);
 
-pub(crate) struct SupervisedProcessContainment {
+pub(crate) struct ExecProcessContainment {
     backend: ContainmentBackend,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProcessContainmentCleanupMode {
+    Graceful,
+    Forced,
 }
 
 enum ContainmentBackend {
@@ -65,13 +71,13 @@ impl ProcessContainmentError {
     }
 }
 
-impl SupervisedProcessContainment {
+impl ExecProcessContainment {
     pub(crate) fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
         // Host-side debug integration tests have no guest cgroup hierarchy.
         // A real guest, including a debug build, gets the hierarchy from
         // guest-init before vsock-guest starts and therefore uses cgroups.
         if cfg!(feature = "test-support")
-            || (cfg!(debug_assertions) && !Path::new(SUPERVISED_CGROUP_BASE_PATH).is_dir())
+            || (cfg!(debug_assertions) && !Path::new(EXEC_CGROUP_BASE_PATH).is_dir())
         {
             return Ok(Self {
                 backend: ContainmentBackend::TestNoop,
@@ -95,9 +101,12 @@ impl SupervisedProcessContainment {
         }
     }
 
-    pub(crate) fn cleanup(self) -> Result<(), ProcessContainmentError> {
+    pub(crate) fn cleanup(
+        self,
+        mode: ProcessContainmentCleanupMode,
+    ) -> Result<(), ProcessContainmentError> {
         match self.backend {
-            ContainmentBackend::Cgroup(guard) => guard.cleanup(),
+            ContainmentBackend::Cgroup(guard) => guard.cleanup(mode),
             ContainmentBackend::TestNoop => Ok(()),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(group_path) => fs::remove_dir(group_path)
@@ -108,7 +117,7 @@ impl SupervisedProcessContainment {
 
 impl CgroupGuard {
     fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
-        Self::create_in(Path::new(SUPERVISED_CGROUP_BASE_PATH), sequence)
+        Self::create_in(Path::new(EXEC_CGROUP_BASE_PATH), sequence)
     }
 
     fn create_in(base_path: &Path, sequence: u32) -> Result<Self, ProcessContainmentError> {
@@ -129,7 +138,7 @@ impl CgroupGuard {
                     log(
                         "ERROR",
                         &format!(
-                            "supervised process containment creation rollback failed group={group_name} original_stage={} original_error={} rollback_stage={} rollback_error={}",
+                            "exec process containment creation rollback failed group={group_name} original_stage={} original_error={} rollback_stage={} rollback_error={}",
                             original.stage, original.source, rollback.stage, rollback.source
                         ),
                     );
@@ -155,7 +164,7 @@ impl CgroupGuard {
         Ok(())
     }
 
-    fn cleanup(self) -> Result<(), ProcessContainmentError> {
+    fn cleanup(self, mode: ProcessContainmentCleanupMode) -> Result<(), ProcessContainmentError> {
         let started = Instant::now();
         let CgroupGuard {
             group_name,
@@ -165,13 +174,13 @@ impl CgroupGuard {
         } = self;
         drop(placement);
 
-        let result = cleanup_cgroup(&group_path);
+        let result = cleanup_cgroup(&group_path, mode);
         match result {
             Ok(report) => {
                 log(
                     "INFO",
                     &format!(
-                        "supervised process containment cleaned group={group_name} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
+                        "exec process containment cleaned group={group_name} mode={mode:?} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
                         report.descendants_observed,
                         report.cgroup_kill_used,
                         report.initial_members,
@@ -186,7 +195,7 @@ impl CgroupGuard {
                 log(
                     "ERROR",
                     &format!(
-                        "supervised process containment cleanup failed group={group_name} stage={} error={}",
+                        "exec process containment cleanup failed group={group_name} mode={mode:?} stage={} error={}",
                         error.stage, error.source
                     ),
                 );
@@ -196,6 +205,7 @@ impl CgroupGuard {
     }
 }
 
+#[derive(Debug)]
 struct CleanupReport {
     descendants_observed: bool,
     cgroup_kill_used: bool,
@@ -203,13 +213,28 @@ struct CleanupReport {
     graceful_errors: usize,
 }
 
-fn cleanup_cgroup(group_path: &Path) -> Result<CleanupReport, ProcessContainmentError> {
-    let descendants_observed = read_populated(group_path)?;
+fn cleanup_cgroup(
+    group_path: &Path,
+    mode: ProcessContainmentCleanupMode,
+) -> Result<CleanupReport, ProcessContainmentError> {
+    let descendants_observed = match read_populated(group_path) {
+        Ok(populated) => populated,
+        Err(error) if mode == ProcessContainmentCleanupMode::Forced => {
+            log(
+                "WARN",
+                &format!(
+                    "exec process containment forced cleanup could not read populated state error={error}"
+                ),
+            );
+            true
+        }
+        Err(error) => return Err(error),
+    };
     let mut cgroup_kill_used = false;
     let mut initial_members = 0;
     let mut graceful_errors = 0;
 
-    if descendants_observed {
+    if descendants_observed && mode == ProcessContainmentCleanupMode::Graceful {
         match read_member_pids(group_path) {
             Ok(pids) => {
                 initial_members = pids.len();
@@ -219,26 +244,26 @@ fn cleanup_cgroup(group_path: &Path) -> Result<CleanupReport, ProcessContainment
                 graceful_errors = 1;
                 log(
                     "WARN",
-                    &format!(
-                        "supervised process containment graceful enumeration failed error={error}"
-                    ),
+                    &format!("exec process containment graceful enumeration failed error={error}"),
                 );
             }
         }
 
-        if !wait_until_empty(group_path, TERM_GRACE)? {
-            fs::write(group_path.join(CGROUP_KILL_FILE), b"1")
-                .map_err(|error| ProcessContainmentError::new("write cgroup.kill", error))?;
-            cgroup_kill_used = true;
-            if !wait_until_empty(group_path, KILL_EMPTY_TIMEOUT)? {
-                return Err(ProcessContainmentError::new(
-                    "wait for cgroup.kill",
-                    io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        "cgroup remained populated after cgroup.kill",
-                    ),
-                ));
-            }
+        let _ = wait_until_empty(group_path, TERM_GRACE)?;
+    }
+
+    if mode == ProcessContainmentCleanupMode::Forced || read_populated(group_path)? {
+        fs::write(group_path.join(CGROUP_KILL_FILE), b"1")
+            .map_err(|error| ProcessContainmentError::new("write cgroup.kill", error))?;
+        cgroup_kill_used = true;
+        if !wait_until_empty(group_path, KILL_EMPTY_TIMEOUT)? {
+            return Err(ProcessContainmentError::new(
+                "wait for cgroup.kill",
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "cgroup remained populated after cgroup.kill",
+                ),
+            ));
         }
     }
 
@@ -458,6 +483,19 @@ mod tests {
     }
 
     #[test]
+    fn forced_cleanup_attempts_cgroup_kill_when_events_are_unreadable() {
+        let group = tempfile::tempdir().unwrap();
+        let kill_path = group.path().join(CGROUP_KILL_FILE);
+        fs::write(&kill_path, b"").unwrap();
+
+        let error = cleanup_cgroup(group.path(), ProcessContainmentCleanupMode::Forced)
+            .expect_err("missing cgroup.events should leave cleanup unproven");
+
+        assert_eq!(error.stage, "read cgroup.events");
+        assert_eq!(fs::read(&kill_path).unwrap(), b"1");
+    }
+
+    #[test]
     fn pre_exec_writes_child_into_open_placement_file() {
         let mut placement = tempfile::tempfile().unwrap();
         let child_fd: OwnedFd = placement.try_clone().unwrap().into();
@@ -493,7 +531,7 @@ mod tests {
         let base = tempfile::tempdir().unwrap();
         let group_path = base.path().join("exec-spawn-failure");
         fs::create_dir(&group_path).unwrap();
-        let containment = SupervisedProcessContainment {
+        let containment = ExecProcessContainment {
             backend: ContainmentBackend::TestDirectory(group_path.clone()),
         };
 
@@ -502,7 +540,7 @@ mod tests {
             &[],
             false,
             false,
-            Some(containment),
+            containment,
         );
         let Err(error) = result else {
             panic!("invalid command unexpectedly spawned");
@@ -518,7 +556,7 @@ mod tests {
         let group_path = base.path().join("exec-cleanup-failure");
         fs::create_dir(&group_path).unwrap();
         fs::write(group_path.join("blocker"), b"keep directory non-empty").unwrap();
-        let containment = SupervisedProcessContainment {
+        let containment = ExecProcessContainment {
             backend: ContainmentBackend::TestDirectory(group_path.clone()),
         };
 
@@ -527,7 +565,7 @@ mod tests {
             &[],
             false,
             false,
-            Some(containment),
+            containment,
         );
         let Err(error) = result else {
             panic!("invalid command unexpectedly spawned");

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -180,18 +180,25 @@ impl CgroupGuard {
         let result = cleanup_cgroup(&group_path, mode);
         match result {
             Ok(report) => {
-                log(
-                    "INFO",
-                    &format!(
-                        "exec process containment cleaned group={group_name} mode={mode:?} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
-                        report.descendants_observed,
-                        report.cgroup_kill_used,
-                        report.initial_members,
-                        report.graceful_errors,
-                        create_elapsed.as_micros(),
-                        started.elapsed().as_millis()
-                    ),
-                );
+                // Healthy exec cleanup is a hot path. Emit diagnostics
+                // only when containment had work beyond removing an empty leaf.
+                if report.descendants_observed
+                    || report.cgroup_kill_used
+                    || report.graceful_errors > 0
+                {
+                    log(
+                        "INFO",
+                        &format!(
+                            "exec process containment cleaned group={group_name} mode={mode:?} descendants_observed={} cgroup_kill_used={} initial_members={} graceful_errors={} create_us={} cleanup_ms={}",
+                            report.descendants_observed,
+                            report.cgroup_kill_used,
+                            report.initial_members,
+                            report.graceful_errors,
+                            create_elapsed.as_micros(),
+                            started.elapsed().as_millis()
+                        ),
+                    );
+                }
                 Ok(())
             }
             Err(error) => {

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use guest_contracts::process_containment::EXEC_CGROUP_BASE_PATH;
+use guest_contracts::process_containment::{EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX};
 
 use crate::log::log;
 
@@ -123,7 +123,10 @@ impl CgroupGuard {
     fn create_in(base_path: &Path, sequence: u32) -> Result<Self, ProcessContainmentError> {
         let started = Instant::now();
         let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
-        let group_name = format!("exec-{}-{sequence}-{id}", std::process::id());
+        let group_name = format!(
+            "{EXEC_CGROUP_NAME_PREFIX}{}-{sequence}-{id}",
+            std::process::id()
+        );
         let group_path = base_path.join(&group_name);
         fs::create_dir(&group_path)
             .map_err(|error| ProcessContainmentError::new("create cgroup", error))?;

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -32,7 +32,7 @@
 //! spawned operation. Callers must retain the guard while the shell wrapper may
 //! still need to open the script; dropping it too early can remove the script
 //! before bash reads it.
-//! `SpawnedShellCommand` also returns supervised process-containment ownership
+//! `SpawnedShellCommand` also returns exec process-containment ownership
 //! only after a successful spawn. Setup failures clean that containment before
 //! returning the original spawn error.
 
@@ -47,7 +47,7 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 use shell_quote::quote_shell_arg;
 
-use crate::process_containment::SupervisedProcessContainment;
+use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
@@ -157,7 +157,7 @@ pub(crate) struct PreparedShellCommand {
 pub(crate) struct SpawnedShellCommand {
     pub(crate) child: Child,
     pub(crate) env_script: Option<EnvScriptGuard>,
-    pub(crate) process_containment: Option<SupervisedProcessContainment>,
+    pub(crate) process_containment: ExecProcessContainment,
 }
 
 fn effective_uid() -> libc::uid_t {
@@ -557,7 +557,7 @@ pub(crate) fn spawn_shell_command_with_pipes(
     env: &[(&str, &str)],
     sudo: bool,
     pipe_stdin: bool,
-    process_containment: Option<SupervisedProcessContainment>,
+    process_containment: ExecProcessContainment,
 ) -> io::Result<SpawnedShellCommand> {
     let spawn_result = (|| -> io::Result<(Child, Option<EnvScriptGuard>)> {
         let PreparedShellCommand {
@@ -568,13 +568,11 @@ pub(crate) fn spawn_shell_command_with_pipes(
         if pipe_stdin {
             command.stdin(Stdio::piped());
         }
-        if let Some(process_containment) = process_containment.as_ref() {
-            process_containment
-                .configure_command(&mut command)
-                .map_err(|error| {
-                    io::Error::other(format!("process containment setup failed: {error}"))
-                })?;
-        }
+        process_containment
+            .configure_command(&mut command)
+            .map_err(|error| {
+                io::Error::other(format!("process containment setup failed: {error}"))
+            })?;
         let child = crate::process::spawn_in_own_process_group(&mut command)?;
         Ok((child, env_script))
     })();
@@ -586,9 +584,7 @@ pub(crate) fn spawn_shell_command_with_pipes(
             process_containment,
         }),
         Err(error) => {
-            if let Some(process_containment) = process_containment {
-                let _ = process_containment.cleanup();
-            }
+            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
             Err(error)
         }
     }

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -5,10 +5,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::process::{
-    ProcessTreeKillTarget, kill_and_reap_child_with_target, kill_process_tree_target,
-    process_signal_pid, process_tree_kill_target, refresh_process_tree_kill_target,
-};
+use crate::process::{kill_and_reap_child, kill_owned_child_process_group, process_signal_pid};
 use crate::threading::spawn_scoped_named;
 
 /// After the child process exits, continue draining stdout/stderr for this
@@ -65,32 +62,27 @@ pub(crate) fn await_drain_deadline(
 }
 
 /// Wait for `child` while observing its owning connection cancellation flag
-/// and allowing pre-reap process-tree cleanup after natural exit.
+/// and allowing direct-child-group cleanup before reap after natural exit.
 pub(crate) fn wait_with_kill_timeout_or_connection_cancelled(
     child: Child,
     timeout_ms: u32,
     connection_cancel: &AtomicBool,
     pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
-    let kill_target = process_tree_kill_target(child.id());
     wait_with_kill_timeout_or_cancelled_by(
         child,
-        kill_target,
         timeout_ms,
         || connection_cancel.load(Ordering::Acquire),
         pre_reap_cleanup,
     )
 }
 
-/// Wait for `child` while observing either cancel flag and using a kill target
-/// snapshotted before entering the wait path.
+/// Wait for `child` while observing either cancel flag.
 ///
 /// Exec operations have both connection-level cancellation and request-level
-/// cancellation, and they snapshot process-tree targets before stdio setup can
-/// introduce cleanup races.
-pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
+/// cancellation.
+pub(crate) fn wait_with_kill_timeout_or_cancelled_either(
     child: Child,
-    kill_target: ProcessTreeKillTarget,
     timeout_ms: u32,
     first_cancel: &AtomicBool,
     second_cancel: &AtomicBool,
@@ -98,7 +90,6 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
 ) -> WaitOutcome {
     wait_with_kill_timeout_or_cancelled_by(
         child,
-        kill_target,
         timeout_ms,
         || first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire),
         pre_reap_cleanup,
@@ -107,14 +98,11 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
 
 fn wait_with_kill_timeout_or_cancelled_by(
     mut child: Child,
-    mut kill_target: ProcessTreeKillTarget,
     timeout_ms: u32,
     is_cancelled: impl Fn() -> bool,
     mut pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
     let child_id = child.id();
-    debug_assert_eq!(kill_target.child_id(), child_id);
-    refresh_process_tree_kill_target(&mut kill_target);
     let deadline = if timeout_ms > 0 {
         let now = Instant::now();
         Some(
@@ -136,38 +124,36 @@ fn wait_with_kill_timeout_or_cancelled_by(
             Err(e) => {
                 // Without a non-reaping observer, natural exit cannot be
                 // distinguished safely from timeout/cancel before reap.
-                kill_and_reap_child_with_target(child, kill_target);
+                kill_and_reap_child(child);
                 return WaitOutcome::WaitFailed(format!("failed to spawn wait observer: {e}"));
             }
         };
 
-        let mut decision = wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled);
-        if matches!(&decision, WaitDecision::Kill(_)) {
-            refresh_process_tree_kill_target(&mut kill_target);
-            decision = apply_final_exit_priority(decision, &observed_rx);
-        }
+        let decision = apply_final_exit_priority(
+            wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled),
+            &observed_rx,
+        );
 
         match decision {
             WaitDecision::Exited => {
                 let observed = match observer.join() {
                     Ok(observed) => observed,
                     Err(panic) => {
-                        kill_and_reap_child_with_target(child, kill_target);
+                        kill_and_reap_child(child);
                         std::panic::resume_unwind(panic);
                     }
                 };
                 if let Err(e) = observed {
-                    kill_and_reap_child_with_target(child, kill_target);
+                    kill_and_reap_child(child);
                     return WaitOutcome::WaitFailed(format!(
                         "failed to observe child exit without reaping: {e}"
                     ));
                 }
 
                 if pre_reap_cleanup() {
-                    refresh_process_tree_kill_target(&mut kill_target);
                     // SAFETY: the exit observer used WNOWAIT, so this owner
                     // still holds the unreaped direct child identity.
-                    let _ = unsafe { kill_process_tree_target(kill_target) };
+                    let _ = unsafe { kill_owned_child_process_group(child_id) };
                 }
 
                 match child.wait() {
@@ -176,7 +162,7 @@ fn wait_with_kill_timeout_or_cancelled_by(
                 }
             }
             WaitDecision::Kill(reason) => {
-                let child_killed = kill_child(&mut child, kill_target);
+                let child_killed = kill_child(&mut child);
                 let observed = observer.join();
                 let status = child.wait();
 
@@ -285,99 +271,21 @@ fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
     }
 }
 
-fn kill_child(child: &mut Child, kill_target: ProcessTreeKillTarget) -> bool {
+fn kill_child(child: &mut Child) -> bool {
     // SAFETY: this owner has not reaped child, so its PID/process group cannot
-    // have been reused since the owner refreshed kill_target.
-    let tree_killed = unsafe { kill_process_tree_target(kill_target) };
+    // have been reused.
+    let group_killed = unsafe { kill_owned_child_process_group(child.id()) };
     let child_killed = child.kill().is_ok();
-    tree_killed || child_killed
+    group_killed || child_killed
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     #[cfg(target_os = "linux")]
-    use std::io::Write;
-    #[cfg(target_os = "linux")]
-    use std::os::unix::fs::PermissionsExt;
-    #[cfg(target_os = "linux")]
     use std::os::unix::process::CommandExt;
-    #[cfg(target_os = "linux")]
-    use std::path::{Path, PathBuf};
-    #[cfg(target_os = "linux")]
-    use std::process::Child;
     use std::process::{Command, Stdio};
     use std::sync::Arc;
-    #[cfg(target_os = "linux")]
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[cfg(target_os = "linux")]
-    use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
-
-    #[cfg(target_os = "linux")]
-    struct TempDirGuard(PathBuf);
-
-    #[cfg(target_os = "linux")]
-    impl Drop for TempDirGuard {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn temp_dir(label: &str) -> (PathBuf, TempDirGuard) {
-        let dir = std::env::temp_dir().join(format!(
-            "vsock-guest-{label}-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
-        let guard = TempDirGuard(dir.clone());
-        (dir, guard)
-    }
-
-    #[cfg(target_os = "linux")]
-    fn wait_for_path(path: &Path, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            if path.exists() {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        path.exists()
-    }
-
-    #[cfg(target_os = "linux")]
-    fn read_pid_file<T: std::str::FromStr>(path: &Path) -> Option<T> {
-        std::fs::read_to_string(path).ok()?.trim().parse().ok()
-    }
-
-    #[cfg(target_os = "linux")]
-    fn wait_for_pid_file<T: std::str::FromStr>(path: &Path, timeout: Duration) -> Option<T> {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            if let Some(pid) = read_pid_file(path) {
-                return Some(pid);
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        read_pid_file(path)
-    }
-
-    #[cfg(target_os = "linux")]
-    fn kill_spawned_child(child: &mut Option<Child>) {
-        if let Some(mut child) = child.take() {
-            let mut target = process_tree_kill_target(child.id());
-            refresh_process_tree_kill_target(&mut target);
-            let _ = kill_child(&mut child, target);
-            let _ = child.wait();
-        }
-    }
 
     #[test]
     fn fast_exit_wait_does_not_pay_cancel_poll_interval_per_child() {
@@ -451,20 +359,12 @@ mod tests {
             command.process_group(0);
         }
         let child = command.spawn().unwrap();
-        let kill_target = process_tree_kill_target(child.id());
-
         let cancel_thread = thread::spawn(move || {
             cancel_for_thread.store(true, Ordering::Release);
         });
 
-        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
-            child,
-            kill_target,
-            0,
-            &cancel,
-            &other_cancel,
-            || false,
-        );
+        let outcome =
+            wait_with_kill_timeout_or_cancelled_either(child, 0, &cancel, &other_cancel, || false);
         cancel_thread.join().unwrap();
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
@@ -485,11 +385,8 @@ mod tests {
             command.process_group(0);
         }
         let child = command.spawn().unwrap();
-        let kill_target = process_tree_kill_target(child.id());
-
-        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
+        let outcome = wait_with_kill_timeout_or_cancelled_either(
             child,
-            kill_target,
             30_000,
             &cancel,
             &other_cancel,
@@ -566,106 +463,5 @@ mod tests {
 
         assert!(cleanup_called);
         assert!(matches!(outcome, WaitOutcome::Exited(status) if status.success()));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn owner_kill_refreshes_stale_process_tree_target_before_signal() {
-        let (dir, _guard) = temp_dir("owner-kill-refresh");
-        let fifo = dir.join("parent-fifo");
-        let ready = dir.join("ready");
-        let child_pid_path = dir.join("setsid-child-pid");
-
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "mkfifo \"$FIFO\"; \
-                 exec 3<> \"$FIFO\"; \
-                 : > \"$READY\"; \
-                 read _ <&3; \
-                 exec 3>&-; \
-                 setsid sh -c 'printf %s \"$$\" > \"$CHILD_PID\"; sleep 60' & \
-                 wait",
-            )
-            .env("FIFO", &fifo)
-            .env("READY", &ready)
-            .env("CHILD_PID", &child_pid_path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
-        command.process_group(0);
-
-        let mut child = Some(command.spawn().unwrap());
-        if !wait_for_path(&ready, Duration::from_secs(2)) {
-            kill_spawned_child(&mut child);
-            panic!("parent should block before spawning the setsid child");
-        }
-
-        let stale_target = process_tree_kill_target(child.as_ref().unwrap().id());
-        {
-            let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
-                Ok(writer) => writer,
-                Err(e) => {
-                    kill_spawned_child(&mut child);
-                    panic!("failed to open parent fifo: {e}");
-                }
-            };
-            if let Err(e) = writeln!(fifo_writer, "go") {
-                kill_spawned_child(&mut child);
-                panic!("failed to write parent fifo: {e}");
-            }
-        }
-
-        let child_pid: libc::pid_t =
-            match wait_for_pid_file(&child_pid_path, Duration::from_secs(2)) {
-                Some(pid) => pid,
-                None => {
-                    let child_pid_text =
-                        std::fs::read_to_string(&child_pid_path).unwrap_or_default();
-                    kill_spawned_child(&mut child);
-                    panic!("failed to parse setsid child pid {child_pid_text:?}");
-                }
-            };
-        if child_pid <= 0 {
-            kill_spawned_child(&mut child);
-            panic!("setsid child pid should be positive, got {child_pid}");
-        }
-        let child_pidfd = match open_pidfd(child_pid) {
-            Ok(pidfd) => pidfd,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                // SAFETY: best-effort cleanup of a test-owned process.
-                let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
-                panic!("failed to open pidfd for setsid child pid {child_pid}: {e}");
-            }
-        };
-
-        let mut refreshed_target = stale_target;
-        refresh_process_tree_kill_target(&mut refreshed_target);
-        let child_killed = kill_child(child.as_mut().unwrap(), refreshed_target);
-        if !child_killed {
-            kill_spawned_child(&mut child);
-            kill_pidfd_and_wait(&child_pidfd)
-                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-            panic!("owner kill should signal at least one process target");
-        }
-        let _ = child.take().unwrap().wait().unwrap();
-
-        match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
-            Ok(true) => {}
-            Ok(false) => {
-                kill_pidfd_and_wait(&child_pidfd)
-                    .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-                panic!(
-                    "owner kill should terminate delayed setsid child pid {child_pid} after refreshing stale target"
-                );
-            }
-            Err(e) => {
-                let cleanup = kill_pidfd_and_wait(&child_pidfd);
-                panic!(
-                    "failed to wait for delayed setsid child pid {child_pid} exit: {e}; cleanup={cleanup:?}"
-                );
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary

- place both one-shot and supervised exec operations in dedicated cgroup v2 leaves under the shared `vm0-exec` hierarchy
- remove `/proc` descendant process-group discovery and limit raw group signaling to the still-owned direct child group
- run graceful containment cleanup after normal exits and immediate `cgroup.kill` cleanup after timeout, cancellation, setup, or wait failures, before output-drain completion
- fail one-shot operations with `WaitFailed` when containment cleanup cannot be proven, while preserving supervised terminal results and reuse rejection behavior
- make reuse preparation recognize only its own active exec leaf while rejecting direct base membership and every other stale operation leaf
- revalidate that the entire exec containment tree is empty at the race-free guest quiesce boundary before parking
- preserve primary wait/setup diagnostics when containment cleanup also fails, and still attempt authoritative kill when graceful state reads fail
- avoid per-exec stderr churn by emitting cleanup metrics only when descendants or forced cleanup require attention

## User impact

Exec cleanup no longer caches or later signals descendant process-group IDs that may have been reused by unrelated work. Descendants that escape the direct child group remain owned by the operation cgroup and are terminated without using an unstable PGID. A completed one-shot exec now owns and reclaims detached descendants; intentionally long-lived work continues to use the supervised exec API.

## Scope

- Renames the guest containment base from `vm0-supervised` to `vm0-exec` across the embedded guest components.
- Keeps the write-file helper on its trusted direct-child process group.
- Does not change the vsock protocol, database schema, persisted data, or public API.
- Adds production-like runner behavior coverage for both supervised cleanup and ordinary one-shot cleanup through the release `su` boundary.
- Verifies the exact completed operation leaf so concurrent live exec leaves remain valid.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-contracts -p guest-init -p vsock-guest -p guest-agent`
- `cargo clippy -p guest-contracts -p guest-init -p vsock-guest -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets -- -D warnings`
- `cargo doc -p guest-contracts -p guest-init -p vsock-guest -p guest-agent --all-features --no-deps`
- `bash -n` and `shellcheck` for the affected runner behavior scripts

Closes #22003

