### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -533,11 +533,12 @@ sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c '
   "$pg_bin/pg_ctl" -D /tmp/pgdata -l /tmp/pgdata/log -o "-c listen_addresses=localhost" -w -t 30 start
   pg_isready -h localhost
   [ "$(psql -h localhost -d postgres -Atc "select 1")" = "1" ]
+  psql -h localhost -d postgres -v ON_ERROR_STOP=1 -c "CREATE EXTENSION vector"
   "$pg_bin/pg_ctl" -D /tmp/pgdata stop
   pg_started=0
 ' \
-  || { sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL start"; }
-echo "  PostgreSQL start/stop: ok"
+  || { sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL/pgvector smoke test"; }
+echo "  PostgreSQL/pgvector smoke test: ok"
 echo "PASS: runtime availability"
 
 # Test 7: verify /etc/environment is loaded for both user and root

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -357,7 +357,7 @@ install_packages() {
     php php-cli php-common php-curl php-mbstring php-xml php-zip \
     default-jdk maven gradle \
     gcc g++ clang make cmake \
-    postgresql-18 postgresql-contrib-18 \
+    postgresql-18 postgresql-contrib-18 postgresql-18-pgvector \
     redis-server \
     gh
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -337,6 +337,7 @@ fi
 check_bin "/usr/lib/postgresql/*/bin/postgres" "PostgreSQL server"
 check_bin "/usr/lib/postgresql/*/bin/initdb"   "PostgreSQL initdb"
 check_bin "/usr/lib/postgresql/*/bin/pg_ctl"   "PostgreSQL pg_ctl"
+check_bin "/usr/share/postgresql/*/extension/vector.control" "pgvector extension"
 
 if [[ -f "${MOUNT_DIR}/usr/bin/redis-server" ]]; then
   echo "  redis-server: found"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -512,6 +512,20 @@ wait
     }
 
     #[test]
+    fn template_installs_and_verifies_pgvector() {
+        assert!(
+            template_build_installs_apt_package("postgresql-18-pgvector"),
+            "build-template.sh should install pgvector into sandbox templates"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(
+                r#"check_bin "/usr/share/postgresql/*/extension/vector.control" "pgvector extension""#
+            ),
+            "verify-rootfs.sh should verify pgvector is present in sandbox images"
+        );
+    }
+
+    #[test]
     fn verify_script_checks_sandbox_helper_runtime_commands() {
         assert!(
             VERIFY_SCRIPT.contains("resolve_rootfs_path()"),


### PR DESCRIPTION
## Summary

- Add pgvector to the runner RootFS template: not installed -> `postgresql-18-pgvector` (currently `0.8.5-1.pgdg24.04+1` in PGDG for amd64 and arm64).
- Verify the pgvector extension control file is present when validating template and RootFS images.
- Extend the runner behavior smoke test to start PostgreSQL and run `CREATE EXTENSION vector`.

The extension package is preinstalled, but pgvector is not enabled automatically in user databases.

## Verification

- `bash -n .github/scripts/runner-behavior-exec.sh crates/runner/scripts/build-template.sh crates/runner/scripts/verify-rootfs.sh`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `git diff --check`
- Confirmed the PGDG Noble repository publishes `postgresql-18-pgvector` for amd64 and arm64.

The targeted runner test binary was type-checked by Clippy, but local test linking could not complete within this runtime's 3.8 GiB memory limit (`rustc` was terminated with SIGKILL). The PR pipeline will run the full test and RootFS smoke coverage.
