### PR TITLE
perf(guest-agent): bound cli event delivery buffering

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -20,7 +20,7 @@ use super::codex_app_server::{
     CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, ServerNotification,
 };
 use super::codex_app_server_events::{IGNORED_NOTIFICATION_METHODS, notification_to_codex_event};
-use super::event_delivery::{PreparedEvent, run_event_sender};
+use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
     CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
     LOG_TAG, ParsedEventAction, command,
@@ -50,7 +50,7 @@ struct EventIngestSink<'a> {
     log_file: &'a mut tokio::fs::File,
     masker: &'a SecretMasker,
     should_send_events: bool,
-    event_tx: &'a tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+    event_tx: &'a EventDeliverySender,
 }
 
 struct CodexTurnScope<'a> {
@@ -72,41 +72,27 @@ pub(super) async fn execute_codex_app_server_for_runtime(
 ) -> Result<CliExecutionResult, AgentError> {
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
-    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let should_send_events = http.has_api();
-    let event_sender = tokio::spawn(run_event_sender(
-        event_rx,
-        http.clone(),
-        runtime.event_error_flag.to_string(),
-    ));
+    let event_delivery =
+        EventDeliveryRuntime::start(http.clone(), runtime.event_error_flag.to_string());
 
     let run_result = run_codex_app_server(
         masker,
         &mut heartbeat_monitor,
         should_send_events,
-        &event_tx,
+        event_delivery.sender(),
         active_input,
         runtime,
     )
     .await;
 
-    drop(event_tx);
-
     match run_result {
         Ok(mut result) => {
-            match event_sender.await {
-                Ok(sequence) => {
-                    result.last_event_sequence = sequence;
-                }
-                Err(error) => {
-                    log_warn!(LOG_TAG, "Event sender task failed: {error}");
-                }
-            }
+            result.last_event_sequence = event_delivery.finish().await?;
             Ok(result)
         }
         Err(error) => {
-            event_sender.abort();
-            let _ = event_sender.await;
+            event_delivery.abort().await;
             Err(error)
         }
     }
@@ -116,7 +102,7 @@ async fn run_codex_app_server(
     masker: &SecretMasker,
     heartbeat_monitor: &mut HeartbeatMonitor,
     should_send_events: bool,
-    event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+    event_tx: &EventDeliverySender,
     mut active_input: ActiveInputWriter,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
@@ -810,8 +796,12 @@ async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<()
             if let Some(text) = codex_agent_message_text(&event) {
                 println!("{}", sink.masker.mask_string(text));
             }
-            sink.ingestor
-                .enqueue_event(event, sink.masker, sink.should_send_events, sink.event_tx);
+            sink.ingestor.enqueue_event(
+                event,
+                sink.masker,
+                sink.should_send_events,
+                sink.event_tx,
+            )?;
         }
         ParsedEventAction::Skip => {}
     }

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -3,15 +3,140 @@
 //! Event schema transformation and HTTP retry details stay in `events` and
 //! `http`; this module owns ordered background delivery shared by CLI backends.
 
+use crate::error::AgentError;
 use crate::events;
 use crate::http::HttpClient;
 use guest_common::log_warn;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
+use tokio::task::JoinHandle;
 
 use super::LOG_TAG;
 
-pub(super) struct PreparedEvent {
-    pub(super) sequence: u32,
-    pub(super) payload: serde_json::Value,
+const EVENT_DELIVERY_QUEUE_CAPACITY: usize = 128;
+const EVENT_DELIVERY_MAX_BYTES: usize = 16 * 1024 * 1024;
+const EVENT_DELIVERY_DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
+
+struct PreparedEvent {
+    sequence: u32,
+    payload: serde_json::Value,
+    _byte_budget: OwnedSemaphorePermit,
+}
+
+pub(super) struct EventDeliverySender {
+    tx: mpsc::Sender<PreparedEvent>,
+    byte_budget: Arc<Semaphore>,
+}
+
+impl EventDeliverySender {
+    pub(super) fn try_send(
+        &self,
+        sequence: u32,
+        payload: serde_json::Value,
+    ) -> Result<(), AgentError> {
+        let payload_bytes = serialized_size(&payload)?;
+        if payload_bytes > EVENT_DELIVERY_MAX_BYTES {
+            return Err(AgentError::Execution(format!(
+                "CLI event delivery payload at sequence {sequence} is {payload_bytes} bytes, exceeding the {EVENT_DELIVERY_MAX_BYTES}-byte buffer limit"
+            )));
+        }
+
+        let available_bytes = self.byte_budget.available_permits();
+        let byte_budget = Arc::clone(&self.byte_budget)
+            .try_acquire_many_owned(payload_bytes as u32)
+            .map_err(|_| {
+                AgentError::Execution(format!(
+                    "CLI event delivery byte buffer exhausted at sequence {sequence}: payload is {payload_bytes} bytes, {available_bytes} of {EVENT_DELIVERY_MAX_BYTES} bytes available"
+                ))
+            })?;
+        let prepared = PreparedEvent {
+            sequence,
+            payload,
+            _byte_budget: byte_budget,
+        };
+
+        match self.tx.try_send(prepared) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(AgentError::Execution(format!(
+                "CLI event delivery queue exceeded {EVENT_DELIVERY_QUEUE_CAPACITY} pending events at sequence {sequence}"
+            ))),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(AgentError::Execution(format!(
+                "CLI event delivery worker stopped before sequence {sequence} could be queued"
+            ))),
+        }
+    }
+}
+
+pub(super) struct EventDeliveryRuntime {
+    sender: EventDeliverySender,
+    worker: JoinHandle<Option<u32>>,
+}
+
+impl EventDeliveryRuntime {
+    pub(super) fn start(http: HttpClient, event_error_flag: String) -> Self {
+        let (tx, event_rx) = mpsc::channel(EVENT_DELIVERY_QUEUE_CAPACITY);
+        let sender = EventDeliverySender {
+            tx,
+            byte_budget: Arc::new(Semaphore::new(EVENT_DELIVERY_MAX_BYTES)),
+        };
+        let worker = tokio::spawn(run_event_sender(event_rx, http, event_error_flag));
+        Self { sender, worker }
+    }
+
+    pub(super) fn sender(&self) -> &EventDeliverySender {
+        &self.sender
+    }
+
+    pub(super) async fn finish(self) -> Result<Option<u32>, AgentError> {
+        let Self { sender, mut worker } = self;
+        drop(sender);
+
+        match tokio::time::timeout(EVENT_DELIVERY_DRAIN_TIMEOUT, &mut worker).await {
+            Ok(Ok(sequence)) => Ok(sequence),
+            Ok(Err(error)) => Err(AgentError::Execution(format!(
+                "CLI event delivery worker failed: {error}"
+            ))),
+            Err(_) => {
+                worker.abort();
+                let _ = worker.await;
+                Err(AgentError::Execution(format!(
+                    "CLI event delivery did not drain within {} seconds",
+                    EVENT_DELIVERY_DRAIN_TIMEOUT.as_secs()
+                )))
+            }
+        }
+    }
+
+    pub(super) async fn abort(self) {
+        let Self { sender, worker } = self;
+        drop(sender);
+        worker.abort();
+        let _ = worker.await;
+    }
+}
+
+#[derive(Default)]
+struct SerializedSize {
+    bytes: usize,
+}
+
+impl Write for SerializedSize {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buffer.len());
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_size(payload: &serde_json::Value) -> Result<usize, AgentError> {
+    let mut size = SerializedSize::default();
+    serde_json::to_writer(&mut size, payload)?;
+    Ok(size.bytes)
 }
 
 #[derive(Default)]
@@ -46,13 +171,16 @@ impl AckedEventPrefix {
     }
 }
 
-pub(super) async fn run_event_sender(
-    mut event_rx: tokio::sync::mpsc::UnboundedReceiver<PreparedEvent>,
+async fn run_event_sender(
+    mut event_rx: mpsc::Receiver<PreparedEvent>,
     http: HttpClient,
     event_error_flag: String,
 ) -> Option<u32> {
     let mut acked_prefix = AckedEventPrefix::default();
-    while let Some(PreparedEvent { sequence, payload }) = event_rx.recv().await {
+    while let Some(PreparedEvent {
+        sequence, payload, ..
+    }) = event_rx.recv().await
+    {
         match events::post_event_with_error_flag(&http, &payload, &event_error_flag).await {
             Ok(()) => {
                 acked_prefix.record_success(sequence);

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -44,7 +44,7 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
-use event_delivery::{PreparedEvent, run_event_sender};
+use event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
@@ -509,26 +509,16 @@ impl CliEventIngestor {
         event: serde_json::Value,
         masker: &SecretMasker,
         should_send_events: bool,
-        event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
-    ) {
+        event_tx: &EventDeliverySender,
+    ) -> Result<(), AgentError> {
+        let sequence = self.seq;
+        self.seq += 1;
         if should_send_events {
             let payload =
-                events::prepare_event_payload_for_run_id(event, self.seq, masker, &self.run_id);
-            if event_tx
-                .send(PreparedEvent {
-                    sequence: self.seq,
-                    payload,
-                })
-                .is_err()
-            {
-                log_warn!(
-                    LOG_TAG,
-                    "Event channel closed, dropping event seq={}",
-                    self.seq
-                );
-            }
+                events::prepare_event_payload_for_run_id(event, sequence, masker, &self.run_id);
+            event_tx.try_send(sequence, payload)?;
         }
-        self.seq += 1;
+        Ok(())
     }
 
     fn last_read_event_at(&self) -> Option<Instant> {
@@ -754,16 +744,12 @@ async fn execute_cli_inner(
     // MAINTENANCE: update if Claude Code adds new network tools that can hang.
     const STUCK_TOOL_NAMES: &[&str] = &["WebSearch", "WebFetch"];
 
-    // Background event sender: HTTP POSTs happen here, never in the
-    // stdout reading loop.  Unbounded channel because events are small
-    // and CLI lifetime is bounded by JOB_TIMEOUT.
-    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
-    let should_send_events = http.has_api();
-    let event_sender = tokio::spawn(run_event_sender(
-        event_rx,
-        http.clone(),
-        runtime.event_error_flag.to_string(),
-    ));
+    // Background event sender: HTTP POSTs happen here, never in the stdout
+    // reading loop. Admission is non-blocking and bounded by count and bytes;
+    // overload enters controlled CLI termination rather than blocking stdout.
+    let mut should_send_events = http.has_api();
+    let event_delivery =
+        EventDeliveryRuntime::start(http.clone(), runtime.event_error_flag.to_string());
 
     let mut heartbeat_done = false;
     let mut cli_exit_at: Option<Instant> = None;
@@ -954,7 +940,24 @@ async fn execute_cli_inner(
                             );
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
-                            event_ingestor.enqueue_event(event, masker, should_send_events, &event_tx);
+                            if let Err(error) = event_ingestor.enqueue_event(
+                                event,
+                                masker,
+                                should_send_events,
+                                event_delivery.sender(),
+                            ) {
+                                should_send_events = false;
+                                if cli_status.is_some() {
+                                    break Err(error);
+                                }
+                                let error_log = error.to_string();
+                                termination_runtime.begin_control_failure(
+                                    TerminationReason::EventDelivery,
+                                    error,
+                                    ControlTerminationLog::EventDeliveryFailed { error: error_log },
+                                    termination_deadline.as_mut(),
+                                );
+                            }
                         } else {
                             CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes()).await;
                         }
@@ -1143,25 +1146,14 @@ async fn execute_cli_inner(
         event_result.err()
     };
 
-    // Close the channel so the background sender can finish.
-    // On error (e.g. heartbeat failure) the server is likely unreachable,
-    // so we drop unsent events to avoid stalling on retries.
-    drop(event_tx);
-    let mut last_event_sequence = None;
-    if event_error.is_none() && !has_control_error {
-        match event_sender.await {
-            Ok(sequence) => {
-                last_event_sequence = sequence;
-            }
-            Err(e) => {
-                log_warn!(LOG_TAG, "Event sender task failed: {e}");
-            }
-        }
+    // On success, boundedly drain accepted events. On any execution or
+    // control error, abort unsent delivery rather than stalling on retries.
+    let delivery_result = if event_error.is_none() && !has_control_error {
+        event_delivery.finish().await
     } else {
-        event_sender.abort();
-        let _ = event_sender.await;
-    }
-
+        event_delivery.abort().await;
+        Ok(None)
+    };
     let status = match cli_status {
         Some(s) => s,
         None => {
@@ -1214,6 +1206,7 @@ async fn execute_cli_inner(
     if let Some(err) = event_error {
         return Err(err);
     }
+    let last_event_sequence = delivery_result?;
 
     Ok(CliExecutionResult {
         exit_code,

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -69,6 +69,7 @@ pub(super) enum TerminationReason {
     StuckTool,
     HeartbeatError,
     HeartbeatPanic,
+    EventDelivery,
 }
 
 impl TerminationReason {
@@ -79,6 +80,7 @@ impl TerminationReason {
             TerminationReason::StuckTool => "stuck-tool watchdog",
             TerminationReason::HeartbeatError => "heartbeat error",
             TerminationReason::HeartbeatPanic => "heartbeat panic",
+            TerminationReason::EventDelivery => "event delivery",
         }
     }
 }
@@ -222,6 +224,7 @@ pub(super) enum ControlTerminationLog {
     HeartbeatFailed,
     HeartbeatTaskPanicked,
     HeartbeatStoppedBeforeStatus,
+    EventDeliveryFailed { error: String },
 }
 
 impl ControlTerminationLog {
@@ -255,6 +258,12 @@ impl ControlTerminationLog {
                 log_warn!(
                     LOG_TAG,
                     "Heartbeat task stopped before reporting status, SIGTERM pgid={pgid}"
+                );
+            }
+            Self::EventDeliveryFailed { error } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Event delivery failed, SIGTERM pgid={pgid}: {error}"
                 );
             }
         }
@@ -560,6 +569,7 @@ fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTermina
         TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,
         TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
         TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
+        TerminationReason::EventDelivery => DiagnosticTerminationReason::EventDelivery,
     }
 }
 

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_byte_overload.rs
@@ -1,0 +1,72 @@
+//! The Codex app-server backend must enforce the shared aggregate byte budget
+//! across queued and in-flight downstream event delivery.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use std::time::Duration;
+
+const RUN_ID: &str = "codex-app-server-event-delivery-byte-overload-test";
+
+#[tokio::test]
+async fn codex_app_server_event_delivery_byte_overload_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: RUN_ID,
+                prompt: "drive app-server event delivery byte overload",
+                scenario: Some("runtime-large-event-flood"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        RUN_ID,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let stalled_events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200).delay(Duration::from_secs(30));
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let error = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("app-server byte overload should not wait for the stalled request")
+    .expect_err("delivery byte overload should fail the app-server run");
+
+    let error = error.to_string();
+    assert!(
+        error.contains("event delivery byte buffer exhausted") && error.contains("16777216 bytes"),
+        "unexpected byte-overload error: {error}"
+    );
+    assert!(
+        !error.contains("server notification byte buffer exhausted"),
+        "the test must exercise the downstream delivery byte budget: {error}"
+    );
+    assert!(
+        stalled_events.calls() <= 1,
+        "the serial sender should have at most one stalled request in flight"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery_overload.rs
@@ -1,0 +1,72 @@
+//! The Codex app-server backend must use the same bounded downstream event
+//! delivery queue as the ordinary CLI backend.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use std::time::Duration;
+
+const RUN_ID: &str = "codex-app-server-event-delivery-overload-test";
+
+#[tokio::test]
+async fn codex_app_server_event_delivery_count_overload_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: RUN_ID,
+                prompt: "drive app-server event delivery overload",
+                scenario: Some("runtime-event-flood"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        RUN_ID,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let stalled_events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200).delay(Duration::from_secs(30));
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("app-server delivery overload should not wait for the stalled request")
+    .expect_err("delivery queue overload should fail the app-server run");
+
+    let error = error.to_string();
+    assert!(
+        error.contains("event delivery queue exceeded 128 pending events"),
+        "unexpected overload error: {error}"
+    );
+    assert!(
+        !error.contains("server notification queue exceeded"),
+        "the test must exercise the downstream delivery queue: {error}"
+    );
+    assert!(
+        stalled_events.calls() <= 1,
+        "the serial sender should have at most one stalled request in flight"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_byte_overload.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use std::time::Duration;
 
 const EVENT_BYTES: usize = 2 * 1024 * 1024;
+const EVENT_COUNT: usize = 8;
 
 #[tokio::test]
 async fn ordinary_cli_event_delivery_byte_overload_terminates_promptly()
@@ -17,7 +18,10 @@ async fn ordinary_cli_event_delivery_byte_overload_terminates_promptly()
     let tmp = tempfile::tempdir()?;
     let server = MockServer::start();
     let mut prompt_lines = vec!["@ECHO@".to_string()];
-    prompt_lines.extend((0..10).map(|index| {
+    // One in-flight payload plus seven queued payloads crosses the byte budget;
+    // seven queued payloads alone do not. This distinguishes queued-plus-in-flight
+    // accounting from a queue-only implementation.
+    prompt_lines.extend((0..EVENT_COUNT).map(|index| {
         json!({
             "type": "assistant",
             "index": index,
@@ -65,9 +69,10 @@ async fn ordinary_cli_event_delivery_byte_overload_terminates_promptly()
             .reason,
         guest_contracts::diagnostics::CliTerminationReason::EventDelivery
     );
-    assert!(
-        events.calls() <= 1,
-        "the serial sender should have at most one stalled request in flight"
+    assert_eq!(
+        events.calls(),
+        1,
+        "the byte limit must include the one stalled request in flight"
     );
 
     Ok(())

--- a/crates/guest-agent/tests/event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_byte_overload.rs
@@ -1,0 +1,74 @@
+//! Ordinary CLI event delivery must reject an aggregate of individually valid
+//! payloads that exceeds the queued-plus-in-flight byte budget.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use serde_json::json;
+use std::time::Duration;
+
+const EVENT_BYTES: usize = 2 * 1024 * 1024;
+
+#[tokio::test]
+async fn ordinary_cli_event_delivery_byte_overload_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines.extend((0..10).map(|index| {
+        json!({
+            "type": "assistant",
+            "index": index,
+            "content": "x".repeat(EVENT_BYTES),
+        })
+        .to_string()
+    }));
+    let prompt = prompt_lines.join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200).delay(Duration::from_secs(30));
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("aggregate byte overload should terminate promptly");
+
+    let result = execution.expect("the live CLI should use controlled delivery termination");
+    let error = result
+        .control_error
+        .expect("byte overload should be exposed as a control error")
+        .to_string();
+    assert!(
+        error.contains("event delivery byte buffer exhausted") && error.contains("16777216 bytes"),
+        "unexpected byte-overload error: {error}"
+    );
+    assert_eq!(result.last_event_sequence, None);
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("delivery overload should record process-group termination")
+            .reason,
+        guest_contracts::diagnostics::CliTerminationReason::EventDelivery
+    );
+    assert!(
+        events.calls() <= 1,
+        "the serial sender should have at most one stalled request in flight"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_count_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_count_overload.rs
@@ -1,0 +1,64 @@
+//! Ordinary CLI event delivery must fail without blocking stdout when the
+//! bounded delivery queue fills behind a stalled event endpoint.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::test]
+async fn ordinary_cli_event_delivery_count_overload_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines
+        .extend((0..260).map(|index| json!({ "type": "assistant", "index": index }).to_string()));
+    let prompt = prompt_lines.join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let stalled_events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200).delay(Duration::from_secs(30));
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("delivery overload should not wait for the stalled event request");
+
+    let (error, last_event_sequence) = match execution {
+        Ok(result) => (
+            result
+                .control_error
+                .expect("a live CLI should expose delivery overload as a control error")
+                .to_string(),
+            result.last_event_sequence,
+        ),
+        Err(error) => (error.to_string(), None),
+    };
+    assert!(
+        error.contains("event delivery queue exceeded 128 pending events"),
+        "unexpected overload error: {error}"
+    );
+    assert_eq!(last_event_sequence, None);
+    assert!(
+        stalled_events.calls() <= 1,
+        "the serial sender should have at most one stalled request in flight"
+    );
+
+    Ok(())
+}

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -333,6 +333,8 @@ pub enum CliTerminationReason {
     HeartbeatPanic,
     /// Writing the initial prompt to stdin failed and required termination.
     InitialPromptStdin,
+    /// Event delivery overloaded or stopped and required termination.
+    EventDelivery,
 }
 
 impl CliTerminationReason {
@@ -345,6 +347,7 @@ impl CliTerminationReason {
             Self::HeartbeatError => "heartbeat_error",
             Self::HeartbeatPanic => "heartbeat_panic",
             Self::InitialPromptStdin => "initial_prompt_stdin",
+            Self::EventDelivery => "event_delivery",
         }
     }
 }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -296,7 +296,6 @@ impl AppServerState {
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
             for index in 0..EVENT_DELIVERY_FLOOD_COUNT {
                 write_json_line(output, &warning_notification(&thread_id, index))?;
-                output.flush()?;
                 thread::sleep(std::time::Duration::from_millis(1));
             }
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
@@ -312,7 +311,6 @@ impl AppServerState {
                         EVENT_DELIVERY_LARGE_EVENT_BYTES,
                     ),
                 )?;
-                output.flush()?;
                 thread::sleep(std::time::Duration::from_millis(50));
             }
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -1,9 +1,9 @@
 use super::messages::{
     initialize_response, large_server_notification, server_notification,
     server_notification_with_index, server_request, thread_response, thread_started_notification,
-    turn, turn_completed_notification, turn_started_notification, write_error, write_json_line,
-    write_split_json_line_prefix, write_success, write_turn_completion_notifications,
-    write_turn_notifications,
+    turn, turn_completed_notification, turn_started_notification, warning_notification,
+    write_error, write_json_line, write_split_json_line_prefix, write_success,
+    write_turn_completion_notifications, write_turn_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
+const EVENT_DELIVERY_FLOOD_COUNT: usize = 260;
 
 impl AppServerState {
     pub(super) fn handle_initialize<W: Write>(
@@ -288,6 +289,15 @@ impl AppServerState {
             Scenario::RuntimeTurnComplete | Scenario::RuntimeTurnCompleteWithoutThreadStarted
         ) {
             write_turn_notifications(output, &thread_id, &turn_id)?;
+        }
+        if self.scenario == Scenario::RuntimeEventFlood {
+            write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
+            for index in 0..EVENT_DELIVERY_FLOOD_COUNT {
+                write_json_line(output, &warning_notification(&thread_id, index))?;
+                output.flush()?;
+                thread::sleep(std::time::Duration::from_millis(1));
+            }
+            write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
         }
         Ok(ServerAction::Continue)
     }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -1,9 +1,9 @@
 use super::messages::{
-    initialize_response, large_server_notification, server_notification,
-    server_notification_with_index, server_request, thread_response, thread_started_notification,
-    turn, turn_completed_notification, turn_started_notification, warning_notification,
-    write_error, write_json_line, write_split_json_line_prefix, write_success,
-    write_turn_completion_notifications, write_turn_notifications,
+    initialize_response, large_server_notification, large_warning_notification,
+    server_notification, server_notification_with_index, server_request, thread_response,
+    thread_started_notification, turn, turn_completed_notification, turn_started_notification,
+    warning_notification, write_error, write_json_line, write_split_json_line_prefix,
+    write_success, write_turn_completion_notifications, write_turn_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
@@ -16,6 +16,8 @@ use uuid::Uuid;
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 260;
+const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
+const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
 
 impl AppServerState {
     pub(super) fn handle_initialize<W: Write>(
@@ -296,6 +298,22 @@ impl AppServerState {
                 write_json_line(output, &warning_notification(&thread_id, index))?;
                 output.flush()?;
                 thread::sleep(std::time::Duration::from_millis(1));
+            }
+            write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
+        }
+        if self.scenario == Scenario::RuntimeLargeEventFlood {
+            write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
+            for index in 0..EVENT_DELIVERY_LARGE_EVENT_COUNT {
+                write_json_line(
+                    output,
+                    &large_warning_notification(
+                        &thread_id,
+                        index,
+                        EVENT_DELIVERY_LARGE_EVENT_BYTES,
+                    ),
+                )?;
+                output.flush()?;
+                thread::sleep(std::time::Duration::from_millis(50));
             }
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
         }

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -121,6 +121,20 @@ pub(super) fn warning_notification(thread_id: &str, index: usize) -> Value {
     })
 }
 
+pub(super) fn large_warning_notification(
+    thread_id: &str,
+    index: usize,
+    message_bytes: usize,
+) -> Value {
+    json!({
+        "method": "warning",
+        "params": {
+            "threadId": thread_id,
+            "message": format!("{index}:{}", "x".repeat(message_bytes)),
+        }
+    })
+}
+
 pub(super) fn write_turn_notifications<W: Write>(
     output: &mut W,
     thread_id: &str,

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -111,6 +111,16 @@ pub(super) fn turn_completed_notification(thread_id: &str, turn_id: &str) -> Val
     })
 }
 
+pub(super) fn warning_notification(thread_id: &str, index: usize) -> Value {
+    json!({
+        "method": "warning",
+        "params": {
+            "threadId": thread_id,
+            "message": format!("guest-mock-codex warning {index}")
+        }
+    })
+}
+
 pub(super) fn write_turn_notifications<W: Write>(
     output: &mut W,
     thread_id: &str,

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -33,6 +33,7 @@ pub(super) enum Scenario {
     RuntimeTurnStartedBeforeSteer,
     RuntimeTurnCompleteWithoutThreadStarted,
     RuntimeEventFlood,
+    RuntimeLargeEventFlood,
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
     ThreadStartInvalidThreadId,
@@ -84,6 +85,7 @@ impl Scenario {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
                 "runtime-event-flood" => Ok(Self::RuntimeEventFlood),
+                "runtime-large-event-flood" => Ok(Self::RuntimeLargeEventFlood),
                 "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "thread-start-invalid-thread-id" => Ok(Self::ThreadStartInvalidThreadId),

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -32,6 +32,7 @@ pub(super) enum Scenario {
     RuntimeTurnCompleteBeforeSteerResponse,
     RuntimeTurnStartedBeforeSteer,
     RuntimeTurnCompleteWithoutThreadStarted,
+    RuntimeEventFlood,
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
     ThreadStartInvalidThreadId,
@@ -82,6 +83,7 @@ impl Scenario {
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
+                "runtime-event-flood" => Ok(Self::RuntimeEventFlood),
                 "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "thread-start-invalid-thread-id" => Ok(Self::ThreadStartInvalidThreadId),


### PR DESCRIPTION
## Summary

- replace the unbounded ordinary CLI and Codex app-server event channels with one shared delivery runtime
- cap waiting delivery at 128 queued events and cap queued-plus-in-flight serialized payloads at 16 MiB
- fail overload admission without blocking stdout, terminate a live ordinary CLI through the existing controlled process-group path, and bound successful drain to 120 seconds
- preserve acknowledged-prefix watermark semantics while preventing a later watermark from being reported after delivery-control failure
- add deterministic stalled-endpoint coverage for count and byte overloads in both the ordinary CLI and app-server backends

## User-visible impact

Runs can no longer grow guest memory without bound when the event endpoint stalls or retries slowly. Once either delivery limit is reached, the run fails with an explicit delivery error instead of silently dropping events or continuing to buffer them.

## Exclusions

- no event API or database schema changes
- no change to HTTP retry policy or event ordering
- no change to limits on the app-server protocol's upstream notification queue

## Verification

- `cargo check -p guest-agent`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex -p guest-contracts --all-targets --all-features`
- `cargo doc -p guest-agent -p guest-mock-codex -p guest-contracts --all-features --no-deps`
- `cargo test -p guest-agent`
- `cargo test -p guest-mock-codex`
- `cargo test -p guest-contracts`

Closes #22001
