### PR TITLE
refactor(mitm-addon): centralize model usage pricing contract

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata.py
+++ b/crates/runner/mitm-addon/src/flow_metadata.py
@@ -97,28 +97,6 @@ def model_usage_provider(meta: Mapping[str, object]) -> str:
     return _metadata_str(meta, metadata_keys.MODEL_USAGE_PROVIDER)
 
 
-def model_usage_pricing(
-    meta: Mapping[str, object],
-) -> tuple[int, dict[str, int]] | None:
-    value = meta.get(metadata_keys.MODEL_USAGE_PRICING)
-    if not isinstance(value, dict):
-        return None
-    unit_size = value.get("unitSize")
-    raw_unit_prices = value.get("unitPrices")
-    if not isinstance(unit_size, int) or isinstance(unit_size, bool) or unit_size <= 0:
-        return None
-    if not isinstance(raw_unit_prices, dict):
-        return None
-    unit_prices: dict[str, int] = {}
-    for category, unit_price in raw_unit_prices.items():
-        if not isinstance(category, str):
-            return None
-        if not isinstance(unit_price, int) or isinstance(unit_price, bool) or unit_price < 0:
-            return None
-        unit_prices[category] = unit_price
-    return unit_size, unit_prices
-
-
 def start_request_timing(meta: MutableMapping[str, object]) -> None:
     if metadata_keys.HTTP_REQUEST_START_MONOTONIC not in meta:
         meta[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()

--- a/crates/runner/mitm-addon/src/model_usage_pricing.py
+++ b/crates/runner/mitm-addon/src/model_usage_pricing.py
@@ -6,6 +6,8 @@ import hashlib
 import hmac
 import json
 import time
+from collections.abc import Mapping
+from dataclasses import dataclass
 
 from mitmproxy import http
 
@@ -18,6 +20,14 @@ PRICING_SIGNATURE_HEADER = "x-vm0-usage-pricing-signature"
 _PRICING_SIGNATURE_DOMAIN = b"vm0-model-usage-pricing-v1\0"
 _MAX_PRICING_BYTES = 2048
 _MAX_CLOCK_SKEW_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class ModelUsagePricing:
+    """Validated model token prices used while constructing usage events."""
+
+    unit_size: int
+    unit_prices: dict[str, int]
 
 
 def apply_signed_usage_pricing(flow: http.HTTPFlow) -> bool:
@@ -68,10 +78,18 @@ def apply_signed_usage_pricing(flow: http.HTTPFlow) -> bool:
     if pricing is None:
         return False
     flow.metadata[metadata_keys.MODEL_USAGE_PRICING] = {
-        "unitSize": pricing[0],
-        "unitPrices": pricing[1],
+        "unitSize": pricing.unit_size,
+        "unitPrices": pricing.unit_prices,
     }
     return True
+
+
+def from_flow_metadata(meta: Mapping[str, object]) -> ModelUsagePricing | None:
+    """Read one complete pricing schedule from primitive flow metadata."""
+    value = meta.get(metadata_keys.MODEL_USAGE_PRICING)
+    if not isinstance(value, dict) or set(value) != {"unitSize", "unitPrices"}:
+        return None
+    return _pricing_from_fields(value["unitSize"], value["unitPrices"])
 
 
 def _bearer_token(value: str) -> str | None:
@@ -98,7 +116,7 @@ def _decode_base64url(value: str) -> bytes | None:
         return None
 
 
-def _decode_pricing(value: str) -> tuple[int, dict[str, int]] | None:
+def _decode_pricing(value: str) -> ModelUsagePricing | None:
     decoded = _decode_base64url(value)
     if decoded is None:
         return None
@@ -120,10 +138,14 @@ def _decode_pricing(value: str) -> tuple[int, dict[str, int]] | None:
         return None
     if abs(int(time.time()) - issued_at) > _MAX_CLOCK_SKEW_SECONDS:
         return None
-    unit_size = pricing["unitSize"]
+
+    return _pricing_from_fields(pricing["unitSize"], pricing["unitPrices"])
+
+
+def _pricing_from_fields(unit_size: object, raw_unit_prices: object) -> ModelUsagePricing | None:
+    """Construct an atomic schedule or reject all of its prices."""
     if not isinstance(unit_size, int) or isinstance(unit_size, bool) or unit_size <= 0:
         return None
-    raw_unit_prices = pricing["unitPrices"]
     if not isinstance(raw_unit_prices, dict) or set(raw_unit_prices) != set(MODEL_USAGE_CATEGORIES):
         return None
     unit_prices: dict[str, int] = {}
@@ -132,4 +154,4 @@ def _decode_pricing(value: str) -> tuple[int, dict[str, int]] | None:
         if not isinstance(unit_price, int) or isinstance(unit_price, bool) or unit_price < 0:
             return None
         unit_prices[category] = unit_price
-    return unit_size, unit_prices
+    return ModelUsagePricing(unit_size=unit_size, unit_prices=unit_prices)

--- a/crates/runner/mitm-addon/src/model_usage_pricing.py
+++ b/crates/runner/mitm-addon/src/model_usage_pricing.py
@@ -1,4 +1,4 @@
-"""Verification for signed model token price schedules."""
+"""Signed response-header verification for model token price schedules."""
 
 import base64
 import binascii
@@ -6,28 +6,18 @@ import hashlib
 import hmac
 import json
 import time
-from collections.abc import Mapping
-from dataclasses import dataclass
 
 from mitmproxy import http
 
 import flow_metadata
 import flow_metadata_keys as metadata_keys
-from usage.model_tokens import MODEL_USAGE_CATEGORIES
+from usage.model_pricing import ModelUsagePricing, parse_model_usage_pricing
 
 PRICING_HEADER = "x-vm0-usage-pricing"
 PRICING_SIGNATURE_HEADER = "x-vm0-usage-pricing-signature"
 _PRICING_SIGNATURE_DOMAIN = b"vm0-model-usage-pricing-v1\0"
 _MAX_PRICING_BYTES = 2048
 _MAX_CLOCK_SKEW_SECONDS = 300
-
-
-@dataclass(frozen=True)
-class ModelUsagePricing:
-    """Validated model token prices used while constructing usage events."""
-
-    unit_size: int
-    unit_prices: dict[str, int]
 
 
 def apply_signed_usage_pricing(flow: http.HTTPFlow) -> bool:
@@ -84,14 +74,6 @@ def apply_signed_usage_pricing(flow: http.HTTPFlow) -> bool:
     return True
 
 
-def from_flow_metadata(meta: Mapping[str, object]) -> ModelUsagePricing | None:
-    """Read one complete pricing schedule from primitive flow metadata."""
-    value = meta.get(metadata_keys.MODEL_USAGE_PRICING)
-    if not isinstance(value, dict) or set(value) != {"unitSize", "unitPrices"}:
-        return None
-    return _pricing_from_fields(value["unitSize"], value["unitPrices"])
-
-
 def _bearer_token(value: str) -> str | None:
     if not value.startswith("Bearer "):
         return None
@@ -139,19 +121,4 @@ def _decode_pricing(value: str) -> ModelUsagePricing | None:
     if abs(int(time.time()) - issued_at) > _MAX_CLOCK_SKEW_SECONDS:
         return None
 
-    return _pricing_from_fields(pricing["unitSize"], pricing["unitPrices"])
-
-
-def _pricing_from_fields(unit_size: object, raw_unit_prices: object) -> ModelUsagePricing | None:
-    """Construct an atomic schedule or reject all of its prices."""
-    if not isinstance(unit_size, int) or isinstance(unit_size, bool) or unit_size <= 0:
-        return None
-    if not isinstance(raw_unit_prices, dict) or set(raw_unit_prices) != set(MODEL_USAGE_CATEGORIES):
-        return None
-    unit_prices: dict[str, int] = {}
-    for category in MODEL_USAGE_CATEGORIES:
-        unit_price = raw_unit_prices[category]
-        if not isinstance(unit_price, int) or isinstance(unit_price, bool) or unit_price < 0:
-            return None
-        unit_prices[category] = unit_price
-    return ModelUsagePricing(unit_size=unit_size, unit_prices=unit_prices)
+    return parse_model_usage_pricing(pricing["unitSize"], pricing["unitPrices"])

--- a/crates/runner/mitm-addon/src/usage/model_pricing.py
+++ b/crates/runner/mitm-addon/src/usage/model_pricing.py
@@ -1,0 +1,42 @@
+"""Validated model usage pricing contract."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import flow_metadata_keys as metadata_keys
+
+from .model_tokens import MODEL_USAGE_CATEGORIES
+
+
+@dataclass(frozen=True)
+class ModelUsagePricing:
+    """Validated model token prices used while constructing usage events."""
+
+    unit_size: int
+    unit_prices: dict[str, int]
+
+
+def from_flow_metadata(meta: Mapping[str, object]) -> ModelUsagePricing | None:
+    """Read one complete pricing schedule from primitive flow metadata."""
+    value = meta.get(metadata_keys.MODEL_USAGE_PRICING)
+    if not isinstance(value, dict) or set(value) != {"unitSize", "unitPrices"}:
+        return None
+    return parse_model_usage_pricing(value["unitSize"], value["unitPrices"])
+
+
+def parse_model_usage_pricing(
+    unit_size: object,
+    raw_unit_prices: object,
+) -> ModelUsagePricing | None:
+    """Construct an atomic schedule or reject all of its prices."""
+    if not isinstance(unit_size, int) or isinstance(unit_size, bool) or unit_size <= 0:
+        return None
+    if not isinstance(raw_unit_prices, dict) or set(raw_unit_prices) != set(MODEL_USAGE_CATEGORIES):
+        return None
+    unit_prices: dict[str, int] = {}
+    for category in MODEL_USAGE_CATEGORIES:
+        unit_price = raw_unit_prices[category]
+        if not isinstance(unit_price, int) or isinstance(unit_price, bool) or unit_price < 0:
+            return None
+        unit_prices[category] = unit_price
+    return ModelUsagePricing(unit_size=unit_size, unit_prices=unit_prices)

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -22,7 +22,6 @@ from mitmproxy import http
 
 import flow_metadata
 import flow_metadata_keys as metadata_keys
-import model_usage_pricing
 from logging_utils import log_proxy_entry
 
 from ..buffer import (
@@ -37,6 +36,7 @@ from ..idempotency import (
     USAGE_OBSERVATION_NAMESPACE_MODEL,
     derive_usage_idempotency_key,
 )
+from ..model_pricing import ModelUsagePricing, from_flow_metadata
 from ..model_tokens import (
     MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
@@ -374,7 +374,7 @@ def _build_model_provider_usage_events(
     run_id: str,
     namespace: uuid.UUID,
     *,
-    billing_pricing: model_usage_pricing.ModelUsagePricing | None,
+    billing_pricing: ModelUsagePricing | None,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for source_id, usage in _iter_model_provider_usage_sources(flow):
@@ -415,7 +415,7 @@ def _build_usage_events(
     usage: dict,
     namespace: uuid.UUID,
     *,
-    billing_pricing: model_usage_pricing.ModelUsagePricing | None,
+    billing_pricing: ModelUsagePricing | None,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for category in MODEL_USAGE_CATEGORIES:
@@ -441,8 +441,8 @@ def _build_usage_events(
 
 def _model_usage_pricing(
     flow: http.HTTPFlow,
-) -> model_usage_pricing.ModelUsagePricing | None:
-    return model_usage_pricing.from_flow_metadata(flow.metadata)
+) -> ModelUsagePricing | None:
+    return from_flow_metadata(flow.metadata)
 
 
 def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -22,6 +22,7 @@ from mitmproxy import http
 
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import model_usage_pricing
 from logging_utils import log_proxy_entry
 
 from ..buffer import (
@@ -46,7 +47,6 @@ from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
-ModelUsagePricing = tuple[int, dict[str, int]]
 _MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
     (
         MODEL_USAGE_CATEGORY_INPUT,
@@ -374,7 +374,7 @@ def _build_model_provider_usage_events(
     run_id: str,
     namespace: uuid.UUID,
     *,
-    billing_pricing: ModelUsagePricing | None,
+    billing_pricing: model_usage_pricing.ModelUsagePricing | None,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for source_id, usage in _iter_model_provider_usage_sources(flow):
@@ -415,7 +415,7 @@ def _build_usage_events(
     usage: dict,
     namespace: uuid.UUID,
     *,
-    billing_pricing: ModelUsagePricing | None,
+    billing_pricing: model_usage_pricing.ModelUsagePricing | None,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
     for category in MODEL_USAGE_CATEGORIES:
@@ -433,18 +433,16 @@ def _build_usage_events(
             "quantity": quantity,
         }
         if billing_pricing is not None:
-            unit_price = billing_pricing[1].get(category)
-            if unit_price is not None:
-                event["billingUnitPrice"] = unit_price
-                event["billingUnitSize"] = billing_pricing[0]
+            event["billingUnitPrice"] = billing_pricing.unit_prices[category]
+            event["billingUnitSize"] = billing_pricing.unit_size
         events.append(event)
     return events
 
 
 def _model_usage_pricing(
     flow: http.HTTPFlow,
-) -> ModelUsagePricing | None:
-    return flow_metadata.model_usage_pricing(flow.metadata)
+) -> model_usage_pricing.ModelUsagePricing | None:
+    return model_usage_pricing.from_flow_metadata(flow.metadata)
 
 
 def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:

--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -1,5 +1,10 @@
 """Shared model-provider flow helpers for mitm-addon tests."""
 
+import base64
+import hashlib
+import hmac
+import json
+import time
 from collections.abc import Callable
 from pathlib import Path
 
@@ -12,6 +17,50 @@ from tests.flow_helpers import header_map
 RealFlowFactory = Callable[..., http.HTTPFlow]
 _WEBSOCKET_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
 _WEBSOCKET_ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+
+def signed_usage_pricing_headers(
+    unit_prices: dict[str, object] | None = None,
+    *,
+    unit_size: int = 1_000_000,
+) -> dict[str, str]:
+    if unit_prices is None:
+        unit_prices = {
+            "tokens.input": 1000,
+            "tokens.cache_read": 100,
+            "tokens.cache_creation": 1250,
+            "tokens.output": 6000,
+        }
+    pricing = (
+        base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "version": 1,
+                    "issuedAt": int(time.time()),
+                    "unitSize": unit_size,
+                    "unitPrices": unit_prices,
+                },
+                separators=(",", ":"),
+            ).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
+    signature = (
+        base64.urlsafe_b64encode(
+            hmac.new(
+                b"proxy-secret",
+                b"vm0-model-usage-pricing-v1\0" + pricing.encode(),
+                hashlib.sha256,
+            ).digest()
+        )
+        .decode()
+        .rstrip("=")
+    )
+    return {
+        "x-vm0-usage-pricing": pricing,
+        "x-vm0-usage-pricing-signature": signature,
+    }
 
 
 def _openai_responses_websocket_request_headers() -> http.Headers:

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -13,6 +13,14 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
+from tests.model_provider_flow_helpers import signed_usage_pricing_headers
+
+_MODEL_USAGE_UNIT_PRICES: dict[str, object] = {
+    "tokens.input": 7,
+    "tokens.output": 13,
+    "tokens.cache_read": 11,
+    "tokens.cache_creation": 17,
+}
 
 
 class TestReportModelProviderUsage:
@@ -87,21 +95,21 @@ class TestReportModelProviderUsage:
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.6-luna"
-        flow.metadata[metadata_keys.MODEL_USAGE_PRICING] = {
-            "unitSize": 100,
-            "unitPrices": {
-                "tokens.input": 7,
-                "tokens.output": 13,
-                "tokens.cache_read": 11,
-                "tokens.cache_creation": 17,
-            },
-        }
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "tokens.input": 100,
             "tokens.output": 50,
             "tokens.cache_read": 25,
             "tokens.cache_creation": 10,
         }
+        flow.request.headers["authorization"] = "Bearer proxy-secret"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                signed_usage_pricing_headers(_MODEL_USAGE_UNIT_PRICES, unit_size=100)
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
@@ -114,6 +122,60 @@ class TestReportModelProviderUsage:
             "tokens.cache_read": 3,
             "tokens.cache_creation": 2,
         }
+
+    @pytest.mark.parametrize(
+        "unit_prices",
+        [
+            {
+                category: price
+                for category, price in _MODEL_USAGE_UNIT_PRICES.items()
+                if category != "tokens.output"
+            },
+            {**_MODEL_USAGE_UNIT_PRICES, "tokens.unknown": 19},
+            {**_MODEL_USAGE_UNIT_PRICES, "tokens.output": True},
+        ],
+        ids=["partial", "extra", "invalid"],
+    )
+    def test_rejects_malformed_model_pricing_atomically(
+        self,
+        real_flow,
+        usage_webhook_api,
+        unit_prices,
+    ):
+        flow = real_flow(with_response=False, host="model.vm0.ai")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0-model"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.6-luna"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "tokens.input": 100,
+            "tokens.output": 50,
+            "tokens.cache_read": 25,
+            "tokens.cache_creation": 10,
+        }
+        flow.request.headers["authorization"] = "Bearer proxy-secret"
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(signed_usage_pricing_headers(unit_prices, unit_size=100)),
+        )
+
+        mitm_addon.responseheaders(flow)
+
+        assert metadata_keys.MODEL_USAGE_PRICING not in flow.metadata
+
+        # Exercise the primitive metadata boundary independently of signed ingestion.
+        flow.metadata[metadata_keys.MODEL_USAGE_PRICING] = {
+            "unitSize": 100,
+            "unitPrices": unit_prices,
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+
+        events = webhook.requests[0].json_body()["events"]
+        assert {event["category"] for event in events} == set(_MODEL_USAGE_UNIT_PRICES)
+        assert all("grossCredits" not in event for event in events)
 
     def test_falls_back_to_response_model_then_unknown(self, real_flow, usage_webhook_api):
         """Provider falls back only when selected vm0 model metadata is absent."""

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -1,54 +1,11 @@
 """Tests for the mitm addon responseheaders hook."""
 
-import base64
-import hashlib
-import hmac
-import json
-import time
-
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.flow_helpers import header_map, response_stream
-
-
-def signed_usage_pricing_headers() -> dict[str, str]:
-    pricing = (
-        base64.urlsafe_b64encode(
-            json.dumps(
-                {
-                    "version": 1,
-                    "issuedAt": int(time.time()),
-                    "unitSize": 1_000_000,
-                    "unitPrices": {
-                        "tokens.input": 1000,
-                        "tokens.cache_read": 100,
-                        "tokens.cache_creation": 1250,
-                        "tokens.output": 6000,
-                    },
-                },
-                separators=(",", ":"),
-            ).encode()
-        )
-        .decode()
-        .rstrip("=")
-    )
-    signature = (
-        base64.urlsafe_b64encode(
-            hmac.new(
-                b"proxy-secret",
-                b"vm0-model-usage-pricing-v1\0" + pricing.encode(),
-                hashlib.sha256,
-            ).digest()
-        )
-        .decode()
-        .rstrip("=")
-    )
-    return {
-        "x-vm0-usage-pricing": pricing,
-        "x-vm0-usage-pricing-signature": signature,
-    }
+from tests.model_provider_flow_helpers import signed_usage_pricing_headers
 
 
 class TestResponseHeadersHandler:


### PR DESCRIPTION
## Summary

- define one named model-usage pricing value with exact, atomic validation in an acyclic usage-layer contract module
- keep signed response-header verification separate while preserving primitive mitmproxy metadata
- reject missing, extra, or invalid category prices as one schedule instead of partially pricing usage
- remove the provider-local tuple alias, positional access, and per-category optional pricing
- cover complete and malformed schedules across signed response-header ingestion and usage webhook output

## Behavior

A complete signed schedule supplies prices for every emitted model usage category. If signed ingestion or primitive metadata contains an incomplete or malformed schedule, the complete schedule is ignored and all usage remains unpriced for the existing API fallback and underbilling path; usage events are not dropped.

The pricing value and metadata parser live in `usage/model_pricing.py`, so both the signed-header adapter and provider consume the same contract without an import-order dependency.

## Exclusions

- no pricing values or model usage categories changed
- no signed header, HMAC, version, or freshness behavior changed
- no TypeScript, API contract, database schema, migration, or deployment configuration changed

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright`
- `cd crates/runner/mitm-addon && .venv/bin/python scripts/check-flow-metadata-keys.py`
- clean-process imports in both `model_usage_pricing -> usage` and `usage -> model_usage_pricing` orders, plus `mitm_addon`
- `cd crates/runner/mitm-addon && .venv/bin/pytest -q tests/test_response_headers_handler.py tests/test_model_provider_usage.py` — 35 passed
- `cd crates/runner/mitm-addon && .venv/bin/pytest -qq` — passed

Closes #21997
