### PR TITLE
perf(mitm-addon): avoid jsonl backlog copies

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -12,6 +12,7 @@ from mitmproxy import ctx
 
 MAX_PENDING_JSONL_WRITES = 4096
 MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
+MAX_JSONL_IOVECS = os.sysconf("SC_IOV_MAX")
 SHUTDOWN_JOIN_TIMEOUT_SECONDS = 1.0
 
 
@@ -238,21 +239,42 @@ def _write_batch(items: list[object]) -> None:
         if not path_items:
             continue
         try:
-            _append_lines(log_path, b"".join(item.line for item in path_items))
+            _append_lines(log_path, [item.line for item in path_items])
         except Exception as exc:
             log_name = path_items[0].log_name
             _warn(f"Failed to write {log_name} log: {type(exc).__name__}: {exc}")
 
 
-def _append_lines(log_path: str, content: bytes) -> None:
+def _append_lines(log_path: str, lines: list[bytes]) -> None:
     fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
     try:
-        written = 0
-        while written < len(content):
-            chunk = os.write(fd, content[written:])
-            if chunk == 0:
+        line_index = 0
+        line_offset = 0
+        while line_index < len(lines):
+            while line_index < len(lines) and not lines[line_index]:
+                line_index += 1
+            if line_index == len(lines):
+                return
+
+            batch_end = min(line_index + MAX_JSONL_IOVECS, len(lines))
+            buffers: list[bytes | memoryview] = list(lines[line_index:batch_end])
+            if line_offset:
+                buffers[0] = memoryview(lines[line_index])[line_offset:]
+
+            written = os.writev(fd, buffers)
+            if written == 0:
                 raise OSError("write returned 0 bytes")
-            written += chunk
+
+            while line_index < batch_end:
+                remaining = len(lines[line_index]) - line_offset
+                if written < remaining:
+                    line_offset += written
+                    break
+                written -= remaining
+                line_index += 1
+                line_offset = 0
+                if written == 0:
+                    break
     finally:
         os.close(fd)
 

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -35,6 +35,69 @@ def test_worker_start_failure_does_not_publish_or_consume_retry_capacity(tmp_pat
         assert log_path.read_bytes() == line
 
 
+def test_writer_appends_vectored_batch_across_partial_writes(tmp_path, mitm_ctx):
+    log_path = str(tmp_path / "network.jsonl")
+    gate_started = threading.Event()
+    release_gate = threading.Event()
+    writev_calls: list[tuple[bytes, ...]] = []
+    original_writev = jsonl_writer.os.writev
+
+    def writev(fd: int, buffers: list[bytes | memoryview]) -> int:
+        writev_calls.append(tuple(bytes(buffer) for buffer in buffers))
+        if not gate_started.is_set():
+            gate_started.set()
+            release_gate.wait()
+
+        remaining = 3
+        limited_buffers: list[memoryview] = []
+        for buffer in buffers:
+            if not buffer:
+                continue
+            chunk_size = min(len(buffer), remaining)
+            limited_buffers.append(memoryview(buffer)[:chunk_size])
+            remaining -= chunk_size
+            if remaining == 0:
+                break
+        return original_writev(fd, limited_buffers)
+
+    with (
+        patch.object(jsonl_writer, "MAX_JSONL_IOVECS", 2),
+        patch.object(jsonl_writer.os, "writev", side_effect=writev),
+        mitm_ctx() as log,
+    ):
+        try:
+            jsonl_writer.write_jsonl_line(log_path, b"gate\n", "network")
+            assert gate_started.wait(timeout=1)
+
+            jsonl_writer.write_jsonl_line(log_path, b"first\n", "network")
+            jsonl_writer.write_jsonl_line(log_path, b"", "network")
+            jsonl_writer.write_jsonl_line(log_path, b"second\n", "network")
+            jsonl_writer.write_jsonl_line(log_path, b"third\n", "network")
+        finally:
+            release_gate.set()
+
+        assert jsonl_writer.flush_log_path(log_path, timeout=1)
+
+    assert (tmp_path / "network.jsonl").read_bytes() == b"gate\nfirst\nsecond\nthird\n"
+    assert all(len(buffers) <= 2 for buffers in writev_calls)
+    assert any(len(buffers) == 2 and all(buffers) for buffers in writev_calls)
+    log.warn.assert_not_called()
+
+
+def test_writer_warns_and_retires_batch_when_writev_returns_zero(tmp_path, mitm_ctx):
+    log_path = str(tmp_path / "network.jsonl")
+
+    with (
+        patch.object(jsonl_writer.os, "writev", return_value=0),
+        mitm_ctx() as log,
+    ):
+        jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+        assert jsonl_writer.flush_log_path(log_path, timeout=1)
+
+    log.warn.assert_called_once_with("Failed to write network log: OSError: write returned 0 bytes")
+    assert (tmp_path / "network.jsonl").read_bytes() == b""
+
+
 def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     class ObservedCondition:
         def __init__(self) -> None:
@@ -99,17 +162,17 @@ def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     later_line = b"later-2\n"
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         if path == gate_path:
             gate_started.set()
             release_gate.wait()
         elif path == pruned_path:
             target_batch_started.set()
             release_target_batch.wait()
-        elif path == later_write_path and content == later_line:
+        elif path == later_write_path and lines == [later_line]:
             later_batch_started.set()
             release_later_batch.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     def flush_waiter_path() -> None:
         assert jsonl_writer.flush_log_path(waiter_path)
@@ -199,10 +262,10 @@ def test_flush_prunes_completed_path_state(tmp_path):
     flush_thread: ThreadUnderTest | None = None
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         append_started.set()
         release_append.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     def flush_log_path() -> None:
         jsonl_writer.flush_log_path(log_path)
@@ -248,10 +311,10 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     flush_threads: list[ThreadUnderTest] = []
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         append_started.set()
         release_append.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     def flush_log_path() -> None:
         jsonl_writer.flush_log_path(log_path)
@@ -300,10 +363,10 @@ def test_shutdown_writer_returns_when_normal_write_backlog_is_full(tmp_path):
     shutdown_thread: ThreadUnderTest | None = None
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         append_started.set()
         release_append.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     def shutdown_writer() -> None:
         jsonl_writer.shutdown_writer(timeout=0.01)
@@ -349,10 +412,10 @@ def test_shutdown_writer_timeout_preserves_state_for_retry(tmp_path):
     release_append = threading.Event()
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         append_started.set()
         release_append.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
@@ -385,10 +448,10 @@ def test_flush_log_path_timeout_returns_false_and_cleans_waiter(tmp_path):
     release_append = threading.Event()
     original_append_lines = jsonl_writer._append_lines
 
-    def append_lines(path: str, content: bytes) -> None:
+    def append_lines(path: str, lines: list[bytes]) -> None:
         append_started.set()
         release_append.wait()
-        original_append_lines(path, content)
+        original_append_lines(path, lines)
 
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -371,10 +371,10 @@ class TestRunnerUsageFlushSignal:
         original_append_lines = jsonl_writer._append_lines
         log = MagicMock()
 
-        def append_lines(path: str, content: bytes) -> None:
+        def append_lines(path: str, lines: list[bytes]) -> None:
             append_started.set()
             release_append.wait()
-            original_append_lines(path, content)
+            original_append_lines(path, lines)
 
         with (
             patch.object(


### PR DESCRIPTION
## Summary

- append each JSONL path batch with `os.writev` over the original serialized line buffers instead of creating one payload-sized joined copy
- bound each vectored syscall by `SC_IOV_MAX` and preserve exact progress across partial writes, empty buffers, zero progress, warnings, and attempted-write completion
- cover real-file vector grouping and partial progress through the writer/flush entry points, while updating existing lifecycle gates for the line-list boundary

## Memory evidence

For 4,096 retained lines, isolated `tracemalloc` measurements around the complete path-batch append showed:

| Retained payload | Before additional peak | After additional peak |
| --- | ---: | ---: |
| 4 MiB | proportional join allocation | 206,184 bytes |
| 32 MiB | 33,882,225 bytes | 206,184 bytes |

The after peak is identical for 4 MiB and 32 MiB payloads, so append overhead now scales with bounded buffer references rather than retained payload bytes. Elapsed time was treated as contextual only.

## Compatibility and exclusions

- JSONL format, file flags/mode, admission limits, flush/shutdown semantics, and runner/addon protocols are unchanged.
- This does not change worker drain/completion granularity or add cross-process serialization. Rust DNS/kmsg rows may appear between Python vector groups on the shared path; Linux keeps each `writev` call atomic and ordered.

## Validation

- `.venv/bin/pytest tests/test_jsonl_writer.py` — 10 passed
- `.venv/bin/pytest tests/test_logging_utils.py tests/test_runner_usage_flush_signal.py` — 63 passed
- `.venv/bin/pytest tests/` — 4,066 passed
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- applicable lefthook checks: Ruff format/lint, file size, and generated-firewall guard

Closes #21996
