### PR TITLE
fix(runner): reject unbounded auth.base h2 request bodies

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -5,13 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mitm-addon"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 [project.optional-dependencies]
 dev = [
     "Brotli>=1.2.0",
     "basedpyright>=1.39",
-    "mitmproxy>=10.0",
+    # Private mitmproxy API use is guarded in src/mitmproxy_compat.py.
+    "mitmproxy==12.2.2",
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
     "ruff>=0.8",
@@ -21,7 +22,8 @@ test = [
     "Brotli>=1.2.0",
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
-    "mitmproxy>=10.0",
+    # Keep tests on the exact runtime version from crates/runner/src/deps.rs.
+    "mitmproxy==12.2.2",
     "wsproto>=1.2",
 ]
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -161,6 +161,12 @@ def load(loader: Loader) -> None:
         help="Runner-generated usage-pending state id",
     )
     loader.add_option(
+        name="vm0_addon_ready_path",
+        typespec=str,
+        default="",
+        help="Path for the runner's addon initialization marker",
+    )
+    loader.add_option(
         name="vm0_client_session_id",
         typespec=str,
         default="",
@@ -196,6 +202,11 @@ def configure(updated: set[str]) -> None:
             str(Path(__file__).resolve().parent / "usage-pending"),
             usage_state_id=ctx.options.vm0_usage_state_id or None,
         )
+    if {"vm0_addon_ready_path", "vm0_usage_state_id"} & updated:
+        ready_path = ctx.options.vm0_addon_ready_path
+        usage_state_id = ctx.options.vm0_usage_state_id
+        if ready_path and usage_state_id:
+            Path(ready_path).write_text(usage_state_id, encoding="utf-8")
 
 
 def get_api_url() -> str:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -48,6 +48,7 @@ import flow_metadata_keys as metadata_keys
 import http_local_responses
 import http_network_log
 import matching
+import mitmproxy_compat
 import model_usage_pricing
 import network_log_sanitization
 import platform_api
@@ -125,6 +126,7 @@ class _AuthBaseBodyCheck:
 
 def load(loader: Loader) -> None:
     """Register custom options for the addon."""
+    mitmproxy_compat.install_request_end_stream_bridge()
     signal.signal(
         runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
         runner_flush_lifecycle.handle_runner_usage_flush_signal,
@@ -365,7 +367,11 @@ def _builtin_host_policy_error_for_firewall_allow(
     return None
 
 
-def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
+def _auth_base_body_header_check(
+    flow: http.HTTPFlow,
+    *,
+    request_end_stream: bool | None,
+) -> _AuthBaseBodyCheck:
     if flow.request.headers.get_all("Transfer-Encoding"):
         return _AuthBaseBodyCheck(kind="length_required", reason="transfer_encoding")
 
@@ -373,6 +379,13 @@ def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
     if not raw_content_lengths:
         if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
             return _AuthBaseBodyCheck(kind="length_required", reason="missing_content_length")
+        if request_end_stream is not True:
+            reason = (
+                "request_stream_open"
+                if request_end_stream is False
+                else "request_end_stream_unavailable"
+            )
+            return _AuthBaseBodyCheck(kind="length_required", reason=reason)
         return _AuthBaseBodyCheck(kind="ok")
 
     parsed_length: int | None = None
@@ -590,9 +603,13 @@ def client_disconnected(client: connection.Client) -> None:
 
 def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
+    request_end_stream = mitmproxy_compat.take_request_end_stream(flow)
     connector_intent.capture_and_strip(flow)
 
-    body_check = _auth_base_body_header_check(flow)
+    body_check = _auth_base_body_header_check(
+        flow,
+        request_end_stream=request_end_stream,
+    )
     body_fits_stream_buffer = body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
     if body_fits_stream_buffer:
         _prebind_bounded_requestheaders_upstream_destination(flow)

--- a/crates/runner/mitm-addon/src/mitmproxy_compat.py
+++ b/crates/runner/mitm-addon/src/mitmproxy_compat.py
@@ -1,0 +1,66 @@
+"""Version-locked bridges for mitmproxy state that public hooks omit."""
+
+from mitmproxy import http, version
+from mitmproxy.proxy import layer
+from mitmproxy.proxy.layers.http import HttpStream
+from mitmproxy.proxy.layers.http._events import RequestHeaders
+from mitmproxy.proxy.layers.http._hooks import HttpRequestHeadersHook
+
+# Keep this synchronized with ``crates/runner/src/deps.rs`` and the Python
+# test dependencies. Re-audit the private imports and generator behavior before
+# accepting another version.
+_SUPPORTED_MITMPROXY_VERSION = "12.2.2"
+_BRIDGE_MARKER_ATTRIBUTE = "_vm0_request_end_stream_bridge"
+_REQUEST_END_STREAM_METADATA = "_vm0_request_end_stream"
+
+
+def install_request_end_stream_bridge() -> None:
+    """Expose RequestHeaders.end_stream to the matching public hook once."""
+    if version.VERSION != _SUPPORTED_MITMPROXY_VERSION:
+        raise RuntimeError(
+            "VM0's request framing bridge requires mitmproxy "
+            f"{_SUPPORTED_MITMPROXY_VERSION}; found {version.VERSION}"
+        )
+
+    current_handler = HttpStream.state_wait_for_request_headers
+    if hasattr(current_handler, _BRIDGE_MARKER_ATTRIBUTE):
+        return
+
+    def state_wait_for_request_headers(
+        self: HttpStream,
+        event: RequestHeaders,
+    ) -> layer.CommandGenerator[None]:
+        command_generator = current_handler(self, event)
+        try:
+            command = next(command_generator)
+        except StopIteration:
+            return
+
+        while True:
+            if isinstance(command, HttpRequestHeadersHook):
+                command.flow.metadata[_REQUEST_END_STREAM_METADATA] = event.end_stream
+
+            try:
+                completion: object = yield command
+            except GeneratorExit:
+                command_generator.close()
+                raise
+            except BaseException as error:
+                try:
+                    command = command_generator.throw(error)
+                except StopIteration:
+                    return
+            else:
+                try:
+                    command = command_generator.send(completion)
+                except StopIteration:
+                    return
+
+    setattr(state_wait_for_request_headers, _BRIDGE_MARKER_ATTRIBUTE, True)
+    HttpStream.state_wait_for_request_headers = state_wait_for_request_headers
+
+
+def take_request_end_stream(flow: http.HTTPFlow) -> bool | None:
+    """Consume the internal end-of-stream marker for one requestheaders hook."""
+    value = flow.metadata.pop(_REQUEST_END_STREAM_METADATA, None)
+    return value if isinstance(value, bool) else None

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from mitmproxy.addonmanager import Loader
 
 import mitm_addon
@@ -119,6 +120,15 @@ class TestAddonConfiguration:
             runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
             runner_flush_lifecycle.handle_runner_usage_flush_signal,
         )
+
+    def test_load_rejects_unreviewed_mitmproxy_version(self):
+        loader = Loader(_RecordingMaster())
+
+        with (
+            patch.object(mitm_addon.mitmproxy_compat.version, "VERSION", "12.2.3"),
+            pytest.raises(RuntimeError, match=r"requires mitmproxy 12\.2\.2; found 12\.2\.3"),
+        ):
+            mitm_addon.load(loader)
 
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -148,11 +148,14 @@ class TestAddonConfiguration:
     def test_configure_writes_addon_ready_marker_with_usage_state_id(self, tmp_path):
         ready_path = tmp_path / "addon-ready"
 
-        with patch.object(
-            mitm_addon.ctx,
-            "options",
-            _Options(addon_ready_path=str(ready_path)),
-            create=True,
+        with (
+            patch.object(mitm_addon, "__file__", _addon_file_path(tmp_path)),
+            patch.object(
+                mitm_addon.ctx,
+                "options",
+                _Options(addon_ready_path=str(ready_path)),
+                create=True,
+            ),
         ):
             mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
 

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -60,11 +60,13 @@ class _Options:
         self,
         *,
         usage_state_id: str = "runner-usage-state-id",
+        addon_ready_path: str = "",
         flush_interval_seconds: float = usage.DEFAULT_FLUSH_INTERVAL_SECONDS,
         client_session_id: str = "runner-session-test",
         client_version: str = "runner-version-test",
     ) -> None:
         self.vm0_usage_state_id = usage_state_id
+        self.vm0_addon_ready_path = addon_ready_path
         self.vm0_usage_flush_interval_seconds = flush_interval_seconds
         self.vm0_client_session_id = client_session_id
         self.vm0_client_version = client_version
@@ -112,6 +114,7 @@ class TestAddonConfiguration:
 
         option_names = [option.name for option in master.options.added]
         assert "vm0_usage_state_id" in option_names
+        assert "vm0_addon_ready_path" in option_names
         assert "vm0_client_session_id" in option_names
         assert "vm0_client_version" in option_names
         assert "vm0_usage_flush_interval_seconds" in option_names
@@ -141,6 +144,19 @@ class TestAddonConfiguration:
 
         state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         assert state["usageStateId"] == "runner-usage-state-id"
+
+    def test_configure_writes_addon_ready_marker_with_usage_state_id(self, tmp_path):
+        ready_path = tmp_path / "addon-ready"
+
+        with patch.object(
+            mitm_addon.ctx,
+            "options",
+            _Options(addon_ready_path=str(ready_path)),
+            create=True,
+        ):
+            mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
+
+        assert ready_path.read_text(encoding="utf-8") == "runner-usage-state-id"
 
     def test_configure_writes_fallback_pending_state_id_when_usage_state_id_is_empty(
         self, tmp_path

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -42,7 +42,7 @@ def _write_auth_base_firewall_registry(tmp_path: Path) -> Path:
             api_entry={
                 "base": f"https://{_PLACEHOLDER_HOST}",
                 "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
-                "permissions": [{"name": "send", "rules": ["GET /"]}],
+                "permissions": [{"name": "send", "rules": ["GET /", "HEAD /"]}],
             },
             network_policy={
                 "allow": ["send"],
@@ -74,9 +74,10 @@ def _start_http_layer(
     return client, http_layer
 
 
-def _start_http2_get(
+def _start_http2_request(
     addon_context: taddons.context,
     *,
+    method: str,
     end_stream: bool,
 ) -> tuple[HttpLayer, HttpRequestHeadersHook]:
     client, http_layer = _start_http_layer(addon_context, alpn=b"h2")
@@ -86,7 +87,7 @@ def _start_http2_get(
     http2.send_headers(
         1,
         [
-            (b":method", b"GET"),
+            (b":method", method.encode()),
             (b":scheme", b"https"),
             (b":authority", _PLACEHOLDER_HOST.encode()),
             (b":path", b"/"),
@@ -100,8 +101,10 @@ def _start_http2_get(
     return http_layer, request_headers_hook
 
 
-def _start_http1_get(
+def _start_http1_request(
     addon_context: taddons.context,
+    *,
+    method: str,
 ) -> tuple[HttpLayer, HttpRequestHeadersHook]:
     client, http_layer = _start_http_layer(addon_context, alpn=b"http/1.1")
 
@@ -109,7 +112,7 @@ def _start_http1_get(
         http_layer.handle_event(
             events.DataReceived(
                 client,
-                b"GET / HTTP/1.1\r\nHost: placeholder.example.com\r\n\r\n",
+                f"{method} / HTTP/1.1\r\nHost: placeholder.example.com\r\n\r\n".encode(),
             )
         )
     )
@@ -119,8 +122,10 @@ def _start_http1_get(
     return http_layer, request_headers_hook
 
 
-async def test_http2_open_auth_base_get_without_length_is_rejected_before_body(
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+async def test_http2_open_auth_base_request_without_length_is_rejected_before_body(
     tmp_path: Path,
+    method: Literal["GET", "HEAD"],
 ) -> None:
     registry_path = _write_auth_base_firewall_registry(tmp_path)
     get_headers = AsyncMock()
@@ -134,8 +139,9 @@ async def test_http2_open_auth_base_get_without_length_is_rejected_before_body(
             vm0_api_url="https://api.vm0.ai",
             vm0_proxy_registry_path=str(registry_path),
         )
-        http_layer, request_headers_hook = _start_http2_get(
+        http_layer, request_headers_hook = _start_http2_request(
             addon_context,
+            method=method,
             end_stream=False,
         )
         original_headers = tuple(request_headers_hook.flow.request.headers.fields)
@@ -169,9 +175,11 @@ async def test_http2_open_auth_base_get_without_length_is_rejected_before_body(
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/1.1", "HTTP/2"])
-async def test_headers_only_auth_base_get_without_length_is_forwarded(
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+async def test_headers_only_auth_base_request_without_length_is_forwarded(
     tmp_path: Path,
     http_version: Literal["HTTP/1.1", "HTTP/2"],
+    method: Literal["GET", "HEAD"],
 ) -> None:
     registry_path = _write_auth_base_firewall_registry(tmp_path)
     token_meta = {
@@ -194,12 +202,16 @@ async def test_headers_only_auth_base_get_without_length_is_forwarded(
             vm0_proxy_registry_path=str(registry_path),
         )
         if http_version == "HTTP/2":
-            http_layer, request_headers_hook = _start_http2_get(
+            http_layer, request_headers_hook = _start_http2_request(
                 addon_context,
+                method=method,
                 end_stream=True,
             )
         else:
-            http_layer, request_headers_hook = _start_http1_get(addon_context)
+            http_layer, request_headers_hook = _start_http1_request(
+                addon_context,
+                method=method,
+            )
         original_headers = tuple(request_headers_hook.flow.request.headers.fields)
 
         await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -1,0 +1,213 @@
+"""Request framing integration tests through mitmproxy's real hook pipeline."""
+
+from pathlib import Path
+from typing import Literal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from h2.config import H2Configuration
+from h2.connection import H2Connection
+from mitmproxy import connection
+from mitmproxy.addons.proxyserver import Proxyserver
+from mitmproxy.flow import Error
+from mitmproxy.proxy import events
+from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.layers.http import HttpLayer, HTTPMode
+from mitmproxy.proxy.layers.http._hooks import (
+    HttpErrorHook,
+    HttpRequestHeadersHook,
+    HttpRequestHook,
+)
+from mitmproxy.test import taddons
+
+import auth
+import auth_base_forwarder
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+
+_CLIENT_IP = "10.200.0.5"
+_PLACEHOLDER_HOST = "placeholder.example.com"
+
+
+def _write_auth_base_firewall_registry(tmp_path: Path) -> Path:
+    return _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="webhook",
+            api_entry={
+                "base": f"https://{_PLACEHOLDER_HOST}",
+                "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+                "permissions": [{"name": "send", "rules": ["GET /"]}],
+            },
+            network_policy={
+                "allow": ["send"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+
+
+def _start_http_layer(
+    addon_context: taddons.context,
+    *,
+    alpn: bytes,
+) -> tuple[connection.Client, HttpLayer]:
+    client = connection.Client(
+        peername=(_CLIENT_IP, 12345),
+        sockname=("127.0.0.1", 8080),
+        state=connection.ConnectionState.OPEN,
+        tls=True,
+        alpn=alpn,
+        sni=_PLACEHOLDER_HOST,
+    )
+    context = Context(client, addon_context.options)
+    context.server.address = (_PLACEHOLDER_HOST, 443)
+    http_layer = HttpLayer(context, HTTPMode.regular)
+    list(http_layer.handle_event(events.Start()))
+    return client, http_layer
+
+
+def _start_http2_get(
+    addon_context: taddons.context,
+    *,
+    end_stream: bool,
+) -> tuple[HttpLayer, HttpRequestHeadersHook]:
+    client, http_layer = _start_http_layer(addon_context, alpn=b"h2")
+
+    http2 = H2Connection(H2Configuration(client_side=True, header_encoding=None))
+    http2.initiate_connection()
+    http2.send_headers(
+        1,
+        [
+            (b":method", b"GET"),
+            (b":scheme", b"https"),
+            (b":authority", _PLACEHOLDER_HOST.encode()),
+            (b":path", b"/"),
+        ],
+        end_stream=end_stream,
+    )
+    commands = list(http_layer.handle_event(events.DataReceived(client, http2.data_to_send())))
+    request_headers_hook = next(
+        command for command in commands if isinstance(command, HttpRequestHeadersHook)
+    )
+    return http_layer, request_headers_hook
+
+
+def _start_http1_get(
+    addon_context: taddons.context,
+) -> tuple[HttpLayer, HttpRequestHeadersHook]:
+    client, http_layer = _start_http_layer(addon_context, alpn=b"http/1.1")
+
+    commands = list(
+        http_layer.handle_event(
+            events.DataReceived(
+                client,
+                b"GET / HTTP/1.1\r\nHost: placeholder.example.com\r\n\r\n",
+            )
+        )
+    )
+    request_headers_hook = next(
+        command for command in commands if isinstance(command, HttpRequestHeadersHook)
+    )
+    return http_layer, request_headers_hook
+
+
+async def test_http2_open_auth_base_get_without_length_is_rejected_before_body(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_auth_base_firewall_registry(tmp_path)
+    get_headers = AsyncMock()
+
+    with (
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_http2_get(
+            addon_context,
+            end_stream=False,
+        )
+        original_headers = tuple(request_headers_hook.flow.request.headers.fields)
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        flow = request_headers_hook.flow
+        commands = list(http_layer.handle_event(events.HookCompleted(request_headers_hook, None)))
+        error_hook = next(command for command in commands if isinstance(command, HttpErrorHook))
+        await addon_context.master.addons.invoke_addon(mitm_addon, error_hook)
+
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
+    assert flow.request.raw_content is None
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_length_required"
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+    assert not any(isinstance(command, HttpRequestHook) for command in commands)
+    assert tuple(flow.request.headers.fields) == original_headers
+    get_headers.assert_not_awaited()
+
+    network_log_entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
+    assert network_log_entry["request_size"] == 0
+    assert network_log_entry["firewall_error"] == "auth_base_request_body_length_required"
+
+    proxy_log_entry = next(
+        entry
+        for entry in read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        if "framing_error" in entry
+    )
+    assert proxy_log_entry["framing_error"] == "request_stream_open"
+
+
+@pytest.mark.parametrize("http_version", ["HTTP/1.1", "HTTP/2"])
+async def test_headers_only_auth_base_get_without_length_is_forwarded(
+    tmp_path: Path,
+    http_version: Literal["HTTP/1.1", "HTTP/2"],
+) -> None:
+    registry_path = _write_auth_base_firewall_registry(tmp_path)
+    token_meta = {
+        "headers": {},
+        "base": "https://real.example.com/webhook",
+        "resolved_secrets": ["WEBHOOK_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+    with (
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+        fake_forwarder_upstream(status=200, body=b"ok"),
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        if http_version == "HTTP/2":
+            http_layer, request_headers_hook = _start_http2_get(
+                addon_context,
+                end_stream=True,
+            )
+        else:
+            http_layer, request_headers_hook = _start_http1_get(addon_context)
+        original_headers = tuple(request_headers_hook.flow.request.headers.fields)
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (1, 0)
+        assert tuple(request_headers_hook.flow.request.headers.fields) == original_headers
+
+        commands = list(http_layer.handle_event(events.HookCompleted(request_headers_hook, None)))
+        request_hook = next(command for command in commands if isinstance(command, HttpRequestHook))
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+
+    assert request_hook.flow.response is not None
+    assert request_hook.flow.response.status_code == 200
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -126,6 +126,7 @@ async def test_http2_open_auth_base_get_without_length_is_rejected_before_body(
     get_headers = AsyncMock()
 
     with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
         taddons.context(Proxyserver(), mitm_addon) as addon_context,
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
@@ -183,6 +184,7 @@ async def test_headers_only_auth_base_get_without_length_is_forwarded(
     }
 
     with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
         taddons.context(Proxyserver(), mitm_addon) as addon_context,
         patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
         fake_forwarder_upstream(status=200, body=b"ok"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -220,6 +220,8 @@ async def test_auth_base_requestheaders_rejects_saturated_admission_before_auth(
 @pytest.mark.parametrize(
     ("method", "request_header_pairs"),
     [
+        ("GET", []),
+        ("HEAD", []),
         ("POST", []),
         ("PUT", []),
         ("PATCH", []),
@@ -359,72 +361,6 @@ async def test_auth_base_requestheaders_accepts_matching_duplicate_content_lengt
     assert flow.error is None
     assert flow.live is True
     assert metadata_keys.FIREWALL_ERROR not in flow.metadata
-
-
-@pytest.mark.parametrize("method", ["GET", "HEAD"])
-async def test_auth_base_requestheaders_accepts_no_body_framing(
-    tmp_path, real_flow, mitm_ctx, headers, method
-):
-    reg_path = _write_auth_base_firewall_registry(tmp_path)
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="placeholder.example.com",
-        method=method,
-        path="/",
-        request_headers=headers(("Host", "placeholder.example.com")),
-    )
-    token_meta = {
-        "headers": {},
-        "base": "https://real.example.com/webhook",
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-    }
-
-    with (
-        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-        fake_forwarder_upstream(status=200, body=b"ok"),
-    ):
-        mitm_addon.requestheaders(flow)
-        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
-            1,
-            0,
-        )
-        await mitm_addon.request(flow)
-
-    assert flow.response is not None
-    assert flow.response.status_code == 200
-    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
-
-
-async def test_auth_base_bodyless_requests_do_not_spend_body_budget(
-    tmp_path, real_flow, mitm_ctx, headers
-):
-    reg_path = _write_auth_base_firewall_registry(tmp_path)
-    flows = [
-        real_flow(
-            with_response=False,
-            client_ip="10.200.0.5",
-            host="placeholder.example.com",
-            method="GET",
-            path="/",
-            request_headers=headers(("Host", "placeholder.example.com")),
-        )
-        for _ in range(2)
-    ]
-
-    with (
-        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        patch.object(auth_base_forwarder, "MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES", 1),
-    ):
-        for flow in flows:
-            mitm_addon.requestheaders(flow)
-
-    assert all(flow.response is None for flow in flows)
-    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (2, 0)
 
 
 async def test_requestheaders_skips_registry_for_bounded_body_headers(real_flow, headers):

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -13,6 +13,10 @@
 //! - `vm0_usage_state_id` identifies the currently running mitmdump/addon
 //!   process. Restart rotates this value so stale addon state from an older
 //!   child is rejected.
+//! - `vm0_addon_ready_path` points to a marker the addon writes only after its
+//!   hooks and runner options initialize successfully. Rust requires the
+//!   marker to contain the active usage state before accepting the TCP
+//!   listener as ready.
 //! - `usage-flush-request` is written by Rust before shutdown drain. The addon
 //!   acknowledges in `usage-pending` with the matching usage state, flush
 //!   request id, and pending flow/buffer/report counters.

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -902,6 +902,7 @@ PY
             "builtin_firewall_cache.py",
             "flow_metadata_keys.py",
             "matching.py",
+            "mitmproxy_compat.py",
             "registry.py",
             "response_streaming.py",
             "runner_flush_lifecycle.py",

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1049,6 +1049,7 @@ PY
         // `sleep` never listens on TCP — guarantees timeout.
         let mut child = tokio::process::Command::new("sleep")
             .arg("60")
+            .kill_on_drop(true)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
@@ -1123,6 +1124,7 @@ PY
         let dir = tempfile::tempdir().unwrap();
         let mut child = tokio::process::Command::new("sleep")
             .arg("60")
+            .kill_on_drop(true)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
@@ -1153,6 +1155,7 @@ PY
         std::fs::write(&addon_ready_path, "old-usage-state").unwrap();
         let mut child = tokio::process::Command::new("sleep")
             .arg("60")
+            .kill_on_drop(true)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -21,6 +21,7 @@ include!(concat!(env!("OUT_DIR"), "/addon_files.rs"));
 
 /// Timeout for waiting for mitmdump to become ready after spawn.
 const READY_TIMEOUT: Duration = Duration::from_secs(10);
+const ADDON_READY_FILENAME: &str = "addon-ready";
 /// Short bounded retry for Linux `execve` returning ETXTBSY while a freshly
 /// installed/replaced mitmdump binary is still observed as writable.
 const TEXT_BUSY_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(20);
@@ -510,6 +511,17 @@ pub(crate) async fn spawn_mitmdump(
     usage_state_id: &str,
 ) -> RunnerResult<tokio::process::Child> {
     let _prepared_ca = crate::ca::prepare_for_proxy(&config.ca_dir, &config.ca_lock_path).await?;
+    let addon_ready_path = config.addon_dir.join(ADDON_READY_FILENAME);
+    match tokio::fs::remove_file(&addon_ready_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(RunnerError::Internal(format!(
+                "remove stale addon ready marker {}: {error}",
+                addon_ready_path.display()
+            )));
+        }
+    }
     let mut cmd = tokio::process::Command::new(&config.mitmdump_bin);
     cmd.arg("--mode")
         .arg("transparent")
@@ -526,6 +538,11 @@ pub(crate) async fn spawn_mitmdump(
         ))
         .arg("--set")
         .arg(format!("vm0_usage_state_id={usage_state_id}"))
+        .arg("--set")
+        .arg(format!(
+            "vm0_addon_ready_path={}",
+            addon_ready_path.display()
+        ))
         .arg("--set")
         .arg(format!(
             "vm0_builtin_firewall_catalog_cache_path={}",
@@ -601,8 +618,15 @@ pub(crate) async fn spawn_mitmdump(
         });
     }
 
-    // Wait for process to be alive (poll liveness).
-    if let Err(e) = wait_for_ready(&mut child, port, READY_TIMEOUT).await {
+    if let Err(e) = wait_for_ready(
+        &mut child,
+        port,
+        &addon_ready_path,
+        usage_state_id,
+        READY_TIMEOUT,
+    )
+    .await
+    {
         stopping.store(true, Ordering::Release);
         let _ = child.kill().await;
         return Err(e);
@@ -664,10 +688,12 @@ async fn retry_text_busy_spawn<T>(
     }
 }
 
-/// Wait for mitmdump to start listening on `port` (TCP connect probe).
+/// Wait for the addon to initialize and mitmdump to start listening on `port`.
 async fn wait_for_ready(
     child: &mut tokio::process::Child,
     port: u16,
+    addon_ready_path: &Path,
+    expected_usage_state_id: &str,
     timeout: Duration,
 ) -> RunnerResult<()> {
     let poll_interval = Duration::from_millis(200);
@@ -692,15 +718,24 @@ async fn wait_for_ready(
                 )));
             }
         }
-        // Probe TCP port.
-        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+        let addon_is_ready = match tokio::fs::read_to_string(addon_ready_path).await {
+            Ok(usage_state_id) => usage_state_id == expected_usage_state_id,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "read addon ready marker {}: {error}",
+                    addon_ready_path.display()
+                )));
+            }
+        };
+        if addon_is_ready && tokio::net::TcpStream::connect(addr).await.is_ok() {
             return Ok(());
         }
         tokio::time::sleep(poll_interval).await;
     }
 
     Err(RunnerError::Internal(format!(
-        "mitmdump did not start listening on port {port} within {}s",
+        "mitmdump did not initialize its addon and start listening on port {port} within {}s",
         timeout.as_secs()
     )))
 }
@@ -749,19 +784,28 @@ mod tests {
 set -euo pipefail
 printf '%s\n' "$@" > "$0.args"
 port=""
+ready_path=""
+usage_state_id=""
 prev=""
 for arg in "$@"; do
   if [ "$prev" = "--listen-port" ]; then
     port="$arg"
-    break
   fi
+  case "$arg" in
+    vm0_addon_ready_path=*) ready_path="${arg#vm0_addon_ready_path=}" ;;
+    vm0_usage_state_id=*) usage_state_id="${arg#vm0_usage_state_id=}" ;;
+  esac
   prev="$arg"
 done
-exec python3 - "$port" <<'PY'
+exec python3 - "$port" "$ready_path" "$usage_state_id" <<'PY'
 import socket
 import sys
+from pathlib import Path
 
 port = int(sys.argv[1])
+ready_path = Path(sys.argv[2])
+ready_path.parent.mkdir(parents=True, exist_ok=True)
+ready_path.write_text(sys.argv[3], encoding="utf-8")
 sock = socket.socket()
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 sock.bind(("127.0.0.1", port))
@@ -1013,8 +1057,17 @@ PY
         let raw_pid = child.id().unwrap() as i32;
         let pid = nix::unistd::Pid::from_raw(raw_pid);
         let port = find_available_port().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let addon_ready_path = dir.path().join(ADDON_READY_FILENAME);
 
-        let result = wait_for_ready(&mut child, port, Duration::from_millis(500)).await;
+        let result = wait_for_ready(
+            &mut child,
+            port,
+            &addon_ready_path,
+            "usage-state-test",
+            Duration::from_millis(500),
+        )
+        .await;
         assert!(result.is_err());
 
         // Process must still be alive — wait_for_ready does NOT kill on error.
@@ -1048,8 +1101,46 @@ PY
         let _ = child.wait().await;
 
         let port = find_available_port().unwrap();
-        let result = wait_for_ready(&mut child, port, Duration::from_secs(5)).await;
+        let dir = tempfile::tempdir().unwrap();
+        let result = wait_for_ready(
+            &mut child,
+            port,
+            &dir.path().join(ADDON_READY_FILENAME),
+            "usage-state-test",
+            Duration::from_secs(5),
+        )
+        .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_rejects_stale_marker_when_port_is_open() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dir = tempfile::tempdir().unwrap();
+        let addon_ready_path = dir.path().join(ADDON_READY_FILENAME);
+        std::fs::write(&addon_ready_path, "old-usage-state").unwrap();
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        let error = wait_for_ready(
+            &mut child,
+            port,
+            &addon_ready_path,
+            "current-usage-state",
+            Duration::from_millis(500),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("did not initialize its addon"));
+        let _ = child.kill().await;
     }
 
     #[tokio::test]
@@ -1102,6 +1193,15 @@ PY
             args.lines()
                 .any(|arg| arg == "vm0_usage_state_id=usage-state-test"),
             "mitmdump args should include vm0_usage_state_id option; got:\n{args}",
+        );
+        assert!(
+            args.lines().any(|arg| {
+                arg == format!(
+                    "vm0_addon_ready_path={}",
+                    config.addon_dir.join(ADDON_READY_FILENAME).display()
+                )
+            }),
+            "mitmdump args should include vm0_addon_ready_path option; got:\n{args}",
         );
         assert!(
             args.lines().any(|arg| {

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1059,6 +1059,7 @@ PY
         let port = find_available_port().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let addon_ready_path = dir.path().join(ADDON_READY_FILENAME);
+        std::fs::write(&addon_ready_path, "usage-state-test").unwrap();
 
         let result = wait_for_ready(
             &mut child,
@@ -1111,6 +1112,34 @@ PY
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_rejects_missing_marker_when_port_is_open() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        let error = wait_for_ready(
+            &mut child,
+            port,
+            &dir.path().join(ADDON_READY_FILENAME),
+            "current-usage-state",
+            Duration::from_millis(500),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("did not initialize its addon"));
+        let _ = child.kill().await;
     }
 
     #[tokio::test]

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -36,6 +36,7 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 | `test_request_handler_public_destination.py`            | Request-hook public destination validation and revalidation                                                          |
 | `test_request_handler_connector_diagnostics.py`         | Request-hook connector diagnostics and inactive built-in connector diagnostics                                       |
 | `test_request_handler_auth_base_body.py`                | Request-hook auth-base body admission and cleanup                                                                    |
+| `test_mitmproxy_request_framing.py`                     | HTTP/2 request framing through mitmproxy's state machine and real addon hook dispatch                                 |
 | `test_request_handler_usage_tracking.py`                | Request-hook billable usage tracking lifecycle                                                                       |
 | `test_response_headers_handler.py`                      | Response-header hook stream setup                                                                                    |
 | `test_response_handler_connector_diagnostics.py`        | Response-hook connector diagnostic replacement and streaming lifecycle                                               |


### PR DESCRIPTION
## Summary

- bridge mitmproxy 12.2.2's internal `RequestHeaders.end_stream` value into the real `requestheaders` hook through one-time flow metadata while preserving the original generator's command/reply behavior
- reject no-`Content-Length` `auth.base` GET/HEAD requests unless transport framing proves the request ended with headers; missing or open-stream evidence fails closed before auth, admission, body buffering, or upstream contact
- pin Python tests to the production mitmproxy version, reject unaudited versions, and verify the compatibility module is embedded in the runner binary
- require a per-process addon initialization marker matching the runner's current usage-state nonce in addition to TCP readiness, so script import, load, configure, or version-gate failures cannot leave an apparently ready fail-open proxy
- exercise real HTTP/2 frames and actual addon hook dispatch for GET and HEAD with both END_STREAM values, HTTP/1.1 compatibility, forwarding, logging, admission cleanup, and independent runner/addon readiness gates

## Scope

This keeps the existing bounded, fully buffered `auth.base` forwarder. It does not add a global mitmproxy body cap, change unrelated upload limits, downgrade HTTP/2, introduce streaming or disk spooling, or modify external APIs, persisted data, or cross-version backend/runner protocols.

## Validation

- `ruff format --check src tests scripts`
- `ruff check src tests scripts`
- `basedpyright`
- mitmproxy 12.2.2 environment: `python3 -m pytest -q` — 4051 passed
- current-head focused Python integration: request framing — 6 passed; addon configuration — 9 passed
- real mitmproxy 12.2.2 startup smoke test verified the addon writes the current readiness nonce
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner` — 2745 passed, 12 ignored; guest inventory integration passed
- current-head focused Rust readiness tests — 4 passed

Closes #21968
