### PR TITLE
perf(api): load persisted run environment in one statement

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4880,6 +4880,162 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   });
 });
 
+describe("RUN-02: persisted run environment resolution", () => {
+  it("preserves scope precedence and excludes unreferenced secrets", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsApi(context);
+    const authOrg = createAuthOrgAgentsBddApi(context);
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected persisted environment actor organization");
+    }
+    const orgActor = bdd.user({
+      userId: "__org__",
+      orgId: actor.orgId,
+      orgRole: "org:admin",
+    });
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    api.configureRunnerGroup();
+    await api.grantProEntitlement(actor);
+
+    const suffix = randomUUID().replaceAll("-", "").slice(0, 8).toUpperCase();
+    const names = {
+      orgOnlyVariable: `BDD_ORG_ONLY_VARIABLE_${suffix}`,
+      userVariable: `BDD_USER_VARIABLE_${suffix}`,
+      requestVariable: `BDD_REQUEST_VARIABLE_${suffix}`,
+      orgOnlySecret: `BDD_ORG_ONLY_SECRET_${suffix}`,
+      userSecret: `BDD_USER_SECRET_${suffix}`,
+      requestSecret: `BDD_REQUEST_SECRET_${suffix}`,
+      unreferencedSecret: `BDD_UNREFERENCED_SECRET_${suffix}`,
+    };
+
+    await authOrg.setVariable(orgActor, {
+      name: names.orgOnlyVariable,
+      value: "org-only-variable-value",
+    });
+    await authOrg.setVariable(orgActor, {
+      name: names.userVariable,
+      value: "org-user-variable-value",
+    });
+    await authOrg.setVariable(actor, {
+      name: names.userVariable,
+      value: "user-variable-value",
+    });
+    await authOrg.setVariable(orgActor, {
+      name: names.requestVariable,
+      value: "org-request-variable-value",
+    });
+    await authOrg.setVariable(actor, {
+      name: names.requestVariable,
+      value: "user-request-variable-value",
+    });
+
+    await authOrg.setSecret(orgActor, {
+      name: names.orgOnlySecret,
+      value: "org-only-secret-value",
+    });
+    await authOrg.setSecret(orgActor, {
+      name: names.userSecret,
+      value: "org-user-secret-value",
+    });
+    await authOrg.setSecret(actor, {
+      name: names.userSecret,
+      value: "user-secret-value",
+    });
+    await authOrg.setSecret(orgActor, {
+      name: names.requestSecret,
+      value: "org-request-secret-value",
+    });
+    await authOrg.setSecret(actor, {
+      name: names.requestSecret,
+      value: "user-request-secret-value",
+    });
+    await authOrg.setSecret(actor, {
+      name: names.unreferencedSecret,
+      value: "unreferenced-secret-value",
+    });
+
+    const composeName = `bdd-persisted-environment-${suffix.toLowerCase()}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            ORG_ONLY_VARIABLE: `\${{ vars.${names.orgOnlyVariable} }}`,
+            USER_VARIABLE: `\${{ vars.${names.userVariable} }}`,
+            REQUEST_VARIABLE: `\${{ vars.${names.requestVariable} }}`,
+            ORG_ONLY_SECRET: `\${{ secrets.${names.orgOnlySecret} }}`,
+            USER_SECRET: `\${{ secrets.${names.userSecret} }}`,
+            REQUEST_SECRET: `\${{ secrets.${names.requestSecret} }}`,
+          },
+        },
+      },
+    });
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "resolve persisted environment",
+      vars: { [names.requestVariable]: "request-variable-value" },
+      secrets: { [names.requestSecret]: "request-secret-value" },
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment).toMatchObject({
+      ORG_ONLY_VARIABLE: "org-only-variable-value",
+      USER_VARIABLE: "user-variable-value",
+      REQUEST_VARIABLE: "request-variable-value",
+      ORG_ONLY_SECRET: "org-only-secret-value",
+      USER_SECRET: "user-secret-value",
+      REQUEST_SECRET: "request-secret-value",
+    });
+    expect(claim.secretValues).not.toContain("unreferenced-secret-value");
+    expect(claim.environment).not.toHaveProperty(names.unreferencedSecret);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+
+    const variableOnlyComposeName = `bdd-persisted-vars-${suffix.toLowerCase()}`;
+    const variableOnlyCompose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [variableOnlyComposeName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            ORG_ONLY_VARIABLE: `\${{ vars.${names.orgOnlyVariable} }}`,
+            USER_VARIABLE: `\${{ vars.${names.userVariable} }}`,
+          },
+        },
+      },
+    });
+    const variableOnlyRun = await api.createDirectRun(actor, {
+      agentComposeId: variableOnlyCompose.composeId,
+      prompt: "resolve persisted variables without secret references",
+    });
+    const variableOnlyClaim = await api.claimRunnerJob(variableOnlyRun.runId);
+
+    expect(variableOnlyClaim.environment).toMatchObject({
+      ORG_ONLY_VARIABLE: "org-only-variable-value",
+      USER_VARIABLE: "user-variable-value",
+    });
+    expect(variableOnlyClaim.secretValues).toBeNull();
+    expect(variableOnlyClaim.environment).not.toHaveProperty(
+      names.unreferencedSecret,
+    );
+
+    await api.requestCancelRun(actor, variableOnlyRun.runId, [200]);
+    const variableOnlyCancelled = await api.readRun(
+      actor,
+      variableOnlyRun.runId,
+    );
+    expect(variableOnlyCancelled.status).toBe("cancelled");
+  });
+});
+
 describe("RUN-02: stored connector injection into claimed runs", () => {
   it("omits connected stored connectors when the Zero run allowlist is empty", async () => {
     const api = createRunsApi(context);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -641,6 +641,8 @@ interface PersistedRunEnvironmentSnapshot {
   readonly variables: readonly PersistedRunEnvironmentVariable[];
 }
 
+type PersistedRunEnvironmentRowKind = "variable" | "secret";
+
 interface CustomConnectorRuntimeContext {
   readonly firewalls: readonly ExpandedFirewallConfig[];
   readonly reservedSecretAliases: Record<string, true> | undefined;
@@ -2035,41 +2037,39 @@ async function loadPersistedRunEnvironmentSnapshot(
     readonly content: AgentComposeContent;
   },
 ): Promise<PersistedRunEnvironmentSnapshot> {
-  return await db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
-    );
-    const variableRows = await tx
-      .select({
-        name: variables.name,
-        value: variables.value,
-        userId: variables.userId,
+  const environment = firstAgent(args.content)?.environment;
+  const referencedSecretNames = environment
+    ? extractAndGroupVariables(environment).secrets.map((ref) => {
+        return ref.name;
       })
-      .from(variables)
-      .where(
-        and(
-          eq(variables.orgId, args.orgId),
-          eq(variables.type, "user"),
-          or(
-            eq(variables.userId, ORG_SENTINEL_USER_ID),
-            eq(variables.userId, args.userId),
-          ),
+    : [];
+  const secretNamesToLoad = [...new Set(referencedSecretNames)];
+  const variableQuery = db
+    .select({
+      kind: sql<PersistedRunEnvironmentRowKind>`'variable'`.as("kind"),
+      name: variables.name,
+      value: variables.value,
+      userId: variables.userId,
+    })
+    .from(variables)
+    .where(
+      and(
+        eq(variables.orgId, args.orgId),
+        eq(variables.type, "user"),
+        or(
+          eq(variables.userId, ORG_SENTINEL_USER_ID),
+          eq(variables.userId, args.userId),
         ),
-      );
-
-    const environment = firstAgent(args.content)?.environment;
-    const referencedSecretNames = environment
-      ? extractAndGroupVariables(environment).secrets.map((ref) => {
-          return ref.name;
-        })
-      : [];
-    const secretNamesToLoad = [...new Set(referencedSecretNames)];
-    const secretRows =
-      secretNamesToLoad.length > 0
-        ? await tx
+      ),
+    );
+  const rows =
+    secretNamesToLoad.length > 0
+      ? await variableQuery.unionAll(
+          db
             .select({
+              kind: sql<PersistedRunEnvironmentRowKind>`'secret'`.as("kind"),
               name: secretsTable.name,
-              encryptedValue: secretsTable.encryptedValue,
+              value: secretsTable.encryptedValue,
               userId: secretsTable.userId,
             })
             .from(secretsTable)
@@ -2083,11 +2083,29 @@ async function loadPersistedRunEnvironmentSnapshot(
                 ),
                 inArray(secretsTable.name, secretNamesToLoad),
               ),
-            )
-        : [];
+            ),
+        )
+      : await variableQuery;
 
-    return { variables: variableRows, secrets: secretRows };
-  });
+  const variableRows: PersistedRunEnvironmentVariable[] = [];
+  const secretRows: PersistedRunEnvironmentSecret[] = [];
+  for (const row of rows) {
+    if (row.kind === "variable") {
+      variableRows.push({
+        name: row.name,
+        value: row.value,
+        userId: row.userId,
+      });
+    } else {
+      secretRows.push({
+        name: row.name,
+        encryptedValue: row.value,
+        userId: row.userId,
+      });
+    }
+  }
+
+  return { variables: variableRows, secrets: secretRows };
 }
 
 function buildMergedVariables(args: {


### PR DESCRIPTION
## Summary

- load persisted user and organization variables plus referenced secrets with one PostgreSQL statement
- avoid the transaction setup, isolation command, and commit round trips previously needed for two separate reads
- preserve organization, user, and request override precedence while continuing to exclude unreferenced persisted secrets

This reduces the persisted-environment stage from four or five database client calls to one. A single statement provides one PostgreSQL statement snapshot, so the previous cross-query transaction is no longer needed.

## Scope

- no database schema or migration changes
- no persisted-data format changes
- no API, queue payload, runner protocol, or frontend changes
- the no-secret-reference path executes only the variables branch rather than adding an empty secrets query

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "preserves scope precedence and excludes unreferenced secrets" --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1` (106 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- repository pre-commit hooks, including full Turbo type checking and Knip

Closes #22006

Parent delivery issue: #21674
