### PR TITLE
refactor(runner): remove affinity rollout compatibility

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -533,9 +533,7 @@ mod tests {
     use crate::ids::RunId;
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
-    use crate::types::{
-        SessionHistorySizeBucket, WorkspaceCacheState, WorkspaceSessionHistorySidecarState,
-    };
+    use crate::types::WorkspaceCacheState;
     use crate::workspace_image_cache::{
         WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
@@ -579,18 +577,6 @@ mod tests {
         WorkspaceCacheState {
             profile: profile.to_owned(),
             workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
-            session_history_sidecar: None,
-        }
-    }
-
-    fn workspace_cache_with_sidecar(profile: &str, run_id: RunId) -> WorkspaceCacheState {
-        WorkspaceCacheState {
-            profile: profile.to_owned(),
-            workspace_affinity_version: Some(crate::types::WORKSPACE_AFFINITY_VERSION),
-            session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
-                history_generation_run_id: Some(run_id),
-                raw_size_bucket: SessionHistorySizeBucket::LessThan64Kib,
-            }),
         }
     }
 
@@ -1081,36 +1067,6 @@ mod tests {
         assert_eq!(states, vec![original]);
     }
 
-    #[test]
-    fn held_session_snapshot_concurrent_promotion_clears_stale_sidecar_attribution() {
-        let snapshot = HeldSessionStateSnapshot::new();
-        let run_id = RunId::new_v4();
-        let observed = HeldSessionState {
-            session_id: "sess-shared".into(),
-            last_completed_at: "2026-06-01T00:00:01.000Z".into(),
-            reusable_sandbox: None,
-            workspace_caches: vec![workspace_cache_with_sidecar("vm0/default", run_id)],
-        };
-        refresh_snapshot(&snapshot, vec![observed.clone()]);
-
-        let refresh = snapshot.begin_workspace_cache_refresh();
-        snapshot.upsert_workspace_cache_state(HeldSessionState {
-            session_id: "sess-shared".into(),
-            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
-            reusable_sandbox: None,
-            workspace_caches: vec![workspace_cache("vm0/default")],
-        });
-        let refreshed = snapshot.finish_workspace_cache_refresh(refresh, vec![observed]);
-
-        assert_eq!(refreshed.len(), 1);
-        assert_eq!(refreshed[0].workspace_caches.len(), 1);
-        assert!(
-            refreshed[0].workspace_caches[0]
-                .session_history_sidecar
-                .is_none()
-        );
-    }
-
     fn timestamp_for_index(index: usize) -> String {
         format!("2026-06-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
     }
@@ -1216,7 +1172,6 @@ mod tests {
             workspace_caches: vec![WorkspaceCacheState {
                 profile: "vm0/default".into(),
                 workspace_affinity_version: None,
-                session_history_sidecar: None,
             }],
         };
         let capable = HeldSessionState {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -13,7 +13,6 @@ use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
-use super::HEARTBEAT_PERIOD;
 use super::active_sessions::ActiveCliAgentSessionGuard;
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
@@ -37,8 +36,7 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::paths::short_digest;
 use crate::provider::{
-    ClaimedJob, JobCandidate, LocalAdmissionResourceKind, PreLocalAdmissionOutcome,
-    SessionAffinityLocalResource, SessionHistoryGenerationLocalAvailability,
+    ClaimedJob, JobCandidate, LocalAdmissionResourceKind, SessionAffinityLocalResource,
     SessionHistoryGenerationRelationship,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -106,26 +104,6 @@ impl LocalAdmissionResource {
                 Some(_) => SessionHistoryGenerationRelationship::Different,
                 None => SessionHistoryGenerationRelationship::UnknownReserved,
             },
-        }
-    }
-
-    fn session_history_generation_local_availability(
-        &self,
-        target_generation_run_id: Option<RunId>,
-        candidate_discovered_at: Instant,
-    ) -> Option<SessionHistoryGenerationLocalAvailability> {
-        target_generation_run_id?;
-        let Self::Reusable(reservation) = self else {
-            return None;
-        };
-        let parked_at = reservation.parked_at();
-        if parked_at > candidate_discovered_at {
-            return Some(SessionHistoryGenerationLocalAvailability::AfterDiscovery);
-        }
-        if candidate_discovered_at.duration_since(parked_at) < HEARTBEAT_PERIOD {
-            Some(SessionHistoryGenerationLocalAvailability::BeforeDiscoveryLtHeartbeatPeriod)
-        } else {
-            Some(SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod)
         }
     }
 }
@@ -580,16 +558,7 @@ async fn claim_with_local_admission(
     let relationship = admission
         .resource
         .session_history_generation_relationship(target_generation_run_id);
-    let local_availability = admission
-        .resource
-        .session_history_generation_local_availability(
-            target_generation_run_id,
-            candidate.discovered_at(),
-        );
     candidate.set_session_history_generation_relationship(relationship);
-    if let Some(local_availability) = local_availability {
-        candidate.set_session_history_generation_local_availability(local_availability);
-    }
     // claim() runs in the branch handler: non-interruptible, so a valid
     // successful claim is always paired with complete().
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {
@@ -635,8 +604,7 @@ async fn prepare_affinity_protected_candidate(
         )
         .await
         {
-            let mut candidate =
-                candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+            let mut candidate = candidate;
             candidate
                 .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
             return Some(PreparedAffinityCandidate {
@@ -661,8 +629,7 @@ async fn prepare_affinity_protected_candidate(
 
     if !candidate.is_affinity_protected() {
         return Some(PreparedAffinityCandidate {
-            candidate: candidate
-                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected),
+            candidate,
             resource: None,
         });
     }
@@ -690,8 +657,7 @@ async fn prepare_affinity_protected_candidate(
             )
             .await
             {
-                let mut candidate = candidate
-                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                let mut candidate = candidate;
                 candidate.set_session_affinity_local_resource(
                     SessionAffinityLocalResource::ReusableSandbox,
                 );
@@ -711,8 +677,7 @@ async fn prepare_affinity_protected_candidate(
             )
             .await
             {
-                let mut candidate = candidate
-                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                let mut candidate = candidate;
                 candidate.set_session_affinity_local_resource(
                     SessionAffinityLocalResource::ReusableSandbox,
                 );
@@ -735,8 +700,7 @@ async fn prepare_affinity_protected_candidate(
                 && let Some(lease) =
                     ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
             {
-                let mut candidate = candidate
-                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                let mut candidate = candidate;
                 candidate.set_session_affinity_local_resource(
                     SessionAffinityLocalResource::WorkspaceCache,
                 );

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -39,7 +39,7 @@ use crate::paths::short_digest;
 use crate::provider::{
     ClaimedJob, JobCandidate, LocalAdmissionResourceKind, PreLocalAdmissionOutcome,
     SessionAffinityLocalResource, SessionHistoryGenerationLocalAvailability,
-    SessionHistoryGenerationRelationship, WorkspaceSessionHistorySidecarRelationship,
+    SessionHistoryGenerationRelationship,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
@@ -49,7 +49,7 @@ use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{
     ExecutionContext, HeldSessionState, SandboxReuseResult, SessionAffinityResource,
-    SessionHistorySizeBucket, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState,
+    WORKSPACE_AFFINITY_VERSION,
 };
 
 pub(super) struct DiscoveredJob {
@@ -667,23 +667,16 @@ async fn prepare_affinity_protected_candidate(
         });
     }
     let Some(cli_agent_session_id) = candidate.cli_agent_session_id().map(str::to_owned) else {
-        if candidate.session_affinity_resource().is_some() {
-            let delay = candidate
-                .affinity_protection_remaining()
-                .unwrap_or_default();
-            info!(
-                run_id = %candidate.run_id(),
-                delay_ms = delay.as_millis(),
-                "resource-class affinity candidate missing session metadata, deferring claim"
-            );
-            ctx.spawn_ctx.provider.defer_poll_after(delay).await;
-            return None;
-        }
-        return Some(PreparedAffinityCandidate {
-            candidate: candidate
-                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::MissingSessionMetadata),
-            resource: None,
-        });
+        let delay = candidate
+            .affinity_protection_remaining()
+            .unwrap_or_default();
+        info!(
+            run_id = %candidate.run_id(),
+            delay_ms = delay.as_millis(),
+            "affinity-protected candidate missing session metadata, deferring claim"
+        );
+        ctx.spawn_ctx.provider.defer_poll_after(delay).await;
+        return None;
     };
 
     match candidate.session_affinity_resource() {
@@ -730,15 +723,15 @@ async fn prepare_affinity_protected_candidate(
             }
 
             let held_session_states = current_local_held_session_states(ctx).await;
-            let capable_workspace = held_session_states
+            let has_capable_workspace = held_session_states
                 .iter()
                 .filter(|state| state.session_id == cli_agent_session_id)
                 .flat_map(|state| &state.workspace_caches)
-                .find(|workspace| {
+                .any(|workspace| {
                     workspace.profile == profile_name
                         && workspace.workspace_affinity_version == Some(WORKSPACE_AFFINITY_VERSION)
                 });
-            if let Some(capable_workspace) = capable_workspace
+            if has_capable_workspace
                 && let Some(lease) =
                     ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
             {
@@ -747,47 +740,13 @@ async fn prepare_affinity_protected_candidate(
                 candidate.set_session_affinity_local_resource(
                     SessionAffinityLocalResource::WorkspaceCache,
                 );
-                let (relationship, raw_size_bucket) = workspace_sidecar_observation(
-                    capable_workspace,
-                    candidate.history_generation_run_id(),
-                );
-                candidate.set_workspace_session_history_sidecar_observation(
-                    relationship,
-                    raw_size_bucket,
-                );
                 return Some(PreparedAffinityCandidate {
                     candidate,
                     resource: Some(LocalAdmissionResource::Fresh(lease)),
                 });
             }
         }
-        None => {
-            // Transitional fallback for API candidates without resource classes.
-            // Remove after the rollout gate tracked by #21871.
-            let has_reusable = ctx.idle_pool.lock().await.has_reusable(
-                &cli_agent_session_id,
-                profile_name,
-                device_rate_limits,
-            );
-            let held_session_states = current_local_held_session_states(ctx).await;
-            let has_fresh_affinity = ctx.budget.can_afford(job_vcpu, job_memory)
-                && held_session_states
-                    .iter()
-                    .any(|state| state.session_id == cli_agent_session_id);
-            if has_reusable || has_fresh_affinity {
-                let mut candidate = candidate
-                    .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
-                candidate.set_session_affinity_local_resource(if has_reusable {
-                    SessionAffinityLocalResource::ReusableSandbox
-                } else {
-                    SessionAffinityLocalResource::LegacySession
-                });
-                return Some(PreparedAffinityCandidate {
-                    candidate,
-                    resource: None,
-                });
-            }
-        }
+        None => {}
     }
 
     let delay = candidate
@@ -802,35 +761,6 @@ async fn prepare_affinity_protected_candidate(
     );
     ctx.spawn_ctx.provider.defer_poll_after(delay).await;
     None
-}
-
-fn workspace_sidecar_observation(
-    workspace: &WorkspaceCacheState,
-    target_generation_run_id: Option<RunId>,
-) -> (
-    WorkspaceSessionHistorySidecarRelationship,
-    Option<SessionHistorySizeBucket>,
-) {
-    let Some(target_generation_run_id) = target_generation_run_id else {
-        return (
-            WorkspaceSessionHistorySidecarRelationship::NoTarget,
-            workspace
-                .session_history_sidecar
-                .as_ref()
-                .map(|sidecar| sidecar.raw_size_bucket),
-        );
-    };
-    let Some(sidecar) = workspace.session_history_sidecar.as_ref() else {
-        return (WorkspaceSessionHistorySidecarRelationship::Absent, None);
-    };
-    let relationship = match sidecar.history_generation_run_id {
-        Some(generation_run_id) if generation_run_id == target_generation_run_id => {
-            WorkspaceSessionHistorySidecarRelationship::Exact
-        }
-        Some(_) => WorkspaceSessionHistorySidecarRelationship::Different,
-        None => WorkspaceSessionHistorySidecarRelationship::Legacy,
-    };
-    (relationship, Some(sidecar.raw_size_bucket))
 }
 
 fn diagnostic_session_fingerprint(session_id: &str) -> String {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -73,7 +73,6 @@ fn mark_workspace_cache_snapshot_promoted(
             workspace_caches: vec![WorkspaceCacheState {
                 profile: profile_name.to_owned(),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                session_history_sidecar: None,
             }],
         });
     }

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -5,15 +5,17 @@ use super::super::support::{
     wait_budget_count, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
 };
 
-use crate::types::SandboxReuseResult;
+use crate::types::{SandboxReuseResult, SessionAffinityResource};
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
 fn reusable_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
-    crate::provider::JobCandidate::new(run_id, "vm0/default".into()).with_affinity_metadata(
-        Some(session_id.to_string()),
-        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-    )
+    crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+        .with_affinity_metadata(
+            Some(session_id.to_string()),
+            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+        )
+        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
 }
 
 /// When the runner takes a sandbox out of the idle pool for reuse and

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -11,7 +11,7 @@ use super::support::{
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
-use crate::types::SandboxReuseResult;
+use crate::types::{SandboxReuseResult, SessionAffinityResource};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
@@ -21,10 +21,12 @@ fn reusable_candidate(
     profile_name: &str,
     session_id: &str,
 ) -> crate::provider::JobCandidate {
-    crate::provider::JobCandidate::new(run_id, profile_name.to_string()).with_affinity_metadata(
-        Some(session_id.to_string()),
-        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-    )
+    crate::provider::JobCandidate::new(run_id, profile_name.to_string())
+        .with_affinity_metadata(
+            Some(session_id.to_string()),
+            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+        )
+        .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox))
 }
 
 // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -659,6 +659,38 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
 }
 
 #[tokio::test(start_paused = true)]
+async fn affinity_protected_candidate_without_session_metadata_defers_before_claim() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(minimal_context(run_id)));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_affinity_metadata(None, Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()))
+                .with_session_affinity_resource(Some(SessionAffinityResource::ReusableSandbox)),
+        )
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "a protected candidate without session metadata must not reach claim"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn affinity_protected_candidate_without_resource_defers_even_when_session_is_local() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,17 +1,16 @@
 use super::super::super::*;
 use super::super::support::{
-    TestParkedIdleCandidateSpec, TestWorkspaceSidecar, assert_run_exits_within,
-    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
-    push_job, seed_idle_pool, seed_idle_pool_with_history_generation,
-    seed_idle_pool_with_overrides, seed_idle_pool_with_timing, seed_workspace_cache_state,
-    shutdown, test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
-    wait_discover_entered,
+    TestParkedIdleCandidateSpec, assert_run_exits_within, context_with_session, minimal_context,
+    mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool,
+    seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    seed_idle_pool_with_timing, seed_workspace_cache_state, shutdown, test_profiles,
+    wait_budget_count, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
-use crate::types::{SandboxReuseResult, SessionAffinityResource, SessionHistorySizeBucket};
+use crate::types::{SandboxReuseResult, SessionAffinityResource};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
@@ -381,7 +380,7 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.handle
         .discover_tx
         .send(
-            affinity_protected_candidate(followup_run_id, session_id)
+            reusable_affinity_protected_candidate(followup_run_id, session_id)
                 .with_history_generation_run_id(Some(followup_target_generation_run_id)),
         )
         .unwrap();
@@ -660,6 +659,40 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
 }
 
 #[tokio::test(start_paused = true)]
+async fn affinity_protected_candidate_without_resource_defers_even_when_session_is_local() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let session_id = "sess-local-without-resource";
+    seed_idle_pool(&idle_pool, &budget, session_id, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(affinity_protected_candidate(run_id, session_id))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "a protected candidate without a typed resource must not use legacy local admission"
+    );
+    assert_eq!(env.handle.deferred_poll_delays().len(), 1);
+    assert_eq!(
+        idle_pool.lock().await.held_sessions(),
+        vec![session_id.to_string()]
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn ready_direct_drain_continues_after_affinity_defer() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let run_handle = tokio::spawn(run(config));
@@ -910,7 +943,6 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         session_id,
         "vm0/default",
         image_size_bytes,
-        None,
     )
     .await;
     let cache_key = crate::paths::scoped_session_workspace_cache_key(
@@ -1017,147 +1049,12 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         Some(crate::provider::LocalAdmissionResourceKind::Fresh)
     );
     assert_eq!(
-        claimed_candidate.workspace_session_history_sidecar_relationship(),
-        Some(crate::provider::WorkspaceSessionHistorySidecarRelationship::Absent)
-    );
-    assert_eq!(
-        claimed_candidate.workspace_session_history_sidecar_raw_size_bucket(),
-        None
-    );
-    assert_eq!(
         env.handle.deferred_poll_delays().len(),
         2,
         "the workspace-selected candidate should not add another deferral"
     );
 
     shutdown(&env, run_handle).await;
-}
-
-#[tokio::test]
-async fn workspace_selected_claim_records_observed_sidecar_relationship() {
-    #[derive(Clone, Copy, Debug)]
-    enum Case {
-        Exact,
-        Different,
-        Legacy,
-        Absent,
-        NoTarget,
-    }
-
-    for case in [
-        Case::Exact,
-        Case::Different,
-        Case::Legacy,
-        Case::Absent,
-        Case::NoTarget,
-    ] {
-        let session_id = format!("sess-cache-sidecar-{case:?}").to_ascii_lowercase();
-        let image_size_bytes = 1024 * 1024;
-        let producing_run_id = RunId::new_v4();
-        let (sidecar, target_generation_run_id, expected_relationship, expected_bucket) = match case
-        {
-            Case::Exact => (
-                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
-                Some(producing_run_id),
-                crate::provider::WorkspaceSessionHistorySidecarRelationship::Exact,
-                Some(SessionHistorySizeBucket::LessThan64Kib),
-            ),
-            Case::Different => (
-                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
-                Some(RunId::new_v4()),
-                crate::provider::WorkspaceSessionHistorySidecarRelationship::Different,
-                Some(SessionHistorySizeBucket::LessThan64Kib),
-            ),
-            Case::Legacy => (
-                Some(TestWorkspaceSidecar::Legacy),
-                Some(RunId::new_v4()),
-                crate::provider::WorkspaceSessionHistorySidecarRelationship::Legacy,
-                Some(SessionHistorySizeBucket::LessThan64Kib),
-            ),
-            Case::Absent => (
-                None,
-                Some(RunId::new_v4()),
-                crate::provider::WorkspaceSessionHistorySidecarRelationship::Absent,
-                None,
-            ),
-            Case::NoTarget => (
-                Some(TestWorkspaceSidecar::Attributed(producing_run_id)),
-                None,
-                crate::provider::WorkspaceSessionHistorySidecarRelationship::NoTarget,
-                Some(SessionHistorySizeBucket::LessThan64Kib),
-            ),
-        };
-
-        let mut profiles = test_profiles();
-        profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
-        let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
-        let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
-        let workspace_cache = SessionWorkspaceCache::shared(
-            runner_paths.clone(),
-            &config.paths.home,
-            &config.runner.group,
-        );
-        seed_workspace_cache_state(
-            &workspace_cache,
-            &runner_paths,
-            &session_id,
-            "vm0/default",
-            image_size_bytes,
-            sidecar,
-        )
-        .await;
-        Arc::get_mut(&mut config.exec_config)
-            .unwrap()
-            .workspace_cache = Some(workspace_cache);
-        let run_handle = tokio::spawn(run(config));
-        wait_discover_entered(&env, Duration::from_secs(2)).await;
-
-        let run_id = RunId::new_v4();
-        env.provider
-            .set_claim_result(run_id, Some(context_with_session(run_id, &session_id)));
-        env.handle
-            .discover_tx
-            .send(
-                workspace_affinity_protected_candidate(run_id, &session_id)
-                    .with_history_generation_run_id(target_generation_run_id),
-            )
-            .unwrap();
-        assert!(
-            env.handle
-                .wait_completion(run_id, Duration::from_secs(5))
-                .await
-                .is_some(),
-            "case {case:?} should claim and complete"
-        );
-
-        let claim_candidates = env.handle.claim_candidates();
-        let claimed_candidate = claim_candidates
-            .iter()
-            .find(|candidate| candidate.run_id() == run_id)
-            .expect("claim should record the workspace-selected candidate");
-        assert_eq!(
-            claimed_candidate.session_affinity_local_resource(),
-            Some(crate::provider::SessionAffinityLocalResource::WorkspaceCache),
-            "case: {case:?}"
-        );
-        assert_eq!(
-            claimed_candidate.local_admission_resource(),
-            Some(crate::provider::LocalAdmissionResourceKind::Fresh),
-            "case: {case:?}"
-        );
-        assert_eq!(
-            claimed_candidate.workspace_session_history_sidecar_relationship(),
-            Some(expected_relationship),
-            "case: {case:?}"
-        );
-        assert_eq!(
-            claimed_candidate.workspace_session_history_sidecar_raw_size_bucket(),
-            expected_bucket,
-            "case: {case:?}"
-        );
-
-        shutdown(&env, run_handle).await;
-    }
 }
 
 #[tokio::test]
@@ -1179,7 +1076,6 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
         session_id,
         "vm0/default",
         image_size_bytes,
-        None,
     )
     .await;
     Arc::get_mut(&mut config.exec_config)

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,10 +1,10 @@
 use super::super::super::*;
 use super::super::support::{
-    TestParkedIdleCandidateSpec, assert_run_exits_within, context_with_session, minimal_context,
-    mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool,
+    assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
+    mock_run_config_with_overrides, push_job, seed_idle_pool,
     seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
-    seed_idle_pool_with_timing, seed_workspace_cache_state, shutdown, test_profiles,
-    wait_budget_count, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
+    seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
+    wait_cancel_token_removed, wait_discover_entered,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
@@ -43,33 +43,15 @@ fn generation_affinity_protected_candidate(
     session_id: &str,
     target_generation_run_id: RunId,
 ) -> crate::provider::JobCandidate {
-    generation_affinity_protected_candidate_with_discovered_at(
-        run_id,
-        session_id,
-        target_generation_run_id,
-        std::time::Instant::now(),
-    )
-}
-
-fn generation_affinity_protected_candidate_with_discovered_at(
-    run_id: RunId,
-    session_id: &str,
-    target_generation_run_id: RunId,
-    discovered_at: std::time::Instant,
-) -> crate::provider::JobCandidate {
-    crate::provider::JobCandidate::new_with_discovered_at(
-        run_id,
-        "vm0/default".into(),
-        discovered_at,
-    )
-    .with_affinity_metadata(
-        Some(session_id.to_string()),
-        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
-    )
-    .with_history_generation_run_id(Some(target_generation_run_id))
-    .with_history_generation_affinity_protected_until(Some(
-        FUTURE_AFFINITY_PROTECTED_UNTIL.to_string(),
-    ))
+    crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+        .with_affinity_metadata(
+            Some(session_id.to_string()),
+            Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+        )
+        .with_history_generation_run_id(Some(target_generation_run_id))
+        .with_history_generation_affinity_protected_until(Some(
+            FUTURE_AFFINITY_PROTECTED_UNTIL.to_string(),
+        ))
 }
 
 /// TOCTOU regression: soft drain can arrive after the main loop has selected
@@ -214,10 +196,6 @@ async fn claim_failure_rolls_back_budget() {
         unavailable_candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::Fresh)
     );
-    assert_eq!(
-        unavailable_candidate.session_history_generation_local_availability(),
-        None
-    );
 
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
@@ -244,10 +222,6 @@ async fn claim_failure_rolls_back_budget() {
     assert_eq!(
         followup_candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::UnknownTarget)
-    );
-    assert_eq!(
-        followup_candidate.session_history_generation_local_availability(),
-        None
     );
 
     shutdown(&env, run_handle).await;
@@ -312,19 +286,14 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     let idle_pool = Arc::clone(&env.idle_pool);
     let session_id = "sess-conflict-restore";
     let reserved_generation_run_id = RunId::new_v4();
-    let discovered_at = std::time::Instant::now();
-    seed_idle_pool_with_timing(
+    seed_idle_pool_with_history_generation(
         &idle_pool,
         &budget,
-        TestParkedIdleCandidateSpec {
-            session_id,
-            profile_name: "vm0/default",
-            vcpu: 2,
-            memory_mb: 4096,
-            history_generation_run_id: Some(reserved_generation_run_id),
-            parked_at: discovered_at - HEARTBEAT_PERIOD,
-            idle_timeout: Duration::from_secs(300),
-        },
+        session_id,
+        "vm0/default",
+        2,
+        4096,
+        reserved_generation_run_id,
     )
     .await;
     let run_handle = tokio::spawn(run(config));
@@ -335,11 +304,10 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(conflict_run_id, None);
     env.handle
         .discover_tx
-        .send(generation_affinity_protected_candidate_with_discovered_at(
+        .send(generation_affinity_protected_candidate(
             conflict_run_id,
             session_id,
             reserved_generation_run_id,
-            discovered_at,
         ))
         .unwrap();
 
@@ -363,12 +331,6 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     assert_eq!(
         conflict_candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::Exact)
-    );
-    assert_eq!(
-        conflict_candidate.session_history_generation_local_availability(),
-        Some(
-            crate::provider::SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod
-        )
     );
 
     let followup_run_id = RunId::new_v4();
@@ -446,65 +408,7 @@ async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn reusable_generation_parked_after_discovery_is_attributed_at_claim() {
-    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
-    let budget = Arc::clone(&config.capacity.budget);
-    let idle_pool = Arc::clone(&env.idle_pool);
-    let session_id = "sess-parked-after-discovery";
-    let generation_run_id = RunId::new_v4();
-    let discovered_at = std::time::Instant::now() - Duration::from_secs(1);
-    seed_idle_pool_with_history_generation(
-        &idle_pool,
-        &budget,
-        session_id,
-        "vm0/default",
-        2,
-        4096,
-        generation_run_id,
-    )
-    .await;
-    let run_handle = tokio::spawn(run(config));
-
-    wait_discover_entered(&env, Duration::from_secs(2)).await;
-
-    let run_id = RunId::new_v4();
-    env.provider
-        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
-    env.handle
-        .discover_tx
-        .send(generation_affinity_protected_candidate_with_discovered_at(
-            run_id,
-            session_id,
-            generation_run_id,
-            discovered_at,
-        ))
-        .unwrap();
-
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("post-discovery parked generation should be reused");
-    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    let claim_candidates = env.handle.claim_candidates();
-    let candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("post-discovery parked candidate should reach claim");
-    assert_eq!(
-        candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::Exact)
-    );
-    assert_eq!(
-        candidate.session_history_generation_local_availability(),
-        Some(crate::provider::SessionHistoryGenerationLocalAvailability::AfterDiscovery)
-    );
-
-    shutdown(&env, run_handle).await;
-}
-
-#[tokio::test(start_paused = true)]
-async fn reusable_claim_without_generation_target_omits_local_availability() {
+async fn reusable_claim_without_generation_target_reports_selected_resources() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
@@ -545,10 +449,6 @@ async fn reusable_claim_without_generation_target_omits_local_availability() {
     assert_eq!(
         candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::UnknownTarget)
-    );
-    assert_eq!(
-        candidate.session_history_generation_local_availability(),
-        None
     );
     assert_eq!(
         candidate.session_affinity_resource(),
@@ -922,10 +822,6 @@ async fn expired_generation_protection_preserves_local_session_claim() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("claim should record the protected candidate");
     assert_eq!(
-        claimed_candidate.pre_local_admission_outcome(),
-        Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
-    );
-    assert_eq!(
         claimed_candidate.session_affinity_local_resource(),
         Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
     );
@@ -936,12 +832,6 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     assert_eq!(
         claimed_candidate.session_history_generation_relationship(),
         Some(crate::provider::SessionHistoryGenerationRelationship::UnknownReserved)
-    );
-    assert_eq!(
-        claimed_candidate.session_history_generation_local_availability(),
-        Some(
-            crate::provider::SessionHistoryGenerationLocalAvailability::BeforeDiscoveryLtHeartbeatPeriod
-        )
     );
     assert!(
         claimed_candidate
@@ -1064,10 +954,6 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
         .iter()
         .find(|candidate| candidate.run_id() == run_id)
         .expect("claim should record the protected candidate");
-    assert_eq!(
-        claimed_candidate.pre_local_admission_outcome(),
-        Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
-    );
     assert_eq!(
         claimed_candidate.session_affinity_resource(),
         Some(SessionAffinityResource::WorkspaceCache)

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -6,17 +6,13 @@ use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
-use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::ResumeSessionHistoryRefKind;
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
-    WorkspaceSessionHistorySidecarRepresentation,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
-use sha2::{Digest, Sha256};
 
 fn make_synthetic_parked_candidate(
     session_id: &str,
@@ -241,12 +237,8 @@ pub(in super::super) async fn seed_workspace_cache_state(
     session_id: &str,
     profile_name: &str,
     image_size_bytes: u64,
-    sidecar: Option<TestWorkspaceSidecar>,
 ) {
-    let run_id = match sidecar {
-        Some(TestWorkspaceSidecar::Attributed(run_id)) => run_id,
-        Some(TestWorkspaceSidecar::Legacy) | None => RunId::new_v4(),
-    };
+    let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -268,83 +260,18 @@ pub(in super::super) async fn seed_workspace_cache_state(
     let file = tokio::fs::File::create(&active_image).await.unwrap();
     file.set_len(image_size_bytes).await.unwrap();
     drop(file);
-    let Some(sidecar) = sidecar else {
-        assert!(
-            lease
-                .promote(
-                    run_id,
-                    None,
-                    WorkspaceCacheTerminalStatus::Success,
-                    TEST_SESSION_LAST_COMPLETED_AT.into(),
-                    &StorageFingerprints::default(),
-                )
-                .await
-                .unwrap()
-        );
-        return;
-    };
-
-    let history = br#"{"type":"message","content":"main-loop-sidecar"}"#;
-    let restored_session_identity = RestoredSessionIdentity::new(
-        RestoredSessionFramework::ClaudeCode,
-        session_id,
-        ResumeSessionHistoryRefKind::Blob,
-        hex::encode(Sha256::digest(history)),
-        Some(history.len() as u64),
-    );
-    let promotion = lease
-        .into_promotion_context(WorkspaceImagePromotionRequest {
-            run_id,
-            sandbox_id,
-            cli_agent_session_id_override: None,
-            restored_session_identity: Some(&restored_session_identity),
-            terminal_status: WorkspaceCacheTerminalStatus::Success,
-            completed_at: TEST_SESSION_LAST_COMPLETED_AT.into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        })
-        .expect("workspace image should be promotable");
-    let guard = promotion
-        .try_acquire_session_history_sidecar_entry_guard()
-        .await
-        .expect("sidecar entry guard should be available");
-    let tmp_path = guard.session_history_sidecar_tmp_path();
-    let entry_dir = tmp_path
-        .parent()
-        .expect("sidecar temporary path should have a cache entry parent")
-        .to_path_buf();
-    tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    tokio::fs::write(&tmp_path, history).await.unwrap();
-    let source = guard.session_history_sidecar_source(
-        tmp_path,
-        WorkspaceSessionHistorySidecarRepresentation::Raw,
-        history.len() as u64,
-    );
-    assert_eq!(
-        guard
-            .promote_with_session_history_sidecar(&promotion, &source)
+    assert!(
+        lease
+            .promote(
+                run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                TEST_SESSION_LAST_COMPLETED_AT.into(),
+                &StorageFingerprints::default(),
+            )
             .await
-            .unwrap(),
-        WorkspaceImagePromotionOutcome::Promoted
-    );
-
-    if sidecar == TestWorkspaceSidecar::Legacy {
-        let metadata_path = entry_dir.join("session-history.metadata.json");
-        let mut metadata: serde_json::Value =
-            serde_json::from_slice(&tokio::fs::read(&metadata_path).await.unwrap()).unwrap();
-        metadata
-            .as_object_mut()
             .unwrap()
-            .remove("historyGenerationRunId");
-        tokio::fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
-            .await
-            .unwrap();
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in super::super) enum TestWorkspaceSidecar {
-    Attributed(RunId),
-    Legacy,
+    );
 }
 
 pub(in super::super) async fn seed_idle_pool_expired(

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -9,7 +9,7 @@ pub(super) use self::env::{
     mock_run_config_with_overrides, mock_run_config_with_runtime, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
-    TestParkedIdleCandidateSpec, TestWorkspaceSidecar, WorkspacePromotionSeedSpec, seed_idle_pool,
+    TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
     seed_idle_pool_expired, seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
     seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
     seed_workspace_cache_state,

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -935,10 +935,6 @@ impl ReservedIdleSandbox {
         self.entry.cli_agent_session_id()
     }
 
-    pub(crate) fn parked_at(&self) -> Instant {
-        self.entry.parked_at
-    }
-
     pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
         self.entry.metadata.history_generation_run_id
     }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -74,10 +74,6 @@ struct ClaimRequestTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     session_history_generation_local_availability: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    workspace_session_history_sidecar_relationship: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    workspace_session_history_sidecar_raw_size_bucket: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_http_request_ms: Option<u64>,
@@ -875,12 +871,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             session_history_generation_local_availability: candidate
                 .session_history_generation_local_availability()
                 .map(SessionHistoryGenerationLocalAvailability::as_str),
-            workspace_session_history_sidecar_relationship: candidate
-                .workspace_session_history_sidecar_relationship()
-                .map(crate::provider::WorkspaceSessionHistorySidecarRelationship::as_str),
-            workspace_session_history_sidecar_raw_size_bucket: candidate
-                .workspace_session_history_sidecar_raw_size_bucket()
-                .map(crate::types::SessionHistorySizeBucket::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1687,10 +1677,6 @@ mod tests {
         candidate.set_session_history_generation_local_availability(
             SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod,
         );
-        candidate.set_workspace_session_history_sidecar_observation(
-            crate::provider::WorkspaceSessionHistorySidecarRelationship::Different,
-            Some(crate::types::SessionHistorySizeBucket::From256KibTo1Mib),
-        );
         candidate
             .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
         candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
@@ -1730,14 +1716,6 @@ mod tests {
         assert_eq!(
             body["telemetry"]["sessionHistoryGenerationLocalAvailability"],
             "parked_before_discovery_ge_heartbeat_period"
-        );
-        assert_eq!(
-            body["telemetry"]["workspaceSessionHistorySidecarRelationship"],
-            "different"
-        );
-        assert_eq!(
-            body["telemetry"]["workspaceSessionHistorySidecarRawSizeBucket"],
-            "256_kib_1_mib"
         );
         assert!(
             !body

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -60,6 +60,7 @@ struct ClaimRequestTelemetry {
     provider_discovery_to_main_loop_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     main_loop_to_local_admission_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     session_affinity_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_affinity_local_resource: Option<&'static str>,
@@ -1826,6 +1827,7 @@ mod tests {
         assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
         assert!(body["telemetry"].get("pollHttpRequestMs").is_none());
         assert!(body["telemetry"].get("pollReason").is_none());
+        assert!(body["telemetry"].get("sessionAffinityResource").is_none());
         assert!(
             body["telemetry"]
                 .get("directCandidateNotificationToEnqueueMs")

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -25,8 +25,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    LocalAdmissionResourceKind, PreLocalAdmissionOutcome, SessionAffinityLocalResource,
-    SessionHistoryGenerationLocalAvailability, SessionHistoryGenerationRelationship,
+    LocalAdmissionResourceKind, SessionAffinityLocalResource, SessionHistoryGenerationRelationship,
 };
 use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
@@ -61,9 +60,6 @@ struct ClaimRequestTelemetry {
     provider_discovery_to_main_loop_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     main_loop_to_local_admission_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pre_local_admission_outcome: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     session_affinity_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_affinity_local_resource: Option<&'static str>,
@@ -71,8 +67,6 @@ struct ClaimRequestTelemetry {
     local_admission_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_history_generation_relationship: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    session_history_generation_local_availability: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -819,7 +813,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
         direct_candidate_inbox_wait_ms,
         provider_discovery_to_main_loop_ms,
         main_loop_to_local_admission_ms,
-        pre_local_admission_outcome,
     ) = if is_ably_candidate {
         (
             candidate
@@ -834,12 +827,9 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             candidate
                 .main_loop_to_local_admission_elapsed()
                 .map(claim_telemetry_duration_ms),
-            candidate
-                .pre_local_admission_outcome()
-                .map(PreLocalAdmissionOutcome::as_str),
         )
     } else {
-        (None, None, None, None, None)
+        (None, None, None, None)
     };
 
     ClaimRequestBody {
@@ -855,7 +845,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             direct_candidate_inbox_wait_ms,
             provider_discovery_to_main_loop_ms,
             main_loop_to_local_admission_ms,
-            pre_local_admission_outcome,
             session_affinity_resource: candidate
                 .session_affinity_resource()
                 .map(crate::types::SessionAffinityResource::as_str),
@@ -868,9 +857,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             session_history_generation_relationship: candidate
                 .session_history_generation_relationship()
                 .map(SessionHistoryGenerationRelationship::as_str),
-            session_history_generation_local_availability: candidate
-                .session_history_generation_local_availability()
-                .map(SessionHistoryGenerationLocalAvailability::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1674,9 +1660,6 @@ mod tests {
         candidate.set_session_history_generation_relationship(
             SessionHistoryGenerationRelationship::Exact,
         );
-        candidate.set_session_history_generation_local_availability(
-            SessionHistoryGenerationLocalAvailability::BeforeDiscoveryGeHeartbeatPeriod,
-        );
         candidate
             .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
         candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
@@ -1713,10 +1696,6 @@ mod tests {
             body["telemetry"]["sessionHistoryGenerationRelationship"],
             "exact"
         );
-        assert_eq!(
-            body["telemetry"]["sessionHistoryGenerationLocalAvailability"],
-            "parked_before_discovery_ge_heartbeat_period"
-        );
         assert!(
             !body
                 .to_string()
@@ -1731,15 +1710,14 @@ mod tests {
     }
 
     #[test]
-    fn claim_request_body_serializes_pre_claim_timing_splits() {
+    fn claim_request_body_serializes_ably_timing_splits() {
         let mut candidate =
             JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
                 .with_discovery_source(JobDiscoverySource::Ably)
                 .with_direct_candidate_timing(
                     Some(Duration::from_millis(3)),
                     Some(Duration::from_millis(5)),
-                )
-                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder);
+                );
         candidate.mark_provider_discovery_returned();
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
@@ -1762,15 +1740,6 @@ mod tests {
                 .as_u64()
                 .is_some()
         );
-        assert_eq!(
-            body["telemetry"]["preLocalAdmissionOutcome"],
-            "local_holder"
-        );
-        assert!(
-            body["telemetry"]
-                .get("sessionHistoryGenerationLocalAvailability")
-                .is_none()
-        );
     }
 
     #[test]
@@ -1781,8 +1750,7 @@ mod tests {
                 .with_direct_candidate_timing(
                     Some(Duration::from_millis(3)),
                     Some(Duration::from_millis(5)),
-                )
-                .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected);
+                );
         candidate.mark_provider_discovery_returned();
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
@@ -1810,7 +1778,6 @@ mod tests {
                 .get("mainLoopToLocalAdmissionMs")
                 .is_none()
         );
-        assert!(body["telemetry"].get("preLocalAdmissionOutcome").is_none());
     }
 
     #[test]
@@ -1879,7 +1846,6 @@ mod tests {
                 .get("mainLoopToLocalAdmissionMs")
                 .is_none()
         );
-        assert!(body["telemetry"].get("preLocalAdmissionOutcome").is_none());
     }
 
     #[test]

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -27,10 +27,7 @@ use std::time::{Duration, Instant};
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
-use crate::types::{
-    ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource,
-    SessionHistorySizeBucket,
-};
+use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult, SessionAffinityResource};
 
 /// Low-cardinality source that first discovered a job candidate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -52,7 +49,6 @@ impl JobDiscoverySource {
 pub(crate) enum PreLocalAdmissionOutcome {
     NotProtected,
     LocalHolder,
-    MissingSessionMetadata,
 }
 
 impl PreLocalAdmissionOutcome {
@@ -60,7 +56,6 @@ impl PreLocalAdmissionOutcome {
         match self {
             Self::NotProtected => "not_protected",
             Self::LocalHolder => "local_holder",
-            Self::MissingSessionMetadata => "missing_session_metadata",
         }
     }
 }
@@ -69,7 +64,6 @@ impl PreLocalAdmissionOutcome {
 pub(crate) enum SessionAffinityLocalResource {
     ReusableSandbox,
     WorkspaceCache,
-    LegacySession,
 }
 
 impl SessionAffinityLocalResource {
@@ -77,7 +71,6 @@ impl SessionAffinityLocalResource {
         match self {
             Self::ReusableSandbox => "reusableSandbox",
             Self::WorkspaceCache => "workspaceCache",
-            Self::LegacySession => "legacySession",
         }
     }
 }
@@ -135,27 +128,6 @@ impl SessionHistoryGenerationLocalAvailability {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum WorkspaceSessionHistorySidecarRelationship {
-    Exact,
-    Different,
-    Legacy,
-    Absent,
-    NoTarget,
-}
-
-impl WorkspaceSessionHistorySidecarRelationship {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Exact => "exact",
-            Self::Different => "different",
-            Self::Legacy => "legacy",
-            Self::Absent => "absent",
-            Self::NoTarget => "no_target",
-        }
-    }
-}
-
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -183,9 +155,6 @@ pub struct JobCandidate {
     session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
     session_history_generation_local_availability:
         Option<SessionHistoryGenerationLocalAvailability>,
-    workspace_session_history_sidecar_relationship:
-        Option<WorkspaceSessionHistorySidecarRelationship>,
-    workspace_session_history_sidecar_raw_size_bucket: Option<SessionHistorySizeBucket>,
     history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
@@ -224,8 +193,6 @@ impl JobCandidate {
             history_generation_run_id: None,
             session_history_generation_relationship: None,
             session_history_generation_local_availability: None,
-            workspace_session_history_sidecar_relationship: None,
-            workspace_session_history_sidecar_raw_size_bucket: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
         }
@@ -353,18 +320,6 @@ impl JobCandidate {
         self.session_history_generation_local_availability
     }
 
-    pub(crate) fn workspace_session_history_sidecar_relationship(
-        &self,
-    ) -> Option<WorkspaceSessionHistorySidecarRelationship> {
-        self.workspace_session_history_sidecar_relationship
-    }
-
-    pub(crate) fn workspace_session_history_sidecar_raw_size_bucket(
-        &self,
-    ) -> Option<SessionHistorySizeBucket> {
-        self.workspace_session_history_sidecar_raw_size_bucket
-    }
-
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
         protection_remaining(self.affinity_protected_until)
     }
@@ -437,15 +392,6 @@ impl JobCandidate {
         availability: SessionHistoryGenerationLocalAvailability,
     ) {
         self.session_history_generation_local_availability = Some(availability);
-    }
-
-    pub(crate) fn set_workspace_session_history_sidecar_observation(
-        &mut self,
-        relationship: WorkspaceSessionHistorySidecarRelationship,
-        raw_size_bucket: Option<SessionHistorySizeBucket>,
-    ) {
-        self.workspace_session_history_sidecar_relationship = Some(relationship);
-        self.workspace_session_history_sidecar_raw_size_bucket = raw_size_bucket;
     }
 
     pub(crate) fn set_session_affinity_local_resource(

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -46,21 +46,6 @@ impl JobDiscoverySource {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum PreLocalAdmissionOutcome {
-    NotProtected,
-    LocalHolder,
-}
-
-impl PreLocalAdmissionOutcome {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::NotProtected => "not_protected",
-            Self::LocalHolder => "local_holder",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SessionAffinityLocalResource {
     ReusableSandbox,
     WorkspaceCache,
@@ -111,23 +96,6 @@ impl SessionHistoryGenerationRelationship {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum SessionHistoryGenerationLocalAvailability {
-    AfterDiscovery,
-    BeforeDiscoveryLtHeartbeatPeriod,
-    BeforeDiscoveryGeHeartbeatPeriod,
-}
-
-impl SessionHistoryGenerationLocalAvailability {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::AfterDiscovery => "parked_after_discovery",
-            Self::BeforeDiscoveryLtHeartbeatPeriod => "parked_before_discovery_lt_heartbeat_period",
-            Self::BeforeDiscoveryGeHeartbeatPeriod => "parked_before_discovery_ge_heartbeat_period",
-        }
-    }
-}
-
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -143,7 +111,6 @@ pub struct JobCandidate {
     discovery_source: Option<JobDiscoverySource>,
     direct_candidate_notification_to_enqueue_elapsed: Option<Duration>,
     direct_candidate_inbox_wait_elapsed: Option<Duration>,
-    pre_local_admission_outcome: Option<PreLocalAdmissionOutcome>,
     poll_reason: Option<String>,
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
@@ -153,8 +120,6 @@ pub struct JobCandidate {
     local_admission_resource: Option<LocalAdmissionResourceKind>,
     history_generation_run_id: Option<RunId>,
     session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
-    session_history_generation_local_availability:
-        Option<SessionHistoryGenerationLocalAvailability>,
     history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
@@ -182,7 +147,6 @@ impl JobCandidate {
             discovery_source: None,
             direct_candidate_notification_to_enqueue_elapsed: None,
             direct_candidate_inbox_wait_elapsed: None,
-            pre_local_admission_outcome: None,
             poll_reason: None,
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
@@ -192,7 +156,6 @@ impl JobCandidate {
             local_admission_resource: None,
             history_generation_run_id: None,
             session_history_generation_relationship: None,
-            session_history_generation_local_availability: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
         }
@@ -243,10 +206,6 @@ impl JobCandidate {
         self.discovered_at.elapsed()
     }
 
-    pub(crate) fn discovered_at(&self) -> Instant {
-        self.discovered_at
-    }
-
     pub(crate) fn local_admission_elapsed(&self) -> Option<Duration> {
         self.local_admission_started_at
             .map(|started| started.elapsed())
@@ -266,10 +225,6 @@ impl JobCandidate {
 
     pub(crate) fn main_loop_to_local_admission_elapsed(&self) -> Option<Duration> {
         self.main_loop_to_local_admission_elapsed
-    }
-
-    pub(crate) fn pre_local_admission_outcome(&self) -> Option<PreLocalAdmissionOutcome> {
-        self.pre_local_admission_outcome
     }
 
     pub(crate) fn discovery_source(&self) -> Option<JobDiscoverySource> {
@@ -312,12 +267,6 @@ impl JobCandidate {
         &self,
     ) -> Option<SessionHistoryGenerationRelationship> {
         self.session_history_generation_relationship
-    }
-
-    pub(crate) fn session_history_generation_local_availability(
-        &self,
-    ) -> Option<SessionHistoryGenerationLocalAvailability> {
-        self.session_history_generation_local_availability
     }
 
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
@@ -387,13 +336,6 @@ impl JobCandidate {
         self.session_history_generation_relationship = Some(relationship);
     }
 
-    pub(crate) fn set_session_history_generation_local_availability(
-        &mut self,
-        availability: SessionHistoryGenerationLocalAvailability,
-    ) {
-        self.session_history_generation_local_availability = Some(availability);
-    }
-
     pub(crate) fn set_session_affinity_local_resource(
         &mut self,
         resource: SessionAffinityLocalResource,
@@ -417,14 +359,6 @@ impl JobCandidate {
     ) -> Self {
         self.direct_candidate_notification_to_enqueue_elapsed = notification_to_enqueue_elapsed;
         self.direct_candidate_inbox_wait_elapsed = inbox_wait_elapsed;
-        self
-    }
-
-    pub(crate) fn with_pre_local_admission_outcome(
-        mut self,
-        outcome: PreLocalAdmissionOutcome,
-    ) -> Self {
-        self.pre_local_admission_outcome = Some(outcome);
         self
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1321,20 +1321,10 @@ impl SessionHistorySizeBucket {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct WorkspaceSessionHistorySidecarState {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub history_generation_run_id: Option<RunId>,
-    pub raw_size_bucket: SessionHistorySizeBucket,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub struct WorkspaceCacheState {
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_affinity_version: Option<u8>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_history_sidecar: Option<WorkspaceSessionHistorySidecarState>,
 }
 
 /// Runner state snapshot sent to the server via heartbeat.
@@ -2064,12 +2054,6 @@ mod tests {
                 workspace_caches: vec![WorkspaceCacheState {
                     profile: "vm0/large".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                    session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
-                        history_generation_run_id: Some(
-                            "22222222-2222-4222-8222-222222222222".parse().unwrap(),
-                        ),
-                        raw_size_bucket: SessionHistorySizeBucket::From64To256Kib,
-                    }),
                 }],
             }],
             mode: "running".into(),
@@ -2097,11 +2081,7 @@ mod tests {
                 },
                 "workspaceCaches": [{
                     "profile": "vm0/large",
-                    "workspaceAffinityVersion": 1,
-                    "sessionHistorySidecar": {
-                        "historyGenerationRunId": "22222222-2222-4222-8222-222222222222",
-                        "rawSizeBucket": "64_256_kib"
-                    }
+                    "workspaceAffinityVersion": 1
                 }]
             }])
         );

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -634,10 +634,6 @@ impl SessionWorkspaceCache {
                 )
                 .await
             {
-                let session_history_sidecar = self
-                    .observe_session_history_sidecar(cache_key, &metadata.session_id)
-                    .await
-                    .ok();
                 states.push(HeldSessionState {
                     session_id: metadata.session_id,
                     last_completed_at: metadata.last_completed_at,
@@ -645,7 +641,6 @@ impl SessionWorkspaceCache {
                     workspace_caches: vec![WorkspaceCacheState {
                         profile: metadata.profile_name,
                         workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                        session_history_sidecar,
                     }],
                 });
             }
@@ -1535,11 +1530,6 @@ pub(crate) fn cap_workspace_held_session_states(
                     {
                         *existing_completed_at = state.last_completed_at.clone();
                         *existing = workspace_cache;
-                    } else if capability_order.is_eq()
-                        && state.last_completed_at == *existing_completed_at
-                        && workspace_cache != *existing
-                    {
-                        existing.session_history_sidecar = None;
                     }
                 }
             }

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -1,17 +1,14 @@
 use std::path::Path;
 
-use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryRefKind, SESSION_HISTORY_SIDECAR_MAX_BYTES,
 };
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use tokio::fs;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::restored_session_identity::{RestoredSessionIdentity, RestoredSessionIdentityFields};
-use crate::types::{SessionHistorySizeBucket, WorkspaceSessionHistorySidecarState};
 
 use super::fs::{
     allocated_bytes, ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
@@ -26,19 +23,10 @@ use super::{SessionWorkspaceCache, entry::CacheEntryPaths};
 
 const SESSION_HISTORY_SIDECAR_FORMAT_VERSION: u8 = 1;
 
-fn is_sha256_hex(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WorkspaceSessionHistorySidecarMetadata {
     version: u8,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    history_generation_run_id: Option<RunId>,
     framework: FinalSessionHistoryFramework,
     session_id_hash: String,
     history_ref_kind: FinalSessionHistoryRefKind,
@@ -52,7 +40,6 @@ struct WorkspaceSessionHistorySidecarMetadata {
 
 impl WorkspaceSessionHistorySidecarMetadata {
     fn from_source(
-        history_generation_run_id: RunId,
         source: &WorkspaceSessionHistorySidecarPromotionSource,
         body_metadata: &std::fs::Metadata,
     ) -> Option<Self> {
@@ -65,7 +52,6 @@ impl WorkspaceSessionHistorySidecarMetadata {
         } = source.restored_session_identity.cache_fields()?;
         Some(Self {
             version: SESSION_HISTORY_SIDECAR_FORMAT_VERSION,
-            history_generation_run_id: Some(history_generation_run_id),
             framework,
             session_id_hash: session_id_hash.to_owned(),
             history_ref_kind,
@@ -113,46 +99,6 @@ impl WorkspaceSessionHistorySidecarMetadata {
         }
     }
 
-    fn observe(
-        &self,
-        workspace_session_id: &str,
-    ) -> Result<WorkspaceSessionHistorySidecarState, WorkspaceSessionHistorySidecarMiss> {
-        if self.version != SESSION_HISTORY_SIDECAR_FORMAT_VERSION
-            || self.encoded_size == 0
-            || self.encoded_size > SESSION_HISTORY_SIDECAR_MAX_BYTES
-            || !(1..=RESUME_SESSION_HISTORY_MAX_BYTES).contains(&self.history_size_bytes)
-            || !is_sha256_hex(&self.session_id_hash)
-            || !is_sha256_hex(&self.history_hash)
-        {
-            return Err(WorkspaceSessionHistorySidecarMiss::InvalidMetadata);
-        }
-        match (self.framework, self.representation) {
-            (_, WorkspaceSessionHistorySidecarRepresentation::Raw)
-                if self.encoded_size == self.history_size_bytes => {}
-            (
-                FinalSessionHistoryFramework::Codex,
-                WorkspaceSessionHistorySidecarRepresentation::CodexZstd,
-            ) => {}
-            _ => return Err(WorkspaceSessionHistorySidecarMiss::UnsupportedFormat),
-        }
-        let normalized_session_id = match self.framework {
-            FinalSessionHistoryFramework::ClaudeCode => workspace_session_id.to_owned(),
-            FinalSessionHistoryFramework::Codex => {
-                guest_contracts::codex_thread_id::canonical_codex_thread_id(workspace_session_id)
-                    .ok_or(WorkspaceSessionHistorySidecarMiss::IdentityMismatch)?
-            }
-        };
-        let expected_session_id_hash =
-            hex::encode(Sha256::digest(normalized_session_id.as_bytes()));
-        if self.session_id_hash != expected_session_id_hash {
-            return Err(WorkspaceSessionHistorySidecarMiss::IdentityMismatch);
-        }
-        Ok(WorkspaceSessionHistorySidecarState {
-            history_generation_run_id: self.history_generation_run_id,
-            raw_size_bucket: SessionHistorySizeBucket::from_size(self.history_size_bytes),
-        })
-    }
-
     fn validate_body_metadata(
         &self,
         body_metadata: &std::fs::Metadata,
@@ -193,29 +139,6 @@ impl SessionWorkspaceCache {
             representation: metadata.representation,
             encoded_size: metadata.encoded_size,
         })
-    }
-
-    pub(super) async fn observe_session_history_sidecar(
-        &self,
-        cache_key: &str,
-        workspace_session_id: &str,
-    ) -> Result<WorkspaceSessionHistorySidecarState, WorkspaceSessionHistorySidecarMiss> {
-        let paths = self.entry_paths(cache_key);
-        let metadata = self
-            .read_session_history_sidecar_metadata(paths.session_history_sidecar_metadata())
-            .await?;
-        let state = metadata.observe(workspace_session_id)?;
-        let body_metadata = fs::symlink_metadata(paths.session_history_sidecar())
-            .await
-            .map_err(|error| {
-                if error.kind() == std::io::ErrorKind::NotFound {
-                    WorkspaceSessionHistorySidecarMiss::BodyMissing
-                } else {
-                    WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch
-                }
-            })?;
-        metadata.validate_body_metadata(&body_metadata)?;
-        Ok(state)
     }
 
     pub(super) async fn publish_session_history_sidecar(
@@ -281,7 +204,7 @@ impl SessionWorkspaceCache {
             return Ok(());
         }
         let Some(sidecar_metadata) =
-            WorkspaceSessionHistorySidecarMetadata::from_source(run_id, source, &tmp_metadata)
+            WorkspaceSessionHistorySidecarMetadata::from_source(source, &tmp_metadata)
         else {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             self.prune_session_history_sidecar(cache_key).await?;

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+use std::os::unix::fs::{MetadataExt, symlink};
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -26,9 +26,8 @@ use crate::storage_fingerprints::StorageFingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     HeldSessionState, MAX_HELD_SESSION_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
-    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind, SessionHistorySizeBucket,
-    WORKSPACE_AFFINITY_VERSION, WorkspaceCacheState as HeldWorkspaceCacheState,
-    WorkspaceSessionHistorySidecarState,
+    MAX_WORKSPACE_CACHES_PER_SESSION, ResumeSessionHistoryRefKind, WORKSPACE_AFFINITY_VERSION,
+    WorkspaceCacheState as HeldWorkspaceCacheState,
 };
 use sha2::{Digest, Sha256};
 use tokio::fs;
@@ -1078,7 +1077,6 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: TEST_PROFILE_NAME.to_owned(),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                session_history_sidecar: None,
             }],
         })
         .collect();
@@ -1089,7 +1087,6 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
         workspace_caches: vec![HeldWorkspaceCacheState {
             profile: TEST_PROFILE_NAME.to_owned(),
             workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-            session_history_sidecar: None,
         }],
     });
 
@@ -1121,7 +1118,6 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
             workspace_caches: vec![HeldWorkspaceCacheState {
                 profile: format!("vm0/profile-{index:02}"),
                 workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                session_history_sidecar: None,
             }],
         })
         .collect();
@@ -1145,7 +1141,6 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
                 .map(|profile| HeldWorkspaceCacheState {
                     profile: format!("vm0/profile-{profile}"),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                    session_history_sidecar: None,
                 })
                 .collect(),
         })
@@ -1164,47 +1159,6 @@ fn cap_workspace_held_session_states_bounds_nested_resources() {
         !capped.iter().any(|state| state.session_id == "sess-0000"),
         "oldest session should be dropped at the global workspace cap"
     );
-}
-
-#[test]
-fn cap_workspace_held_session_states_clears_ambiguous_equal_timestamp_sidecars() {
-    let run_id = RunId::new_v4();
-    let attributed = HeldSessionState {
-        session_id: "sess-ambiguous".into(),
-        last_completed_at: "2026-05-01T00:00:00.000Z".into(),
-        reusable_sandbox: None,
-        workspace_caches: vec![HeldWorkspaceCacheState {
-            profile: TEST_PROFILE_NAME.to_owned(),
-            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-            session_history_sidecar: Some(WorkspaceSessionHistorySidecarState {
-                history_generation_run_id: Some(run_id),
-                raw_size_bucket: SessionHistorySizeBucket::LessThan64Kib,
-            }),
-        }],
-    };
-    let absent = HeldSessionState {
-        session_id: "sess-ambiguous".into(),
-        last_completed_at: "2026-05-01T00:00:00.000Z".into(),
-        reusable_sandbox: None,
-        workspace_caches: vec![HeldWorkspaceCacheState {
-            profile: TEST_PROFILE_NAME.to_owned(),
-            workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-            session_history_sidecar: None,
-        }],
-    };
-
-    for states in [
-        vec![attributed.clone(), absent.clone()],
-        vec![absent.clone(), attributed.clone()],
-    ] {
-        let capped = cap_workspace_held_session_states(states);
-        assert_eq!(capped.len(), 1);
-        assert!(
-            capped[0].workspace_caches[0]
-                .session_history_sidecar
-                .is_none()
-        );
-    }
 }
 
 #[tokio::test]
@@ -1264,12 +1218,10 @@ async fn held_session_states_for_profiles_filters_and_aggregates_current_identit
                 HeldWorkspaceCacheState {
                     profile: "vm0/default".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                    session_history_sidecar: None,
                 },
                 HeldWorkspaceCacheState {
                     profile: "vm0/large".into(),
                     workspace_affinity_version: Some(WORKSPACE_AFFINITY_VERSION),
-                    session_history_sidecar: None,
                 },
             ],
         }]
@@ -1722,16 +1674,11 @@ async fn session_history_sidecar_publish_and_probe_hit() {
         .join("session-history.metadata.json");
     let metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
-    assert_eq!(metadata["historyGenerationRunId"], run_id.to_string());
+    assert!(metadata.get("historyGenerationRunId").is_none());
     let held_states = cache.held_session_states().await;
-    let observed_sidecar = held_states[0].workspace_caches[0]
-        .session_history_sidecar
-        .as_ref()
-        .unwrap();
-    assert_eq!(observed_sidecar.history_generation_run_id, Some(run_id));
     assert_eq!(
-        observed_sidecar.raw_size_bucket,
-        SessionHistorySizeBucket::LessThan64Kib
+        held_states[0].workspace_caches[0].profile,
+        TEST_PROFILE_NAME
     );
     let sidecar = cache
         .probe_session_history_sidecar(&cache_key, &identity)
@@ -1747,7 +1694,7 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 }
 
 #[tokio::test]
-async fn legacy_session_history_sidecar_remains_restoreable_and_observable() {
+async fn previous_session_history_sidecar_metadata_remains_restoreable() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -1774,21 +1721,11 @@ async fn legacy_session_history_sidecar_remains_restoreable_and_observable() {
     metadata
         .as_object_mut()
         .unwrap()
-        .remove("historyGenerationRunId");
+        .insert("historyGenerationRunId".into(), run_id.to_string().into());
     fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
         .await
         .unwrap();
 
-    let held_states = cache.held_session_states().await;
-    let observed_sidecar = held_states[0].workspace_caches[0]
-        .session_history_sidecar
-        .as_ref()
-        .unwrap();
-    assert_eq!(observed_sidecar.history_generation_run_id, None);
-    assert_eq!(
-        observed_sidecar.raw_size_bucket,
-        SessionHistorySizeBucket::LessThan64Kib
-    );
     assert!(
         cache
             .probe_session_history_sidecar(&cache_key, &identity)
@@ -1798,41 +1735,7 @@ async fn legacy_session_history_sidecar_remains_restoreable_and_observable() {
 }
 
 #[tokio::test]
-async fn session_history_sidecar_observation_does_not_read_body() {
-    let dir = tempfile::tempdir().unwrap();
-    let paths = RunnerPaths::new(dir.path().join("runner"));
-    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let run_id = RunId::new_v4();
-    let session_id = "sess-sidecar-unreadable";
-    let history = br#"{"type":"message","content":"unreadable"}"#;
-    let cache_key = write_current_cache_entry(
-        &cache,
-        run_id,
-        session_id,
-        CANONICAL_WORKING_DIR,
-        "2026-05-01T00:00:00.000Z",
-        "2026-05-01T00:00:00.000Z",
-    )
-    .await;
-    publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let body_path = paths
-        .session_workspace_cache_entry_dir(&cache_key)
-        .join("session-history.blob");
-    let mut permissions = fs::metadata(&body_path).await.unwrap().permissions();
-    permissions.set_mode(0o0);
-    fs::set_permissions(&body_path, permissions).await.unwrap();
-
-    let held_states = cache.held_session_states().await;
-    assert!(
-        held_states[0].workspace_caches[0]
-            .session_history_sidecar
-            .is_some()
-    );
-}
-
-#[tokio::test]
-async fn invalid_session_history_sidecars_are_not_advertised() {
+async fn invalid_session_history_sidecars_are_rejected_by_probe() {
     #[derive(Clone, Copy, Debug)]
     enum InvalidSidecarCase {
         MissingMetadata,
@@ -1873,7 +1776,9 @@ async fn invalid_session_history_sidecars_are_not_advertised() {
             "2026-05-01T00:00:00.000Z",
         )
         .await;
-        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+        let identity =
+            publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history)
+                .await;
         let entry_dir = paths.session_workspace_cache_entry_dir(&cache_key);
         let metadata_path = entry_dir.join("session-history.metadata.json");
         let body_path = entry_dir.join("session-history.blob");
@@ -1928,12 +1833,11 @@ async fn invalid_session_history_sidecars_are_not_advertised() {
             }
         }
 
-        let held_states = cache.held_session_states().await;
-        assert_eq!(held_states.len(), 1, "case: {case:?}");
         assert!(
-            held_states[0].workspace_caches[0]
-                .session_history_sidecar
-                .is_none(),
+            cache
+                .probe_session_history_sidecar(&cache_key, &identity)
+                .await
+                .is_err(),
             "case: {case:?}"
         );
     }
@@ -2052,12 +1956,6 @@ async fn session_history_sidecar_probe_rejects_mismatched_body_identity() {
             .await
             .unwrap_err(),
         WorkspaceSessionHistorySidecarMiss::FileIdentityMismatch
-    );
-    let held_states = cache.held_session_states().await;
-    assert!(
-        held_states[0].workspace_caches[0]
-            .session_history_sidecar
-            .is_none()
     );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -507,6 +507,22 @@ export function createRunsApi(context: TestContext) {
       );
     },
 
+    async requestRawClaimRunnerJobAs(
+      authorization: string | undefined,
+      runId: string,
+      statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
+      body: unknown,
+    ) {
+      return await accept(
+        runApp(context)(runnersJobClaimContract).claim({
+          headers: authorization === undefined ? {} : { authorization },
+          params: { id: runId },
+          body: body as RunnerJobClaimRequest,
+        }),
+        statuses,
+      );
+    },
+
     async requestRunnerRealtimeTokenAs(
       authorization: string | undefined,
       body: RunnerRealtimeTokenBody,
@@ -1029,6 +1045,22 @@ export function createRunsApi(context: TestContext) {
           headers: runnerHeaders(validAuth),
           params: { id: runId },
           body,
+        }),
+        statuses,
+      );
+    },
+
+    async requestRawClaimRunnerJob(
+      validAuth: boolean,
+      runId: string,
+      statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
+      body: unknown,
+    ) {
+      return await accept(
+        runApp(context)(runnersJobClaimContract).claim({
+          headers: runnerHeaders(validAuth),
+          params: { id: runId },
+          body: body as RunnerJobClaimRequest,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13,10 +13,7 @@ import {
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import type {
-  Job as RunnerJob,
-  SessionHistorySizeBucket,
-} from "@vm0/api-contracts/contracts/runners";
+import type { Job as RunnerJob } from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -2297,10 +2294,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       readonly workspaceCaches?: {
         readonly profile: string;
         readonly workspaceAffinityVersion?: 1;
-        readonly sessionHistorySidecar?: {
-          readonly historyGenerationRunId?: string;
-          readonly rawSizeBucket: SessionHistorySizeBucket;
-        };
       }[];
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
@@ -2412,9 +2405,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue when final heartbeat includes extra legacy fields",
     );
     expect(finalHeartbeatHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(
-      sessionAffinityProtectedUntil(finalHeartbeatHolder.job),
-    ).toStrictEqual(expect.any(String));
+    expect(sessionAffinityProtectedUntil(finalHeartbeatHolder.job)).toBeNull();
     expect(
       historyGenerationAffinityProtectedUntil(finalHeartbeatHolder.job),
     ).toBeNull();
@@ -2512,15 +2503,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       admittableProfiles: ["vm0/default"],
       workspaceCaches: [{ profile: "vm0/default" }],
     });
-    const observationOnlyWorkspace = await pollFollowUp(
-      "continue with an observation-only workspace holder",
+    const untypedWorkspace = await pollFollowUp(
+      "continue with an untyped workspace holder",
     );
-    expect(
-      sessionAffinityProtectedUntil(observationOnlyWorkspace.job),
-    ).toStrictEqual(expect.any(String));
-    expect(
-      sessionAffinityResource(observationOnlyWorkspace.job),
-    ).toBeUndefined();
+    expect(sessionAffinityProtectedUntil(untypedWorkspace.job)).toBeNull();
+    expect(sessionAffinityResource(untypedWorkspace.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -2562,33 +2549,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "reusableSandbox",
     );
 
-    const sidecarVariantRunners = [
-      {
-        runnerId: randomUUID(),
-        sessionHistorySidecar: {
-          historyGenerationRunId: first.runId,
-          rawSizeBucket: "64_256_kib" as const,
-        },
-      },
-      {
-        runnerId: randomUUID(),
-        sessionHistorySidecar: {
-          historyGenerationRunId: randomUUID(),
-          rawSizeBucket: "256_kib_1_mib" as const,
-        },
-      },
-      {
-        runnerId: randomUUID(),
-        sessionHistorySidecar: {
-          rawSizeBucket: "1_4_mib" as const,
-        },
-      },
-      { runnerId: randomUUID(), sessionHistorySidecar: undefined },
-    ];
-    for (const variant of sidecarVariantRunners) {
-      await api.requestHeartbeatRunner(true, [200], {
-        runnerId: variant.runnerId,
-        group: runnerGroup,
+    const previousSidecarRunnerId = randomUUID();
+    const previousSidecarHeartbeat = await api.requestRawHeartbeatRunner(
+      true,
+      [200],
+      rawHeartbeatBody({
+        runnerId: previousSidecarRunnerId,
         admittableProfiles: ["vm0/default"],
         heldSessionStates: [
           {
@@ -2598,49 +2564,51 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
               {
                 profile: "vm0/default",
                 workspaceAffinityVersion: 1,
-                ...(variant.sessionHistorySidecar
-                  ? {
-                      sessionHistorySidecar: variant.sessionHistorySidecar,
-                    }
-                  : {}),
+                sessionHistorySidecar: {
+                  historyGenerationRunId: first.runId,
+                  rawSizeBucket: "64_256_kib",
+                },
               },
             ],
           },
         ],
-      });
-    }
-    const reusableWithCompetingWorkspaceSidecars = await pollFollowUp(
-      "observe workspace sidecars while reusable sandbox remains preferred",
+      }),
+    );
+    expect(previousSidecarHeartbeat.body).toStrictEqual({ ok: true });
+    const reusableWithPreviousSidecarHeartbeat = await pollFollowUp(
+      "accept a previous heartbeat while preferring reusable affinity",
     );
     expect(
-      sessionAffinityProtectedUntil(reusableWithCompetingWorkspaceSidecars.job),
+      sessionAffinityProtectedUntil(reusableWithPreviousSidecarHeartbeat.job),
     ).toStrictEqual(expect.any(String));
     expect(
       historyGenerationAffinityProtectedUntil(
-        reusableWithCompetingWorkspaceSidecars.job,
+        reusableWithPreviousSidecarHeartbeat.job,
       ),
     ).toStrictEqual(expect.any(String));
     expect(
-      sessionAffinityResource(reusableWithCompetingWorkspaceSidecars.job),
+      sessionAffinityResource(reusableWithPreviousSidecarHeartbeat.job),
     ).toBe("reusableSandbox");
 
     await heartbeatHolder({ admittableProfiles: [], mode: "stopping" });
-    const competingWorkspaceSidecars = await pollFollowUp(
-      "observe competing workspace sidecars without routing by them",
+    const workspaceFromPreviousHeartbeat = await pollFollowUp(
+      "use typed workspace affinity from a previous heartbeat",
     );
-    expect(sessionAffinityResource(competingWorkspaceSidecars.job)).toBe(
+    expect(sessionAffinityResource(workspaceFromPreviousHeartbeat.job)).toBe(
       "workspaceCache",
     );
     expect(
-      historyGenerationAffinityProtectedUntil(competingWorkspaceSidecars.job),
+      historyGenerationAffinityProtectedUntil(
+        workspaceFromPreviousHeartbeat.job,
+      ),
     ).toBeNull();
     for (const { runId, resource } of [
       {
-        runId: reusableWithCompetingWorkspaceSidecars.run.runId,
+        runId: reusableWithPreviousSidecarHeartbeat.run.runId,
         resource: "reusableSandbox",
       },
       {
-        runId: competingWorkspaceSidecars.run.runId,
+        runId: workspaceFromPreviousHeartbeat.run.runId,
         resource: "workspaceCache",
       },
     ]) {
@@ -2653,23 +2621,23 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         expect(events[0]).toStrictEqual(
           expect.objectContaining({
             session_affinity_resource: resource,
-            workspace_sidecar_exact_holder: "true",
-            workspace_sidecar_different_holder: "true",
-            workspace_sidecar_legacy_holder: "true",
-            workspace_sidecar_absent_holder: "true",
           }),
         );
+        expect(events[0]).not.toHaveProperty("workspace_sidecar_exact_holder");
+        expect(events[0]).not.toHaveProperty(
+          "workspace_sidecar_different_holder",
+        );
+        expect(events[0]).not.toHaveProperty("workspace_sidecar_legacy_holder");
+        expect(events[0]).not.toHaveProperty("workspace_sidecar_absent_holder");
       }
     }
-    for (const variant of sidecarVariantRunners) {
-      await api.requestHeartbeatRunner(true, [200], {
-        runnerId: variant.runnerId,
-        group: runnerGroup,
-        admittableProfiles: [],
-        heldSessionStates: [],
-        mode: "stopping",
-      });
-    }
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: previousSidecarRunnerId,
+      group: runnerGroup,
+      admittableProfiles: [],
+      heldSessionStates: [],
+      mode: "stopping",
+    });
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -7868,7 +7836,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       prompt: "attribute terminal generation claims",
       modelProvider: "anthropic-api-key",
     });
-    const accepted = await api.requestClaimRunnerJob(
+    const accepted = await api.requestRawClaimRunnerJob(
       true,
       attributed.runId,
       [200],
@@ -7884,7 +7852,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     );
     expect(accepted.status).toBe(200);
 
-    const lateUser = await api.requestClaimRunnerJobAs(
+    const lateUser = await api.requestRawClaimRunnerJobAs(
       actorBearer,
       attributed.runId,
       [404],
@@ -7905,7 +7873,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       ),
     ).toHaveLength(1);
 
-    const lateOfficial = await api.requestClaimRunnerJob(
+    const lateOfficial = await api.requestRawClaimRunnerJob(
       true,
       attributed.runId,
       [404],
@@ -7930,8 +7898,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         generation_relationship: "different",
         generation_local_availability:
           "parked_before_discovery_lt_heartbeat_period",
-        workspace_sidecar_relationship: "different",
-        workspace_sidecar_raw_size_bucket: "256_kib_1_mib",
         claim_outcome: "accepted",
         auth_type: "official-runner",
         runner_group: runnerGroup,
@@ -7942,8 +7908,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         duration_ms: 0,
         generation_relationship: "exact",
         generation_local_availability: "parked_after_discovery",
-        workspace_sidecar_relationship: "exact",
-        workspace_sidecar_raw_size_bucket: "64_256_kib",
         claim_outcome: "unavailable",
         auth_type: "official-runner",
       }),
@@ -7957,9 +7921,10 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(event).not.toHaveProperty("generation_local_availability_ms");
       expect(event).not.toHaveProperty("workspace_sidecar_generation_run_id");
       expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bytes");
+      expect(event).not.toHaveProperty("workspace_sidecar_relationship");
+      expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bucket");
       expect(JSON.stringify(event)).not.toContain(actorRunnerKey.token);
     }
-
     const guarded = await api.createRun(actor, {
       agentId,
       prompt: "reject untrusted generation attribution",
@@ -8068,7 +8033,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     context.mocks.s3.send.mockRejectedValueOnce(
       new Error("session history metadata unavailable"),
     );
-    const failedClaim = await api.requestClaimRunnerJob(
+    const failedClaim = await api.requestRawClaimRunnerJob(
       true,
       resumed.runId,
       [500],
@@ -8095,8 +8060,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         generation_relationship: "exact",
         generation_local_availability:
           "parked_before_discovery_ge_heartbeat_period",
-        workspace_sidecar_relationship: "legacy",
-        workspace_sidecar_raw_size_bucket: "1_4_mib",
         claim_outcome: "preclaim_error",
         auth_type: "official-runner",
         runner_group: runnerGroup,
@@ -8105,6 +8068,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     ]);
     expect(JSON.stringify(events)).not.toContain(source.runId);
     expect(JSON.stringify(events)).not.toContain(historyHash);
+    expect(events[0]).not.toHaveProperty("workspace_sidecar_relationship");
+    expect(events[0]).not.toHaveProperty("workspace_sidecar_raw_size_bucket");
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -769,10 +769,10 @@ function expectDirectAblyClaimTimingEvents(args: {
         profile: "vm0/default",
         auth_type: "user",
         discovery_source: "ably",
-        pre_local_admission_outcome: "local_holder",
       }),
     );
     expect(event).not.toHaveProperty("poll_reason");
+    expect(event).not.toHaveProperty("pre_local_admission_outcome");
   }
 
   expect(
@@ -783,7 +783,6 @@ function expectDirectAblyClaimTimingEvents(args: {
   ).toStrictEqual(
     expect.objectContaining({
       duration_ms: 12,
-      pre_local_admission_outcome: "local_holder",
     }),
   );
   expect(
@@ -791,7 +790,6 @@ function expectDirectAblyClaimTimingEvents(args: {
   ).toStrictEqual(
     expect.objectContaining({
       duration_ms: 34,
-      pre_local_admission_outcome: "local_holder",
     }),
   );
   expect(
@@ -799,7 +797,6 @@ function expectDirectAblyClaimTimingEvents(args: {
   ).toStrictEqual(
     expect.objectContaining({
       duration_ms: 45,
-      pre_local_admission_outcome: "local_holder",
     }),
   );
   expect(
@@ -807,7 +804,6 @@ function expectDirectAblyClaimTimingEvents(args: {
   ).toStrictEqual(
     expect.objectContaining({
       duration_ms: 67,
-      pre_local_admission_outcome: "local_holder",
     }),
   );
 
@@ -7896,8 +7892,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         success: true,
         duration_ms: 0,
         generation_relationship: "different",
-        generation_local_availability:
-          "parked_before_discovery_lt_heartbeat_period",
         claim_outcome: "accepted",
         auth_type: "official-runner",
         runner_group: runnerGroup,
@@ -7907,7 +7901,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         success: false,
         duration_ms: 0,
         generation_relationship: "exact",
-        generation_local_availability: "parked_after_discovery",
         claim_outcome: "unavailable",
         auth_type: "official-runner",
       }),
@@ -7918,6 +7911,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(event).not.toHaveProperty("history_hash");
       expect(event).not.toHaveProperty("parked_at");
       expect(event).not.toHaveProperty("discovered_at");
+      expect(event).not.toHaveProperty("generation_local_availability");
       expect(event).not.toHaveProperty("generation_local_availability_ms");
       expect(event).not.toHaveProperty("workspace_sidecar_generation_run_id");
       expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bytes");
@@ -8058,8 +8052,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         success: false,
         duration_ms: 0,
         generation_relationship: "exact",
-        generation_local_availability:
-          "parked_before_discovery_ge_heartbeat_period",
         claim_outcome: "preclaim_error",
         auth_type: "official-runner",
         runner_group: runnerGroup,
@@ -8068,6 +8060,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     ]);
     expect(JSON.stringify(events)).not.toContain(source.runId);
     expect(JSON.stringify(events)).not.toContain(historyHash);
+    expect(events[0]).not.toHaveProperty("generation_local_availability");
     expect(events[0]).not.toHaveProperty("workspace_sidecar_relationship");
     expect(events[0]).not.toHaveProperty("workspace_sidecar_raw_size_bucket");
 
@@ -8361,7 +8354,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           directCandidateInboxWaitMs: 34,
           providerDiscoveryToMainLoopMs: 45,
           mainLoopToLocalAdmissionMs: 67,
-          preLocalAdmissionOutcome: "local_holder",
         },
       },
     );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -11,7 +11,6 @@ import {
   type ExecutionContext,
   type HeldSessionState,
   type SessionHistoryDownloadSource,
-  type SessionHistoryGenerationLocalAvailability,
   type SessionHistoryGenerationRelationship,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
@@ -683,9 +682,6 @@ type SessionHistoryGenerationClaimOutcome =
 function recordSessionHistoryGenerationClaimAttempt(args: {
   readonly runId: string;
   readonly relationship: SessionHistoryGenerationRelationship | undefined;
-  readonly localAvailability:
-    | SessionHistoryGenerationLocalAvailability
-    | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly runnerGroup?: string;
@@ -699,9 +695,6 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
     claim_outcome: args.outcome,
     auth_type: args.authType,
   };
-  if (args.localAvailability) {
-    dimensions.generation_local_availability = args.localAvailability;
-  }
   if (args.runnerGroup) {
     dimensions.runner_group = args.runnerGroup;
   }
@@ -723,9 +716,6 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
 function recordSessionHistoryGenerationClaimAttemptForJob(args: {
   readonly runId: string;
   readonly relationship: SessionHistoryGenerationRelationship | undefined;
-  readonly localAvailability:
-    | SessionHistoryGenerationLocalAvailability
-    | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly job: ClaimableJob["job"];
@@ -733,7 +723,6 @@ function recordSessionHistoryGenerationClaimAttemptForJob(args: {
   recordSessionHistoryGenerationClaimAttempt({
     runId: args.runId,
     relationship: args.relationship,
-    localAvailability: args.localAvailability,
     outcome: args.outcome,
     authType: args.authType,
     runnerGroup: args.job.runnerGroup,
@@ -1639,7 +1628,6 @@ interface ClaimTimingTelemetry {
   readonly directCandidateInboxWaitMs?: number;
   readonly providerDiscoveryToMainLoopMs?: number;
   readonly mainLoopToLocalAdmissionMs?: number;
-  readonly preLocalAdmissionOutcome?: string;
   readonly sessionAffinityResource?: string;
   readonly sessionAffinityLocalResource?: string;
   readonly localAdmissionResource?: string;
@@ -1695,7 +1683,6 @@ function scheduleSuccessfulClaimSideEffects(args: {
     providerDiscoveryToMainLoopMs:
       args.telemetry?.providerDiscoveryToMainLoopMs,
     mainLoopToLocalAdmissionMs: args.telemetry?.mainLoopToLocalAdmissionMs,
-    preLocalAdmissionOutcome: args.telemetry?.preLocalAdmissionOutcome,
     sessionAffinityResource: args.telemetry?.sessionAffinityResource,
     sessionAffinityLocalResource: args.telemetry?.sessionAffinityLocalResource,
     localAdmissionResource: args.telemetry?.localAdmissionResource,
@@ -1724,7 +1711,6 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly directCandidateInboxWaitMs: number | undefined;
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
-  readonly preLocalAdmissionOutcome: string | undefined;
   readonly sessionAffinityResource: string | undefined;
   readonly sessionAffinityLocalResource: string | undefined;
   readonly localAdmissionResource: string | undefined;
@@ -1763,7 +1749,6 @@ interface ClaimTimingMetricArgs {
   readonly directCandidateInboxWaitMs: number | undefined;
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
-  readonly preLocalAdmissionOutcome: string | undefined;
   readonly sessionAffinityResource: string | undefined;
   readonly sessionAffinityLocalResource: string | undefined;
   readonly localAdmissionResource: string | undefined;
@@ -1864,9 +1849,6 @@ function claimTimingDimensions(
   }
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
-  }
-  if (args.preLocalAdmissionOutcome) {
-    dimensions.pre_local_admission_outcome = args.preLocalAdmissionOutcome;
   }
   if (args.sessionAffinityResource) {
     dimensions.session_affinity_resource = args.sessionAffinityResource;
@@ -2043,9 +2025,6 @@ const claimAuthorizedJob$ = command(
       readonly generationRelationship:
         | SessionHistoryGenerationRelationship
         | undefined;
-      readonly generationLocalAvailability:
-        | SessionHistoryGenerationLocalAvailability
-        | undefined;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;
       readonly claimRouteTiming: ClaimRouteTimingCollector;
@@ -2058,7 +2037,6 @@ const claimAuthorizedJob$ = command(
       recordSessionHistoryGenerationClaimAttemptForJob({
         runId,
         relationship: args.generationRelationship,
-        localAvailability: args.generationLocalAvailability,
         outcome,
         authType: args.authType,
         job: jobWithRun.job,
@@ -2172,8 +2150,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const runId = get(pathParamsOf(runnersJobClaimContract.claim)).id;
   const generationRelationship =
     body.data.telemetry?.sessionHistoryGenerationRelationship;
-  const generationLocalAvailability =
-    body.data.telemetry?.sessionHistoryGenerationLocalAvailability;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -2188,7 +2164,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       recordSessionHistoryGenerationClaimAttempt({
         runId,
         relationship: generationRelationship,
-        localAvailability: generationLocalAvailability,
         outcome: "unavailable",
         authType: auth.type,
       });
@@ -2211,7 +2186,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     authType: auth.type,
     jobWithRun,
     generationRelationship,
-    generationLocalAvailability,
     telemetry: body.data.telemetry,
     claimRequestStartedAtMs,
     claimRouteTiming,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -13,9 +13,7 @@ import {
   type SessionHistoryDownloadSource,
   type SessionHistoryGenerationLocalAvailability,
   type SessionHistoryGenerationRelationship,
-  type SessionHistorySizeBucket,
   type StoredExecutionContext,
-  type WorkspaceSessionHistorySidecarRelationship,
 } from "@vm0/api-contracts/contracts/runners";
 import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
@@ -73,7 +71,6 @@ import {
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
   runnerSessionAffinityTelemetryResource,
-  runnerWorkspaceSidecarTelemetryDimensions,
 } from "../services/runner-session-affinity";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
@@ -346,22 +343,6 @@ function canonicalizeHeldSessionStates(
                         workspaceCache.workspaceAffinityVersion,
                     }
                   : {}),
-                ...(workspaceCache.sessionHistorySidecar
-                  ? {
-                      sessionHistorySidecar: {
-                        ...(workspaceCache.sessionHistorySidecar
-                          .historyGenerationRunId
-                          ? {
-                              historyGenerationRunId:
-                                workspaceCache.sessionHistorySidecar
-                                  .historyGenerationRunId,
-                            }
-                          : {}),
-                        rawSizeBucket:
-                          workspaceCache.sessionHistorySidecar.rawSizeBucket,
-                      },
-                    }
-                  : {}),
               };
             }),
           }
@@ -454,7 +435,6 @@ function recordPollTimingMetrics(args: {
   readonly sessionAffinity: string;
   readonly sessionAffinityResource: string;
   readonly historyGenerationAffinity: string;
-  readonly workspaceSidecarDimensions: Readonly<Record<string, string>>;
   readonly queueCreatedAtMs: number;
   readonly pollRequestStartedAtMs: number;
   readonly pendingJobLookupStartedAtMs: number;
@@ -468,7 +448,6 @@ function recordPollTimingMetrics(args: {
     session_affinity: args.sessionAffinity,
     session_affinity_resource: args.sessionAffinityResource,
     history_generation_affinity: args.historyGenerationAffinity,
-    ...args.workspaceSidecarDimensions,
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -630,8 +609,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     sessionAffinity: affinity.status,
     sessionAffinityResource: runnerSessionAffinityTelemetryResource(affinity),
     historyGenerationAffinity: affinity.historyGenerationStatus,
-    workspaceSidecarDimensions:
-      runnerWorkspaceSidecarTelemetryDimensions(affinity),
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
     pollRequestStartedAtMs,
     pendingJobLookupStartedAtMs,
@@ -709,10 +686,6 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
   readonly localAvailability:
     | SessionHistoryGenerationLocalAvailability
     | undefined;
-  readonly workspaceSidecarRelationship:
-    | WorkspaceSessionHistorySidecarRelationship
-    | undefined;
-  readonly workspaceSidecarRawSizeBucket: SessionHistorySizeBucket | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly runnerGroup?: string;
@@ -728,14 +701,6 @@ function recordSessionHistoryGenerationClaimAttempt(args: {
   };
   if (args.localAvailability) {
     dimensions.generation_local_availability = args.localAvailability;
-  }
-  if (args.workspaceSidecarRelationship) {
-    dimensions.workspace_sidecar_relationship =
-      args.workspaceSidecarRelationship;
-  }
-  if (args.workspaceSidecarRawSizeBucket) {
-    dimensions.workspace_sidecar_raw_size_bucket =
-      args.workspaceSidecarRawSizeBucket;
   }
   if (args.runnerGroup) {
     dimensions.runner_group = args.runnerGroup;
@@ -761,10 +726,6 @@ function recordSessionHistoryGenerationClaimAttemptForJob(args: {
   readonly localAvailability:
     | SessionHistoryGenerationLocalAvailability
     | undefined;
-  readonly workspaceSidecarRelationship:
-    | WorkspaceSessionHistorySidecarRelationship
-    | undefined;
-  readonly workspaceSidecarRawSizeBucket: SessionHistorySizeBucket | undefined;
   readonly outcome: SessionHistoryGenerationClaimOutcome;
   readonly authType: RunnerAuthContext["type"];
   readonly job: ClaimableJob["job"];
@@ -773,8 +734,6 @@ function recordSessionHistoryGenerationClaimAttemptForJob(args: {
     runId: args.runId,
     relationship: args.relationship,
     localAvailability: args.localAvailability,
-    workspaceSidecarRelationship: args.workspaceSidecarRelationship,
-    workspaceSidecarRawSizeBucket: args.workspaceSidecarRawSizeBucket,
     outcome: args.outcome,
     authType: args.authType,
     runnerGroup: args.job.runnerGroup,
@@ -2087,12 +2046,6 @@ const claimAuthorizedJob$ = command(
       readonly generationLocalAvailability:
         | SessionHistoryGenerationLocalAvailability
         | undefined;
-      readonly workspaceSidecarRelationship:
-        | WorkspaceSessionHistorySidecarRelationship
-        | undefined;
-      readonly workspaceSidecarRawSizeBucket:
-        | SessionHistorySizeBucket
-        | undefined;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;
       readonly claimRouteTiming: ClaimRouteTimingCollector;
@@ -2106,8 +2059,6 @@ const claimAuthorizedJob$ = command(
         runId,
         relationship: args.generationRelationship,
         localAvailability: args.generationLocalAvailability,
-        workspaceSidecarRelationship: args.workspaceSidecarRelationship,
-        workspaceSidecarRawSizeBucket: args.workspaceSidecarRawSizeBucket,
         outcome,
         authType: args.authType,
         job: jobWithRun.job,
@@ -2223,10 +2174,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     body.data.telemetry?.sessionHistoryGenerationRelationship;
   const generationLocalAvailability =
     body.data.telemetry?.sessionHistoryGenerationLocalAvailability;
-  const workspaceSidecarRelationship =
-    body.data.telemetry?.workspaceSessionHistorySidecarRelationship;
-  const workspaceSidecarRawSizeBucket =
-    body.data.telemetry?.workspaceSessionHistorySidecarRawSizeBucket;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -2242,8 +2189,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         runId,
         relationship: generationRelationship,
         localAvailability: generationLocalAvailability,
-        workspaceSidecarRelationship,
-        workspaceSidecarRawSizeBucket,
         outcome: "unavailable",
         authType: auth.type,
       });
@@ -2267,8 +2212,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     jobWithRun,
     generationRelationship,
     generationLocalAvailability,
-    workspaceSidecarRelationship,
-    workspaceSidecarRawSizeBucket,
     telemetry: body.data.telemetry,
     claimRequestStartedAtMs,
     claimRouteTiming,

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -7,7 +7,6 @@ import {
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
   runnerSessionAffinityTelemetryResource,
-  runnerWorkspaceSidecarTelemetryDimensions,
 } from "./runner-session-affinity";
 import { tapError } from "../utils";
 
@@ -75,7 +74,6 @@ export async function notifyRunnerJob(
     session_affinity: affinity.status,
     session_affinity_resource: runnerSessionAffinityTelemetryResource(affinity),
     history_generation_affinity: affinity.historyGenerationStatus,
-    ...runnerWorkspaceSidecarTelemetryDimensions(affinity),
   };
   // Queue-relative actions are cumulative boundaries. Affinity and publish
   // durations are nested children and must not be added to those boundaries.

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -63,33 +63,6 @@ function capableWorkspaceCondition(args: {
   )`;
 }
 
-function legacySessionCondition(args: {
-  readonly sessionId: SessionIdSqlValue;
-  readonly profile: ProfileSqlValue;
-}): SQL<boolean> {
-  // Transitional fallback for runners without resource-class capabilities.
-  // Remove after the rollout gate tracked by #21871.
-  return sql<boolean>`(
-    ${runnerState.admittableProfiles} @> jsonb_build_array(
-      cast(${args.profile} as text)
-    )
-    AND EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS session_state(value)
-      WHERE session_state.value->>'sessionId' = cast(${args.sessionId} as text)
-    )
-    AND NOT EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS capable_session(value)
-      CROSS JOIN LATERAL jsonb_array_elements(
-        coalesce(capable_session.value->'workspaceCaches', '[]'::jsonb)
-      ) AS workspace_cache(value)
-      WHERE capable_session.value->>'sessionId' = cast(${args.sessionId} as text)
-        AND workspace_cache.value @> '{"workspaceAffinityVersion": 1}'::jsonb
-    )
-  )`;
-}
-
 function runnerStateHas(args: {
   readonly runnerId?: string;
   readonly runnerGroup: string;
@@ -135,7 +108,6 @@ export function runnerSessionAffinityPollPriority(args: {
   });
   const reusableCondition = reusableSandboxCondition({ sessionId, profile });
   const workspaceCondition = capableWorkspaceCondition({ sessionId, profile });
-  const legacyCondition = legacySessionCondition({ sessionId, profile });
   const global = (resourceCondition: SQL<boolean>) => {
     return runnerStateHas({
       runnerGroup: args.runnerGroup,
@@ -157,8 +129,6 @@ export function runnerSessionAffinityPollPriority(args: {
   const hasLocalReusable = local(reusableCondition);
   const hasGlobalWorkspace = global(workspaceCondition);
   const hasLocalWorkspace = local(workspaceCondition);
-  const hasGlobalLegacy = global(legacyCondition);
-  const hasLocalLegacy = local(legacyCondition);
   return sql<number>`CASE
     WHEN ${runnerJobQueue.createdAt} > ${generationProtectedAfter}
     AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
@@ -177,11 +147,6 @@ export function runnerSessionAffinityPollPriority(args: {
       WHEN ${hasLocalWorkspace} THEN 3
       ELSE 0
     END
-    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
-    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
-    AND ${hasGlobalLegacy}
-    AND ${hasLocalLegacy}
-    THEN 2
     ELSE 0
   END`;
 }
@@ -199,14 +164,6 @@ interface RunnerSessionAffinityProtection {
   readonly resource: SessionAffinityResource | null;
   readonly historyGenerationProtectedUntil: Date | null;
   readonly historyGenerationStatus: RunnerHistoryGenerationAffinityStatus;
-  readonly workspaceSidecarAvailability?: RunnerWorkspaceSidecarAvailability;
-}
-
-interface RunnerWorkspaceSidecarAvailability {
-  readonly exact: boolean;
-  readonly different: boolean;
-  readonly legacy: boolean;
-  readonly absent: boolean;
 }
 
 type RunnerHistoryGenerationAffinityStatus =
@@ -224,21 +181,6 @@ export function runnerSessionAffinityLookupError(): RunnerSessionAffinityProtect
     resource: null,
     historyGenerationProtectedUntil: null,
     historyGenerationStatus: "lookup_error",
-  };
-}
-
-export function runnerWorkspaceSidecarTelemetryDimensions(
-  affinity: RunnerSessionAffinityProtection,
-): Record<string, string> {
-  const availability = affinity.workspaceSidecarAvailability;
-  if (!availability) {
-    return {};
-  }
-  return {
-    workspace_sidecar_exact_holder: String(availability.exact),
-    workspace_sidecar_different_holder: String(availability.different),
-    workspace_sidecar_legacy_holder: String(availability.legacy),
-    workspace_sidecar_absent_holder: String(availability.absent),
   };
 }
 
@@ -269,48 +211,6 @@ interface RunnerSessionAffinityHolders {
   readonly hasSessionHolder: boolean;
   readonly hasExactGenerationHolder: boolean;
   readonly resource: SessionAffinityResource | null;
-  readonly workspaceSidecarAvailability?: RunnerWorkspaceSidecarAvailability;
-}
-
-const WORKSPACE_SIDECAR_EXACT_BIT = 1;
-const WORKSPACE_SIDECAR_DIFFERENT_BIT = 2;
-const WORKSPACE_SIDECAR_LEGACY_BIT = 4;
-const WORKSPACE_SIDECAR_ABSENT_BIT = 8;
-
-function workspaceSidecarAvailabilityMask(args: {
-  readonly sessionId: string;
-  readonly profile: string;
-  readonly historyGenerationRunId: string | undefined;
-}): SQL<number> {
-  if (!args.historyGenerationRunId) {
-    return sql<number>`0`;
-  }
-  return sql<number>`CASE
-    WHEN ${runnerState.admittableProfiles} @> jsonb_build_array(
-      cast(${args.profile} as text)
-    )
-    THEN coalesce((
-      SELECT bit_or(
-        CASE
-          WHEN jsonb_typeof(workspace_cache.value->'sessionHistorySidecar') IS DISTINCT FROM 'object'
-            THEN cast(${WORKSPACE_SIDECAR_ABSENT_BIT} as integer)
-          WHEN workspace_cache.value->'sessionHistorySidecar'->>'historyGenerationRunId' IS NULL
-            THEN cast(${WORKSPACE_SIDECAR_LEGACY_BIT} as integer)
-          WHEN workspace_cache.value->'sessionHistorySidecar'->>'historyGenerationRunId' = cast(${args.historyGenerationRunId} as text)
-            THEN cast(${WORKSPACE_SIDECAR_EXACT_BIT} as integer)
-          ELSE cast(${WORKSPACE_SIDECAR_DIFFERENT_BIT} as integer)
-        END
-      )
-      FROM jsonb_array_elements(${runnerState.heldSessionStates}) AS session_state(value)
-      CROSS JOIN LATERAL jsonb_array_elements(
-        coalesce(session_state.value->'workspaceCaches', '[]'::jsonb)
-      ) AS workspace_cache(value)
-      WHERE session_state.value->>'sessionId' = cast(${args.sessionId} as text)
-        AND workspace_cache.value->>'profile' = cast(${args.profile} as text)
-        AND workspace_cache.value @> '{"workspaceAffinityVersion": 1}'::jsonb
-    ), 0::integer)
-    ELSE 0::integer
-  END`;
 }
 
 async function runnerSessionAffinityHolders(args: {
@@ -330,10 +230,6 @@ async function runnerSessionAffinityHolders(args: {
     sessionId: args.cliAgentSessionId,
     profile: args.profile,
   });
-  const legacyCondition = legacySessionCondition({
-    sessionId: args.cliAgentSessionId,
-    profile: args.profile,
-  });
   const exactGenerationCondition = args.shouldLookUpExactGeneration
     ? reusableSandboxCondition({
         sessionId: args.cliAgentSessionId,
@@ -341,18 +237,11 @@ async function runnerSessionAffinityHolders(args: {
         historyGenerationRunId: args.historyGenerationRunId,
       })
     : sql<boolean>`false`;
-  const workspaceSidecarMask = workspaceSidecarAvailabilityMask({
-    sessionId: args.cliAgentSessionId,
-    profile: args.profile,
-    historyGenerationRunId: args.historyGenerationRunId,
-  });
   const [holders] = await args.db
     .select({
       hasReusableHolder: sql<boolean>`coalesce(bool_or(${reusableCondition}), false)`,
       hasWorkspaceHolder: sql<boolean>`coalesce(bool_or(${workspaceCondition}), false)`,
-      hasLegacyHolder: sql<boolean>`coalesce(bool_or(${legacyCondition}), false)`,
       hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationCondition}), false)`,
-      workspaceSidecarMask: sql<number>`coalesce(bit_or((${workspaceSidecarMask})::integer), 0)`,
     })
     .from(runnerState)
     .where(
@@ -365,36 +254,14 @@ async function runnerSessionAffinityHolders(args: {
 
   const hasReusableHolder = holders?.hasReusableHolder ?? false;
   const hasWorkspaceHolder = holders?.hasWorkspaceHolder ?? false;
-  const hasLegacyHolder = holders?.hasLegacyHolder ?? false;
-  const observedWorkspaceSidecarMask = holders?.workspaceSidecarMask ?? 0;
   return {
-    hasSessionHolder:
-      hasReusableHolder || hasWorkspaceHolder || hasLegacyHolder,
+    hasSessionHolder: hasReusableHolder || hasWorkspaceHolder,
     hasExactGenerationHolder: holders?.hasExactGenerationHolder ?? false,
     resource: hasReusableHolder
       ? "reusableSandbox"
       : hasWorkspaceHolder
         ? "workspaceCache"
         : null,
-    ...(args.historyGenerationRunId
-      ? {
-          workspaceSidecarAvailability: {
-            exact:
-              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_EXACT_BIT) !==
-              0,
-            different:
-              (observedWorkspaceSidecarMask &
-                WORKSPACE_SIDECAR_DIFFERENT_BIT) !==
-              0,
-            legacy:
-              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_LEGACY_BIT) !==
-              0,
-            absent:
-              (observedWorkspaceSidecarMask & WORKSPACE_SIDECAR_ABSENT_BIT) !==
-              0,
-          },
-        }
-      : {}),
   };
 }
 
@@ -464,15 +331,11 @@ export async function runnerSessionAffinityProtection(args: {
       ? historyGenerationProtectedUntil
       : null,
     historyGenerationStatus,
-    workspaceSidecarAvailability: holders.workspaceSidecarAvailability,
   };
 }
 
 export function runnerSessionAffinityTelemetryResource(
   affinity: RunnerSessionAffinityProtection,
-): "reusableSandbox" | "workspaceCache" | "legacy" | "none" {
-  if (affinity.resource) {
-    return affinity.resource;
-  }
-  return affinity.status === "protected" ? "legacy" : "none";
+): "reusableSandbox" | "workspaceCache" | "none" {
+  return affinity.resource ?? "none";
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -653,7 +653,6 @@ describe("runner claim capability contract", () => {
         directCandidateInboxWaitMs: 2,
         providerDiscoveryToMainLoopMs: 3,
         mainLoopToLocalAdmissionMs: 4,
-        preLocalAdmissionOutcome: "local_holder",
         sessionAffinityResource: "workspaceCache",
         sessionAffinityLocalResource: "workspaceCache",
         localAdmissionResource: "fresh",
@@ -664,36 +663,13 @@ describe("runner claim capability contract", () => {
     expect(result.success).toBe(true);
   });
 
-  it.each([
-    "parked_after_discovery",
-    "parked_before_discovery_lt_heartbeat_period",
-    "parked_before_discovery_ge_heartbeat_period",
-  ])("accepts %s generation local availability", (localAvailability) => {
-    const result = runnersJobClaimContract.claim.body.safeParse({
-      telemetry: {
-        sessionHistoryGenerationRelationship: "exact",
-        sessionHistoryGenerationLocalAvailability: localAvailability,
-      },
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it("rejects non-enum generation local availability", () => {
-    const result = runnersJobClaimContract.claim.body.safeParse({
-      telemetry: {
-        sessionHistoryGenerationRelationship: "exact",
-        sessionHistoryGenerationLocalAvailability: "parked_for_123_ms",
-      },
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it("accepts and strips previous workspace sidecar telemetry", () => {
+  it("accepts and strips previous attribution telemetry", () => {
     const body = runnersJobClaimContract.claim.body.parse({
       telemetry: {
+        preLocalAdmissionOutcome: "local_holder",
         sessionHistoryGenerationRelationship: "fresh",
+        sessionHistoryGenerationLocalAvailability:
+          "parked_before_discovery_ge_heartbeat_period",
         workspaceSessionHistorySidecarRelationship: "exact",
         workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
       },

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -330,7 +330,7 @@ describe("runner resume session contract", () => {
     ).toBe(true);
   });
 
-  it("keeps generation metadata in stored and discovery shapes only", () => {
+  it("keeps generation metadata in stable discovery and reusable shapes", () => {
     const historyGenerationAffinityProtectedUntil = "2026-07-15T00:00:00.500Z";
     const storedResumeSession = {
       sessionId: "sess-123",
@@ -395,10 +395,6 @@ describe("runner resume session contract", () => {
       {
         profile: "vm0/default",
         workspaceAffinityVersion: 1,
-        sessionHistorySidecar: {
-          historyGenerationRunId,
-          rawSizeBucket: "64_256_kib",
-        },
       },
       { profile: "vm0/large" },
     ]);
@@ -662,8 +658,6 @@ describe("runner claim capability contract", () => {
         sessionAffinityLocalResource: "workspaceCache",
         localAdmissionResource: "fresh",
         sessionHistoryGenerationRelationship: "exact",
-        workspaceSessionHistorySidecarRelationship: "exact",
-        workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
       },
     });
 
@@ -696,35 +690,29 @@ describe("runner claim capability contract", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects dynamic workspace sidecar telemetry values", () => {
-    expect(
-      runnersJobClaimContract.claim.body.safeParse({
-        telemetry: {
-          sessionHistoryGenerationRelationship: "fresh",
-          workspaceSessionHistorySidecarRelationship:
-            "exact-for-11111111-1111-4111-8111-111111111111",
-        },
-      }).success,
-    ).toBe(false);
-    expect(
-      runnersJobClaimContract.claim.body.safeParse({
-        telemetry: {
-          sessionHistoryGenerationRelationship: "fresh",
-          workspaceSessionHistorySidecarRawSizeBucket: "exact_123_bytes",
-        },
-      }).success,
-    ).toBe(false);
+  it("accepts and strips previous workspace sidecar telemetry", () => {
+    const body = runnersJobClaimContract.claim.body.parse({
+      telemetry: {
+        sessionHistoryGenerationRelationship: "fresh",
+        workspaceSessionHistorySidecarRelationship: "exact",
+        workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
+      },
+    });
+
+    expect(body.telemetry).toEqual({
+      sessionHistoryGenerationRelationship: "fresh",
+    });
   });
 
   it("accepts old claim bodies without generation telemetry", () => {
     expect(runnersJobClaimContract.claim.body.safeParse({}).success).toBe(true);
   });
 
-  it("rejects non-enum affinity resource telemetry", () => {
+  it("rejects the removed legacy local resource value", () => {
     const result = runnersJobClaimContract.claim.body.safeParse({
       telemetry: {
-        sessionAffinityResource: "legacySession",
-        sessionAffinityLocalResource: "workspaceCache",
+        sessionAffinityResource: "workspaceCache",
+        sessionAffinityLocalResource: "legacySession",
         localAdmissionResource: "fresh",
       },
     });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -84,7 +84,6 @@ export const sessionAffinityResourceSchema = z.enum([
 const sessionAffinityLocalResourceSchema = z.enum([
   "reusableSandbox",
   "workspaceCache",
-  "legacySession",
 ]);
 const runnerLocalAdmissionResourceSchema = z.enum(["reusableSandbox", "fresh"]);
 
@@ -92,7 +91,6 @@ const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
 const runnerPreLocalAdmissionOutcomeSchema = z.enum([
   "not_protected",
   "local_holder",
-  "missing_session_metadata",
 ]);
 export const sessionHistoryGenerationRelationshipSchema = z.enum([
   "exact",
@@ -106,14 +104,6 @@ export const sessionHistoryGenerationLocalAvailabilitySchema = z.enum([
   "parked_before_discovery_lt_heartbeat_period",
   "parked_before_discovery_ge_heartbeat_period",
 ]);
-export const workspaceSessionHistorySidecarRelationshipSchema = z.enum([
-  "exact",
-  "different",
-  "legacy",
-  "absent",
-  "no_target",
-]);
-
 const runnerClaimTelemetrySchema = z.object({
   discoverySource: runnerClaimDiscoverySourceSchema.optional(),
   jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
@@ -134,10 +124,6 @@ const runnerClaimTelemetrySchema = z.object({
     sessionHistoryGenerationRelationshipSchema.optional(),
   sessionHistoryGenerationLocalAvailability:
     sessionHistoryGenerationLocalAvailabilitySchema.optional(),
-  workspaceSessionHistorySidecarRelationship:
-    workspaceSessionHistorySidecarRelationshipSchema.optional(),
-  workspaceSessionHistorySidecarRawSizeBucket:
-    sessionHistorySizeBucketSchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),
@@ -243,12 +229,6 @@ export const heldSessionStateSchema = z.object({
       z.object({
         profile: z.string(),
         workspaceAffinityVersion: z.literal(1).optional(),
-        sessionHistorySidecar: z
-          .object({
-            historyGenerationRunId: z.uuid().optional(),
-            rawSizeBucket: sessionHistorySizeBucketSchema,
-          })
-          .optional(),
       }),
     )
     .max(8)
@@ -749,9 +729,6 @@ export type SessionHistoryGenerationLocalAvailability = z.infer<
 >;
 export type SessionHistorySizeBucket = z.infer<
   typeof sessionHistorySizeBucketSchema
->;
-export type WorkspaceSessionHistorySidecarRelationship = z.infer<
-  typeof workspaceSessionHistorySidecarRelationshipSchema
 >;
 export type SessionAffinityResource = z.infer<
   typeof sessionAffinityResourceSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -88,21 +88,12 @@ const sessionAffinityLocalResourceSchema = z.enum([
 const runnerLocalAdmissionResourceSchema = z.enum(["reusableSandbox", "fresh"]);
 
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
-const runnerPreLocalAdmissionOutcomeSchema = z.enum([
-  "not_protected",
-  "local_holder",
-]);
 export const sessionHistoryGenerationRelationshipSchema = z.enum([
   "exact",
   "different",
   "fresh",
   "unknown_target",
   "unknown_reserved",
-]);
-export const sessionHistoryGenerationLocalAvailabilitySchema = z.enum([
-  "parked_after_discovery",
-  "parked_before_discovery_lt_heartbeat_period",
-  "parked_before_discovery_ge_heartbeat_period",
 ]);
 const runnerClaimTelemetrySchema = z.object({
   discoverySource: runnerClaimDiscoverySourceSchema.optional(),
@@ -116,14 +107,11 @@ const runnerClaimTelemetrySchema = z.object({
   directCandidateInboxWaitMs: z.number().int().nonnegative().optional(),
   providerDiscoveryToMainLoopMs: z.number().int().nonnegative().optional(),
   mainLoopToLocalAdmissionMs: z.number().int().nonnegative().optional(),
-  preLocalAdmissionOutcome: runnerPreLocalAdmissionOutcomeSchema.optional(),
   sessionAffinityResource: sessionAffinityResourceSchema.optional(),
   sessionAffinityLocalResource: sessionAffinityLocalResourceSchema.optional(),
   localAdmissionResource: runnerLocalAdmissionResourceSchema.optional(),
   sessionHistoryGenerationRelationship:
     sessionHistoryGenerationRelationshipSchema.optional(),
-  sessionHistoryGenerationLocalAvailability:
-    sessionHistoryGenerationLocalAvailabilitySchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),
@@ -723,9 +711,6 @@ export type SessionHistoryDownloadSource = z.infer<
 >;
 export type SessionHistoryGenerationRelationship = z.infer<
   typeof sessionHistoryGenerationRelationshipSchema
->;
-export type SessionHistoryGenerationLocalAvailability = z.infer<
-  typeof sessionHistoryGenerationLocalAvailabilitySchema
 >;
 export type SessionHistorySizeBucket = z.infer<
   typeof sessionHistorySizeBucketSchema

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -1,5 +1,3 @@
-import type { SessionHistorySizeBucket } from "@vm0/api-contracts/contracts/runners";
-
 export type RunnerAdmittableProfiles = string[];
 
 export interface RunnerHeldSessionState {
@@ -14,10 +12,6 @@ export interface RunnerHeldSessionState {
   readonly workspaceCaches?: readonly {
     readonly profile: string;
     readonly workspaceAffinityVersion?: 1;
-    readonly sessionHistorySidecar?: {
-      readonly historyGenerationRunId?: string;
-      readonly rawSizeBucket: SessionHistorySizeBucket;
-    };
   }[];
 }
 


### PR DESCRIPTION
## Summary

- require affinity-protected candidates to use typed `reusableSandbox` or `workspaceCache` resources, removing legacy session-only matching from API ranking and runner admission
- remove rollout-only workspace sidecar advertisement, deprecated affinity telemetry values, and redundant pre-local/generation-availability attribution across the runner, claim contract, and API metrics
- stop writing observation-only generation attribution into new sidecar metadata while retaining sidecar publication, probing, restoration, fallback, and garbage collection
- preserve omission of absent optional affinity telemetry so ordinary claims remain valid at the API contract boundary

## Compatibility

- previous heartbeat and claim payloads containing removed attribution or workspace sidecar fields remain accepted and those fields are stripped
- existing sidecar metadata containing `historyGenerationRunId` remains readable
- `legacySession` and `missing_session_metadata` are removed after the verified supported-version rollout gate
- absent `sessionAffinityResource` claim telemetry is omitted rather than serialized as `null`
- no physical database schema migration is required; the change only narrows JSONB and wire contracts

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner` (2,744 passed; 12 ignored)
- focused runner claim serialization and local-admission tests
- `pnpm format`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=4 --silent=passed-only` (46 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected API claim lifecycle scenarios (3 passed)
- `pnpm knip`
- earlier branch validation for `@vm0/db`, affinity metadata, and compatibility behavior remains covered by the current PR head and CI

Closes #21871

Parent delivery issue: #21861
