### PR TITLE
feat: support custom credits in atom grant invoices

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3801,6 +3801,41 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
         }),
       ]),
     );
+
+    // Manual grants use a zero-price invoice and declare the credit amount in
+    // trusted invoice metadata instead of encoding it in the subtotal.
+    const metadataCreditInvoiceId = `in_bdd_metadata_credit_${suffix}`;
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: {
+          id: metadataCreditInvoiceId,
+          customer: null,
+          subtotal: 0,
+          metadata: {
+            type: "credit_purchase",
+            purpose: "credit_purchase",
+            orgId,
+            creditsAmountMode: "metadata",
+            creditsAmount: "2500",
+            creditsExpiresAt: String(invoiceCreditExpiresAt),
+          },
+          parent: null,
+        },
+      }),
+      [200],
+    );
+    const afterMetadataCredit = await billing.readBillingStatus(actor);
+    expect(afterMetadataCredit.credits).toBe(baselineCredits + 302_500);
+    expect(afterMetadataCredit.creditGrants).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "credit_purchase",
+          amount: 2500,
+          expiresAt: new Date(invoiceCreditExpiresAt * 1000).toISOString(),
+        }),
+      ]),
+    );
   });
 
   it("restores and schedules cancellations through setup checkouts and schedule webhooks", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3647,7 +3647,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect(lateStatus.hasSubscription).toBeTruthy();
   });
 
-  it("grants one-time and custom credit purchases once payment settles", async () => {
+  it("grants purchased and Atom-issued custom credits", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
@@ -3802,8 +3802,8 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       ]),
     );
 
-    // Manual grants use a zero-price invoice and declare the credit amount in
-    // trusted invoice metadata instead of encoding it in the subtotal.
+    // Atom grants use the configured zero-price line and declare the credit
+    // amount in trusted invoice metadata instead of encoding it in subtotal.
     const metadataCreditInvoiceId = `in_bdd_metadata_credit_${suffix}`;
     await api.postStripeEvent(
       stripeEvent({
@@ -3813,14 +3813,29 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
           customer: null,
           subtotal: 0,
           metadata: {
-            type: "credit_purchase",
-            purpose: "credit_purchase",
+            type: "atom_grant",
+            purpose: "atom_grant",
+            source: "atom_custom_credits",
+            grantType: "credits",
             orgId,
-            creditsAmountMode: "metadata",
             creditsAmount: "2500",
             creditsExpiresAt: String(invoiceCreditExpiresAt),
           },
           parent: null,
+          lines: {
+            data: [
+              {
+                id: `il_bdd_metadata_credit_${suffix}`,
+                quantity: 1,
+                price: { id: "price_bdd_atom_grant" },
+                period: {
+                  start: epochSeconds(0),
+                  end: invoiceCreditExpiresAt,
+                },
+                parent: { type: "invoice_item_details" },
+              },
+            ],
+          },
         },
       }),
       [200],
@@ -3835,6 +3850,46 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
           expiresAt: new Date(invoiceCreditExpiresAt * 1000).toISOString(),
         }),
       ]),
+    );
+
+    // Metadata credit amounts are ignored outside the configured Atom grant
+    // price path.
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: {
+          id: `in_bdd_untrusted_metadata_credit_${suffix}`,
+          customer: null,
+          subtotal: 0,
+          metadata: {
+            type: "atom_grant",
+            purpose: "atom_grant",
+            source: "atom_custom_credits",
+            grantType: "credits",
+            orgId,
+            creditsAmount: "9000",
+          },
+          parent: null,
+          lines: {
+            data: [
+              {
+                id: `il_bdd_untrusted_metadata_credit_${suffix}`,
+                quantity: 1,
+                price: { id: "price_bdd_other" },
+                period: {
+                  start: epochSeconds(0),
+                  end: invoiceCreditExpiresAt,
+                },
+                parent: { type: "invoice_item_details" },
+              },
+            ],
+          },
+        },
+      }),
+      [200],
+    );
+    expect((await billing.readBillingStatus(actor)).credits).toBe(
+      baselineCredits + 302_500,
     );
   });
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -431,6 +431,16 @@ function creditPurchaseAmount(session: CheckoutSessionInput): number {
   return Number(metadata.creditsAmount);
 }
 
+function creditPurchaseInvoiceAmount(
+  invoice: Pick<InvoiceInput, "metadata" | "subtotal">,
+): number {
+  if (invoice.metadata?.creditsAmountMode === "metadata") {
+    return Number(invoice.metadata.creditsAmount);
+  }
+
+  return creditsFromAmountCents(invoice.subtotal);
+}
+
 function checkoutSessionInvoiceId(
   session: CheckoutSessionInput,
 ): string | null {
@@ -1210,9 +1220,9 @@ async function handleCreditPurchaseInvoicePaid(
   }
 
   const orgId = metadata.orgId;
-  const creditsAmount = creditsFromAmountCents(invoice.subtotal);
+  const creditsAmount = creditPurchaseInvoiceAmount(invoice);
   if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
-    L.warn("credit_purchase invoice has invalid metadata or subtotal", {
+    L.warn("credit_purchase invoice has invalid metadata or amount", {
       invoiceId: invoice.id,
       hasOrgId: Boolean(orgId),
       subtotal: invoice.subtotal ?? null,

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -185,7 +185,8 @@ interface PaidWebhookOutcome {
 
 type AtomGrantTier = Extract<OrgTier, "pro" | "team" | "custom">;
 
-interface AtomGrantInvoiceDetails {
+interface AtomPlanGrantInvoiceDetails {
+  readonly kind: "plan";
   readonly orgId: string;
   readonly tier: AtomGrantTier;
   readonly grantExpiresAt: Date | null;
@@ -193,6 +194,18 @@ interface AtomGrantInvoiceDetails {
   readonly customerId: string | null;
   readonly credits: number;
 }
+
+interface AtomCreditGrantInvoiceDetails {
+  readonly kind: "credits";
+  readonly orgId: string;
+  readonly creditExpiresAt: Date;
+  readonly customerId: string | null;
+  readonly credits: number;
+}
+
+type AtomGrantInvoiceDetails =
+  | AtomPlanGrantInvoiceDetails
+  | AtomCreditGrantInvoiceDetails;
 
 interface UsageAllowanceInvoiceDetails {
   readonly orgId: string;
@@ -431,16 +444,6 @@ function creditPurchaseAmount(session: CheckoutSessionInput): number {
   return Number(metadata.creditsAmount);
 }
 
-function creditPurchaseInvoiceAmount(
-  invoice: Pick<InvoiceInput, "metadata" | "subtotal">,
-): number {
-  if (invoice.metadata?.creditsAmountMode === "metadata") {
-    return Number(invoice.metadata.creditsAmount);
-  }
-
-  return creditsFromAmountCents(invoice.subtotal);
-}
-
 function checkoutSessionInvoiceId(
   session: CheckoutSessionInput,
 ): string | null {
@@ -615,6 +618,35 @@ function atomGrantInvoiceDetails(
   }
 
   const orgId = metadata.orgId;
+  const customerId = customerIdFromInvoice(invoice);
+  if (metadata.grantType === "credits") {
+    const credits = Number(metadata.creditsAmount);
+    const creditExpiresAt = creditPurchaseExpiresAt(metadata);
+    if (
+      !orgId ||
+      !Number.isSafeInteger(credits) ||
+      credits <= 0 ||
+      !creditExpiresAt
+    ) {
+      L.warn("atom credit grant invoice has invalid metadata", {
+        invoiceId: invoice.id,
+        hasOrgId: Boolean(orgId),
+        creditsAmount: metadata.creditsAmount ?? null,
+        creditsExpiresAt:
+          metadata[CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY] ?? null,
+      });
+      return null;
+    }
+
+    return {
+      kind: "credits",
+      orgId,
+      creditExpiresAt,
+      customerId,
+      credits,
+    };
+  }
+
   const tier = atomGrantTier(metadata.tier ?? metadata.planId);
   const grantExpiresAt = atomGrantExpiresAt(metadata, line);
   if (!orgId || !tier) {
@@ -637,11 +669,12 @@ function atomGrantInvoiceDetails(
   }
 
   return {
+    kind: "plan",
     orgId,
     tier,
     grantExpiresAt,
     creditExpiresAt: atomGrantCreditExpiresAt(grantExpiresAt),
-    customerId: customerIdFromInvoice(invoice),
+    customerId,
     credits: monthlyCreditsForTier(tier),
   };
 }
@@ -1220,9 +1253,9 @@ async function handleCreditPurchaseInvoicePaid(
   }
 
   const orgId = metadata.orgId;
-  const creditsAmount = creditPurchaseInvoiceAmount(invoice);
+  const creditsAmount = creditsFromAmountCents(invoice.subtotal);
   if (!orgId || !creditsAmount || Number.isNaN(creditsAmount)) {
-    L.warn("credit_purchase invoice has invalid metadata or amount", {
+    L.warn("credit_purchase invoice has invalid metadata or subtotal", {
       invoiceId: invoice.id,
       hasOrgId: Boolean(orgId),
       subtotal: invoice.subtotal ?? null,
@@ -1264,10 +1297,34 @@ async function handleCreditPurchaseInvoicePaid(
   return { handled: true, drainOrgId: orgId };
 }
 
-async function processAtomGrantInvoicePaid(
+async function processAtomCreditGrantInvoicePaid(
   db: Db,
   invoice: InvoiceInput,
-  details: AtomGrantInvoiceDetails,
+  details: AtomCreditGrantInvoiceDetails,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const inserted = await createExpiresRecord(tx, details.orgId, {
+      source: "credit_purchase",
+      stripeInvoiceId: invoice.id,
+      amount: details.credits,
+      expiresAt: details.creditExpiresAt,
+    });
+    if (!inserted) {
+      L.debug("atom credit grant invoice already processed", {
+        invoiceId: invoice.id,
+        orgId: details.orgId,
+      });
+      return;
+    }
+
+    await grantOrgCredits(tx, details.orgId, details.credits);
+  });
+}
+
+async function processAtomPlanGrantInvoicePaid(
+  db: Db,
+  invoice: InvoiceInput,
+  details: AtomPlanGrantInvoiceDetails,
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
     await tx
@@ -1392,7 +1449,7 @@ async function processAtomGrantInvoicePaid(
 async function upsertAtomGrantPlanEntitlement(
   tx: WriteTx,
   invoice: InvoiceInput,
-  details: AtomGrantInvoiceDetails,
+  details: AtomPlanGrantInvoiceDetails,
 ): Promise<void> {
   const grantLine = invoiceAtomGrantLine(invoice);
   const periodStart = grantLine?.period.start;
@@ -1422,7 +1479,18 @@ async function handleAtomGrantInvoicePaid(
     return { handled: true, drainOrgId: null };
   }
 
-  const processed = await processAtomGrantInvoicePaid(db, invoice, details);
+  if (details.kind === "credits") {
+    await processAtomCreditGrantInvoicePaid(db, invoice, details);
+    L.debug("atom credit grant invoice processed", {
+      invoiceId: invoice.id,
+      orgId: details.orgId,
+      credits: details.credits,
+      creditExpiresAt: details.creditExpiresAt.toISOString(),
+    });
+    return { handled: true, drainOrgId: details.orgId };
+  }
+
+  const processed = await processAtomPlanGrantInvoicePaid(db, invoice, details);
   if (!processed) {
     return { handled: true, drainOrgId: null };
   }


### PR DESCRIPTION
## Summary

- extend the existing Atom grant invoice handler to support credit-only grants
- require the configured ATOM_GRANT_PRICE line before consuming any custom credit metadata
- distinguish plan grants from credit grants with grantType=credits
- keep normal paid credit_purchase invoices subtotal-based
- cover both a valid zero-price Atom credit grant and rejection outside the configured grant-price path

## Metadata contract

Custom credit grants use type=atom_grant, purpose=atom_grant, grantType=credits, orgId, creditsAmount, and optional creditsExpiresAt. Plan grants continue using tier/planId and the existing duration metadata.

## Validation

- pnpm -F api check-types
- Prettier check for changed files
- The database-backed integration file cannot complete locally because PostgreSQL is not running (ECONNREFUSED); CI runs the integration scenario

## Rollout

Merge and deploy this PR before vm0-ai/vm0-atom#4 starts sending Atom credit grant invoices.