### PR TITLE
refactor(chat): centralize append-only message mutations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1131,6 +1131,65 @@ describe("CHAT-02: queueing and recalling messages", () => {
     await cancelChatRun(actor, first.runId);
     expect((await api.readRun(actor, first.runId)).status).toBe("cancelled");
   }, 90_000);
+
+  it("keeps a queued message when recall targets another owned thread", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "cross-thread recall anchor",
+    });
+    const queuedMessageId = randomUUID();
+    const queued = await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "must remain queued in the original thread",
+        clientMessageId: queuedMessageId,
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+
+    const otherThread = await chat.createThread(actor, {
+      agentId,
+      title: "Cross-thread recall target",
+    });
+    await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: otherThread.id,
+        revokesMessageId: queuedMessageId,
+        clientMessageId: randomUUID(),
+      },
+      [201, 400],
+    );
+
+    await cancelChatRun(actor, anchor.runId);
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesMessageId === queuedMessageId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const promoted = userMessages(messages.messages).find((message) => {
+      return message.revokesMessageId === queuedMessageId;
+    });
+    if (!promoted?.runId) {
+      throw new Error("Expected the original queued message to create a run");
+    }
+    expect(promoted.content).toBe("must remain queued in the original thread");
+    await cancelChatRun(actor, promoted.runId);
+  }, 90_000);
 });
 
 describe("CHAT-02: org queue markers", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1089,12 +1089,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       throw new Error("Expected the recall send to be accepted");
     }
     expect(recalled.body.runId).toBeNull();
-    const afterRecall = await chat.listThreadMessages(actor, first.threadId);
-    expect(
-      afterRecall.messages.some((message) => {
-        return message.id === queuedId || message.revokesMessageId === queuedId;
-      }),
-    ).toBeFalsy();
 
     const repeatedRecall = await chat.requestSendMessage(
       actor,
@@ -1111,11 +1105,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       threadId: first.threadId,
     });
     const afterRepeated = await chat.listThreadMessages(actor, first.threadId);
-    expect(
-      afterRepeated.messages.some((message) => {
-        return message.id === queuedId || message.revokesMessageId === queuedId;
-      }),
-    ).toBeFalsy();
 
     // Run-associated messages cannot be recalled.
     const associated = userMessages(afterRepeated.messages).find((message) => {
@@ -3921,7 +3910,7 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, claimed.runId);
   }, 90_000);
 
-  it("appends replacements on auto-send and recalls queued messages by deletion", async () => {
+  it("appends replacements on auto-send and keeps queued recalls idempotent", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -3944,8 +3933,7 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(queued.body).toMatchObject({ runId: null });
 
-    // A second queued message recalls by deletion: the row disappears
-    // entirely instead of being shadowed by a revoke control row.
+    // A second queued message can be recalled before dispatch.
     const recalledId = randomUUID();
     const toRecall = await chat.requestSendMessage(
       actor,
@@ -3969,16 +3957,8 @@ describe("CHAT-02: shared user message queue", () => {
       [201],
     );
     expect(recalled.body).toMatchObject({ runId: null });
-    const afterRecall = await chat.listThreadMessages(actor, anchor.threadId);
-    expect(
-      afterRecall.messages.some((message) => {
-        return (
-          message.id === recalledId || message.revokesMessageId === recalledId
-        );
-      }),
-    ).toBeFalsy();
 
-    // A repeated recall of the deleted message stays idempotent.
+    // A repeated recall stays idempotent.
     const repeatedRecall = await chat.requestSendMessage(
       actor,
       {
@@ -4031,6 +4011,9 @@ describe("CHAT-02: shared user message queue", () => {
 
     const followUp = await api.readRun(actor, promoted.runId);
     expect(followUp.prompt).toContain("queue-first waits for the anchor");
+    expect(followUp.appendSystemPrompt ?? "").not.toContain(
+      "queue-first message to recall",
+    );
     await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -93,6 +93,12 @@ import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
 } from "../services/zero-chat-message-shared.service";
+import {
+  deleteChatMessage,
+  insertChatMessage,
+  type NewChatMessage,
+  updateChatMessage,
+} from "../services/zero-chat-message.service";
 import { loadWebChatIncompleteContext } from "../services/zero-chat-incomplete-context.service";
 import { appendQueuedRunAssistantMarker } from "../services/zero-chat-queue-marker.service";
 import {
@@ -1583,9 +1589,9 @@ function appendUnassociatedUserMessage(params: {
     const explicitId = params.clientMessageId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
     const fileMetadata = attachFileMetadata(params.userId, params.attachFiles);
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
+    const inserted = await insertChatMessage(
+      tx,
+      {
         ...(explicitId ? { id: explicitId } : {}),
         chatThreadId: params.threadId,
         role: "user",
@@ -1594,9 +1600,9 @@ function appendUnassociatedUserMessage(params: {
         attachFiles: fileIds,
         attachFileMetadata: fileMetadata,
         generationTemplate: params.generationTemplate,
-      })
-      .onConflictDoNothing({ target: chatMessages.id })
-      .returning({ id: chatMessages.id, createdAt: chatMessages.createdAt });
+      },
+      "id",
+    );
     if (inserted) {
       await enqueueUserMessageQueueItem(tx, {
         orgId: params.orgId,
@@ -1684,21 +1690,19 @@ async function appendAssociatedUserMessage(params: {
     const explicitId = params.clientMessageId ?? undefined;
     const fileIds = attachFileIds(params.attachFiles);
     const fileMetadata = attachFileMetadata(params.userId, params.attachFiles);
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
-        ...(explicitId ? { id: explicitId } : {}),
-        chatThreadId: params.threadId,
-        role: "user",
-        content: params.prompt,
-        runId: params.runId,
-        revokesMessageId: params.revokesMessageId,
-        attachFiles: fileIds,
-        attachFileMetadata: fileMetadata,
-        generationTemplate: params.generationTemplate,
-      })
-      .onConflictDoNothing({ target: chatMessages.id })
-      .returning({ createdAt: chatMessages.createdAt });
+    const message: NewChatMessage = {
+      ...(explicitId ? { id: explicitId } : {}),
+      chatThreadId: params.threadId,
+      role: "user",
+      content: params.prompt,
+      runId: params.runId,
+      attachFiles: fileIds,
+      attachFileMetadata: fileMetadata,
+      generationTemplate: params.generationTemplate,
+    };
+    const inserted = params.revokesMessageId
+      ? await updateChatMessage(tx, params.revokesMessageId, message)
+      : await insertChatMessage(tx, message, "id");
     if (inserted && params.touchThreadSort) {
       await touchChatThreadLastMessageAt(
         tx,
@@ -1714,7 +1718,7 @@ async function appendAssociatedUserMessage(params: {
         createdAfter: inserted?.createdAt ?? nowDate(),
       });
     }
-    return inserted !== undefined;
+    return inserted !== null;
   });
 }
 
@@ -1725,26 +1729,10 @@ function appendRecallUserMessage(params: {
   readonly clientMessageId: string | undefined;
 }): Promise<AppendMessageResult> {
   return params.db.transaction(async (tx) => {
-    // Deleting the queue item atomically wins the queued message before
-    // removing its immutable row. If a concurrent claim wins first, its
-    // replacement remains linked and the revoker check below rejects recall.
-    if (await deleteUserMessageQueueItem(tx, params.revokesMessageId)) {
-      const [deleted] = await tx
-        .delete(chatMessages)
-        .where(
-          and(
-            eq(chatMessages.id, params.revokesMessageId),
-            eq(chatMessages.chatThreadId, params.threadId),
-            eq(chatMessages.role, "user"),
-            isNull(chatMessages.runId),
-          ),
-        )
-        .returning({ createdAt: chatMessages.createdAt });
-      if (!deleted) {
-        throw new Error("Claimed queue item has no recallable user message");
-      }
-      return { ok: true, createdAt: nowDate() };
-    }
+    // Deleting the queue item atomically wins the queued message. If a
+    // concurrent claim wins first, its replacement remains linked and the
+    // revoker check below rejects recall.
+    await deleteUserMessageQueueItem(tx, params.revokesMessageId);
 
     const [existingRevoker] = await tx
       .select({
@@ -1806,8 +1794,8 @@ function appendRecallUserMessage(params: {
         )
         .limit(1);
       if (!exists) {
-        // Queue-first recalls delete the message row, so a repeated recall
-        // finds nothing — treat it as an already-completed recall.
+        // Older queue-first recalls deleted the message row, so a repeated
+        // request can still find nothing during rollout.
         return { ok: true, createdAt: nowDate() };
       }
       return {
@@ -1816,19 +1804,12 @@ function appendRecallUserMessage(params: {
       };
     }
 
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
-        ...(params.clientMessageId ? { id: params.clientMessageId } : {}),
-        chatThreadId: params.threadId,
-        role: "user",
-        content: null,
-        runId: null,
-        revokesMessageId: params.revokesMessageId,
-        attachFiles: null,
-      })
-      .onConflictDoNothing()
-      .returning({ createdAt: chatMessages.createdAt });
+    const inserted = await deleteChatMessage(tx, params.revokesMessageId, {
+      ...(params.clientMessageId ? { id: params.clientMessageId } : {}),
+      chatThreadId: params.threadId,
+      role: "user",
+      runId: null,
+    });
     if (inserted) {
       return { ok: true, createdAt: inserted.createdAt };
     }
@@ -1947,9 +1928,9 @@ function appendInterruptUserMessage(params: {
       };
     }
 
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
+    const inserted = await insertChatMessage(
+      tx,
+      {
         ...(params.clientMessageId ? { id: params.clientMessageId } : {}),
         chatThreadId: params.threadId,
         role: "user",
@@ -1957,9 +1938,9 @@ function appendInterruptUserMessage(params: {
         runId: null,
         interruptsRunId: params.interruptsRunId,
         attachFiles: null,
-      })
-      .onConflictDoNothing()
-      .returning({ createdAt: chatMessages.createdAt });
+      },
+      "any",
+    );
     if (inserted) {
       return { ok: true, createdAt: inserted.createdAt };
     }
@@ -2697,29 +2678,24 @@ async function appendQueueFirstInsufficientCreditsMessages(params: {
     }
 
     await deleteUserMessageQueueItem(tx, params.messageId);
-    const [replacement] = await tx
-      .insert(chatMessages)
-      .values({
-        chatThreadId: params.prepared.thread.threadId,
-        role: "user",
-        content: queuedMessage.content,
-        runId: null,
-        revokesMessageId: params.messageId,
-        error: INSUFFICIENT_CREDITS_MARKER,
-        sequenceNumber: 0,
-        createdAt: userCreatedAt,
-        attachFiles: queuedMessage.attachFiles
-          ? [...queuedMessage.attachFiles]
-          : null,
-        attachFileMetadata: queuedMessage.attachFileMetadata
-          ? [...queuedMessage.attachFileMetadata]
-          : null,
-        generationTemplate: queuedMessage.generationTemplate,
-      })
-      .onConflictDoNothing({ target: chatMessages.revokesMessageId })
-      .returning({ id: chatMessages.id });
+    const replacement = await updateChatMessage(tx, params.messageId, {
+      chatThreadId: params.prepared.thread.threadId,
+      role: "user",
+      content: queuedMessage.content,
+      runId: null,
+      error: INSUFFICIENT_CREDITS_MARKER,
+      sequenceNumber: 0,
+      createdAt: userCreatedAt,
+      attachFiles: queuedMessage.attachFiles
+        ? [...queuedMessage.attachFiles]
+        : null,
+      attachFileMetadata: queuedMessage.attachFileMetadata
+        ? [...queuedMessage.attachFileMetadata]
+        : null,
+      generationTemplate: queuedMessage.generationTemplate,
+    });
     if (replacement) {
-      await tx.insert(chatMessages).values({
+      await insertChatMessage(tx, {
         chatThreadId: params.prepared.thread.threadId,
         role: "assistant",
         content: params.assistantContent,
@@ -2784,23 +2760,21 @@ async function appendInsufficientCreditsMessages(params: {
       params.userId,
       params.body.attachFiles,
     );
-    const [userMessage] = await tx
-      .insert(chatMessages)
-      .values({
-        ...(explicitId ? { id: explicitId } : {}),
-        chatThreadId: params.prepared.thread.threadId,
-        role: "user",
-        content: params.body.prompt,
-        runId: null,
-        revokesMessageId: params.body.revokesMessageId,
-        error: INSUFFICIENT_CREDITS_MARKER,
-        sequenceNumber: 0,
-        createdAt: userCreatedAt,
-        attachFiles: fileIds,
-        attachFileMetadata: fileMetadata,
-      })
-      .onConflictDoNothing({ target: chatMessages.id })
-      .returning({ createdAt: chatMessages.createdAt });
+    const userValues: NewChatMessage = {
+      ...(explicitId ? { id: explicitId } : {}),
+      chatThreadId: params.prepared.thread.threadId,
+      role: "user",
+      content: params.body.prompt,
+      runId: null,
+      error: INSUFFICIENT_CREDITS_MARKER,
+      sequenceNumber: 0,
+      createdAt: userCreatedAt,
+      attachFiles: fileIds,
+      attachFileMetadata: fileMetadata,
+    };
+    const userMessage = params.body.revokesMessageId
+      ? await updateChatMessage(tx, params.body.revokesMessageId, userValues)
+      : await insertChatMessage(tx, userValues, "id");
 
     const createdAt = userMessage?.createdAt ?? userCreatedAt;
     if (userMessage && params.touchThreadSort) {
@@ -2811,7 +2785,7 @@ async function appendInsufficientCreditsMessages(params: {
         params.body.chatThreadSortEventId,
       );
     }
-    await tx.insert(chatMessages).values({
+    await insertChatMessage(tx, {
       chatThreadId: params.prepared.thread.threadId,
       role: "assistant",
       content: assistantContent,
@@ -2820,7 +2794,7 @@ async function appendInsufficientCreditsMessages(params: {
       createdAt: assistantCreatedAt,
       runId: null,
     });
-    return { createdAt, inserted: userMessage !== undefined };
+    return { createdAt, inserted: userMessage !== null };
   });
 
   await publishChatMessageCreated(

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1732,7 +1732,10 @@ function appendRecallUserMessage(params: {
     // Deleting the queue item atomically wins the queued message. If a
     // concurrent claim wins first, its replacement remains linked and the
     // revoker check below rejects recall.
-    await deleteUserMessageQueueItem(tx, params.revokesMessageId);
+    const queueItemDeleted = await deleteUserMessageQueueItem(tx, {
+      threadId: params.threadId,
+      messageId: params.revokesMessageId,
+    });
 
     const [existingRevoker] = await tx
       .select({
@@ -1783,6 +1786,9 @@ function appendRecallUserMessage(params: {
       (target.revokesMessageId !== null &&
         target.error !== INSUFFICIENT_CREDITS_MARKER)
     ) {
+      if (queueItemDeleted) {
+        throw new Error("Queued message is not recallable");
+      }
       const [exists] = await tx
         .select({ id: chatMessages.id })
         .from(chatMessages)
@@ -1826,6 +1832,9 @@ function appendRecallUserMessage(params: {
       )
       .limit(1);
     if (!resolved) {
+      if (queueItemDeleted) {
+        throw new Error("Failed to append recall user message");
+      }
       return { ok: false, message: "Failed to insert recall user message" };
     }
     return { ok: true, createdAt: resolved.createdAt };
@@ -2677,7 +2686,10 @@ async function appendQueueFirstInsufficientCreditsMessages(params: {
       throw new Error("Queue-first message is no longer available");
     }
 
-    await deleteUserMessageQueueItem(tx, params.messageId);
+    const queueItemDeleted = await deleteUserMessageQueueItem(tx, {
+      threadId: params.prepared.thread.threadId,
+      messageId: params.messageId,
+    });
     const replacement = await updateChatMessage(tx, params.messageId, {
       chatThreadId: params.prepared.thread.threadId,
       role: "user",
@@ -2704,6 +2716,8 @@ async function appendQueueFirstInsufficientCreditsMessages(params: {
         createdAt: assistantCreatedAt,
         runId: null,
       });
+    } else if (queueItemDeleted) {
+      throw new Error("Failed to append insufficient-credits replacement");
     }
     return queuedMessage.createdAt;
   });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -61,6 +61,7 @@ import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
+import { insertChatMessage } from "./zero-chat-message.service";
 import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { recommendedFollowupsMessageIdForRun } from "./assistant-message-id";
@@ -808,9 +809,9 @@ async function insertAssistantErrorMessage(args: {
   const displayErrorMessage = await args.getFormattedError();
   const runGroupId = await runGroupIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
-    const message = await tx
-      .insert(chatMessages)
-      .values({
+    const message = await insertChatMessage(
+      tx,
+      {
         chatThreadId: args.threadId,
         role: "assistant",
         content: displayErrorMessage,
@@ -818,20 +819,13 @@ async function insertAssistantErrorMessage(args: {
         runGroupId,
         error: displayErrorMessage,
         runLifecycleEvent: args.lifecycleEvent,
-      })
-      .onConflictDoNothing({
-        target: chatMessages.runId,
-        where: sql`${chatMessages.runLifecycleEvent} IS NOT NULL`,
-      })
-      .returning({ id: chatMessages.id, createdAt: chatMessages.createdAt });
-    if (message.length === 0) {
+      },
+      "run-lifecycle",
+    );
+    if (!message) {
       return false;
     }
-    await touchChatThreadLastMessageAt(
-      tx,
-      args.threadId,
-      message[0]!.createdAt,
-    );
+    await touchChatThreadLastMessageAt(tx, args.threadId, message.createdAt);
     return true;
   });
   if (!inserted) {
@@ -856,9 +850,9 @@ async function insertRunLifecycleMarker(args: {
   const markerCreatedAt = nowDate();
   const runGroupId = await runGroupIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
-    const marker = await tx
-      .insert(chatMessages)
-      .values({
+    const marker = await insertChatMessage(
+      tx,
+      {
         chatThreadId: args.threadId,
         role: "assistant",
         content: null,
@@ -866,13 +860,10 @@ async function insertRunLifecycleMarker(args: {
         runGroupId,
         runLifecycleEvent: args.event,
         createdAt: markerCreatedAt,
-      })
-      .onConflictDoNothing({
-        target: chatMessages.runId,
-        where: sql`${chatMessages.runLifecycleEvent} IS NOT NULL`,
-      })
-      .returning({ id: chatMessages.id });
-    if (marker.length === 0) {
+      },
+      "run-lifecycle",
+    );
+    if (!marker) {
       return false;
     }
     await touchChatThreadLastMessageAt(tx, args.threadId, markerCreatedAt);
@@ -897,9 +888,9 @@ async function insertRecommendedFollowupsMessage(args: {
   readonly recommendedFollowups: ChatMessageRecommendedFollowups;
 }): Promise<boolean> {
   const runGroupId = await runGroupIdForRun(args.db, args.runId);
-  const inserted = await args.db
-    .insert(chatMessages)
-    .values({
+  const inserted = await insertChatMessage(
+    args.db,
+    {
       id: recommendedFollowupsMessageIdForRun(args.runId),
       chatThreadId: args.threadId,
       role: "assistant",
@@ -907,11 +898,11 @@ async function insertRecommendedFollowupsMessage(args: {
       runId: args.runId,
       runGroupId,
       recommendedFollowups: args.recommendedFollowups,
-    })
-    .onConflictDoNothing({ target: chatMessages.id })
-    .returning({ id: chatMessages.id });
+    },
+    "id",
+  );
 
-  if (inserted.length === 0) {
+  if (!inserted) {
     return false;
   }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -5,6 +5,7 @@ import {
 import { sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
+import { insertChatMessage } from "./zero-chat-message.service";
 import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 
 /**
@@ -21,7 +22,7 @@ export async function appendGoalEventMarker(
     readonly event: ChatMessageGoalEvent;
   },
 ): Promise<void> {
-  await tx.insert(chatMessages).values({
+  await insertChatMessage(tx, {
     chatThreadId: args.chatThreadId,
     role: "assistant",
     content: null,

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -12,6 +12,7 @@ import {
   runGroupIdForRun,
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
+import { insertChatMessage } from "./zero-chat-message.service";
 
 const log = logger("api:zero:chat-initial-thinking");
 
@@ -207,9 +208,9 @@ export async function generateAndPersistInitialThinkingMessage(args: {
     return false;
   }
 
-  const [inserted] = await args.db
-    .insert(chatMessages)
-    .values({
+  const inserted = await insertChatMessage(
+    args.db,
+    {
       id: assistantMessageIdForRunEvent(
         args.runId,
         INITIAL_THINKING_RUN_EVENT_ID,
@@ -221,9 +222,9 @@ export async function generateAndPersistInitialThinkingMessage(args: {
       content: null,
       thinking,
       runEventId: INITIAL_THINKING_RUN_EVENT_ID,
-    })
-    .onConflictDoNothing()
-    .returning({ id: chatMessages.id });
+    },
+    "any",
+  );
 
   if (!inserted) {
     return false;

--- a/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
@@ -22,6 +22,7 @@ import {
 import { listS3Objects } from "../external/s3";
 import { nowDate } from "../external/time";
 import { assistantMessageIdForRunEvent } from "./assistant-message-id";
+import { insertChatMessages } from "./zero-chat-message.service";
 import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 
 const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
@@ -208,48 +209,42 @@ export async function insertAssistantEventMessages(
   const deterministicRows =
     itemsWithRunEventId.length === 0
       ? []
-      : await writeDb
-          .insert(chatMessages)
-          .values(
-            itemsWithRunEventId.map((item) => {
-              return {
-                id: assistantMessageIdForRunEvent(args.runId, item.runEventId),
-                chatThreadId: args.threadId,
-                runId: args.runId,
-                runGroupId,
-                role: "assistant",
-                content: item.content,
-                sequenceNumber: item.sequenceNumber,
-                runEventId: item.runEventId,
-              };
-            }),
-          )
-          .onConflictDoNothing()
-          .returning({ id: chatMessages.id });
+      : await insertChatMessages(
+          writeDb,
+          itemsWithRunEventId.map((item) => {
+            return {
+              id: assistantMessageIdForRunEvent(args.runId, item.runEventId),
+              chatThreadId: args.threadId,
+              runId: args.runId,
+              runGroupId,
+              role: "assistant",
+              content: item.content,
+              sequenceNumber: item.sequenceNumber,
+              runEventId: item.runEventId,
+            };
+          }),
+          "any",
+        );
   signal.throwIfAborted();
 
   const legacyRows =
     legacyItems.length === 0
       ? []
-      : await writeDb
-          .insert(chatMessages)
-          .values(
-            legacyItems.map((item) => {
-              return {
-                chatThreadId: args.threadId,
-                runId: args.runId,
-                runGroupId,
-                role: "assistant",
-                content: item.content,
-                sequenceNumber: item.sequenceNumber,
-                runEventId: null,
-              };
-            }),
-          )
-          .onConflictDoNothing({
-            target: [chatMessages.runId, chatMessages.sequenceNumber],
-          })
-          .returning({ id: chatMessages.id });
+      : await insertChatMessages(
+          writeDb,
+          legacyItems.map((item) => {
+            return {
+              chatThreadId: args.threadId,
+              runId: args.runId,
+              runGroupId,
+              role: "assistant",
+              content: item.content,
+              sequenceNumber: item.sequenceNumber,
+              runEventId: null,
+            };
+          }),
+          "run-sequence",
+        );
   signal.throwIfAborted();
 
   const insertedRowCount = deterministicRows.length + legacyRows.length;

--- a/turbo/apps/api/src/signals/services/zero-chat-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message.service.ts
@@ -1,0 +1,122 @@
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+type ChatMessageInsert = typeof chatMessages.$inferInsert;
+type ChatMessageWriteDb = Pick<Db, "insert">;
+
+export type NewChatMessage = Omit<ChatMessageInsert, "revokesMessageId">;
+
+export interface ChatMessageCommandResult {
+  readonly id: string;
+  readonly createdAt: Date;
+}
+
+export type InsertChatMessageConflict = "none" | "any" | "id" | "run-lifecycle";
+
+export type InsertChatMessagesConflict = "any" | "run-sequence";
+
+export interface DeleteChatMessageInput {
+  readonly id?: string;
+  readonly chatThreadId: string;
+  readonly role: ChatMessageInsert["role"];
+  readonly runId?: string | null;
+  readonly runGroupId?: string | null;
+  readonly runEventId?: string | null;
+  readonly sequenceNumber?: number | null;
+  readonly createdAt?: Date;
+}
+
+/** Insert an immutable chat message using the caller-owned transaction. */
+export async function insertChatMessage(
+  tx: ChatMessageWriteDb,
+  values: NewChatMessage,
+  conflict: InsertChatMessageConflict = "none",
+): Promise<ChatMessageCommandResult | null> {
+  const query = tx.insert(chatMessages).values(values);
+  const rows =
+    conflict === "any"
+      ? await query.onConflictDoNothing().returning({
+          id: chatMessages.id,
+          createdAt: chatMessages.createdAt,
+        })
+      : conflict === "id"
+        ? await query
+            .onConflictDoNothing({ target: chatMessages.id })
+            .returning({
+              id: chatMessages.id,
+              createdAt: chatMessages.createdAt,
+            })
+        : conflict === "run-lifecycle"
+          ? await query
+              .onConflictDoNothing({
+                target: chatMessages.runId,
+                where: sql`${chatMessages.runLifecycleEvent} IS NOT NULL`,
+              })
+              .returning({
+                id: chatMessages.id,
+                createdAt: chatMessages.createdAt,
+              })
+          : await query.returning({
+              id: chatMessages.id,
+              createdAt: chatMessages.createdAt,
+            });
+
+  return rows[0] ?? null;
+}
+
+export async function insertChatMessages(
+  tx: ChatMessageWriteDb,
+  values: readonly NewChatMessage[],
+  conflict: InsertChatMessagesConflict,
+): Promise<readonly ChatMessageCommandResult[]> {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const query = tx.insert(chatMessages).values([...values]);
+  if (conflict === "any") {
+    return await query.onConflictDoNothing().returning({
+      id: chatMessages.id,
+      createdAt: chatMessages.createdAt,
+    });
+  }
+  return await query
+    .onConflictDoNothing({
+      target: [chatMessages.runId, chatMessages.sequenceNumber],
+    })
+    .returning({
+      id: chatMessages.id,
+      createdAt: chatMessages.createdAt,
+    });
+}
+
+/** Append and return a replacement row for an existing chat message. */
+export async function updateChatMessage(
+  tx: ChatMessageWriteDb,
+  messageId: string,
+  replacement: NewChatMessage,
+): Promise<ChatMessageCommandResult | null> {
+  const rows = await tx
+    .insert(chatMessages)
+    .values({ ...replacement, revokesMessageId: messageId })
+    .onConflictDoNothing()
+    .returning({
+      id: chatMessages.id,
+      createdAt: chatMessages.createdAt,
+    });
+  return rows[0] ?? null;
+}
+
+/** Append and return a contentless tombstone for an existing chat message. */
+export async function deleteChatMessage(
+  tx: ChatMessageWriteDb,
+  messageId: string,
+  tombstone: DeleteChatMessageInput,
+): Promise<ChatMessageCommandResult | null> {
+  return await updateChatMessage(tx, messageId, {
+    ...tombstone,
+    content: null,
+  });
+}

--- a/turbo/apps/api/src/signals/services/zero-chat-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message.service.ts
@@ -8,16 +8,16 @@ type ChatMessageWriteDb = Pick<Db, "insert">;
 
 export type NewChatMessage = Omit<ChatMessageInsert, "revokesMessageId">;
 
-export interface ChatMessageCommandResult {
+interface ChatMessageCommandResult {
   readonly id: string;
   readonly createdAt: Date;
 }
 
-export type InsertChatMessageConflict = "none" | "any" | "id" | "run-lifecycle";
+type InsertChatMessageConflict = "none" | "any" | "id" | "run-lifecycle";
 
-export type InsertChatMessagesConflict = "any" | "run-sequence";
+type InsertChatMessagesConflict = "any" | "run-sequence";
 
-export interface DeleteChatMessageInput {
+interface DeleteChatMessageInput {
   readonly id?: string;
   readonly chatThreadId: string;
   readonly role: ChatMessageInsert["role"];

--- a/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
@@ -3,6 +3,10 @@ import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, eq, sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
+import {
+  deleteChatMessage,
+  insertChatMessage,
+} from "./zero-chat-message.service";
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
@@ -55,7 +59,7 @@ export async function appendQueuedRunAssistantMarker(
     return;
   }
 
-  await tx.insert(chatMessages).values({
+  await insertChatMessage(tx, {
     chatThreadId: args.chatThreadId,
     role: "assistant",
     content: QUEUED_RUN_ASSISTANT_MESSAGE,
@@ -97,19 +101,13 @@ export async function revokeQueuedRunAssistantMarkers(
 
   let notifiedThreadId: string | null = null;
   for (const marker of markers) {
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
-        chatThreadId: marker.chatThreadId,
-        role: "assistant",
-        content: null,
-        runId: args.runId,
-        runGroupId: marker.runGroupId ?? undefined,
-        revokesMessageId: marker.id,
-        runEventId: QUEUED_RUN_MARKER_REVOKE_EVENT_ID,
-      })
-      .onConflictDoNothing({ target: chatMessages.revokesMessageId })
-      .returning({ id: chatMessages.id });
+    const inserted = await deleteChatMessage(tx, marker.id, {
+      chatThreadId: marker.chatThreadId,
+      role: "assistant",
+      runId: args.runId,
+      runGroupId: marker.runGroupId ?? undefined,
+      runEventId: QUEUED_RUN_MARKER_REVOKE_EVENT_ID,
+    });
     if (inserted) {
       notifiedThreadId = marker.chatThreadId;
     }

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -101,14 +101,18 @@ export async function enqueueUserMessageQueueItem(
 
 export async function deleteUserMessageQueueItem(
   db: Db,
-  chatMessageId: string,
+  args: {
+    readonly threadId: string;
+    readonly messageId: string;
+  },
 ): Promise<boolean> {
   const deleted = await db
     .delete(chatMessageQueue)
     .where(
       and(
         eq(chatMessageQueue.itemType, "user_message"),
-        eq(chatMessageQueue.chatMessageId, chatMessageId),
+        eq(chatMessageQueue.chatThreadId, args.threadId),
+        eq(chatMessageQueue.chatMessageId, args.messageId),
       ),
     )
     .returning({ id: chatMessageQueue.id });
@@ -173,7 +177,14 @@ export async function appendClaimedUserMessage(
   if (!claimed) {
     return null;
   }
-  await deleteUserMessageQueueItem(db, args.messageId);
+  if (
+    !(await deleteUserMessageQueueItem(db, {
+      threadId: args.threadId,
+      messageId: args.messageId,
+    }))
+  ) {
+    throw new Error("Claimed user message queue item disappeared");
+  }
   return claimed;
 }
 
@@ -216,11 +227,20 @@ export async function discardUnclaimedUserMessage(
   },
 ): Promise<void> {
   await db.transaction(async (tx) => {
-    await deleteUserMessageQueueItem(tx, args.messageId);
-    await deleteChatMessage(tx, args.messageId, {
+    const queueItemDeleted = await deleteUserMessageQueueItem(tx, {
+      threadId: args.threadId,
+      messageId: args.messageId,
+    });
+    if (!queueItemDeleted) {
+      return;
+    }
+    const tombstone = await deleteChatMessage(tx, args.messageId, {
       chatThreadId: args.threadId,
       role: "user",
       runId: null,
     });
+    if (!tombstone) {
+      throw new Error("Failed to append discarded user message tombstone");
+    }
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -9,6 +9,10 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { and, asc, eq, isNull, sql, type SQL } from "drizzle-orm";
 
 import type { Db } from "../external/db";
+import {
+  deleteChatMessage,
+  updateChatMessage,
+} from "./zero-chat-message.service";
 
 export interface QueuedUserMessage {
   readonly id: string;
@@ -155,22 +159,17 @@ export async function appendClaimedUserMessage(
     return null;
   }
 
-  const [claimed] = await db
-    .insert(chatMessages)
-    .values({
-      chatThreadId: args.threadId,
-      role: "user",
-      content: queued.content,
-      runId: args.runId,
-      revokesMessageId: args.messageId,
-      attachFiles: queued.attachFiles ? [...queued.attachFiles] : null,
-      attachFileMetadata: queued.attachFileMetadata
-        ? [...queued.attachFileMetadata]
-        : null,
-      generationTemplate: queued.generationTemplate,
-    })
-    .onConflictDoNothing({ target: chatMessages.revokesMessageId })
-    .returning({ createdAt: chatMessages.createdAt });
+  const claimed = await updateChatMessage(db, args.messageId, {
+    chatThreadId: args.threadId,
+    role: "user",
+    content: queued.content,
+    runId: args.runId,
+    attachFiles: queued.attachFiles ? [...queued.attachFiles] : null,
+    attachFileMetadata: queued.attachFileMetadata
+      ? [...queued.attachFileMetadata]
+      : null,
+    generationTemplate: queued.generationTemplate,
+  });
   if (!claimed) {
     return null;
   }
@@ -206,8 +205,8 @@ export async function claimQueuedUserMessage(
 
 /**
  * Discard a queue-first user message that never dispatched (run creation
- * failed): remove both the queue item and the unclaimed message row so the
- * thread history matches the legacy direct-send failure behavior.
+ * failed): consume the queue item and append a tombstone so the failed send is
+ * absent from the visible thread while the message stream stays append-only.
  */
 export async function discardUnclaimedUserMessage(
   db: Db,
@@ -218,15 +217,10 @@ export async function discardUnclaimedUserMessage(
 ): Promise<void> {
   await db.transaction(async (tx) => {
     await deleteUserMessageQueueItem(tx, args.messageId);
-    await tx
-      .delete(chatMessages)
-      .where(
-        and(
-          eq(chatMessages.id, args.messageId),
-          eq(chatMessages.chatThreadId, args.threadId),
-          eq(chatMessages.role, "user"),
-          isNull(chatMessages.runId),
-        ),
-      );
+    await deleteChatMessage(tx, args.messageId, {
+      chatThreadId: args.threadId,
+      role: "user",
+      runId: null,
+    });
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -17,6 +17,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { nowDate } from "../external/time";
+import { insertChatMessage } from "./zero-chat-message.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import {
@@ -167,17 +168,14 @@ export async function postRunUserMessage(params: {
       }
     : undefined;
   await params.db.transaction(async (tx) => {
-    const [inserted] = await tx
-      .insert(chatMessages)
-      .values({
-        chatThreadId: params.threadId,
-        role: "user",
-        content: params.prompt,
-        runId: params.runId,
-        runGroupId: params.runGroupId,
-        goalSnapshot,
-      })
-      .returning({ createdAt: chatMessages.createdAt });
+    const inserted = await insertChatMessage(tx, {
+      chatThreadId: params.threadId,
+      role: "user",
+      content: params.prompt,
+      runId: params.runId,
+      runGroupId: params.runGroupId,
+      goalSnapshot,
+    });
     if (params.appendQueueMarker) {
       await appendQueuedRunAssistantMarker(tx, {
         chatThreadId: params.threadId,

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -15,6 +15,7 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
+import { insertChatMessage } from "./zero-chat-message.service";
 
 const L = logger("ChatUsageMessage");
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -184,18 +185,15 @@ export const maybeEmitRunUsageMessage$ = command(
         breakdown: buildUsageBreakdown(breakdownRows),
       };
 
-      const [inserted] = await tx
-        .insert(chatMessages)
-        .values({
-          chatThreadId: context.chatThreadId,
-          role: "assistant",
-          content: null,
-          runId,
-          runGroupId: context.runGroupId,
-          usagePayload: payload,
-          createdAt: new Date(payload.settledAt),
-        })
-        .returning({ id: chatMessages.id });
+      const inserted = await insertChatMessage(tx, {
+        chatThreadId: context.chatThreadId,
+        role: "assistant",
+        content: null,
+        runId,
+        runGroupId: context.runGroupId,
+        usagePayload: payload,
+        createdAt: new Date(payload.settledAt),
+      });
       signal.throwIfAborted();
 
       if (!inserted) {

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -31,6 +31,7 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
+import { insertChatMessage } from "./zero-chat-message.service";
 
 const L = logger("api:zero-mail");
 
@@ -231,15 +232,12 @@ async function persistMailDraft(args: {
 }): Promise<ZeroMailDraftMutationResult> {
   const created = await args.db.transaction(async (tx) => {
     const mailDraftId = randomUUID();
-    const [message] = await tx
-      .insert(chatMessages)
-      .values({
-        chatThreadId: args.threadId,
-        role: "assistant",
-        content: null,
-        mailDraftId,
-      })
-      .returning({ id: chatMessages.id });
+    const message = await insertChatMessage(tx, {
+      chatThreadId: args.threadId,
+      role: "assistant",
+      content: null,
+      mailDraftId,
+    });
     if (!message) {
       throw new Error("Mail draft message insert did not return an id");
     }


### PR DESCRIPTION
## Summary

- add a chat message command service with insert, update, and delete operations while keeping transaction ownership with callers
- make update append and return a replacement message, and make delete append a contentless tombstone
- migrate production chat message writers to the service, including queued claims, recalls, run events, markers, usage, and mail drafts
- replace standalone physical deletes for queued recall and failed queue-first sends with append-only deletion records
- scope queued-message consumption by both thread and message, and roll back when a claimed queue mutation cannot append its replacement or tombstone

## Behavior

- logical chat history behavior remains unchanged: recalled and discarded queued messages stay hidden and are not dispatched
- a recall sent through another owned thread can no longer consume the original thread queued message
- claim, recall, discard, and insufficient-credit replacement keep queue consumption and message append in one atomic caller-owned transaction
- repeated recalls remain idempotent
- deleting a chat thread still physically deletes its chat messages through the existing foreign-key cascade
- HTTP request and response contracts remain unchanged in this PR

## Verification

- Prettier check on all changed files
- API TypeScript check with `tsc --noEmit`
- full API lint with zero warnings and zero errors
- `pnpm knip`
- targeted API Vitest: basic queued recall and cross-thread recall regression passed (2/2)
- the existing claim-vs-recall race test was also attempted locally, but its runner claim setup returned 404 before reaching the changed queue code; it passed on the prior PR CI run and is rerunning in the new PR pipeline
- API BDD coverage uses production endpoints without importing services or querying the database
