### PR TITLE
fix: show web fetch and web search in credit usage details

### DIFF
--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -1,0 +1,87 @@
+import { getModelDisplayName } from "@vm0/core/model-display-name";
+
+const CONNECTOR_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  firecrawl: "Web Fetch",
+  perplexity: "Web Search",
+};
+
+function titleCaseUsageToken(token: string): string {
+  const upper = token.toUpperCase();
+  if (["AI", "API", "GLM", "GPT", "ID", "SQL", "URL", "VM0"].includes(upper)) {
+    return upper;
+  }
+
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+function formatUsageIdentifier(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "Usage";
+  }
+
+  return normalized
+    .split(/[/._-]+/)
+    .filter((token) => {
+      return token.length > 0;
+    })
+    .map(titleCaseUsageToken)
+    .join(" ");
+}
+
+function stripUsageProviderPrefix(value: string): string {
+  const normalized = value.trim();
+  if (normalized.startsWith("fal-ai/")) {
+    return normalized.slice("fal-ai/".length);
+  }
+  if (normalized.startsWith("bytedance/")) {
+    return normalized.slice("bytedance/".length);
+  }
+  if (normalized.startsWith("dreamina-")) {
+    return normalized.slice("dreamina-".length);
+  }
+  return normalized;
+}
+
+function usageModelDisplayName(model: string): string {
+  const directDisplayName = getModelDisplayName(model);
+  if (directDisplayName !== model) {
+    return directDisplayName;
+  }
+
+  const strippedModel = stripUsageProviderPrefix(model);
+  const strippedDisplayName = getModelDisplayName(strippedModel);
+  if (strippedDisplayName !== strippedModel) {
+    return strippedDisplayName;
+  }
+
+  return formatUsageIdentifier(strippedModel);
+}
+
+function usageKindBase(kind: string): string {
+  return kind.split("/", 1)[0];
+}
+
+export function getCreditUsageDisplayName(
+  kind: string,
+  provider: string,
+): string {
+  if (!provider || provider === "unknown") {
+    return formatUsageIdentifier(kind);
+  }
+
+  const normalizedProvider = provider.trim();
+  const baseKind = usageKindBase(kind);
+  if (baseKind === "connector") {
+    const connectorDisplayName = CONNECTOR_DISPLAY_NAMES[normalizedProvider];
+    if (connectorDisplayName) {
+      return connectorDisplayName;
+    }
+  }
+
+  if (baseKind === "model" || baseKind === "image" || baseKind === "video") {
+    return usageModelDisplayName(normalizedProvider);
+  }
+
+  return formatUsageIdentifier(normalizedProvider);
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2366,7 +2366,11 @@ describe("chat lifecycle", () => {
               {
                 kind: "connector",
                 credits: 108,
-                providers: [{ provider: "x", credits: 108 }],
+                providers: [
+                  { provider: "firecrawl", credits: 36 },
+                  { provider: "perplexity", credits: 36 },
+                  { provider: "google-map", credits: 36 },
+                ],
               },
             ],
           },
@@ -2399,8 +2403,10 @@ describe("chat lifecycle", () => {
     click(connectorCredit);
 
     await waitFor(() => {
-      expect(screen.getAllByText("X").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText("108").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Web Fetch")).toBeInTheDocument();
+      expect(screen.getByText("Web Search")).toBeInTheDocument();
+      expect(screen.getByText("Google Map")).toBeInTheDocument();
+      expect(screen.getAllByText("36")).toHaveLength(3);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -4,6 +4,7 @@ import {
   type UsageRecordRow,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -20,7 +21,17 @@ function usageRows(): UsageRecordRow[] {
       title: "Quarterly planning chat",
       credits: 980,
       tokens: 2200,
-      breakdown: [],
+      breakdown: [
+        {
+          kind: "connector",
+          credits: 980,
+          providers: [
+            { provider: "firecrawl", credits: 300 },
+            { provider: "perplexity", credits: 300 },
+            { provider: "google-map", credits: 380 },
+          ],
+        },
+      ],
       member: null,
       lastActivityAt: "2026-03-21T10:00:00Z",
     },
@@ -161,6 +172,7 @@ async function openUsageSettings(): Promise<void> {
 
 describe("personal usage settings", () => {
   it("shows personal usage, loads more, and changes the usage range", async () => {
+    const user = userEvent.setup();
     const requestedRanges = mockPersonalUsageStory();
     await openUsageSettings();
 
@@ -172,6 +184,19 @@ describe("personal usage settings", () => {
     expect(screen.queryByText("Extended CLI audit")).not.toBeInTheDocument();
     expect(screen.queryByText("All sources")).not.toBeInTheDocument();
     expect(requestedRanges).toContain("today");
+
+    await user.hover(screen.getByTestId("usage-kind-segment-connector"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Web Fetch").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Web Search").length).toBeGreaterThanOrEqual(
+        1,
+      );
+      expect(screen.getAllByText("Google Map").length).toBeGreaterThanOrEqual(
+        1,
+      );
+      expect(screen.queryByText("google-map")).not.toBeInTheDocument();
+    });
 
     click(screen.getByText("Load more"));
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -43,6 +43,7 @@ import {
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { closeSettingsModal$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { nowDate } from "../../../../lib/time.ts";
+import { getCreditUsageDisplayName } from "../../../../lib/credit-usage-display.ts";
 import { Link } from "../../../router/link.tsx";
 import { MemberUsageTable } from "../org-manage/org-usage-tab.tsx";
 
@@ -247,7 +248,12 @@ function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
                         key={provider.provider}
                         className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
                       >
-                        <span className="truncate">{provider.provider}</span>
+                        <span className="truncate">
+                          {getCreditUsageDisplayName(
+                            segment.kind,
+                            provider.provider,
+                          )}
+                        </span>
                         <span className="shrink-0 tabular-nums">
                           {provider.credits.toLocaleString()}
                         </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -101,7 +101,6 @@ import {
   findWorkflowTemplateItem,
   r2ImageTransformUrl,
 } from "@vm0/core";
-import { getModelDisplayName } from "@vm0/core/model-display-name";
 import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
@@ -115,6 +114,7 @@ import {
   captureRecommendedFollowupSelected,
   captureRecommendedFollowupsShown,
 } from "../../lib/posthog.ts";
+import { getCreditUsageDisplayName } from "../../lib/credit-usage-display.ts";
 import {
   AttachmentLightbox,
   FileAttachmentChip,
@@ -6655,77 +6655,12 @@ interface RunUsageDisplayRow {
   readonly credits: number;
 }
 
-function titleCaseUsageToken(token: string): string {
-  const upper = token.toUpperCase();
-  if (["AI", "API", "GLM", "GPT", "ID", "SQL", "URL", "VM0"].includes(upper)) {
-    return upper;
-  }
-
-  return token.charAt(0).toUpperCase() + token.slice(1);
-}
-
-function formatUsageIdentifier(value: string): string {
-  const normalized = value.trim();
-  if (!normalized) {
-    return "Usage";
-  }
-
-  return normalized
-    .split(/[/._-]+/)
-    .filter((token) => {
-      return token.length > 0;
-    })
-    .map(titleCaseUsageToken)
-    .join(" ");
-}
-
 function isUsageModelBackedKind(kind: string): boolean {
   return kind === "model" || kind === "image" || kind === "video";
 }
 
 function isUsageCategoryPart(part: string): boolean {
   return part.startsWith("tokens.") || part.startsWith("output_");
-}
-
-function stripUsageProviderPrefix(value: string): string {
-  const normalized = value.trim();
-  if (normalized.startsWith("fal-ai/")) {
-    return normalized.slice("fal-ai/".length);
-  }
-  if (normalized.startsWith("bytedance/")) {
-    return normalized.slice("bytedance/".length);
-  }
-  if (normalized.startsWith("dreamina-")) {
-    return normalized.slice("dreamina-".length);
-  }
-  return normalized;
-}
-
-function getUsageModelDisplayName(model: string): string {
-  const directDisplayName = getModelDisplayName(model);
-  if (directDisplayName !== model) {
-    return directDisplayName;
-  }
-
-  const strippedModel = stripUsageProviderPrefix(model);
-  const strippedDisplayName = getModelDisplayName(strippedModel);
-  if (strippedDisplayName !== strippedModel) {
-    return strippedDisplayName;
-  }
-
-  return formatUsageIdentifier(strippedModel);
-}
-
-function usageDisplayLabel(kind: string, provider: string): string {
-  if (isUsageModelBackedKind(kind) && provider && provider !== "unknown") {
-    return getUsageModelDisplayName(provider);
-  }
-
-  if (provider && provider !== "unknown") {
-    return formatUsageIdentifier(provider);
-  }
-
-  return formatUsageIdentifier(kind);
 }
 
 function parseUsageKind(kind: string): {
@@ -6763,7 +6698,8 @@ function buildRunUsageDisplayRows(
       const credits = Math.max(0, providerBreakdown.credits);
       rows.set(key, {
         key,
-        label: existing?.label ?? usageDisplayLabel(parsed.kind, provider),
+        label:
+          existing?.label ?? getCreditUsageDisplayName(parsed.kind, provider),
         credits: (existing?.credits ?? 0) + credits,
       });
     }


### PR DESCRIPTION
## Summary

- share provider display-name formatting between chat credit usage popovers and settings usage tooltips
- display Firecrawl usage as `Web Fetch` and Perplexity usage as `Web Search`
- keep other provider identifiers consistent across both surfaces, including `google-map` as `Google Map`

## User impact

Credit usage details now use the same product-facing provider names in chat messages and settings.

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace apps/platform`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --maxWorkers=4 --silent=passed-only` (132 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx --maxWorkers=4 --silent=passed-only` (3 passed)

Browser verification was not run because the vm0 PR workflow delegates UI runtime verification to the PR preview pipeline.
