### PR TITLE
fix(platform): show auto for vm0 model credit usage

### DIFF
--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -5,6 +5,10 @@ const CONNECTOR_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   perplexity: "Web Search",
 };
 
+const MODEL_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  "vm0-model": "Auto",
+};
+
 function titleCaseUsageToken(token: string): string {
   const upper = token.toUpperCase();
   if (["AI", "API", "GLM", "GPT", "ID", "SQL", "URL", "VM0"].includes(upper)) {
@@ -44,6 +48,11 @@ function stripUsageProviderPrefix(value: string): string {
 }
 
 function usageModelDisplayName(model: string): string {
+  const usageDisplayName = MODEL_DISPLAY_NAMES[model];
+  if (usageDisplayName) {
+    return usageDisplayName;
+  }
+
   const directDisplayName = getModelDisplayName(model);
   if (directDisplayName !== model) {
     return directDisplayName;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2102,7 +2102,7 @@ describe("chat lifecycle", () => {
           runId: "run-usage-chip",
           usage: {
             version: 1,
-            totalCredits: 24_234,
+            totalCredits: 24_734,
             settledAt: "2026-06-09T10:00:02Z",
             breakdown: [
               {
@@ -2114,6 +2114,11 @@ describe("chat lifecycle", () => {
                 kind: "model/kimi-k2.5/tokens.output",
                 credits: 1000,
                 providers: [{ provider: "moonshot", credits: 1000 }],
+              },
+              {
+                kind: "model/vm0-model/tokens.output",
+                credits: 500,
+                providers: [{ provider: "vm0-model", credits: 500 }],
               },
               {
                 kind: "image",
@@ -2133,7 +2138,7 @@ describe("chat lifecycle", () => {
     });
 
     const credit = await waitFor(() => {
-      return buttonByLabel("Credit usage 24,234");
+      return buttonByLabel("Credit usage 24,734");
     });
     const actions = credit.closest('[data-testid="chat-message-actions"]');
     expect(actions).not.toBeNull();
@@ -2148,9 +2153,10 @@ describe("chat lifecycle", () => {
       expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
         1,
       );
-      expect(screen.getAllByText("24,234").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("24,734").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("1,234").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Auto").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("GPT Image 2").length).toBeGreaterThanOrEqual(
         1,
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -128,8 +128,9 @@ function mockBillingStatus(): void {
   });
 }
 
-function mockPersonalUsageStory(): string[] {
-  const rows = usageRows();
+function mockPersonalUsageStory(
+  rows: UsageRecordRow[] = usageRows(),
+): string[] {
   const requestedRanges: string[] = [];
 
   context.mocks.data.org({
@@ -210,6 +211,36 @@ describe("personal usage settings", () => {
     await waitFor(() => {
       expect(screen.getByText("Last 7 days")).toBeInTheDocument();
       expect(requestedRanges).toContain("7d");
+    });
+  });
+
+  it("shows Auto for VM0 model usage", async () => {
+    const user = userEvent.setup();
+    const row = usageRow({
+      title: "Auto model usage",
+      credits: 100,
+      runId: "run-auto-model",
+    });
+    mockPersonalUsageStory([
+      {
+        ...row,
+        breakdown: [
+          {
+            kind: "model",
+            credits: 100,
+            providers: [{ provider: "vm0-model", credits: 100 }],
+          },
+        ],
+      },
+    ]);
+    await openUsageSettings();
+
+    await user.hover(screen.getByTestId("usage-kind-segment-model"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Auto").length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText("VM0 Model")).not.toBeInTheDocument();
+      expect(screen.queryByText("vm0-model")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Display `vm0-model` as **Auto** in credit usage details
- Apply the shared label to both chat credit usage and Settings → Credit usage
- Add regression coverage for both surfaces

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/personal-usage-tab.test.tsx` (136 tests passed)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- Prettier and `git diff --check`
