### PR TITLE
fix(chat): preserve sessions between gpt and auto

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -42,6 +42,10 @@ import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import {
+  deleteVm0ManagedDefaultModelKey,
+  seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
+} from "./helpers/runtime-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { overwriteModelProviderSecretForTests } from "./helpers/zero-model-provider-state";
@@ -216,6 +220,13 @@ async function entitledChatActor(): Promise<EntitledChatActor> {
     visibility: "private",
   });
   return { actor, agentId: agent.agentId, runnerGroup, providerId };
+}
+
+async function seedVm0ManagedModelKey(selectedModel: string): Promise<string> {
+  onTestFinished(async () => {
+    await deleteVm0ManagedDefaultModelKey(context);
+  });
+  return await seedVm0ManagedModelKeyState(context, selectedModel);
 }
 
 async function sendChatRun(
@@ -512,14 +523,17 @@ async function readThreadTitleFromEvents(
 async function completeChatRunOk(
   runId: string,
   sandboxHeaders: { readonly authorization: string },
-  options: { readonly lastEventSequence?: number } = {},
+  options: {
+    readonly cliAgentType?: "claude-code" | "codex";
+    readonly lastEventSequence?: number;
+  } = {},
 ): Promise<void> {
   const history = `bdd chat session history ${runId}`;
   const historyHash = createHash("sha256").update(history).digest("hex");
   await webhooks.requestAgentCheckpoint(
     {
       runId,
-      cliAgentType: "claude-code",
+      cliAgentType: options.cliAgentType ?? "claude-code",
       cliAgentSessionId: `bdd-cli-${runId}`,
       cliAgentSessionHistoryHash: historyHash,
     },
@@ -2308,6 +2322,57 @@ describe("CHAT-02: run-level model overrides", () => {
     expect(claimEnvironment(secondClaim.claim).ANTHROPIC_MODEL).toBe(
       "claude-sonnet-4-6",
     );
+    await cancelChatRun(actor, second.runId);
+  }, 90_000);
+
+  it("resumes the CLI session when switching between GPT and Auto", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockOptionalEnv("VM0_MODEL_PROXY_TOKEN", "vm0-model-proxy-token");
+    mockOptionalEnv("VM0_MODEL_PROXY_HOST", "https://www.vm0.test");
+    await seedVm0ManagedModelKey("gpt-5.5");
+    await chatCallbacks.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.5",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+      {
+        model: "vm0-model",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "start on GPT before switching to Auto",
+      model: "gpt-5.5",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders, {
+      cliAgentType: "codex",
+    });
+    await flushWaitUntilForTest();
+
+    await seedVm0ManagedModelKey("vm0-model");
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue on Auto in the same session",
+      model: "vm0-model",
+    });
+    const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
+    expect(claimEnvironment(secondClaim.claim).OPENAI_MODEL).toBe("vm0-model");
+
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -5,14 +5,18 @@ import { normalizeRunModelId } from "@vm0/api-contracts/contracts/model-provider
  *
  * Model IDs may be provider-qualified (for example, anthropic/claude-opus),
  * while the session family is the first part of the canonical model ID
- * (claude, gpt, glm, ...). This intentionally treats model variants in one
- * family as compatible while keeping different families isolated.
+ * (claude, gpt, glm, ...). Auto is explicitly treated as part of the GPT
+ * family. This intentionally treats model variants in one family as compatible
+ * while keeping different families isolated.
  */
 function chatSessionModelFamily(model: string): string {
   const normalized = normalizeRunModelId(model.trim()).toLowerCase();
   const modelName = normalized.includes("/")
     ? normalized.slice(normalized.lastIndexOf("/") + 1)
     : normalized;
+  if (modelName === "vm0-model") {
+    return "gpt";
+  }
   return modelName.split(/[-_.]/, 1)[0] ?? modelName;
 }
 


### PR DESCRIPTION
## Summary

- Treat Auto (`vm0-model`) as part of the GPT chat session family.
- Preserve the existing CLI session when a chat switches between an explicit GPT model and Auto.
- Add BDD coverage for a managed GPT 5.5 to Auto transition, including the resumed session ID and Auto runtime model.

## User impact

Users can switch between GPT models and Auto without starting a fresh CLI session, so the active session context remains available across the model change.

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "resumes the CLI session when switching between GPT and Auto"`
