### PR TITLE
fix(chat): preserve sessions when switching between Auto and GPT models

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2311,6 +2311,89 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
+  it("resumes the CLI session when switching between GPT and Auto", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const keySuffix = randomUUID();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockOptionalEnv("VM0_MODEL_PROXY_TOKEN", "bdd-vm0-model-proxy-token");
+    mockOptionalEnv("VM0_MODEL_PROXY_HOST", "https://www.vm0.test");
+    onTestFinished(async () => {
+      await deleteBddVm0ApiKeys({ vendor: "openai", model: "vm0-model" });
+    });
+    await replaceBddVm0ApiKeys({
+      vendor: "openai",
+      model: "vm0-model",
+      keys: [
+        {
+          apiKey: `vm0-key-bdd-dev-seed-${keySuffix}`,
+          label: "dev-seed",
+        },
+      ],
+    });
+    await misc.upsertPersonalModelProvider(
+      actor,
+      {
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secrets: { CODEX_AUTH_JSON: codexAuthJson() },
+      },
+      [200, 201],
+    );
+    await chatCallbacks.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.4",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+      {
+        model: "vm0-model",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "start on GPT before switching to Auto",
+      model: "gpt-5.4",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue with Auto in the same session",
+      model: "vm0-model",
+    });
+    const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
+    expect(claimEnvironment(secondClaim.claim).OPENAI_MODEL).toBe("vm0-model");
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const third = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "return to the stored GPT model",
+    });
+    const thirdClaim = await claimChatRun(runnerGroup, third.runId);
+    expect(thirdClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${second.runId}`,
+    );
+    expect(claimEnvironment(thirdClaim.claim).OPENAI_MODEL).toBe("gpt-5.4");
+    await cancelChatRun(actor, third.runId);
+  }, 90_000);
+
   it("uses the stored provider pin on follow-up sends", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -6,13 +6,18 @@ import { normalizeRunModelId } from "@vm0/api-contracts/contracts/model-provider
  * Model IDs may be provider-qualified (for example, anthropic/claude-opus),
  * while the session family is the first part of the canonical model ID
  * (claude, gpt, glm, ...). This intentionally treats model variants in one
- * family as compatible while keeping different families isolated.
+ * family as compatible while keeping different families isolated. Auto joins
+ * the GPT family so switching between Auto and an explicit GPT model resumes
+ * the same session.
  */
 function chatSessionModelFamily(model: string): string {
   const normalized = normalizeRunModelId(model.trim()).toLowerCase();
   const modelName = normalized.includes("/")
     ? normalized.slice(normalized.lastIndexOf("/") + 1)
     : normalized;
+  if (modelName === "vm0-model") {
+    return "gpt";
+  }
   return modelName.split(/[-_.]/, 1)[0] ?? modelName;
 }
 


### PR DESCRIPTION
## Summary

- treat Auto's canonical `vm0-model` ID as part of the GPT chat session family
- preserve the CLI session in both GPT-to-Auto and Auto-to-GPT model switches while keeping other families isolated
- cover the round trip through the chat API with real model-provider resolution

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/chat-session-continuity.service.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts` (Prettier 3.8.1)
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "resumes the CLI session when switching between GPT and Auto"`
