### PR TITLE
fix(platform): prevent duplicate clerk verification emails

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1502,7 +1502,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.32.1
       - name: Run browser E2E tests

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1504,7 +1504,7 @@ jobs:
         with:
           node-version: 22
       - name: Install E2E dependencies
-        run: npm install -g agent-browser@0.22.0
+        run: npm install -g agent-browser@0.32.1
       - name: Run browser E2E tests
         continue-on-error: ${{ vars.CI_CHECK_BROWSER_E2E != '1' }}
         run: |

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -67,6 +67,23 @@ encode_uri_component() {
   node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$1"
 }
 
+clear_browser_requests() {
+  agent-browser network requests --clear >/dev/null
+}
+
+assert_clerk_post_request_count() {
+  local url_pattern="$1"
+  local expected_count="$2"
+  local description="$3"
+  local actual_count
+
+  actual_count="$(agent-browser --json network requests | \
+    jq -r --arg pattern "$url_pattern" \
+      '[(.data.requests // [])[] | select(.method == "POST" and (.url | test($pattern)))] | length')"
+  echo "# $description: expected $expected_count, observed $actual_count" >&3
+  assert [ "$actual_count" -eq "$expected_count" ]
+}
+
 wait_for_auth_completion() {
   local stuck_pattern="$1"
   local current_url snap
@@ -127,9 +144,19 @@ wait_for_auth_completion() {
   agent-browser find label "Password" fill "$SIGNUP_PASSWORD"
   agent-browser wait 500
   accept_legal_consent
+  clear_browser_requests
   click_continue
   agent-browser wait 5000
   step_screenshot "after-sign-up-continue"
+
+  assert_clerk_post_request_count \
+    '/v1/client/sign_ups([?]|$)' \
+    1 \
+    "Clerk sign-up creation requests"
+  assert_clerk_post_request_count \
+    '/v1/client/sign_ups/[^/?]+/prepare_verification([?]|$)' \
+    0 \
+    "redundant Clerk sign-up verification preparation requests"
 
   # Handle OTP verification if prompted
   local snap
@@ -189,6 +216,7 @@ wait_for_auth_completion() {
   echo "# Entering email: $E2E_ACCOUNT" >&3
   agent-browser find label "Email address" fill "$E2E_ACCOUNT"
   agent-browser wait 500
+  clear_browser_requests
   click_continue
   agent-browser wait 1000
 
@@ -228,6 +256,11 @@ wait_for_auth_completion() {
     echo "# Clerk sign-in did not reach OTP verification" >&3
     return 1
   fi
+
+  assert_clerk_post_request_count \
+    '/v1/client/sign_ins/[^/?]+/prepare_first_factor([?]|$)' \
+    1 \
+    "Clerk email-code sign-in preparation requests"
 
   enter_otp "$OTP"
   step_screenshot "after-sign-in-otp"

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -270,9 +270,11 @@ function createMockedSignUpResource(): MockedSignUpResource {
         flow: "sign-up",
         strategy: params?.strategy ?? "email_code",
       });
-      resource.verifications.emailAddress =
-        preparedEmailCodeVerification("sign-up");
-      return Promise.resolve(resource);
+      return Promise.resolve().then(() => {
+        resource.verifications.emailAddress =
+          preparedEmailCodeVerification("sign-up");
+        return resource;
+      });
     },
     verifications: {
       emailAddress: emptyEmailCodeVerification(),
@@ -290,11 +292,13 @@ function createMockedSignInResource(): MockedSignInResource {
         flow: "sign-in",
         strategy: params.strategy,
       });
-      if (params.strategy === "email_code") {
-        resource.firstFactorVerification =
-          preparedEmailCodeVerification("sign-in");
-      }
-      return Promise.resolve(resource);
+      return Promise.resolve().then(() => {
+        if (params.strategy === "email_code") {
+          resource.firstFactorVerification =
+            preparedEmailCodeVerification("sign-in");
+        }
+        return resource;
+      });
     },
   };
   return resource;

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { vi, type Mock } from "vitest";
 
 export interface MockedInvitation {
   id: string;
@@ -28,6 +28,13 @@ export interface MockedClientSession {
     imageUrl?: string;
     primaryEmailAddress?: { emailAddress: string } | null;
   };
+}
+
+export interface MockedEmailCodeVerification {
+  expireAt: Date | null;
+  nonce: string | null;
+  status: "expired" | "unverified" | "verified" | null;
+  strategy: string | null;
 }
 
 interface MockedUser {
@@ -151,6 +158,8 @@ export function clearMockedAuth() {
   internalMockedInvitations = [];
   internalMockedMemberships = [{ id: "org_default" }];
   internalMockedClientSessions = [];
+  verificationSequence = 0;
+  resetMockedClerkAuthResources();
   clerkListeners.length = 0;
   mockedClerk.signOut.mockReset();
   mockedClerk.openSignIn.mockReset();
@@ -189,6 +198,129 @@ const clientSignInCreate = vi.fn(
     });
   },
 );
+
+interface MockedSignUpPrepareParams {
+  redirectUrl?: string;
+  strategy: "email_code" | "email_link";
+}
+
+interface MockedSignInPrepareParams {
+  emailAddressId?: string;
+  phoneNumberId?: string;
+  strategy: string;
+}
+
+type MockedSignUpPrepare = (
+  params?: MockedSignUpPrepareParams,
+) => Promise<MockedSignUpResource>;
+
+type MockedSignInPrepare = (
+  params: MockedSignInPrepareParams,
+) => Promise<MockedSignInResource>;
+
+interface MockedSignUpResource {
+  prepareEmailAddressVerification: MockedSignUpPrepare;
+  prepareEmailAddressVerificationRequest: Mock<MockedSignUpPrepare>;
+  verifications: {
+    emailAddress: MockedEmailCodeVerification;
+  };
+}
+
+interface MockedSignInResource {
+  create: typeof clientSignInCreate;
+  firstFactorVerification: MockedEmailCodeVerification;
+  prepareFirstFactor: MockedSignInPrepare;
+  prepareFirstFactorRequest: Mock<MockedSignInPrepare>;
+}
+
+let verificationSequence = 0;
+
+function emptyEmailCodeVerification(): MockedEmailCodeVerification {
+  return {
+    expireAt: null,
+    nonce: null,
+    status: null,
+    strategy: null,
+  };
+}
+
+function preparedEmailCodeVerification(
+  prefix: string,
+): MockedEmailCodeVerification {
+  verificationSequence += 1;
+  return {
+    expireAt: new Date(Date.now() + 10 * 60 * 1000),
+    nonce: `${prefix}-${verificationSequence}`,
+    status: "unverified",
+    strategy: "email_code",
+  };
+}
+
+function createMockedSignUpResource(): MockedSignUpResource {
+  const prepareEmailAddressVerificationRequest = vi.fn<MockedSignUpPrepare>();
+  const resource: MockedSignUpResource = {
+    prepareEmailAddressVerification: prepareEmailAddressVerificationRequest,
+    prepareEmailAddressVerificationRequest,
+    verifications: {
+      emailAddress: emptyEmailCodeVerification(),
+    },
+  };
+  prepareEmailAddressVerificationRequest.mockImplementation(() => {
+    resource.verifications.emailAddress =
+      preparedEmailCodeVerification("sign-up");
+    return Promise.resolve(resource);
+  });
+  return resource;
+}
+
+function createMockedSignInResource(): MockedSignInResource {
+  const prepareFirstFactorRequest = vi.fn<MockedSignInPrepare>();
+  const resource: MockedSignInResource = {
+    create: clientSignInCreate,
+    firstFactorVerification: emptyEmailCodeVerification(),
+    prepareFirstFactor: prepareFirstFactorRequest,
+    prepareFirstFactorRequest,
+  };
+  prepareFirstFactorRequest.mockImplementation((params) => {
+    if (params.strategy === "email_code") {
+      resource.firstFactorVerification =
+        preparedEmailCodeVerification("sign-in");
+    }
+    return Promise.resolve(resource);
+  });
+  return resource;
+}
+
+let internalMockedSignUpResource = createMockedSignUpResource();
+let internalMockedSignInResource = createMockedSignInResource();
+
+function resetMockedClerkAuthResources(): void {
+  internalMockedSignUpResource = createMockedSignUpResource();
+  internalMockedSignInResource = createMockedSignInResource();
+}
+
+export function mockSignUpEmailVerification(
+  verification: MockedEmailCodeVerification,
+): void {
+  internalMockedSignUpResource.verifications.emailAddress = {
+    ...verification,
+  };
+}
+
+export function mockSignInFirstFactorVerification(
+  verification: MockedEmailCodeVerification,
+): void {
+  internalMockedSignInResource.firstFactorVerification = {
+    ...verification,
+  };
+}
+
+export function replaceMockedClerkAuthResources(): void {
+  resetMockedClerkAuthResources();
+  for (const listener of clerkListeners) {
+    listener();
+  }
+}
 const defaultBuildUrlWithAuthImpl = (to: string) => {
   return to;
 };
@@ -211,12 +343,21 @@ export const mockedClerk = {
   },
   sessionGetToken,
   clientSignInCreate,
+  get clientSignInPrepareFirstFactor() {
+    return internalMockedSignInResource.prepareFirstFactorRequest;
+  },
+  get clientSignUpPrepareEmailAddressVerification() {
+    return internalMockedSignUpResource.prepareEmailAddressVerificationRequest;
+  },
   client: {
     get sessions() {
       return internalMockedClientSessions;
     },
-    signIn: {
-      create: clientSignInCreate,
+    get signIn() {
+      return internalMockedSignInResource;
+    },
+    get signUp() {
+      return internalMockedSignUpResource;
     },
   },
   signOut: vi.fn(() => {

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,4 +1,6 @@
-import { vi, type Mock } from "vitest";
+import { vi } from "vitest";
+
+import { now } from "../lib/time.ts";
 
 export interface MockedInvitation {
   id: string;
@@ -159,6 +161,7 @@ export function clearMockedAuth() {
   internalMockedMemberships = [{ id: "org_default" }];
   internalMockedClientSessions = [];
   verificationSequence = 0;
+  internalMockedFactorPreparations = [];
   resetMockedClerkAuthResources();
   clerkListeners.length = 0;
   mockedClerk.signOut.mockReset();
@@ -218,9 +221,13 @@ type MockedSignInPrepare = (
   params: MockedSignInPrepareParams,
 ) => Promise<MockedSignInResource>;
 
+interface MockedFactorPreparation {
+  flow: "sign-in" | "sign-up";
+  strategy: string;
+}
+
 interface MockedSignUpResource {
   prepareEmailAddressVerification: MockedSignUpPrepare;
-  prepareEmailAddressVerificationRequest: Mock<MockedSignUpPrepare>;
   verifications: {
     emailAddress: MockedEmailCodeVerification;
   };
@@ -230,10 +237,10 @@ interface MockedSignInResource {
   create: typeof clientSignInCreate;
   firstFactorVerification: MockedEmailCodeVerification;
   prepareFirstFactor: MockedSignInPrepare;
-  prepareFirstFactorRequest: Mock<MockedSignInPrepare>;
 }
 
 let verificationSequence = 0;
+let internalMockedFactorPreparations: MockedFactorPreparation[] = [];
 
 function emptyEmailCodeVerification(): MockedEmailCodeVerification {
   return {
@@ -249,7 +256,7 @@ function preparedEmailCodeVerification(
 ): MockedEmailCodeVerification {
   verificationSequence += 1;
   return {
-    expireAt: new Date(Date.now() + 10 * 60 * 1000),
+    expireAt: new Date(now() + 10 * 60 * 1000),
     nonce: `${prefix}-${verificationSequence}`,
     status: "unverified",
     strategy: "email_code",
@@ -257,37 +264,39 @@ function preparedEmailCodeVerification(
 }
 
 function createMockedSignUpResource(): MockedSignUpResource {
-  const prepareEmailAddressVerificationRequest = vi.fn<MockedSignUpPrepare>();
   const resource: MockedSignUpResource = {
-    prepareEmailAddressVerification: prepareEmailAddressVerificationRequest,
-    prepareEmailAddressVerificationRequest,
+    prepareEmailAddressVerification: (params) => {
+      internalMockedFactorPreparations.push({
+        flow: "sign-up",
+        strategy: params?.strategy ?? "email_code",
+      });
+      resource.verifications.emailAddress =
+        preparedEmailCodeVerification("sign-up");
+      return Promise.resolve(resource);
+    },
     verifications: {
       emailAddress: emptyEmailCodeVerification(),
     },
   };
-  prepareEmailAddressVerificationRequest.mockImplementation(() => {
-    resource.verifications.emailAddress =
-      preparedEmailCodeVerification("sign-up");
-    return Promise.resolve(resource);
-  });
   return resource;
 }
 
 function createMockedSignInResource(): MockedSignInResource {
-  const prepareFirstFactorRequest = vi.fn<MockedSignInPrepare>();
   const resource: MockedSignInResource = {
     create: clientSignInCreate,
     firstFactorVerification: emptyEmailCodeVerification(),
-    prepareFirstFactor: prepareFirstFactorRequest,
-    prepareFirstFactorRequest,
+    prepareFirstFactor: (params) => {
+      internalMockedFactorPreparations.push({
+        flow: "sign-in",
+        strategy: params.strategy,
+      });
+      if (params.strategy === "email_code") {
+        resource.firstFactorVerification =
+          preparedEmailCodeVerification("sign-in");
+      }
+      return Promise.resolve(resource);
+    },
   };
-  prepareFirstFactorRequest.mockImplementation((params) => {
-    if (params.strategy === "email_code") {
-      resource.firstFactorVerification =
-        preparedEmailCodeVerification("sign-in");
-    }
-    return Promise.resolve(resource);
-  });
   return resource;
 }
 
@@ -343,11 +352,8 @@ export const mockedClerk = {
   },
   sessionGetToken,
   clientSignInCreate,
-  get clientSignInPrepareFirstFactor() {
-    return internalMockedSignInResource.prepareFirstFactorRequest;
-  },
-  get clientSignUpPrepareEmailAddressVerification() {
-    return internalMockedSignUpResource.prepareEmailAddressVerificationRequest;
+  get factorPreparations() {
+    return internalMockedFactorPreparations;
   },
   client: {
     get sessions() {

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -324,8 +324,17 @@ export function mockSignInFirstFactorVerification(
   };
 }
 
-export function replaceMockedClerkAuthResources(): void {
+export function replaceMockedClerkAuthResources(options?: {
+  signInVerification?: MockedEmailCodeVerification;
+  signUpVerification?: MockedEmailCodeVerification;
+}): void {
   resetMockedClerkAuthResources();
+  if (options?.signInVerification) {
+    mockSignInFirstFactorVerification(options.signInVerification);
+  }
+  if (options?.signUpVerification) {
+    mockSignUpEmailVerification(options.signUpVerification);
+  }
   for (const listener of clerkListeners) {
     listener();
   }

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -207,6 +207,14 @@ interface MockedSignUpPrepareParams {
   strategy: "email_code" | "email_link";
 }
 
+interface MockedSignUpCreateParams {
+  emailAddress?: string;
+  externalAccountStrategy?: string;
+  legalAccepted?: boolean;
+  password?: string;
+  strategy?: string;
+}
+
 interface MockedSignInPrepareParams {
   emailAddressId?: string;
   phoneNumberId?: string;
@@ -215,6 +223,10 @@ interface MockedSignInPrepareParams {
 
 type MockedSignUpPrepare = (
   params?: MockedSignUpPrepareParams,
+) => Promise<MockedSignUpResource>;
+
+type MockedSignUpCreate = (
+  params: MockedSignUpCreateParams,
 ) => Promise<MockedSignUpResource>;
 
 type MockedSignInPrepare = (
@@ -227,6 +239,7 @@ interface MockedFactorPreparation {
 }
 
 interface MockedSignUpResource {
+  create: MockedSignUpCreate;
   prepareEmailAddressVerification: MockedSignUpPrepare;
   verifications: {
     emailAddress: MockedEmailCodeVerification;
@@ -265,6 +278,9 @@ function preparedEmailCodeVerification(
 
 function createMockedSignUpResource(): MockedSignUpResource {
   const resource: MockedSignUpResource = {
+    create: () => {
+      return Promise.resolve(resource);
+    },
     prepareEmailAddressVerification: (params) => {
       internalMockedFactorPreparations.push({
         flow: "sign-up",

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -10,6 +10,8 @@ const AUTOMATIC_PREPARATION_WINDOW_MS = 5000;
 // for Clerk's complete disabled-resend interval so a slow reload cannot send a
 // replacement code.
 const SIGN_UP_CREATION_PREPARATION_WINDOW_MS = 30_000;
+// Persist only the expiration timestamp; Clerk and user identifiers stay in
+// the SDK-managed client state.
 const SIGN_UP_PREPARATION_STORAGE_KEY =
   "vm0:clerk-sign-up-email-code-preparation";
 
@@ -116,11 +118,10 @@ function createPreparationGuard<Resource, Params>(options: {
   activePreparations: ActivePreparations;
   getVerification: (resource: Resource) => EmailCodeVerification;
   key: (params: Params) => string;
+  pendingPreparations: Map<string, Promise<Resource>>;
   prepare: (params: Params) => Promise<Resource>;
   resource: Resource;
 }): (params: Params) => Promise<Resource> {
-  const pendingPreparations = new Map<string, Promise<Resource>>();
-
   return (params: Params): Promise<Resource> => {
     const key = options.key(params);
     const currentTime = now();
@@ -158,14 +159,14 @@ function createPreparationGuard<Resource, Params>(options: {
       }
     }
 
-    const pendingPreparation = pendingPreparations.get(key);
+    const pendingPreparation = options.pendingPreparations.get(key);
     if (pendingPreparation) {
       return pendingPreparation;
     }
 
     const preparation = (async () => {
       const resource = await options.prepare(params).finally(() => {
-        pendingPreparations.delete(key);
+        options.pendingPreparations.delete(key);
       });
       const preparedAt = now();
       const preparedFingerprint = activeEmailCodeFingerprint(
@@ -179,7 +180,7 @@ function createPreparationGuard<Resource, Params>(options: {
       return resource;
     })();
 
-    pendingPreparations.set(key, preparation);
+    options.pendingPreparations.set(key, preparation);
     return preparation;
   };
 }
@@ -188,6 +189,7 @@ function guardSignUpResource(
   signUp: SignUpResource,
   guardedResources: WeakSet<SignUpResource>,
   activePreparations: ActivePreparations,
+  pendingPreparations: Map<string, Promise<SignUpResource>>,
 ): void {
   if (guardedResources.has(signUp)) {
     return;
@@ -207,6 +209,7 @@ function guardSignUpResource(
     key: () => {
       return SIGN_UP_EMAIL_CODE_KEY;
     },
+    pendingPreparations,
     prepare: originalPrepare,
     resource: signUp,
   });
@@ -245,6 +248,7 @@ function guardSignInResource(
   signIn: SignInResource,
   guardedResources: WeakSet<SignInResource>,
   activePreparations: ActivePreparations,
+  pendingPreparations: Map<string, Promise<SignInResource>>,
 ): void {
   if (guardedResources.has(signIn)) {
     return;
@@ -266,6 +270,7 @@ function guardSignInResource(
       }
       return params.strategy;
     },
+    pendingPreparations,
     prepare: originalPrepare,
     resource: signIn,
   });
@@ -290,6 +295,8 @@ function guardSignInResource(
 export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
   const signInActivePreparations = new Map<string, ActivePreparation>();
   const signUpActivePreparations = createSignUpActivePreparations();
+  const signInPendingPreparations = new Map<string, Promise<SignInResource>>();
+  const signUpPendingPreparations = new Map<string, Promise<SignUpResource>>();
   const guardedSignInResources = new WeakSet<SignInResource>();
   const guardedSignUpResources = new WeakSet<SignUpResource>();
   const guardCurrentResources = (): void => {
@@ -300,11 +307,13 @@ export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
       clerk.client.signUp,
       guardedSignUpResources,
       signUpActivePreparations,
+      signUpPendingPreparations,
     );
     guardSignInResource(
       clerk.client.signIn,
       guardedSignInResources,
       signInActivePreparations,
+      signInPendingPreparations,
     );
   };
 

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -11,9 +11,12 @@ type ClerkClient = NonNullable<Clerk["client"]>;
 type SignInResource = ClerkClient["signIn"];
 type SignUpResource = ClerkClient["signUp"];
 type SignInPrepareParams = Parameters<SignInResource["prepareFirstFactor"]>[0];
+type SignUpCreateParams = Parameters<SignUpResource["create"]>[0];
 type SignUpPrepareParams = Parameters<
   SignUpResource["prepareEmailAddressVerification"]
 >[0];
+
+const SIGN_UP_EMAIL_CODE_KEY = "email_code";
 
 interface EmailCodeVerification {
   readonly expireAt: Date | null;
@@ -23,7 +26,7 @@ interface EmailCodeVerification {
 }
 
 interface ActivePreparation {
-  readonly fingerprint: string;
+  readonly fingerprint: string | null;
   readonly suppressUntil: number;
 }
 
@@ -44,6 +47,15 @@ function activeEmailCodeFingerprint(
   return `${verification.nonce ?? "no-nonce"}:${expiresAt}`;
 }
 
+function signUpCreateSendsEmailCode(params: SignUpCreateParams): boolean {
+  return (
+    typeof params.emailAddress === "string" &&
+    params.emailAddress.length > 0 &&
+    params.strategy === undefined &&
+    params.externalAccountStrategy === undefined
+  );
+}
+
 function createPreparationGuard<Resource, Params>(options: {
   activePreparations: Map<string, ActivePreparation>;
   getVerification: (resource: Resource) => EmailCodeVerification;
@@ -60,13 +72,26 @@ function createPreparationGuard<Resource, Params>(options: {
       options.getVerification(options.resource),
       currentTime,
     );
-    const activePreparation = options.activePreparations.get(key);
+    let activePreparation = options.activePreparations.get(key);
+
+    if (fingerprint && activePreparation?.fingerprint === null) {
+      activePreparation = { ...activePreparation, fingerprint };
+      options.activePreparations.set(key, activePreparation);
+    }
+
+    if (
+      activePreparation &&
+      activePreparation.suppressUntil > currentTime &&
+      (fingerprint === null || activePreparation.fingerprint === fingerprint)
+    ) {
+      return Promise.resolve(options.resource);
+    }
 
     if (fingerprint && activePreparation?.fingerprint !== fingerprint) {
       const knownForAnotherFactor = Array.from(
-        options.activePreparations.values(),
-      ).some((preparation) => {
-        return preparation.fingerprint === fingerprint;
+        options.activePreparations.entries(),
+      ).some(([activeKey, preparation]) => {
+        return activeKey !== key && preparation.fingerprint === fingerprint;
       });
       if (!knownForAnotherFactor) {
         options.activePreparations.set(key, {
@@ -75,14 +100,6 @@ function createPreparationGuard<Resource, Params>(options: {
         });
         return Promise.resolve(options.resource);
       }
-    }
-
-    if (
-      fingerprint &&
-      activePreparation?.fingerprint === fingerprint &&
-      activePreparation.suppressUntil > currentTime
-    ) {
-      return Promise.resolve(options.resource);
     }
 
     const pendingPreparation = pendingPreparations.get(key);
@@ -99,12 +116,10 @@ function createPreparationGuard<Resource, Params>(options: {
         options.getVerification(resource),
         preparedAt,
       );
-      if (preparedFingerprint) {
-        options.activePreparations.set(key, {
-          fingerprint: preparedFingerprint,
-          suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
-        });
-      }
+      options.activePreparations.set(key, {
+        fingerprint: preparedFingerprint,
+        suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
+      });
       return resource;
     })();
 
@@ -123,6 +138,7 @@ function guardSignUpResource(
   }
   guardedResources.add(signUp);
 
+  const originalCreate = signUp.create.bind(signUp);
   const originalPrepare = signUp.prepareEmailAddressVerification.bind(signUp);
   const guardedPrepare = createPreparationGuard<
     SignUpResource,
@@ -133,11 +149,31 @@ function guardSignUpResource(
       return resource.verifications.emailAddress;
     },
     key: () => {
-      return "email_code";
+      return SIGN_UP_EMAIL_CODE_KEY;
     },
     prepare: originalPrepare,
     resource: signUp,
   });
+
+  signUp.create = async (
+    params: SignUpCreateParams,
+  ): Promise<SignUpResource> => {
+    const resource = await originalCreate(params);
+    if (!signUpCreateSendsEmailCode(params)) {
+      activePreparations.delete(SIGN_UP_EMAIL_CODE_KEY);
+      return resource;
+    }
+
+    const preparedAt = now();
+    activePreparations.set(SIGN_UP_EMAIL_CODE_KEY, {
+      fingerprint: activeEmailCodeFingerprint(
+        resource.verifications.emailAddress,
+        preparedAt,
+      ),
+      suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
+    });
+    return resource;
+  };
 
   signUp.prepareEmailAddressVerification = (
     params?: SignUpPrepareParams,

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -45,12 +45,12 @@ function activeEmailCodeFingerprint(
 }
 
 function createPreparationGuard<Resource, Params>(options: {
+  activePreparations: Map<string, ActivePreparation>;
   getVerification: (resource: Resource) => EmailCodeVerification;
   key: (params: Params) => string;
   prepare: (params: Params) => Promise<Resource>;
   resource: Resource;
 }): (params: Params) => Promise<Resource> {
-  const activePreparations = new Map<string, ActivePreparation>();
   const pendingPreparations = new Map<string, Promise<Resource>>();
 
   return (params: Params): Promise<Resource> => {
@@ -60,14 +60,21 @@ function createPreparationGuard<Resource, Params>(options: {
       options.getVerification(options.resource),
       currentTime,
     );
-    const activePreparation = activePreparations.get(key);
+    const activePreparation = options.activePreparations.get(key);
 
     if (fingerprint && activePreparation?.fingerprint !== fingerprint) {
-      activePreparations.set(key, {
-        fingerprint,
-        suppressUntil: currentTime + AUTOMATIC_PREPARATION_WINDOW_MS,
+      const knownForAnotherFactor = Array.from(
+        options.activePreparations.values(),
+      ).some((preparation) => {
+        return preparation.fingerprint === fingerprint;
       });
-      return Promise.resolve(options.resource);
+      if (!knownForAnotherFactor) {
+        options.activePreparations.set(key, {
+          fingerprint,
+          suppressUntil: currentTime + AUTOMATIC_PREPARATION_WINDOW_MS,
+        });
+        return Promise.resolve(options.resource);
+      }
     }
 
     if (
@@ -93,7 +100,7 @@ function createPreparationGuard<Resource, Params>(options: {
         preparedAt,
       );
       if (preparedFingerprint) {
-        activePreparations.set(key, {
+        options.activePreparations.set(key, {
           fingerprint: preparedFingerprint,
           suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
         });
@@ -109,6 +116,7 @@ function createPreparationGuard<Resource, Params>(options: {
 function guardSignUpResource(
   signUp: SignUpResource,
   guardedResources: WeakSet<SignUpResource>,
+  activePreparations: Map<string, ActivePreparation>,
 ): void {
   if (guardedResources.has(signUp)) {
     return;
@@ -120,6 +128,7 @@ function guardSignUpResource(
     SignUpResource,
     SignUpPrepareParams
   >({
+    activePreparations,
     getVerification: (resource) => {
       return resource.verifications.emailAddress;
     },
@@ -143,6 +152,7 @@ function guardSignUpResource(
 function guardSignInResource(
   signIn: SignInResource,
   guardedResources: WeakSet<SignInResource>,
+  activePreparations: Map<string, ActivePreparation>,
 ): void {
   if (guardedResources.has(signIn)) {
     return;
@@ -154,6 +164,7 @@ function guardSignInResource(
     SignInResource,
     SignInPrepareParams
   >({
+    activePreparations,
     getVerification: (resource) => {
       return resource.firstFactorVerification;
     },
@@ -185,14 +196,24 @@ function guardSignInResource(
  * https://github.com/clerk/javascript/issues/4324
  */
 export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
+  const signInActivePreparations = new Map<string, ActivePreparation>();
+  const signUpActivePreparations = new Map<string, ActivePreparation>();
   const guardedSignInResources = new WeakSet<SignInResource>();
   const guardedSignUpResources = new WeakSet<SignUpResource>();
   const guardCurrentResources = (): void => {
     if (!clerk.client) {
       return;
     }
-    guardSignUpResource(clerk.client.signUp, guardedSignUpResources);
-    guardSignInResource(clerk.client.signIn, guardedSignInResources);
+    guardSignUpResource(
+      clerk.client.signUp,
+      guardedSignUpResources,
+      signUpActivePreparations,
+    );
+    guardSignInResource(
+      clerk.client.signIn,
+      guardedSignInResources,
+      signInActivePreparations,
+    );
   };
 
   guardCurrentResources();

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -1,0 +1,195 @@
+import type { Clerk } from "@clerk/clerk-js";
+
+// Clerk keeps the OTP resend control disabled for 30 seconds. This shorter
+// window covers automatic rerenders and route remounts without blocking a
+// user-visible resend.
+const AUTOMATIC_PREPARATION_WINDOW_MS = 5000;
+
+type ClerkClient = NonNullable<Clerk["client"]>;
+type SignInResource = ClerkClient["signIn"];
+type SignUpResource = ClerkClient["signUp"];
+type SignInPrepareParams = Parameters<SignInResource["prepareFirstFactor"]>[0];
+type SignUpPrepareParams = Parameters<
+  SignUpResource["prepareEmailAddressVerification"]
+>[0];
+
+interface EmailCodeVerification {
+  readonly expireAt: Date | null;
+  readonly nonce: string | null;
+  readonly status: string | null;
+  readonly strategy: string | null;
+}
+
+interface ActivePreparation {
+  readonly fingerprint: string;
+  readonly suppressUntil: number;
+}
+
+const guardedSignInResources = new WeakSet<SignInResource>();
+const guardedSignUpResources = new WeakSet<SignUpResource>();
+
+function activeEmailCodeFingerprint(
+  verification: EmailCodeVerification,
+  now: number,
+): string | null {
+  const expiresAt = verification.expireAt?.getTime();
+  if (
+    verification.status !== "unverified" ||
+    verification.strategy !== "email_code" ||
+    !expiresAt ||
+    expiresAt <= now
+  ) {
+    return null;
+  }
+
+  return `${verification.nonce ?? "no-nonce"}:${expiresAt}`;
+}
+
+function createPreparationGuard<Resource, Params>(options: {
+  getVerification: (resource: Resource) => EmailCodeVerification;
+  key: (params: Params) => string;
+  prepare: (params: Params) => Promise<Resource>;
+  resource: Resource;
+}): (params: Params) => Promise<Resource> {
+  const activePreparations = new Map<string, ActivePreparation>();
+  const pendingPreparations = new Map<string, Promise<Resource>>();
+
+  return (params: Params): Promise<Resource> => {
+    const key = options.key(params);
+    const now = Date.now();
+    const fingerprint = activeEmailCodeFingerprint(
+      options.getVerification(options.resource),
+      now,
+    );
+    const activePreparation = activePreparations.get(key);
+
+    if (fingerprint && activePreparation?.fingerprint !== fingerprint) {
+      activePreparations.set(key, {
+        fingerprint,
+        suppressUntil: now + AUTOMATIC_PREPARATION_WINDOW_MS,
+      });
+      return Promise.resolve(options.resource);
+    }
+
+    if (
+      fingerprint &&
+      activePreparation?.fingerprint === fingerprint &&
+      activePreparation.suppressUntil > now
+    ) {
+      return Promise.resolve(options.resource);
+    }
+
+    const pendingPreparation = pendingPreparations.get(key);
+    if (pendingPreparation) {
+      return pendingPreparation;
+    }
+
+    const preparation = (async () => {
+      try {
+        const resource = await options.prepare(params);
+        const preparedAt = Date.now();
+        const preparedFingerprint = activeEmailCodeFingerprint(
+          options.getVerification(resource),
+          preparedAt,
+        );
+        if (preparedFingerprint) {
+          activePreparations.set(key, {
+            fingerprint: preparedFingerprint,
+            suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
+          });
+        }
+        return resource;
+      } finally {
+        pendingPreparations.delete(key);
+      }
+    })();
+
+    pendingPreparations.set(key, preparation);
+    return preparation;
+  };
+}
+
+function guardSignUpResource(signUp: SignUpResource): void {
+  if (guardedSignUpResources.has(signUp)) {
+    return;
+  }
+  guardedSignUpResources.add(signUp);
+
+  const originalPrepare = signUp.prepareEmailAddressVerification.bind(signUp);
+  const guardedPrepare = createPreparationGuard<
+    SignUpResource,
+    SignUpPrepareParams
+  >({
+    getVerification: (resource) => {
+      return resource.verifications.emailAddress;
+    },
+    key: () => {
+      return "email_code";
+    },
+    prepare: originalPrepare,
+    resource: signUp,
+  });
+
+  signUp.prepareEmailAddressVerification = (
+    params?: SignUpPrepareParams,
+  ): Promise<SignUpResource> => {
+    if (params?.strategy && params.strategy !== "email_code") {
+      return originalPrepare(params);
+    }
+    return guardedPrepare(params);
+  };
+}
+
+function guardSignInResource(signIn: SignInResource): void {
+  if (guardedSignInResources.has(signIn)) {
+    return;
+  }
+  guardedSignInResources.add(signIn);
+
+  const originalPrepare = signIn.prepareFirstFactor.bind(signIn);
+  const guardedPrepare = createPreparationGuard<
+    SignInResource,
+    SignInPrepareParams
+  >({
+    getVerification: (resource) => {
+      return resource.firstFactorVerification;
+    },
+    key: (params) => {
+      if (params.strategy === "email_code") {
+        return `${params.strategy}:${params.emailAddressId}`;
+      }
+      return params.strategy;
+    },
+    prepare: originalPrepare,
+    resource: signIn,
+  });
+
+  signIn.prepareFirstFactor = (
+    params: SignInPrepareParams,
+  ): Promise<SignInResource> => {
+    if (params.strategy !== "email_code") {
+      return originalPrepare(params);
+    }
+    return guardedPrepare(params);
+  };
+}
+
+/**
+ * Clerk's prebuilt email-code screens can prepare a second code immediately
+ * after the current code was created. Keep this compatibility guard until the
+ * upstream sign-up and sign-in fixes are verified in vm0:
+ * https://github.com/clerk/javascript/issues/8684
+ * https://github.com/clerk/javascript/issues/4324
+ */
+export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
+  const guardCurrentResources = (): void => {
+    if (!clerk.client) {
+      return;
+    }
+    guardSignUpResource(clerk.client.signUp);
+    guardSignInResource(clerk.client.signIn);
+  };
+
+  guardCurrentResources();
+  clerk.addListener(guardCurrentResources);
+}

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -1,5 +1,7 @@
 import type { Clerk } from "@clerk/clerk-js";
 
+import { now } from "./time.ts";
+
 // Clerk keeps the OTP resend control disabled for 30 seconds. This shorter
 // window covers automatic rerenders and route remounts without blocking a
 // user-visible resend.
@@ -24,9 +26,6 @@ interface ActivePreparation {
   readonly fingerprint: string;
   readonly suppressUntil: number;
 }
-
-const guardedSignInResources = new WeakSet<SignInResource>();
-const guardedSignUpResources = new WeakSet<SignUpResource>();
 
 function activeEmailCodeFingerprint(
   verification: EmailCodeVerification,
@@ -56,17 +55,17 @@ function createPreparationGuard<Resource, Params>(options: {
 
   return (params: Params): Promise<Resource> => {
     const key = options.key(params);
-    const now = Date.now();
+    const currentTime = now();
     const fingerprint = activeEmailCodeFingerprint(
       options.getVerification(options.resource),
-      now,
+      currentTime,
     );
     const activePreparation = activePreparations.get(key);
 
     if (fingerprint && activePreparation?.fingerprint !== fingerprint) {
       activePreparations.set(key, {
         fingerprint,
-        suppressUntil: now + AUTOMATIC_PREPARATION_WINDOW_MS,
+        suppressUntil: currentTime + AUTOMATIC_PREPARATION_WINDOW_MS,
       });
       return Promise.resolve(options.resource);
     }
@@ -74,7 +73,7 @@ function createPreparationGuard<Resource, Params>(options: {
     if (
       fingerprint &&
       activePreparation?.fingerprint === fingerprint &&
-      activePreparation.suppressUntil > now
+      activePreparation.suppressUntil > currentTime
     ) {
       return Promise.resolve(options.resource);
     }
@@ -85,23 +84,21 @@ function createPreparationGuard<Resource, Params>(options: {
     }
 
     const preparation = (async () => {
-      try {
-        const resource = await options.prepare(params);
-        const preparedAt = Date.now();
-        const preparedFingerprint = activeEmailCodeFingerprint(
-          options.getVerification(resource),
-          preparedAt,
-        );
-        if (preparedFingerprint) {
-          activePreparations.set(key, {
-            fingerprint: preparedFingerprint,
-            suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
-          });
-        }
-        return resource;
-      } finally {
+      const resource = await options.prepare(params).finally(() => {
         pendingPreparations.delete(key);
+      });
+      const preparedAt = now();
+      const preparedFingerprint = activeEmailCodeFingerprint(
+        options.getVerification(resource),
+        preparedAt,
+      );
+      if (preparedFingerprint) {
+        activePreparations.set(key, {
+          fingerprint: preparedFingerprint,
+          suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
+        });
       }
+      return resource;
     })();
 
     pendingPreparations.set(key, preparation);
@@ -109,11 +106,14 @@ function createPreparationGuard<Resource, Params>(options: {
   };
 }
 
-function guardSignUpResource(signUp: SignUpResource): void {
-  if (guardedSignUpResources.has(signUp)) {
+function guardSignUpResource(
+  signUp: SignUpResource,
+  guardedResources: WeakSet<SignUpResource>,
+): void {
+  if (guardedResources.has(signUp)) {
     return;
   }
-  guardedSignUpResources.add(signUp);
+  guardedResources.add(signUp);
 
   const originalPrepare = signUp.prepareEmailAddressVerification.bind(signUp);
   const guardedPrepare = createPreparationGuard<
@@ -140,11 +140,14 @@ function guardSignUpResource(signUp: SignUpResource): void {
   };
 }
 
-function guardSignInResource(signIn: SignInResource): void {
-  if (guardedSignInResources.has(signIn)) {
+function guardSignInResource(
+  signIn: SignInResource,
+  guardedResources: WeakSet<SignInResource>,
+): void {
+  if (guardedResources.has(signIn)) {
     return;
   }
-  guardedSignInResources.add(signIn);
+  guardedResources.add(signIn);
 
   const originalPrepare = signIn.prepareFirstFactor.bind(signIn);
   const guardedPrepare = createPreparationGuard<
@@ -182,12 +185,14 @@ function guardSignInResource(signIn: SignInResource): void {
  * https://github.com/clerk/javascript/issues/4324
  */
 export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
+  const guardedSignInResources = new WeakSet<SignInResource>();
+  const guardedSignUpResources = new WeakSet<SignUpResource>();
   const guardCurrentResources = (): void => {
     if (!clerk.client) {
       return;
     }
-    guardSignUpResource(clerk.client.signUp);
-    guardSignInResource(clerk.client.signIn);
+    guardSignUpResource(clerk.client.signUp, guardedSignUpResources);
+    guardSignInResource(clerk.client.signIn, guardedSignInResources);
   };
 
   guardCurrentResources();

--- a/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
+++ b/turbo/apps/platform/src/lib/clerk-email-code-preparation-guard.ts
@@ -6,6 +6,12 @@ import { now } from "./time.ts";
 // window covers automatic rerenders and route remounts without blocking a
 // user-visible resend.
 const AUTOMATIC_PREPARATION_WINDOW_MS = 5000;
+// Sign-up creation performs a full-page route transition. Preserve its marker
+// for Clerk's complete disabled-resend interval so a slow reload cannot send a
+// replacement code.
+const SIGN_UP_CREATION_PREPARATION_WINDOW_MS = 30_000;
+const SIGN_UP_PREPARATION_STORAGE_KEY =
+  "vm0:clerk-sign-up-email-code-preparation";
 
 type ClerkClient = NonNullable<Clerk["client"]>;
 type SignInResource = ClerkClient["signIn"];
@@ -28,6 +34,56 @@ interface EmailCodeVerification {
 interface ActivePreparation {
   readonly fingerprint: string | null;
   readonly suppressUntil: number;
+}
+
+interface ActivePreparations {
+  readonly delete: (key: string) => void;
+  readonly entries: () => IterableIterator<[string, ActivePreparation]>;
+  readonly get: (key: string) => ActivePreparation | undefined;
+  readonly set: (key: string, preparation: ActivePreparation) => void;
+}
+
+function readStoredSignUpPreparation(): ActivePreparation | null {
+  const value = sessionStorage.getItem(SIGN_UP_PREPARATION_STORAGE_KEY);
+  if (!value) {
+    return null;
+  }
+
+  const suppressUntil = Number(value);
+  if (!Number.isFinite(suppressUntil) || suppressUntil <= now()) {
+    sessionStorage.removeItem(SIGN_UP_PREPARATION_STORAGE_KEY);
+    return null;
+  }
+
+  return { fingerprint: null, suppressUntil };
+}
+
+function createSignUpActivePreparations(): ActivePreparations {
+  const preparations = new Map<string, ActivePreparation>();
+  const storedPreparation = readStoredSignUpPreparation();
+  if (storedPreparation) {
+    preparations.set(SIGN_UP_EMAIL_CODE_KEY, storedPreparation);
+  }
+
+  return {
+    delete: (key) => {
+      preparations.delete(key);
+      sessionStorage.removeItem(SIGN_UP_PREPARATION_STORAGE_KEY);
+    },
+    entries: () => {
+      return preparations.entries();
+    },
+    get: (key) => {
+      return preparations.get(key);
+    },
+    set: (key, preparation) => {
+      preparations.set(key, preparation);
+      sessionStorage.setItem(
+        SIGN_UP_PREPARATION_STORAGE_KEY,
+        String(preparation.suppressUntil),
+      );
+    },
+  };
 }
 
 function activeEmailCodeFingerprint(
@@ -57,7 +113,7 @@ function signUpCreateSendsEmailCode(params: SignUpCreateParams): boolean {
 }
 
 function createPreparationGuard<Resource, Params>(options: {
-  activePreparations: Map<string, ActivePreparation>;
+  activePreparations: ActivePreparations;
   getVerification: (resource: Resource) => EmailCodeVerification;
   key: (params: Params) => string;
   prepare: (params: Params) => Promise<Resource>;
@@ -131,7 +187,7 @@ function createPreparationGuard<Resource, Params>(options: {
 function guardSignUpResource(
   signUp: SignUpResource,
   guardedResources: WeakSet<SignUpResource>,
-  activePreparations: Map<string, ActivePreparation>,
+  activePreparations: ActivePreparations,
 ): void {
   if (guardedResources.has(signUp)) {
     return;
@@ -170,7 +226,7 @@ function guardSignUpResource(
         resource.verifications.emailAddress,
         preparedAt,
       ),
-      suppressUntil: preparedAt + AUTOMATIC_PREPARATION_WINDOW_MS,
+      suppressUntil: preparedAt + SIGN_UP_CREATION_PREPARATION_WINDOW_MS,
     });
     return resource;
   };
@@ -188,7 +244,7 @@ function guardSignUpResource(
 function guardSignInResource(
   signIn: SignInResource,
   guardedResources: WeakSet<SignInResource>,
-  activePreparations: Map<string, ActivePreparation>,
+  activePreparations: ActivePreparations,
 ): void {
   if (guardedResources.has(signIn)) {
     return;
@@ -233,7 +289,7 @@ function guardSignInResource(
  */
 export function installClerkEmailCodePreparationGuard(clerk: Clerk): void {
   const signInActivePreparations = new Map<string, ActivePreparation>();
-  const signUpActivePreparations = new Map<string, ActivePreparation>();
+  const signUpActivePreparations = createSignUpActivePreparations();
   const guardedSignInResources = new WeakSet<SignInResource>();
   const guardedSignUpResources = new WeakSet<SignUpResource>();
   const guardCurrentResources = (): void => {

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -71,10 +71,10 @@ describe("clerk email code preparation", () => {
       emailAddressId: "idn_primary",
       strategy: "email_code",
     } as const;
-    await Promise.all([
-      signIn.prepareFirstFactor(params),
-      signIn.prepareFirstFactor(params),
-    ]);
+    const preparation = signIn.prepareFirstFactor(params);
+    const concurrentPreparation = signIn.prepareFirstFactor(params);
+    expect(concurrentPreparation).toBe(preparation);
+    await Promise.all([preparation, concurrentPreparation]);
     await signIn.prepareFirstFactor(params);
     expect(mockedClerk.factorPreparations).toStrictEqual([
       { flow: "sign-in", strategy: "email_code" },
@@ -162,6 +162,23 @@ describe("clerk email code preparation", () => {
     expect(mockedClerk.factorPreparations).toStrictEqual([
       { flow: "sign-in", strategy: "email_code" },
       { flow: "sign-in", strategy: "phone_code" },
+    ]);
+  });
+
+  it("passes through sign-up email-link preparation", async () => {
+    const now = Date.UTC(2026, 6, 18, 10, 30);
+    mockNow(now);
+    mockSignUpEmailVerification(activeEmailCode(now, "active-email-code"));
+
+    await setupAuthSignals("/sign-up");
+
+    await mockedClerk.client.signUp.prepareEmailAddressVerification({
+      redirectUrl: "https://app.vm0.ai/sign-up/verify",
+      strategy: "email_link",
+    });
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-up", strategy: "email_link" },
     ]);
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -89,6 +89,54 @@ describe("clerk email code preparation", () => {
     ]);
   });
 
+  it("preserves sign-in resend state across replacement resources", async () => {
+    let now = Date.UTC(2026, 6, 18, 9, 30);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-in");
+
+    const params = {
+      emailAddressId: "idn_primary",
+      strategy: "email_code",
+    } as const;
+    const initialSignIn = mockedClerk.client.signIn;
+    await initialSignIn.prepareFirstFactor(params);
+    replaceMockedClerkAuthResources({
+      signInVerification: initialSignIn.firstFactorVerification,
+    });
+
+    now += 60_000;
+    mockNow(now);
+    await mockedClerk.client.signIn.prepareFirstFactor(params);
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-in", strategy: "email_code" },
+      { flow: "sign-in", strategy: "email_code" },
+    ]);
+  });
+
+  it("prepares a code for a different sign-in email factor", async () => {
+    const now = Date.UTC(2026, 6, 18, 9, 45);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-in");
+
+    const signIn = mockedClerk.client.signIn;
+    await signIn.prepareFirstFactor({
+      emailAddressId: "idn_primary",
+      strategy: "email_code",
+    });
+    await signIn.prepareFirstFactor({
+      emailAddressId: "idn_secondary",
+      strategy: "email_code",
+    });
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-in", strategy: "email_code" },
+      { flow: "sign-in", strategy: "email_code" },
+    ]);
+  });
+
   it("prepares expired and non-email sign-in factors", async () => {
     const now = Date.UTC(2026, 6, 18, 10);
     mockNow(now);
@@ -123,8 +171,9 @@ describe("clerk email code preparation", () => {
 
     await setupAuthSignals("/sign-up");
 
-    replaceMockedClerkAuthResources();
-    mockSignUpEmailVerification(activeEmailCode(now, "replacement-code"));
+    replaceMockedClerkAuthResources({
+      signUpVerification: activeEmailCode(now, "replacement-code"),
+    });
     await mockedClerk.client.signUp.prepareEmailAddressVerification({
       strategy: "email_code",
     });

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -65,7 +65,7 @@ describe("clerk email code preparation", () => {
     ]);
   });
 
-  it("reuses the code sent by sign-up creation without verification metadata", async () => {
+  it("reuses the sign-up creation code across a full-page reload", async () => {
     let now = Date.UTC(2026, 6, 18, 8, 30);
     mockNow(now);
 
@@ -178,6 +178,28 @@ describe("clerk email code preparation", () => {
 
     expect(mockedClerk.factorPreparations).toStrictEqual([
       { flow: "sign-in", strategy: "email_code" },
+      { flow: "sign-in", strategy: "email_code" },
+    ]);
+  });
+
+  it("coalesces sign-in preparation across replacement resources", async () => {
+    const now = Date.UTC(2026, 6, 18, 9, 40);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-in");
+
+    const params = {
+      emailAddressId: "idn_primary",
+      strategy: "email_code",
+    } as const;
+    const preparation = mockedClerk.client.signIn.prepareFirstFactor(params);
+    replaceMockedClerkAuthResources();
+    const replacementPreparation =
+      mockedClerk.client.signIn.prepareFirstFactor(params);
+
+    expect(replacementPreparation).toBe(preparation);
+    await Promise.all([preparation, replacementPreparation]);
+    expect(mockedClerk.factorPreparations).toStrictEqual([
       { flow: "sign-in", strategy: "email_code" },
     ]);
   });

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { setupPage } from "../../__tests__/page-helper.ts";
+import {
+  mockedClerk,
+  mockSignInFirstFactorVerification,
+  mockSignUpEmailVerification,
+  replaceMockedClerkAuthResources,
+} from "../../__tests__/mock-auth.ts";
+import { mockNow } from "../../__tests__/time.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+function activeEmailCode(now: number, nonce: string) {
+  return {
+    expireAt: new Date(now + 10 * 60 * 1000),
+    nonce,
+    status: "unverified" as const,
+    strategy: "email_code",
+  };
+}
+
+async function setupAuthSignals(path: "/sign-in" | "/sign-up"): Promise<void> {
+  await setupPage({
+    context,
+    path,
+    withoutRender: true,
+    user: null,
+    session: null,
+    org: { activeOrg: null, memberships: [] },
+  });
+}
+
+describe("clerk email code preparation", () => {
+  it("reuses the active sign-up code and allows a later resend", async () => {
+    let now = Date.UTC(2026, 6, 18, 8);
+    mockNow(now);
+    mockSignUpEmailVerification(activeEmailCode(now, "signup-initial"));
+
+    await setupAuthSignals("/sign-up");
+
+    const signUp = mockedClerk.client.signUp;
+    await Promise.all([
+      signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
+      signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
+    ]);
+    expect(mockedClerk.factorPreparations).toStrictEqual([]);
+
+    now += 60_000;
+    mockNow(now);
+    await signUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
+    await signUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-up", strategy: "email_code" },
+    ]);
+  });
+
+  it("coalesces sign-in preparation and preserves resend", async () => {
+    let now = Date.UTC(2026, 6, 18, 9);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-in");
+
+    const signIn = mockedClerk.client.signIn;
+    const params = {
+      emailAddressId: "idn_primary",
+      strategy: "email_code",
+    } as const;
+    await Promise.all([
+      signIn.prepareFirstFactor(params),
+      signIn.prepareFirstFactor(params),
+    ]);
+    await signIn.prepareFirstFactor(params);
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-in", strategy: "email_code" },
+    ]);
+
+    now += 60_000;
+    mockNow(now);
+    await signIn.prepareFirstFactor(params);
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-in", strategy: "email_code" },
+      { flow: "sign-in", strategy: "email_code" },
+    ]);
+  });
+
+  it("prepares expired and non-email sign-in factors", async () => {
+    const now = Date.UTC(2026, 6, 18, 10);
+    mockNow(now);
+    mockSignInFirstFactorVerification({
+      expireAt: new Date(now - 1),
+      nonce: "expired-email-code",
+      status: "unverified",
+      strategy: "email_code",
+    });
+
+    await setupAuthSignals("/sign-in");
+
+    const signIn = mockedClerk.client.signIn;
+    await signIn.prepareFirstFactor({
+      emailAddressId: "idn_primary",
+      strategy: "email_code",
+    });
+    await signIn.prepareFirstFactor({
+      phoneNumberId: "idn_phone",
+      strategy: "phone_code",
+    });
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-in", strategy: "email_code" },
+      { flow: "sign-in", strategy: "phone_code" },
+    ]);
+  });
+
+  it("guards replacement Clerk authentication resources", async () => {
+    const now = Date.UTC(2026, 6, 18, 11);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-up");
+
+    replaceMockedClerkAuthResources();
+    mockSignUpEmailVerification(activeEmailCode(now, "replacement-code"));
+    await mockedClerk.client.signUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import { setupPage } from "../../__tests__/page-helper.ts";
 import {
+  clearMockedAuth,
   mockedClerk,
   mockSignInFirstFactorVerification,
   mockSignUpEmailVerification,
   replaceMockedClerkAuthResources,
 } from "../../__tests__/mock-auth.ts";
 import { mockNow } from "../../__tests__/time.ts";
-import { testContext } from "./test-helpers.ts";
+import { testContext, type TestContext } from "./test-helpers.ts";
 
 const context = testContext();
+const reloadContext = testContext();
 
 function activeEmailCode(now: number, nonce: string) {
   return {
@@ -21,9 +23,12 @@ function activeEmailCode(now: number, nonce: string) {
   };
 }
 
-async function setupAuthSignals(path: "/sign-in" | "/sign-up"): Promise<void> {
+async function setupAuthSignals(
+  path: "/sign-in" | "/sign-up" | "/sign-up/verify-email-address",
+  targetContext: TestContext = context,
+): Promise<void> {
   await setupPage({
-    context,
+    context: targetContext,
     path,
     withoutRender: true,
     user: null,
@@ -79,14 +84,26 @@ describe("clerk email code preparation", () => {
       strategy: null,
     });
 
-    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    clearMockedAuth();
+    await setupAuthSignals("/sign-up/verify-email-address", reloadContext);
+
+    const reloadedSignUp = mockedClerk.client.signUp;
+    await reloadedSignUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
+    await reloadedSignUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
     expect(mockedClerk.factorPreparations).toStrictEqual([]);
 
     now += 60_000;
     mockNow(now);
-    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
-    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    await reloadedSignUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
+    await reloadedSignUp.prepareEmailAddressVerification({
+      strategy: "email_code",
+    });
     expect(mockedClerk.factorPreparations).toStrictEqual([
       { flow: "sign-up", strategy: "email_code" },
     ]);

--- a/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-email-code.test.ts
@@ -60,6 +60,56 @@ describe("clerk email code preparation", () => {
     ]);
   });
 
+  it("reuses the code sent by sign-up creation without verification metadata", async () => {
+    let now = Date.UTC(2026, 6, 18, 8, 30);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-up");
+
+    const signUp = mockedClerk.client.signUp;
+    await signUp.create({
+      emailAddress: "person@example.com",
+      legalAccepted: true,
+      password: "test-password",
+    });
+    expect(signUp.verifications.emailAddress).toStrictEqual({
+      expireAt: null,
+      nonce: null,
+      status: null,
+      strategy: null,
+    });
+
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    expect(mockedClerk.factorPreparations).toStrictEqual([]);
+
+    now += 60_000;
+    mockNow(now);
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-up", strategy: "email_code" },
+    ]);
+  });
+
+  it("prepares email code after an external sign-up creation", async () => {
+    const now = Date.UTC(2026, 6, 18, 8, 45);
+    mockNow(now);
+
+    await setupAuthSignals("/sign-up");
+
+    const signUp = mockedClerk.client.signUp;
+    await signUp.create({
+      emailAddress: "person@example.com",
+      strategy: "oauth_google",
+    });
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+
+    expect(mockedClerk.factorPreparations).toStrictEqual([
+      { flow: "sign-up", strategy: "email_code" },
+    ]);
+  });
+
   it("coalesces sign-in preparation and preserves resend", async () => {
     let now = Date.UTC(2026, 6, 18, 9);
     mockNow(now);

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -7,6 +7,7 @@ import {
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
+import { installClerkEmailCodePreparationGuard } from "../lib/clerk-email-code-preparation-guard.ts";
 
 const reload$ = state(0);
 const clerkVersion$ = state(0);
@@ -270,6 +271,7 @@ export const clerk$ = computed(async () => {
     signUpUrl: resolveAppAuthUrl("/sign-up"),
     afterSignOutUrl: resolveAppAuthUrl("/sign-in"),
   });
+  installClerkEmailCodePreparationGuard(clerkInstance);
   return clerkInstance;
 });
 

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -1,13 +1,8 @@
 import { act, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import {
-  mockedClerk,
-  mockSignInFirstFactorVerification,
-  mockSignUpEmailVerification,
-  replaceMockedClerkAuthResources,
-} from "../../../__tests__/mock-auth.ts";
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
@@ -16,15 +11,6 @@ const context = testContext();
 
 function setBrowserUrl(url: string): void {
   window.location.href = url;
-}
-
-function activeEmailCode(now: number, nonce: string) {
-  return {
-    expireAt: new Date(now + 10 * 60 * 1000),
-    nonce,
-    status: "unverified" as const,
-    strategy: "email_code",
-  };
 }
 
 describe("app auth pages", () => {
@@ -276,140 +262,5 @@ describe("app auth pages", () => {
     expect(
       screen.getByTestId("clerk-sign-up").dataset.clerkForceRedirectUrl,
     ).toBe("https://app.vm0.ai");
-  });
-
-  it("reuses the active sign-up email code and allows a later resend", async () => {
-    let now = Date.UTC(2026, 6, 18, 8);
-    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
-      return now;
-    });
-    mockSignUpEmailVerification(activeEmailCode(now, "signup-initial"));
-    setBrowserUrl("https://app.vm0.ai/sign-up");
-
-    try {
-      detachedSetupPage({ context, path: "/sign-up" });
-      await screen.findByTestId("clerk-sign-up");
-
-      const signUp = mockedClerk.client.signUp;
-      await Promise.all([
-        signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
-        signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
-      ]);
-      expect(
-        mockedClerk.clientSignUpPrepareEmailAddressVerification,
-      ).not.toHaveBeenCalled();
-
-      now += 60_000;
-      await signUp.prepareEmailAddressVerification({
-        strategy: "email_code",
-      });
-      expect(
-        mockedClerk.clientSignUpPrepareEmailAddressVerification,
-      ).toHaveBeenCalledTimes(1);
-
-      await signUp.prepareEmailAddressVerification({
-        strategy: "email_code",
-      });
-      expect(
-        mockedClerk.clientSignUpPrepareEmailAddressVerification,
-      ).toHaveBeenCalledTimes(1);
-    } finally {
-      dateNow.mockRestore();
-    }
-  });
-
-  it("coalesces sign-in email code preparation and preserves resend", async () => {
-    let now = Date.UTC(2026, 6, 18, 9);
-    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
-      return now;
-    });
-    setBrowserUrl("https://app.vm0.ai/sign-in");
-
-    try {
-      detachedSetupPage({ context, path: "/sign-in" });
-      await screen.findByTestId("clerk-sign-in");
-
-      const signIn = mockedClerk.client.signIn;
-      const params = {
-        emailAddressId: "idn_primary",
-        strategy: "email_code",
-      } as const;
-      await Promise.all([
-        signIn.prepareFirstFactor(params),
-        signIn.prepareFirstFactor(params),
-      ]);
-      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
-        1,
-      );
-
-      await signIn.prepareFirstFactor(params);
-      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
-        1,
-      );
-
-      now += 60_000;
-      await signIn.prepareFirstFactor(params);
-      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
-        2,
-      );
-    } finally {
-      dateNow.mockRestore();
-    }
-  });
-
-  it("prepares expired and non-email sign-in factors", async () => {
-    const now = Date.UTC(2026, 6, 18, 10);
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
-    mockSignInFirstFactorVerification({
-      expireAt: new Date(now - 1),
-      nonce: "expired-email-code",
-      status: "unverified",
-      strategy: "email_code",
-    });
-    setBrowserUrl("https://app.vm0.ai/sign-in");
-
-    try {
-      detachedSetupPage({ context, path: "/sign-in" });
-      await screen.findByTestId("clerk-sign-in");
-
-      const signIn = mockedClerk.client.signIn;
-      await signIn.prepareFirstFactor({
-        emailAddressId: "idn_primary",
-        strategy: "email_code",
-      });
-      await signIn.prepareFirstFactor({
-        phoneNumberId: "idn_phone",
-        strategy: "phone_code",
-      });
-
-      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
-        2,
-      );
-    } finally {
-      dateNow.mockRestore();
-    }
-  });
-
-  it("guards replacement Clerk authentication resources", async () => {
-    const now = Date.UTC(2026, 6, 18, 11);
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
-    setBrowserUrl("https://app.vm0.ai/sign-up");
-
-    try {
-      detachedSetupPage({ context, path: "/sign-up" });
-      await screen.findByTestId("clerk-sign-up");
-
-      replaceMockedClerkAuthResources();
-      mockSignUpEmailVerification(activeEmailCode(now, "replacement-code"));
-      await mockedClerk.client.signUp.prepareEmailAddressVerification({
-        strategy: "email_code",
-      });
-
-      expect(
-        mockedClerk.clientSignUpPrepareEmailAddressVerification,
-      ).not.toHaveBeenCalled();
-    } finally {
-      dateNow.mockRestore();
-    }
   });
 });

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -1,8 +1,13 @@
 import { act, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import {
+  mockedClerk,
+  mockSignInFirstFactorVerification,
+  mockSignUpEmailVerification,
+  replaceMockedClerkAuthResources,
+} from "../../../__tests__/mock-auth.ts";
 import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
@@ -11,6 +16,15 @@ const context = testContext();
 
 function setBrowserUrl(url: string): void {
   window.location.href = url;
+}
+
+function activeEmailCode(now: number, nonce: string) {
+  return {
+    expireAt: new Date(now + 10 * 60 * 1000),
+    nonce,
+    status: "unverified" as const,
+    strategy: "email_code",
+  };
 }
 
 describe("app auth pages", () => {
@@ -262,5 +276,140 @@ describe("app auth pages", () => {
     expect(
       screen.getByTestId("clerk-sign-up").dataset.clerkForceRedirectUrl,
     ).toBe("https://app.vm0.ai");
+  });
+
+  it("reuses the active sign-up email code and allows a later resend", async () => {
+    let now = Date.UTC(2026, 6, 18, 8);
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
+      return now;
+    });
+    mockSignUpEmailVerification(activeEmailCode(now, "signup-initial"));
+    setBrowserUrl("https://app.vm0.ai/sign-up");
+
+    try {
+      detachedSetupPage({ context, path: "/sign-up" });
+      await screen.findByTestId("clerk-sign-up");
+
+      const signUp = mockedClerk.client.signUp;
+      await Promise.all([
+        signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
+        signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
+      ]);
+      expect(
+        mockedClerk.clientSignUpPrepareEmailAddressVerification,
+      ).not.toHaveBeenCalled();
+
+      now += 60_000;
+      await signUp.prepareEmailAddressVerification({
+        strategy: "email_code",
+      });
+      expect(
+        mockedClerk.clientSignUpPrepareEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+
+      await signUp.prepareEmailAddressVerification({
+        strategy: "email_code",
+      });
+      expect(
+        mockedClerk.clientSignUpPrepareEmailAddressVerification,
+      ).toHaveBeenCalledTimes(1);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("coalesces sign-in email code preparation and preserves resend", async () => {
+    let now = Date.UTC(2026, 6, 18, 9);
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
+      return now;
+    });
+    setBrowserUrl("https://app.vm0.ai/sign-in");
+
+    try {
+      detachedSetupPage({ context, path: "/sign-in" });
+      await screen.findByTestId("clerk-sign-in");
+
+      const signIn = mockedClerk.client.signIn;
+      const params = {
+        emailAddressId: "idn_primary",
+        strategy: "email_code",
+      } as const;
+      await Promise.all([
+        signIn.prepareFirstFactor(params),
+        signIn.prepareFirstFactor(params),
+      ]);
+      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
+        1,
+      );
+
+      await signIn.prepareFirstFactor(params);
+      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
+        1,
+      );
+
+      now += 60_000;
+      await signIn.prepareFirstFactor(params);
+      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
+        2,
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("prepares expired and non-email sign-in factors", async () => {
+    const now = Date.UTC(2026, 6, 18, 10);
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+    mockSignInFirstFactorVerification({
+      expireAt: new Date(now - 1),
+      nonce: "expired-email-code",
+      status: "unverified",
+      strategy: "email_code",
+    });
+    setBrowserUrl("https://app.vm0.ai/sign-in");
+
+    try {
+      detachedSetupPage({ context, path: "/sign-in" });
+      await screen.findByTestId("clerk-sign-in");
+
+      const signIn = mockedClerk.client.signIn;
+      await signIn.prepareFirstFactor({
+        emailAddressId: "idn_primary",
+        strategy: "email_code",
+      });
+      await signIn.prepareFirstFactor({
+        phoneNumberId: "idn_phone",
+        strategy: "phone_code",
+      });
+
+      expect(mockedClerk.clientSignInPrepareFirstFactor).toHaveBeenCalledTimes(
+        2,
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("guards replacement Clerk authentication resources", async () => {
+    const now = Date.UTC(2026, 6, 18, 11);
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+    setBrowserUrl("https://app.vm0.ai/sign-up");
+
+    try {
+      detachedSetupPage({ context, path: "/sign-up" });
+      await screen.findByTestId("clerk-sign-up");
+
+      replaceMockedClerkAuthResources();
+      mockSignUpEmailVerification(activeEmailCode(now, "replacement-code"));
+      await mockedClerk.client.signUp.prepareEmailAddressVerification({
+        strategy: "email_code",
+      });
+
+      expect(
+        mockedClerk.clientSignUpPrepareEmailAddressVerification,
+      ).not.toHaveBeenCalled();
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- install an email-code-only compatibility guard after the Clerk client loads
- remember the code sent by a successful ordinary email sign-up creation, including when Clerk returns no verification fingerprint, and carry that marker through Clerk's full-page verification-route transition
- reuse active codes and coalesce identical sign-up or sign-in preparations across Clerk resource replacements while preserving expiry, non-email factors, and later resend behavior
- assert the real Clerk request counts in browser E2E and run `agent-browser@0.32.1` on its supported Node 24 runtime

## Scope

- This does not change Clerk routing, authentication UI, dashboard configuration, or application dependencies.
- The guard only changes Clerk `email_code` preparation. OAuth and other sign-up strategies, phone codes, email links, password sign-in, MFA, and recovery operations continue through Clerk unchanged.
- The tab-scoped sign-up marker stores only an expiration timestamp in `sessionStorage`; it contains no email address, verification code, token, or Clerk identifier.
- The creation marker expires with Clerk's 30-second disabled-resend interval, while ordinary rerender/remount suppression remains five seconds. A later resend still performs one real preparation.
- The compatibility module links the upstream Clerk regressions and can be removed after a verified upstream fix.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx src/signals/__tests__/auth-email-code.test.ts --silent=passed-only` (21 tests, including a fresh Clerk bootstrap after sign-up creation and an in-flight resource replacement)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- Prettier check for changed files
- pre-commit hook, including full Turbo type checking (13 tasks)
- `git diff --check`

The deployed browser E2E remains the acceptance gate for one sign-up creation request, no redundant sign-up preparation request, and one sign-in preparation request.

Closes #22052
