### PR TITLE
test(sandbox-fc): verify netns pool shutdown ownership

### DIFF
--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -598,7 +598,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_cleans_owned_netns_pool_with_extra_arc_refs() {
-        let (pool, mut lease) = test_pool_with_lease("owned-test-ns");
+        let pool = NetnsPoolHandle::new_for_test(NetnsPool::active_for_test());
         let _destroy_task_clone = pool.clone();
         let mut factory = test_factory_with_resources(
             pool.clone(),
@@ -606,32 +606,31 @@ mod tests {
             test_leak_cleaner(),
         );
 
+        assert!(pool.is_active_for_test().await);
         factory.shutdown().await;
 
         assert!(factory.resources.is_none());
-        let retained = factory
-            .shutdown_netns_pool
-            .as_ref()
-            .expect("shutdown factory should retain netns release authority");
-        let _ = retained.release(&mut lease).await;
-        assert!(lease.is_none());
+        assert!(!pool.is_active_for_test().await);
     }
 
     #[tokio::test]
     async fn shutdown_keeps_shared_netns_pool_for_runtime_shutdown() {
-        let (pool, mut lease) = test_pool_with_lease("shared-test-ns");
+        let pool = NetnsPoolHandle::new_for_test(NetnsPool::active_for_test());
         let mut factory = test_factory_with_resources(
             pool.clone(),
             NetnsPoolOwnership::Shared,
             test_leak_cleaner(),
         );
 
+        assert!(pool.is_active_for_test().await);
         factory.shutdown().await;
 
         assert!(factory.resources.is_none());
         assert!(factory.shutdown_netns_pool.is_some());
-        let _ = pool.release(&mut lease).await;
-        assert!(lease.is_none());
+        assert!(pool.is_active_for_test().await);
+
+        pool.cleanup().await.unwrap();
+        assert!(!pool.is_active_for_test().await);
     }
 
     fn test_config(base_dir: PathBuf) -> FirecrackerConfig {

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -1248,6 +1248,13 @@ impl NetnsPool {
     }
 
     #[cfg(test)]
+    pub(crate) fn active_for_test() -> Self {
+        let mut state = NetnsPoolState::inactive_for_test();
+        state.active = true;
+        Self::from_state_for_test(state)
+    }
+
+    #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
         Self::from_state_for_test(NetnsPoolState::inactive_for_test())
     }
@@ -1284,6 +1291,11 @@ impl NetnsPoolHandle {
     #[cfg(test)]
     pub(crate) fn new_for_test(pool: NetnsPool) -> Self {
         Self::new(pool)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn is_active_for_test(&self) -> bool {
+        self.inner.state.lock().await.active
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary

- add test-only helpers for constructing an active, empty netns pool and observing its synchronized lifecycle state
- make owned factory shutdown assert that cleanup deactivates the pool even when extra handle clones exist
- make shared factory shutdown assert that the pool stays active until explicit runtime-style cleanup
- keep retained post-shutdown lease release covered by its existing separate test

## User-visible impact

Regressions that remove or invert the `Owned` versus `Shared` netns cleanup branch now fail focused tests. This protects directly owned factories from leaking pooled namespaces and shared runtime pools from being deactivated while other factories still depend on them.

## Scope

This PR changes tests and `#[cfg(test)]` crate-private helpers only. Production shutdown behavior, public APIs, and runtime resource handling are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p sandbox-fc factory::tests::shutdown_`
- `cargo test -p sandbox-fc` — 723 tests passed
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox-fc --no-deps`

Closes #22038
