### PR TITLE
test(mitm-addon): cover signed pricing freshness

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -23,6 +23,7 @@ def signed_usage_pricing_headers(
     unit_prices: dict[str, object] | None = None,
     *,
     unit_size: int = 1_000_000,
+    issued_at: object | None = None,
 ) -> dict[str, str]:
     if unit_prices is None:
         unit_prices = {
@@ -36,7 +37,7 @@ def signed_usage_pricing_headers(
             json.dumps(
                 {
                     "version": 1,
-                    "issuedAt": int(time.time()),
+                    "issuedAt": int(time.time()) if issued_at is None else issued_at,
                     "unitSize": unit_size,
                     "unitPrices": unit_prices,
                 },

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -1,11 +1,31 @@
 """Tests for the mitm addon responseheaders hook."""
 
+import pytest
+from mitmproxy import http
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import model_usage_pricing
 from tests.flow_helpers import header_map, response_stream
-from tests.model_provider_flow_helpers import signed_usage_pricing_headers
+from tests.model_provider_flow_helpers import RealFlowFactory, signed_usage_pricing_headers
+
+_FIXED_TIME = 1_750_000_000
+
+
+def _signed_pricing_flow(
+    real_flow: RealFlowFactory,
+    issued_at: object,
+) -> http.HTTPFlow:
+    flow = real_flow(with_response=False, host="model.vm0.ai")
+    flow.request.headers["authorization"] = "Bearer proxy-secret"
+    flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0-model"
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+    flow.response = tutils.tresp(
+        status_code=200,
+        headers=header_map(signed_usage_pricing_headers(issued_at=issued_at)),
+    )
+    return flow
 
 
 class TestResponseHeadersHandler:
@@ -49,15 +69,19 @@ class TestResponseHeadersHandler:
 
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
 
-    def test_accepts_and_strips_signed_model_usage_pricing(self, real_flow):
-        flow = real_flow(with_response=False, host="model.vm0.ai")
-        flow.request.headers["authorization"] = "Bearer proxy-secret"
-        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0-model"
-        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
-        flow.response = tutils.tresp(
-            status_code=200,
-            headers=header_map(signed_usage_pricing_headers()),
-        )
+    @pytest.mark.parametrize(
+        "issued_at",
+        [_FIXED_TIME - 300, _FIXED_TIME + 300],
+        ids=["oldest-accepted", "furthest-future-accepted"],
+    )
+    def test_accepts_and_strips_signed_model_usage_pricing_at_clock_skew_boundary(
+        self,
+        real_flow: RealFlowFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        issued_at: int,
+    ) -> None:
+        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        flow = _signed_pricing_flow(real_flow, issued_at)
 
         mitm_addon.responseheaders(flow)
 
@@ -70,6 +94,49 @@ class TestResponseHeadersHandler:
                 "tokens.output": 6000,
             },
         }
+        assert flow.response is not None
+        assert "x-vm0-usage-pricing" not in flow.response.headers
+        assert "x-vm0-usage-pricing-signature" not in flow.response.headers
+
+    @pytest.mark.parametrize(
+        "issued_at",
+        [_FIXED_TIME - 301, _FIXED_TIME + 301],
+        ids=["too-old", "too-far-future"],
+    )
+    def test_rejects_and_strips_signed_model_usage_pricing_outside_clock_skew(
+        self,
+        real_flow: RealFlowFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        issued_at: int,
+    ) -> None:
+        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        flow = _signed_pricing_flow(real_flow, issued_at)
+
+        mitm_addon.responseheaders(flow)
+
+        assert metadata_keys.MODEL_USAGE_PRICING not in flow.metadata
+        assert flow.response is not None
+        assert "x-vm0-usage-pricing" not in flow.response.headers
+        assert "x-vm0-usage-pricing-signature" not in flow.response.headers
+
+    @pytest.mark.parametrize(
+        "issued_at",
+        [True, str(_FIXED_TIME)],
+        ids=["boolean", "string"],
+    )
+    def test_rejects_and_strips_invalid_signed_model_usage_pricing_issued_at(
+        self,
+        real_flow: RealFlowFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        issued_at: object,
+    ) -> None:
+        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        flow = _signed_pricing_flow(real_flow, issued_at)
+
+        mitm_addon.responseheaders(flow)
+
+        assert metadata_keys.MODEL_USAGE_PRICING not in flow.metadata
+        assert flow.response is not None
         assert "x-vm0-usage-pricing" not in flow.response.headers
         assert "x-vm0-usage-pricing-signature" not in flow.response.headers
 

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -1,5 +1,7 @@
 """Tests for the mitm addon responseheaders hook."""
 
+from types import SimpleNamespace
+
 import pytest
 from mitmproxy import http
 from mitmproxy.test import tutils
@@ -11,6 +13,14 @@ from tests.flow_helpers import header_map, response_stream
 from tests.model_provider_flow_helpers import RealFlowFactory, signed_usage_pricing_headers
 
 _FIXED_TIME = 1_750_000_000
+
+
+def _fix_pricing_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        model_usage_pricing,
+        "time",
+        SimpleNamespace(time=lambda: _FIXED_TIME),
+    )
 
 
 def _signed_pricing_flow(
@@ -80,7 +90,7 @@ class TestResponseHeadersHandler:
         monkeypatch: pytest.MonkeyPatch,
         issued_at: int,
     ) -> None:
-        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        _fix_pricing_clock(monkeypatch)
         flow = _signed_pricing_flow(real_flow, issued_at)
 
         mitm_addon.responseheaders(flow)
@@ -109,7 +119,7 @@ class TestResponseHeadersHandler:
         monkeypatch: pytest.MonkeyPatch,
         issued_at: int,
     ) -> None:
-        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        _fix_pricing_clock(monkeypatch)
         flow = _signed_pricing_flow(real_flow, issued_at)
 
         mitm_addon.responseheaders(flow)
@@ -130,7 +140,7 @@ class TestResponseHeadersHandler:
         monkeypatch: pytest.MonkeyPatch,
         issued_at: object,
     ) -> None:
-        monkeypatch.setattr(model_usage_pricing.time, "time", lambda: _FIXED_TIME)
+        _fix_pricing_clock(monkeypatch)
         flow = _signed_pricing_flow(real_flow, issued_at)
 
         mitm_addon.responseheaders(flow)


### PR DESCRIPTION
## Summary

- allow signed-pricing test fixtures to select the encoded `issuedAt`
- cover both inclusive ±300-second freshness boundaries through `responseheaders()`
- reject correctly signed ±301-second and invalid-type payloads while verifying private-header removal

## Behavior

The tests now pin the verifier clock and exercise valid signatures at every relevant freshness and type boundary. Accepted schedules populate `MODEL_USAGE_PRICING`; rejected schedules leave it absent. Both private pricing headers are stripped in every outcome.

## Exclusions

- no production verifier or clock-skew policy changes
- no signing protocol, pricing value, runtime API, persistence, or deployment changes

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright`
- `cd crates/runner/mitm-addon && .venv/bin/pytest -q tests/test_response_headers_handler.py tests/test_model_provider_usage.py` — 40 passed
- `cd crates/runner/mitm-addon && .venv/bin/pytest -qq` — passed

Closes #22050
