### PR TITLE
refactor(mitm-addon): make catalog snapshot identity explicit

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -71,7 +71,7 @@ class DiagnosticCatalogSnapshot:
     catalog_identity: builtin_firewall_cache.CatalogIdentity | None
     catalog: _DiagnosticCatalog | None
     cache_path: str | None
-    unavailable_reason: str | None
+    unavailable_reason: builtin_firewall_cache.CatalogUnavailableReason | None
 
 
 @dataclass(frozen=True)

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -6,6 +6,7 @@ import stat
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, NamedTuple
 
 from mitmproxy import ctx
 
@@ -20,8 +21,45 @@ _CACHE_SCHEMA_VERSION = 1
 _SHA256_HEX_LENGTH = 64
 _RESERVED_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
-CatalogFileKey = tuple[str, int, int, int, int]
-CatalogIdentity = tuple[str, str, str, CatalogFileKey]
+
+
+class CatalogFileKey(NamedTuple):
+    """Filesystem identity used to validate catalog cache dependencies.
+
+    Tuple order is `absolute_path`, `st_dev`, `st_ino`, `st_mtime_ns`, then
+    `st_size`. All stat fields in one key come from the same stat result.
+    """
+
+    absolute_path: str
+    st_dev: int
+    st_ino: int
+    st_mtime_ns: int
+    st_size: int
+
+
+class CatalogIdentity(NamedTuple):
+    """Validated catalog source identity used by compiled firewall cache keys.
+
+    Tuple order is `source`, `catalog_digest`, `catalog_version`, then
+    `file_key`. The source is `cache`, and `file_key` identifies the exact file
+    from which the validated catalog was loaded.
+    """
+
+    source: Literal["cache"]
+    catalog_digest: str
+    catalog_version: str
+    file_key: CatalogFileKey
+
+
+CatalogUnavailableReason = Literal[
+    "cache_path_missing",
+    "cache_file_missing",
+    "cache_permission_denied",
+    "cache_not_regular",
+    "cache_untrusted",
+    "cache_unavailable",
+    "cache_invalid",
+]
 
 
 class BuiltinFirewallCatalogCacheError(ValueError):
@@ -29,23 +67,50 @@ class BuiltinFirewallCatalogCacheError(ValueError):
 
 
 class _CatalogCacheOpenError(OSError):
-    def __init__(self, reason: str, message: str) -> None:
+    reason: CatalogUnavailableReason
+
+    def __init__(self, reason: CatalogUnavailableReason, message: str) -> None:
         super().__init__(message)
         self.reason = reason
 
 
 @dataclass(frozen=True)
 class BuiltinFirewallCatalog:
+    """Validated firewall map bound to the catalog cache file that supplied it.
+
+    `identity` records the cache source, declared digest and version, and exact
+    opened file key. `firewalls` is the validated catalog payload used for
+    builtin firewall resolution.
+    """
+
     identity: CatalogIdentity
     firewalls: dict[str, dict]
 
 
 @dataclass(frozen=True)
 class BuiltinFirewallCatalogSnapshot:
+    """Result of loading one catalog cache dependency for a consumer pass.
+
+    Loader-produced states are:
+
+    - Success has `dependency_file_key`, `catalog`, and `cache_path`, with no
+      `unavailable_reason`.
+    - Missing path configuration has no dependency, catalog, or cache path and
+      uses `cache_path_missing`.
+    - Open or trust failure has no dependency or catalog, retains the absolute
+      cache path, and uses the corresponding open-failure reason.
+    - Read, decode, schema, or validation failure has the opened file key and
+      absolute cache path, no catalog, and uses `cache_invalid`.
+
+    `dependency_file_key` comes from the descriptor actually opened for this
+    snapshot, not a preliminary path stat. Registry snapshots compare it with
+    the current path identity to decide whether cached resolution remains valid.
+    """
+
     dependency_file_key: CatalogFileKey | None
     catalog: BuiltinFirewallCatalog | None
     cache_path: str | None = None
-    unavailable_reason: str | None = None
+    unavailable_reason: CatalogUnavailableReason | None = None
 
 
 @dataclass
@@ -53,7 +118,7 @@ class _CatalogCacheState:
     path_key: str | None = None
     loaded_key: CatalogFileKey | None = None
     failed_key: CatalogFileKey | None = None
-    failed_reason: str | None = None
+    failed_reason: CatalogUnavailableReason | None = None
     catalog: BuiltinFirewallCatalog | None = None
 
     def reset(self, path_key: str | None = None) -> None:
@@ -112,7 +177,13 @@ def catalog_file_key(cache_path: str | None) -> CatalogFileKey | None:
         return None
     if not _cache_file_stat_is_trusted(st):
         return None
-    return (_path_key(path), st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+    return CatalogFileKey(
+        absolute_path=_path_key(path),
+        st_dev=st.st_dev,
+        st_ino=st.st_ino,
+        st_mtime_ns=st.st_mtime_ns,
+        st_size=st.st_size,
+    )
 
 
 def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnapshot:
@@ -140,7 +211,13 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
         )
 
     try:
-        key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+        key = CatalogFileKey(
+            absolute_path=path_key,
+            st_dev=st.st_dev,
+            st_ino=st.st_ino,
+            st_mtime_ns=st.st_mtime_ns,
+            st_size=st.st_size,
+        )
         if key == state.loaded_key:
             return BuiltinFirewallCatalogSnapshot(key, state.catalog, cache_path=path_key)
         if key == state.failed_key:
@@ -174,7 +251,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
     return BuiltinFirewallCatalogSnapshot(key, catalog, cache_path=path_key)
 
 
-def _open_error_unavailable_reason(exc: OSError) -> str:
+def _open_error_unavailable_reason(exc: OSError) -> CatalogUnavailableReason:
     if isinstance(exc, _CatalogCacheOpenError):
         return exc.reason
     if isinstance(exc, FileNotFoundError):
@@ -275,7 +352,12 @@ def _read_catalog(
     _validate_firewall_map(firewalls)
 
     return BuiltinFirewallCatalog(
-        identity=("cache", catalog_digest, catalog_version, key),
+        identity=CatalogIdentity(
+            source="cache",
+            catalog_digest=catalog_digest,
+            catalog_version=catalog_version,
+            file_key=key,
+        ),
         firewalls=firewalls,
     )
 

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -131,10 +131,10 @@ def _catalog_source_for_name(
         )
     catalog_firewall = cached_catalog.firewalls.get(raw_name)
     if catalog_firewall is None:
-        _, catalog_digest, catalog_version, _ = cached_catalog.identity
         raise FirewallEntryResolutionError(
             f'builtin firewall "{raw_name}" missing from catalog cache '
-            f"(catalog_digest={catalog_digest}, catalog_version={catalog_version})"
+            f"(catalog_digest={cached_catalog.identity.catalog_digest}, "
+            f"catalog_version={cached_catalog.identity.catalog_version})"
         )
     return catalog_firewall, cached_catalog.identity
 

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -3,12 +3,12 @@
 import builtin_connector_diagnostics
 import builtin_firewall_cache
 
-_TEST_FILE_KEY: builtin_firewall_cache.CatalogFileKey = (
-    "/test/catalog.json",
-    1,
-    1,
-    1,
-    1,
+_TEST_FILE_KEY = builtin_firewall_cache.CatalogFileKey(
+    absolute_path="/test/catalog.json",
+    st_dev=1,
+    st_ino=1,
+    st_mtime_ns=1,
+    st_size=1,
 )
 
 
@@ -47,10 +47,15 @@ def _diagnostic_snapshot(
     raw_snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
         dependency_file_key=_TEST_FILE_KEY,
         catalog=builtin_firewall_cache.BuiltinFirewallCatalog(
-            identity=("cache", "sha256:" + "0" * 64, "test", _TEST_FILE_KEY),
+            identity=builtin_firewall_cache.CatalogIdentity(
+                source="cache",
+                catalog_digest="sha256:" + "0" * 64,
+                catalog_version="test",
+                file_key=_TEST_FILE_KEY,
+            ),
             firewalls={firewall["name"]: firewall for firewall in firewalls},
         ),
-        cache_path=_TEST_FILE_KEY[0],
+        cache_path=_TEST_FILE_KEY.absolute_path,
     )
     return builtin_connector_diagnostics._compile_diagnostic_snapshot(raw_snapshot)
 

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -97,7 +97,7 @@ def test_unchanged_cache_reuses_compiled_diagnostic_snapshot(tmp_path, mitm_ctx)
     assert first is second
     assert first.catalog is not None
     assert first.catalog_identity is not None
-    assert first.catalog_identity[2] == "catalog-a"
+    assert first.catalog_identity.catalog_version == "catalog-a"
 
 
 @pytest.mark.parametrize("terminal_hook", ["response", "stream", "error"])
@@ -263,7 +263,7 @@ async def test_repeated_preferred_catalog_does_not_reopen_cache(
     assert len(pinned_snapshots) == 2
     assert pinned_snapshots[0] is pinned_snapshots[1]
     assert pinned_snapshots[0].catalog_identity is not None
-    assert pinned_snapshots[0].catalog_identity[2] == "catalog-a"
+    assert pinned_snapshots[0].catalog_identity.catalog_version == "catalog-a"
 
 
 async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
@@ -319,9 +319,9 @@ async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
 
     assert _response_connector(first_flow) == "inactive-a"
     assert current_before_delayed_flow.catalog_identity is not None
-    assert current_before_delayed_flow.catalog_identity[2] == "catalog-b"
+    assert current_before_delayed_flow.catalog_identity.catalog_version == "catalog-b"
     assert current_after_delayed_flow.catalog_identity is not None
-    assert current_after_delayed_flow.catalog_identity[2] == "catalog-b"
+    assert current_after_delayed_flow.catalog_identity.catalog_version == "catalog-b"
     assert _response_connector(second_flow) == "inactive-b"
 
 
@@ -380,9 +380,9 @@ async def test_stream_safe_firewall_request_commit_pins_classification_catalog(
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert len(pinned_snapshots) == 1
     assert pinned_snapshots[0].catalog_identity is not None
-    assert pinned_snapshots[0].catalog_identity[2] == "catalog-a"
+    assert pinned_snapshots[0].catalog_identity.catalog_version == "catalog-a"
     assert current_snapshot.catalog_identity is not None
-    assert current_snapshot.catalog_identity[2] == "catalog-b"
+    assert current_snapshot.catalog_identity.catalog_version == "catalog-b"
 
 
 async def test_unavailable_flow_stays_unavailable_after_cache_recovers(

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -561,15 +561,26 @@ class TestRegistryBuiltinCache:
                 )
             },
         )
+        assert snapshot.catalog is not None
+        rewritten_key = builtin_firewall_cache.CatalogFileKey(
+            absolute_path="catalog-cache/catalog-a.json",
+            st_dev=1,
+            st_ino=2,
+            st_mtime_ns=3,
+            st_size=4,
+        )
         rewritten_snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
-            dependency_file_key=builtin_firewall_cache.CatalogFileKey(
-                absolute_path="catalog-cache/catalog-a.json",
-                st_dev=1,
-                st_ino=2,
-                st_mtime_ns=3,
-                st_size=4,
+            dependency_file_key=rewritten_key,
+            catalog=builtin_firewall_cache.BuiltinFirewallCatalog(
+                identity=builtin_firewall_cache.CatalogIdentity(
+                    source=snapshot.catalog.identity.source,
+                    catalog_digest=snapshot.catalog.identity.catalog_digest,
+                    catalog_version=snapshot.catalog.identity.catalog_version,
+                    file_key=rewritten_key,
+                ),
+                firewalls=snapshot.catalog.firewalls,
             ),
-            catalog=snapshot.catalog,
+            cache_path=rewritten_key.absolute_path,
         )
         expected_digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -120,14 +120,26 @@ def _catalog_snapshot(
     version: str,
     firewalls: dict[str, dict],
 ) -> builtin_firewall_cache.BuiltinFirewallCatalogSnapshot:
-    key = (f"catalog-cache/{version}.json", 1, 1, len(version), len(firewalls))
+    key = builtin_firewall_cache.CatalogFileKey(
+        absolute_path=f"catalog-cache/{version}.json",
+        st_dev=1,
+        st_ino=1,
+        st_mtime_ns=len(version),
+        st_size=len(firewalls),
+    )
     digest = f"sha256:{digest_char * 64}"
     return builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
         dependency_file_key=key,
         catalog=builtin_firewall_cache.BuiltinFirewallCatalog(
-            identity=("cache", digest, version, key),
+            identity=builtin_firewall_cache.CatalogIdentity(
+                source="cache",
+                catalog_digest=digest,
+                catalog_version=version,
+                file_key=key,
+            ),
             firewalls=firewalls,
         ),
+        cache_path=key.absolute_path,
     )
 
 
@@ -550,7 +562,13 @@ class TestRegistryBuiltinCache:
             },
         )
         rewritten_snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
-            dependency_file_key=("catalog-cache/catalog-a.json", 1, 2, 3, 4),
+            dependency_file_key=builtin_firewall_cache.CatalogFileKey(
+                absolute_path="catalog-cache/catalog-a.json",
+                st_dev=1,
+                st_ino=2,
+                st_mtime_ns=3,
+                st_size=4,
+            ),
             catalog=snapshot.catalog,
         )
         expected_digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1334,6 +1352,11 @@ class TestRegistryBuiltinCache:
 
             snapshot = registry_firewalls.load_catalog_snapshot(str(cache_path))
             assert snapshot.catalog is not None
+            assert snapshot.dependency_file_key is not None
+            assert snapshot.dependency_file_key.absolute_path == str(cache_path.absolute())
+            assert snapshot.catalog.identity.source == "cache"
+            assert snapshot.catalog.identity.catalog_version == "catalog-a"
+            assert snapshot.catalog.identity.file_key == snapshot.dependency_file_key
             retained_catalog = builtin_firewall_cache._cache_state.catalog
             assert retained_catalog is snapshot.catalog
 


### PR DESCRIPTION
## Summary

- replace positional catalog file and catalog identity aliases with named, immutable tuple-compatible contracts
- define one closed static type for every catalog snapshot unavailability reason
- document catalog ownership, loader-produced snapshot states, and actual-opened-file invalidation semantics
- migrate registry and diagnostic consumers plus existing integration fixtures to named fields

## Compatibility

- preserves tuple equality, hashing, ordering, indexing, and unpacking used by registry and compiled firewall caches
- keeps all diagnostic reason strings and catalog loading behavior unchanged
- does not change the catalog JSON schema, API contracts, database schema, persisted data, queue payloads, or runner protocols
- requires no migration, feature switch, compatibility shim, or rollout sequencing

## Validation

- `ruff format .`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .` — 0 errors
- focused registry catalog, base URL, diagnostic, and diagnostic lifecycle pytest suite — 140 passed
- addon-load and request-framing regression tests under the repository-pinned mitmproxy 12.2.2 environment — 8 passed
- full mitm-addon pytest suite in the repository-pinned `.[dev]` environment — 4070 passed

Closes #22048
