### PR TITLE
refactor(mail): publish draft cards through assistant links

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1629,7 +1629,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(appendSystemPrompt).toContain("zero web upload-file -h");
     expect(appendSystemPrompt).toContain("zero mail send --help");
     expect(appendSystemPrompt).toContain(
-      "The card appears automatically, so do not repeat the draft",
+      "include the returned Card URL exactly once in your assistant response",
     );
     expect(appendSystemPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
     expect(appendSystemPrompt).not.toContain("When running in Codex");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -213,6 +213,11 @@ describe("POST /api/zero/mail/drafts", () => {
     expect(created.body.mailDraftUrl).toBe(
       `http://localhost:3002/mail/drafts/${created.body.mailDraftId}`,
     );
+    const threadAfterCreate = await chat.listThreadMessages(
+      fixture.actor,
+      fixture.thread.id,
+    );
+    expect(threadAfterCreate.messages).toHaveLength(0);
     expect(Buffer.from(gmail.raw, "base64url").toString("utf8")).toContain(
       "References: <first@example.com> <original@example.com>",
     );
@@ -287,17 +292,6 @@ describe("POST /api/zero/mail/drafts", () => {
     );
     expect(duplicate.body.error.message).toContain("can no longer be sent");
     expect(gmail.sendCount).toBe(1);
-
-    const page = await chat.listThreadMessages(
-      fixture.actor,
-      fixture.thread.id,
-    );
-    const persisted = page.messages.find((message) => {
-      return message.content === created.body.mailDraftUrl;
-    });
-    expect(persisted).toMatchObject({
-      content: created.body.mailDraftUrl,
-    });
 
     await connectors.deleteConnectorByType(fixture.actor, "gmail");
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -109,7 +109,6 @@ type ChatMessageRow = {
   readonly runEventId: string | null;
   readonly goalEvent: ChatMessageGoalEvent | null;
   readonly goalSnapshot: ChatMessageGoalSnapshot | null;
-  readonly mailDraftId: string | null;
   readonly error: string | null;
   readonly runLifecycleEvent: string | null;
   readonly sequenceNumber: number | null;
@@ -219,7 +218,6 @@ const messageColumns = {
   runEventId: chatMessages.runEventId,
   goalEvent: chatMessages.goalEvent,
   goalSnapshot: chatMessages.goalSnapshot,
-  mailDraftId: chatMessages.mailDraftId,
   error: chatMessages.error,
   runLifecycleEvent: chatMessages.runLifecycleEvent,
   sequenceNumber: chatMessages.sequenceNumber,
@@ -650,7 +648,6 @@ function toPagedMessage(
       runEventId: row.runEventId ?? undefined,
       goalEvent: goalEventFromRow(row.goalEvent),
       goalSnapshot: goalSnapshotFromRow(row.goalSnapshot),
-      mailDraftId: row.mailDraftId ?? undefined,
       revokesMessageId: row.revokesMessageId ?? undefined,
       interruptsRunId: row.interruptsRunId ?? undefined,
       error: row.error ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -23,7 +23,6 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { publishUserSignal } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { settleIncludingAbort, tapError } from "../utils";
 import { lockConnectorState } from "./auth-state-lock.service";
@@ -31,7 +30,6 @@ import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
 } from "./crypto.utils";
-import { insertChatMessage } from "./zero-chat-message.service";
 
 const L = logger("api:zero-mail");
 
@@ -892,48 +890,22 @@ async function persistCreatedDraft(args: {
   readonly gmail: GmailDraftValue;
   readonly connection: MailConnection;
   readonly threadId: string;
-  readonly userId: string;
 }): Promise<void> {
   const createdAt = nowDate();
-  const link = mailDraftUrl(args.mailDraftId);
-  const created = await args.db.transaction(async (tx) => {
-    const message = await insertChatMessage(tx, {
-      chatThreadId: args.threadId,
-      role: "assistant",
-      content: link,
-    });
-    if (!message) {
-      throw new Error("Mail draft message insert did not return an id");
-    }
-    await tx.insert(mailDrafts).values({
-      id: args.mailDraftId,
-      chatThreadId: args.threadId,
-      connectorId: args.connection.connectorId,
-      gmailDraftId: args.gmail.draftId,
-      gmailThreadId: args.gmail.threadId,
-      gmailMessageId: args.gmail.messageId,
-      status: "draft",
-      senderName: args.gmail.details.fromName ?? null,
-      senderAddress: args.gmail.details.from,
-      subject: args.gmail.details.subject,
-      createdAt,
-      updatedAt: createdAt,
-    });
-    return message.id;
+  await args.db.insert(mailDrafts).values({
+    id: args.mailDraftId,
+    chatThreadId: args.threadId,
+    connectorId: args.connection.connectorId,
+    gmailDraftId: args.gmail.draftId,
+    gmailThreadId: args.gmail.threadId,
+    gmailMessageId: args.gmail.messageId,
+    status: "draft",
+    senderName: args.gmail.details.fromName ?? null,
+    senderAddress: args.gmail.details.from,
+    subject: args.gmail.details.subject,
+    createdAt,
+    updatedAt: createdAt,
   });
-  await tapError(
-    publishUserSignal(
-      [args.userId],
-      `chatThreadMessageCreated:${args.threadId}`,
-    ),
-    (error) => {
-      L.warn("Failed to publish Gmail draft creation", {
-        threadId: args.threadId,
-        messageId: created,
-        error,
-      });
-    },
-  );
 }
 
 async function markDeleted(args: {
@@ -1154,7 +1126,6 @@ export const createZeroMailDraft$ = command(
       gmail,
       connection,
       threadId: args.threadId,
-      userId: args.userId,
     });
     signal.throwIfAborted();
     const stored = await loadOwnedNewMailDraft({

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -277,7 +277,7 @@ function buildIntegrationToolsPrompt(
         crossIntegrationMessage,
         ...(zeroMailEnabled
           ? [
-              "- Email from web chat: use `zero mail list` to inspect the current agent's authorized Gmail and Outlook accounts, `zero mail connect gmail|outlook` to get a connect or authorization link, and `zero mail send --help` to create a persistent editable mail card. `zero mail send` creates the card but does not send the message; the user sends or cancels it from the card. The card appears automatically, so do not repeat the draft or command output in your response.",
+              "- Email from web chat: use `zero mail list` to inspect the current agent's authorized Gmail and Outlook accounts, `zero mail connect gmail|outlook` to get a connect or authorization link, and `zero mail send --help` to create a persistent editable mail card. `zero mail send` creates the card but does not send the message; the user sends or cancels it from the card. After the command succeeds, include the returned Card URL exactly once in your assistant response so the platform renders the card. Do not repeat the draft text or the rest of the command output.",
             ]
           : []),
         ...localFileContextLines,

--- a/turbo/apps/cli/src/commands/zero/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mail/__tests__/index.test.ts
@@ -104,7 +104,7 @@ describe("zero mail", () => {
     );
   });
 
-  it("creates a persistent mail card without asking the model to echo JSON", async () => {
+  it("creates a persistent mail card and guides the model to share its URL", async () => {
     server.use(
       http.post(
         "http://localhost:3000/api/zero/mail/drafts",
@@ -174,7 +174,7 @@ describe("zero mail", () => {
     expect(output).toContain("sender@example.com");
     expect(output).toContain(MAIL_DRAFT_ID);
     expect(output).toContain(`https://app.vm0.ai/mail/drafts/${MAIL_DRAFT_ID}`);
-    expect(output).toContain("do not repeat the draft");
+    expect(output).toContain("Include the Card URL in your response");
     expect(output).not.toContain('"mailDraft"');
   });
 });

--- a/turbo/apps/cli/src/commands/zero/mail/send.ts
+++ b/turbo/apps/cli/src/commands/zero/mail/send.ts
@@ -80,9 +80,11 @@ Notes:
       console.log(chalk.dim(`  Sender: ${result.mailDraft.from}`));
       console.log(chalk.dim(`  Draft: ${result.mailDraftId}`));
       console.log(chalk.dim(`  Card: ${result.mailDraftUrl}`));
+      console.log();
+      console.log("Next step:");
       console.log(
         chalk.dim(
-          "  The card is already visible in chat; do not repeat the draft in your response",
+          "  Include the Card URL in your response so the user can review and send the draft",
         ),
       );
     }),

--- a/turbo/apps/platform/src/signals/chat-page/chat-message-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message-body-blocks.ts
@@ -24,13 +24,7 @@ export function parseMessageBodyBlocks(
   message: PagedChatMessage,
 ): ParsedBodyBlock[] {
   const content = chatMessageBodyContent(message);
-  const { blocks } = parseBodyBlocks(content, {
+  return parseBodyBlocks(content, {
     previews: message.role === "assistant",
-  });
-  if (blocks.length === 0 && message.mailDraftId) {
-    return parseBodyBlocks(`/mail/drafts/${message.mailDraftId}`, {
-      previews: message.role === "assistant",
-    }).blocks;
-  }
-  return blocks;
+  }).blocks;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3231,9 +3231,7 @@ function attachUsageToCompletedWorkGroups(
 function isRenderableAssistantMessage(message: EnrichedChatMessage): boolean {
   return (
     message.role === "assistant" &&
-    (Boolean(message.content) ||
-      Boolean(message.error) ||
-      Boolean(message.mailDraftId))
+    (Boolean(message.content) || Boolean(message.error))
   );
 }
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -323,7 +323,6 @@ const pagedChatMessageBaseSchema = z.object({
   error: z.string().optional(),
   attachFiles: z.array(resolvedAttachFileSchema).optional(),
   generationTemplate: generationTemplateRequestSchema.optional(),
-  mailDraftId: z.string().uuid().optional(),
   sequenceNumber: z.number().nullable().optional(),
   workflowSnapshot: workflowSnapshotSchema.optional(),
   createdAt: z.string(),

--- a/turbo/packages/db/src/schema/chat-message.ts
+++ b/turbo/packages/db/src/schema/chat-message.ts
@@ -107,8 +107,9 @@ export const chatMessages = pgTable(
     generationTemplate: jsonb(
       "generation_template",
     ).$type<ChatMessageGenerationTemplate>(),
-    // Compatibility-only marker for messages created before mail draft cards
-    // became link-backed. New messages leave this null.
+    // Database-only rollout marker for API versions that still read legacy
+    // mail cards. Drop this column after the link-only reader has fully
+    // deployed; migrations run before API traffic promotion.
     mailDraftId: uuid("mail_draft_id").unique(
       "chat_messages_mail_draft_id_unique",
     ),


### PR DESCRIPTION
## Summary

- stop Zero Mail draft creation from inserting a synthetic, runless assistant chat message
- return the stable mail draft URL and instruct the agent to include it exactly once in the normal assistant response, matching the permission-card transport model
- remove `mailDraftId` from the paged chat message contract, API projection, frontend compatibility parser, and renderability checks
- keep the existing URL parser, thread-scoped mail signals registry, and React card renderer as the only card hydration path

## User-visible impact

Mail draft cards now appear as part of the assistant response that created them, just like permission cards. Creating a draft no longer adds a separate assistant-owned transcript row that can be visually grouped under another response. Review, edit, delete, and send behavior is unchanged.

## Deployment compatibility

The physical `chat_messages.mail_draft_id` column remains as a database-only rollout marker for one release. Production migrations run before API traffic promotion, while the currently deployed API still selects that column. This PR removes every runtime reader and response field, allowing a follow-up migration to drop the physical column safely after this version has fully deployed.

## Verification

- pinned Prettier formatting on all changed TypeScript files
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts check-types`
- lint passed with zero warnings for `api`, `@vm0/cli`, `@vm0/app`, and `@vm0/api-contracts`
- local Vitest was not run per repository PR guidance; the PR pipeline will run tests
