### PR TITLE
perf(mitm-addon): bound starred argument expansion

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -41,75 +41,90 @@ def _argument_annotations(args: ast.arguments) -> list[ast.expr]:
     return annotations
 
 
-def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AST]:
+def _static_first_call_argument_nodes(args: list[ast.expr]) -> list[ast.AST]:
+    """Return static nodes that can occupy a call's first positional argument."""
     result: list[ast.AST] = []
-    consumed_counts = [0]
     for argument in args:
-        next_consumed_counts: list[int] = []
         if isinstance(argument, ast.Starred):
-            expansions, has_unknown_expansion = _static_starred_argument_expansions(argument.value)
-            for consumed in consumed_counts:
-                for expansion in expansions:
-                    for offset, expanded_argument in enumerate(expansion):
-                        if consumed + offset == index:
-                            result.append(expanded_argument)
-                    next_consumed_counts.append(consumed + len(expansion))
-            if has_unknown_expansion:
-                next_consumed_counts.extend(
-                    consumed for consumed in consumed_counts if consumed <= index
-                )
-        else:
-            for consumed in consumed_counts:
-                if consumed == index:
-                    result.append(argument)
-                next_consumed_counts.append(consumed + 1)
-        consumed_counts = next_consumed_counts
+            outcomes, has_unknown_expansion = _static_iterable_first_outcomes(argument.value)
+            result.extend(outcome for outcome in outcomes if outcome is not None)
+            if has_unknown_expansion or any(outcome is None for outcome in outcomes):
+                continue
+            break
+        result.append(argument)
+        break
     return result
 
 
-def _static_starred_argument_expansions(node: ast.AST) -> tuple[list[list[ast.AST]], bool]:
+def _deduplicate_static_argument_outcomes(
+    outcomes: list[ast.AST | None],
+) -> list[ast.AST | None]:
+    result: list[ast.AST | None] = []
+    seen_node_ids: set[int] = set()
+    has_empty_outcome = False
+    for outcome in outcomes:
+        if outcome is None:
+            if has_empty_outcome:
+                continue
+            has_empty_outcome = True
+        else:
+            node_id = id(outcome)
+            if node_id in seen_node_ids:
+                continue
+            seen_node_ids.add(node_id)
+        result.append(outcome)
+    return result
+
+
+def _static_iterable_first_outcomes(node: ast.AST) -> tuple[list[ast.AST | None], bool]:
+    """Return ordered first-node/empty outcomes and whether any expansion is unknown.
+
+    ``None`` represents a statically empty expansion. The unknown flag remains separate because
+    the linter conservatively treats any dynamic nested expansion as a possible empty call prefix.
+    """
     if isinstance(node, ast.NamedExpr):
-        return _static_starred_argument_expansions(node.value)
+        return _static_iterable_first_outcomes(node.value)
     if isinstance(node, ast.IfExp):
-        body_expansions, body_has_unknown_expansion = _static_starred_argument_expansions(node.body)
-        orelse_expansions, orelse_has_unknown_expansion = _static_starred_argument_expansions(
-            node.orelse
-        )
-        return [
-            *body_expansions,
-            *orelse_expansions,
-        ], body_has_unknown_expansion or orelse_has_unknown_expansion
+        body_outcomes, body_has_unknown_expansion = _static_iterable_first_outcomes(node.body)
+        orelse_outcomes, orelse_has_unknown_expansion = _static_iterable_first_outcomes(node.orelse)
+        return _deduplicate_static_argument_outcomes(
+            [*body_outcomes, *orelse_outcomes]
+        ), body_has_unknown_expansion or orelse_has_unknown_expansion
     if isinstance(node, ast.BoolOp):
-        expansions: list[list[ast.AST]] = []
+        alternative_outcomes: list[ast.AST | None] = []
         has_unknown_expansion = False
         for value in node.values:
-            value_expansions, value_has_unknown_expansion = _static_starred_argument_expansions(
-                value
-            )
-            expansions.extend(value_expansions)
+            value_outcomes, value_has_unknown_expansion = _static_iterable_first_outcomes(value)
+            alternative_outcomes.extend(value_outcomes)
             has_unknown_expansion = has_unknown_expansion or value_has_unknown_expansion
-        return expansions, has_unknown_expansion
+        return (
+            _deduplicate_static_argument_outcomes(alternative_outcomes),
+            has_unknown_expansion,
+        )
     if not isinstance(node, ast.List | ast.Tuple):
         return [], True
-    expansions = [[]]
+    outcomes: list[ast.AST | None] = [None]
     has_unknown_expansion = False
     for element in node.elts:
         if isinstance(element, ast.Starred):
-            nested_expansions, nested_has_unknown_expansion = _static_starred_argument_expansions(
+            element_outcomes, element_has_unknown_expansion = _static_iterable_first_outcomes(
                 element.value
             )
-            next_expansions: list[list[ast.AST]] = []
-            if nested_expansions:
-                next_expansions.extend(
-                    [*prefix, *nested] for prefix in expansions for nested in nested_expansions
-                )
-            if nested_has_unknown_expansion:
-                next_expansions.extend(expansions)
-            expansions = next_expansions
-            has_unknown_expansion = has_unknown_expansion or nested_has_unknown_expansion
         else:
-            expansions = [[*prefix, element] for prefix in expansions]
-    return expansions, has_unknown_expansion
+            element_outcomes = [element]
+            element_has_unknown_expansion = False
+        if any(outcome is None for outcome in outcomes):
+            next_outcomes: list[ast.AST | None] = []
+            for outcome in outcomes:
+                if outcome is None:
+                    next_outcomes.extend(element_outcomes)
+                else:
+                    next_outcomes.append(outcome)
+            if element_has_unknown_expansion:
+                next_outcomes.extend(outcomes)
+            outcomes = _deduplicate_static_argument_outcomes(next_outcomes)
+        has_unknown_expansion = has_unknown_expansion or element_has_unknown_expansion
+    return outcomes, has_unknown_expansion
 
 
 def _type_params(node: ast.AST) -> list[ast.AST]:

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/metadata_rules.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/metadata_rules.py
@@ -6,7 +6,7 @@ import ast
 from enum import Enum, auto
 from pathlib import Path
 
-from flow_metadata_linter.ast_helpers import _static_call_argument_nodes
+from flow_metadata_linter.ast_helpers import _static_first_call_argument_nodes
 from flow_metadata_linter.paths import ADDON_ROOT as _ADDON_ROOT
 from flow_metadata_linter.registry import REGISTERED_METADATA_KEYS as _REGISTERED_METADATA_KEYS
 
@@ -167,7 +167,7 @@ def _metadata_collection_call_violations(
             and node.func.attr == "fromkeys"
         ):
             violations: list[str] = []
-            for keys_arg in _static_call_argument_nodes(node.args, 0):
+            for keys_arg in _static_first_call_argument_nodes(node.args):
                 violations.extend(
                     _metadata_collection_violations(
                         path, keys_arg, _MetadataCollectionMode.KEY_SEQUENCE
@@ -197,7 +197,7 @@ def _metadata_collection_call_violations(
         return []
     if node.func.id == "dict" and mode is not _MetadataCollectionMode.PAIR_ITERABLE:
         violations = []
-        for update_arg in _static_call_argument_nodes(node.args, 0):
+        for update_arg in _static_first_call_argument_nodes(node.args):
             violations.extend(
                 _metadata_collection_violations(
                     path, update_arg, _MetadataCollectionMode.MAPPING_INPUT
@@ -207,7 +207,7 @@ def _metadata_collection_call_violations(
         return violations
     if node.func.id == "zip" and mode is not _MetadataCollectionMode.KEY_SEQUENCE:
         violations = []
-        for keys_arg in _static_call_argument_nodes(node.args, 0):
+        for keys_arg in _static_first_call_argument_nodes(node.args):
             violations.extend(
                 _metadata_collection_violations(
                     path, keys_arg, _MetadataCollectionMode.KEY_SEQUENCE
@@ -216,7 +216,7 @@ def _metadata_collection_call_violations(
         return violations
     if node.func.id in _SEQUENCE_WRAPPER_CALLS:
         violations = []
-        for collection_arg in _static_call_argument_nodes(node.args, 0):
+        for collection_arg in _static_first_call_argument_nodes(node.args):
             violations.extend(_metadata_collection_violations(path, collection_arg, mode))
         return violations
     return []

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -14,7 +14,7 @@ from flow_metadata_linter.ast_helpers import (
     _pattern_names,
     _scope_bound_name_visitor,
     _statement_can_fall_through,
-    _static_call_argument_nodes,
+    _static_first_call_argument_nodes,
     _target_names,
     _type_alias_target_names,
     _type_alias_value,
@@ -675,10 +675,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self._record_metadata_merge_key_violations(keyword.value)
         if isinstance(node.func, ast.Attribute) and self._is_metadata_alias_value(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
-                for key_arg in _static_call_argument_nodes(node.args, 0):
+                for key_arg in _static_first_call_argument_nodes(node.args):
                     self._add_violations(_metadata_key_expression_violations(self.path, key_arg))
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
-                for update_arg in _static_call_argument_nodes(node.args, 0):
+                for update_arg in _static_first_call_argument_nodes(node.args):
                     self._record_metadata_dict_key_violations(update_arg)
                 for keyword in node.keywords:
                     if keyword.arg is None:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -14,6 +14,8 @@ _ADDON_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE_ROOT = _ADDON_ROOT / "tests" / "fixtures" / "flow_metadata_key_linter"
 _CHECK_SCRIPT = _ADDON_ROOT / "scripts" / "check-flow-metadata-keys.py"
 _CLI_TIMEOUT_SECONDS = 30
+_COMPLEX_STAR_ARGS_TIMEOUT_SECONDS = 2
+_COMPLEX_STAR_ARGS_BRANCH_COUNT = 24
 _SUPPORTS_EXCEPT_STAR_SYNTAX = sys.version_info >= (3, 11)
 _SUPPORTS_PEP695_SYNTAX = sys.version_info >= (3, 12)
 
@@ -43,7 +45,10 @@ def _violations_expected_fixture_name() -> str:
 
 
 def _run_check_script(
-    check_script: Path, addon_root: Path, executable_dir: Path
+    check_script: Path,
+    addon_root: Path,
+    executable_dir: Path,
+    timeout_seconds: int = _CLI_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess[str]:
     python3 = executable_dir / "python3"
     python3.symlink_to(Path(sys.executable).resolve())
@@ -63,8 +68,25 @@ def _run_check_script(
         text=True,
         capture_output=True,
         check=False,
-        timeout=_CLI_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
     )
+
+
+def _copy_linter_scripts(addon_root: Path) -> Path:
+    scripts_root = addon_root / "scripts"
+    scripts_root.mkdir(parents=True)
+    check_script = scripts_root / _CHECK_SCRIPT.name
+    shutil.copy2(_CHECK_SCRIPT, check_script)
+    shutil.copy2(
+        _ADDON_ROOT / "scripts" / "flow_metadata_key_linter.py",
+        scripts_root / "flow_metadata_key_linter.py",
+    )
+    shutil.copytree(
+        _ADDON_ROOT / "scripts" / "flow_metadata_linter",
+        scripts_root / "flow_metadata_linter",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+    return check_script
 
 
 def test_registered_flow_metadata_keys_are_unique():
@@ -85,21 +107,9 @@ def test_check_flow_metadata_keys_cli_passes_current_repository(tmp_path):
 
 def test_check_flow_metadata_keys_cli_reports_configured_registry_path(tmp_path):
     addon_root = tmp_path / "mitm-addon"
-    scripts_root = addon_root / "scripts"
-    scripts_root.mkdir(parents=True)
-    check_script = scripts_root / _CHECK_SCRIPT.name
-    shutil.copy2(_CHECK_SCRIPT, check_script)
-    shutil.copy2(
-        _ADDON_ROOT / "scripts" / "flow_metadata_key_linter.py",
-        scripts_root / "flow_metadata_key_linter.py",
-    )
-    shutil.copytree(
-        _ADDON_ROOT / "scripts" / "flow_metadata_linter",
-        scripts_root / "flow_metadata_linter",
-        ignore=shutil.ignore_patterns("__pycache__"),
-    )
+    check_script = _copy_linter_scripts(addon_root)
 
-    paths_file = scripts_root / "flow_metadata_linter" / "paths.py"
+    paths_file = addon_root / "scripts" / "flow_metadata_linter" / "paths.py"
     paths_file.write_text(
         paths_file.read_text(encoding="utf-8").replace(
             '"flow_metadata_keys.py"', '"renamed_flow_metadata_keys.py"'
@@ -117,6 +127,50 @@ def test_check_flow_metadata_keys_cli_reports_configured_registry_path(tmp_path)
     assert result.returncode == 1
     assert result.stdout == (
         "src/renamed_flow_metadata_keys.py: duplicate metadata key 'duplicate': FIRST, SECOND\n"
+    )
+    assert result.stderr == ""
+
+
+def test_check_flow_metadata_keys_cli_bounds_conditional_starred_arguments(tmp_path):
+    addon_root = tmp_path / "mitm-addon"
+    check_script = _copy_linter_scripts(addon_root)
+    src_root = addon_root / "src"
+    src_root.mkdir()
+    (src_root / "flow_metadata_keys.py").write_text(
+        'VM_RUN_ID = "vm_run_id"\n'
+        'FIREWALL_NAME = "firewall_name"\n'
+        'FIREWALL_ACTION = "firewall_action"\n',
+        encoding="utf-8",
+    )
+    tests_root = addon_root / "tests"
+    tests_root.mkdir()
+    starred_elements = [
+        '    *([] if c0 else ["vm_run_id"]),',
+        '    *(["firewall_name"] if c1 else ["firewall_action"]),',
+        *[
+            f'    *(["external-{index}-left"] if c{index} else ["external-{index}-right"]),'
+            for index in range(2, _COMPLEX_STAR_ARGS_BRANCH_COUNT)
+        ],
+    ]
+    (tests_root / "complex_star_args.py").write_text(
+        "flow.metadata.get(*[\n" + "\n".join(starred_elements) + "\n])\n",
+        encoding="utf-8",
+    )
+
+    result = _run_check_script(
+        check_script,
+        addon_root,
+        tmp_path,
+        timeout_seconds=_COMPLEX_STAR_ARGS_TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == (
+        "tests/complex_star_args.py:3: use metadata_keys.FIREWALL_NAME "
+        "for flow.metadata access\n"
+        "tests/complex_star_args.py:3: use metadata_keys.FIREWALL_ACTION "
+        "for flow.metadata access\n"
+        "tests/complex_star_args.py:2: use metadata_keys.VM_RUN_ID for flow.metadata access\n"
     )
     assert result.stderr == ""
 


### PR DESCRIPTION
## Summary

- replace Cartesian starred-argument expansion with ordered, de-duplicated first-argument outcomes
- specialize all six linter consumers on the positional argument they actually inspect while preserving empty and unknown expansion behavior
- add an isolated 24-branch CLI regression that bounds execution and pins first-seen diagnostic order

## Explicit exclusions

- no mitmproxy runtime behavior changes
- no API, schema, persistence, runner protocol, migration, or deployment compatibility changes
- no generic later-positional-index abstraction or arbitrary expansion budget

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python scripts/check-flow-metadata-keys.py`
- `.venv/bin/python -m pytest tests/test_flow_metadata_key_contract.py -q` (16 passed)
- `.venv/bin/python -m pytest tests/ -q` (4071 passed)

Closes #22049
