### PR TITLE
fix(mitm-addon): drain retained usage after executor shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1421,23 +1421,25 @@ def done():
 
     The runner flush lifecycle waits for any active SIGUSR1 worker, drains
     accepted requests, and closes admission before this hook shuts down the
-    usage executor and JSONL writer. Auth.base forwarding does not need to
-    finish running work during shutdown, so its worker shutdown stops new
-    forwards and best-effort closes active upstream sockets without waiting for
-    slow upstream responses. JSONL writer shutdown is also bounded and
-    best-effort; if it times out, process shutdown continues with accepted log
-    entries possibly still pending.
+    usage executor. Any retryable outcome retained by those completed workers
+    is then delivered synchronously before the remaining workers and JSONL
+    writer stop. Auth.base forwarding does not need to finish running work
+    during shutdown, so its worker shutdown stops new forwards and best-effort
+    closes active upstream sockets without waiting for slow upstream responses.
+    JSONL writer shutdown is also bounded and best-effort; if it times out,
+    process shutdown continues with accepted log entries possibly still pending.
     """
     try:
         runner_flush_lifecycle.drain_and_close()
     finally:
         try:
-            usage.webhook.usage_executor.shutdown(wait=True)
-        finally:
             try:
-                auth_base_forwarder.shutdown_forward_request_workers(wait=False)
+                usage.webhook.usage_executor.shutdown(wait=True)
+                usage.drain_usage_events_after_executor_shutdown()
             finally:
-                shutdown_log_writer()
+                auth_base_forwarder.shutdown_forward_request_workers(wait=False)
+        finally:
+            shutdown_log_writer()
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1422,8 +1422,8 @@ def done():
     The runner flush lifecycle waits for any active SIGUSR1 worker, drains
     accepted requests, and closes admission before this hook shuts down the
     usage executor. Any retryable outcome retained by those completed workers
-    is then delivered synchronously before the remaining workers and JSONL
-    writer stop. Auth.base forwarding does not need to finish running work
+    is then retried synchronously before the remaining workers and JSONL writer
+    stop. Auth.base forwarding does not need to finish running work
     during shutdown, so its worker shutdown stops new forwards and best-effort
     closes active upstream sockets without waiting for slow upstream responses.
     JSONL writer shutdown is also bounded and best-effort; if it times out,

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -34,6 +34,7 @@ from .buffer import (
     buffer_source_usage_events,
     buffer_usage_events,
     configure_usage_buffer,
+    drain_usage_events_after_executor_shutdown,
     flush_usage_events,
     reset_usage_buffer_for_tests,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "create_openai_responses_sse_usage_extractor",
     "current_usage_state_id",
     "decrement_in_flight_flows",
+    "drain_usage_events_after_executor_shutdown",
     "extract_anthropic_messages_usage_from_json",
     "extract_anthropic_messages_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event_json",

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "buffer_source_usage_events",
     "buffer_usage_events",
     "configure_usage_buffer",
+    "drain_usage_events_after_executor_shutdown",
     "flush_usage_events",
     "reset_usage_buffer_for_tests",
 ]
@@ -181,6 +182,11 @@ def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
     schedule another timer.
     """
     return _usage_event_buffer.flush_usage_events(trigger=trigger)
+
+
+def drain_usage_events_after_executor_shutdown() -> None:
+    """Synchronously drain usage retained after the executor has stopped."""
+    _usage_event_buffer.drain_usage_events_after_executor_shutdown()
 
 
 def reset_usage_buffer_for_tests(

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -164,6 +164,20 @@ class UsageEventBuffer:
         """
         return self._flush_usage_events(trigger=trigger)
 
+    def drain_usage_events_after_executor_shutdown(self) -> None:
+        """Synchronously drain work retained by completed executor callbacks.
+
+        The caller must first shut down and join the usage executor so no
+        earlier asynchronous delivery can retain another batch after this
+        method observes an empty schedulable state. New deliveries then use
+        the webhook layer's synchronous fallback.
+        """
+        while True:
+            with self._lock:
+                if not self._state.has_schedulable_work():
+                    return
+            self._flush_usage_events(trigger="shutdown")
+
     def close(self) -> None:
         """Cancel any pending timer for test cleanup or process shutdown."""
         with self._lock:

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -12,7 +12,7 @@ import usage
 from tests.pending_helpers import assert_current_pending
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
 from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
-from tests.usage_helpers import install_recording_usage_timer
+from tests.usage_helpers import UsageWebhookServer, install_recording_usage_timer
 
 
 class TestDoneHook:
@@ -241,41 +241,35 @@ class TestDoneHook:
         self,
         tmp_path,
         fresh_usage_executor,
+        mitm_ctx,
     ):
         pending_path = tmp_path / "usage-pending"
         proxy_log_path = tmp_path / "proxy.jsonl"
         usage.set_pending_path(str(pending_path))
         timers = install_recording_usage_timer()
-        post_payloads: list[bytes] = []
-        post_threads: list[threading.Thread] = []
-
-        def post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
-            del url, sandbox_token
-            post_payloads.append(data)
-            post_threads.append(threading.current_thread())
-            if len(post_payloads) <= 2:
-                raise OSError("retry after executor shutdown")
-
-        usage.buffer_usage_events(
-            "https://api.test/api/webhooks/agent/usage-event",
-            "token-a",
-            "run-1",
-            [event(source_key="source-1")],
-            str(proxy_log_path),
-        )
+        server = UsageWebhookServer()
+        server.queue_response(500)
+        server.queue_response(500)
+        server.queue_response(204)
 
         with (
-            patch.object(usage.webhook, "_post_webhook", side_effect=post_webhook),
+            server.run(),
+            mitm_ctx(),
             patch.object(usage.webhook.time, "sleep"),
             patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
             patch.object(mitm_addon, "shutdown_log_writer"),
         ):
+            usage.buffer_usage_events(
+                server.url(),
+                "token-a",
+                "run-1",
+                [event(source_key="source-1")],
+                str(proxy_log_path),
+            )
             mitm_addon.done()
 
-        assert len(post_payloads) == 3
-        assert post_payloads == [post_payloads[0]] * 3
-        assert post_threads[:2] == [post_threads[0]] * 2
-        assert post_threads[2] is threading.current_thread()
+        assert server.request_count == 3
+        assert server.json_bodies() == [server.json_bodies()[0]] * 3
         assert len(timers) == 1
         assert timers[0].cancelled is True
         assert_current_pending(
@@ -290,27 +284,18 @@ class TestDoneHook:
         self,
         tmp_path,
         fresh_usage_executor,
+        mitm_ctx,
     ):
         pending_path = tmp_path / "usage-pending"
         proxy_log_path = tmp_path / "proxy.jsonl"
         usage.set_pending_path(str(pending_path))
         timers = install_recording_usage_timer()
-        first_post_started = threading.Event()
         release_first_post = threading.Event()
         executor_shutdown_started = threading.Event()
-        post_payloads: list[bytes] = []
-        post_threads: list[threading.Thread] = []
-
-        def post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
-            del url, sandbox_token
-            post_payloads.append(data)
-            post_threads.append(threading.current_thread())
-            if len(post_payloads) == 1:
-                first_post_started.set()
-                if not release_first_post.wait(timeout=1):
-                    raise AssertionError("test did not release the first delivery")
-            if len(post_payloads) <= 2:
-                raise OSError("retry after executor shutdown")
+        server = UsageWebhookServer()
+        server.queue_response(500, release_event=release_first_post)
+        server.queue_response(500)
+        server.queue_response(204)
 
         original_shutdown = fresh_usage_executor.shutdown
 
@@ -319,7 +304,8 @@ class TestDoneHook:
             original_shutdown(wait=wait)
 
         with (
-            patch.object(usage.webhook, "_post_webhook", side_effect=post_webhook),
+            server.run(),
+            mitm_ctx(),
             patch.object(usage.webhook.time, "sleep"),
             patch.object(
                 fresh_usage_executor,
@@ -330,14 +316,14 @@ class TestDoneHook:
             patch.object(mitm_addon, "shutdown_log_writer"),
         ):
             usage.buffer_usage_events(
-                "https://api.test/api/webhooks/agent/usage-event",
+                server.url(),
                 "token-a",
                 "run-1",
                 [event(source_key="source-1")],
                 str(proxy_log_path),
             )
             assert usage.flush_usage_events(trigger="runner") == 1
-            assert first_post_started.wait(timeout=1)
+            assert server.wait_for_request_count(1)
 
             done_thread = ThreadUnderTest(target=mitm_addon.done)
             try:
@@ -355,10 +341,8 @@ class TestDoneHook:
                 release_first_post.set()
                 done_thread.join(timeout=1)
 
-        assert len(post_payloads) == 3
-        assert post_payloads == [post_payloads[0]] * 3
-        assert post_threads[:2] == [post_threads[0]] * 2
-        assert post_threads[2] is not post_threads[0]
+        assert server.request_count == 3
+        assert server.json_bodies() == [server.json_bodies()[0]] * 3
         assert len(timers) == 2
         assert all(timer.cancelled for timer in timers)
         assert_current_pending(

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -1,6 +1,7 @@
 """Tests for mitm addon shutdown hooks."""
 
 import threading
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,7 +9,10 @@ import pytest
 import mitm_addon
 import runner_flush_lifecycle
 import usage
+from tests.pending_helpers import assert_current_pending
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
+from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
+from tests.usage_helpers import install_recording_usage_timer
 
 
 class TestDoneHook:
@@ -232,3 +236,198 @@ class TestDoneHook:
         with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker") as start_worker:
             runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
         start_worker.assert_not_called()
+
+    def test_done_retries_shutdown_delivery_after_executor_join(
+        self,
+        tmp_path,
+        fresh_usage_executor,
+    ):
+        pending_path = tmp_path / "usage-pending"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        usage.set_pending_path(str(pending_path))
+        timers = install_recording_usage_timer()
+        post_payloads: list[bytes] = []
+        post_threads: list[threading.Thread] = []
+
+        def post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
+            del url, sandbox_token
+            post_payloads.append(data)
+            post_threads.append(threading.current_thread())
+            if len(post_payloads) <= 2:
+                raise OSError("retry after executor shutdown")
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            str(proxy_log_path),
+        )
+
+        with (
+            patch.object(usage.webhook, "_post_webhook", side_effect=post_webhook),
+            patch.object(usage.webhook.time, "sleep"),
+            patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
+            patch.object(mitm_addon, "shutdown_log_writer"),
+        ):
+            mitm_addon.done()
+
+        assert len(post_payloads) == 3
+        assert post_payloads == [post_payloads[0]] * 3
+        assert post_threads[:2] == [post_threads[0]] * 2
+        assert post_threads[2] is threading.current_thread()
+        assert len(timers) == 1
+        assert timers[0].cancelled is True
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="done-drained",
+        )
+
+    def test_done_waits_for_preexisting_delivery_before_final_retry(
+        self,
+        tmp_path,
+        fresh_usage_executor,
+    ):
+        pending_path = tmp_path / "usage-pending"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        usage.set_pending_path(str(pending_path))
+        timers = install_recording_usage_timer()
+        first_post_started = threading.Event()
+        release_first_post = threading.Event()
+        executor_shutdown_started = threading.Event()
+        post_payloads: list[bytes] = []
+        post_threads: list[threading.Thread] = []
+
+        def post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
+            del url, sandbox_token
+            post_payloads.append(data)
+            post_threads.append(threading.current_thread())
+            if len(post_payloads) == 1:
+                first_post_started.set()
+                if not release_first_post.wait(timeout=1):
+                    raise AssertionError("test did not release the first delivery")
+            if len(post_payloads) <= 2:
+                raise OSError("retry after executor shutdown")
+
+        original_shutdown = fresh_usage_executor.shutdown
+
+        def shutdown_executor(*, wait: bool) -> None:
+            executor_shutdown_started.set()
+            original_shutdown(wait=wait)
+
+        with (
+            patch.object(usage.webhook, "_post_webhook", side_effect=post_webhook),
+            patch.object(usage.webhook.time, "sleep"),
+            patch.object(
+                fresh_usage_executor,
+                "shutdown",
+                side_effect=shutdown_executor,
+            ),
+            patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
+            patch.object(mitm_addon, "shutdown_log_writer"),
+        ):
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                "run-1",
+                [event(source_key="source-1")],
+                str(proxy_log_path),
+            )
+            assert usage.flush_usage_events(trigger="runner") == 1
+            assert first_post_started.wait(timeout=1)
+
+            done_thread = ThreadUnderTest(target=mitm_addon.done)
+            try:
+                done_thread.start()
+                wait_for_event(
+                    executor_shutdown_started,
+                    timeout=1,
+                    threads=(done_thread,),
+                    message="done did not begin executor shutdown",
+                )
+                assert done_thread.is_alive()
+                release_first_post.set()
+                done_thread.join_and_raise(timeout=1)
+            finally:
+                release_first_post.set()
+                done_thread.join(timeout=1)
+
+        assert len(post_payloads) == 3
+        assert post_payloads == [post_payloads[0]] * 3
+        assert post_threads[:2] == [post_threads[0]] * 2
+        assert post_threads[2] is not post_threads[0]
+        assert len(timers) == 2
+        assert all(timer.cancelled for timer in timers)
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="preexisting-delivery-drained",
+        )
+
+    def test_done_drops_repeatedly_retained_delivery_at_existing_retry_budget(
+        self,
+        tmp_path,
+    ):
+        pending_path = tmp_path / "usage-pending"
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        usage.set_pending_path(str(pending_path))
+        lifecycle_calls: list[str] = []
+
+        def reject_delivery(
+            url: str,
+            sandbox_token: str,
+            payload: dict,
+            path: str,
+            log_type: str,
+            delivery_outcome_callback: Callable[[usage.webhook.WebhookDeliveryOutcome], None],
+        ) -> bool:
+            del url, sandbox_token, payload, path, log_type, delivery_outcome_callback
+            lifecycle_calls.append("enqueue")
+            return False
+
+        enqueue = RecordingEnqueue(side_effect=reject_delivery)
+        timers = install_recording_usage_timer(
+            enqueue_webhook=enqueue,
+            max_retained_batch_retries=1,
+        )
+        mock_executor = MagicMock()
+        mock_executor.shutdown.side_effect = lambda *, wait: lifecycle_calls.append(
+            f"shutdown:{wait}"
+        )
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "secret-token",
+            "run-1",
+            [event(source_key="source-1")],
+            str(proxy_log_path),
+        )
+
+        with (
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
+            patch.object(mitm_addon, "shutdown_log_writer"),
+        ):
+            mitm_addon.done()
+
+        assert lifecycle_calls == ["enqueue", "shutdown:True", "enqueue"]
+        assert enqueue.payloads == [enqueue.payloads[0]] * 2
+        assert len(timers) == 1
+        assert timers[0].cancelled is True
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="retry-budget-drained",
+        )
+        dropped_entries = [
+            entry for entry in flush_log_entries(proxy_log_path) if entry["phase"] == "dropped"
+        ]
+        assert len(dropped_entries) == 1
+        assert dropped_entries[0]["reason"] == "retry_budget_exhausted"
+        assert dropped_entries[0]["underbilling_class"] == "confirmed"

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -68,7 +68,7 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_pa
         use_fresh_executor()
 
     flush.assert_called_once_with(trigger="shutdown")
-    enqueue.assert_called_once()
+    assert enqueue.call_count == 2
     assert usage.webhook.usage_executor is original
     with pytest.raises(RuntimeError, match="shutdown"):
         executors[0].submit(lambda: None)

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -9,7 +9,12 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
-from tests.usage_helpers import UsageWebhookServer, fresh_usage_executor_context
+from tests.pending_helpers import assert_current_pending
+from tests.usage_helpers import (
+    UsageWebhookServer,
+    fresh_usage_executor_context,
+    install_recording_usage_timer,
+)
 
 
 def _event(source_key: str = "source-1") -> usage_buffer.UsageEvent:
@@ -97,3 +102,39 @@ def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path, 
     assert usage.webhook.usage_executor is original
     with pytest.raises(RuntimeError, match="shutdown"):
         executors[0].submit(lambda: None)
+
+
+def test_fresh_usage_executor_drains_retryable_delivery_after_join(tmp_path, mitm_ctx):
+    pending_path = tmp_path / "usage-pending"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
+    timers = install_recording_usage_timer()
+    server = UsageWebhookServer()
+    server.queue_response(500)
+    server.queue_response(500)
+
+    with (
+        server.run(),
+        mitm_ctx(),
+        patch.object(usage.webhook.time, "sleep"),
+        fresh_usage_executor_context(),
+    ):
+        usage.buffer_usage_events(
+            server.url(),
+            "token-a",
+            "run-1",
+            [_event()],
+            str(proxy_log_path),
+        )
+
+    assert server.request_count == 3
+    assert server.json_bodies() == [server.json_bodies()[0]] * 3
+    assert len(timers) == 1
+    assert timers[0].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="fixture-drained",
+    )

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -88,6 +88,7 @@ def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
                 usage.flush_usage_events(trigger="shutdown")
             finally:
                 executor.shutdown(wait=True)
+            usage.drain_usage_events_after_executor_shutdown()
         finally:
             usage.webhook.usage_executor = original
 

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -88,7 +88,7 @@ def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
                 usage.flush_usage_events(trigger="shutdown")
             finally:
                 executor.shutdown(wait=True)
-            usage.drain_usage_events_after_executor_shutdown()
+                usage.drain_usage_events_after_executor_shutdown()
         finally:
             usage.webhook.usage_executor = original
 
@@ -98,6 +98,7 @@ class WebhookResponse:
     status: int = 204
     headers: tuple[tuple[str, str], ...] = ()
     body: bytes = b""
+    release_event: threading.Event | None = None
 
 
 @dataclass(frozen=True)
@@ -119,8 +120,10 @@ class CapturedWebhookRequest:
 class UsageWebhookServer:
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._request_condition = threading.Condition()
         self._requests: list[CapturedWebhookRequest] = []
         self._responses: deque[WebhookResponse] = deque()
+        self._release_events: list[threading.Event] = []
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
 
@@ -151,10 +154,27 @@ class UsageWebhookServer:
         *,
         headers: Sequence[tuple[str, str]] = (),
         body: bytes = b"",
+        release_event: threading.Event | None = None,
     ) -> None:
+        """Queue a response, optionally blocking it until an event is set."""
         with self._lock:
+            if release_event is not None:
+                self._release_events.append(release_event)
             self._responses.append(
-                WebhookResponse(status=status, headers=tuple(headers), body=body)
+                WebhookResponse(
+                    status=status,
+                    headers=tuple(headers),
+                    body=body,
+                    release_event=release_event,
+                )
+            )
+
+    def wait_for_request_count(self, count: int, *, timeout: float = 2.0) -> bool:
+        """Wait until at least ``count`` requests have been recorded."""
+        with self._request_condition:
+            return self._request_condition.wait_for(
+                lambda: self.request_count >= count,
+                timeout,
             )
 
     def json_bodies(self) -> list[dict[str, Any]]:
@@ -204,6 +224,11 @@ class UsageWebhookServer:
         try:
             yield self
         finally:
+            with self._lock:
+                release_events = tuple(self._release_events)
+                self._release_events.clear()
+            for release_event in release_events:
+                release_event.set()
             self._server.shutdown()
             self._thread.join(timeout=2.0)
             self._server.server_close()
@@ -215,9 +240,10 @@ class UsageWebhookServer:
     ) -> WebhookResponse:
         with self._lock:
             self._requests.append(request)
-            if self._responses:
-                return self._responses.popleft()
-            return WebhookResponse()
+            response = self._responses.popleft() if self._responses else WebhookResponse()
+        with self._request_condition:
+            self._request_condition.notify_all()
+        return response
 
     def _handle_request(self, handler: BaseHTTPRequestHandler) -> None:
         content_length = int(handler.headers.get("content-length", "0"))
@@ -230,6 +256,8 @@ class UsageWebhookServer:
                 body=body,
             )
         )
+        if response.release_event is not None:
+            response.release_event.wait()
 
         handler.send_response(response.status)
         for name, value in response.headers:


### PR DESCRIPTION
## Summary

- wait for the usage executor to finish all admitted deliveries before the final shutdown drain
- synchronously retry batches retained by completed delivery callbacks until they succeed or reach the existing retry budget
- preserve payloads and idempotency keys across the shutdown retry, and align the temporary test executor lifecycle with production

## Not changed

- no database schema, migration, persisted-data format, API, runner protocol, or queue payload changes
- no new timeout, background worker, durable outbox, or retry policy

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright`
- `.venv/bin/pytest -q tests/test_done_hook.py tests/test_fresh_usage_executor.py tests/test_usage_buffer_timer_shutdown.py`
- `.venv/bin/pytest` (4074 passed)

Closes #22053
