### PR TITLE
fix: dismiss feedback pill after system copy

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -444,7 +444,18 @@ function createSelectionToolbarRef({
       el.ownerDocument.addEventListener(
         "keydown",
         onDomEventFn(async (event: KeyboardEvent) => {
-          if (event.defaultPrevented || toolbarSignal.aborted) {
+          if (toolbarSignal.aborted) {
+            return;
+          }
+          if (matchShortcut("mod+c", event)) {
+            // Let the browser copy the native selection before clearing it.
+            // Closing synchronously here would leave the default copy action
+            // with no selected text to put on the clipboard.
+            await delay(0, { signal: toolbarSignal });
+            set(closeSelectionToolbar$);
+            return;
+          }
+          if (event.defaultPrevented) {
             return;
           }
           if (matchShortcut("escape", event)) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -197,10 +197,14 @@ async function replaceFeedbackNote(
   await fastUser.keyboard(value);
 }
 
-function dispatchDocumentShortcut(key: string): KeyboardEvent {
+function dispatchDocumentShortcut(
+  key: string,
+  init?: Omit<KeyboardEventInit, "key">,
+): KeyboardEvent {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
     cancelable: true,
+    ...init,
     key,
   });
   document.dispatchEvent(event);
@@ -766,6 +770,48 @@ describe("chat inline feedback", () => {
     await waitForDeferredSelectionCapture();
 
     expect(composerEditor).toHaveFocus();
+  });
+
+  it("dismisses the inline feedback toolbar after the system copy shortcut", async () => {
+    const assistantReply = "Copy this passage with the system shortcut.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-copy-shortcut-user",
+          role: "user",
+          content: "Review this passage",
+          runId: "run-feedback-copy-shortcut",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-copy-shortcut-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-copy-shortcut",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+
+    const event = dispatchDocumentShortcut("c", { ctrlKey: true });
+    expect(event.defaultPrevented).toBeFalsy();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    });
   });
 
   it("focuses the inline feedback composer when started from the keyboard shortcut", async () => {


### PR DESCRIPTION
## Summary

- dismiss the feedback selection pill after `Cmd+C` or `Ctrl+C`
- preserve the browser's native copy behavior by clearing the selection after the default copy action completes
- add page-level regression coverage for the system copy shortcut

## Verification

- `pnpm exec prettier --write src/signals/zero-page/chat-feedback.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (16 passed)

Browser verification was not run, following the vm0 PR verification policy.
