### PR TITLE
fix(sandbox-fc): preserve graceful shutdown failure details

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1708,11 +1708,23 @@ impl Sandbox for FirecrackerSandbox {
         // with no user workload.
         let was_parked = self.is_parked;
         let guest = self.guest.lock().await.take();
-        if !was_parked
-            && let Some(guest) = guest
-            && !guest.shutdown(SHUTDOWN_TIMEOUT).await
-        {
-            warn!(id = %self.id, "graceful shutdown timed out");
+        if !was_parked && let Some(guest) = guest {
+            let started_at = tokio::time::Instant::now();
+            if let Err(error) = guest.shutdown(SHUTDOWN_TIMEOUT).await {
+                let failure_kind = match error.kind() {
+                    io::ErrorKind::TimedOut => "timeout",
+                    io::ErrorKind::InvalidData => "unexpected_response",
+                    _ => "request_failure",
+                };
+                warn!(
+                    sandbox_id = %self.id,
+                    timeout_ms = duration_ms(SHUTDOWN_TIMEOUT),
+                    elapsed_ms = duration_ms(started_at.elapsed()),
+                    failure_kind,
+                    error = %error,
+                    "graceful shutdown failed"
+                );
+            }
         }
         release_park_state_for_termination(
             &mut self.is_parked,

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3617,7 +3617,6 @@ async fn stop_logs_shutdown_timeout_and_reaches_stopped() {
     let mut sandbox = test_sandbox_with_state(SandboxState::Running);
     let sandbox_id = sandbox.id.clone();
     let mut guest = attach_mock_shutdown_guest(&sandbox).await;
-    tokio::time::pause();
     let (shutdown_seen_tx, shutdown_seen_rx) = tokio::sync::oneshot::channel();
     let (release_guest_tx, release_guest_rx) = tokio::sync::oneshot::channel();
     let guest_task = tokio::spawn(async move {
@@ -3634,6 +3633,7 @@ async fn stop_logs_shutdown_timeout_and_reaches_stopped() {
             result = &mut stop => panic!("stop completed before timeout: {result:?}"),
             seen = shutdown_seen_rx => seen.unwrap(),
         }
+        tokio::time::pause();
         tokio::time::advance(SHUTDOWN_TIMEOUT).await;
         stop.await
     })

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -9,7 +9,8 @@ use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 use vsock_proto::{
     Decoder, ExecControlStatus, HEADER_SIZE, MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_EXEC_CONTROL,
-    MSG_EXEC_CONTROL_RESULT, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
+    MSG_EXEC_CONTROL_RESULT, MSG_PING, MSG_PONG, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    RawMessage,
 };
 
 struct TestNormalOperationFence;
@@ -158,6 +159,26 @@ async fn mock_vsock_handshake(stream: &mut UnixStream, decoder: &mut Decoder) {
 
     let pong = vsock_proto::encode(MSG_PONG, msgs[0].seq, &[]).unwrap();
     stream.write_all(&pong).await.unwrap();
+}
+
+async fn attach_mock_shutdown_guest(sandbox: &FirecrackerSandbox) -> UnixStream {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let vsock_path = temp_dir
+        .path()
+        .join("shutdown")
+        .to_string_lossy()
+        .into_owned();
+    let wait_vsock_path = vsock_path.clone();
+    let host_task = tokio::spawn(async move {
+        VsockHost::wait_for_connection(&wait_vsock_path, Duration::from_secs(5))
+            .await
+            .unwrap()
+    });
+    let mut guest = connect_mock_guest(&vsock_path).await;
+    let mut decoder = Decoder::new();
+    mock_vsock_handshake(&mut guest, &mut decoder).await;
+    *sandbox.guest.lock().await = Some(Arc::new(host_task.await.unwrap()));
+    guest
 }
 
 async fn setup_exec_process_control_fixture() -> ExecProcessControlFixture {
@@ -3508,11 +3529,15 @@ fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Capture
         .unwrap_or_else(|| panic!("missing event {message}; events={events:#?}"))
 }
 
-fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
-    let actual = event
+fn captured_event_field<'a>(event: &'a CapturedEvent, field: &str) -> &'a str {
+    event
         .fields
         .get(field)
-        .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+        .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"))
+}
+
+fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
+    let actual = captured_event_field(event, field);
     assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
 }
 
@@ -3550,6 +3575,146 @@ fn has_captured_event(events: &[CapturedEvent], message: &str) -> bool {
             .get("message")
             .is_some_and(|actual| actual == message)
     })
+}
+
+fn assert_shutdown_failure_event<'a>(
+    events: &'a [CapturedEvent],
+    sandbox_id: &str,
+    failure_kind: &str,
+) -> &'a CapturedEvent {
+    let event = captured_event(events, "graceful shutdown failed");
+    assert_event_field(event, "sandbox_id", sandbox_id);
+    assert_event_field(event, "timeout_ms", "5000");
+    assert_event_field(event, "failure_kind", failure_kind);
+    captured_event_field(event, "elapsed_ms")
+        .parse::<u64>()
+        .unwrap_or_else(|error| panic!("invalid elapsed_ms; error={error}; event={event:#?}"));
+    event
+}
+
+#[tokio::test]
+async fn stop_with_shutdown_ack_is_quiet() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let guest_task = tokio::spawn(async move {
+        let shutdown = read_vsock_message(&mut guest).await;
+        assert_eq!(shutdown.msg_type, MSG_SHUTDOWN);
+        assert!(shutdown.payload.is_empty());
+        let response = vsock_proto::encode(MSG_SHUTDOWN_ACK, shutdown.seq, &[]).unwrap();
+        guest.write_all(&response).await.unwrap();
+    });
+
+    let (result, events) = capture_async_log_events(sandbox.stop()).await;
+
+    result.unwrap();
+    guest_task.await.unwrap();
+    assert_eq!(sandbox.current_state(), SandboxState::Stopped);
+    assert!(!has_captured_event(&events, "graceful shutdown failed"));
+}
+
+#[tokio::test]
+async fn stop_logs_shutdown_timeout_and_reaches_stopped() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let sandbox_id = sandbox.id.clone();
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    tokio::time::pause();
+    let (shutdown_seen_tx, shutdown_seen_rx) = tokio::sync::oneshot::channel();
+    let (release_guest_tx, release_guest_rx) = tokio::sync::oneshot::channel();
+    let guest_task = tokio::spawn(async move {
+        let shutdown = read_vsock_message(&mut guest).await;
+        assert_eq!(shutdown.msg_type, MSG_SHUTDOWN);
+        shutdown_seen_tx.send(()).unwrap();
+        let _ = release_guest_rx.await;
+    });
+
+    let (result, events) = capture_async_log_events(async {
+        let stop = sandbox.stop();
+        tokio::pin!(stop);
+        tokio::select! {
+            result = &mut stop => panic!("stop completed before timeout: {result:?}"),
+            seen = shutdown_seen_rx => seen.unwrap(),
+        }
+        tokio::time::advance(SHUTDOWN_TIMEOUT).await;
+        stop.await
+    })
+    .await;
+
+    result.unwrap();
+    let _ = release_guest_tx.send(());
+    guest_task.await.unwrap();
+    assert_eq!(sandbox.current_state(), SandboxState::Stopped);
+    let event = assert_shutdown_failure_event(&events, &sandbox_id, "timeout");
+    let elapsed_ms = captured_event_field(event, "elapsed_ms")
+        .parse::<u64>()
+        .unwrap();
+    assert!(
+        elapsed_ms >= duration_ms(SHUTDOWN_TIMEOUT),
+        "shutdown timeout elapsed too early; event={event:#?}"
+    );
+    assert_event_field(event, "error", "request timeout");
+}
+
+#[tokio::test]
+async fn stop_logs_shutdown_request_failure_and_reaches_stopped() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let sandbox_id = sandbox.id.clone();
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let guest_task = tokio::spawn(async move {
+        let shutdown = read_vsock_message(&mut guest).await;
+        assert_eq!(shutdown.msg_type, MSG_SHUTDOWN);
+        drop(guest);
+    });
+
+    let (result, events) = capture_async_log_events(sandbox.stop()).await;
+
+    result.unwrap();
+    guest_task.await.unwrap();
+    assert_eq!(sandbox.current_state(), SandboxState::Stopped);
+    let event = assert_shutdown_failure_event(&events, &sandbox_id, "request_failure");
+    assert_event_field(event, "error", "connection closed");
+}
+
+#[tokio::test]
+async fn stop_logs_unexpected_shutdown_response_and_kills_process() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let sandbox_id = sandbox.id.clone();
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let child = tokio::process::Command::new("cat")
+        .process_group(0)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let child_pid = child.id().unwrap();
+    let process = monitor_process(
+        &sandbox.id,
+        child,
+        Arc::clone(&sandbox.state),
+        Arc::clone(&sandbox.state_publish_lock),
+        sandbox.state_tx.clone(),
+        Arc::clone(&sandbox.guest),
+        CancellationToken::new(),
+    );
+    sandbox.runtime.set_process(process);
+    let guest_task = tokio::spawn(async move {
+        let shutdown = read_vsock_message(&mut guest).await;
+        assert_eq!(shutdown.msg_type, MSG_SHUTDOWN);
+        let response = vsock_proto::encode(MSG_PONG, shutdown.seq, &[]).unwrap();
+        guest.write_all(&response).await.unwrap();
+    });
+
+    let (result, events) = capture_async_log_events(sandbox.stop()).await;
+
+    result.unwrap();
+    guest_task.await.unwrap();
+    assert_eq!(sandbox.current_state(), SandboxState::Stopped);
+    assert!(!pid_is_running(child_pid), "fallback must kill the process");
+    let event = assert_shutdown_failure_event(&events, &sandbox_id, "unexpected_response");
+    assert!(
+        captured_event_field(event, "error").contains("unexpected lifecycle response type"),
+        "unexpected shutdown error; event={event:#?}"
+    );
 }
 
 fn mib(value: i64) -> i64 {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1183,12 +1183,15 @@ impl VsockHost {
     /// Request graceful shutdown from guest.
     ///
     /// The timeout covers waiting for the shared writer, writing the request,
-    /// and waiting for the acknowledgement. Returns `true` if the guest
-    /// acknowledges, and `false` on timeout, request failure, or an unexpected
-    /// response.
-    pub async fn shutdown(&self, timeout: Duration) -> bool {
-        let result = self.request(MSG_SHUTDOWN, &[], timeout).await;
-        matches!(result, Ok(ref m) if m.msg_type == MSG_SHUTDOWN_ACK)
+    /// and waiting for the acknowledgement.
+    pub async fn shutdown(&self, timeout: Duration) -> io::Result<()> {
+        self.lifecycle_request(
+            MSG_SHUTDOWN,
+            MSG_SHUTDOWN_ACK,
+            "shutdown_ack payload must be empty",
+            timeout,
+        )
+        .await
     }
 }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -1184,6 +1184,12 @@ impl VsockHost {
     ///
     /// The timeout covers waiting for the shared writer, writing the request,
     /// and waiting for the acknowledgement.
+    ///
+    /// # Errors
+    ///
+    /// Returns the request error if the guest cannot be reached or does not
+    /// acknowledge before the deadline. An unexpected response type or a
+    /// non-empty acknowledgement returns [`io::ErrorKind::InvalidData`].
     pub async fn shutdown(&self, timeout: Duration) -> io::Result<()> {
         self.lifecycle_request(
             MSG_SHUTDOWN,

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -78,7 +78,62 @@ async fn wait_for_connection_removes_listener_socket_on_abort() {
 }
 
 #[tokio::test]
-async fn test_shutdown() {
+async fn shutdown_accepts_empty_ack() {
+    let (host_stream, guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
+
+        let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+        assert!(shutdown.payload.is_empty());
+        guest
+            .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
+            .await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    host.shutdown(Duration::from_secs(2)).await.unwrap();
+    await_mock_guest(guest_task).await;
+}
+
+#[tokio::test]
+async fn shutdown_times_out_without_ack() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let shutdown_task = tokio::spawn(async move { host.shutdown(Duration::from_millis(50)).await });
+
+    let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+    assert!(shutdown.payload.is_empty());
+
+    let error = tokio::time::timeout(Duration::from_secs(2), shutdown_task)
+        .await
+        .expect("shutdown should respect its timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(error.to_string(), "request timeout");
+}
+
+#[tokio::test]
+async fn shutdown_preserves_connection_failure() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let shutdown_task = tokio::spawn(async move { host.shutdown(Duration::from_secs(2)).await });
+
+    let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+    assert!(shutdown.payload.is_empty());
+    drop(guest);
+
+    let error = tokio::time::timeout(Duration::from_secs(2), shutdown_task)
+        .await
+        .expect("shutdown should observe the closed connection")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(error.to_string(), "connection closed");
+}
+
+#[tokio::test]
+async fn shutdown_surfaces_guest_error() {
     let (host_stream, guest) = make_pair();
 
     let guest_task = tokio::spawn(async move {
@@ -87,12 +142,64 @@ async fn test_shutdown() {
 
         let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
         guest
-            .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
+            .send_error_response(shutdown.seq, "guest refused shutdown")
             .await;
     });
 
     let host = host_from_stream(host_stream).await.unwrap();
-    assert!(host.shutdown(Duration::from_secs(2)).await);
+    let error = host.shutdown(Duration::from_secs(2)).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert_eq!(error.to_string(), "guest refused shutdown");
+    await_mock_guest(guest_task).await;
+}
+
+#[tokio::test]
+async fn shutdown_rejects_wrong_ack_type() {
+    let (host_stream, guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
+
+        let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+        guest
+            .send_empty_response(MSG_OPERATIONS_RESUMED, shutdown.seq)
+            .await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let error = host.shutdown(Duration::from_secs(2)).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        error
+            .to_string()
+            .contains("unexpected lifecycle response type")
+    );
+    await_mock_guest(guest_task).await;
+}
+
+#[tokio::test]
+async fn shutdown_rejects_non_empty_ack_payload() {
+    let (host_stream, guest) = make_pair();
+
+    let guest_task = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest);
+        guest.complete_handshake().await;
+
+        let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+        guest
+            .send_response(MSG_SHUTDOWN_ACK, shutdown.seq, b"x")
+            .await;
+    });
+
+    let host = host_from_stream(host_stream).await.unwrap();
+    let error = host.shutdown(Duration::from_secs(2)).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        error
+            .to_string()
+            .contains("shutdown_ack payload must be empty")
+    );
     await_mock_guest(guest_task).await;
 }
 

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -854,7 +854,7 @@ async fn lifecycle_request_writes_while_file_frame_builder_waits() {
     guest
         .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
         .await;
-    assert!(shutdown_task.await.unwrap());
+    shutdown_task.await.unwrap().unwrap();
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
 
     drop(frame_builder_guard);
@@ -897,7 +897,7 @@ async fn file_write_gate_holds_through_result_and_lifecycle_bypasses_it() {
     guest
         .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
         .await;
-    assert!(shutdown_task.await.unwrap());
+    shutdown_task.await.unwrap().unwrap();
     assert!(host.shared.file_write_gate.try_lock().is_err());
 
     send_write_file_success(guest.stream_mut(), first.seq()).await;

--- a/crates/vsock-test/tests/integration/shutdown.rs
+++ b/crates/vsock-test/tests/integration/shutdown.rs
@@ -8,8 +8,7 @@ use crate::support::{Harness, exec_exit_code, run_exec};
 async fn test_shutdown() {
     let h = Harness::new().await;
 
-    let acked = h.host().shutdown(Duration::from_secs(5)).await;
-    assert!(acked);
+    h.host().shutdown(Duration::from_secs(5)).await.unwrap();
 
     h.finish_ignore_guest();
 }
@@ -24,8 +23,7 @@ async fn test_shutdown_after_exec() {
         .expect("exec failed");
     assert_eq!(exec_exit_code(&result), Some(0));
 
-    let acked = h.host().shutdown(Duration::from_secs(5)).await;
-    assert!(acked);
+    h.host().shutdown(Duration::from_secs(5)).await.unwrap();
 
     h.finish_ignore_guest();
 }


### PR DESCRIPTION
## Summary

- Preserve shutdown lifecycle errors and validate that the guest returns an empty shutdown acknowledgement.
- Emit structured graceful-shutdown diagnostics for timeouts, unexpected responses, and request failures.
- Keep the existing force-kill fallback and verify that shutdown failures still reach `Stopped`, including with a real monitored child process.

## Scope

- The five-second graceful-shutdown deadline is unchanged.
- No retries, wire-protocol changes, or persisted-state changes are introduced.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::connection`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc shutdown`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test --test integration shutdown`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-fc -p vsock-test --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-fc --all-features --no-deps`

Closes #22057
