### PR TITLE
fix(runner): keep local submit secrets out of argv

### DIFF
--- a/.github/scripts/runner-behavior-local-claude-active-input-smoke.sh
+++ b/.github/scripts/runner-behavior-local-claude-active-input-smoke.sh
@@ -8,10 +8,9 @@ fi
 
 REMOTE="${METAL_USER}@${HOST}"
 {
-  # Keep the CI provider key off SSH/bash argv; the runner CLI still
-  # receives it through --secret-env because that is the behavior
-  # under test.
-  printf 'ANTHROPIC_API_KEY=%q\n' "$ANTHROPIC_API_KEY"
+  # Transfer the provider key through remote shell stdin so runner argv
+  # contains only the environment variable name.
+  printf 'export ANTHROPIC_API_KEY=%q\n' "$ANTHROPIC_API_KEY"
   cat <<'REMOTE_SCRIPT'
 set -euo pipefail
 
@@ -68,12 +67,12 @@ PROMPT='This is a CI smoke test for Claude Code active input. The initial prompt
 EXPECTED_RESULT='RESULT=ci-initial-5k2+ci-active-one-7f3+ci-active-two-9q4'
 
 echo "--- Submitting active-input smoke job ---"
-if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+if ! SUBMIT_OUTPUT=$(sudo --preserve-env=ANTHROPIC_API_KEY "$BIN_DIR/runner" local submit \
   --group "$GROUP" \
   --timeout 180 \
   --cli-agent-type claude-code \
   --env ANTHROPIC_MODEL=claude-haiku-4-5 \
-  --secret-env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  --secret-env ANTHROPIC_API_KEY \
   --prompt "$PROMPT" \
   --active-input 'after=100ms,text=ci-active-one-7f3' \
   --active-input 'after=300ms,text=ci-active-two-9q4' 2>&1); then

--- a/.github/scripts/runner-behavior-local-codex-active-input-smoke.sh
+++ b/.github/scripts/runner-behavior-local-codex-active-input-smoke.sh
@@ -8,10 +8,9 @@ fi
 
 REMOTE="${METAL_USER}@${HOST}"
 {
-  # Keep the CI provider key off SSH/bash argv; the runner CLI still
-  # receives it through --secret-env because that is the behavior
-  # under test.
-  printf 'OPENAI_API_KEY=%q\n' "$OPENAI_API_KEY"
+  # Transfer the provider key through remote shell stdin so runner argv
+  # contains only the environment variable name.
+  printf 'export OPENAI_API_KEY=%q\n' "$OPENAI_API_KEY"
   cat <<'REMOTE_SCRIPT'
 set -euo pipefail
 
@@ -68,12 +67,12 @@ PROMPT='This is a CI smoke test for Codex active input. The initial prompt token
 EXPECTED_RESULT='RESULT=codex-initial-8m6+codex-active-one-2p9+codex-active-two-6v1'
 
 echo "--- Submitting Codex active-input smoke job ---"
-if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+if ! SUBMIT_OUTPUT=$(sudo --preserve-env=OPENAI_API_KEY "$BIN_DIR/runner" local submit \
   --group "$GROUP" \
   --timeout 240 \
   --cli-agent-type codex \
   --env OPENAI_MODEL=gpt-5.4-mini \
-  --secret-env OPENAI_API_KEY="$OPENAI_API_KEY" \
+  --secret-env OPENAI_API_KEY \
   --prompt "$PROMPT" \
   --active-input 'after=100ms,text=codex-active-one-2p9' \
   --active-input 'after=300ms,text=codex-active-two-6v1' 2>&1); then

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -54,7 +54,7 @@ pub struct SubmitArgs {
     /// Ordinary environment variables to pass to the local job (KEY=VALUE)
     #[arg(long = "env")]
     env: Vec<String>,
-    /// Local-only secret environment variables to pass and register for masking (KEY=VALUE)
+    /// Names of inherited environment variables to pass to the local job and register for masking
     #[arg(long = "secret-env")]
     secret_env: Vec<String>,
     /// Timeout in seconds waiting for a runner to complete the job (max: 24 hours)
@@ -371,8 +371,8 @@ impl SubmitPlan {
         };
 
         let feature_flags = Self::parse_feature_flags(&feature_flags)?;
-        let environment = Self::parse_env_entries("--env", &env, true)?;
-        let secret_environment = Self::parse_env_entries("--secret-env", &secret_env, false)?;
+        let environment = Self::parse_env_entries("--env", &env)?;
+        let secret_environment = Self::resolve_secret_env(&secret_env)?;
         Self::validate_disjoint_env_keys(&environment, &secret_environment)?;
         let timeout = Self::validate_timeout(timeout)?;
         let group_dir = home.groups_dir().join(&group);
@@ -549,7 +549,6 @@ impl SubmitPlan {
     fn parse_env_entries(
         flag: &str,
         entries: &[String],
-        allow_guest_agent_tuning_keys: bool,
     ) -> RunnerResult<Option<HashMap<String, String>>> {
         if entries.is_empty() {
             return Ok(None);
@@ -575,29 +574,70 @@ impl SubmitPlan {
 
             let key = &entry[..eq_pos];
             let value = &entry[eq_pos + 1..];
-            if !guest_contracts::env::is_shell_identifier_env_key(key) {
-                return Err(RunnerError::Config(format!(
-                    "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
-                )));
-            }
-            let is_guest_agent_tuning_key =
-                guest_contracts::env::is_guest_agent_tuning_env_key(key);
-            if is_guest_agent_tuning_key && !allow_guest_agent_tuning_keys {
-                return Err(RunnerError::Config(format!(
-                    "invalid {flag} key '{key}': guest-agent tuning environment variables must be passed with --env"
-                )));
-            }
-            if guest_contracts::env::is_runner_owned_env_key(key) && !is_guest_agent_tuning_key {
-                return Err(RunnerError::Config(format!(
-                    "invalid {flag} key '{key}': runner-owned environment variables are not allowed"
-                )));
-            }
+            Self::validate_env_key(flag, key, true)?;
             if map.insert(key.to_owned(), value.to_owned()).is_some() {
                 return Err(RunnerError::Config(format!("duplicate {flag} key '{key}'")));
             }
         }
 
         Ok(Some(map))
+    }
+
+    fn resolve_secret_env(keys: &[String]) -> RunnerResult<Option<HashMap<String, String>>> {
+        if keys.is_empty() {
+            return Ok(None);
+        }
+
+        let mut unique_keys = HashSet::with_capacity(keys.len());
+        for key in keys {
+            if key.contains(['\0', '=']) {
+                return Err(RunnerError::Config(
+                    "invalid --secret-env value: expected an environment variable name without a value"
+                        .to_string(),
+                ));
+            }
+            Self::validate_env_key("--secret-env", key, false)?;
+            if !unique_keys.insert(key.as_str()) {
+                return Err(RunnerError::Config(format!(
+                    "duplicate --secret-env key '{key}'"
+                )));
+            }
+        }
+
+        let mut map = HashMap::with_capacity(keys.len());
+        for key in keys {
+            let value = std::env::var(key).map_err(|_| {
+                RunnerError::Config(format!(
+                    "secret environment variable '{key}' is not set or is not valid Unicode"
+                ))
+            })?;
+            map.insert(key.clone(), value);
+        }
+        Ok(Some(map))
+    }
+
+    fn validate_env_key(
+        flag: &str,
+        key: &str,
+        allow_guest_agent_tuning_keys: bool,
+    ) -> RunnerResult<()> {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
+            return Err(RunnerError::Config(format!(
+                "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
+            )));
+        }
+        let is_guest_agent_tuning_key = guest_contracts::env::is_guest_agent_tuning_env_key(key);
+        if is_guest_agent_tuning_key && !allow_guest_agent_tuning_keys {
+            return Err(RunnerError::Config(format!(
+                "invalid {flag} key '{key}': guest-agent tuning environment variables must be passed with --env"
+            )));
+        }
+        if guest_contracts::env::is_runner_owned_env_key(key) && !is_guest_agent_tuning_key {
+            return Err(RunnerError::Config(format!(
+                "invalid {flag} key '{key}': runner-owned environment variables are not allowed"
+            )));
+        }
+        Ok(())
     }
 
     fn validate_disjoint_env_keys(

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -55,7 +55,7 @@ pub struct SubmitArgs {
     #[arg(long = "env")]
     env: Vec<String>,
     /// Names of inherited environment variables to pass to the local job and register for masking
-    #[arg(long = "secret-env")]
+    #[arg(long = "secret-env", value_name = "NAME")]
     secret_env: Vec<String>,
     /// Timeout in seconds waiting for a runner to complete the job (max: 24 hours)
     #[arg(long, default_value_t = DEFAULT_LOCAL_SUBMIT_TIMEOUT_SECS)]

--- a/crates/runner/src/cmd/local/submit/tests/mod.rs
+++ b/crates/runner/src/cmd/local/submit/tests/mod.rs
@@ -4,6 +4,7 @@ mod completed_cleanup;
 mod queue_publication;
 mod request;
 mod result_markers;
+mod secret_env;
 mod support;
 mod timezone;
 mod validation;

--- a/crates/runner/src/cmd/local/submit/tests/request.rs
+++ b/crates/runner/src/cmd/local/submit/tests/request.rs
@@ -118,7 +118,7 @@ async fn submit_serializes_feature_flags() {
 }
 
 #[tokio::test]
-async fn submit_serializes_env_and_secret_env() {
+async fn submit_serializes_env() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().to_path_buf());
     let group = "test/group";
@@ -138,15 +138,10 @@ async fn submit_serializes_env_and_secret_env() {
         "MULTILINE=line1\nline2".into(),
         "VM0_STUCK_TOOL_TIMEOUT_SECS=3".into(),
     ];
-    args.secret_env = vec![
-        "ANTHROPIC_API_KEY=sk-ant-local-secret".into(),
-        "PRIVATE_KEY=-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----".into(),
-    ];
 
     let code = run_submit_with_home(args, home).await.unwrap();
     let request = watcher.await.unwrap();
     let environment = request.environment.as_ref().unwrap();
-    let secret_environment = request.secret_environment.as_ref().unwrap();
 
     assert_eq!(code, ExitCode::SUCCESS);
     assert_eq!(environment.get("FOO").map(String::as_str), Some("bar"));
@@ -165,81 +160,41 @@ async fn submit_serializes_env_and_secret_env() {
             .map(String::as_str),
         Some("3")
     );
-    assert_eq!(
-        secret_environment
-            .get("ANTHROPIC_API_KEY")
-            .map(String::as_str),
-        Some("sk-ant-local-secret")
-    );
-    assert_eq!(
-        secret_environment.get("PRIVATE_KEY").map(String::as_str),
-        Some("-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----")
-    );
+    assert!(request.secret_environment.is_none());
 }
 
 #[tokio::test]
 async fn rejects_invalid_env_entries_before_submit() {
     let cases = vec![
-        (vec!["FOO".to_string()], Vec::new(), "expected KEY=VALUE"),
-        (vec!["=VALUE".to_string()], Vec::new(), "expected KEY=VALUE"),
+        (vec!["FOO".to_string()], "expected KEY=VALUE"),
+        (vec!["=VALUE".to_string()], "expected KEY=VALUE"),
         (
             vec!["BAD-KEY=value".to_string()],
-            Vec::new(),
             "expected [_A-Za-z][_A-Za-z0-9]*",
         ),
         (
             vec!["1KEY=value".to_string()],
-            Vec::new(),
             "expected [_A-Za-z][_A-Za-z0-9]*",
         ),
         (
             vec!["KEY SPACE=value".to_string()],
-            Vec::new(),
             "expected [_A-Za-z][_A-Za-z0-9]*",
-        ),
-        (
-            Vec::new(),
-            vec!["ÅKEY=value".to_string()],
-            "expected [_A-Za-z][_A-Za-z0-9]*",
-        ),
-        (
-            Vec::new(),
-            vec!["KEY=with\0nul".to_string()],
-            "NUL characters",
         ),
         (
             vec!["VM0_PROMPT=value".to_string()],
-            Vec::new(),
             "runner-owned environment variables",
-        ),
-        (
-            Vec::new(),
-            vec!["CLI_AGENT_TYPE=codex".to_string()],
-            "runner-owned environment variables",
-        ),
-        (
-            Vec::new(),
-            vec!["VM0_STUCK_TOOL_TIMEOUT_SECS=3".to_string()],
-            "must be passed with --env",
         ),
         (
             vec!["FOO=1".to_string(), "FOO=2".to_string()],
-            Vec::new(),
             "duplicate --env key 'FOO'",
-        ),
-        (
-            vec!["FOO=1".to_string()],
-            vec!["FOO=2".to_string()],
-            "across --env and --secret-env",
         ),
     ];
 
-    for (env, secret_env, expected) in cases {
+    for (env, expected) in cases {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
         let mut args = submit_args_for_test();
         args.env = env;
-        args.secret_env = secret_env;
 
         let err = run_submit_with_home(args, home).await.unwrap_err();
 

--- a/crates/runner/src/cmd/local/submit/tests/secret_env.rs
+++ b/crates/runner/src/cmd/local/submit/tests/secret_env.rs
@@ -1,0 +1,247 @@
+use std::time::Duration;
+
+use clap::{CommandFactory, Parser};
+
+use super::super::{SubmitArgs, run_submit_with_home};
+use super::support::{submit_args_for_test, wait_for_job_and_write_success};
+use crate::paths::HomePaths;
+use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+const CHILD_SCENARIO_ENV: &str = "VM0_RUNNER_LOCAL_SUBMIT_SECRET_ENV_TEST_SCENARIO";
+const CHILD_TEST: &str = "cmd::local::submit::tests::secret_env::secret_env_child";
+const SUCCESS_SCENARIO: &str = "success";
+const MISSING_SCENARIO: &str = "missing";
+const CONFLICT_SCENARIO: &str = "conflict";
+
+const PRIMARY_KEY: &str = "LOCAL_SUBMIT_PRIMARY_SECRET";
+const PRIMARY_VALUE: &str = "line1\nline2=密钥";
+const SECONDARY_KEY: &str = "LOCAL_SUBMIT_SECONDARY_SECRET";
+const SECONDARY_VALUE: &str = "second-secret-value";
+const EMPTY_KEY: &str = "LOCAL_SUBMIT_EMPTY_SECRET";
+const MISSING_KEY: &str = "LOCAL_SUBMIT_MISSING_SECRET";
+const CONFLICT_KEY: &str = "LOCAL_SUBMIT_CONFLICT";
+const CONFLICT_VALUE: &str = "conflict-secret-value";
+
+#[derive(Parser)]
+struct TestSubmitCli {
+    #[command(flatten)]
+    args: SubmitArgs,
+}
+
+#[test]
+fn help_describes_secret_environment_name_lookup() {
+    let help = TestSubmitCli::command().render_help().to_string();
+    let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(normalized_help.contains(
+        "Names of inherited environment variables to pass to the local job and register for masking"
+    ));
+}
+
+#[tokio::test]
+async fn resolves_secret_environment_names_without_argv_values() {
+    run_secret_env_child(
+        SUCCESS_SCENARIO,
+        &[
+            (PRIMARY_KEY, Some(PRIMARY_VALUE)),
+            (SECONDARY_KEY, Some(SECONDARY_VALUE)),
+            (EMPTY_KEY, Some("")),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn rejects_missing_secret_environment_variable() {
+    run_secret_env_child(MISSING_SCENARIO, &[(MISSING_KEY, None)]).await;
+}
+
+#[tokio::test]
+async fn rejects_key_shared_with_ordinary_environment() {
+    run_secret_env_child(CONFLICT_SCENARIO, &[(CONFLICT_KEY, Some(CONFLICT_VALUE))]).await;
+}
+
+async fn run_secret_env_child(
+    scenario: &'static str,
+    child_env: &[(&'static str, Option<&'static str>)],
+) {
+    run_ignored_child_test(
+        CHILD_TEST,
+        (CHILD_SCENARIO_ENV, scenario),
+        child_env,
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "spawned by local-submit secret environment scenario tests"]
+async fn secret_env_child() {
+    let Ok(scenario) = std::env::var(CHILD_SCENARIO_ENV) else {
+        return;
+    };
+    if !ignored_child_test_env_guard_enabled((CHILD_SCENARIO_ENV, &scenario)) {
+        return;
+    }
+
+    match scenario.as_str() {
+        SUCCESS_SCENARIO => submit_selected_secret_environment().await,
+        MISSING_SCENARIO => reject_missing_secret_environment().await,
+        CONFLICT_SCENARIO => reject_conflicting_secret_environment().await,
+        other => panic!("unknown local-submit secret environment scenario: {other}"),
+    }
+}
+
+async fn submit_selected_secret_environment() {
+    let cli = TestSubmitCli::try_parse_from([
+        "runner-local-submit",
+        "--group",
+        "test/group",
+        "--prompt",
+        "hello",
+        "--env",
+        "ORDINARY=value",
+        "--secret-env",
+        PRIMARY_KEY,
+        "--secret-env",
+        SECONDARY_KEY,
+        "--secret-env",
+        EMPTY_KEY,
+        "--timeout",
+        "5",
+    ])
+    .unwrap();
+    assert_eq!(cli.args.secret_env, [PRIMARY_KEY, SECONDARY_KEY, EMPTY_KEY]);
+
+    let cmdline = std::fs::read("/proc/self/cmdline").unwrap();
+    let cmdline = String::from_utf8_lossy(&cmdline);
+    for secret in [PRIMARY_VALUE, SECONDARY_VALUE] {
+        assert!(
+            !cmdline.contains(secret),
+            "secret value must not appear in the child process argument vector"
+        );
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let group_dir = home.groups_dir().join("test/group");
+    let watcher = tokio::spawn(wait_for_job_and_write_success(
+        group_dir,
+        crate::profile::DEFAULT_PROFILE.to_owned(),
+    ));
+
+    run_submit_with_home(cli.args, home).await.unwrap();
+    let request = watcher.await.unwrap();
+    let environment = request.environment.as_ref().unwrap();
+    let secret_environment = request.secret_environment.as_ref().unwrap();
+
+    assert_eq!(
+        environment.get("ORDINARY").map(String::as_str),
+        Some("value")
+    );
+    assert_eq!(
+        secret_environment.get(PRIMARY_KEY).map(String::as_str),
+        Some(PRIMARY_VALUE)
+    );
+    assert_eq!(
+        secret_environment.get(SECONDARY_KEY).map(String::as_str),
+        Some(SECONDARY_VALUE)
+    );
+    assert_eq!(
+        secret_environment.get(EMPTY_KEY).map(String::as_str),
+        Some("")
+    );
+}
+
+async fn reject_missing_secret_environment() {
+    let mut args = submit_args_for_test();
+    args.secret_env = vec![MISSING_KEY.to_string()];
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let error = run_submit_with_home(args, home).await.unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains(MISSING_KEY), "got: {message}");
+    assert!(message.contains("not set or is not valid Unicode"));
+}
+
+async fn reject_conflicting_secret_environment() {
+    let mut args = submit_args_for_test();
+    args.env = vec![format!("{CONFLICT_KEY}=ordinary-value")];
+    args.secret_env = vec![CONFLICT_KEY.to_string()];
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let error = run_submit_with_home(args, home).await.unwrap_err();
+    let message = error.to_string();
+
+    assert!(
+        message.contains("across --env and --secret-env"),
+        "got: {message}"
+    );
+    assert!(
+        !message.contains(CONFLICT_VALUE),
+        "error must not expose the resolved secret value: {message}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_legacy_secret_value_without_echoing_it() {
+    const SENTINEL: &str = "legacy-argv-secret-sentinel";
+
+    let mut args = submit_args_for_test();
+    args.secret_env = vec![format!("OPENAI_API_KEY={SENTINEL}")];
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let error = run_submit_with_home(args, home).await.unwrap_err();
+    let message = error.to_string();
+
+    assert!(
+        message.contains("expected an environment variable name without a value"),
+        "got: {message}"
+    );
+    assert!(
+        !message.contains(SENTINEL),
+        "error must not echo the legacy secret value: {message}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_invalid_secret_environment_names_before_lookup() {
+    let cases = [
+        (vec!["".to_string()], "expected [_A-Za-z]"),
+        (vec!["BAD-KEY".to_string()], "expected [_A-Za-z]"),
+        (vec!["1KEY".to_string()], "expected [_A-Za-z]"),
+        (vec!["KEY SPACE".to_string()], "expected [_A-Za-z]"),
+        (vec!["ÅKEY".to_string()], "expected [_A-Za-z]"),
+        (
+            vec!["KEY\0WITH_NUL".to_string()],
+            "expected an environment variable name",
+        ),
+        (
+            vec!["CLI_AGENT_TYPE".to_string()],
+            "runner-owned environment variables",
+        ),
+        (
+            vec!["VM0_STUCK_TOOL_TIMEOUT_SECS".to_string()],
+            "must be passed with --env",
+        ),
+        (
+            vec!["DUPLICATE_KEY".to_string(), "DUPLICATE_KEY".to_string()],
+            "duplicate --secret-env key 'DUPLICATE_KEY'",
+        ),
+    ];
+
+    for (secret_env, expected) in cases {
+        let mut args = submit_args_for_test();
+        args.secret_env = secret_env;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+
+        let error = run_submit_with_home(args, home).await.unwrap_err();
+
+        assert!(error.to_string().contains(expected), "got: {error}");
+    }
+}

--- a/crates/runner/src/cmd/local/submit/tests/secret_env.rs
+++ b/crates/runner/src/cmd/local/submit/tests/secret_env.rs
@@ -33,6 +33,7 @@ fn help_describes_secret_environment_name_lookup() {
     let help = TestSubmitCli::command().render_help().to_string();
     let normalized_help = help.split_whitespace().collect::<Vec<_>>().join(" ");
 
+    assert!(normalized_help.contains("--secret-env <NAME>"));
     assert!(normalized_help.contains(
         "Names of inherited environment variables to pass to the local job and register for masking"
     ));


### PR DESCRIPTION
## Summary

- change `runner local submit --secret-env` to accept inherited environment variable names instead of raw `KEY=VALUE` secrets
- reject the legacy value-bearing form without echoing secret content, while preserving existing key validation and downstream masking
- migrate the Claude and Codex metal smoke callers to preserve only their provider key across `sudo`
- add bounded integration coverage for clap parsing, argv absence, environment lookup, queue delivery, validation, and help text

## Compatibility

This intentionally changes the local-only CLI input form. Ordinary `--env KEY=VALUE`, the local queue schema, private queue publication, guest injection, and masking contracts are unchanged.

No API, persisted-state, feature-switch, or runner/guest protocol changes are included.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner cmd::local::submit`
- `cargo test -p runner provider::local::tests::claim::claim_maps_secret_environment_into_context_and_masking`
- `cargo test -p runner`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `bash -n .github/scripts/runner-behavior-local-claude-active-input-smoke.sh`
- `bash -n .github/scripts/runner-behavior-local-codex-active-input-smoke.sh`
- `git diff --check`
- staged repository pre-commit hooks

Closes #22042
