### PR TITLE
test(runner): exercise guest binary hash assembly

### DIFF
--- a/crates/runner/src/cmd/build/hashes.rs
+++ b/crates/runner/src/cmd/build/hashes.rs
@@ -23,6 +23,12 @@ const ROOTFS_CACHE_VERSION: u32 = 1;
 /// Bump to invalidate all cached snapshots (local only; R2 stores only the template).
 const SNAPSHOT_CACHE_VERSION: u32 = 3;
 
+/// Shared template and local rootfs identities for a full image build.
+pub(super) struct RootfsBuildHashes {
+    pub(super) template_hash: String,
+    pub(super) rootfs_hash: String,
+}
+
 /// Compute a template hash for shared R2 image caching.
 ///
 /// Inputs:
@@ -85,6 +91,22 @@ pub(super) async fn compute_rootfs_hash(
     }
 
     Ok(hex::encode(hasher.finalize()))
+}
+
+/// Compute the two-layer rootfs identity used by a full image build.
+pub(super) async fn compute_rootfs_build_hashes(
+    guest_bins: &[(&Path, &str)],
+    ca_fingerprint: &str,
+    rootfs_disk_mb: u32,
+) -> RunnerResult<RootfsBuildHashes> {
+    let template_hash = compute_template_hash(rootfs_disk_mb);
+    let rootfs_hash =
+        compute_rootfs_hash(&template_hash, guest_bins, ca_fingerprint, rootfs_disk_mb).await?;
+
+    Ok(RootfsBuildHashes {
+        template_hash,
+        rootfs_hash,
+    })
 }
 
 pub(super) async fn compute_ca_cert_fingerprint(paths: &HomePaths) -> RunnerResult<String> {
@@ -173,18 +195,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn template_hash_ignores_guest_binaries() {
+    async fn rootfs_build_hashes_keep_template_shared_across_guest_content() {
         let dir = tempfile::tempdir().unwrap();
         let bin_a = dir.path().join("agent-a");
         let bin_b = dir.path().join("agent-b");
         tokio::fs::write(&bin_a, b"content-a").await.unwrap();
         tokio::fs::write(&bin_b, b"content-b").await.unwrap();
 
-        let template_a = compute_template_hash(16384);
-        let template_b = compute_template_hash(16384);
+        let hashes_a = compute_rootfs_build_hashes(
+            &[(&bin_a, "/usr/local/bin/guest-agent")],
+            "ca-fingerprint",
+            16384,
+        )
+        .await
+        .unwrap();
+        let hashes_b = compute_rootfs_build_hashes(
+            &[(&bin_b, "/usr/local/bin/guest-agent")],
+            "ca-fingerprint",
+            16384,
+        )
+        .await
+        .unwrap();
+
         assert_eq!(
-            template_a, template_b,
+            hashes_a.template_hash, hashes_b.template_hash,
             "template hash must not depend on guest binary content"
+        );
+        assert_ne!(
+            hashes_a.rootfs_hash, hashes_b.rootfs_hash,
+            "rootfs hash must depend on guest binary content"
         );
     }
 

--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -22,7 +22,8 @@ mod snapshot;
 
 use guest::{GuestBinaries, guest_definitions};
 use hashes::{
-    compute_ca_cert_fingerprint, compute_rootfs_hash, compute_snapshot_hash, compute_template_hash,
+    compute_ca_cert_fingerprint, compute_rootfs_build_hashes, compute_snapshot_hash,
+    compute_template_hash,
 };
 use local_publish::LocalFilePublish;
 use scripts::{RootfsScripts, rootfs_script_command, run_rootfs_script};
@@ -357,10 +358,9 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
         BuildMode::WarmRootfsCache => None,
     };
 
-    let template_hash = compute_template_hash(def.rootfs_disk_mb);
     let hashes = match mode {
         BuildMode::WarmRootfsCache => BuildHashes {
-            template_hash,
+            template_hash: compute_template_hash(def.rootfs_disk_mb),
             rootfs_hash: None,
             snapshot_hash: None,
         },
@@ -374,15 +374,14 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
             ca::ensure(&paths).await?;
             let ca_fingerprint = compute_ca_cert_fingerprint(&paths).await?;
             let guest_hash_inputs = guests.hash_inputs();
-            let rootfs_hash = compute_rootfs_hash(
-                &template_hash,
+            let rootfs_hashes = compute_rootfs_build_hashes(
                 &guest_hash_inputs,
                 &ca_fingerprint,
                 def.rootfs_disk_mb,
             )
             .await?;
             let snapshot_hash = compute_snapshot_hash(
-                &rootfs_hash,
+                &rootfs_hashes.rootfs_hash,
                 def.vcpu,
                 def.memory_mb,
                 def.workspace_disk_mb,
@@ -391,8 +390,8 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 &provider.config_hash(),
             );
             BuildHashes {
-                template_hash,
-                rootfs_hash: Some(rootfs_hash),
+                template_hash: rootfs_hashes.template_hash,
+                rootfs_hash: Some(rootfs_hashes.rootfs_hash),
                 snapshot_hash: Some(snapshot_hash),
             }
         }


### PR DESCRIPTION
## Summary

- extract a private, production-used boundary for shared template and local rootfs hash assembly
- route full-image `run_build` hash computation through the named two-layer result
- replace the disconnected guest-binary exclusion test with real file inputs that prove template identity stays shared while rootfs identity changes

## Compatibility

- does not change hash primitives, cache versions, input ordering, or resulting cache keys
- does not change runtime build behavior, CLI output, persisted state, schemas, APIs, or protocols
- keeps warm-cache and snapshot assembly behavior in their existing owners

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::` (92 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (2745 passed, 12 ignored)
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- pre-commit: workspace Rust format, Clippy, documentation, file-size, and generated-firewall checks

Closes #22037
