### PR TITLE
ci(platform): publish okou app previews on omby.ai

### DIFF
--- a/.github/pages/okou-app/_headers
+++ b/.github/pages/okou-app/_headers
@@ -1,0 +1,19 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate
+
+/manifest.webmanifest
+  Cache-Control: public, max-age=3600, must-revalidate
+  Content-Type: application/manifest+json
+
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(), clipboard-read=(), microphone=(self), bluetooth=(self), clipboard-write=(self), fullscreen=(self)

--- a/.github/scripts/manage-okou-pages-domain.sh
+++ b/.github/scripts/manage-okou-pages-domain.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# < 5 )); then
+  echo "usage: $0 <ensure|delete> <account-id> <zone-id> <project-name> <domain> [branch]" >&2
+  exit 1
+fi
+
+action="$1"
+account_id="$2"
+zone_id="$3"
+project_name="$4"
+domain="$5"
+branch="${6:-}"
+
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+
+api_base="https://api.cloudflare.com/client/v4"
+auth_header="Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+pages_domains_url="${api_base}/accounts/${account_id}/pages/projects/${project_name}/domains"
+dns_records_url="${api_base}/zones/${zone_id}/dns_records"
+
+cloudflare_request() {
+  curl --fail-with-body --silent --show-error "$@" \
+    --header "$auth_header" \
+    --header "Content-Type: application/json"
+}
+
+dns_record_id() {
+  cloudflare_request \
+    "${dns_records_url}?type=CNAME&name=${domain}" |
+    jq -r '.result[0].id // empty'
+}
+
+upsert_cname() {
+  local target="$1"
+  local record_id
+  local body
+
+  record_id="$(dns_record_id)"
+  body="$(jq -n \
+    --arg name "$domain" \
+    --arg target "$target" \
+    '{
+      type: "CNAME",
+      name: $name,
+      content: $target,
+      proxied: true,
+      ttl: 1,
+      comment: "Managed by vm0 PR preview lifecycle"
+    }')"
+
+  if [[ -n "$record_id" ]]; then
+    cloudflare_request \
+      --request PUT \
+      "${dns_records_url}/${record_id}" \
+      --data "$body" >/dev/null
+  else
+    cloudflare_request \
+      --request POST \
+      "$dns_records_url" \
+      --data "$body" >/dev/null
+  fi
+}
+
+case "$action" in
+  ensure)
+    : "${branch:?branch is required for ensure}"
+
+    domains="$(cloudflare_request "$pages_domains_url")"
+    if ! jq -e --arg domain "$domain" \
+      '.result[] | select(.name == $domain)' <<< "$domains" >/dev/null; then
+      cloudflare_request \
+        --request POST \
+        "$pages_domains_url" \
+        --data "$(jq -n --arg name "$domain" '{name: $name}')" >/dev/null
+    fi
+
+    domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+    domain_status="$(jq -r '.result.status' <<< "$domain_state")"
+    verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
+
+    if [[ "$domain_status" != "active" && "$verification_status" != "active" ]]; then
+      upsert_cname "${project_name}.pages.dev"
+
+      for _ in {1..30}; do
+        domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+        verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
+        if [[ "$verification_status" == "active" ]]; then
+          break
+        fi
+        sleep 2
+      done
+
+      if [[ "$verification_status" != "active" ]]; then
+        echo "Cloudflare Pages did not verify ${domain}" >&2
+        exit 1
+      fi
+    fi
+
+    upsert_cname "${branch}.${project_name}.pages.dev"
+    echo "Cloudflare Pages custom branch domain configured: https://${domain}"
+    ;;
+  delete)
+    domains="$(cloudflare_request "$pages_domains_url")"
+    if jq -e --arg domain "$domain" \
+      '.result[] | select(.name == $domain)' <<< "$domains" >/dev/null; then
+      cloudflare_request \
+        --request DELETE \
+        "${pages_domains_url}/${domain}" >/dev/null
+    fi
+
+    record_id="$(dns_record_id)"
+    if [[ -n "$record_id" ]]; then
+      cloudflare_request \
+        --request DELETE \
+        "${dns_records_url}/${record_id}" >/dev/null
+    fi
+    echo "Cloudflare Pages custom branch domain deleted: ${domain}"
+    ;;
+  *)
+    echo "unsupported action: $action" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/prepare-okou-pages-dist.sh
+++ b/.github/scripts/prepare-okou-pages-dist.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "usage: $0 <canonical-dist> <empty-pages-dist>" >&2
+  exit 1
+fi
+
+canonical_dist="$1"
+pages_dist="$2"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+headers_file="${script_dir}/../pages/okou-app/_headers"
+
+if [[ ! -f "${canonical_dist}/index.html" ]]; then
+  echo "canonical app artifact must contain index.html" >&2
+  exit 1
+fi
+
+if [[ ! -d "$pages_dist" ]] || [[ -n "$(find "$pages_dist" -mindepth 1 -print -quit)" ]]; then
+  echo "Pages output directory must exist and be empty: $pages_dist" >&2
+  exit 1
+fi
+
+cp -a "${canonical_dist}/." "$pages_dist/"
+find "$pages_dist" -type f -name '*.map' -delete
+rm -f \
+  "${pages_dist}/.gitkeep" \
+  "${pages_dist}/manifest.json" \
+  "${pages_dist}/ready.json"
+cp "$headers_file" "${pages_dist}/_headers"

--- a/.github/scripts/resolve-okou-pages-branch.sh
+++ b/.github/scripts/resolve-okou-pages-branch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 3 )); then
+  echo "usage: $0 <event-name> <pull-request-number> <merge-group-head-ref>" >&2
+  exit 1
+fi
+
+event_name="$1"
+pull_request_number="$2"
+merge_group_head_ref="$3"
+
+case "$event_name" in
+  pull_request)
+    printf 'pr-%s-app\n' "${pull_request_number:?pull request number is required}"
+    ;;
+  merge_group)
+    pull_request_number="$(grep -oE 'pr-[0-9]+' <<< "$merge_group_head_ref" | head -1 | cut -d- -f2)"
+    printf 'pr-%s-app\n' "${pull_request_number:?pull request number is required in merge group head ref}"
+    ;;
+  push)
+    printf 'staging-app\n'
+    ;;
+  *)
+    echo "unsupported GitHub event: $event_name" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/tests/prepare-okou-pages-dist-test.sh
+++ b/.github/scripts/tests/prepare-okou-pages-dist-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/prepare-okou-pages-dist.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+canonical_dist="${tmp_dir}/canonical"
+pages_dist="${tmp_dir}/pages"
+mkdir -p "${canonical_dist}/assets" "$pages_dist"
+
+printf '<!doctype html>\n' > "${canonical_dist}/index.html"
+printf 'console.log("app");\n' > "${canonical_dist}/assets/app-123.js"
+printf '{"version":3}\n' > "${canonical_dist}/assets/app-123.js.map"
+printf '{"version":1}\n' > "${canonical_dist}/manifest.json"
+printf '{"version":1}\n' > "${canonical_dist}/ready.json"
+touch "${canonical_dist}/.gitkeep"
+
+bash "$script" "$canonical_dist" "$pages_dist"
+
+test -f "${pages_dist}/index.html"
+test -f "${pages_dist}/assets/app-123.js"
+test -f "${pages_dist}/_headers"
+test ! -e "${pages_dist}/assets/app-123.js.map"
+test ! -e "${pages_dist}/manifest.json"
+test ! -e "${pages_dist}/ready.json"
+test ! -e "${pages_dist}/.gitkeep"
+grep -Fxq '/assets/*' "${pages_dist}/_headers"
+grep -Fq 'Cache-Control: public, max-age=31536000, immutable' \
+  "${pages_dist}/_headers"
+
+nonempty_dist="${tmp_dir}/nonempty"
+mkdir -p "$nonempty_dist"
+touch "${nonempty_dist}/existing"
+if bash "$script" "$canonical_dist" "$nonempty_dist" >/dev/null 2>&1; then
+  echo "expected a non-empty Pages output directory to be rejected" >&2
+  exit 1
+fi
+
+missing_index="${tmp_dir}/missing-index"
+mkdir -p "$missing_index"
+if bash "$script" "$missing_index" "${tmp_dir}/unused" >/dev/null 2>&1; then
+  echo "expected an artifact without index.html to be rejected" >&2
+  exit 1
+fi
+
+echo "prepare-okou-pages-dist tests passed"

--- a/.github/scripts/tests/resolve-okou-pages-branch-test.sh
+++ b/.github/scripts/tests/resolve-okou-pages-branch-test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/resolve-okou-pages-branch.sh"
+
+test "$(bash "$script" pull_request 22085 '')" = "pr-22085-app"
+test "$(bash "$script" merge_group '' 'gh-readonly-queue/main/pr-22085-deadbeef')" = "pr-22085-app"
+test "$(bash "$script" push '' '')" = "staging-app"
+
+if bash "$script" merge_group '' 'gh-readonly-queue/main/no-pr' >/dev/null 2>&1; then
+  echo "expected a merge group ref without a PR number to be rejected" >&2
+  exit 1
+fi
+
+if bash "$script" workflow_dispatch '' '' >/dev/null 2>&1; then
+  echo "expected an unsupported GitHub event to be rejected" >&2
+  exit 1
+fi
+
+echo "resolve-okou-pages-branch tests passed"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,6 +9,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cleanup-okou-pages-domain:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Delete Cloudflare Pages custom preview domain
+        env:
+          CF_PAGES_PREVIEW_DOMAIN: ${{ vars.CF_PAGES_PREVIEW_DOMAIN }}
+          CF_PAGES_PREVIEW_ZONE_ID: ${{ vars.CF_PAGES_PREVIEW_ZONE_ID }}
+          CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
+          : "${CF_PAGES_PREVIEW_ZONE_ID:?CF_PAGES_PREVIEW_ZONE_ID variable is required}"
+          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
+          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+          bash .github/scripts/manage-okou-pages-domain.sh \
+            delete \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$CF_PAGES_PREVIEW_ZONE_ID" \
+            "$CF_PAGES_PROJECT_NAME" \
+            "pr-${PR_NUMBER}-app.${CF_PAGES_PREVIEW_DOMAIN}"
+
   cleanup-runner:
     # Skip for release-please PRs (only version bumps and changelogs)
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1345,13 +1345,13 @@ jobs:
       - name: Deploy Cloudflare Pages preview
         env:
           ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_BRANCH: ${{ steps.pages-preview.outputs.branch }}
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
         working-directory: turbo
         run: |
           set -euo pipefail
-          : "${CLOUDFLARE_API_TOKEN:?CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN secret is required}"
+          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
           pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
             --project-name "$CF_PAGES_PROJECT_NAME" \
             --branch "$PAGES_BRANCH" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1154,6 +1154,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
+      CF_PAGES_PREVIEW_DOMAIN: ${{ vars.CF_PAGES_PREVIEW_DOMAIN }}
+      CF_PAGES_PREVIEW_ZONE_ID: ${{ vars.CF_PAGES_PREVIEW_ZONE_ID }}
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
       R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
       R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
@@ -1351,6 +1353,14 @@ jobs:
           {
             echo "dist=$pages_dist"
             echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
+            if [[ "$PAGES_BRANCH" == pr-*-app ]]; then
+              : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
+              echo "custom-domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
+              echo "custom-url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
+            else
+              echo "custom-domain="
+              echo "custom-url="
+            fi
           } >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
@@ -1369,11 +1379,31 @@ jobs:
             --commit-hash "$ARTIFACT_SHA" \
             --commit-dirty=false
 
+      - name: Configure Cloudflare Pages custom preview domain
+        if: steps.pages-preview.outputs.custom-domain != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
+          PAGES_CUSTOM_DOMAIN: ${{ steps.pages-preview.outputs.custom-domain }}
+        run: |
+          : "${CF_PAGES_PREVIEW_ZONE_ID:?CF_PAGES_PREVIEW_ZONE_ID variable is required}"
+          bash .github/scripts/manage-okou-pages-domain.sh \
+            ensure \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$CF_PAGES_PREVIEW_ZONE_ID" \
+            "$CF_PAGES_PROJECT_NAME" \
+            "$PAGES_CUSTOM_DOMAIN" \
+            "$PAGES_BRANCH"
+
       - name: Record Cloudflare Pages preview
         env:
+          PAGES_CUSTOM_URL: ${{ steps.pages-preview.outputs.custom-url }}
           PAGES_PREVIEW_URL: ${{ steps.pages-preview.outputs.url }}
         run: |
           echo "Cloudflare Pages preview: ${PAGES_PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "$PAGES_CUSTOM_URL" ]]; then
+            echo "Cloudflare Pages custom preview: ${PAGES_CUSTOM_URL}" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # Deploy app (Vite SPA)
   deploy-app:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1336,10 +1336,11 @@ jobs:
             "$canonical_dist" \
             "$pages_dist"
 
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "dist=$pages_dist" >> "$GITHUB_OUTPUT"
-          echo "url=https://${branch}.${CF_PAGES_PROJECT_NAME}.pages.dev" \
-            >> "$GITHUB_OUTPUT"
+          {
+            echo "branch=$branch"
+            echo "dist=$pages_dist"
+            echo "url=https://${branch}.${CF_PAGES_PROJECT_NAME}.pages.dev"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1344,13 +1344,13 @@ jobs:
       - name: Deploy Cloudflare Pages preview
         env:
           ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN }}
           PAGES_BRANCH: ${{ steps.pages-preview.outputs.branch }}
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
         working-directory: turbo
         run: |
           set -euo pipefail
-          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
+          : "${CLOUDFLARE_API_TOKEN:?CF_ZERO_HOST_WORKER_DEPLOY_API_TOKEN secret is required}"
           pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
             --project-name "$CF_PAGES_PROJECT_NAME" \
             --branch "$PAGES_BRANCH" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1188,6 +1188,19 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "prefix=okou-app/$sha" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Cloudflare Pages preview branch
+        id: pages-branch
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: |
+          branch="$(bash .github/scripts/resolve-okou-pages-branch.sh \
+            "$EVENT_NAME" \
+            "$PULL_REQUEST_NUMBER" \
+            "$MERGE_GROUP_HEAD_REF")"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
       - name: Check for existing artifact
         id: existing
         env:
@@ -1316,7 +1329,7 @@ jobs:
         id: pages-preview
         env:
           ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
-          ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
         run: |
           set -euo pipefail
 
@@ -1327,7 +1340,6 @@ jobs:
           artifact_uri="s3://${R2_BUCKET_NAME}/${ARTIFACT_PREFIX}"
           canonical_dist="$(mktemp -d)"
           pages_dist="$(mktemp -d)"
-          branch="preview-${ARTIFACT_SHA:0:12}"
 
           aws s3 cp "$artifact_uri/" "$canonical_dist/" \
             --endpoint-url "$r2_endpoint" \
@@ -1337,16 +1349,15 @@ jobs:
             "$pages_dist"
 
           {
-            echo "branch=$branch"
             echo "dist=$pages_dist"
-            echo "url=https://${branch}.${CF_PAGES_PROJECT_NAME}.pages.dev"
+            echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
           } >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
         env:
           ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
-          PAGES_BRANCH: ${{ steps.pages-preview.outputs.branch }}
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
         working-directory: turbo
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1129,7 +1129,8 @@ jobs:
             /tmp/e2e-token-runner.json
           retention-days: 1
 
-  # Build the canonical Cloudflare app artifact independently of Vercel.
+  # Build the canonical Cloudflare app artifact independently of Vercel, then
+  # deploy the verified R2 artifact to a Pages preview branch.
   build-app-cf:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1152,6 +1153,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
+      CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
       R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
       R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
     steps:
@@ -1308,6 +1311,57 @@ jobs:
             --if-none-match "*"
 
           echo "Artifact ready: ${artifact_uri}/"
+
+      - name: Prepare Cloudflare Pages preview
+        id: pages-preview
+        env:
+          ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
+          ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
+          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          artifact_uri="s3://${R2_BUCKET_NAME}/${ARTIFACT_PREFIX}"
+          canonical_dist="$(mktemp -d)"
+          pages_dist="$(mktemp -d)"
+          branch="preview-${ARTIFACT_SHA:0:12}"
+
+          aws s3 cp "$artifact_uri/" "$canonical_dist/" \
+            --endpoint-url "$r2_endpoint" \
+            --recursive
+          bash .github/scripts/prepare-okou-pages-dist.sh \
+            "$canonical_dist" \
+            "$pages_dist"
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "dist=$pages_dist" >> "$GITHUB_OUTPUT"
+          echo "url=https://${branch}.${CF_PAGES_PROJECT_NAME}.pages.dev" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Deploy Cloudflare Pages preview
+        env:
+          ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PAGES_BRANCH: ${{ steps.pages-preview.outputs.branch }}
+          PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
+        working-directory: turbo
+        run: |
+          set -euo pipefail
+          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
+          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
+            --project-name "$CF_PAGES_PROJECT_NAME" \
+            --branch "$PAGES_BRANCH" \
+            --commit-hash "$ARTIFACT_SHA" \
+            --commit-dirty=false
+
+      - name: Record Cloudflare Pages preview
+        env:
+          PAGES_PREVIEW_URL: ${{ steps.pages-preview.outputs.url }}
+        run: |
+          echo "Cloudflare Pages preview: ${PAGES_PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"
 
   # Deploy app (Vite SPA)
   deploy-app:

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -790,6 +790,32 @@ describe("createApp", () => {
       expect(allowHeaders).toContain("X-Client-Version");
     });
 
+    it("allows okou preview app origins", async () => {
+      mockEnv("ENV", "preview");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://pr-22085-app.omby.ai" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(
+        "https://pr-22085-app.omby.ai",
+      );
+    });
+
+    it("does not allow lookalike okou preview origins", async () => {
+      mockEnv("ENV", "preview");
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { origin: "https://pr-22085-app.omby.ai.evil.example" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    });
+
     it("rejects disallowed origins by omitting the allow-origin header", async () => {
       mockEnv("ENV", "production");
       const app = createApp({ signal: context.signal });

--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -51,7 +51,9 @@ function getAllowedOrigin(origin: string | undefined): string | null {
 
   if (
     deployEnv === "preview" &&
-    (hostname.endsWith(".vm6.ai") || hostname.endsWith(".vm7.ai"))
+    (hostname.endsWith(".vm6.ai") ||
+      hostname.endsWith(".vm7.ai") ||
+      hostname.endsWith(".omby.ai"))
   ) {
     return normalizedOrigin;
   }

--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -237,6 +237,21 @@ describe("portable platform runtime environment", () => {
     );
   });
 
+  it("routes okou preview services through vm6.ai", async () => {
+    setBrowserUrl("https://pr-22085-app.omby.ai/agents");
+    const runtime = await loadRuntimeSurfaces();
+
+    expect(runtime.apiBase.resolveApiBase()).toBe(
+      "https://pr-22085-api.vm6.ai",
+    );
+    expect(runtime.auth.resolveWebOrigin()).toBe("https://pr-22085-www.vm6.ai");
+    expect(runtime.platformHost.resolvePlatformRuntimeConfig()).toMatchObject({
+      environment: "preview",
+      clerkPublishableKey: PREVIEW_CLERK_KEY,
+      vapidPublicKey: PREVIEW_VAPID_KEY,
+    });
+  });
+
   it("keeps unrecognized provider hosts on the same origin", async () => {
     setBrowserUrl("https://deployment.pages.dev/agents");
     const runtime = await loadRuntimeSurfaces();

--- a/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  appendPreviewBypassToUrl,
   buildPreviewBypassCookie,
   writePreviewBypassCookie,
 } from "../preview-bypass-cookie.ts";
@@ -56,5 +57,35 @@ describe("preview bypass cookie", () => {
     expect(setCookie).toHaveBeenCalledWith(
       "x-vercel-protection-bypass=preview%20secret; Path=/; Max-Age=3600; SameSite=Lax; Domain=.vm6.ai; Secure",
     );
+  });
+
+  it("forwards an omby host cookie only to the vm6 preview domain", () => {
+    const location = {
+      hostname: "pr-22085-app.omby.ai",
+      protocol: "https:",
+      search: "",
+    };
+    const cookie = "x-vercel-protection-bypass=preview%20secret";
+    const apiUrl = new URL("https://pr-22085-api.vm6.ai/api/zero/status");
+    const lookalikeUrl = new URL(
+      "https://pr-22085-api.vm6.ai.evil.example/api/zero/status",
+    );
+    const otherPreviewUrl = new URL(
+      "https://pr-22086-api.vm6.ai/api/zero/status",
+    );
+
+    appendPreviewBypassToUrl(apiUrl, location, cookie);
+    appendPreviewBypassToUrl(lookalikeUrl, location, cookie);
+    appendPreviewBypassToUrl(otherPreviewUrl, location, cookie);
+
+    expect(apiUrl.searchParams.get("x-vercel-protection-bypass")).toBe(
+      "preview secret",
+    );
+    expect(
+      lookalikeUrl.searchParams.has("x-vercel-protection-bypass"),
+    ).toBeFalsy();
+    expect(
+      otherPreviewUrl.searchParams.has("x-vercel-protection-bypass"),
+    ).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -15,6 +15,8 @@ export interface PlatformRuntimeConfig {
 
 const PRODUCTION_DOMAIN = "vm0.ai";
 const OKOU_PRODUCTION_DOMAIN = "okou.ai";
+const OKOU_PREVIEW_DOMAIN = "omby.ai";
+const PREVIEW_SERVICE_DOMAIN = "vm6.ai";
 export const PRODUCTION_SATELLITE_HOSTNAME = "app.okou.ai";
 const PLATFORM_SERVICE_LABELS = ["platform", "app", "www", "api"] as const;
 
@@ -81,6 +83,18 @@ export function rewritePlatformHostname(
   return hostname;
 }
 
+function rewritePreviewServiceHostname(
+  hostname: string,
+  target: PlatformService,
+): string {
+  const rewrittenHostname = rewritePlatformHostname(hostname, target);
+  const okouPreviewSuffix = `.${OKOU_PREVIEW_DOMAIN}`;
+  if (!rewrittenHostname.endsWith(okouPreviewSuffix)) {
+    return rewrittenHostname;
+  }
+  return `${rewrittenHostname.slice(0, -okouPreviewSuffix.length)}.${PREVIEW_SERVICE_DOMAIN}`;
+}
+
 export function derivePlatformServiceOrigin(
   currentOrigin: string,
   target: PlatformService,
@@ -91,7 +105,7 @@ export function derivePlatformServiceOrigin(
   // hostname. They all share the canonical API and web services.
   url.hostname = isProductionHostname(url.hostname)
     ? `${target}.${PRODUCTION_DOMAIN}`
-    : rewritePlatformHostname(url.hostname, target);
+    : rewritePreviewServiceHostname(url.hostname, target);
 
   return url.origin;
 }

--- a/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
+++ b/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
@@ -2,6 +2,9 @@ const VERCEL_PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
 
 const PREVIEW_BYPASS_COOKIE_MAX_AGE_SECONDS = 60 * 60;
 const PREVIEW_COOKIE_ROOT_DOMAIN = "vm6.ai";
+const OKOU_PREVIEW_ROOT_DOMAIN = "omby.ai";
+const APP_SERVICE_SUFFIX = "-app";
+const BYPASS_TARGET_SERVICE_SUFFIXES = ["-api", "-www"] as const;
 
 interface PreviewBypassCookieLocation {
   readonly hostname: string;
@@ -15,6 +18,108 @@ function previewCookieDomain(hostname: string): string | undefined {
     normalized.endsWith(`.${PREVIEW_COOKIE_ROOT_DOMAIN}`)
     ? `.${PREVIEW_COOKIE_ROOT_DOMAIN}`
     : undefined;
+}
+
+function isHostnameWithin(hostname: string, rootDomain: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === rootDomain || normalized.endsWith(`.${rootDomain}`);
+}
+
+function hostnameBeforeRoot(hostname: string, rootDomain: string): string {
+  return hostname.slice(0, -(rootDomain.length + 1));
+}
+
+function isCorrespondingPreviewService(
+  sourceHostname: string,
+  targetHostname: string,
+): boolean {
+  const source = hostnameBeforeRoot(sourceHostname, OKOU_PREVIEW_ROOT_DOMAIN);
+  if (!source.endsWith(APP_SERVICE_SUFFIX)) {
+    return false;
+  }
+  const prefix = source.slice(0, -APP_SERVICE_SUFFIX.length);
+  const target = hostnameBeforeRoot(targetHostname, PREVIEW_COOKIE_ROOT_DOMAIN);
+  return BYPASS_TARGET_SERVICE_SUFFIXES.some((suffix) => {
+    return target === `${prefix}${suffix}`;
+  });
+}
+
+function cookieValue(cookieHeader: string, name: string): string | null {
+  for (const segment of cookieHeader.split(";")) {
+    const separatorIndex = segment.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    if (segment.slice(0, separatorIndex).trim() !== name) {
+      continue;
+    }
+    return decodeURIComponent(segment.slice(separatorIndex + 1).trim());
+  }
+  return null;
+}
+
+type PreviewBypassTarget = string | URL | Request;
+
+function targetUrl(target: PreviewBypassTarget): URL {
+  const value = target instanceof Request ? target.url : target.toString();
+  return new URL(value);
+}
+
+function previewBypassForTarget(
+  target: PreviewBypassTarget,
+  location: PreviewBypassCookieLocation,
+  cookieHeader: string,
+): string | null {
+  const targetHostname = targetUrl(target).hostname.toLowerCase();
+  if (
+    !isHostnameWithin(location.hostname, OKOU_PREVIEW_ROOT_DOMAIN) ||
+    !isHostnameWithin(targetHostname, PREVIEW_COOKIE_ROOT_DOMAIN) ||
+    !isCorrespondingPreviewService(
+      location.hostname.toLowerCase(),
+      targetHostname,
+    )
+  ) {
+    return null;
+  }
+  return (
+    new URLSearchParams(location.search).get(VERCEL_PROTECTION_BYPASS_NAME) ??
+    cookieValue(cookieHeader, VERCEL_PROTECTION_BYPASS_NAME)
+  );
+}
+
+export function appendPreviewBypassToUrl(
+  url: URL,
+  location: PreviewBypassCookieLocation,
+  cookieHeader: string,
+): void {
+  const bypass = previewBypassForTarget(url, location, cookieHeader);
+  if (bypass) {
+    url.searchParams.set(VERCEL_PROTECTION_BYPASS_NAME, bypass);
+  }
+}
+
+export function appendCapturedPreviewBypassToUrl(url: URL): void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+  appendPreviewBypassToUrl(url, window.location, document.cookie);
+}
+
+export function addCapturedPreviewBypassHeader(
+  headers: Headers,
+  target: PreviewBypassTarget,
+): void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+  const bypass = previewBypassForTarget(
+    target,
+    window.location,
+    document.cookie,
+  );
+  if (bypass) {
+    headers.set(VERCEL_PROTECTION_BYPASS_NAME, bypass);
+  }
 }
 
 export function buildPreviewBypassCookie(

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -49,6 +49,10 @@ function mockSignedInUser(): void {
   });
 }
 
+function setBrowserUrl(url: string): void {
+  window.location.href = url;
+}
+
 function getFetchForTest() {
   // eslint-disable-next-line ccstate/no-direct-fetch -- this regression test file covers fetch$ itself.
   return context.store.get(fetch$);
@@ -134,6 +138,55 @@ describe("api client headers", () => {
     expect(first.requestId).toMatch(UUID_REGEX);
     expect(second.requestId).toMatch(UUID_REGEX);
     expect(second.requestId).not.toBe(first.requestId);
+  });
+
+  it("forwards the captured omby preview bypass to vm6 API requests", async () => {
+    setBrowserUrl(
+      "https://pr-22085-app.omby.ai/?x-vercel-protection-bypass=preview-secret",
+    );
+    mockSignedInUser();
+    const observedBypassHeaders: (string | null)[] = [];
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+    context.mocks.api(
+      zeroUserConnectorsContract.get,
+      ({ request, respond }) => {
+        observedBypassHeaders.push(
+          request.headers.get("x-vercel-protection-bypass"),
+        );
+        return respond(200, { enabledTypes: [] });
+      },
+    );
+    context.mocks.http.get("*/api/zero/preview-bypass-test", ({ request }) => {
+      observedBypassHeaders.push(
+        request.headers.get("x-vercel-protection-bypass"),
+      );
+      return new Response(null, { status: 204 });
+    });
+
+    const client = context.store.get(zeroClient$)(zeroUserConnectorsContract);
+    await accept(client.get({ params: { id: agentId } }), [200]);
+    await getFetchForTest()("/api/zero/preview-bypass-test");
+
+    expect(observedBypassHeaders).toStrictEqual([
+      "preview-secret",
+      "preview-secret",
+    ]);
+  });
+
+  it("does not forward an omby lookalike preview bypass", async () => {
+    setBrowserUrl(
+      "https://pr-22085-app.omby.ai.evil.example/?x-vercel-protection-bypass=preview-secret",
+    );
+    mockSignedInUser();
+    let observedBypassHeader: string | null = "not-called";
+    context.mocks.http.get("*/api/zero/preview-bypass-test", ({ request }) => {
+      observedBypassHeader = request.headers.get("x-vercel-protection-bypass");
+      return new Response(null, { status: 204 });
+    });
+
+    await getFetchForTest()("/api/zero/preview-bypass-test");
+
+    expect(observedBypassHeader).toBeNull();
   });
 
   it("opens the force upgrade dialog for contract client responses", async () => {

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -9,6 +9,7 @@ import {
 } from "@vm0/api-contracts/contracts/trpc-contract";
 
 import { IN_VITEST } from "../env.ts";
+import { addCapturedPreviewBypassHeader } from "../lib/preview-bypass-cookie.ts";
 import {
   fetchFreshToken,
   handleUnauthorizedRedirect,
@@ -49,6 +50,7 @@ export function createAuthedContractClient<T extends AppRouter>(
           headers.set("Authorization", `Bearer ${token}`);
         }
         addClientHeaders(headers);
+        addCapturedPreviewBypassHeader(headers, options.baseUrl);
         return trpcRestFetchApi({
           ...args,
           fetchOptions: { ...args.fetchOptions, credentials: "include" },

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 import { clearPostHogUser, setPostHogUser } from "../lib/posthog.ts";
+import { appendCapturedPreviewBypassToUrl } from "../lib/preview-bypass-cookie.ts";
 import {
   derivePlatformServiceOrigin,
   isProductionSatelliteHostname,
@@ -143,6 +144,7 @@ export function resolveWebAuthUrl(
   if (options.redirectUrl) {
     url.searchParams.set("redirect_url", options.redirectUrl);
   }
+  appendCapturedPreviewBypassToUrl(url);
   return url.toString();
 }
 
@@ -225,8 +227,10 @@ function buildVm0OnboardingEntryUrl(paramsInit?: URLSearchParams): string {
     params.set("vm0_experiment", VM0_ONBOARDING_EXPERIMENT);
   }
   setCurrentLandingContext(params);
-  const query = params.toString();
-  return `${onboardingBaseUrl()}${VM0_ONBOARDING_PATH}${query ? `?${query}` : ""}`;
+  const url = new URL(VM0_ONBOARDING_PATH, onboardingBaseUrl());
+  url.search = params.toString();
+  appendCapturedPreviewBypassToUrl(url);
+  return url.toString();
 }
 
 function isAllowedRedirectOrigin(

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -1,4 +1,5 @@
 import { computed } from "ccstate";
+import { addCapturedPreviewBypassHeader } from "../lib/preview-bypass-cookie.ts";
 import { clerk$ } from "./auth.ts";
 import {
   fetchFreshToken,
@@ -157,6 +158,10 @@ export const fetch$ = computed((get) => {
           finalUrl = rewritten;
         }
       }
+
+      const finalHeaders = new Headers(finalInit.headers);
+      addCapturedPreviewBypassHeader(finalHeaders, finalUrl);
+      finalInit.headers = finalHeaders;
 
       return await fetch(finalUrl, finalInit);
     };

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { appendCapturedPreviewBypassToUrl } from "../../lib/preview-bypass-cookie.ts";
 import { clerk$, resolveAppAuthUrl, resolveWebOrigin } from "../auth.ts";
 import { searchParams$ } from "../route.ts";
 import {
@@ -17,6 +18,7 @@ function onboardingUrl(searchParams: URLSearchParams): string {
   if (search) {
     url.search = search;
   }
+  appendCapturedPreviewBypassToUrl(url);
   return url.toString();
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -54,6 +54,31 @@ describe("zero onboarding", () => {
     });
   });
 
+  it("forwards the omby preview bypass through the Clerk onboarding handoff", async () => {
+    mockOnboardingNeeded();
+    mockedClerk.buildUrlWithAuth.mockImplementation((to) => {
+      const url = new URL(to);
+      url.searchParams.set("__clerk_db_jwt", "dvb_test_handoff");
+      return url.toString();
+    });
+    setBrowserUrl("https://pr-22085-app.omby.ai/");
+
+    detachedSetupPage({
+      context,
+      path: "/?x-vercel-protection-bypass=preview-secret",
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://pr-22085-www.vm6.ai");
+      expect(url.pathname).toBe("/onboarding/491858");
+      expect(url.searchParams.get("x-vercel-protection-bypass")).toBe(
+        "preview-secret",
+      );
+      expect(url.searchParams.get("__clerk_db_jwt")).toBe("dvb_test_handoff");
+    });
+  });
+
   it("redirects direct onboarding visits to external onboarding", async () => {
     setBrowserUrl("https://app.vm7.ai:8443/");
     detachedSetupPage({


### PR DESCRIPTION
## Summary

- deploy every completed `okou-app/<commit-sha>` R2 artifact to the stable Cloudflare Pages branch for its pull request
- expose that branch at `pr-<id>-app.omby.ai`, while keeping the generated `pages.dev` branch alias available for diagnostics
- route `pr-<id>-app.omby.ai` to the matching preview services at `pr-<id>-api.vm6.ai` and `pr-<id>-www.vm6.ai`
- capture the standard Vercel bypass from the preview entry URL, forward it through Clerk onboarding navigation, and attach it to the matching vm6 API requests
- scope bypass forwarding to the same PR API/WWW hosts so other PRs, lookalike domains, and production hosts never receive it
- allow exact `*.omby.ai` app preview origins through preview API CORS while rejecting lookalike suffixes
- remove source maps and internal artifact metadata before Pages upload while applying the existing Platform security and cache headers
- delete the Pages custom domain and exact Cloudflare DNS record when the pull request closes
- keep the Pages production branch reserved as `production` without binding `app.okou.ai` or changing the existing Vercel deployment

## Infrastructure

- created the Direct Upload Pages project `okou-app` with `production` as its production branch
- configured `CF_PAGES_PROJECT_NAME=okou-app`, `CF_PAGES_PREVIEW_DOMAIN=omby.ai`, and the exact Cloudflare zone ID
- use the dedicated `CF_PAGES_DEPLOY_API_TOKEN` secret for Pages Edit and DNS Edit limited to `omby.ai`
- do not compile the Vercel bypass secret into the Pages artifact; authorized preview entry URLs provide it as `?x-vercel-protection-bypass=<secret>`

## Verification

- live custom preview: https://pr-22085-app.omby.ai
- latest Pages deployment completed successfully for commit `34a17022050ceefd2ba5c32ddc82a5e81fe1a749` on branch `pr-22085-app`
- custom domain, DNS verification, and TLS validation are active
- native browser sign-in with the standard bypass query reached `pr-22085-www.vm6.ai/onboarding/491858` without injected scripts or cookie changes
- browser-observed feature switch, onboarding, and billing requests to `pr-22085-api.vm6.ai` returned 200; CORS preflights returned 204
- the Clerk onboarding URL retained the standard bypass query while API request URLs kept it out of the URL and sent it as a header
- no browser runtime errors; only the expected Clerk development-key warning
- targeted Platform tests: 3 files and 15 tests passed
- Platform lint and type checks passed
- full pre-commit checks passed, including Prettier, Knip, and all 13 repository type-check tasks
- behavior tests reject lookalike domains and different PR IDs

No production domain or traffic is changed by this PR.