### PR TITLE
fix(platform): organize mobile chat completion layout

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -320,6 +320,12 @@ describe("chat message action cards", () => {
       });
       expect(cards).toHaveLength(2);
     });
+    for (const card of cards) {
+      expect(
+        within(card).getByText("To: recipient@example.com"),
+      ).toBeInTheDocument();
+      expect(within(card).queryByText("sender@example.com")).toBeNull();
+    }
     const untrustedLink = queryAllByRoleFast("link").find((link) => {
       return link.textContent === "Untrusted email";
     });

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -35,7 +35,7 @@ function statusLabel(status: ZeroMailDraftStatus): string {
 
 function MailDraftCardSkeleton() {
   return (
-    <div className="flex h-[92px] w-full max-w-xl items-center gap-3 rounded-xl border border-border/70 bg-card px-4">
+    <div className="flex min-h-[76px] w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3">
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted/60">
         <IconLoader2 className="animate-spin text-muted-foreground" size={16} />
       </span>
@@ -63,17 +63,18 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const draft = draftLoadable.data;
   const deleted = draft.status === "deleted";
   const selected = selectedMailDraftId === signals.mailDraftId;
+  const recipients = draft.to.join(", ") || "(No recipient)";
   const content = (
     <>
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-background">
         <ConnectorIcon icon={GMAIL_ICON} size={23} />
       </span>
-      <span className="min-w-0 flex-1 self-stretch py-0.5">
-        <span className="line-clamp-2 min-h-10 text-sm font-medium leading-5 text-foreground">
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium leading-5 text-foreground">
           {draft.subject || "(No subject)"}
         </span>
-        <span className="mt-1 block truncate text-xs text-muted-foreground">
-          {draft.fromName ?? draft.from}
+        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+          To: {recipients}
         </span>
       </span>
       <span className="flex shrink-0 items-center gap-1.5 self-center">
@@ -103,7 +104,7 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
         aria-label={`Deleted email: ${draft.subject || "No subject"}`}
         data-mail-draft-card
         data-mail-draft-status="deleted"
-        className="flex h-[92px] w-full max-w-xl cursor-default items-center gap-3 rounded-xl border border-border/60 bg-card px-4 opacity-70"
+        className="flex min-h-[76px] w-full max-w-xl cursor-default items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/60 bg-card px-4 py-3 opacity-70"
       >
         {content}
       </div>
@@ -121,7 +122,7 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
         openSidebar(signals.mailDraftId);
       }}
       className={cn(
-        "flex h-[92px] w-full max-w-xl items-center gap-3 rounded-xl border bg-card px-4 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "flex min-h-[76px] w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         selected ? "border-ring/60 bg-muted/20" : "border-border/70",
       )}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3417,27 +3417,37 @@ function CompletedWorkFoldRow({
   groups,
   expanded,
   onToggle,
+  thread,
 }: {
   groups: readonly GroupedChatMessageGroup[];
   expanded: boolean;
   onToggle: () => void;
+  thread: ChatThreadSignals;
 }) {
   const label = completedWorkLabel(groups);
+  const displayName = useLastResolved(thread.agentDisplayName$) ?? "Zero";
   return (
-    <div data-chat-completed-work-fold className="-mx-2 @[900px]:-mb-[15px]">
+    <div
+      data-chat-completed-work-fold
+      className="min-w-0 border-b border-border/40 pb-2 @[900px]:-mx-2 @[900px]:-mb-[15px] @[900px]:border-b-0 @[900px]:pb-0"
+    >
       <button
         type="button"
         aria-expanded={expanded}
         aria-label={expanded ? "Collapse work history" : "Expand work history"}
         onClick={onToggle}
-        className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-muted/50"
+        className="inline-flex min-h-7 max-w-full items-center gap-1.5 rounded-lg px-1 py-0.5 text-muted-foreground transition-colors hover:bg-muted/50 @[900px]:mt-1.5 @[900px]:min-h-9 @[900px]:gap-2 @[900px]:px-2 @[900px]:py-1.5"
       >
         <IconHourglass
           aria-hidden
           size={14}
-          className="shrink-0 text-muted-foreground/70"
+          className="hidden shrink-0 text-muted-foreground/70 @[900px]:block"
         />
-        <span className="text-[13px]">{label}</span>
+        <span className="truncate text-[13px] font-medium text-foreground @[900px]:hidden">
+          {displayName}
+        </span>
+        <span className="text-muted-foreground/50 @[900px]:hidden">·</span>
+        <span className="shrink-0 text-[13px]">{label}</span>
         <IconChevronRight
           aria-hidden
           size={14}
@@ -3820,14 +3830,17 @@ function RecommendedFollowupList({
   };
 
   return (
-    <div ref={handleRecommendedFollowupsRef} className="-mx-2">
+    <div
+      ref={handleRecommendedFollowupsRef}
+      className="flex flex-col gap-1 @[900px]:-mx-2 @[900px]:gap-0"
+    >
       {source.followups.map((followup, followupIndex) => {
         return (
           <button
             key={followup.prompt}
             type="button"
             title={followup.prompt}
-            className="group flex min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted/40"
+            className="group flex min-h-10 w-full items-center gap-2 rounded-lg border border-border/60 bg-background px-2 py-2 text-left transition-colors hover:bg-muted/40 @[900px]:border-transparent @[900px]:bg-transparent"
             onClick={() => {
               handleSelect(followup, followupIndex);
             }}
@@ -4482,12 +4495,12 @@ function FinishedRunRow({
   const label = source ? "Keep going" : donePhrase;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 rounded-[var(--zero-card-radius)] bg-gray-50 p-3 @[900px]:rounded-none @[900px]:bg-transparent @[900px]:p-0">
       <div className="flex h-5 flex-col justify-center gap-1.5">
-        <div className="h-px w-full bg-border/40" />
+        <div className="hidden h-px w-full bg-border/40 @[900px]:block" />
         <div className="flex items-center gap-2">
           <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
-          <div className="h-px flex-1 bg-border/40" />
+          <div className="hidden h-px flex-1 bg-border/40 @[900px]:block" />
         </div>
       </div>
       {source ? (
@@ -6618,6 +6631,24 @@ function PagedAssistantGroup({
       />
     );
   };
+  const assistantMessages = (
+    <>
+      {showCompletedWorkFold && completedWorkFold.expanded
+        ? completedWorkFold.hiddenGroups.map((hiddenGroup) => {
+            return (
+              <div key={hiddenGroup.beginMessageId} className="contents">
+                {hiddenGroup.messages.map((msg) => {
+                  return renderAssistantMessageItem(msg);
+                })}
+              </div>
+            );
+          })
+        : null}
+      {group.messages.map((msg) => {
+        return renderAssistantMessageItem(msg);
+      })}
+    </>
+  );
 
   return (
     <div
@@ -6625,37 +6656,34 @@ function PagedAssistantGroup({
       data-role="assistant"
       className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
     >
-      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-        <AssistantBubbleAvatar thread={thread} />
-        <div className="relative flex flex-col gap-2">
-          {runGroupFolds?.map((fold) => {
-            return (
-              <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
-            );
-          })}
-          {showCompletedWorkFold && (
+      {showCompletedWorkFold ? (
+        <div className="grid grid-cols-[28px_minmax(0,1fr)] items-start gap-x-2 gap-y-2 @[900px]:-ml-[46px] @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-x-2.5 @[900px]:gap-y-0">
+          <AssistantBubbleAvatar thread={thread} />
+          <div className="contents @[900px]:relative @[900px]:flex @[900px]:flex-col @[900px]:gap-2">
             <CompletedWorkFoldRow
               groups={completedWorkFold.groups}
               expanded={completedWorkFold.expanded}
               onToggle={completedWorkFold.onToggle}
+              thread={thread}
             />
-          )}
-          {showCompletedWorkFold && completedWorkFold.expanded
-            ? completedWorkFold.hiddenGroups.map((hiddenGroup) => {
-                return (
-                  <div key={hiddenGroup.beginMessageId} className="contents">
-                    {hiddenGroup.messages.map((msg) => {
-                      return renderAssistantMessageItem(msg);
-                    })}
-                  </div>
-                );
-              })
-            : null}
-          {group.messages.map((msg) => {
-            return renderAssistantMessageItem(msg);
-          })}
+            <div className="relative col-span-2 flex flex-col gap-2">
+              {assistantMessages}
+            </div>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+          <AssistantBubbleAvatar thread={thread} />
+          <div className="relative flex flex-col gap-2">
+            {runGroupFolds?.map((fold) => {
+              return (
+                <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
+              );
+            })}
+            {assistantMessages}
+          </div>
+        </div>
+      )}
       <PagedGroupActions group={group} content={fullContent} thread={thread} />
     </div>
   );


### PR DESCRIPTION
## Summary

- group the mobile assistant avatar and completed-work status into one compact response header
- place mobile follow-up suggestions on a calm gray surface while preserving the desktop layout
- tighten Gmail result cards and show `To: <recipient>` instead of sender details

## User impact

Completed mobile chat runs now read as one response instead of several disconnected rows, and email results make the intended recipient immediately visible.

## Verification

- Prettier 3.8.1 on all changed files
- 156 targeted platform tests passed across chat lifecycle and message action cards
- platform production and test TypeScript checks passed
- platform static asset check, Oxlint, type-aware Oxlint, and ESLint passed
- platform Knip check passed

Local browser verification was not run per the vm0 PR workflow; the PR preview is the visual verification surface.
