### PR TITLE
fix: hide sub-hour expiry text on chat permission cards

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -617,7 +617,7 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: isoFromNowMs(60 * 60 * 1000),
+            expiresAt: isoFromNowMs(30 * 60 * 1000),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },
@@ -673,12 +673,18 @@ describe("chat message action cards", () => {
         within(createCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
     });
+    expect(
+      within(createCard).queryByText("Expires in less than 1 hour"),
+    ).not.toBeInTheDocument();
     await confirmPermissionAction(user, writeCard);
     await waitFor(() => {
       expect(
         within(writeCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
     });
+    expect(
+      within(writeCard).queryByText("Expires in less than 1 hour"),
+    ).not.toBeInTheDocument();
 
     expect(capturedPermissionGrantBodies).toStrictEqual([
       {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5410,9 +5410,11 @@ function PermissionActionCardContent({
   expiresAt: string | null;
   onClick: () => void;
 }) {
-  const expiryText = expirationAvailable
+  const rawExpiryText = expirationAvailable
     ? permissionGrantExpiryText(expiresAt)
     : null;
+  const expiryText =
+    rawExpiryText === "Expires in less than 1 hour" ? null : rawExpiryText;
   const showDurationSelect =
     expirationAvailable &&
     (status.kind === "ready" ||


### PR DESCRIPTION
## Summary

- hide the `Expires in less than 1 hour` line on chat permission cards
- preserve longer expiry labels and expired-state messaging
- cover short-lived grants in the permission action card integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx`

Browser verification was not run, following the repository preference to rely on the PR pipeline unless explicitly requested.