### PR TITLE
feat: remove workflow queue feature switch and legacy dispatch paths

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,7 +132,7 @@ The orchestration layer coordinates job execution between web API and runners.
 
 #### Per-Thread Chat Scheduling
 
-Chat threads run at most one run at a time. Queued work lives in
+A chat thread runs at most one run at a time. Queued work lives in
 `chat_message_queue` with two item types: `user_message` (a chat message
 waiting for its run) and `workflow_event` (a fired workflow automation event
 carrying its encrypted payload). Admission and consumption serialize on a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,26 @@ The orchestration layer coordinates job execution between web API and runners.
 - Official runners: HMAC signature using `OFFICIAL_RUNNER_SECRET`
 - User runners: JWT bearer token with userId claim
 
+#### Per-Thread Chat Scheduling
+
+Chat threads run at most one run at a time. Queued work lives in
+`chat_message_queue` with two item types: `user_message` (a chat message
+waiting for its run) and `workflow_event` (a fired workflow automation event
+carrying its encrypted payload). Admission and consumption serialize on a
+per-thread Postgres advisory lock and pop in `ORDER BY created_at, id` order,
+with user messages always draining before workflow events.
+
+All scheduling flows converge on a single drain entry
+(`drainChatThreadQueueForThread$` in
+`turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts`):
+terminal run callbacks, run cancellation, queue resume, and a cron sweep for
+threads missed by callbacks. A run-creation failure for a dequeued workflow
+event restores the event at its original queue position and pauses the
+thread's queue (`chat_threads.queue_paused_at` / `pause_reason`); pause
+freezes consumption while intake continues. Schedule ticks coalesce to at
+most one pending event per automation. The drain entry is the designated
+mounting point for a future unified per-thread rate limiter.
+
 ---
 
 ## Infrastructure

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomUUID } from "node:crypto";
 
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
@@ -11,7 +11,6 @@ import type { ApiTestUser } from "./helpers/api-bdd";
 import { createGithubBddApi } from "./helpers/api-bdd-github";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -29,6 +28,10 @@ function authHeaders() {
 
 function automationsClient() {
   return setupApp({ context })(zeroWorkflowAutomationsContract);
+}
+
+function queueClient() {
+  return setupApp({ context })(zeroWorkflowQueueContract);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -128,11 +131,6 @@ async function postGithubWebhook(args: {
 describe("POST /api/webhooks/github for workflow automations", () => {
   it("dispatches matching label events and de-duplicates deliveries", async () => {
     const { fixture, actor, agentId, workflowId } = await setupFixture();
-    // Pin the workflow queue off: this test covers the legacy concurrent
-    // dispatch path that remains behind the switch.
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.WorkflowQueue]: false,
-    });
     const runnerGroup = runsApi.configureRunnerGroup();
     const installed = await gh.installGithubApp(actor, agentId, {
       oauthCode: {
@@ -211,36 +209,36 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     await flushWaitUntilForTest();
     await flushWaitUntilForTest();
 
-    // Two deliveries matched two automations each; the duplicate redelivery was
-    // recorded as processed and added nothing. Exactly four distinct
-    // workflow-event runs exist: two admitted within the pro concurrency
-    // limit (claimable through the runner API) and two queued behind it
-    // (visible on the org run queue).
-    const runIds = new Set<string>();
+    // Two deliveries matched two automations each; the duplicate redelivery
+    // was recorded as processed and added nothing. Under the per-thread
+    // workflow queue, the first matched event creates the only admitted run
+    // and the remaining three wait as pending workflow queue events.
     await runsApi.heartbeatRunner(runnerGroup);
-    for (let index = 0; index < 2; index += 1) {
-      const polled = await runsApi.pollRunner(runnerGroup);
-      const runId = polled.body.job?.runId;
-      if (!runId) {
-        throw new Error(
-          `Expected an admitted workflow event run #${index + 1}`,
-        );
-      }
-      runIds.add(runId);
-      await runsApi.claimRunnerJob(runId);
+    const polled = await runsApi.pollRunner(runnerGroup);
+    const admittedRunId = polled.body.job?.runId;
+    if (!admittedRunId) {
+      throw new Error("Expected an admitted workflow event run");
     }
-    const queueState = await runsApi.readRunQueue(actor);
-    expect(queueState.body.queue).toHaveLength(2);
-    for (const entry of queueState.body.queue) {
-      expect(entry.triggerSource).toBe("workflow-event");
-      if (!entry.runId) {
-        throw new Error("Expected queued workflow event run id");
-      }
-      runIds.add(entry.runId);
-    }
-    expect(runIds.size).toBe(4);
+    await runsApi.claimRunnerJob(admittedRunId);
+    const idle = await runsApi.pollRunner(runnerGroup);
+    expect(idle.body.job).toBeNull();
 
-    for (const runId of runIds) {
+    const queueState = await runsApi.readRunQueue(actor);
+    expect(queueState.body.queue).toHaveLength(0);
+
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to have a chat thread");
+    }
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: created.body.chatThreadId },
+      }),
+      [200],
+    );
+    expect(queue.body.pending).toHaveLength(3);
+
+    for (const runId of [admittedRunId]) {
       const timingEvents = sandboxOperationEventsForRun(runId);
       const actionTypes = new Set(
         timingEvents.map((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -14,7 +14,6 @@ import {
   zeroWorkflowAutomationsContract,
   type ZeroWorkflowAutomationSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { HttpResponse, http } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -37,7 +36,6 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { replaceBddVm0ApiKeys } from "../../../test-fixtures/chat-messages";
 
 const context = testContext();
@@ -358,21 +356,6 @@ function expectResponseStatus(
   }
 }
 
-async function enableGmailWorkflowAutomations(
-  actor: ApiTestUser & { readonly orgId: string },
-  options: { readonly workflowQueue?: boolean } = {},
-): Promise<void> {
-  await updateFeatureSwitchesForUser(
-    context,
-    actor,
-    options.workflowQueue === false
-      ? { [FeatureSwitchKey.WorkflowQueue]: false }
-      : options.workflowQueue
-        ? { [FeatureSwitchKey.WorkflowQueue]: true }
-        : {},
-  );
-}
-
 async function configureWorkspaceModelProvider(
   actor: ApiTestUser,
 ): Promise<void> {
@@ -648,7 +631,6 @@ describe("POST /api/webhooks/gmail", () => {
     configureGmailMessageMocks(gmailEmail);
 
     const { actor, workflowId } = await setupFixture();
-    await enableGmailWorkflowAutomations(actor);
     await connectGmail(actor, gmailEmail);
     await configureWorkspaceModelProvider(actor);
 
@@ -804,7 +786,6 @@ describe("POST /api/webhooks/gmail", () => {
     configureGmailLabelAppliedMocks("Label_support_new", gmailEmail);
 
     const { actor, workflowId } = await setupFixture();
-    await enableGmailWorkflowAutomations(actor);
     await connectGmail(actor, gmailEmail);
     await configureWorkspaceModelProvider(actor);
 
@@ -870,75 +851,6 @@ describe("POST /api/webhooks/gmail", () => {
     );
   });
 
-  it("starts an event run when the automation's previous run is still active", async () => {
-    const gmailEmail = uniqueGmailEmail();
-    configureGmailEnv();
-    configureGmailWatchMock();
-    configureGmailMessageMocks(gmailEmail);
-
-    const { actor, workflowId } = await setupFixture();
-    // Pin the workflow queue off: this test covers the legacy concurrent
-    // dispatch path that remains behind the switch.
-    await enableGmailWorkflowAutomations(actor, { workflowQueue: false });
-    await connectGmail(actor, gmailEmail);
-    await configureWorkspaceModelProvider(actor);
-
-    const created = await accept(
-      automationsClient().create({
-        headers: authHeaders(actor),
-        params: { workflowId },
-        body: {
-          kind: "event",
-          eventType: "gmail-new-message",
-          eventConfig: {
-            provider: "gmail",
-            event: "new_message",
-            match: { subject: { contains: "invoice" } },
-          },
-        },
-      }),
-      [201],
-    );
-    const chatThreadId = requireAutomationChatThreadId(created.body);
-    await configureAutomationThreadModel(actor, chatThreadId);
-    const activeRun = await runAutomationNow(actor, created.body.id);
-    expect(activeRun.chatThreadId).toBe(chatThreadId);
-    const triggerBriefsBeforeWebhook = await workflowAutomationBriefs(
-      actor,
-      chatThreadId,
-    );
-
-    const response = await postGmailWebhook(
-      gmailPushBody({
-        emailAddress: gmailEmail,
-        historyId: 101,
-        messageId: "pubsub-active-run",
-      }),
-    );
-
-    expectResponseStatus(response, 200);
-    expect(response.body).toMatchObject({ dispatched: 1, duplicates: 0 });
-
-    const expectedAutomationBrief = [
-      "Gmail new message",
-      "From: Customer Example <customer@example.com>",
-      "Subject: Invoice needs a reply",
-    ].join("\n");
-    const triggerBriefsAfterWebhook = await workflowAutomationBriefs(
-      actor,
-      chatThreadId,
-    );
-    expect(triggerBriefsAfterWebhook).toContain(expectedAutomationBrief);
-    expect(triggerBriefsAfterWebhook).toHaveLength(
-      triggerBriefsBeforeWebhook.length + 1,
-    );
-    await expect(readAutomation(actor, created.body.id)).resolves.toMatchObject(
-      {
-        lastRunAt: expect.any(String),
-      },
-    );
-  });
-
   it("preserves metadata-only context through the workflow queue", async () => {
     const gmailEmail = uniqueGmailEmail();
     configureGmailEnv();
@@ -947,7 +859,6 @@ describe("POST /api/webhooks/gmail", () => {
     configureGmailMessageMocks(gmailEmail);
 
     const { actor, workflowId } = await setupFixture();
-    await enableGmailWorkflowAutomations(actor, { workflowQueue: true });
     await connectGmail(actor, gmailEmail);
     await configureWorkspaceModelProvider(actor);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -10,7 +9,6 @@ import type { ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -341,73 +339,5 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
       throw new Error("Expected a webhook automation");
     }
     expect(after.disabledReason).toBeNull();
-  });
-
-  it("starts an event run when the automation's previous run is still active", async () => {
-    const { fixture, workflowId } = await setupFixture();
-    // Pin the workflow queue off: this test covers the legacy concurrent
-    // dispatch path that remains behind the switch.
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.WorkflowQueue]: false,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-
-    const created = await accept(
-      automationsClient().create({
-        headers: authHeaders(),
-        params: { workflowId },
-        body: { kind: "event", eventType: "webhook-received" },
-      }),
-      [201],
-    );
-    if (
-      created.body.kind !== "event" ||
-      created.body.eventType !== "webhook-received" ||
-      !created.body.webhookUrl ||
-      !created.body.webhookSecret
-    ) {
-      throw new Error("Expected a webhook automation with a one-time secret");
-    }
-
-    const token = new URL(created.body.webhookUrl).pathname.split("/").at(-1);
-    if (!token) {
-      throw new Error("Expected webhook URL token");
-    }
-
-    // The first delivery starts a run that stays active (nothing claims or
-    // completes it).
-    const first = await postWorkflowWebhook({
-      token,
-      rawBody: JSON.stringify({ event: "active-run" }),
-      secret: created.body.webhookSecret,
-    });
-    expect(first.status).toBe(200);
-    expect(first.body).toMatchObject({
-      success: true,
-      duplicate: false,
-      runId: expect.any(String),
-    });
-    const firstRunId = isRecord(first.body) ? first.body.runId : null;
-
-    // A second, distinct delivery still starts a new event run even though
-    // the previous run is active.
-    const second = await postWorkflowWebhook({
-      token,
-      rawBody: JSON.stringify({ event: "active-run-second" }),
-      secret: created.body.webhookSecret,
-    });
-
-    expect(second.status).toBe(200);
-    expect(second.body).toMatchObject({
-      success: true,
-      duplicate: false,
-      runId: expect.any(String),
-    });
-    expect(isRecord(second.body) ? second.body.runId : null).not.toBe(
-      firstRunId,
-    );
-
-    const automation = await wf.readAutomation(created.body.id);
-    expect(typeof automation.lastRunAt).toBe("string");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -1,7 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-
 import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
@@ -21,7 +19,6 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -398,50 +395,6 @@ describe("zero workflow automation scheduler", () => {
         "u",
       ),
     );
-    await disableAutomation(automation.automationId);
-  });
-
-  it("skips an automation whose previous run is still active", async () => {
-    const scenario = await setup();
-    // Pin the workflow queue off: this test covers the legacy skip-while-busy
-    // scheduler path that remains behind the switch.
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId: scenario.orgId, userId: scenario.userId },
-      { [FeatureSwitchKey.WorkflowQueue]: false },
-    );
-    mocks.clerk.session(scenario.userId, scenario.orgId);
-    const automation = await createDueLoopAutomation(scenario, 60);
-
-    // First tick fires a run that stays active (never claimed or completed).
-    await executeDueWorkflowAutomations();
-    await onlyWorkflowRunMessage(automation.threadId);
-
-    // Re-arm the schedule through the public update route, then move time
-    // past the recomputed next run.
-    const updated = await accept(
-      automationsClient().update({
-        headers: authHeaders(),
-        params: { id: automation.automationId },
-        body: { schedule: { type: "loop", intervalSeconds: 60 } },
-      }),
-      [200],
-    );
-    if (!updated.body.nextRunAt) {
-      throw new Error("Expected the loop automation to be rescheduled");
-    }
-    mockNow(Date.parse(updated.body.nextRunAt) + 1000);
-
-    await executeDueWorkflowAutomations();
-
-    // The due automation was skipped: no second run message and the schedule is
-    // left untouched for the next tick.
-    const messages = await workflowRunMessages(automation.threadId);
-    expect(messages).toHaveLength(1);
-    const read = await wf.readAutomation(automation.automationId);
-    expect(read.enabled).toBeTruthy();
-    expect(read.nextRunAt).toBe(updated.body.nextRunAt);
-
     await disableAutomation(automation.automationId);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
@@ -14,7 +13,6 @@ import type { ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -46,9 +44,7 @@ interface Scenario {
   readonly runnerGroup: string;
 }
 
-async function setup(
-  options: { readonly workflowQueue?: boolean } = {},
-): Promise<Scenario> {
+async function setup(): Promise<Scenario> {
   const runnerGroup = runsApi.configureRunnerGroup();
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   const { actor } = await wf.setupWorkflowOrg({ tier: "team" });
@@ -62,14 +58,6 @@ async function setup(
     agentId: agent.agentId,
     name: WORKFLOW_NAME,
   });
-  const fixture = { orgId: actor.orgId, userId: actor.userId };
-  await updateFeatureSwitchesForUser(
-    context,
-    fixture,
-    options.workflowQueue === false
-      ? { [FeatureSwitchKey.WorkflowQueue]: false }
-      : { [FeatureSwitchKey.WorkflowQueue]: true },
-  );
   mocks.clerk.session(actor.userId, actor.orgId);
   context.mocks.s3.send.mockResolvedValue({});
   return {
@@ -232,19 +220,6 @@ describe("workflow queue API", () => {
     );
     expect(queue.body.pausedAt).toBeNull();
     expect(queue.body.pauseReason).toBeNull();
-  });
-
-  it("rejects queue reads when the feature switch is off", async () => {
-    const scenario = await setup({ workflowQueue: false });
-    const automation = await createWebhookAutomation(scenario);
-
-    await accept(
-      queueClient().get({
-        headers: authHeaders(),
-        params: { threadId: automation.threadId },
-      }),
-      [403],
-    );
   });
 
   it("skips a single pending event", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 
@@ -15,7 +14,6 @@ import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -50,9 +48,7 @@ interface Scenario {
   readonly runnerGroup: string;
 }
 
-async function setup(
-  options: { readonly workflowQueue?: boolean } = {},
-): Promise<Scenario> {
+async function setup(): Promise<Scenario> {
   const runnerGroup = runsApi.configureRunnerGroup();
   mockEnv("CRON_SECRET", CRON_SECRET);
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
@@ -67,14 +63,6 @@ async function setup(
     agentId: agent.agentId,
     name: WORKFLOW_NAME,
   });
-  const fixture = { orgId: actor.orgId, userId: actor.userId };
-  await updateFeatureSwitchesForUser(
-    context,
-    fixture,
-    options.workflowQueue === false
-      ? { [FeatureSwitchKey.WorkflowQueue]: false }
-      : { [FeatureSwitchKey.WorkflowQueue]: true },
-  );
   mocks.clerk.session(actor.userId, actor.orgId);
   context.mocks.s3.send.mockResolvedValue({});
   return {
@@ -251,15 +239,6 @@ describe("workflow queue", () => {
     // The queue is empty: completing the last run creates nothing new.
     await completeRunThroughSandbox(scenario, afterSecond[2]!);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(3);
-  });
-
-  it("keeps the current concurrent behavior when the switch is off", async () => {
-    const scenario = await setup({ workflowQueue: false });
-    const automation = await createWebhookAutomation(scenario);
-
-    expectAcceptedRunId(await postWorkflowWebhook(automation, "first"));
-    expectAcceptedRunId(await postWorkflowWebhook(automation, "second"));
-    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
   });
 
   it("coalesces schedule ticks: at most one pending tick per automation", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
@@ -1,7 +1,5 @@
-import { command, computed, type Computed } from "ccstate";
+import { command, computed } from "ccstate";
 import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
-import { FeatureSwitchKey } from "@vm0/core";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -10,7 +8,6 @@ import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
 import { notFound } from "../../lib/error";
 import { nowDate } from "../external/time";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   clearWorkflowQueueEvents,
   deleteWorkflowQueueEventById,
@@ -35,37 +32,6 @@ const workflowWriteAuth = {
   missingOrganizationStatus: 401,
   requiredCapability: "agent:write",
 } as const;
-
-const featureDisabled = Object.freeze({
-  status: 403 as const,
-  body: {
-    error: {
-      message: "The workflow queue feature is not available",
-      code: "FORBIDDEN",
-    },
-  },
-});
-
-interface AuthIdentity {
-  readonly orgId: string;
-  readonly userId: string;
-}
-
-type ComputedGetter = <T>(computedValue: Computed<T>) => T;
-
-async function workflowQueueDisabled(
-  get: ComputedGetter,
-  auth: AuthIdentity,
-): Promise<boolean> {
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return !isFeatureEnabled(FeatureSwitchKey.WorkflowQueue, {
-    userId: auth.userId,
-    orgId: auth.orgId,
-    overrides,
-  });
-}
 
 async function workflowQueueResponse(
   db: ReadonlyDb,
@@ -105,9 +71,6 @@ async function workflowQueueResponse(
 const getQueueInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroWorkflowQueueContract.get));
-  if (await workflowQueueDisabled(get, auth)) {
-    return featureDisabled;
-  }
   const db = get(db$);
   const thread = await loadWorkflowQueueThread(db, {
     orgId: auth.orgId,
@@ -123,9 +86,6 @@ const getQueueInner$ = computed(async (get) => {
 const skipEventInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroWorkflowQueueContract.skipEvent));
-  if (await workflowQueueDisabled(get, auth)) {
-    return featureDisabled;
-  }
   const db = set(writeDb$);
   const deleted = await deleteWorkflowQueueEventById(db, {
     orgId: auth.orgId,
@@ -156,9 +116,6 @@ const skipEventInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const clearQueueInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroWorkflowQueueContract.clear));
-  if (await workflowQueueDisabled(get, auth)) {
-    return featureDisabled;
-  }
   const db = set(writeDb$);
   const thread = await loadWorkflowQueueThread(db, {
     orgId: auth.orgId,
@@ -189,9 +146,6 @@ const setPauseInner = (paused: boolean) => {
           : zeroWorkflowQueueContract.resume,
       ),
     );
-    if (await workflowQueueDisabled(get, auth)) {
-      return featureDisabled;
-    }
     const db = set(writeDb$);
     const thread = await loadWorkflowQueueThread(db, {
       orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -1,6 +1,4 @@
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
-import { FeatureSwitchKey } from "@vm0/core";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -85,18 +83,6 @@ export async function decryptWorkflowQueueEventParams(
     return null;
   }
   return workflowQueueEventParamsWireSchema.parse(JSON.parse(raw));
-}
-
-export function workflowQueueEnabledForOwner(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly overrides: Record<string, boolean>;
-}): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.WorkflowQueue, {
-    userId: args.userId,
-    orgId: args.orgId,
-    overrides: args.overrides,
-  });
 }
 
 function chatMessageQueueLock(chatThreadId: string) {

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -20,12 +20,15 @@ interface DrainChatThreadQueueInput {
 }
 
 /**
- * The single per-thread scheduler entry. User messages are attempted first;
- * the workflow drain then observes the newly-created active run and stops, or
- * consumes the oldest workflow event when no user message dispatched.
+ * The single per-thread scheduler entry: terminal run callbacks, cancel,
+ * resume, and the stale sweep all converge here. User messages are attempted
+ * first; the workflow drain then observes the newly-created active run and
+ * stops, or consumes the oldest workflow event when no user message
+ * dispatched. Both halves serialize on the same per-thread advisory lock and
+ * pop in `ORDER BY created_at, id` order.
  *
- * Compatibility-specific reads remain inside the two drain halves until the
- * follow-up cleanup removes the old queue representations.
+ * This entry is the designated mounting point for a future unified per-thread
+ * rate limiter: admission delays belong here, before either drain half runs.
  */
 export const drainChatThreadQueueForThread$ = command(
   async (

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-poller.service.ts
@@ -1,4 +1,3 @@
-import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import {
@@ -6,7 +5,7 @@ import {
   zeroWorkflowAutomations,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
-import { command, type Computed } from "ccstate";
+import { command } from "ccstate";
 import { and, eq, lte } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -21,8 +20,6 @@ import {
   type RunFailure,
   type AutomationRow,
 } from "./zero-workflow-automation-run.service";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { workflowQueueEnabledForOwner } from "./chat-message-queue.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { buildWorkflowScheduleAutomationBrief } from "./zero-workflow-automation-brief.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
@@ -71,10 +68,6 @@ function isInsufficientCreditsFailure(error: unknown): boolean {
     error.kind === "run_error" &&
     error.response.body.error.code === "INSUFFICIENT_CREDITS"
   );
-}
-
-function isActivePreviousRunStatus(status: string): boolean {
-  return status === "pending" || status === "running";
 }
 
 async function hasOrgMembership(
@@ -277,48 +270,13 @@ async function dueWorkflowAutomationRows(
 /**
  * Time poller over `zero_workflow_automations`, run from the
  * execute-workflow-automations cron route. Mirrors the automation poller: scan
- * enabled automations whose `next_run_at` is due, skip any whose previous run is
- * still active, optimistic-lock claim the due row, then fire a run that injects
+ * enabled automations whose `next_run_at` is due, optimistic-lock claim the due
+ * row, then fire a run that injects
  * the workflow skill (via the agent's attachment) and carries the recurrence
  * completion callback.
  */
-type ComputedGetter = <T>(computedValue: Computed<T>) => T;
-
-/**
- * Legacy skip-if-busy gate. With the workflow queue enabled the tick enqueues
- * behind the active run instead of being skipped, so the lastRunId check only
- * applies when the switch is off.
- */
-async function shouldSkipBusyAutomation(input: {
-  readonly get: ComputedGetter;
-  readonly db: Db;
-  readonly automation: AutomationRow;
-  readonly signal: AbortSignal;
-}): Promise<boolean> {
-  const { get, db, automation, signal } = input;
-  const overrides = await get(
-    userFeatureSwitchOverrides(automation.orgId, automation.ownerUserId),
-  );
-  signal.throwIfAborted();
-  const queueEnabled = workflowQueueEnabledForOwner({
-    orgId: automation.orgId,
-    userId: automation.ownerUserId,
-    overrides,
-  });
-  if (queueEnabled || !automation.lastRunId) {
-    return false;
-  }
-  const [lastRun] = await db
-    .select({ status: agentRuns.status })
-    .from(agentRuns)
-    .where(eq(agentRuns.id, automation.lastRunId))
-    .limit(1);
-  signal.throwIfAborted();
-  return lastRun !== undefined && isActivePreviousRunStatus(lastRun.status);
-}
-
 export const executeDueWorkflowAutomations$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<ExecuteResult> => {
+  async ({ set }, signal: AbortSignal): Promise<ExecuteResult> => {
     const db = set(writeDb$);
     const currentTime = nowDate();
 
@@ -364,18 +322,6 @@ export const executeDueWorkflowAutomations$ = command(
           orgId: row.automation.orgId,
           userId: row.automation.ownerUserId,
         });
-        skipped++;
-        continue;
-      }
-
-      if (
-        await shouldSkipBusyAutomation({
-          get,
-          db,
-          automation: row.automation,
-          signal,
-        })
-      ) {
         skipped++;
         continue;
       }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -4,7 +4,7 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
-import { command, type Computed } from "ccstate";
+import { command } from "ccstate";
 import { eq } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
@@ -25,11 +25,7 @@ import {
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
-import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import {
-  admitWorkflowAutomationEvent,
-  workflowQueueEnabledForOwner,
-} from "./chat-message-queue.service";
+import { admitWorkflowAutomationEvent } from "./chat-message-queue.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 
 export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
@@ -380,34 +376,18 @@ async function buildTimedWorkflowAutomationRunInput(args: {
 }
 
 /**
- * Workflow-queue admission: with the switch on, an event fired while the
- * workflow is busy (or its queue is paused/non-empty) is persisted as a queue
- * event instead of creating a run. Returns true when the event was enqueued.
+ * Workflow-queue admission: an event fired while the workflow is busy (or its
+ * queue is paused/non-empty) is persisted as a queue event instead of creating
+ * a run. Returns true when the event was enqueued.
  */
-type ComputedGetter = <T>(computedValue: Computed<T>) => T;
-
 async function enqueueWorkflowAutomationEventIfBusy(input: {
-  readonly get: ComputedGetter;
   readonly db: Db;
   readonly args: RunWorkflowAutomationNowArgs;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  const { get, db, args, signal } = input;
+  const { db, args, signal } = input;
   const { automation, chatThreadId } = args.due;
   if (args.bypassWorkflowQueue === true) {
-    return false;
-  }
-  const overrides = await get(
-    userFeatureSwitchOverrides(automation.orgId, automation.ownerUserId),
-  );
-  signal.throwIfAborted();
-  if (
-    !workflowQueueEnabledForOwner({
-      orgId: automation.orgId,
-      userId: automation.ownerUserId,
-      overrides,
-    })
-  ) {
     return false;
   }
   const admission = await admitWorkflowAutomationEvent(db, {
@@ -483,7 +463,7 @@ async function recordWorkflowAutomationRunStart(input: {
 
 export const runWorkflowAutomationNow$ = command(
   async (
-    { get, set },
+    { set },
     args: RunWorkflowAutomationNowArgs,
     signal: AbortSignal,
   ): Promise<RunWorkflowAutomationResult> => {
@@ -492,7 +472,6 @@ export const runWorkflowAutomationNow$ = command(
     const timing = workflowAutomationTiming(args);
 
     const enqueued = await enqueueWorkflowAutomationEventIfBusy({
-      get,
       db,
       args,
       signal,

--- a/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
+++ b/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
@@ -4,10 +4,8 @@ import {
   zeroWorkflowQueueContract,
   type WorkflowQueueResponse,
 } from "@vm0/api-contracts/contracts/zero-workflow-queue";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { openHeaderAutomationSidebar$ } from "./header-automation-sidebar.ts";
 
 export interface WorkflowQueueSignals {
@@ -37,10 +35,6 @@ export function createWorkflowQueueSignals(
   const queue$ = computed(
     async (get): Promise<WorkflowQueueResponse | null> => {
       get(reloadVersion$);
-      const switches = get(featureSwitch$);
-      if (!switches[FeatureSwitchKey.WorkflowQueue]) {
-        return null;
-      }
       const client = get(zeroClient$)(zeroWorkflowQueueContract);
       const response = await accept(
         client.get({ params: { threadId } }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -3,7 +3,6 @@ import {
   zeroWorkflowQueueContract,
   type WorkflowQueueResponse,
 } from "@vm0/api-contracts/contracts/zero-workflow-queue";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -66,9 +65,7 @@ function buttonByLabel(label: string): HTMLElement {
   return button;
 }
 
-async function openAutomationsPanel(
-  workflowQueueEnabled = true,
-): Promise<void> {
+async function openAutomationsPanel(): Promise<void> {
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
     threadTitle: "Workflow queue thread",
@@ -91,9 +88,6 @@ async function openAutomationsPanel(
   detachedSetupPage({
     context,
     path: `/chats/${THREAD_ID}`,
-    featureSwitches: {
-      [FeatureSwitchKey.WorkflowQueue]: workflowQueueEnabled,
-    },
   });
 
   await waitFor(() => {
@@ -189,23 +183,6 @@ describe("workflow queue panel", () => {
     await waitFor(() => {
       expect(screen.getByText(/Queue paused/)).toBeInTheDocument();
       expect(buttonByLabel("Resume queue")).toBeInTheDocument();
-    });
-  });
-
-  it("hides the queue UI when the feature switch is off", async () => {
-    context.mocks.api(zeroWorkflowQueueContract.get, ({ respond }) => {
-      return respond(200, queueResponse());
-    });
-
-    await openAutomationsPanel(false);
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("workflow-queue-section"),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByTestId("workflow-queue-badge"),
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -77,7 +77,6 @@ export enum FeatureSwitchKey {
   ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
   WebsiteTemplates = "websiteTemplates",
-  WorkflowQueue = "workflowQueue",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ConnectorActionCallback = "connectorActionCallback",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -468,12 +468,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the built-in R2-backed website template picker and generation-template flow.",
     enabled: true,
   },
-  [FeatureSwitchKey.WorkflowQueue]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Queue workflow automation events per workflow and run them serially instead of firing concurrent runs.",
-    enabled: true,
-  },
   [FeatureSwitchKey.OrgPlanEntitlementReads]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Queue unification P3, PR-D (#21336, tasks 1–2, 5) — the finale. With `WorkflowQueue` globally enabled since #21853 and observed healthy in production for two days, the per-thread queue becomes the only dispatch behavior and the switch plus every legacy bypass is deleted (16 files, −475/+73):

- **Switch removal**: drop `FeatureSwitchKey.WorkflowQueue` and its definition; delete `workflowQueueEnabledForOwner` and the admission gate in `runWorkflowAutomationNow$` (events always go through queue admission unless internally bypassed by the dequeue/manual-run path).
- **Legacy scheduler path**: delete `shouldSkipBusyAutomation` from the automation poller — the switch-off-only "skip tick while previous run active" behavior; ticks now always coalesce into the queue.
- **Route/UI gates**: remove the 403 feature gate from all five `/api/zero/chat-threads/:threadId/workflow-queue` handlers and the switch gate in the platform queue signal (the queue panel now renders for everyone, matching production reality).
- **Legacy tests**: delete the switch-pinned tests from #21853 (`keeps concurrent behavior when switch off`, `rejects queue reads when switch off`, scheduler skip-while-busy, gmail/webhook `previous run still active`, platform `hides queue UI when switch off`) and the `workflowQueue` setup plumbing. The github label-dispatch test is adapted to queue semantics instead of deleted — it keeps the label-matching/delivery-dedup coverage (1 admitted run + 3 pending queue events, empty org run queue).
- **Docs (task 5)**: new "Per-Thread Chat Scheduling" section in `docs/architecture.md` and an updated doc comment on `drainChatThreadQueueForThread$`, marking the single drain entry as the designated mounting point for a future unified per-thread rate limiter (limiter itself out of scope).

Note on task 1 (single drain entry): the consolidation itself already landed on main — `drainChatThreadQueueForThread$` unifies terminal callback, cancel, resume, and the stale sweep behind one per-thread advisory lock with `ORDER BY created_at, id`. This PR removes the last switch-conditional branches around it and documents the invariant.

## User-visible impact

None intended: the switch has been globally `enabled: true` since #21853, so deleted branches were already dead in production. The only behavioral edge: per-user overrides that force-disabled the queue (test-only usage) no longer exist.

## Verification

- tsc clean for `@vm0/core`, `@vm0/connectors`, `apps/api`, `apps/platform`; oxlint/eslint clean; prettier clean; knip clean on all four touched workspaces.
- Platform `workflow-queue-panel` tests pass locally (3/3). Api queue tests: the non-runner-poll case passes locally; the 3 runner-poll cases fail identically on unmodified main in this environment (known local pg/claim issue) — CI is authoritative, as with #21853/#22058.
- Repo-wide grep: no remaining references to the switch key.

## Rollback

Revert the commit. No schema or wire-format changes; the switch and its branches restore cleanly.

Closes #21336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)