### PR TITLE
fix(guest-agent): bound ordinary cli stdout ingestion

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -20,7 +20,7 @@ use guest_common::log_warn;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -29,7 +29,7 @@ use crate::error::AgentError;
 
 use super::{
     LOG_TAG, child_env, child_exit_notifier::ChildExitNotifier, diagnostics, exec_boundary,
-    process_group::ChildProcessGroup,
+    line_reader, process_group::ChildProcessGroup,
 };
 
 const METHOD_NOT_FOUND: i64 = -32601;
@@ -1039,56 +1039,28 @@ async fn read_stdout_line<R>(
 where
     R: AsyncBufRead + Unpin,
 {
-    loop {
-        let (consumed, reached_line_end) = {
-            let available = stdout_reader.fill_buf().await?;
-            if available.is_empty() {
-                if partial_line.is_empty() {
-                    return Ok(None);
+    match line_reader::read_bounded_utf8_line(stdout_reader, partial_line, STDOUT_MAX_LINE_BYTES)
+        .await
+    {
+        Ok(line) => Ok(line),
+        Err(line_reader::BoundedLineError::Io(error)) => Err(CodexAppServerError::Io(error)),
+        Err(line_reader::BoundedLineError::TooLong) => Err(stdout_line_too_large_error()),
+        Err(line_reader::BoundedLineError::InvalidUtf8 {
+            valid_up_to,
+            error_len,
+            line_bytes,
+        }) => {
+            let utf8_error = match error_len {
+                Some(error_len) => {
+                    format!("invalid utf-8 sequence of {error_len} bytes from index {valid_up_to}")
                 }
-                let line = std::mem::take(partial_line);
-                return decode_stdout_line(line).map(Some);
-            }
-
-            if let Some(newline_index) = available.iter().position(|byte| *byte == b'\n') {
-                if partial_line.len() + newline_index > STDOUT_MAX_LINE_BYTES {
-                    return Err(stdout_line_too_large_error());
-                }
-                let line_chunk = available.get(..newline_index).ok_or_else(|| {
-                    CodexAppServerError::Protocol(
-                        "app-server stdout reader returned an invalid newline offset".to_string(),
-                    )
-                })?;
-                partial_line.extend_from_slice(line_chunk);
-                (newline_index + 1, true)
-            } else {
-                if partial_line.len() + available.len() > STDOUT_MAX_LINE_BYTES {
-                    return Err(stdout_line_too_large_error());
-                }
-                partial_line.extend_from_slice(available);
-                (available.len(), false)
-            }
-        };
-
-        stdout_reader.consume(consumed);
-        if reached_line_end {
-            if partial_line.last() == Some(&b'\r') {
-                partial_line.pop();
-            }
-            let line = std::mem::take(partial_line);
-            return decode_stdout_line(line).map(Some);
+                None => format!("incomplete utf-8 byte sequence from index {valid_up_to}"),
+            };
+            Err(CodexAppServerError::Protocol(format!(
+                "app-server stdout line is not UTF-8: {utf8_error}; line_bytes={line_bytes}"
+            )))
         }
     }
-}
-
-fn decode_stdout_line(line: Vec<u8>) -> Result<String, CodexAppServerError> {
-    String::from_utf8(line).map_err(|error| {
-        CodexAppServerError::Protocol(format!(
-            "app-server stdout line is not UTF-8: {}; line_bytes={}",
-            error.utf8_error(),
-            error.as_bytes().len()
-        ))
-    })
 }
 
 fn stdout_line_too_large_error() -> CodexAppServerError {

--- a/crates/guest-agent/src/cli/line_reader.rs
+++ b/crates/guest-agent/src/cli/line_reader.rs
@@ -1,0 +1,74 @@
+use std::io;
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+
+#[derive(Debug)]
+pub(super) enum BoundedLineError {
+    Io(io::Error),
+    TooLong,
+    InvalidUtf8 {
+        valid_up_to: usize,
+        error_len: Option<usize>,
+        line_bytes: usize,
+    },
+}
+
+/// Read one bounded UTF-8 record without losing partial bytes when cancelled.
+///
+/// The LF terminator is excluded from `max_line_bytes`. A preceding CR counts
+/// toward the limit and is removed only after an LF-terminated record is
+/// accepted. EOF-terminated records preserve all accumulated bytes.
+pub(super) async fn read_bounded_utf8_line<R>(
+    reader: &mut R,
+    partial_line: &mut Vec<u8>,
+    max_line_bytes: usize,
+) -> Result<Option<String>, BoundedLineError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        let (consumed, reached_line_end) = {
+            let available = reader.fill_buf().await.map_err(BoundedLineError::Io)?;
+            if available.is_empty() {
+                if partial_line.is_empty() {
+                    return Ok(None);
+                }
+                let line = std::mem::take(partial_line);
+                return decode_line(line).map(Some);
+            }
+
+            let newline_index = available.iter().position(|byte| *byte == b'\n');
+            let available_line_bytes = newline_index.unwrap_or(available.len());
+            if available_line_bytes > max_line_bytes - partial_line.len() {
+                return Err(BoundedLineError::TooLong);
+            }
+
+            partial_line.extend(available.iter().take(available_line_bytes).copied());
+            match newline_index {
+                Some(index) => (index + 1, true),
+                None => (available.len(), false),
+            }
+        };
+
+        reader.consume(consumed);
+        if reached_line_end {
+            if partial_line.last() == Some(&b'\r') {
+                partial_line.pop();
+            }
+            let line = std::mem::take(partial_line);
+            return decode_line(line).map(Some);
+        }
+    }
+}
+
+fn decode_line(line: Vec<u8>) -> Result<String, BoundedLineError> {
+    let line_bytes = line.len();
+    String::from_utf8(line).map_err(|error| {
+        let utf8_error = error.utf8_error();
+        BoundedLineError::InvalidUtf8 {
+            valid_up_to: utf8_error.valid_up_to(),
+            error_len: utf8_error.error_len(),
+            line_bytes,
+        }
+    })
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -29,6 +29,7 @@ mod diagnostics;
 mod event_delivery;
 mod exec_boundary;
 mod framework;
+mod line_reader;
 mod process_group;
 mod termination;
 
@@ -62,12 +63,16 @@ use std::time::{Duration, Instant};
 use termination::{
     CliTerminationRuntime, ControlTerminationLog, PostResultCleanupPolicy, TerminationReason,
 };
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 use tokio::time::Sleep;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
+/// Maximum retained bytes for one ordinary CLI stdout record before parsing.
+///
+/// LF is excluded. A preceding CR counts before CRLF normalization.
+const STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(serde::Serialize)]
 struct ClaudeUserFrame<'a> {
@@ -697,8 +702,9 @@ async fn execute_cli_inner(
     // writes, so if the agent's HTTP POSTs are slow and the pipe buffer
     // fills, the CLI's entire event loop blocks — including TCP I/O.
     // See: https://github.com/vm0-ai/vm0/issues/3645
-    let mut reader = tokio::io::BufReader::new(stdout).lines();
-    let mut stdout_eof = false;
+    let mut reader = tokio::io::BufReader::new(stdout);
+    let mut stdout_partial_line = Vec::new();
+    let mut stdout_closed = false;
 
     // Capture the process group ID before wait() reaps the child, since
     // child.id() returns None after the process has been reaped.
@@ -771,12 +777,12 @@ async fn execute_cli_inner(
                     &mut cli_exit_at,
                     &active_input_controller,
                     &mut termination_runtime,
-                    stdout_eof,
+                    stdout_closed,
                     drain_deadline.as_mut(),
                 )? {
                     CliExitObservation::NoNewExit => {}
                     CliExitObservation::ExitedDrainingStdout => continue,
-                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 let can_terminate_for_stdin_error = termination_runtime
                     .can_begin_initial_prompt_stdin_control_failure(cli_status.is_some());
@@ -813,7 +819,11 @@ async fn execute_cli_inner(
                     None => {}
                 }
             }
-            line_result = reader.next_line(), if !stdout_eof => {
+            line_result = line_reader::read_bounded_utf8_line(
+                &mut reader,
+                &mut stdout_partial_line,
+                STDOUT_MAX_LINE_BYTES,
+            ), if !stdout_closed => {
                 match line_result {
                     Ok(Some(line)) => {
                         let stripped = line.trim();
@@ -882,12 +892,12 @@ async fn execute_cli_inner(
                                     &mut cli_exit_at,
                                     &active_input_controller,
                                     &mut termination_runtime,
-                                    stdout_eof,
+                                    stdout_closed,
                                     drain_deadline.as_mut(),
                                 )? {
                                     CliExitObservation::NoNewExit
                                     | CliExitObservation::ExitedDrainingStdout => {}
-                                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                                 }
                             }
                             // Print Claude Code final result to stdout if applicable.
@@ -963,13 +973,68 @@ async fn execute_cli_inner(
                         }
                     }
                     Ok(None) => {
-                        stdout_eof = true;
+                        stdout_closed = true;
                         active_input_controller.close_terminal();
                         if cli_status.is_some() {
                             break Ok(());
                         }
                     }
-                    Err(e) => break Err(AgentError::Io(e)),
+                    Err(error) => {
+                        stdout_closed = true;
+                        active_input_controller.close_terminal();
+                        let error = match error {
+                            line_reader::BoundedLineError::Io(error) => AgentError::Io(error),
+                            line_reader::BoundedLineError::TooLong => AgentError::Execution(
+                                format!(
+                                    "CLI stdout line exceeded {STDOUT_MAX_LINE_BYTES} bytes"
+                                ),
+                            ),
+                            line_reader::BoundedLineError::InvalidUtf8 {
+                                valid_up_to,
+                                error_len,
+                                line_bytes,
+                            } => {
+                                let utf8_error = match error_len {
+                                    Some(error_len) => format!(
+                                        "invalid utf-8 sequence of {error_len} bytes from index {valid_up_to}"
+                                    ),
+                                    None => format!(
+                                        "incomplete utf-8 byte sequence from index {valid_up_to}"
+                                    ),
+                                };
+                                AgentError::Execution(format!(
+                                    "CLI stdout line is not UTF-8: {utf8_error}; line_bytes={line_bytes}"
+                                ))
+                            }
+                        };
+
+                        if cli_status.is_some() {
+                            break Err(error);
+                        }
+                        match try_observe_cli_exit(
+                            &mut child,
+                            &mut cli_status,
+                            &mut cli_exit_at,
+                            &active_input_controller,
+                            &mut termination_runtime,
+                            stdout_closed,
+                            drain_deadline.as_mut(),
+                        )? {
+                            CliExitObservation::NoNewExit => {
+                                let error_log = error.to_string();
+                                termination_runtime.begin_control_failure(
+                                    TerminationReason::StdoutIngestion,
+                                    error,
+                                    ControlTerminationLog::StdoutIngestionFailed {
+                                        error: error_log,
+                                    },
+                                    termination_deadline.as_mut(),
+                                );
+                            }
+                            CliExitObservation::ExitedDrainingStdout
+                            | CliExitObservation::ExitedAndStdoutClosed => break Err(error),
+                        }
+                    }
                 }
             }
             status = child.wait(), if cli_status.is_none() => {
@@ -982,10 +1047,10 @@ async fn execute_cli_inner(
                                 &mut cli_exit_at,
                                 &active_input_controller,
                                 &mut termination_runtime,
-                                stdout_eof,
+                                stdout_closed,
                                 drain_deadline.as_mut(),
                             ),
-                            CliExitObservation::ExitedAndStdoutEof
+                            CliExitObservation::ExitedAndStdoutClosed
                         ) {
                             break Ok(());
                         }
@@ -1000,12 +1065,12 @@ async fn execute_cli_inner(
                     &mut cli_exit_at,
                     &active_input_controller,
                     &mut termination_runtime,
-                    stdout_eof,
+                    stdout_closed,
                     drain_deadline.as_mut(),
                 )? {
                     CliExitObservation::NoNewExit => {}
                     CliExitObservation::ExitedDrainingStdout => continue,
-                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 termination_runtime.handle_deadline(termination_deadline.as_mut());
             }
@@ -1036,12 +1101,12 @@ async fn execute_cli_inner(
                         &mut cli_exit_at,
                         &active_input_controller,
                         &mut termination_runtime,
-                        stdout_eof,
+                        stdout_closed,
                         drain_deadline.as_mut(),
                     )? {
                         CliExitObservation::NoNewExit => {}
                         CliExitObservation::ExitedDrainingStdout => continue,
-                        CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                        CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                     }
                     let timeout_error = AgentError::Execution(format!(
                         "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
@@ -1070,12 +1135,12 @@ async fn execute_cli_inner(
                     &mut cli_exit_at,
                     &active_input_controller,
                     &mut termination_runtime,
-                    stdout_eof,
+                    stdout_closed,
                     drain_deadline.as_mut(),
                 )? {
                     CliExitObservation::NoNewExit => {}
                     CliExitObservation::ExitedDrainingStdout => continue,
-                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                    CliExitObservation::ExitedAndStdoutClosed => break Ok(()),
                 }
                 match heartbeat_result {
                     Ok(HeartbeatStatus::Failed(e)) => {
@@ -1243,7 +1308,7 @@ fn cli_exit_summary_from_status(status: &ExitStatus) -> (i32, Option<CliObserved
 enum CliExitObservation {
     NoNewExit,
     ExitedDrainingStdout,
-    ExitedAndStdoutEof,
+    ExitedAndStdoutClosed,
 }
 
 fn try_observe_cli_exit(
@@ -1252,7 +1317,7 @@ fn try_observe_cli_exit(
     cli_exit_at: &mut Option<Instant>,
     active_input_controller: &ActiveInputController,
     termination_runtime: &mut CliTerminationRuntime,
-    stdout_eof: bool,
+    stdout_closed: bool,
     drain_deadline: Pin<&mut Sleep>,
 ) -> Result<CliExitObservation, AgentError> {
     if cli_status.is_some() {
@@ -1269,7 +1334,7 @@ fn try_observe_cli_exit(
         cli_exit_at,
         active_input_controller,
         termination_runtime,
-        stdout_eof,
+        stdout_closed,
         drain_deadline,
     ))
 }
@@ -1280,7 +1345,7 @@ fn record_cli_exit(
     cli_exit_at: &mut Option<Instant>,
     active_input_controller: &ActiveInputController,
     termination_runtime: &mut CliTerminationRuntime,
-    stdout_eof: bool,
+    stdout_closed: bool,
     mut drain_deadline: Pin<&mut Sleep>,
 ) -> CliExitObservation {
     debug_assert!(cli_status.is_none(), "CLI exit recorded more than once");
@@ -1295,8 +1360,8 @@ fn record_cli_exit(
     // termination FSM so it can't re-arm on late result/control events while
     // stdout is draining.
     termination_runtime.mark_child_exited();
-    if stdout_eof {
-        return CliExitObservation::ExitedAndStdoutEof;
+    if stdout_closed {
+        return CliExitObservation::ExitedAndStdoutClosed;
     }
 
     drain_deadline.as_mut().reset(

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -70,6 +70,7 @@ pub(super) enum TerminationReason {
     HeartbeatError,
     HeartbeatPanic,
     EventDelivery,
+    StdoutIngestion,
 }
 
 impl TerminationReason {
@@ -81,6 +82,7 @@ impl TerminationReason {
             TerminationReason::HeartbeatError => "heartbeat error",
             TerminationReason::HeartbeatPanic => "heartbeat panic",
             TerminationReason::EventDelivery => "event delivery",
+            TerminationReason::StdoutIngestion => "stdout ingestion",
         }
     }
 }
@@ -225,6 +227,7 @@ pub(super) enum ControlTerminationLog {
     HeartbeatTaskPanicked,
     HeartbeatStoppedBeforeStatus,
     EventDeliveryFailed { error: String },
+    StdoutIngestionFailed { error: String },
 }
 
 impl ControlTerminationLog {
@@ -264,6 +267,12 @@ impl ControlTerminationLog {
                 log_warn!(
                     LOG_TAG,
                     "Event delivery failed, SIGTERM pgid={pgid}: {error}"
+                );
+            }
+            Self::StdoutIngestionFailed { error } => {
+                log_warn!(
+                    LOG_TAG,
+                    "CLI stdout ingestion failed, SIGTERM pgid={pgid}: {error}"
                 );
             }
         }
@@ -570,6 +579,7 @@ fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTermina
         TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
         TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
         TerminationReason::EventDelivery => DiagnosticTerminationReason::EventDelivery,
+        TerminationReason::StdoutIngestion => DiagnosticTerminationReason::StdoutIngestion,
     }
 }
 

--- a/crates/guest-agent/tests/cli_stdout_invalid_utf8.rs
+++ b/crates/guest-agent/tests/cli_stdout_invalid_utf8.rs
@@ -1,0 +1,49 @@
+//! Invalid ordinary CLI stdout UTF-8 must fail without exposing record content
+//! and must trigger bounded cleanup of a live child.
+
+mod common;
+
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn invalid_stdout_utf8_terminates_promptly_without_logging_content()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@stdout-invalid-utf8", 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("invalid stdout UTF-8 should terminate promptly")?;
+
+    let error = execution
+        .control_error
+        .expect("stdout decoding failure should be a controlled execution error")
+        .to_string();
+    assert!(
+        error.contains("CLI stdout line is not UTF-8")
+            && error.contains("line_bytes=")
+            && !error.contains("do-not-log-invalid-stdout"),
+        "unexpected stdout UTF-8 error: {error}"
+    );
+    assert_eq!(execution.last_event_sequence, None);
+    let termination = execution
+        .cli_termination
+        .expect("stdout decoding failure should record process-group termination");
+    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stdout_oversized_newline.rs
+++ b/crates/guest-agent/tests/cli_stdout_oversized_newline.rs
@@ -1,0 +1,47 @@
+//! An oversized LF-terminated ordinary CLI stdout record must fail before it
+//! is retained or logged and must trigger bounded cleanup of a live child.
+
+mod common;
+
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn oversized_newline_terminated_stdout_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@stdout-over-limit-newline", 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("oversized LF stdout should terminate promptly")?;
+
+    let error = execution
+        .control_error
+        .expect("stdout framing failure should be a controlled execution error")
+        .to_string();
+    assert!(
+        error.contains("CLI stdout line exceeded 16777216 bytes"),
+        "unexpected stdout limit error: {error}"
+    );
+    assert_eq!(execution.last_event_sequence, None);
+    let termination = execution
+        .cli_termination
+        .expect("stdout framing failure should record process-group termination");
+    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stdout_oversized_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stdout_oversized_no_newline.rs
@@ -1,0 +1,47 @@
+//! An oversized newline-free ordinary CLI stdout record must fail before it is
+//! retained or logged and must trigger bounded cleanup of a live child.
+
+mod common;
+
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn oversized_newline_free_stdout_terminates_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@stdout-over-limit-no-newline", 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("oversized newline-free stdout should terminate promptly")?;
+
+    let error = execution
+        .control_error
+        .expect("stdout framing failure should be a controlled execution error")
+        .to_string();
+    assert!(
+        error.contains("CLI stdout line exceeded 16777216 bytes"),
+        "unexpected stdout limit error: {error}"
+    );
+    assert_eq!(execution.last_event_sequence, None);
+    let termination = execution
+        .cli_termination
+        .expect("stdout framing failure should record process-group termination");
+    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stdout_record_boundaries.rs
+++ b/crates/guest-agent/tests/cli_stdout_record_boundaries.rs
@@ -1,0 +1,62 @@
+//! Accepted ordinary CLI stdout preserves exact-limit, CRLF normalization, and
+//! EOF-final-record behavior through the production execution entry point.
+
+mod common;
+
+use std::io::{Read, Seek, SeekFrom};
+use std::time::Duration;
+
+const CRLF_RECORD: &[u8] = b"crlf-record\n";
+const EOF_RECORD: &[u8] = b"eof-record\n";
+
+#[tokio::test]
+async fn accepted_stdout_record_boundaries_preserve_raw_logging()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@stdout-record-boundaries", 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("accepted stdout boundary records should complete promptly")?;
+
+    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
+    assert!(execution.control_error.is_none());
+    assert!(execution.cli_termination.is_none());
+    assert_eq!(execution.last_event_sequence, None);
+
+    let expected_large_line_start = CRLF_RECORD.len() as u64;
+    let expected_eof_record_start =
+        expected_large_line_start + common::CLI_STDOUT_MAX_LINE_BYTES as u64 + 1;
+    let expected_log_bytes = expected_eof_record_start + EOF_RECORD.len() as u64;
+    let mut log = std::fs::File::open(runtime.paths.agent_log_file())?;
+    assert_eq!(log.metadata()?.len(), expected_log_bytes);
+
+    let mut crlf_record = [0u8; CRLF_RECORD.len()];
+    log.read_exact(&mut crlf_record)?;
+    assert_eq!(&crlf_record, CRLF_RECORD);
+
+    log.seek(SeekFrom::Start(expected_large_line_start))?;
+    let mut large_line_prefix = [0u8; 8];
+    log.read_exact(&mut large_line_prefix)?;
+    assert_eq!(large_line_prefix, [b'x'; 8]);
+
+    log.seek(SeekFrom::Start(expected_eof_record_start - 2))?;
+    let mut large_line_end = [0u8; 2];
+    log.read_exact(&mut large_line_end)?;
+    assert_eq!(large_line_end, [b'x', b'\n']);
+
+    let mut eof_record = [0u8; EOF_RECORD.len()];
+    log.read_exact(&mut eof_record)?;
+    assert_eq!(&eof_record, EOF_RECORD);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -56,6 +56,9 @@ pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
 /// Documented maximum byte length for one returned stderr line after CRLF normalization.
 pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 
+/// Integration contract for one accepted ordinary CLI stdout record.
+pub const CLI_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+
 /// Documented replacement for a stderr line that exceeds the diagnostic limit.
 pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
     "[stderr line omitted: exceeded diagnostic size limit]";
@@ -644,6 +647,10 @@ fn read_codex_session_history_events_for_path(
 /// - `@fail-no-newline:<message>` → stderr EOF without trailing newline
 /// - `@fail-invalid-utf8` → stderr bytes that are not valid UTF-8
 /// - `@fail-invalid-utf8-long` → invalid UTF-8 whose lossy form exceeds the limit
+/// - `@stdout-over-limit-no-newline` → oversized stdout record followed by a hang
+/// - `@stdout-over-limit-newline` → oversized LF stdout record followed by a hang
+/// - `@stdout-invalid-utf8` → invalid UTF-8 stdout followed by a hang
+/// - `@stdout-record-boundaries` → exact-limit, CRLF, and EOF stdout records
 /// - `@stuck-tool-deaf` → forced-termination SIGKILL escalation path
 /// - `@stuck-tool-closed-stdout-deaf` → stdout EOF before forced termination
 ///

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -335,6 +335,8 @@ pub enum CliTerminationReason {
     InitialPromptStdin,
     /// Event delivery overloaded or stopped and required termination.
     EventDelivery,
+    /// CLI stdout framing or decoding failed and required termination.
+    StdoutIngestion,
 }
 
 impl CliTerminationReason {
@@ -348,6 +350,7 @@ impl CliTerminationReason {
             Self::HeartbeatPanic => "heartbeat_panic",
             Self::InitialPromptStdin => "initial_prompt_stdin",
             Self::EventDelivery => "event_delivery",
+            Self::StdoutIngestion => "stdout_ingestion",
         }
     }
 }
@@ -685,6 +688,21 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn stdout_ingestion_termination_reason_has_stable_serialization() {
+        let reason = CliTerminationReason::StdoutIngestion;
+        assert_eq!(reason.as_str(), "stdout_ingestion");
+        assert_eq!(
+            serde_json::to_value(reason).unwrap(),
+            serde_json::json!("stdout_ingestion")
+        );
+        assert_eq!(
+            serde_json::from_value::<CliTerminationReason>(serde_json::json!("stdout_ingestion"))
+                .unwrap(),
+            reason
+        );
     }
 
     #[test]

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -14,6 +14,12 @@
 //!                               with code 1
 //!   @fail-invalid-utf8-long   - Output many invalid UTF-8 bytes to stderr and exit
 //!                               with code 1
+//!   @stdout-over-limit-no-newline
+//!                             - Stream an oversized stdout record, then hang
+//!   @stdout-over-limit-newline
+//!                             - Stream an oversized LF record, then hang
+//!   @stdout-invalid-utf8      - Emit invalid stdout UTF-8, then hang
+//!   @stdout-record-boundaries - Emit exact-limit, CRLF, and EOF stdout records
 //!   @stuck-tool               - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
 //!   @stuck-tool-deaf          - Same, but ignores SIGTERM so only SIGKILL
 //!                               can terminate it

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -26,6 +26,9 @@ const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
 const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
 const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
+// Integration contract with guest-agent's ordinary stdout framing policy.
+const ORDINARY_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 #[cfg(unix)]
 const STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS: libc::c_int = 100;
 
@@ -119,6 +122,13 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
         MockScenario::Fail(msg) => {
             eprintln!("{msg}");
             ExitCode::from(1)
+        }
+        MockScenario::StdoutOverLimit { newline } => {
+            run_stdout_over_limit_scenario(output_format, newline)
+        }
+        MockScenario::StdoutInvalidUtf8 => run_stdout_invalid_utf8_scenario(output_format),
+        MockScenario::StdoutRecordBoundaries => {
+            run_stdout_record_boundaries_scenario(output_format)
         }
         MockScenario::StuckTool { deaf, close_stdout } => {
             run_stuck_tool_scenario(output_format, deaf, close_stdout)
@@ -382,6 +392,63 @@ fn ignore_sigterm() {
 
 fn hang_until_reaped() {
     std::thread::sleep(REAPABLE_HANG_DURATION);
+}
+
+fn write_stdout_limit(stdout: &mut impl Write, byte: u8) -> std::io::Result<()> {
+    let chunk = [byte; STDOUT_STREAM_CHUNK_BYTES];
+    for _ in 0..ORDINARY_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
+        stdout.write_all(&chunk)?;
+    }
+    Ok(())
+}
+
+fn run_stdout_over_limit_scenario(output_format: &str, newline: bool) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = write_stdout_limit(&mut stdout, b'x');
+    let suffix: &[u8] = if newline { b"x\n" } else { b"x" };
+    let _ = stdout.write_all(suffix);
+    let _ = stdout.flush();
+    drop(stdout);
+    hang_until_reaped();
+    ExitCode::from(1)
+}
+
+fn run_stdout_invalid_utf8_scenario(output_format: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = stdout.write_all(b"do-not-log-invalid-stdout-\xff\n");
+    let _ = stdout.flush();
+    drop(stdout);
+    hang_until_reaped();
+    ExitCode::from(1)
+}
+
+fn run_stdout_record_boundaries_scenario(output_format: &str) -> ExitCode {
+    if output_format != "stream-json" {
+        return ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let result = stdout
+        .write_all(b"crlf-record\r\n")
+        .and_then(|()| write_stdout_limit(&mut stdout, b'x'))
+        .and_then(|()| stdout.write_all(b"\neof-record"))
+        .and_then(|()| stdout.flush());
+    if let Err(error) = result {
+        eprintln!("write stdout record-boundary fixture: {error}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
 }
 
 fn run_stuck_tool_scenario(output_format: &str, deaf: bool, close_stdout: bool) -> ExitCode {

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -6,6 +6,10 @@ const FAIL_NO_NEWLINE_MARKER: &str = "@fail-no-newline:";
 const FAIL_INVALID_UTF8_MARKER: &str = "@fail-invalid-utf8";
 const FAIL_INVALID_UTF8_LONG_MARKER: &str = "@fail-invalid-utf8-long";
 const FAIL_MARKER: &str = "@fail:";
+const STDOUT_OVER_LIMIT_NO_NEWLINE_MARKER: &str = "@stdout-over-limit-no-newline";
+const STDOUT_OVER_LIMIT_NEWLINE_MARKER: &str = "@stdout-over-limit-newline";
+const STDOUT_INVALID_UTF8_MARKER: &str = "@stdout-invalid-utf8";
+const STDOUT_RECORD_BOUNDARIES_MARKER: &str = "@stdout-record-boundaries";
 const STUCK_TOOL_CLOSED_STDOUT_DEAF_MARKER: &str = "@stuck-tool-closed-stdout-deaf";
 const STUCK_TOOL_DEAF_MARKER: &str = "@stuck-tool-deaf";
 const STUCK_TOOL_MARKER: &str = "@stuck-tool";
@@ -27,6 +31,9 @@ pub(crate) enum MockScenario<'a> {
     FailInvalidUtf8,
     FailInvalidUtf8Long,
     Fail(&'a str),
+    StdoutOverLimit { newline: bool },
+    StdoutInvalidUtf8,
+    StdoutRecordBoundaries,
     StuckTool { deaf: bool, close_stdout: bool },
     OrphanPipe,
     HangAfterResult { deaf: bool },
@@ -54,6 +61,9 @@ enum ScenarioKind {
     FailInvalidUtf8,
     FailInvalidUtf8Long,
     Fail,
+    StdoutOverLimit { newline: bool },
+    StdoutInvalidUtf8,
+    StdoutRecordBoundaries,
     StuckTool { deaf: bool, close_stdout: bool },
     OrphanPipe,
     HangAfterResult { deaf: bool },
@@ -106,6 +116,26 @@ const SCENARIO_RULES: &[ScenarioRule] = &[
         marker: FAIL_MARKER,
         match_kind: ScenarioMatchKind::PrefixPayload,
         scenario_kind: ScenarioKind::Fail,
+    },
+    ScenarioRule {
+        marker: STDOUT_OVER_LIMIT_NO_NEWLINE_MARKER,
+        match_kind: ScenarioMatchKind::Exact,
+        scenario_kind: ScenarioKind::StdoutOverLimit { newline: false },
+    },
+    ScenarioRule {
+        marker: STDOUT_OVER_LIMIT_NEWLINE_MARKER,
+        match_kind: ScenarioMatchKind::Exact,
+        scenario_kind: ScenarioKind::StdoutOverLimit { newline: true },
+    },
+    ScenarioRule {
+        marker: STDOUT_INVALID_UTF8_MARKER,
+        match_kind: ScenarioMatchKind::Exact,
+        scenario_kind: ScenarioKind::StdoutInvalidUtf8,
+    },
+    ScenarioRule {
+        marker: STDOUT_RECORD_BOUNDARIES_MARKER,
+        match_kind: ScenarioMatchKind::Exact,
+        scenario_kind: ScenarioKind::StdoutRecordBoundaries,
     },
     ScenarioRule {
         marker: STUCK_TOOL_CLOSED_STDOUT_DEAF_MARKER,
@@ -210,6 +240,13 @@ impl ScenarioKind {
             (Self::WriteEnvJson, ScenarioMatch::Payload(path)) => MockScenario::WriteEnvJson(path),
             (Self::FailInvalidUtf8, ScenarioMatch::Marker) => MockScenario::FailInvalidUtf8,
             (Self::FailInvalidUtf8Long, ScenarioMatch::Marker) => MockScenario::FailInvalidUtf8Long,
+            (Self::StdoutOverLimit { newline }, ScenarioMatch::Marker) => {
+                MockScenario::StdoutOverLimit { newline }
+            }
+            (Self::StdoutInvalidUtf8, ScenarioMatch::Marker) => MockScenario::StdoutInvalidUtf8,
+            (Self::StdoutRecordBoundaries, ScenarioMatch::Marker) => {
+                MockScenario::StdoutRecordBoundaries
+            }
             (Self::StuckTool { deaf, close_stdout }, ScenarioMatch::Marker) => {
                 MockScenario::StuckTool { deaf, close_stdout }
             }
@@ -320,6 +357,19 @@ mod tests {
             ("@fail-invalid-utf8-long", MockScenario::FailInvalidUtf8Long),
             ("@fail:boom", MockScenario::Fail("boom")),
             (
+                "@stdout-over-limit-no-newline",
+                MockScenario::StdoutOverLimit { newline: false },
+            ),
+            (
+                "@stdout-over-limit-newline",
+                MockScenario::StdoutOverLimit { newline: true },
+            ),
+            ("@stdout-invalid-utf8", MockScenario::StdoutInvalidUtf8),
+            (
+                "@stdout-record-boundaries",
+                MockScenario::StdoutRecordBoundaries,
+            ),
+            (
                 "@stuck-tool-closed-stdout-deaf",
                 MockScenario::StuckTool {
                     deaf: true,
@@ -426,6 +476,22 @@ mod tests {
         );
         assert_eq!(
             MockScenario::from_prompt("@fail-invalid-utf8-long-suffix"),
+            MockScenario::Shell
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@stdout-over-limit-no-newline-suffix"),
+            MockScenario::Shell
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@stdout-over-limit-newline-suffix"),
+            MockScenario::Shell
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@stdout-invalid-utf8-suffix"),
+            MockScenario::Shell
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@stdout-record-boundaries-suffix"),
             MockScenario::Shell
         );
     }


### PR DESCRIPTION
## Summary

- bound ordinary CLI stdout records at 16 MiB before parsing, logging, or delivery
- share cancellation-safe UTF-8 line framing with the Codex app-server path while preserving its 64 MiB policy
- terminate live CLIs through the existing controlled shutdown path when stdout ingestion fails, and record a content-safe diagnostic
- cover oversized records, invalid UTF-8, LF/CRLF boundaries, and EOF without a trailing newline

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent`
- `cargo test -p guest-mock-claude`
- `cargo test -p guest-contracts`
- `cargo test -p runner`
- `cargo clippy -p guest-agent -p guest-mock-claude -p guest-contracts -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent -p guest-mock-claude -p guest-contracts -p runner --all-features --no-deps`

## Compatibility

- no API, database, persisted-data, or migration changes
- no feature switch is needed; runner and guest artifacts remain version-bound

Closes #22039
