### PR TITLE
fix(runner): accept sidecar metadata without allocated bytes

### DIFF
--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -35,7 +35,8 @@ struct WorkspaceSessionHistorySidecarMetadata {
     representation: WorkspaceSessionHistorySidecarRepresentation,
     encoded_size: u64,
     body_file: WorkspaceImageFileIdentity,
-    allocated_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    allocated_bytes: Option<u64>,
 }
 
 impl WorkspaceSessionHistorySidecarMetadata {
@@ -60,7 +61,7 @@ impl WorkspaceSessionHistorySidecarMetadata {
             representation: source.representation,
             encoded_size: source.encoded_size,
             body_file: WorkspaceImageFileIdentity::from_metadata(body_metadata),
-            allocated_bytes: allocated_bytes(body_metadata),
+            allocated_bytes: Some(allocated_bytes(body_metadata)),
         })
     }
 

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1675,11 +1675,61 @@ async fn session_history_sidecar_publish_and_probe_hit() {
     let metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
     assert!(metadata.get("historyGenerationRunId").is_none());
+    assert!(metadata["allocatedBytes"].as_u64().is_some());
     let held_states = cache.held_session_states().await;
     assert_eq!(
         held_states[0].workspace_caches[0].profile,
         TEST_PROFILE_NAME
     );
+    let sidecar = cache
+        .probe_session_history_sidecar(&cache_key, &identity)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sidecar.representation,
+        WorkspaceSessionHistorySidecarRepresentation::Raw
+    );
+    assert_eq!(sidecar.encoded_size, history.len() as u64);
+    assert_eq!(fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn session_history_sidecar_metadata_without_allocated_bytes_remains_restoreable() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-without-allocated-bytes";
+    let history = br#"{"type":"message","content":"without allocated bytes"}"#;
+    let cache_key = write_current_cache_entry(
+        &cache,
+        run_id,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let identity =
+        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
+    let metadata_path = paths
+        .session_workspace_cache_entry_dir(&cache_key)
+        .join("session-history.metadata.json");
+    let mut metadata: serde_json::Value =
+        serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
+    assert!(
+        metadata
+            .as_object_mut()
+            .unwrap()
+            .remove("allocatedBytes")
+            .is_some()
+    );
+    fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
+        .await
+        .unwrap();
+
     let sidecar = cache
         .probe_session_history_sidecar(&cache_key, &identity)
         .await


### PR DESCRIPTION
## Summary

- accept workspace session-history sidecar metadata with or without `allocatedBytes`
- keep current writers emitting the measured numeric value unchanged
- cover the current and future metadata shapes through the real publish/probe boundary

## Compatibility

The metadata member is transitional `Option<u64>` state. Current publishers always construct
`Some(actual)`, so the persisted JSON remains unchanged. Readers map a missing property to `None`,
which prepares a later writer cleanup without making any writer omit the field in this rollout.

The follow-up writer removal remains blocked in #22094 until this reader is deployed and included
in every supported production and rollback runner baseline.

## Exclusions

- no sidecar format-version change or metadata purge
- no validation, fallback, promotion, inspection, or garbage-collection behavior change
- no API contract, database schema, migration, backfill, queue, heartbeat, or guest-protocol change
- no generation-attribution or resource-path telemetry change

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner session_history_sidecar_publish_and_probe_hit`
- `cargo test -p runner --bin runner session_history_sidecar_metadata_without_allocated_bytes_remains_restoreable`
- `cargo test -p runner --bin runner` (2748 passed, 0 failed, 12 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- repository pre-commit and commit-message hooks

Closes #22092

Parent: #22028
