### PR TITLE
fix(api): decode workflow timestamps in bootstrap snapshot

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4851,7 +4851,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     const { actor, runnerGroup } = await entitledRunActor();
     failIfChatCallbackRouteIsFetched();
 
-    const workflowName = "bdd-codex-kit";
+    const workflowNames = ["bdd-codex-kit", "bdd-codex-research"] as const;
 
     await misc.upsertPersonalModelProvider(
       actor,
@@ -4890,13 +4890,15 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       visibility: "private",
     });
     // Workflows are created directly under the owning agent (agent-scoped 1:N).
-    await misc.createWorkflow(
-      actor,
-      agent.agentId,
-      workflowName,
-      { content: "# BDD codex kit\nUse this workflow for codex runs." },
-      [201],
-    );
+    for (const workflowName of workflowNames) {
+      await misc.createWorkflow(
+        actor,
+        agent.agentId,
+        workflowName,
+        { content: `# ${workflowName}\nUse this workflow for codex runs.` },
+        [201],
+      );
+    }
     const thread = await chat.createThread(actor, { agentId: agent.agentId });
     const sent = await chat.requestSendMessage(
       actor,
@@ -4920,11 +4922,11 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        storage_manifest_source_workflow_skill_resolved_count_bucket: "1",
+        storage_manifest_source_workflow_skill_resolved_count_bucket: "2",
         storage_manifest_source_workflow_skill_planned_presign_count_bucket:
-          "1",
+          "2",
         storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
-          "1",
+          "2",
       }),
     );
     expect(
@@ -4935,13 +4937,13 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     ).toStrictEqual(
       expect.objectContaining({
         storage_manifest_source_workflow_skill_planned_presign_count_bucket:
-          "1",
+          "2",
         storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
-          "1",
+          "2",
       }),
     );
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
-      workflowName,
+      ...workflowNames,
       agent.agentId,
       thread.id,
     ]);
@@ -4964,7 +4966,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       claim.storageManifest?.storages.map((storage) => {
         return storage.mountPath;
       }) ?? [];
-    expect(mountPaths).toContain(`/home/user/.codex/skills/${workflowName}`);
+    for (const workflowName of workflowNames) {
+      expect(mountPaths).toContain(`/home/user/.codex/skills/${workflowName}`);
+    }
     expect(
       mountPaths.some((mountPath) => {
         return mountPath.startsWith("/home/user/.claude/skills/");

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -220,7 +220,9 @@ function emptyExecutionScopeSnapshotFields() {
     visibility: sql<ZeroWorkflowVisibility | null>`NULL::text`.as("visibility"),
     ownerUserId: sql<string | null>`NULL::text`.as("owner_user_id"),
     action: sql<FirewallPermissionGrantAction | null>`NULL::text`.as("action"),
-    createdAt: sql<Date | null>`NULL::timestamp`.as("created_at"),
+    createdAt: sql<Date | null>`NULL::timestamp`
+      .mapWith(zeroWorkflows.createdAt)
+      .as("created_at"),
   };
 }
 
@@ -271,7 +273,9 @@ async function queryZeroRunExecutionScopeSnapshot(
       ownerUserId: sql<string | null>`${zeroWorkflows.ownerUserId}`.as(
         "owner_user_id",
       ),
-      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`.as("created_at"),
+      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`
+        .mapWith(zeroWorkflows.createdAt)
+        .as("created_at"),
     })
     .from(zeroWorkflows)
     .where(


### PR DESCRIPTION
## Summary

- Decode `created_at` through the `zeroWorkflows.createdAt` column decoder in both sides of the execution-scope bootstrap `UNION ALL`.
- Extend the existing chat-send PostgreSQL BDD scenario to create two workflows for one agent and verify both are resolved, presigned, and mounted.

## User impact

Sending a chat message to an agent with multiple workflows no longer fails with a 500 when workflow priority sorting reads `createdAt`.

## Verification

- `prettier@3.8.1 --write` on both changed files
- `pnpm -F api lint` — passed with 0 warnings and 0 errors
- `pnpm -F api check-types` — passed
- `pnpm exec knip --workspace api` — passed
- Targeted `run-lifecycle.bdd.test.ts` case attempted locally; the runtime has no PostgreSQL server/cluster, so setup stopped on `ECONNREFUSED` before reaching the test behavior. The PR pipeline will run this case against its real PostgreSQL service.

## Context

- Regression introduced by #22084
- [Slack investigation](https://vm0.slack.com/archives/C09RUN8LVBL/p1784435511833119)
- [Sentry API-2M](https://vm0.sentry.io/issues/7619891703/)
