### PR TITLE
fix(api): prevent unparsed date values in drizzle sql results

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -15,6 +15,35 @@ pnpm db:migrate    # Run pending migrations
 pnpm db:studio     # Open Drizzle Studio UI
 ```
 
+## Query Result Mapping
+
+Prefer Drizzle's schema-aware result mapping in this order:
+
+1. Select a schema column directly.
+2. Use a Drizzle helper such as `max()`, `min()`, or `count()`.
+3. Use `sql` only when the expression cannot be represented otherwise, and
+   attach `.mapWith(column)` or a dedicated decoder when the database driver's
+   value needs runtime conversion.
+
+`sql<T>` is only a compile-time assertion. It does not convert driver values.
+Do not wrap a directly selectable column in `sql<T>`, and never rely on
+`sql<Date>` to produce a JavaScript `Date`. The
+`api/require-sql-date-decoder` rule enforces this for API code.
+
+Whether a decoder is required depends on the driver's runtime value, not on
+whether the TypeScript type is primitive. For example, PostgreSQL `count()` may
+need number conversion, while JSON or array values may already be decoded by
+the configured driver.
+
+Runtime decoders apply only to selected or returned fields. Predicates,
+ordering expressions, and write-only values should use untyped `sql` without
+`.mapWith()`.
+
+For set operations such as `UNION ALL`, Drizzle uses the leftmost selection's
+field decoders for the combined result. Attach the required decoder to a
+database-typed placeholder such as `NULL::timestamp` in the leftmost query when
+later branches return mapped values.
+
 ## Migration Workflows
 
 ### Auto-Generated (simple changes)

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -173,6 +173,7 @@ export default [
       "api/no-logger-info": "error",
       "api/no-new-promise": "error",
       "api/no-store-in-params": "error",
+      "api/require-sql-date-decoder": "error",
       "api/signal-check-await": "error",
     },
   },

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -45,14 +45,14 @@ function lastRunFinishMessageSubquery(db: Pick<Db, "select">) {
 }
 
 function latestRunFinishCreatedAtSql() {
-  return sql<Date>`(
+  return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
     WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
       AND ${chatMessages.runLifecycleEvent} IS NOT NULL
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
-  )`.mapWith(chatMessages.createdAt);
+  )`;
 }
 
 const markAgentReadInner$ = command(

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -52,7 +52,7 @@ function latestRunFinishCreatedAtSql() {
       AND ${chatMessages.runLifecycleEvent} IS NOT NULL
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
-  )`;
+  )`.mapWith(chatMessages.createdAt);
 }
 
 const markAgentReadInner$ = command(

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -21,7 +21,7 @@ function latestRunFinishCreatedAtSql() {
       AND ${chatMessages.runLifecycleEvent} IS NOT NULL
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
-  )`;
+  )`.mapWith(chatMessages.createdAt);
 }
 
 const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -14,14 +14,14 @@ import { zeroChatThreadUnreads } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route-entry";
 
 function latestRunFinishCreatedAtSql() {
-  return sql<Date>`(
+  return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
     WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
       AND ${chatMessages.runLifecycleEvent} IS NOT NULL
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
-  )`.mapWith(chatMessages.createdAt);
+  )`;
 }
 
 const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -13,7 +13,7 @@ import { usageEvent } from "@vm0/db/schema/usage-event";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command, computed, type Computed } from "ccstate";
-import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, lt, max, sql } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import { getDatasetName, queryAxiom } from "../external/axiom";
@@ -140,6 +140,12 @@ interface ActiveUserRow {
   readonly lastActivity: Date;
 }
 
+interface ActiveUserQueryRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly lastActivity: Date | null;
+}
+
 interface OrgUserPair {
   readonly orgId: string;
   readonly userId: string;
@@ -242,10 +248,6 @@ interface NetworkQueryResult {
 interface CurrentOrgMemberScope {
   readonly orgsWithCurrentMembers: Set<string>;
   readonly memberKeys: Set<string>;
-}
-
-function normalizeDbDate(value: Date | string): Date {
-  return value instanceof Date ? value : new Date(value);
 }
 
 type PermissionLabelResolver = (
@@ -765,17 +767,21 @@ async function queryCurrentOrgMembers(
   return { orgsWithCurrentMembers, memberKeys };
 }
 
-function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
+function mergeActiveUserRows(rows: ActiveUserQueryRow[]): ActiveUserRow[] {
   const byUser = new Map<string, ActiveUserRow>();
   for (const row of rows) {
-    const normalizedRow = {
-      ...row,
-      lastActivity: normalizeDbDate(row.lastActivity),
-    };
+    const lastActivity = row.lastActivity;
+    if (lastActivity === null) {
+      throw new Error("Active-user aggregate returned null lastActivity");
+    }
     const key = `${row.orgId}:${row.userId}`;
     const existing = byUser.get(key);
-    if (!existing || normalizedRow.lastActivity > existing.lastActivity) {
-      byUser.set(key, normalizedRow);
+    if (!existing || lastActivity > existing.lastActivity) {
+      byUser.set(key, {
+        orgId: row.orgId,
+        userId: row.userId,
+        lastActivity,
+      });
     }
   }
   return [...byUser.values()];
@@ -791,9 +797,7 @@ async function queryActiveUsers(
       .select({
         orgId: agentRuns.orgId,
         userId: agentRuns.userId,
-        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`
-          .mapWith(agentRuns.completedAt)
-          .as("last_activity"),
+        lastActivity: max(agentRuns.completedAt).as("last_activity"),
       })
       .from(agentRuns)
       .where(
@@ -807,9 +811,7 @@ async function queryActiveUsers(
       .select({
         orgId: usageEvent.orgId,
         userId: usageEvent.userId,
-        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`
-          .mapWith(usageEvent.processedAt)
-          .as("last_activity"),
+        lastActivity: max(usageEvent.processedAt).as("last_activity"),
       })
       .from(usageEvent)
       .where(
@@ -1310,9 +1312,7 @@ export const aggregateInsights$ = command(
       .select({
         orgId: insightsDaily.orgId,
         userId: insightsDaily.userId,
-        lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`
-          .mapWith(insightsDaily.updatedAt)
-          .as("last_updated"),
+        lastUpdated: max(insightsDaily.updatedAt).as("last_updated"),
       })
       .from(insightsDaily)
       .where(
@@ -1324,11 +1324,13 @@ export const aggregateInsights$ = command(
       .groupBy(insightsDaily.orgId, insightsDaily.userId);
     signal.throwIfAborted();
 
-    const lastAggMap = new Map(
-      lastAggRows.map((row) => {
-        return [`${row.orgId}:${row.userId}`, normalizeDbDate(row.lastUpdated)];
-      }),
-    );
+    const lastAggMap = new Map<string, Date>();
+    for (const row of lastAggRows) {
+      if (row.lastUpdated === null) {
+        throw new Error("Insights aggregate returned null lastUpdated");
+      }
+      lastAggMap.set(`${row.orgId}:${row.userId}`, row.lastUpdated);
+    }
 
     const usersToAggregate = activeUsers.filter((user) => {
       const lastAgg = lastAggMap.get(`${user.orgId}:${user.userId}`);

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -791,9 +791,9 @@ async function queryActiveUsers(
       .select({
         orgId: agentRuns.orgId,
         userId: agentRuns.userId,
-        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`.as(
-          "last_activity",
-        ),
+        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`
+          .mapWith(agentRuns.completedAt)
+          .as("last_activity"),
       })
       .from(agentRuns)
       .where(
@@ -807,9 +807,9 @@ async function queryActiveUsers(
       .select({
         orgId: usageEvent.orgId,
         userId: usageEvent.userId,
-        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`.as(
-          "last_activity",
-        ),
+        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`
+          .mapWith(usageEvent.processedAt)
+          .as("last_activity"),
       })
       .from(usageEvent)
       .where(
@@ -1310,9 +1310,9 @@ export const aggregateInsights$ = command(
       .select({
         orgId: insightsDaily.orgId,
         userId: insightsDaily.userId,
-        lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`.as(
-          "last_updated",
-        ),
+        lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`
+          .mapWith(insightsDaily.updatedAt)
+          .as("last_updated"),
       })
       .from(insightsDaily)
       .where(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -771,7 +771,9 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 
   const [message] = await db
     .select({
-      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`,
+      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`.mapWith(
+        chatMessages.createdAt,
+      ),
     })
     .from(chatMessages)
     .where(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -25,6 +25,7 @@ import {
   isNotNull,
   isNull,
   lte,
+  max,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -771,9 +772,7 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 
   const [message] = await db
     .select({
-      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`.mapWith(
-        chatMessages.createdAt,
-      ),
+      lastEventAt: max(chatMessages.createdAt),
     })
     .from(chatMessages)
     .where(
@@ -787,14 +786,13 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
     return;
   }
 
-  const lastEventMs =
-    message.lastEventAt instanceof Date
-      ? message.lastEventAt.getTime()
-      : new Date(message.lastEventAt).getTime();
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "last_event_to_complete",
-    durationMs: Math.max(0, run.completedAt.getTime() - lastEventMs),
+    durationMs: Math.max(
+      0,
+      run.completedAt.getTime() - message.lastEventAt.getTime(),
+    ),
     success: true,
     runId,
   });

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -3281,10 +3281,7 @@ async function expireActiveUsageAllowanceWindows(
       return db
         .update(orgUsageAllowanceWindows)
         .set({
-          expiresAt:
-            sql<Date>`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`.mapWith(
-              orgUsageAllowanceWindows.expiresAt,
-            ),
+          expiresAt: sql`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
           updatedAt: args.updatedAt,
         })
         .where(

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -3281,7 +3281,10 @@ async function expireActiveUsageAllowanceWindows(
       return db
         .update(orgUsageAllowanceWindows)
         .set({
-          expiresAt: sql<Date>`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
+          expiresAt:
+            sql<Date>`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`.mapWith(
+              orgUsageAllowanceWindows.expiresAt,
+            ),
           updatedAt: args.updatedAt,
         })
         .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -89,11 +89,11 @@ function chatMessageOrderSequenceSql() {
 }
 
 function matchedMessageCreatedAtSql(messageId: string) {
-  return sql<Date>`(
+  return sql`(
     SELECT ${matchedChatMessage.createdAt}
     FROM ${chatMessages} AS matched_chat_message
     WHERE ${matchedChatMessage.id} = ${messageId}
-  )`.mapWith(matchedChatMessage.createdAt);
+  )`;
 }
 
 type ChatMessageRow = {
@@ -349,7 +349,7 @@ const messageColumns = {
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
   )`,
-  workflowAutomationAtTime: sql<Date | null>`(
+  workflowAutomationAtTime: sql`(
     SELECT "zero_workflow_automations"."at_time"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -93,7 +93,7 @@ function matchedMessageCreatedAtSql(messageId: string) {
     SELECT ${matchedChatMessage.createdAt}
     FROM ${chatMessages} AS matched_chat_message
     WHERE ${matchedChatMessage.id} = ${messageId}
-  )`;
+  )`.mapWith(matchedChatMessage.createdAt);
 }
 
 type ChatMessageRow = {

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -94,7 +94,7 @@ async function loadUsageMessageContext(tx: WriteTx, runId: string) {
         MAX(${usageEvent.createdAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${agentRuns.completedAt}),
         MAX(${agentRuns.createdAt})
-      )`,
+      )`.mapWith(usageEvent.processedAt),
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -89,12 +89,12 @@ async function loadUsageMessageContext(tx: WriteTx, runId: string) {
       pendingCount: sql<number>`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'pending')::int`,
       processedCount: sql<number>`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'processed')::int`,
       totalCredits: sql<number>`COALESCE(SUM(${usageCreditsExpression()}) FILTER (WHERE ${usageEvent.status} = 'processed'), 0)::bigint`,
-      settledAt: sql<Date>`COALESCE(
+      settledAt: sql`COALESCE(
         MAX(${usageEvent.processedAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${usageEvent.createdAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${agentRuns.completedAt}),
         MAX(${agentRuns.createdAt})
-      )`.mapWith(usageEvent.processedAt),
+      )`.mapWith(agentRuns.createdAt),
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -220,7 +220,7 @@ function emptyExecutionScopeSnapshotFields() {
     visibility: sql<ZeroWorkflowVisibility | null>`NULL::text`.as("visibility"),
     ownerUserId: sql<string | null>`NULL::text`.as("owner_user_id"),
     action: sql<FirewallPermissionGrantAction | null>`NULL::text`.as("action"),
-    createdAt: sql<Date | null>`NULL::timestamp`
+    createdAt: sql`NULL::timestamp`
       .mapWith(zeroWorkflows.createdAt)
       .as("created_at"),
   };
@@ -273,9 +273,7 @@ async function queryZeroRunExecutionScopeSnapshot(
       ownerUserId: sql<string | null>`${zeroWorkflows.ownerUserId}`.as(
         "owner_user_id",
       ),
-      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`
-        .mapWith(zeroWorkflows.createdAt)
-        .as("created_at"),
+      createdAt: zeroWorkflows.createdAt,
     })
     .from(zeroWorkflows)
     .where(

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
@@ -40,6 +40,22 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
     {
       code: `
         import { sql } from "drizzle-orm";
+        function render(sql: (strings: TemplateStringsArray) => string) {
+          return sql<Date>\`NOW()\`;
+        }
+      `,
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        function render(drizzle: { sql: (strings: TemplateStringsArray) => string }) {
+          return drizzle.sql<Date>\`NOW()\`;
+        }
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
         const value = sql<number>\`COUNT(*)\`;
       `,
     },
@@ -73,6 +89,13 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
       code: `
         import * as drizzle from "drizzle-orm";
         const value = drizzle.sql<Date>\`NOW()\`.as("created_at");
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+    {
+      code: `
+        const value = sql<Date>\`NOW()\`;
+        import { sql } from "drizzle-orm";
       `,
       errors: [{ messageId: "missingDecoder" }],
     },

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
@@ -1,0 +1,80 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { requireSqlDateDecoder } from "../rules/require-sql-date-decoder.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
+  valid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const value = sql<Date>\`MAX(\${events.createdAt})\`.mapWith(events.createdAt);
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const value = sql<Date | null>\`NULL::timestamp\`
+          .mapWith(events.createdAt)
+          .as("created_at");
+      `,
+    },
+    {
+      code: `
+        import { sql as drizzleSql } from "drizzle-orm";
+        const value = drizzleSql<Date>\`NOW()\`.mapWith(events.createdAt);
+      `,
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        const value = drizzle.sql<Date>\`NOW()\`.mapWith(events.createdAt);
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const value = sql<number>\`COUNT(*)\`;
+      `,
+    },
+    {
+      code: "const value = sql<Date>`NOW()`;",
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const value = sql<Date>\`MAX(\${events.createdAt})\`;
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const value = sql<Date | null>\`NULL::timestamp\`.as("created_at");
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+    {
+      code: `
+        import { sql as drizzleSql } from "drizzle-orm";
+        const value = drizzleSql<(Date | null)>\`NOW()\`;
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        const value = drizzle.sql<Date>\`NOW()\`.as("created_at");
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts
@@ -14,15 +14,25 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
     {
       code: `
         import { sql } from "drizzle-orm";
-        const value = sql<Date>\`MAX(\${events.createdAt})\`.mapWith(events.createdAt);
+        const value = sql\`GREATEST(\${events.createdAt}, NOW())\`
+          .mapWith(events.createdAt);
+      `,
+    },
+    {
+      code: `
+        const selection = { createdAt: events.createdAt };
+      `,
+    },
+    {
+      code: `
+        import { max } from "drizzle-orm";
+        const selection = { lastCreatedAt: max(events.createdAt) };
       `,
     },
     {
       code: `
         import { sql } from "drizzle-orm";
-        const value = sql<Date | null>\`NULL::timestamp\`
-          .mapWith(events.createdAt)
-          .as("created_at");
+        const update = { expiresAt: sql\`GREATEST(\${events.createdAt}, NOW())\` };
       `,
     },
     {
@@ -34,7 +44,9 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
     {
       code: `
         import * as drizzle from "drizzle-orm";
-        const value = drizzle.sql<Date>\`NOW()\`.mapWith(events.createdAt);
+        const value = drizzle.sql<Date | null>\`NULL::timestamp\`
+          .mapWith(events.createdAt)
+          .as("created_at");
       `,
     },
     {
@@ -56,7 +68,7 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
     {
       code: `
         import { sql } from "drizzle-orm";
-        const value = sql<number>\`COUNT(*)\`;
+        const value = sql<string>\`LOWER(\${events.name})\`;
       `,
     },
     {
@@ -96,6 +108,13 @@ ruleTester.run("require-sql-date-decoder", requireSqlDateDecoder, {
       code: `
         const value = sql<Date>\`NOW()\`;
         import { sql } from "drizzle-orm";
+      `,
+      errors: [{ messageId: "missingDecoder" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const update = { expiresAt: sql<Date>\`NOW()\` };
       `,
       errors: [{ messageId: "missingDecoder" }],
     },

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -6,6 +6,7 @@ import { noNewPromise } from "./rules/no-new-promise.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
+import { requireSqlDateDecoder } from "./rules/require-sql-date-decoder.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
 
 export const apiLintPlugin = {
@@ -22,6 +23,7 @@ export const apiLintPlugin = {
     "no-package-variable": noPackageVariable,
     "no-store-in-params": noStoreInParams,
     "no-test-vi-mocks": noTestViMocks,
+    "require-sql-date-decoder": requireSqlDateDecoder,
     "signal-check-await": signalCheckAwait,
   },
 };

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
@@ -66,14 +66,14 @@ export const requireSqlDateDecoder = createRule({
     type: "problem",
     docs: {
       description:
-        "Require a runtime decoder for Date-valued Drizzle sql expressions",
+        "Prevent Date-valued Drizzle sql type assertions without a runtime decoder",
       recommended: true,
       requiresTypeChecking: false,
     },
     schema: [],
     messages: {
       missingDecoder:
-        "`sql<Date>` only declares a static type. Call `.mapWith(...)` with a timestamp column decoder before using the expression.",
+        "`sql<Date>` does not decode database values. Select a Drizzle column or helper directly, call `.mapWith(...)` for a returned raw expression, or remove the Date generic when the SQL is not returned.",
     },
   },
   create(context) {

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
@@ -1,4 +1,8 @@
-import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import {
+  AST_NODE_TYPES,
+  ASTUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
 
 import { createRule } from "../utils.ts";
 
@@ -73,43 +77,59 @@ export const requireSqlDateDecoder = createRule({
     },
   },
   create(context) {
-    const sqlIdentifiers = new Set<string>();
-    const drizzleNamespaces = new Set<string>();
+    function drizzleImportKind(
+      identifier: TSESTree.Identifier,
+    ): "namespace" | "sql" | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return candidate.type === "ImportBinding";
+      });
+      if (
+        !definition ||
+        definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
+        definition.parent.source.value !== "drizzle-orm" ||
+        definition.parent.importKind === "type"
+      ) {
+        return null;
+      }
+
+      const specifier = definition.node;
+      if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+        return "namespace";
+      }
+      if (
+        specifier.type !== AST_NODE_TYPES.ImportSpecifier ||
+        specifier.importKind === "type"
+      ) {
+        return null;
+      }
+      if (
+        (specifier.imported.type === AST_NODE_TYPES.Identifier &&
+          specifier.imported.name === "sql") ||
+        (specifier.imported.type === AST_NODE_TYPES.Literal &&
+          specifier.imported.value === "sql")
+      ) {
+        return "sql";
+      }
+      return null;
+    }
 
     function isDrizzleSqlTag(tag: TSESTree.Expression): boolean {
       if (tag.type === AST_NODE_TYPES.Identifier) {
-        return sqlIdentifiers.has(tag.name);
+        return drizzleImportKind(tag) === "sql";
       }
       return (
         tag.type === AST_NODE_TYPES.MemberExpression &&
         tag.object.type === AST_NODE_TYPES.Identifier &&
-        drizzleNamespaces.has(tag.object.name) &&
+        drizzleImportKind(tag.object) === "namespace" &&
         memberName(tag) === "sql"
       );
     }
 
     return {
-      ImportDeclaration(node: TSESTree.ImportDeclaration): void {
-        if (node.source.value !== "drizzle-orm") {
-          return;
-        }
-
-        for (const specifier of node.specifiers) {
-          if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
-            drizzleNamespaces.add(specifier.local.name);
-            continue;
-          }
-          if (
-            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
-            ((specifier.imported.type === AST_NODE_TYPES.Identifier &&
-              specifier.imported.name === "sql") ||
-              (specifier.imported.type === AST_NODE_TYPES.Literal &&
-                specifier.imported.value === "sql"))
-          ) {
-            sqlIdentifiers.add(specifier.local.name);
-          }
-        }
-      },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
         const typeArgument = node.typeArguments?.params[0];
         if (

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts
@@ -1,0 +1,131 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+function containsDateType(node: TSESTree.TypeNode): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSTypeReference:
+      return (
+        node.typeName.type === AST_NODE_TYPES.Identifier &&
+        node.typeName.name === "Date"
+      );
+    case AST_NODE_TYPES.TSUnionType:
+    case AST_NODE_TYPES.TSIntersectionType:
+      return node.types.some(containsDateType);
+    default:
+      return false;
+  }
+}
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function hasMapWithCall(node: TSESTree.TaggedTemplateExpression): boolean {
+  let current: TSESTree.Node = node;
+
+  while (current.parent) {
+    const member: TSESTree.Node = current.parent;
+    if (
+      member.type !== AST_NODE_TYPES.MemberExpression ||
+      member.object !== current
+    ) {
+      return false;
+    }
+
+    const call: TSESTree.Node | undefined = member.parent;
+    if (
+      call?.type !== AST_NODE_TYPES.CallExpression ||
+      call.callee !== member
+    ) {
+      return false;
+    }
+    if (memberName(member) === "mapWith") {
+      return true;
+    }
+    current = call;
+  }
+
+  return false;
+}
+
+export const requireSqlDateDecoder = createRule({
+  name: "require-sql-date-decoder",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a runtime decoder for Date-valued Drizzle sql expressions",
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      missingDecoder:
+        "`sql<Date>` only declares a static type. Call `.mapWith(...)` with a timestamp column decoder before using the expression.",
+    },
+  },
+  create(context) {
+    const sqlIdentifiers = new Set<string>();
+    const drizzleNamespaces = new Set<string>();
+
+    function isDrizzleSqlTag(tag: TSESTree.Expression): boolean {
+      if (tag.type === AST_NODE_TYPES.Identifier) {
+        return sqlIdentifiers.has(tag.name);
+      }
+      return (
+        tag.type === AST_NODE_TYPES.MemberExpression &&
+        tag.object.type === AST_NODE_TYPES.Identifier &&
+        drizzleNamespaces.has(tag.object.name) &&
+        memberName(tag) === "sql"
+      );
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration): void {
+        if (node.source.value !== "drizzle-orm") {
+          return;
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+            drizzleNamespaces.add(specifier.local.name);
+            continue;
+          }
+          if (
+            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+            ((specifier.imported.type === AST_NODE_TYPES.Identifier &&
+              specifier.imported.name === "sql") ||
+              (specifier.imported.type === AST_NODE_TYPES.Literal &&
+                specifier.imported.value === "sql"))
+          ) {
+            sqlIdentifiers.add(specifier.local.name);
+          }
+        }
+      },
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
+        const typeArgument = node.typeArguments?.params[0];
+        if (
+          !typeArgument ||
+          !containsDateType(typeArgument) ||
+          !isDrizzleSqlTag(node.tag) ||
+          hasMapWithCall(node)
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "missingDecoder",
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- add an API ESLint rule that requires Drizzle `sql<Date>` and nullable Date expressions to attach a runtime decoder with `.mapWith(...)`
- resolve Drizzle `sql` tags through their ESLint import bindings so aliases, namespace imports, later imports, and locally shadowed names are handled correctly
- attach timestamp column decoders to every existing API Date-valued SQL expression, including the workflow bootstrap union that returned timestamp strings and caused chat creation 500s
- cover the original regression through the real chat-send API flow with two workflows attached to one agent

## User impact

Agents with multiple visible workflows can create chat runs without the workflow-priority sort receiving string timestamps. Future Date-valued raw SQL expressions fail lint unless their runtime decoding is explicit.

## Scope

- no database schema, persisted-data, or public API contract changes
- no changes to SQL generation; `.mapWith(...)` only restores Drizzle result decoding

## Validation

- `pnpm exec prettier --check packages/eslint-rules/src/api/rules/require-sql-date-decoder.ts packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec knip --workspace @vm0/eslint-rules`
- `pnpm exec knip --workspace api`
- `CI=true pnpm knip --cache`
- `pnpm exec vitest run packages/eslint-rules/src/api/__tests__/require-sql-date-decoder.test.ts --reporter=default` (13 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "runs thread-pinned member-scope providers and mounts codex workflows" --reporter=default` (1 passed)
- pre-commit full Turbo type check (13 workspaces passed)
