### PR TITLE
fix(platform): keep pasted prompt text inline

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -7,7 +7,7 @@ import {
   type State,
 } from "ccstate";
 import { Editor, Extension, Node, type JSONContent } from "@tiptap/core";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Slice, type Node as ProseMirrorNode } from "@tiptap/pm/model";
 import {
   Plugin,
   PluginKey,
@@ -2062,8 +2062,17 @@ function createInsertTextCommands(editor: Editor) {
     editor.chain().focus().insertContent(value).run();
   });
   const insertPromptMarkdown$ = command((_context, value: string) => {
-    const content = valueToWorkflowComposerDoc(value).content ?? [];
-    editor.chain().focus().insertContent(content).run();
+    const doc = editor.schema.nodeFromJSON(valueToWorkflowComposerDoc(value));
+    const slice = Slice.maxOpen(doc.content, true);
+    editor
+      .chain()
+      .focus()
+      .command(({ tr }) => {
+        tr.replaceSelection(slice);
+        return true;
+      })
+      .scrollIntoView()
+      .run();
   });
   const appendText$ = command((_context, value: string) => {
     const text = value.trim();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -658,6 +658,83 @@ describe("chat drafts", () => {
     });
   });
 
+  it("keeps pasted plain text inline at the caret", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "thread-plain-text-paste";
+
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Before after");
+    await user.keyboard(
+      "{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}",
+    );
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => {
+          return type === "text/plain" ? "pasted " : "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        Array.from(editor.children, (element) => {
+          return element.textContent ?? "";
+        }).filter((text) => {
+          return text.length > 0;
+        }),
+      ).toStrictEqual(["Before pasted after"]);
+    });
+  });
+
+  it("joins multiline prompt items only at the paste boundaries", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "thread-multiline-paste";
+
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Before after");
+    await user.keyboard(
+      "{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}",
+    );
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => {
+          return type === "text/plain"
+            ? `first\n[Thread 1](/chats/${THREAD_ONE_ID})\nlast `
+            : "";
+        },
+        items: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        Array.from(editor.children, (element) => {
+          return element.textContent ?? "";
+        }).filter((text) => {
+          return text.length > 0;
+        }),
+      ).toStrictEqual(["Before first", "Thread 1", "last after"]);
+      expect(
+        editor.querySelector(
+          `span[data-chat-thread-mention="${THREAD_ONE_ID}"]`,
+        ),
+      ).toHaveTextContent("Thread 1");
+    });
+  });
+
   it("restores copied chat text and attachments from the clipboard", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "thread-copied-attachment";


### PR DESCRIPTION
## Summary

- insert parsed prompt clipboard content as an open ProseMirror slice
- join the first and last pasted paragraphs with the surrounding caret context
- preserve internal line breaks and canonical prompt items such as thread mentions
- cover single-line and multiline paste behavior through the rendered chat composer

## User impact

Pasting text in the middle of a Tiptap composer paragraph no longer adds line breaks before and after the pasted content.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-draft.test.tsx --reporter=verbose` (14 passed)

The full local Vitest suite was not run; broader coverage is delegated to the PR pipeline per repository policy.
