### PR TITLE
fix(platform): preserve ime input after adding inline feedback

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -355,12 +355,12 @@ function createFeedbackItemSignals({
   threadId,
   editor,
   selectionState$,
-  closeSelectionToolbar$,
+  hideSelectionToolbar$,
 }: {
   threadId: string;
   editor: FeedbackEditorAdapter;
   selectionState$: State<FeedbackSelection | null>;
-  closeSelectionToolbar$: Command<void, []>;
+  hideSelectionToolbar$: Command<void, []>;
 }) {
   const itemsState$ = state<readonly FeedbackItem[]>([]);
   const rangesState$ = state<ReadonlyMap<number, Range>>(new Map());
@@ -405,7 +405,7 @@ function createFeedbackItemSignals({
     set(rangesState$, ranges);
     set(setFeedbackHighlight$, threadId, ranges);
     editor.insertItem(item);
-    set(closeSelectionToolbar$);
+    set(hideSelectionToolbar$);
   });
   const removeFeedback$ = command(({ get, set }, id: number) => {
     const items = get(itemsState$).filter((item) => {
@@ -664,7 +664,7 @@ export function createFeedbackSignals(
     threadId,
     editor,
     selectionState$: selection.selectionState$,
-    closeSelectionToolbar$: selection.closeSelectionToolbar$,
+    hideSelectionToolbar$: selection.hideSelectionToolbar$,
   });
   const setSelectionToolbarRef$ = createSelectionToolbarRef({
     resetSelectionToolbarSignal$: selection.resetSelectionToolbarSignal$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -212,7 +212,7 @@ function dispatchDocumentShortcut(
 }
 
 describe("chat inline feedback", () => {
-  it("inserts feedback as an atomic block followed by a text line", async () => {
+  it("keeps the composer caret after inserting atomic block feedback", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The rollout dates are unclear in this summary.";
     let sentPrompt: string | undefined;
@@ -253,7 +253,12 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Provide feedback"));
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+    const shortcutEvent = dispatchDocumentShortcut("f");
+    expect(shortcutEvent.defaultPrevented).toBeTruthy();
+    expect(window.getSelection()?.rangeCount).toBe(1);
 
     const feedbackBlock = await waitFor(() => {
       const element = composerEditor.querySelector("[data-composer-feedback]");
@@ -269,17 +274,22 @@ describe("chat inline feedback", () => {
     expect(feedbackBlock?.nextElementSibling?.tagName).toBe("P");
     expect(feedbackBlock?.nextElementSibling).toHaveTextContent("");
 
-    await user.keyboard("Make the dates explicit.");
-    expect(feedbackBlock?.nextElementSibling).toHaveTextContent(
-      "Make the dates explicit.",
-    );
+    await waitFor(() => {
+      const selection = window.getSelection();
+      expect(
+        composerEditor.contains(selection?.focusNode ?? null),
+      ).toBeTruthy();
+    });
+
+    await user.keyboard("补充具体日期");
+    expect(feedbackBlock?.nextElementSibling).toHaveTextContent("补充具体日期");
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
       expect(sentPrompt).toBeDefined();
     });
     expect(sentPrompt).toBe(
-      `Context before feedback.\nFeedback on this part of your reply:\n\n> ${assistantReply}\nMake the dates explicit.`,
+      `Context before feedback.\nFeedback on this part of your reply:\n\n> ${assistantReply}\n补充具体日期`,
     );
   });
 


### PR DESCRIPTION
## Summary

- preserve the browser selection while inline feedback hands the caret to the composer
- keep the existing selection-clearing behavior for copy, Escape, and scroll dismissal
- cover atomic prompt feedback created from the keyboard shortcut, including immediate Chinese input and prompt serialization

## User impact

Chinese IME text can be committed immediately after adding inline feedback. The composer no longer remains focused with an empty native selection range.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (16 passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec knip --workspace @vm0/app`
