### PR TITLE
docs(mitm-addon): define shared-base ownership status contract

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -206,16 +206,18 @@ def resolve_shared_base_ownership(
       ``candidate`` is ``None``.
 
     ``hint_status`` is ``absent`` when no intent was supplied, ``used`` when
-    intent selected the owner, ``ignored`` when a matching intent lost to a
-    unique route owner, and ``outside_candidate_set`` when intent named no
-    candidate. Route-owner reasons can use ``absent``, ``ignored``, or
-    ``outside_candidate_set``; hint-owner reasons use ``used``; ambiguous and
-    base-only reasons use ``absent`` or ``outside_candidate_set``.
+    intent selected the owner, ``ignored`` when a matching intent was not used
+    because a unique route owner took precedence, and ``outside_candidate_set``
+    when intent named no candidate. Route-owner reasons can use ``absent``,
+    ``ignored``, or ``outside_candidate_set``; hint-owner reasons use ``used``;
+    ambiguous and base-only reasons use ``absent`` or
+    ``outside_candidate_set``.
 
     The current caller copies ownership fields into connector diagnostic proxy
     logs only after accepting a non-``None`` candidate and finding no existing
     request auth material. Consequently, logged ``ownership_reason`` values are
-    currently limited to ``route_owner`` and ``hint_owner``; suppressing reasons
+    currently limited to ``route_owner`` and ``hint_owner``, while
+    ``ownership_hint_status`` follows the combinations above. Suppressing reasons
     remain returned outcomes only.
     """
     catalog = diagnostic_snapshot.catalog

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, Literal
 
 import builtin_firewall_cache
 import matching
@@ -25,12 +25,29 @@ class ConnectorDiagnosticCandidate:
     auth_query_param_names: tuple[str, ...]
 
 
+SharedBaseOwnershipReason = Literal[
+    "route_owner",
+    "active_route_owner",
+    "hint_owner",
+    "active_hint_owner",
+    "ambiguous_route_owners",
+    "base_only",
+]
+
+SharedBaseOwnershipHintStatus = Literal[
+    "absent",
+    "used",
+    "ignored",
+    "outside_candidate_set",
+]
+
+
 @dataclass(frozen=True)
 class SharedBaseOwnershipResolution:
     candidate: ConnectorDiagnosticCandidate | None
-    reason: str
+    reason: SharedBaseOwnershipReason
     candidate_connector_types: tuple[str, ...]
-    hint_status: str
+    hint_status: SharedBaseOwnershipHintStatus
 
 
 @dataclass(frozen=True)
@@ -172,10 +189,34 @@ def resolve_shared_base_ownership(
 ) -> SharedBaseOwnershipResolution | None:
     """Resolve shared-base ownership for an active unknown-endpoint allow.
 
-    The returned ``candidate`` is set only when the request should diagnose a
-    missing inactive sibling connector. Active-owner, base-only, and ambiguous
-    outcomes are represented with ``candidate=None`` so callers can keep normal
-    auth injection behavior.
+    Route-specific ownership takes precedence over connector intent.
+
+    ``reason`` values:
+    - ``route_owner``: one route-specific inactive connector owns the request;
+      ``candidate`` is that connector.
+    - ``active_route_owner``: the unique route owner is active; ``candidate`` is
+      ``None`` so normal authentication continues.
+    - ``hint_owner``: without a unique route owner, intent selects an inactive
+      connector; ``candidate`` is that connector.
+    - ``active_hint_owner``: intent selects an active connector; ``candidate`` is
+      ``None`` so normal authentication continues.
+    - ``ambiguous_route_owners``: multiple route owners remain and intent selects
+      none; ``candidate`` is ``None``.
+    - ``base_only``: only shared-base matches remain and intent selects none;
+      ``candidate`` is ``None``.
+
+    ``hint_status`` is ``absent`` when no intent was supplied, ``used`` when
+    intent selected the owner, ``ignored`` when a matching intent lost to a
+    unique route owner, and ``outside_candidate_set`` when intent named no
+    candidate. Route-owner reasons can use ``absent``, ``ignored``, or
+    ``outside_candidate_set``; hint-owner reasons use ``used``; ambiguous and
+    base-only reasons use ``absent`` or ``outside_candidate_set``.
+
+    The current caller copies ownership fields into connector diagnostic proxy
+    logs only after accepting a non-``None`` candidate and finding no existing
+    request auth material. Consequently, logged ``ownership_reason`` values are
+    currently limited to ``route_owner`` and ``hint_owner``; suppressing reasons
+    remain returned outcomes only.
     """
     catalog = diagnostic_snapshot.catalog
     if catalog is None:
@@ -280,7 +321,7 @@ def _hint_status(
     matches: list[_OwnershipMatch],
     *,
     used: bool,
-) -> str:
+) -> SharedBaseOwnershipHintStatus:
     if connector_intent is None:
         return "absent"
     if used:


### PR DESCRIPTION
## Summary

- define finite `Literal` contracts for all shared-base ownership reasons and
  connector-intent statuses
- document route-versus-intent precedence, candidate-producing and suppressing
  outcomes, and every valid status meaning
- clarify that only accepted candidate diagnostics expose ownership fields in
  proxy logs

## Scope

This changes type annotations and documentation only. Resolution branches,
runtime string values, metadata keys, proxy-log fields, APIs, schemas, and
persisted data remain unchanged.

## Validation

- `.venv/bin/ruff format src/builtin_connector_diagnostics.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .` — 0 errors, warnings, or notes
- `.venv/bin/python -m pytest tests/test_builtin_connector_diagnostics.py tests/test_request_handler_connector_diagnostics.py -v` — 32 passed
- `.venv/bin/python -m pytest tests/ -v` — 4,081 passed
- `git diff --check`
- pre-commit and commit-message hooks

Closes #22110
