### PR TITLE
fix(sandbox): align copy file publication contract

### DIFF
--- a/crates/sandbox-mock/Cargo.toml
+++ b/crates/sandbox-mock/Cargo.toml
@@ -7,11 +7,11 @@ edition.workspace = true
 async-trait.workspace = true
 guest-contracts.workspace = true
 sandbox = { workspace = true }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -1,4 +1,7 @@
 use std::collections::VecDeque;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -500,7 +503,18 @@ impl Sandbox for MockSandbox {
         {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(host_path, &bytes)?;
+        let parent = host_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let mut temp_file = tempfile::NamedTempFile::new_in(parent)?;
+        #[cfg(unix)]
+        temp_file
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        temp_file.write_all(&bytes)?;
+        temp_file.flush()?;
+        temp_file.persist(host_path).map_err(|error| error.error)?;
         Ok(CopyFileResult {
             bytes_copied: bytes.len() as u64,
         })

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -47,6 +47,38 @@ async fn sandbox_copy_file_missing_ok_default_preserves_existing_host_file() {
     assert_eq!(std::fs::read(&path).unwrap(), b"old host log");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn sandbox_copy_file_replaces_existing_destination_with_private_file() {
+    use std::io::Read;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let sandbox = MockSandbox::new("test-1");
+    sandbox.push_copy_file_result(Ok(b"new host log".to_vec()));
+    let (_host_dir, path) = temp_host_path("replace-existing.log");
+    std::fs::write(&path, b"old host log").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    let mut old_file = std::fs::File::open(&path).unwrap();
+    let old_metadata = old_file.metadata().unwrap();
+
+    let result = sandbox
+        .copy_file("/tmp/system.log", &path, copy_file_options(false))
+        .await
+        .unwrap();
+
+    assert_eq!(result.bytes_copied, 12);
+    assert_eq!(std::fs::read(&path).unwrap(), b"new host log");
+    let new_metadata = std::fs::metadata(&path).unwrap();
+    assert_eq!(new_metadata.permissions().mode() & 0o777, 0o600);
+    assert_ne!(
+        (old_metadata.dev(), old_metadata.ino()),
+        (new_metadata.dev(), new_metadata.ino())
+    );
+    let mut old_bytes = Vec::new();
+    old_file.read_to_end(&mut old_bytes).unwrap();
+    assert_eq!(old_bytes, b"old host log");
+}
+
 #[tokio::test]
 async fn sandbox_copy_file_rejects_queued_bytes_over_max() {
     let sandbox = MockSandbox::new("test-1");

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -68,7 +68,8 @@ async fn sandbox_copy_file_replaces_existing_destination_with_private_file() {
 
     assert_eq!(result.bytes_copied, 12);
     assert_eq!(std::fs::read(&path).unwrap(), b"new host log");
-    let new_metadata = std::fs::metadata(&path).unwrap();
+    let new_metadata = std::fs::symlink_metadata(&path).unwrap();
+    assert!(new_metadata.is_file());
     assert_eq!(new_metadata.permissions().mode() & 0o777, 0o600);
     assert_ne!(
         (old_metadata.dev(), old_metadata.ino()),

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -227,13 +227,23 @@ pub trait Sandbox: Send + Sync + Any {
 
     /// Stream a guest file to a host path and publish copied contents.
     ///
+    /// A successful copy creates missing host parent directories as needed and
+    /// atomically replaces an existing non-directory destination with a newly
+    /// created private regular file. On Unix hosts, the published file has mode
+    /// `0o600`. Metadata from an existing destination is not preserved.
+    ///
     /// The guest path must be non-empty and must not contain NUL bytes.
     ///
     /// If [`CopyFileOptions::missing_ok`] is enabled, a backend result that
     /// reports the path does not resolve to a regular file is treated as
     /// success with `bytes_copied == 0` without publishing a host file or
     /// replacing an existing host file. Host-side setup and validation errors
-    /// can still fail the operation.
+    /// can still fail the operation, and setup may leave newly created parent
+    /// directories behind.
+    ///
+    /// Failures before host publication leave an existing destination
+    /// unchanged. An error reported after publication does not imply that the
+    /// destination was rolled back.
     async fn copy_file(
         &self,
         path: &str,

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -396,11 +396,22 @@ impl VsockHost {
     /// Stream a guest file to a host path and atomically rename it into place
     /// after the exec operation exits successfully.
     ///
+    /// A successful copy creates missing host parent directories as needed and
+    /// replaces an existing non-directory destination with a newly created
+    /// regular file owned by the host process's effective user. The published
+    /// file has mode `0o600`; metadata from an existing destination is not
+    /// preserved.
+    ///
     /// Options are validated before guest work starts. When `missing_ok` is
     /// enabled, a guest helper result that reports the path does not resolve
     /// to a regular file is treated as success with `bytes_copied == 0`
     /// without publishing a host file. Host-side setup and validation errors
-    /// can still fail the operation.
+    /// can still fail the operation, and setup may leave newly created parent
+    /// directories behind.
+    ///
+    /// Failures before the final rename leave an existing destination
+    /// unchanged. An error reported after the rename does not roll back the
+    /// published destination.
     ///
     /// The guest path must be non-empty and must not contain NUL bytes.
     ///
@@ -420,8 +431,8 @@ impl VsockHost {
     /// Stream a guest file to a host path and report when the helper exec
     /// frame is about to be written to the guest.
     ///
-    /// This has the same copy semantics as `copy_file`, including option
-    /// validation and `missing_ok` handling.
+    /// This has the same copy semantics as [`copy_file`](Self::copy_file),
+    /// including option validation and `missing_ok` handling.
     pub async fn copy_file_with_write_observer(
         &self,
         path: &str,

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -173,7 +173,8 @@ async fn copy_file_streams_to_temp_then_renames() {
     fixture.assert_readiness(NormalOperationReadiness::Idle);
     fixture.assert_host_bytes(b"line 1\nline 2\n");
     assert_eq!(mode(&fixture.host_path), 0o600);
-    let new_metadata = std::fs::metadata(&fixture.host_path).unwrap();
+    let new_metadata = std::fs::symlink_metadata(&fixture.host_path).unwrap();
+    assert!(new_metadata.is_file());
     assert_ne!(
         (old_metadata.dev(), old_metadata.ino()),
         (new_metadata.dev(), new_metadata.ino())

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -1,5 +1,5 @@
-use std::io;
-use std::os::unix::fs::PermissionsExt;
+use std::io::{self, Read};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -122,6 +122,10 @@ async fn copy_file_rejects_max_bytes_above_stream_budget() {
 #[tokio::test]
 async fn copy_file_streams_to_temp_then_renames() {
     let mut fixture = CopyFileFixture::new("vsock-host-copy", "system.log").await;
+    fixture.write_host_bytes(b"old host log");
+    std::fs::set_permissions(&fixture.host_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    let mut old_file = std::fs::File::open(&fixture.host_path).unwrap();
+    let old_metadata = old_file.metadata().unwrap();
     let copy_task = fixture.spawn_copy("/tmp/vm0-system-run.log", default_copy_options());
 
     let start = fixture.expect_start().await;
@@ -169,6 +173,14 @@ async fn copy_file_streams_to_temp_then_renames() {
     fixture.assert_readiness(NormalOperationReadiness::Idle);
     fixture.assert_host_bytes(b"line 1\nline 2\n");
     assert_eq!(mode(&fixture.host_path), 0o600);
+    let new_metadata = std::fs::metadata(&fixture.host_path).unwrap();
+    assert_ne!(
+        (old_metadata.dev(), old_metadata.ino()),
+        (new_metadata.dev(), new_metadata.ino())
+    );
+    let mut old_bytes = Vec::new();
+    old_file.read_to_end(&mut old_bytes).unwrap();
+    assert_eq!(old_bytes, b"old host log");
     fixture.assert_no_temp_files();
 }
 


### PR DESCRIPTION
## Summary

- define the successful `Sandbox::copy_file` host publication contract, including atomic replacement, private Unix permissions, metadata replacement, and the pre-publication failure boundary
- document the concrete `VsockHost` behavior while keeping observer-specific documentation linked to the canonical method
- align `MockSandbox` successful copies with the contract by staging bytes in the destination directory and atomically persisting a mode `0600` file
- verify both production and mock paths replace the inode rather than truncating it in place

## Scope

- production `VsockHost` behavior is unchanged
- `sandbox-mock` now replaces successful destinations instead of preserving their inode and permissions
- no API signature, wire protocol, database schema, generated artifact, or deployment configuration changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox -p sandbox-mock -p vsock-host -p runner`

Closes #22104
