### PR TITLE
fix(api): decode workflow timestamps in bootstrap snapshot

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4851,7 +4851,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     const { actor, runnerGroup } = await entitledRunActor();
     failIfChatCallbackRouteIsFetched();
 
-    const workflowName = "bdd-codex-kit";
+    const workflowNames = ["bdd-codex-kit", "bdd-codex-research"] as const;
 
     await misc.upsertPersonalModelProvider(
       actor,
@@ -4890,13 +4890,15 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       visibility: "private",
     });
     // Workflows are created directly under the owning agent (agent-scoped 1:N).
-    await misc.createWorkflow(
-      actor,
-      agent.agentId,
-      workflowName,
-      { content: "# BDD codex kit\nUse this workflow for codex runs." },
-      [201],
-    );
+    for (const workflowName of workflowNames) {
+      await misc.createWorkflow(
+        actor,
+        agent.agentId,
+        workflowName,
+        { content: `# ${workflowName}\nUse this workflow for codex runs.` },
+        [201],
+      );
+    }
     const thread = await chat.createThread(actor, { agentId: agent.agentId });
     const sent = await chat.requestSendMessage(
       actor,
@@ -4920,11 +4922,11 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        storage_manifest_source_workflow_skill_resolved_count_bucket: "1",
+        storage_manifest_source_workflow_skill_resolved_count_bucket: "2_4",
         storage_manifest_source_workflow_skill_planned_presign_count_bucket:
-          "1",
+          "2_4",
         storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
-          "1",
+          "2_4",
       }),
     );
     expect(
@@ -4935,13 +4937,13 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     ).toStrictEqual(
       expect.objectContaining({
         storage_manifest_source_workflow_skill_planned_presign_count_bucket:
-          "1",
+          "2_4",
         storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
-          "1",
+          "2_4",
       }),
     );
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
-      workflowName,
+      ...workflowNames,
       agent.agentId,
       thread.id,
     ]);
@@ -4964,7 +4966,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       claim.storageManifest?.storages.map((storage) => {
         return storage.mountPath;
       }) ?? [];
-    expect(mountPaths).toContain(`/home/user/.codex/skills/${workflowName}`);
+    for (const workflowName of workflowNames) {
+      expect(mountPaths).toContain(`/home/user/.codex/skills/${workflowName}`);
+    }
     expect(
       mountPaths.some((mountPath) => {
         return mountPath.startsWith("/home/user/.claude/skills/");

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -220,7 +220,9 @@ function emptyExecutionScopeSnapshotFields() {
     visibility: sql<ZeroWorkflowVisibility | null>`NULL::text`.as("visibility"),
     ownerUserId: sql<string | null>`NULL::text`.as("owner_user_id"),
     action: sql<FirewallPermissionGrantAction | null>`NULL::text`.as("action"),
-    createdAt: sql<Date | null>`NULL::timestamp`.as("created_at"),
+    createdAt: sql<Date | null>`NULL::timestamp`
+      .mapWith(zeroWorkflows.createdAt)
+      .as("created_at"),
   };
 }
 
@@ -271,7 +273,9 @@ async function queryZeroRunExecutionScopeSnapshot(
       ownerUserId: sql<string | null>`${zeroWorkflows.ownerUserId}`.as(
         "owner_user_id",
       ),
-      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`.as("created_at"),
+      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`
+        .mapWith(zeroWorkflows.createdAt)
+        .as("created_at"),
     })
     .from(zeroWorkflows)
     .where(


### PR DESCRIPTION
## Summary

- Decode the execution-scope snapshot's workflow timestamps with the Drizzle schema column decoder, including the leftmost `UNION ALL` placeholder that owns result decoding.
- Expand the real-PostgreSQL run lifecycle BDD to create two workflows, send a chat message, and verify the 201 response and both Codex workflow mounts.
- Keep the existing workflow precedence behavior and update the storage-manifest assertions to the existing `2_4` count bucket.

## Scope

- No schema, migration, persisted-data, public API, queue payload, or runner protocol changes.
- No repository-wide `sql<Date>` lint policy is included.

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "runs thread-pinned member-scope providers and mounts codex workflows" --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (107 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- Pre-commit hooks: Prettier, full-repository Knip, and full-repository TypeScript checks

A broader local API run completed 2,266 tests successfully and exposed three failures outside this diff. The chat queue-race case passed when isolated; the remaining failures were an unchanged connector-order assertion and a memory-cron empty-state assertion against a reused local database. All eight API shards are green on the exact `origin/main` base commit.

Closes #22115
