### PR TITLE
fix(runner): block managed credentials on track requests

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -239,7 +239,7 @@ def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) ->
 
 
 def _request_method_forbids_managed_credentials(method: str) -> bool:
-    return method.upper() == "TRACE"
+    return method.upper() in ("TRACE", "TRACK")
 
 
 def _firewall_auth_context_needs_resolution(context: _FirewallAuthContext) -> bool:
@@ -615,7 +615,7 @@ def _preflight_firewall_auth(
         log_proxy_entry(
             context.proxy_log_path,
             "warn",
-            "Refusing to inject firewall credentials into TRACE request",
+            f"Refusing to inject firewall credentials into {request_method} request",
             type="firewall",
             firewall_base=context.firewall_base,
             request_method=request_method,
@@ -625,7 +625,7 @@ def _preflight_firewall_auth(
             status=403,
             action="BLOCK",
             error_code="unsafe_auth_method",
-            message="Firewall credentials cannot be injected into TRACE requests",
+            message=f"Firewall credentials cannot be injected into {request_method} requests",
             permission=context.allow.name,
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1217,6 +1217,7 @@ async def test_reflection_method_firewall_with_managed_credentials_blocks_before
     )
     original_headers = tuple(flow.request.headers.fields)
     original_path = flow.request.path
+    original_url = flow.request.url
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -1236,6 +1237,7 @@ async def test_reflection_method_firewall_with_managed_credentials_blocks_before
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     assert tuple(flow.request.headers.fields) == original_headers
     assert flow.request.path == original_path
+    assert flow.request.url == original_url
     body = json.loads(flow.response.content)
     assert body == {
         "error": "unsafe_auth_method",

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1162,6 +1162,7 @@ async def test_http_firewall_without_managed_credentials_still_matches(
     assert "Authorization" not in flow.request.headers
 
 
+@pytest.mark.parametrize("request_method", ["trace", "track"])
 @pytest.mark.parametrize(
     "auth_config",
     [
@@ -1177,13 +1178,14 @@ async def test_http_firewall_without_managed_credentials_still_matches(
     ],
     ids=["headers", "query", "aws-sigv4", "auth-base"],
 )
-async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
+async def test_reflection_method_firewall_with_managed_credentials_blocks_before_auth(
     tmp_path,
     real_flow,
     mitm_ctx,
     fake_firewall_headers,
     headers,
     auth_config,
+    request_method,
 ):
     reg_path = _write_registry(
         tmp_path,
@@ -1206,7 +1208,7 @@ async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
         with_response=False,
         client_ip="10.200.0.5",
         host="api.github.com",
-        method="trace",
+        method=request_method,
         path="/diagnostic?client=visible",
         request_headers=headers(
             ("Host", "api.github.com"),
@@ -1219,7 +1221,7 @@ async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
-        fake_forwarder_upstream(body=b"Authorization: Bearer reflected-by-trace") as upstream,
+        fake_forwarder_upstream(body=b"Authorization: Bearer reflected-by-request") as upstream,
     ):
         await mitm_addon.request(flow)
 
@@ -1237,7 +1239,9 @@ async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
     body = json.loads(flow.response.content)
     assert body == {
         "error": "unsafe_auth_method",
-        "message": "Firewall credentials cannot be injected into TRACE requests",
+        "message": (
+            f"Firewall credentials cannot be injected into {request_method.upper()} requests"
+        ),
         "permission": "github",
         "base": "https://api.github.com",
     }
@@ -1245,14 +1249,16 @@ async def test_trace_firewall_with_managed_credentials_blocks_before_auth(
     assert proxy_log_entry["level"] == "warn"
     assert proxy_log_entry["type"] == "firewall"
     assert proxy_log_entry["firewall_base"] == "https://api.github.com"
-    assert proxy_log_entry["request_method"] == "TRACE"
+    assert proxy_log_entry["request_method"] == request_method.upper()
 
 
-async def test_trace_firewall_without_managed_credentials_still_matches(
+@pytest.mark.parametrize("request_method", ["trace", "track"])
+async def test_reflection_method_firewall_without_managed_credentials_still_matches(
     tmp_path,
     real_flow,
     mitm_ctx,
     fake_firewall_headers,
+    request_method,
 ):
     reg_path = _write_registry(
         tmp_path,
@@ -1276,7 +1282,7 @@ async def test_trace_firewall_without_managed_credentials_still_matches(
         with_response=False,
         client_ip="10.200.0.5",
         host="api.github.com",
-        method="TRACE",
+        method=request_method,
         path="/diagnostic",
     )
 
@@ -1291,6 +1297,34 @@ async def test_trace_firewall_without_managed_credentials_still_matches(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata.get(metadata_keys.FIREWALL_ERROR) is None
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+
+
+async def test_non_reflection_method_with_managed_credentials_still_matches(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="PROPFIND",
+        path="/webdav/resource",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer resolved"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata.get(metadata_keys.FIREWALL_ERROR) is None
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -944,6 +944,7 @@ async def test_capture_enabled_firewall_allow_header_auth_installs_request_strea
     assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
 
 
+@pytest.mark.parametrize("request_method", ["trace", "track"])
 @pytest.mark.parametrize(
     "auth_config",
     [
@@ -952,13 +953,14 @@ async def test_capture_enabled_firewall_allow_header_auth_installs_request_strea
     ],
     ids=["headers", "query"],
 )
-async def test_capture_enabled_trace_with_managed_auth_defers_to_request_block(
+async def test_capture_enabled_reflection_method_with_managed_auth_defers_to_request_block(
     tmp_path,
     real_flow,
     mitm_ctx,
     fake_firewall_headers,
     headers,
     auth_config,
+    request_method,
 ):
     reg_path = _write_registry(
         tmp_path,
@@ -982,7 +984,7 @@ async def test_capture_enabled_trace_with_managed_auth_defers_to_request_block(
         with_response=False,
         client_ip="10.200.0.5",
         host="api.github.com",
-        method="trace",
+        method=request_method,
         path="/diagnostic?client=visible",
         request_headers=headers(
             ("Host", "api.github.com"),


### PR DESCRIPTION
## Summary

- reject managed credential injection for `TRACK` requests through the same auth-layer safety predicate used for `TRACE`
- preserve credential-free `TRACE`/`TRACK` handling and managed authentication for unrelated WebDAV and custom methods
- cover normal request handling, capture-enabled request-header handling, every managed auth form, normalization, and no-upstream side effects

## Scope

- no global HTTP method allowlist or change to `ANY` permission matching
- no API, database, persisted-state, queue, frontend/backend, runner protocol, migration, or documentation change

## Testing

- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_request_headers_handler.py -k 'reflection_method or non_reflection_method' -q` (15 passed)
- `python3 -m pytest tests/ -q` (4089 passed)

Closes #22114
