### PR TITLE
refactor(api): validate raw execute result rows

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -163,6 +163,12 @@ export default [
   ...config,
   {
     files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     plugins: {
       api: apiLintPlugin,
     },

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -173,7 +173,16 @@ export default [
       "api/no-logger-info": "error",
       "api/no-new-promise": "error",
       "api/no-store-in-params": "error",
+      "api/require-execute-row-schema": "error",
       "api/signal-check-await": "error",
+    },
+  },
+  {
+    files: ["src/lib/db-raw-rows.ts"],
+    rules: {
+      // This is the single reviewed boundary that turns driver rows into
+      // schema-derived values before returning them to application code.
+      "api/require-execute-row-schema": "off",
     },
   },
   {

--- a/turbo/apps/api/src/lib/db-raw-rows.ts
+++ b/turbo/apps/api/src/lib/db-raw-rows.ts
@@ -1,0 +1,37 @@
+import type { SQLWrapper } from "drizzle-orm";
+import { z, type output, type ZodType } from "zod";
+
+type ApiDb = ReturnType<(typeof import("./db"))["db"]>;
+
+type RawSqlExecutor = Pick<ApiDb, "execute">;
+
+export const pgInt8ToSafeIntegerSchema = z
+  .string()
+  .regex(/^-?\d+$/)
+  .transform(Number)
+  .pipe(z.int());
+
+export const pgInt8ToBigIntSchema = z
+  .string()
+  .regex(/^-?\d+$/)
+  .transform((value) => {
+    return BigInt(value);
+  });
+
+export const pgTimestampWithoutTimezoneToDateSchema = z
+  .string()
+  .transform((value) => {
+    return new Date(`${value}+0000`);
+  })
+  .pipe(z.date());
+
+export async function executeRawRows<TSchema extends ZodType>(
+  executor: RawSqlExecutor,
+  query: SQLWrapper,
+  rowSchema: TSchema,
+): Promise<output<TSchema>[]> {
+  const result = await executor.execute(query);
+  return result.rows.map((row) => {
+    return rowSchema.parse(row);
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -28,7 +28,9 @@ import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-co
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { zeroUserPreferencesContract } from "@vm0/api-contracts/contracts/zero-user-preferences";
+import { z } from "zod";
 
+import { executeRawRows } from "../../../lib/db-raw-rows";
 import { mockEnv } from "../../../lib/env";
 import { setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -65,6 +67,7 @@ const BULK_INSERT_CHUNK = 500;
 const TARGET_ATTACHMENT_COUNT = 6;
 const MOCK_R2_LIST_DELAY_MS = 10;
 const STATUSES = ["completed", "completed", "failed", "running"] as const;
+const queryPlanRowSchema = z.object({ "QUERY PLAN": z.string() });
 
 const chatThreadClient = setupApp({ context })(chatThreadByIdContract);
 const chatThreadMessagesClient = setupApp({ context })(
@@ -540,14 +543,18 @@ async function logPlannerDiagnostic(
       model_providers,
       credit_expires_record
   `);
-  const plan = await db.execute<{ "QUERY PLAN": string }>(sql`
-    EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
-    SELECT zero_runs.id, agent_runs.status
-    FROM zero_runs
-    INNER JOIN agent_runs ON zero_runs.id = agent_runs.id
-    WHERE zero_runs.chat_thread_id = ${fixture.threadId}
-  `);
-  const lines = plan.rows.map((row) => {
+  const plan = await executeRawRows(
+    db,
+    sql`
+      EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+      SELECT zero_runs.id, agent_runs.status
+      FROM zero_runs
+      INNER JOIN agent_runs ON zero_runs.id = agent_runs.id
+      WHERE zero_runs.chat_thread_id = ${fixture.threadId}
+    `,
+    queryPlanRowSchema,
+  );
+  const lines = plan.map((row) => {
     return row["QUERY PLAN"];
   });
   process.stdout.write(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -28,6 +28,7 @@ import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import { and, desc, eq, gt, inArray, lt, sql, type SQL } from "drizzle-orm";
+import { z } from "zod";
 
 import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
 import { authorization$ } from "../context/hono";
@@ -49,6 +50,7 @@ import { now, nowDate } from "../external/time";
 import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
@@ -871,11 +873,6 @@ type FailedClaimTransitionResult = Exclude<
   { readonly status: "claimed" }
 >;
 
-interface LockedClaimRunRow extends Record<string, unknown> {
-  readonly id: string;
-  readonly status: string;
-}
-
 function claimTransitionErrorResponse(result: FailedClaimTransitionResult) {
   if (result.status === "job-not-found") {
     return notFound("Job not found in queue");
@@ -883,44 +880,53 @@ function claimTransitionErrorResponse(result: FailedClaimTransitionResult) {
   return notFound("Run not found");
 }
 
-interface LockedRunnerJobRow extends Record<string, unknown> {
-  readonly runId: string;
-  readonly isExpired: boolean;
-}
+const lockedRunnerJobRowSchema = z.object({
+  runId: z.string(),
+  isExpired: z.boolean(),
+});
 
-interface ClaimTransitionSqlRow extends Record<string, unknown> {
-  readonly status: ClaimTransitionResult["status"] | "invariant-error";
-  readonly claimedAtMs: number | null;
-}
+const claimTransitionSqlRowSchema = z.object({
+  status: z.enum([
+    "claimed",
+    "job-not-found",
+    "run-not-found",
+    "invariant-error",
+  ]),
+  claimedAtMs: z.number().nullable(),
+});
 
 async function lockClaimRun(
-  db: Pick<Db, "execute">,
+  db: Pick<Db, "select">,
   runId: string,
-): Promise<LockedClaimRunRow | undefined> {
-  const rows = await db.execute<LockedClaimRunRow>(sql`
-    SELECT
-      ${agentRuns.id} AS "id",
-      ${agentRuns.status} AS "status"
-    FROM ${agentRuns}
-    WHERE ${agentRuns.id} = ${runId}
-    FOR UPDATE
-  `);
-  return rows.rows[0];
+): Promise<{ readonly id: string; readonly status: string } | undefined> {
+  const [run] = await db
+    .select({
+      id: agentRuns.id,
+      status: agentRuns.status,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .for("update");
+  return run;
 }
 
 async function lockRunnerJob(
   db: Pick<Db, "execute">,
   runId: string,
-): Promise<LockedRunnerJobRow | undefined> {
-  const rows = await db.execute<LockedRunnerJobRow>(sql`
-    SELECT
-      ${runnerJobQueue.runId} AS "runId",
-      ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
-    FROM ${runnerJobQueue}
-    WHERE ${runnerJobQueue.runId} = ${runId}
-    FOR UPDATE
-  `);
-  return rows.rows[0];
+): Promise<z.output<typeof lockedRunnerJobRowSchema> | undefined> {
+  const rows = await executeRawRows(
+    db,
+    sql`
+      SELECT
+        ${runnerJobQueue.runId} AS "runId",
+        ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
+      FROM ${runnerJobQueue}
+      WHERE ${runnerJobQueue.runId} = ${runId}
+      FOR UPDATE
+    `,
+    lockedRunnerJobRowSchema,
+  );
+  return rows[0];
 }
 
 async function transitionClaimedJobToRunning(
@@ -935,7 +941,9 @@ async function transitionClaimedJobToRunning(
       "nested",
       async () => {
         // Materialized outputs make the row locks depend on run, then queue.
-        return await tx.execute<ClaimTransitionSqlRow>(sql`
+        return await executeRawRows(
+          tx,
+          sql`
           WITH locked_run AS MATERIALIZED (
             SELECT
               ${agentRuns.id} AS "id",
@@ -1028,11 +1036,13 @@ async function transitionClaimedJobToRunning(
                 )::double precision
               FROM updated_run
             ) AS "claimedAtMs"
-        `);
+          `,
+          claimTransitionSqlRowSchema,
+        );
       },
     );
     signal.throwIfAborted();
-    const row = result.rows[0];
+    const row = result[0];
     if (!row || row.status === "invariant-error") {
       throw new Error("Runner job claim transition violated its invariant");
     }

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -16,7 +16,9 @@ import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { eq, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
@@ -53,14 +55,11 @@ const orgAdmissionLockGate = testOverride<OrgAdmissionLockGate | null>(() => {
   return null;
 });
 
-interface OrgAdmissionLockHolderRow extends Record<string, unknown> {
-  readonly holderPid: number;
-}
-
-interface OrgAdmissionLockStateRow extends Record<string, unknown> {
-  readonly held: boolean;
-  readonly waiting: boolean;
-}
+const orgAdmissionLockHolderRowSchema = z.object({ holderPid: z.int() });
+const orgAdmissionLockStateRowSchema = z.object({
+  held: z.boolean(),
+  waiting: z.boolean(),
+});
 
 function createOrgAdmissionLockGate(signal: AbortSignal): OrgAdmissionLockGate {
   const released = createDeferredPromise<void>(signal);
@@ -93,13 +92,17 @@ async function holdOrgAdmissionLock(
   orgAdmissionLockGate.set(gate);
   await onRejection(
     db.transaction(async (tx) => {
-      const result = await tx.execute<OrgAdmissionLockHolderRow>(sql`
-        SELECT
-          pg_backend_pid() AS "holderPid",
-          pg_advisory_xact_lock(hashtext(${orgId}))
-      `);
+      const rows = await executeRawRows(
+        tx,
+        sql`
+          SELECT
+            pg_backend_pid() AS "holderPid",
+            pg_advisory_xact_lock(hashtext(${orgId}))
+        `,
+        orgAdmissionLockHolderRowSchema,
+      );
       signal.throwIfAborted();
-      const holder = result.rows[0];
+      const holder = rows[0];
       if (!holder) {
         throw new Error("Failed to acquire org admission lock");
       }
@@ -121,34 +124,38 @@ async function readOrgAdmissionLockState(
   if (holderPid === null || holderPid === undefined) {
     return { held: false, waiting: false };
   }
-  const result = await db.execute<OrgAdmissionLockStateRow>(sql`
-    SELECT
-      EXISTS (
-        SELECT 1
-        FROM pg_locks held
-        WHERE
-          held.pid = ${holderPid}
-          AND held.locktype = 'advisory'
-          AND held.granted
-      ) AS "held",
-      EXISTS (
-        SELECT 1
-        FROM pg_locks held
-        INNER JOIN pg_locks waiting
-          ON waiting.locktype = held.locktype
-          AND waiting.database IS NOT DISTINCT FROM held.database
-          AND waiting.classid IS NOT DISTINCT FROM held.classid
-          AND waiting.objid IS NOT DISTINCT FROM held.objid
-          AND waiting.objsubid IS NOT DISTINCT FROM held.objsubid
-        WHERE
-          held.pid = ${holderPid}
-          AND held.locktype = 'advisory'
-          AND held.granted
-          AND NOT waiting.granted
-      ) AS "waiting"
-  `);
+  const rows = await executeRawRows(
+    db,
+    sql`
+      SELECT
+        EXISTS (
+          SELECT 1
+          FROM pg_locks held
+          WHERE
+            held.pid = ${holderPid}
+            AND held.locktype = 'advisory'
+            AND held.granted
+        ) AS "held",
+        EXISTS (
+          SELECT 1
+          FROM pg_locks held
+          INNER JOIN pg_locks waiting
+            ON waiting.locktype = held.locktype
+            AND waiting.database IS NOT DISTINCT FROM held.database
+            AND waiting.classid IS NOT DISTINCT FROM held.classid
+            AND waiting.objid IS NOT DISTINCT FROM held.objid
+            AND waiting.objsubid IS NOT DISTINCT FROM held.objsubid
+          WHERE
+            held.pid = ${holderPid}
+            AND held.locktype = 'advisory'
+            AND held.granted
+            AND NOT waiting.granted
+        ) AS "waiting"
+    `,
+    orgAdmissionLockStateRowSchema,
+  );
   signal.throwIfAborted();
-  const state = result.rows[0];
+  const state = rows[0];
   if (!state) {
     throw new Error("Failed to read org admission lock state");
   }

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -6,7 +6,9 @@ import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { imageArtifactEditSnapshots } from "@vm0/db/schema/image-artifact-edit-snapshot";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { env } from "../../lib/env";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -20,6 +22,8 @@ import {
 import { nowDate } from "../../lib/time";
 import { notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
+
+const artifactAccessRowSchema = z.object({ canAccess: z.boolean() });
 
 interface UserArtifactUrlAccessArgs {
   readonly artifactUrl: string;
@@ -87,14 +91,18 @@ async function userCanAccessArtifactUrl(
   db: Db,
   args: UserArtifactUrlAccessArgs,
 ): Promise<boolean> {
-  const result = await db.execute<{ readonly canAccess: boolean }>(sql`
-    SELECT (
-      ${uploadedArtifactAccessCondition(args)}
-      OR ${attachedArtifactAccessCondition(args)}
-    ) AS "canAccess"
-  `);
+  const rows = await executeRawRows(
+    db,
+    sql`
+      SELECT (
+        ${uploadedArtifactAccessCondition(args)}
+        OR ${attachedArtifactAccessCondition(args)}
+      ) AS "canAccess"
+    `,
+    artifactAccessRowSchema,
+  );
 
-  return result.rows[0]?.canAccess === true;
+  return rows[0]?.canAccess === true;
 }
 
 async function deleteImageEditSnapshotRow(

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -35,7 +35,7 @@ import {
   isNull,
   sql,
 } from "drizzle-orm";
-import type { z } from "zod";
+import { z } from "zod";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -56,6 +56,7 @@ import {
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
 import {
@@ -325,6 +326,7 @@ const sendBody$ = bodyResultOf(chatMessagesContract.send);
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
+const idRowSchema = z.object({ id: z.string() });
 
 function forbidden(message: string) {
   return {
@@ -825,30 +827,34 @@ async function activeRunExistsForThread(
   db: Db,
   threadId: string,
 ): Promise<boolean> {
-  const runs = await db.execute<{ readonly id: string }>(sql`
-    SELECT ${zeroRuns.id} AS "id"
-    FROM ${zeroRuns}
-    INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-    WHERE ${zeroRuns.chatThreadId} = ${threadId}
-      AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-      AND (
-        NOT EXISTS (
-          SELECT 1
-          FROM ${agentRunCallbacks}
-          WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-            AND ${agentRunCallbacks.internalKind} = 'chat'
-            AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+  const runs = await executeRawRows(
+    db,
+    sql`
+      SELECT ${zeroRuns.id} AS "id"
+      FROM ${zeroRuns}
+      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
+      WHERE ${zeroRuns.chatThreadId} = ${threadId}
+        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM ${agentRunCallbacks}
+            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+              AND ${agentRunCallbacks.internalKind} = 'chat'
+              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM ${chatMessages}
+            WHERE ${chatMessages.runId} = ${zeroRuns.id}
+              AND ${chatMessages.role} = 'user'
+          )
         )
-        OR EXISTS (
-          SELECT 1
-          FROM ${chatMessages}
-          WHERE ${chatMessages.runId} = ${zeroRuns.id}
-            AND ${chatMessages.role} = 'user'
-        )
-      )
-    LIMIT 1
-  `);
-  return runs.rows[0] !== undefined;
+      LIMIT 1
+    `,
+    idRowSchema,
+  );
+  return runs[0] !== undefined;
 }
 
 async function resolveClientMessageSend(params: {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -408,11 +408,6 @@ interface LaunchRunIdentity {
 
 type LaunchRunStatus = "pending" | "queued" | "failed";
 
-interface LockedRunPersistenceRow extends Record<string, unknown> {
-  readonly status: string;
-  readonly sandboxId: string | null;
-}
-
 interface DerivedPersistenceResult {
   readonly status: RunStatus;
   readonly sandboxId?: string;
@@ -5433,15 +5428,14 @@ async function lockRunForDerivedPersistence(
   tx: DbTransaction,
   runId: string,
 ): Promise<DerivedPersistenceResult | null> {
-  const rows = await tx.execute<LockedRunPersistenceRow>(sql`
-    SELECT
-      ${agentRuns.status} AS "status",
-      ${agentRuns.sandboxId} AS "sandboxId"
-    FROM ${agentRuns}
-    WHERE ${agentRuns.id} = ${runId}
-    FOR UPDATE
-  `);
-  const row = rows.rows[0];
+  const [row] = await tx
+    .select({
+      status: agentRuns.status,
+      sandboxId: agentRuns.sandboxId,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .for("update");
   if (!row) {
     return null;
   }

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -58,7 +58,9 @@ import { modelProviders } from "@vm0/db/schema/model-provider";
 import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { variables as variablesTable } from "@vm0/db/schema/variable";
 import { and, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows, pgInt8ToBigIntSchema } from "../../lib/db-raw-rows";
 import { optionalEnv } from "../../lib/env";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -99,6 +101,10 @@ const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
 const FIREWALL_AUTH_REFRESH_TIMEOUT_MS = 30_000;
 const REFRESH_TIMEOUT_ERROR_CODE = "oauth_refresh_timeout";
 const MAX_OAUTH_REFRESH_LOG_FIELD_LENGTH = 128;
+const databaseTimestampMicrosRowSchema = z.object({
+  now: pgInt8ToBigIntSchema,
+});
+
 function firewallAuthRefreshTimeoutMs(): number {
   const configured = optionalEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS");
   if (configured === undefined) {
@@ -1506,14 +1512,16 @@ function refreshSourceStateFromRow(args: {
 }
 
 async function currentDatabaseTimestampMicros(db: Db): Promise<bigint> {
-  const result = await db.execute<{ now: bigint | number | string }>(
+  const rows = await executeRawRows(
+    db,
     sql`SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::bigint AS now`,
+    databaseTimestampMicrosRowSchema,
   );
-  const row = result.rows[0];
+  const row = rows[0];
   if (!row) {
     throw new Error("Failed to read database timestamp");
   }
-  return BigInt(row.now);
+  return row.now;
 }
 
 function shouldUseLockedCurrentAccess(args: {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -23,7 +23,7 @@ export const aggregateUsageDaily$ = command(
     );
     const targetDate = yesterday.toISOString().split("T")[0]!;
 
-    const result = await db.execute(sql`
+    const { rowCount } = await db.execute(sql`
       INSERT INTO ${usageDaily} (user_id, org_id, date, run_count, run_time_ms)
       SELECT
         ${agentRuns.userId},
@@ -45,7 +45,7 @@ export const aggregateUsageDaily$ = command(
 
     return {
       date: targetDate,
-      aggregated: result.rowCount ?? 0,
+      aggregated: rowCount ?? 0,
     };
   },
 );

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -424,13 +424,13 @@ async function cleanupExpiredRunnerJobs(
   db: Db,
   signal: AbortSignal,
 ): Promise<number> {
-  const result = await db.execute(sql`
+  const { rowCount } = await db.execute(sql`
     DELETE FROM ${runnerJobQueue}
     WHERE ${runnerJobQueue.expiresAt} <= now()
   `);
   signal.throwIfAborted();
 
-  const deletedCount = Number(result.rowCount ?? 0);
+  const deletedCount = rowCount ?? 0;
   if (deletedCount > 0) {
     L.debug("Cleaned up expired runner job queue entries", {
       count: deletedCount,
@@ -443,13 +443,13 @@ async function cleanupExpiredCustomConnectorAuthRefs(
   db: Db,
   signal: AbortSignal,
 ): Promise<number> {
-  const result = await db.execute(sql`
+  const { rowCount } = await db.execute(sql`
     DELETE FROM ${agentRunCustomConnectorAuthRefs}
     WHERE ${agentRunCustomConnectorAuthRefs.expiresAt} <= now()
   `);
   signal.throwIfAborted();
 
-  const deletedCount = Number(result.rowCount ?? 0);
+  const deletedCount = rowCount ?? 0;
   if (deletedCount > 0) {
     L.debug("Cleaned up expired custom connector auth refs", {
       count: deletedCount,

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -4,7 +4,9 @@ import { chatThreadEvents } from "@vm0/db/schema/chat-thread-event";
 import { chatThreadSnapshots } from "@vm0/db/schema/chat-thread-snapshot";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../external/time";
 import { writeDb$, type Db } from "../external/db";
@@ -35,11 +37,13 @@ function chatThreadSnapshotBatchSize(): number {
   return parsed;
 }
 
-interface SnapshotBatchRow extends Record<string, unknown> {
-  readonly scopes: number;
-  readonly eventsApplied: number;
-  readonly removedDeletedAgentThreads: number;
-}
+const snapshotBatchRowSchema = z.object({
+  scopes: z.int(),
+  eventsApplied: z.int(),
+  removedDeletedAgentThreads: z.int(),
+});
+
+const prunedEventsRowSchema = z.object({ count: z.int() });
 
 function allScopesCte(staleCutoff: Date): SQL {
   return sql`
@@ -231,18 +235,20 @@ async function compactChatThreadSnapshotBatch(
   const staleCutoff = new Date(
     updatedAt.getTime() - CHAT_THREAD_SNAPSHOT_STALE_MS,
   );
-  const result = await db.execute<SnapshotBatchRow>(
+  const rows = await executeRawRows(
+    db,
     compactChatThreadSnapshotBatchSql({
       updatedAt,
       staleCutoff,
       batchSize: chatThreadSnapshotBatchSize(),
     }),
+    snapshotBatchRowSchema,
   );
 
   return {
-    scopes: result.rows[0]?.scopes ?? 0,
-    eventsApplied: result.rows[0]?.eventsApplied ?? 0,
-    removedDeletedAgentThreads: result.rows[0]?.removedDeletedAgentThreads ?? 0,
+    scopes: rows[0]?.scopes ?? 0,
+    eventsApplied: rows[0]?.eventsApplied ?? 0,
+    removedDeletedAgentThreads: rows[0]?.removedDeletedAgentThreads ?? 0,
   };
 }
 
@@ -259,29 +265,33 @@ async function compactChatThreadSnapshotsForAllScopes(
 
   signal?.throwIfAborted();
   const cutoff = new Date(nowDate().getTime() - CHAT_THREAD_EVENT_RETENTION_MS);
-  const pruned = await db.execute<{ readonly count: number }>(sql`
-    WITH pruned AS (
-      DELETE FROM ${chatThreadEvents} event
-      USING ${chatThreadSnapshots} snapshot
-      INNER JOIN ${chatThreadEvents} marker
-        ON marker.id = snapshot.latest_event_id
-       AND marker.user_id = snapshot.user_id
-       AND marker.org_id = snapshot.org_id
-      WHERE event.user_id = snapshot.user_id
-        AND event.org_id = snapshot.org_id
-        AND event.created_at < ${cutoff}
-        AND (event.created_at, event.id) < (marker.created_at, marker.id)
-      RETURNING 1
-    )
-    SELECT COUNT(*)::int AS "count"
-    FROM pruned
-  `);
+  const pruned = await executeRawRows(
+    db,
+    sql`
+      WITH pruned AS (
+        DELETE FROM ${chatThreadEvents} event
+        USING ${chatThreadSnapshots} snapshot
+        INNER JOIN ${chatThreadEvents} marker
+          ON marker.id = snapshot.latest_event_id
+         AND marker.user_id = snapshot.user_id
+         AND marker.org_id = snapshot.org_id
+        WHERE event.user_id = snapshot.user_id
+          AND event.org_id = snapshot.org_id
+          AND event.created_at < ${cutoff}
+          AND (event.created_at, event.id) < (marker.created_at, marker.id)
+        RETURNING 1
+      )
+      SELECT COUNT(*)::int AS "count"
+      FROM pruned
+    `,
+    prunedEventsRowSchema,
+  );
 
   return {
     scopes: compacted.scopes,
     eventsApplied: compacted.eventsApplied,
     removedDeletedAgentThreads: compacted.removedDeletedAgentThreads,
-    eventsPruned: pruned.rows[0]?.count ?? 0,
+    eventsPruned: pruned[0]?.count ?? 0,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-telegram-cleanup.service.ts
@@ -17,7 +17,7 @@ export const cleanupTelegramMessages$ = command(
     let batchDeleted: number;
 
     do {
-      const result = await db.execute(sql`
+      const { rowCount } = await db.execute(sql`
         DELETE FROM telegram_messages
         WHERE ctid IN (
           SELECT ctid FROM telegram_messages
@@ -27,7 +27,7 @@ export const cleanupTelegramMessages$ = command(
       `);
       signal.throwIfAborted();
 
-      batchDeleted = Number(result.rowCount ?? 0);
+      batchDeleted = rowCount ?? 0;
       totalDeleted += batchDeleted;
     } while (batchDeleted === TELEGRAM_MESSAGE_DELETE_BATCH_SIZE);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -31,6 +31,7 @@ import { z } from "zod";
 
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
@@ -89,6 +90,7 @@ const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
+const idRowSchema = z.object({ id: z.string() });
 
 type ChatCallbackPreCreateTimingSpanKind = "top_level" | "nested";
 
@@ -1575,30 +1577,34 @@ async function activeChatRunExistsForThread(
   db: Db,
   threadId: string,
 ): Promise<boolean> {
-  const runs = await db.execute<{ readonly id: string }>(sql`
-    SELECT ${zeroRuns.id} AS "id"
-    FROM ${zeroRuns}
-    INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-    WHERE ${zeroRuns.chatThreadId} = ${threadId}
-      AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-      AND (
-        NOT EXISTS (
-          SELECT 1
-          FROM ${agentRunCallbacks}
-          WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-            AND ${agentRunCallbacks.internalKind} = 'chat'
-            AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+  const runs = await executeRawRows(
+    db,
+    sql`
+      SELECT ${zeroRuns.id} AS "id"
+      FROM ${zeroRuns}
+      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
+      WHERE ${zeroRuns.chatThreadId} = ${threadId}
+        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
+        AND (
+          NOT EXISTS (
+            SELECT 1
+            FROM ${agentRunCallbacks}
+            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+              AND ${agentRunCallbacks.internalKind} = 'chat'
+              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM ${chatMessages}
+            WHERE ${chatMessages.runId} = ${zeroRuns.id}
+              AND ${chatMessages.role} = 'user'
+          )
         )
-        OR EXISTS (
-          SELECT 1
-          FROM ${chatMessages}
-          WHERE ${chatMessages.runId} = ${zeroRuns.id}
-            AND ${chatMessages.role} = 'user'
-        )
-      )
-    LIMIT 1
-  `);
-  return runs.rows[0] !== undefined;
+      LIMIT 1
+    `,
+    idRowSchema,
+  );
+  return runs[0] !== undefined;
 }
 
 async function chatThreadExists(db: Db, threadId: string): Promise<boolean> {
@@ -1809,29 +1815,24 @@ async function claimQueuedUserMessageForDispatch(args: {
     // Serialize auto-send dispatch decisions per thread. Otherwise two terminal
     // callbacks can insert candidate runs, each see the other as active, and
     // both cancel before either claims the queued message.
-    const threadRows = await tx.execute<{ readonly id: string }>(sql`
-      SELECT ${chatThreads.id} AS "id"
-      FROM ${chatThreads}
-      WHERE ${chatThreads.id} = ${args.threadId}
-      FOR UPDATE
-    `);
-    if (!threadRows.rows[0]) {
+    const [thread] = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .for("update");
+    if (!thread) {
       return null;
     }
 
-    const rows = await tx.execute<{
-      readonly status: string;
-      readonly chatThreadId: string | null;
-    }>(sql`
-      SELECT
-        ${agentRuns.status} AS "status",
-        ${zeroRuns.chatThreadId} AS "chatThreadId"
-      FROM ${agentRuns}
-      INNER JOIN ${zeroRuns} ON ${zeroRuns.id} = ${agentRuns.id}
-      WHERE ${agentRuns.id} = ${args.runId}
-      FOR UPDATE OF ${agentRuns}
-    `);
-    const run = rows.rows[0];
+    const [run] = await tx
+      .select({
+        status: agentRuns.status,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.id, args.runId))
+      .for("update", { of: agentRuns });
     if (
       !run ||
       run.chatThreadId !== args.threadId ||
@@ -1844,31 +1845,35 @@ async function claimQueuedUserMessageForDispatch(args: {
     // message. Concurrent drains may insert more than one candidate before
     // reaching this serialized gate; ignoring those unclaimed candidates lets
     // one claim win while the others cancel before dispatch.
-    const competingRuns = await tx.execute<{ readonly id: string }>(sql`
-      SELECT ${zeroRuns.id} AS "id"
-      FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-      WHERE ${zeroRuns.chatThreadId} = ${args.threadId}
-        AND ${zeroRuns.id} <> ${args.runId}
-        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-        AND (
-          NOT EXISTS (
-            SELECT 1
-            FROM ${agentRunCallbacks}
-            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-              AND ${agentRunCallbacks.internalKind} = 'chat'
-              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+    const competingRuns = await executeRawRows(
+      tx,
+      sql`
+        SELECT ${zeroRuns.id} AS "id"
+        FROM ${zeroRuns}
+        INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
+        WHERE ${zeroRuns.chatThreadId} = ${args.threadId}
+          AND ${zeroRuns.id} <> ${args.runId}
+          AND ${agentRuns.status} IN ('queued', 'pending', 'running')
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM ${agentRunCallbacks}
+              WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+                AND ${agentRunCallbacks.internalKind} = 'chat'
+                AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM ${chatMessages}
+              WHERE ${chatMessages.runId} = ${zeroRuns.id}
+                AND ${chatMessages.role} = 'user'
+            )
           )
-          OR EXISTS (
-            SELECT 1
-            FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${zeroRuns.id}
-              AND ${chatMessages.role} = 'user'
-          )
-        )
-      LIMIT 1
-    `);
-    if (competingRuns.rows[0]) {
+        LIMIT 1
+      `,
+      idRowSchema,
+    );
+    if (competingRuns[0]) {
       return null;
     }
 
@@ -1889,13 +1894,12 @@ async function appendAutoSentQueuedRunMarker(args: {
   readonly threadId: string;
 }): Promise<void> {
   await args.db.transaction(async (tx) => {
-    const threadRows = await tx.execute<{ readonly id: string }>(sql`
-      SELECT ${chatThreads.id} AS "id"
-      FROM ${chatThreads}
-      WHERE ${chatThreads.id} = ${args.threadId}
-      FOR KEY SHARE
-    `);
-    if (!threadRows.rows[0]) {
+    const [thread] = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .for("key share");
+    if (!thread) {
       return;
     }
 

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -7,7 +7,12 @@ import {
   VM0_MODEL_ALIAS_TO_MODEL,
   VM0_MODEL_TO_PROVIDER,
 } from "@vm0/api-contracts/contracts/model-providers";
+import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgInt8ToSafeIntegerSchema,
+} from "../../lib/db-raw-rows";
 import { type Db, writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
 
@@ -38,13 +43,23 @@ interface ModelRankingResult {
   readonly rows: readonly ModelRankingRow[];
 }
 
-interface RawModelRankingRow extends Record<string, unknown> {
-  readonly model: string;
-  readonly input_tokens: string | number | bigint;
-  readonly output_tokens: string | number | bigint;
-  readonly total_tokens: string | number | bigint;
-  readonly previous_total_tokens: string | number | bigint;
-}
+const modelRankingSqlRowSchema = z
+  .object({
+    model: z.string(),
+    input_tokens: pgInt8ToSafeIntegerSchema,
+    output_tokens: pgInt8ToSafeIntegerSchema,
+    total_tokens: pgInt8ToSafeIntegerSchema,
+    previous_total_tokens: pgInt8ToSafeIntegerSchema,
+  })
+  .transform((row): ModelRankingRow => {
+    return {
+      model: row.model,
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
+      totalTokens: row.total_tokens,
+      previousTotalTokens: row.previous_total_tokens,
+    };
+  });
 
 function getModelAliasEntries() {
   return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
@@ -110,16 +125,6 @@ function currentWindow(
   return { start: startOfUtcWeek(now), end };
 }
 
-function toNumber(value: string | number | bigint): number {
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "bigint") {
-    return Number(value);
-  }
-  return Number(value);
-}
-
 function utcTimestampParam(date: Date): string {
   return date.toISOString().replace("T", " ").replace("Z", "");
 }
@@ -163,7 +168,7 @@ async function replaceModelStats(
   const windowStartParam = utcTimestampParam(windowStart);
   const windowEndParam = utcTimestampParam(windowEnd);
 
-  const result = await db.transaction(async (tx) => {
+  const insertedCount = await db.transaction(async (tx) => {
     await tx.execute(sql`
       DELETE FROM ${modelStat}
       WHERE ${modelStat.hourStart} >= ${windowStartParam}::timestamp
@@ -171,7 +176,7 @@ async function replaceModelStats(
         AND ${modelStat.model} IN (${modelStatsModelIdSql})
     `);
 
-    return tx.execute(sql`
+    const { rowCount } = await tx.execute(sql`
       WITH usage_rows AS (
         SELECT
           date_trunc('hour', ${modelUsageObservation.observedAt})::timestamp AS hour_start,
@@ -263,9 +268,10 @@ async function replaceModelStats(
         updated_at = NOW()
       RETURNING id
     `);
+    return rowCount ?? 0;
   });
 
-  return result.rowCount ?? 0;
+  return insertedCount;
 }
 
 async function deleteExpiredModelUsageObservations(
@@ -293,8 +299,10 @@ async function selectModelRankings(
   const previousStartParam = utcTimestampParam(previousStart);
   const previousEndParam = utcTimestampParam(previousEnd);
 
-  const result = await db.execute<RawModelRankingRow>(sql`
-    WITH current_period AS (
+  const rows = await executeRawRows(
+    db,
+    sql`
+      WITH current_period AS (
       SELECT
         ${modelExpr} AS model,
         COALESCE(SUM(${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS input_tokens,
@@ -326,18 +334,10 @@ async function selectModelRankings(
     LEFT JOIN previous_period ON previous_period.model = current_period.model
     WHERE current_period.total_tokens > 0
     ORDER BY current_period.total_tokens DESC
-    LIMIT 50
-  `);
-
-  const rows = result.rows.map((row) => {
-    return {
-      model: row.model,
-      inputTokens: toNumber(row.input_tokens),
-      outputTokens: toNumber(row.output_tokens),
-      totalTokens: toNumber(row.total_tokens),
-      previousTotalTokens: toNumber(row.previous_total_tokens),
-    };
-  });
+      LIMIT 50
+    `,
+    modelRankingSqlRowSchema,
+  );
 
   return {
     period,

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { systemStoragePresignedUrlCache } from "@vm0/db/schema/system-storage-presigned-url-cache";
 import type { Computed } from "ccstate";
 import { and, asc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import type { Db } from "../external/db";
 import { generatePresignedGetUrl } from "../external/s3";
 import { nowDate, timestampWithoutTimeZone } from "../external/time";
@@ -28,6 +30,7 @@ const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_CACHE_POLICY =
   "workflow-skill-storage-url-v1";
 export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_REFRESH_LIMIT = 32;
 export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_PRUNE_LIMIT = 100;
+const deletedCacheRowSchema = z.object({ cacheKey: z.string() });
 
 type StoragePresignedUrlCacheStatus =
   | "hit"
@@ -329,8 +332,10 @@ async function pruneInactiveExpiredCacheRows(
   const inactiveCutoff = activeCutoff(issuedAt);
   const issuedAtTimestamp = timestampWithoutTimeZone(issuedAt);
   const inactiveCutoffTimestamp = timestampWithoutTimeZone(inactiveCutoff);
-  const deletedRows = await db.execute<{ readonly cacheKey: string }>(sql`
-    WITH candidates AS (
+  const deletedRows = await executeRawRows(
+    db,
+    sql`
+      WITH candidates AS (
       SELECT ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
       FROM ${systemStoragePresignedUrlCache}
       WHERE
@@ -358,10 +363,12 @@ async function pruneInactiveExpiredCacheRows(
     DELETE FROM ${systemStoragePresignedUrlCache}
     USING locked
     WHERE ${systemStoragePresignedUrlCache.cacheKey} = locked."cacheKey"
-    RETURNING ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
-  `);
+      RETURNING ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
+    `,
+    deletedCacheRowSchema,
+  );
   signal?.throwIfAborted();
-  return deletedRows.rows.length;
+  return deletedRows.length;
 }
 
 async function resolveStoragePresignedUrls<TRequest>(args: {

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,7 +1,9 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import type { Db } from "../external/db";
 import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
 
@@ -25,11 +27,11 @@ interface IncompleteRound extends IncompleteRoundSelection {
   readonly messages: IncompleteRoundMessage[];
 }
 
-interface IncompleteRoundFrontierRow extends Record<string, unknown> {
-  readonly runId: string;
-  readonly runStatus: string;
-  readonly isSuccess: boolean;
-}
+const incompleteRoundFrontierRowSchema = z.object({
+  runId: z.string(),
+  runStatus: z.string(),
+  isSuccess: z.boolean(),
+});
 
 function isIncompleteRunStatus(value: string): value is IncompleteRunStatus {
   return value === "cancelled" || value === "failed" || value === "timeout";
@@ -50,8 +52,10 @@ async function selectIncompleteRoundFrontier(
   // Terminal chat materialization runs in waitUntil, so lifecycle rows can lag
   // behind agent_runs.status. Walk the existing recent-message index instead.
   // The fixed 21-run frontier is the 20-round output plus one boundary candidate.
-  const result = await db.execute<IncompleteRoundFrontierRow>(sql`
-    WITH RECURSIVE incomplete_frontier AS (
+  const rows = await executeRawRows(
+    db,
+    sql`
+      WITH RECURSIVE incomplete_frontier AS (
       SELECT
         ARRAY[]::uuid[] AS seen_run_ids,
         NULL::uuid AS run_id,
@@ -104,12 +108,14 @@ async function selectIncompleteRoundFrontier(
       is_success AS "isSuccess"
     FROM incomplete_frontier
     WHERE depth > 0
-    ORDER BY depth
-  `);
+      ORDER BY depth
+    `,
+    incompleteRoundFrontierRowSchema,
+  );
 
   const rounds: IncompleteRoundSelection[] = [];
   let successfulRunId: string | null = null;
-  for (const row of result.rows) {
+  for (const row of rows) {
     if (row.isSuccess) {
       successfulRunId = row.runId;
       break;

--- a/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
@@ -20,10 +20,6 @@ export interface QueueMarkerRevokeNotification {
   readonly userId: string;
 }
 
-interface LockedRunStatusRow extends Record<string, unknown> {
-  readonly status: string;
-}
-
 export async function appendQueuedRunAssistantMarker(
   tx: DbTransaction,
   args: {
@@ -33,13 +29,11 @@ export async function appendQueuedRunAssistantMarker(
     readonly createdAfter?: Date;
   },
 ): Promise<void> {
-  const runRows = await tx.execute<LockedRunStatusRow>(sql`
-    SELECT ${agentRuns.status} AS "status"
-    FROM ${agentRuns}
-    WHERE ${agentRuns.id} = ${args.runId}
-    FOR UPDATE
-  `);
-  const run = runRows.rows[0];
+  const [run] = await tx
+    .select({ status: agentRuns.status })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, args.runId))
+    .for("update");
   if (run?.status !== "queued") {
     return;
   }

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -201,13 +201,12 @@ export async function claimQueuedUserMessage(
   },
 ): Promise<ClaimedUserMessage | null> {
   return await db.transaction(async (tx) => {
-    const threadRows = await tx.execute<{ readonly id: string }>(sql`
-      SELECT ${chatThreads.id} AS "id"
-      FROM ${chatThreads}
-      WHERE ${chatThreads.id} = ${args.threadId}
-      FOR UPDATE
-    `);
-    if (!threadRows.rows[0]) {
+    const [thread] = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .for("update");
+    if (!thread) {
       return null;
     }
     return await appendClaimedUserMessage(tx, args);

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -60,6 +60,11 @@ import {
 } from "drizzle-orm";
 import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgInt8ToSafeIntegerSchema,
+  pgTimestampWithoutTimezoneToDateSchema,
+} from "../../lib/db-raw-rows";
 import { type Db, db$, writeDb$ } from "../external/db";
 import {
   inferMimetype,
@@ -135,25 +140,28 @@ type ChatMessageRow = {
   readonly workflowAutomationUserTimezone: string | null;
 };
 
-type ArtifactListSqlRow = Record<string, unknown> & {
-  readonly row_id: string;
-  readonly run_id: string;
-  readonly external_id: string;
-  readonly filename: string | null;
-  readonly content_type: string | null;
-  readonly size_bytes: number | string | null;
-  readonly url: string;
-  readonly preview_image_url: string | null;
-  readonly metadata: unknown;
-  readonly created_at: Date | string;
-  readonly cursor_created_at: string;
-  readonly thread_id: string;
-  readonly thread_title: string | null;
-  readonly agent_id: string;
-  readonly agent_name: string | null;
-  readonly agent_avatar_url: string | null;
-  readonly is_favorited: boolean;
-};
+const artifactListSqlRowSchema = z.object({
+  row_id: z.string(),
+  run_id: z.string(),
+  external_id: z.string(),
+  filename: z.string().nullable(),
+  content_type: z.string().nullable(),
+  size_bytes: pgInt8ToSafeIntegerSchema.nullable(),
+  url: z.string(),
+  preview_image_url: z.string().nullable(),
+  metadata: z.unknown(),
+  created_at: pgTimestampWithoutTimezoneToDateSchema,
+  cursor_created_at: z.string(),
+  thread_id: z.string(),
+  thread_title: z.string().nullable(),
+  agent_id: z.string(),
+  agent_name: z.string().nullable(),
+  agent_avatar_url: z.string().nullable(),
+  is_favorited: z.boolean(),
+});
+type ArtifactListSqlRow = z.output<typeof artifactListSqlRowSchema>;
+
+const artifactVisibilityRowSchema = z.object({ visible: z.boolean() });
 
 type ChatSearchMessageRow = {
   readonly messageId: string;
@@ -1030,12 +1038,6 @@ function artifactVisibilityConditions(args: {
   ];
 }
 
-function artifactRowCreatedAt(row: ArtifactListSqlRow): Date {
-  return row.created_at instanceof Date
-    ? row.created_at
-    : new Date(row.created_at);
-}
-
 function toArtifactItem(row: ArtifactListSqlRow): ArtifactItem {
   const filename = row.filename ?? row.external_id;
   const artifactKind = parseHostedArtifactKindFromMetadata(row.metadata);
@@ -1050,9 +1052,9 @@ function toArtifactItem(row: ArtifactListSqlRow): ArtifactItem {
     threadTitle: row.thread_title,
     filename,
     contentType: row.content_type ?? inferMimetype(filename),
-    size: Number(row.size_bytes ?? 0),
+    size: row.size_bytes ?? 0,
     url: row.url,
-    createdAt: artifactRowCreatedAt(row).toISOString(),
+    createdAt: row.created_at.toISOString(),
     ...(row.preview_image_url
       ? { previewImageUrl: row.preview_image_url }
       : {}),
@@ -1123,8 +1125,10 @@ export const zeroArtifacts$ = command(
       : sql``;
     const conditions = artifactVisibilityConditions(args);
 
-    const rows = await db.execute<ArtifactListSqlRow>(sql`
-      WITH scoped_artifacts AS (
+    const rows = await executeRawRows(
+      db,
+      sql`
+        WITH scoped_artifacts AS (
         SELECT
           ${runUploadedFiles.id} AS row_id,
           ${runUploadedFiles.runId} AS run_id,
@@ -1182,13 +1186,15 @@ export const zeroArtifacts$ = command(
         AND ${userArtifactFavorites.artifactUrl} = deduped_artifacts.url
       ${keysetClause}
       ORDER BY created_at DESC, row_id DESC
-      LIMIT ${limit + 1}
-    `);
+        LIMIT ${limit + 1}
+      `,
+      artifactListSqlRowSchema,
+    );
     signal.throwIfAborted();
 
     // Over-fetch one row to detect whether a further page exists.
-    const hasMore = rows.rows.length > limit;
-    const pageRows = hasMore ? rows.rows.slice(0, limit) : rows.rows;
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
     const lastRow = pageRows.at(-1);
     const nextCursor =
       hasMore && lastRow
@@ -1214,8 +1220,10 @@ async function artifactUrlIsVisible(
     ...artifactVisibilityConditions(args),
     sql`${runUploadedFiles.url} = ${args.artifactUrl}`,
   ];
-  const result = await db.execute<{ readonly visible: boolean }>(sql`
-    SELECT EXISTS (
+  const rows = await executeRawRows(
+    db,
+    sql`
+      SELECT EXISTS (
       SELECT 1
       FROM ${runUploadedFiles}
       INNER JOIN ${agentRuns}
@@ -1237,9 +1245,11 @@ async function artifactUrlIsVisible(
         ON ${agentComposes.id} = ${chatThreads.agentComposeId}
       WHERE ${sql.join(conditions, sql` AND `)}
       LIMIT 1
-    ) AS visible
-  `);
-  return result.rows[0]?.visible === true;
+      ) AS visible
+    `,
+    artifactVisibilityRowSchema,
+  );
+  return rows[0]?.visible === true;
 }
 
 export const favoriteArtifact$ = command(
@@ -1686,19 +1696,19 @@ export const deleteChatThread$ = command(
     const writeDb = set(writeDb$);
 
     const deletion = await writeDb.transaction(async (tx) => {
-      const lockedRows = await tx.execute<{
-        readonly id: string;
-        readonly agentComposeId: string;
-      }>(sql`
-        SELECT
-          ${chatThreads.id} AS "id",
-          ${chatThreads.agentComposeId} AS "agentComposeId"
-        FROM ${chatThreads}
-        WHERE ${chatThreads.id} = ${args.threadId}
-          AND ${chatThreads.userId} = ${args.userId}
-        FOR UPDATE
-      `);
-      const ownedThread = lockedRows.rows[0];
+      const [ownedThread] = await tx
+        .select({
+          id: chatThreads.id,
+          agentComposeId: chatThreads.agentComposeId,
+        })
+        .from(chatThreads)
+        .where(
+          and(
+            eq(chatThreads.id, args.threadId),
+            eq(chatThreads.userId, args.userId),
+          ),
+        )
+        .for("update");
       if (!ownedThread) {
         return {
           deleted: false,

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -18,7 +18,9 @@ import { convert, type FormatCallback } from "html-to-text";
 import { Resend } from "resend";
 import { delay } from "signal-timers";
 import { Webhook } from "svix";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -91,84 +93,100 @@ interface ReceivedEmailAttachment {
   readonly downloadUrl: string;
 }
 
-interface AgentReplyTemplate {
-  readonly template: "agent-reply";
-  readonly props: {
-    readonly agentName: string;
-    readonly output: string;
-    readonly logsUrl?: string;
-    readonly unsubscribeUrl?: string;
-  };
-}
+const emailTemplateSchema = z.discriminatedUnion("template", [
+  z.object({
+    template: z.literal("agent-reply"),
+    props: z.object({
+      agentName: z.string(),
+      output: z.string(),
+      logsUrl: z.string().optional(),
+      unsubscribeUrl: z.string().optional(),
+    }),
+  }),
+  z.object({
+    template: z.literal("inbound-error"),
+    props: z.object({
+      errorMessage: z.string(),
+      unsubscribeUrl: z.string().optional(),
+    }),
+  }),
+  z.object({
+    template: z.literal("data-export-ready"),
+    props: z.object({
+      downloadUrl: z.string(),
+      expiresAt: z.string(),
+      artifactCount: z.number(),
+      unsubscribeUrl: z.string().optional(),
+    }),
+  }),
+  z.object({
+    template: z.literal("developer-support"),
+    props: z.object({
+      title: z.string(),
+      description: z.string(),
+      reference: z.string(),
+      userId: z.string(),
+      userEmail: z.string(),
+      orgId: z.string(),
+      orgName: z.string(),
+      runId: z.string(),
+      downloadUrl: z.string(),
+      expiresAt: z.string(),
+    }),
+  }),
+  z.object({
+    template: z.literal("credit-low-balance"),
+    props: z.object({
+      orgName: z.string(),
+      remainingCredits: z.number(),
+      thresholdCredits: z.number(),
+      billingUrl: z.string(),
+      unsubscribeUrl: z.string().optional(),
+    }),
+  }),
+]);
 
-interface InboundErrorTemplate {
-  readonly template: "inbound-error";
-  readonly props: {
-    readonly errorMessage: string;
-    readonly unsubscribeUrl?: string;
-  };
-}
+const postSendActionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("save_thread_session"),
+    userId: z.string(),
+    agentId: z.string(),
+    agentSessionId: z.string(),
+    replyToToken: z.string(),
+    orgId: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("update_thread_session"),
+    sessionId: z.string(),
+    agentSessionId: z.string().optional(),
+  }),
+]);
 
-interface DataExportReadyTemplate {
-  readonly template: "data-export-ready";
-  readonly props: {
-    readonly downloadUrl: string;
-    readonly expiresAt: string;
-    readonly artifactCount: number;
-    readonly unsubscribeUrl?: string;
-  };
-}
+export type EmailTemplate = z.output<typeof emailTemplateSchema>;
+type PostSendAction = z.output<typeof postSendActionSchema>;
+type SaveThreadSessionAction = Extract<
+  PostSendAction,
+  { readonly action: "save_thread_session" }
+>;
+type UpdateThreadSessionAction = Extract<
+  PostSendAction,
+  { readonly action: "update_thread_session" }
+>;
 
-interface DeveloperSupportTemplate {
-  readonly template: "developer-support";
-  readonly props: {
-    readonly title: string;
-    readonly description: string;
-    readonly reference: string;
-    readonly userId: string;
-    readonly userEmail: string;
-    readonly orgId: string;
-    readonly orgName: string;
-    readonly runId: string;
-    readonly downloadUrl: string;
-    readonly expiresAt: string;
-  };
-}
-
-interface CreditLowBalanceTemplate {
-  readonly template: "credit-low-balance";
-  readonly props: {
-    readonly orgName: string;
-    readonly remainingCredits: number;
-    readonly thresholdCredits: number;
-    readonly billingUrl: string;
-    readonly unsubscribeUrl?: string;
-  };
-}
-
-export type EmailTemplate =
-  | AgentReplyTemplate
-  | InboundErrorTemplate
-  | DataExportReadyTemplate
-  | DeveloperSupportTemplate
-  | CreditLowBalanceTemplate;
-
-interface SaveThreadSessionAction {
-  readonly action: "save_thread_session";
-  readonly userId: string;
-  readonly agentId: string;
-  readonly agentSessionId: string;
-  readonly replyToToken: string;
-  readonly orgId?: string;
-}
-
-interface UpdateThreadSessionAction {
-  readonly action: "update_thread_session";
-  readonly sessionId: string;
-  readonly agentSessionId?: string;
-}
-
-type PostSendAction = SaveThreadSessionAction | UpdateThreadSessionAction;
+const emailAddressesSchema = z.union([z.string(), z.array(z.string())]);
+const outboxRowSchema = z.object({
+  id: z.string(),
+  from_address: z.string(),
+  to_addresses: emailAddressesSchema,
+  cc_addresses: emailAddressesSchema.nullable(),
+  subject: z.string(),
+  reply_to: z.string().nullable(),
+  headers: z.record(z.string(), z.string()).nullable(),
+  template: emailTemplateSchema,
+  post_send_action: postSendActionSchema.nullable(),
+  attempts: z.int(),
+});
+type OutboxRow = z.output<typeof outboxRowSchema>;
 
 interface EnqueueEmailOptions {
   readonly from: string;
@@ -179,19 +197,6 @@ interface EnqueueEmailOptions {
   readonly replyTo?: string;
   readonly headers?: Record<string, string>;
   readonly threadAction?: PostSendAction;
-}
-
-interface OutboxRow extends Record<string, unknown> {
-  readonly id: string;
-  readonly from_address: string;
-  readonly to_addresses: unknown;
-  readonly cc_addresses: unknown;
-  readonly subject: string;
-  readonly reply_to: string | null;
-  readonly headers: unknown;
-  readonly template: unknown;
-  readonly post_send_action: unknown;
-  readonly attempts: number;
 }
 
 interface OrgIdentity {
@@ -537,18 +542,6 @@ async function getMessageId(resendId: string): Promise<string | null> {
     : null;
 }
 
-function normalizeAddresses(raw: unknown): string[] {
-  if (typeof raw === "string") {
-    return [raw];
-  }
-  if (Array.isArray(raw)) {
-    return raw.filter((value): value is string => {
-      return typeof value === "string";
-    });
-  }
-  return [];
-}
-
 async function findSuppressedAddress(
   tx: Transaction,
   addresses: readonly string[],
@@ -583,8 +576,10 @@ async function findSuppressedAddress(
   );
 }
 
+type EmailThreadSessionDb = Pick<Db, "insert" | "update">;
+
 async function saveEmailThreadSession(
-  db: Db,
+  db: EmailThreadSessionDb,
   action: SaveThreadSessionAction,
   lastEmailMessageId: string | null,
 ): Promise<void> {
@@ -599,7 +594,7 @@ async function saveEmailThreadSession(
 }
 
 async function updateEmailThreadSession(
-  db: Db,
+  db: EmailThreadSessionDb,
   action: UpdateThreadSessionAction,
   lastEmailMessageId: string | null,
 ): Promise<void> {
@@ -616,7 +611,7 @@ async function updateEmailThreadSession(
 }
 
 async function executePostSendAction(
-  db: Db,
+  db: EmailThreadSessionDb,
   action: PostSendAction,
   resendId: string,
 ): Promise<void> {
@@ -640,7 +635,10 @@ async function processOutboxItem(
     .set({ status: "sending", attempts })
     .where(eq(emailOutbox.id, itemId));
 
-  const toAddresses = normalizeAddresses(row.to_addresses);
+  const toAddresses =
+    typeof row.to_addresses === "string"
+      ? [row.to_addresses]
+      : row.to_addresses;
   const suppressedAddress = await findSuppressedAddress(tx, toAddresses);
   if (suppressedAddress) {
     await tx
@@ -655,12 +653,12 @@ async function processOutboxItem(
 
   const result = await sendEmailDirect({
     from: row.from_address,
-    to: row.to_addresses as string | readonly string[],
+    to: row.to_addresses,
     subject: row.subject,
-    template: row.template as EmailTemplate,
-    cc: (row.cc_addresses as string | readonly string[] | null) ?? undefined,
+    template: row.template,
+    cc: row.cc_addresses ?? undefined,
     replyTo: row.reply_to ?? undefined,
-    headers: (row.headers as Record<string, string> | null) ?? undefined,
+    headers: row.headers ?? undefined,
   });
 
   if (!result.ok) {
@@ -688,24 +686,26 @@ async function processOutboxItem(
     .set({ status: "sent", resendId: result.resendId })
     .where(eq(emailOutbox.id, itemId));
 
-  const postSendAction = row.post_send_action as PostSendAction | null;
+  const postSendAction = row.post_send_action;
   if (postSendAction) {
-    await executePostSendAction(tx as Db, postSendAction, result.resendId);
+    await executePostSendAction(tx, postSendAction, result.resendId);
   }
   return true;
 }
 
 async function drainById(db: Db, itemId: string): Promise<boolean> {
   return await db.transaction(async (tx) => {
-    const rows = await tx.execute<OutboxRow>(
+    const rows = await executeRawRows(
+      tx,
       sql`SELECT id, from_address, to_addresses, cc_addresses, subject,
              reply_to, headers, template, post_send_action, attempts
           FROM email_outbox
           WHERE id = ${itemId}
             AND status = 'pending'
           FOR UPDATE SKIP LOCKED`,
+      outboxRowSchema,
     );
-    const row = rows.rows[0];
+    const row = rows[0];
     return row ? await processOutboxItem(tx, row) : false;
   });
 }
@@ -716,7 +716,8 @@ async function drainNextOutboxItem(
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
     const currentTime = new Date(currentTimeMs);
-    const rows = await tx.execute<OutboxRow>(
+    const rows = await executeRawRows(
+      tx,
       sql`SELECT id, from_address, to_addresses, cc_addresses, subject,
              reply_to, headers, template, post_send_action, attempts
           FROM email_outbox
@@ -725,8 +726,9 @@ async function drainNextOutboxItem(
           ORDER BY created_at ASC
           LIMIT 1
           FOR UPDATE SKIP LOCKED`,
+      outboxRowSchema,
     );
-    const row = rows.rows[0];
+    const row = rows[0];
     return row ? await processOutboxItem(tx, row, currentTimeMs) : false;
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -4,17 +4,19 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows, pgInt8ToBigIntSchema } from "../../lib/db-raw-rows";
 import { writeDb$ } from "../external/db";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 
-interface CreditCheckRow extends Record<string, unknown> {
-  readonly credits: string | null;
-  readonly unsettled_expired: string | null;
-  readonly unit_price: string | null;
-  readonly unit_size: string | null;
-}
+const creditCheckRowSchema = z.object({
+  credits: pgInt8ToBigIntSchema.nullable(),
+  unsettled_expired: pgInt8ToBigIntSchema.nullable(),
+  unit_price: pgInt8ToBigIntSchema.nullable(),
+  unit_size: pgInt8ToBigIntSchema.nullable(),
+});
 
 export interface ManagedUsageErrorResponse {
   readonly status: 402 | 503;
@@ -64,22 +66,20 @@ function pricingNotConfigured(label: string): ManagedUsageErrorResponse {
 }
 
 function estimatedCredits(
-  unitPrice: string,
-  unitSize: string,
+  unitPrice: bigint,
+  unitSize: bigint,
   quantity: number,
 ): bigint {
   if (!Number.isSafeInteger(quantity) || quantity <= 0) {
     throw new Error("Managed usage quantity must be a positive safe integer");
   }
-  const price = BigInt(unitPrice);
-  const size = BigInt(unitSize);
-  if (price < 0n || size <= 0n) {
+  if (unitPrice < 0n || unitSize <= 0n) {
     throw new Error(
       "Managed usage pricing must be non-negative with a positive unit size",
     );
   }
-  const total = BigInt(quantity) * price;
-  return (total + size - 1n) / size;
+  const total = BigInt(quantity) * unitPrice;
+  return (total + unitSize - 1n) / unitSize;
 }
 
 export const checkManagedCredits$ = command(
@@ -93,32 +93,36 @@ export const checkManagedCredits$ = command(
     signal: AbortSignal,
   ): Promise<ManagedUsageErrorResponse | null> => {
     const writeDb = set(writeDb$);
-    const { rows } = await writeDb.execute<CreditCheckRow>(sql`
-      WITH pricing AS (
-        SELECT unit_price, unit_size FROM usage_pricing
-        WHERE kind = ${args.resource.kind}
-          AND provider = ${args.resource.provider}
-          AND category = ${args.resource.category}
-        LIMIT 1
-      ),
-      org AS (
-        SELECT credits FROM org_metadata
-        WHERE org_id = ${args.orgId}
-        LIMIT 1
-      ),
-      expired AS (
-        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-        FROM credit_expires_record
-        WHERE org_id = ${args.orgId}
-          AND expires_at <= now()
-          AND remaining > 0
-      )
-      SELECT
-        (SELECT credits FROM org) AS credits,
-        (SELECT total FROM expired) AS unsettled_expired,
-        (SELECT unit_price FROM pricing) AS unit_price,
-        (SELECT unit_size FROM pricing) AS unit_size
-    `);
+    const rows = await executeRawRows(
+      writeDb,
+      sql`
+        WITH pricing AS (
+          SELECT unit_price, unit_size FROM usage_pricing
+          WHERE kind = ${args.resource.kind}
+            AND provider = ${args.resource.provider}
+            AND category = ${args.resource.category}
+          LIMIT 1
+        ),
+        org AS (
+          SELECT credits FROM org_metadata
+          WHERE org_id = ${args.orgId}
+          LIMIT 1
+        ),
+        expired AS (
+          SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+          FROM credit_expires_record
+          WHERE org_id = ${args.orgId}
+            AND expires_at <= now()
+            AND remaining > 0
+        )
+        SELECT
+          (SELECT credits FROM org) AS credits,
+          (SELECT total FROM expired) AS unsettled_expired,
+          (SELECT unit_price FROM pricing) AS unit_price,
+          (SELECT unit_size FROM pricing) AS unit_size
+      `,
+      creditCheckRowSchema,
+    );
     signal.throwIfAborted();
 
     const row = rows[0];
@@ -130,8 +134,8 @@ export const checkManagedCredits$ = command(
       return insufficientCredits();
     }
 
-    const credits = BigInt(row.credits);
-    const unsettledExpired = BigInt(row.unsettled_expired ?? "0");
+    const credits = row.credits;
+    const unsettledExpired = row.unsettled_expired ?? 0n;
     const quantity = args.resource.quantity ?? 1;
     const requiredCredits = estimatedCredits(
       row.unit_price,

--- a/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-admission.service.ts
@@ -1,6 +1,11 @@
 import { sql } from "drizzle-orm";
 import { isLimitedFree1RestrictedRunModel } from "@vm0/api-contracts/contracts/model-providers";
+import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgInt8ToSafeIntegerSchema,
+} from "../../lib/db-raw-rows";
 import { insufficientCredits } from "../../lib/error";
 import type { Db } from "../external/db";
 import {
@@ -11,10 +16,10 @@ import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 
 type CreditDb = Pick<Db, "execute" | "select">;
 
-interface CreditCheckRow extends Record<string, unknown> {
-  readonly credits: string | null;
-  readonly unsettled_expired: string | null;
-}
+const creditCheckRowSchema = z.object({
+  credits: pgInt8ToSafeIntegerSchema.nullable(),
+  unsettled_expired: pgInt8ToSafeIntegerSchema.nullable(),
+});
 
 interface OrgCreditAvailability {
   readonly status: OrgPlanCapabilities["status"];
@@ -32,31 +37,35 @@ export async function resolveOrgCreditAvailability(params: {
   readonly db: CreditDb;
   readonly orgId: string;
 }): Promise<OrgCreditAvailability | null> {
-  const { rows } = await params.db.execute<CreditCheckRow>(sql`
-    WITH org AS (
-      SELECT credits FROM org_metadata
-      WHERE org_id = ${params.orgId}
-      LIMIT 1
-    ),
-    expired AS (
-      SELECT COALESCE(SUM(remaining), 0)::bigint AS total
-      FROM credit_expires_record
-      WHERE org_id = ${params.orgId}
-        AND expires_at <= now()
-        AND remaining > 0
-    )
-    SELECT
-      (SELECT credits FROM org) AS credits,
-      (SELECT total FROM expired) AS unsettled_expired
-  `);
+  const rows = await executeRawRows(
+    params.db,
+    sql`
+      WITH org AS (
+        SELECT credits FROM org_metadata
+        WHERE org_id = ${params.orgId}
+        LIMIT 1
+      ),
+      expired AS (
+        SELECT COALESCE(SUM(remaining), 0)::bigint AS total
+        FROM credit_expires_record
+        WHERE org_id = ${params.orgId}
+          AND expires_at <= now()
+          AND remaining > 0
+      )
+      SELECT
+        (SELECT credits FROM org) AS credits,
+        (SELECT total FROM expired) AS unsettled_expired
+    `,
+    creditCheckRowSchema,
+  );
 
   const row = rows[0];
   if (!row || row.credits === null) {
     return null;
   }
 
-  const credits = Number(row.credits);
-  const unsettledExpired = Number(row.unsettled_expired ?? 0);
+  const credits = row.credits;
+  const unsettledExpired = row.unsettled_expired ?? 0;
   const spendableCredits = credits - unsettledExpired;
   const capabilities = await loadOrgPlanCapabilities(params.db, params.orgId);
   if (!capabilities) {

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../external/time";
@@ -41,15 +41,6 @@ type RunNotCancellableResponse = ReturnType<typeof runNotCancellable>;
 const ACTIVE_STATUSES = ["queued", "pending", "running"] as const;
 type ActiveStatus = (typeof ACTIVE_STATUSES)[number];
 
-interface LockedCancelRunRow extends Record<string, unknown> {
-  readonly id: string;
-  readonly status: string;
-  readonly userId: string;
-  readonly orgId: string;
-  readonly sandboxId: string | null;
-  readonly runnerGroup: string | null;
-}
-
 function isActiveStatus(status: string): status is ActiveStatus {
   return (ACTIVE_STATUSES as readonly string[]).includes(status);
 }
@@ -79,21 +70,24 @@ export const cancelRun$ = command(
     const writeDb = set(writeDb$);
 
     const result = await writeDb.transaction(async (tx) => {
-      const lockedRows = await tx.execute<LockedCancelRunRow>(sql`
-        SELECT
-          ${agentRuns.id} AS "id",
-          ${agentRuns.status} AS "status",
-          ${agentRuns.userId} AS "userId",
-          ${agentRuns.orgId} AS "orgId",
-          ${agentRuns.sandboxId} AS "sandboxId",
-          ${agentRuns.runnerGroup} AS "runnerGroup"
-        FROM ${agentRuns}
-        WHERE ${agentRuns.id} = ${args.runId}
-          AND ${agentRuns.userId} = ${args.userId}
-          AND ${agentRuns.orgId} = ${args.orgId}
-        FOR UPDATE
-      `);
-      const run = lockedRows.rows[0];
+      const [run] = await tx
+        .select({
+          id: agentRuns.id,
+          status: agentRuns.status,
+          userId: agentRuns.userId,
+          orgId: agentRuns.orgId,
+          sandboxId: agentRuns.sandboxId,
+          runnerGroup: agentRuns.runnerGroup,
+        })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.id, args.runId),
+            eq(agentRuns.userId, args.userId),
+            eq(agentRuns.orgId, args.orgId),
+          ),
+        )
+        .for("update");
       if (!run) {
         return notFound(`No such run: '${args.runId}'`);
       }

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -99,10 +99,6 @@ interface QueuedRunMaintenanceResult {
   readonly timedOutRuns: readonly QueuedRunMaintenanceTimeout[];
 }
 
-interface LockedQueueRunRow extends Record<string, unknown> {
-  readonly status: string;
-}
-
 async function timedOutQueuedRunsWithMarkerNotifications(
   tx: DbTransaction,
   rows: readonly TimedOutQueuedRunRow[],
@@ -241,13 +237,11 @@ async function promoteQueuedCandidate(
       return { status: "full" };
     }
 
-    const lockedRunRows = await tx.execute<LockedQueueRunRow>(sql`
-      SELECT ${agentRuns.status} AS "status"
-      FROM ${agentRuns}
-      WHERE ${agentRuns.id} = ${args.row.runId}
-      FOR UPDATE
-    `);
-    const lockedRun = lockedRunRows.rows[0];
+    const [lockedRun] = await tx
+      .select({ status: agentRuns.status })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, args.row.runId))
+      .for("update");
     if (!lockedRun) {
       await tx
         .delete(agentRunQueue)

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -5,7 +5,13 @@ import type {
   UsageInsightChatRow,
   UsageInsightResponse,
 } from "@vm0/api-contracts/contracts/zero-usage-insight";
+import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgInt8ToSafeIntegerSchema,
+  pgTimestampWithoutTimezoneToDateSchema,
+} from "../../lib/db-raw-rows";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 
@@ -44,12 +50,36 @@ interface UsageInsightSqlParams {
   tzLit: string;
 }
 
-interface UsageInsightBucketRow extends Record<string, unknown> {
-  ts: Date | string;
-  bucket: string;
-  credits: string;
-  tokens: string;
-}
+const usageInsightBucketRowSchema = z.object({
+  ts: pgTimestampWithoutTimezoneToDateSchema,
+  bucket: z.string(),
+  credits: pgInt8ToSafeIntegerSchema,
+  tokens: pgInt8ToSafeIntegerSchema,
+});
+type UsageInsightBucketRow = z.output<typeof usageInsightBucketRowSchema>;
+
+const usageInsightGrandTotalRowSchema = z.object({
+  grand_credits: pgInt8ToSafeIntegerSchema,
+  grand_tokens: pgInt8ToSafeIntegerSchema,
+});
+
+const usageInsightChannelTotalRowSchema = z.object({
+  source: z.enum(["email", "slack"]),
+  credits: pgInt8ToSafeIntegerSchema,
+  tokens: pgInt8ToSafeIntegerSchema,
+});
+
+const usageInsightTopChatRowSchema = z.object({
+  thread_id: z.string().nullable(),
+  thread_title: z.string().nullable(),
+  credits: pgInt8ToSafeIntegerSchema,
+  tokens: pgInt8ToSafeIntegerSchema,
+  rn: pgInt8ToSafeIntegerSchema,
+});
+
+const usageInsightCountRowSchema = z.object({
+  cnt: pgInt8ToSafeIntegerSchema,
+});
 
 interface UsageInsightArgs {
   readonly userId: string;
@@ -342,8 +372,7 @@ function pivotBucketRows(
     { series: Record<string, number>; tokens: Record<string, number> }
   >();
   for (const row of rows) {
-    const tsStr =
-      row.ts instanceof Date ? row.ts.toISOString() : String(row.ts);
+    const tsStr = row.ts.toISOString();
     if (!bucketMap.has(tsStr)) {
       bucketMap.set(tsStr, { series: {}, tokens: {} });
     }
@@ -351,8 +380,8 @@ function pivotBucketRows(
     if (!entry) {
       continue;
     }
-    entry.series[row.bucket] = Number(row.credits);
-    entry.tokens[row.bucket] = Number(row.tokens);
+    entry.series[row.bucket] = row.credits;
+    entry.tokens[row.bucket] = row.tokens;
   }
   return [...bucketMap.entries()]
     .sort(([a], [b]) => {
@@ -364,7 +393,8 @@ function pivotBucketRows(
 }
 
 function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
-  return db.execute<UsageInsightBucketRow>(
+  return executeRawRows(
+    db,
     sql.raw(`
       ${usageRowsWith(p)}
       SELECT
@@ -383,13 +413,15 @@ function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
       GROUP BY 1, 2
       ORDER BY 1
     `),
+    usageInsightBucketRowSchema,
   );
 }
 
 function queryUsageInsightAgentBuckets(db: Db, p: UsageInsightSqlParams) {
   const agentName = agentNameExpr();
 
-  return db.execute<UsageInsightBucketRow>(
+  return executeRawRows(
+    db,
     sql.raw(`
       ${usageRowsWith(p)},
       agent_totals AS (
@@ -422,6 +454,7 @@ function queryUsageInsightAgentBuckets(db: Db, p: UsageInsightSqlParams) {
       GROUP BY 1, 2
       ORDER BY 1
     `),
+    usageInsightBucketRowSchema,
   );
 }
 
@@ -429,10 +462,8 @@ async function queryUsageInsightGrandTotal(
   db: Db,
   p: UsageInsightSqlParams,
 ): Promise<{ grandTotalCredits: number; grandTotalTokens: number }> {
-  const rows = await db.execute<{
-    grand_credits: string;
-    grand_tokens: string;
-  }>(
+  const rows = await executeRawRows(
+    db,
     sql.raw(`
       ${usageRowsWith(p)}
       SELECT
@@ -440,10 +471,11 @@ async function queryUsageInsightGrandTotal(
         COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS grand_tokens
       FROM usage_rows ${USAGE_ROW_ALIAS}
     `),
+    usageInsightGrandTotalRowSchema,
   );
   return {
-    grandTotalCredits: Number(rows.rows[0]?.grand_credits ?? 0),
-    grandTotalTokens: Number(rows.rows[0]?.grand_tokens ?? 0),
+    grandTotalCredits: rows[0]?.grand_credits ?? 0,
+    grandTotalTokens: rows[0]?.grand_tokens ?? 0,
   };
 }
 
@@ -456,11 +488,8 @@ async function queryUsageInsightChannelTotals(
   slackCredits: number;
   slackTokens: number;
 }> {
-  const rows = await db.execute<{
-    source: string;
-    credits: string;
-    tokens: string;
-  }>(
+  const rows = await executeRawRows(
+    db,
     sql.raw(`
       ${usageRowsWith(p)}
       SELECT
@@ -472,18 +501,19 @@ async function queryUsageInsightChannelTotals(
       WHERE zr.trigger_source IN ('email', 'slack')
       GROUP BY 1
     `),
+    usageInsightChannelTotalRowSchema,
   );
   let emailCredits = 0;
   let emailTokens = 0;
   let slackCredits = 0;
   let slackTokens = 0;
-  for (const row of rows.rows) {
+  for (const row of rows) {
     if (row.source === "email") {
-      emailCredits = Number(row.credits);
-      emailTokens = Number(row.tokens);
-    } else if (row.source === "slack") {
-      slackCredits = Number(row.credits);
-      slackTokens = Number(row.tokens);
+      emailCredits = row.credits;
+      emailTokens = row.tokens;
+    } else {
+      slackCredits = row.credits;
+      slackTokens = row.tokens;
     }
   }
   return { emailCredits, emailTokens, slackCredits, slackTokens };
@@ -497,13 +527,8 @@ async function queryUsageInsightTopChats(
   chatOtherCount: number;
   chatOtherCredits: number;
 }> {
-  const rows = await db.execute<{
-    thread_id: string | null;
-    thread_title: string | null;
-    credits: string;
-    tokens: string;
-    rn: string;
-  }>(
+  const rows = await executeRawRows(
+    db,
     sql.raw(`
       ${usageRowsWith(p)},
       agg AS (
@@ -531,28 +556,30 @@ async function queryUsageInsightTopChats(
       FROM agg WHERE rn > 100
       ORDER BY rn
     `),
+    usageInsightTopChatRowSchema,
   );
 
   const chats: UsageInsightChatRow[] = [];
   let chatOtherCredits = 0;
   let hasChatOverflow = false;
-  for (const row of rows.rows) {
-    if (Number(row.rn) > 100) {
-      chatOtherCredits = Number(row.credits);
+  for (const row of rows) {
+    if (row.rn > 100) {
+      chatOtherCredits = row.credits;
       hasChatOverflow = true;
     } else if (row.thread_id) {
       chats.push({
         threadId: row.thread_id,
         threadTitle: row.thread_title ?? null,
-        credits: Number(row.credits),
-        tokens: Number(row.tokens),
+        credits: row.credits,
+        tokens: row.tokens,
       });
     }
   }
 
   let chatOtherCount = 0;
   if (hasChatOverflow) {
-    const countRows = await db.execute<{ cnt: string }>(
+    const countRows = await executeRawRows(
+      db,
       sql.raw(`
         ${usageRowsWith(p)},
         agg AS (
@@ -565,8 +592,9 @@ async function queryUsageInsightTopChats(
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100
       `),
+      usageInsightCountRowSchema,
     );
-    chatOtherCount = Number(countRows.rows[0]?.cnt ?? 0);
+    chatOtherCount = countRows[0]?.cnt ?? 0;
   }
 
   return { chats, chatOtherCount, chatOtherCredits };
@@ -600,7 +628,7 @@ export const zeroUsageInsight$ = command(
         : await queryUsageInsightAgentBuckets(db, params);
 
     signal.throwIfAborted();
-    const buckets = pivotBucketRows(bucketsResult.rows);
+    const buckets = pivotBucketRows(bucketsResult);
     const { grandTotalCredits, grandTotalTokens } =
       await queryUsageInsightGrandTotal(db, params);
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,13 +1,21 @@
 import { command } from "ccstate";
 import { sql } from "drizzle-orm";
-import type {
-  UsageRecordKind,
-  UsageRecordRow,
-  UsageRecordResponse,
-  UsageRecordScope,
-  UsageRecordSource,
+import {
+  type UsageRecordKind,
+  type UsageRecordRow,
+  type UsageRecordResponse,
+  type UsageRecordScope,
+  type UsageRecordSource,
+  usageRecordKindSchema,
+  usageRecordSourceSchema,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { z } from "zod";
 
+import {
+  executeRawRows,
+  pgInt8ToSafeIntegerSchema,
+  pgTimestampWithoutTimezoneToDateSchema,
+} from "../../lib/db-raw-rows";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
@@ -49,29 +57,53 @@ interface UsageRecordArgs {
   readonly source?: UsageRecordSource;
 }
 
-interface UsageRecordSqlRow extends Record<string, unknown> {
-  row_key: string;
-  source: string;
-  user_id: string;
-  thread_id: string | null;
-  run_id: string | null;
-  title: string | null;
-  credits: string;
-  tokens: string;
-  last_activity: Date | string;
-}
-
 interface UsageRecordIntermediateRow extends UsageRecordRow {
   readonly rowKey: string;
   readonly userId: string;
 }
 
-interface UsageRecordBreakdownSqlRow extends Record<string, unknown> {
-  row_key: string;
-  kind: string;
-  provider: string;
-  credits: string;
-}
+const usageRecordSqlRowSchema = z
+  .object({
+    row_key: z.string(),
+    source: usageRecordSourceSchema,
+    user_id: z.string(),
+    thread_id: z.string().nullable(),
+    run_id: z.string().nullable(),
+    title: z.string().nullable(),
+    credits: pgInt8ToSafeIntegerSchema,
+    tokens: pgInt8ToSafeIntegerSchema,
+    last_activity: pgTimestampWithoutTimezoneToDateSchema,
+  })
+  .transform((row): UsageRecordIntermediateRow => {
+    return {
+      rowKey: row.row_key,
+      source: row.source,
+      userId: row.user_id,
+      threadId: row.thread_id,
+      runId: row.run_id,
+      title: row.title,
+      credits: row.credits,
+      tokens: row.tokens,
+      breakdown: [],
+      member: null,
+      lastActivityAt: row.last_activity.toISOString(),
+    };
+  });
+
+const usageRecordTotalsSqlRowSchema = z.object({
+  total: pgInt8ToSafeIntegerSchema,
+  total_credits: pgInt8ToSafeIntegerSchema,
+});
+
+const usageRecordBreakdownSqlRowSchema = z.object({
+  row_key: z.string(),
+  kind: usageRecordKindSchema,
+  provider: z.string(),
+  credits: pgInt8ToSafeIntegerSchema,
+});
+type UsageRecordBreakdownSqlRow = z.output<
+  typeof usageRecordBreakdownSqlRowSchema
+>;
 
 function pgLit(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
@@ -217,7 +249,8 @@ async function queryUsageRecordRows(
   offset: number,
 ): Promise<UsageRecordIntermediateRow[]> {
   const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
-  const result = await db.execute<UsageRecordSqlRow>(
+  return await executeRawRows(
+    db,
     sql.raw(`
       ${recordCte}
       SELECT row_key, source, user_id, thread_id, run_id, title, credits, tokens, last_activity
@@ -226,26 +259,8 @@ async function queryUsageRecordRows(
       ORDER BY last_activity DESC
       LIMIT ${pageSize} OFFSET ${offset}
     `),
+    usageRecordSqlRowSchema,
   );
-  return result.rows.map((row) => {
-    const lastActivity =
-      row.last_activity instanceof Date
-        ? row.last_activity.toISOString()
-        : new Date(row.last_activity).toISOString();
-    return {
-      rowKey: row.row_key,
-      source: row.source as UsageRecordSource,
-      userId: row.user_id,
-      threadId: row.thread_id,
-      runId: row.run_id,
-      title: row.title,
-      credits: Number(row.credits),
-      tokens: Number(row.tokens),
-      breakdown: [],
-      member: null,
-      lastActivityAt: lastActivity,
-    };
-  });
 }
 
 async function queryUsageRecordTotals(
@@ -254,16 +269,18 @@ async function queryUsageRecordTotals(
   sourceFilterLit: string | null,
 ): Promise<{ total: number; totalCredits: number }> {
   const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
-  const result = await db.execute<{ total: string; total_credits: string }>(
+  const rows = await executeRawRows(
+    db,
     sql.raw(`
       ${recordCte}
       SELECT COUNT(*)::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
       FROM record ${where}
     `),
+    usageRecordTotalsSqlRowSchema,
   );
   return {
-    total: Number(result.rows[0]?.total ?? 0),
-    totalCredits: Number(result.rows[0]?.total_credits ?? 0),
+    total: rows[0]?.total ?? 0,
+    totalCredits: rows[0]?.total_credits ?? 0,
   };
 }
 
@@ -305,7 +322,8 @@ async function queryUsageRecordBreakdown(
   const sourceSql = sourceExpr("zr.trigger_source");
   const kindSql = usageKindExpr("ue.kind");
 
-  const result = await db.execute<UsageRecordBreakdownSqlRow>(
+  const rows = await executeRawRows(
+    db,
     sql.raw(`
       WITH usage_rows AS (
         SELECT
@@ -339,14 +357,15 @@ async function queryUsageRecordBreakdown(
       HAVING SUM(credits) > 0
       ORDER BY row_key, kind, provider
     `),
+    usageRecordBreakdownSqlRowSchema,
   );
 
   const byRow = new Map<
     string,
     Map<UsageRecordKind, UsageRecordBreakdownSqlRow[]>
   >();
-  for (const row of result.rows) {
-    const kind = row.kind as UsageRecordKind;
+  for (const row of rows) {
+    const kind = row.kind;
     const kinds = byRow.get(row.row_key) ?? new Map();
     const providers = kinds.get(kind) ?? [];
     providers.push(row);
@@ -371,7 +390,7 @@ async function queryUsageRecordBreakdown(
       const providers = providerRows.map((row) => {
         return {
           provider: row.provider,
-          credits: Number(row.credits),
+          credits: row.credits,
         };
       });
       breakdown.push({

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,8 +1,10 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, eq, like, or, sql } from "drizzle-orm";
+import { z } from "zod";
 
 import { db } from "../lib/db";
+import { executeRawRows } from "../lib/db-raw-rows";
 import { createDeferredPromise } from "../signals/utils";
 
 /**
@@ -14,6 +16,8 @@ const VM0_BDD_API_KEY_PREFIXES = [
   "vm0-key-bdd-fake-",
   "vm0-key-bdd-dev-seed-",
 ] as const;
+const databasePidRowSchema = z.object({ pid: z.int() });
+const waiterCountRowSchema = z.object({ waiterCount: z.int() });
 
 function bddVm0ApiKeyFilter(vendor: string, model: string) {
   const [fakePrefix, devSeedPrefix] = VM0_BDD_API_KEY_PREFIXES;
@@ -125,12 +129,16 @@ export async function holdOrgAdmissionLockFixture(args: {
   const started = createDeferredPromise<number>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
   const done = db().transaction(async (tx) => {
-    const result = await tx.execute<{ readonly pid: number }>(sql`
-      SELECT
-        pg_backend_pid() AS "pid",
-        pg_advisory_xact_lock(hashtext(${args.orgId}))
-    `);
-    const holderPid = result.rows[0]?.pid;
+    const rows = await executeRawRows(
+      tx,
+      sql`
+        SELECT
+          pg_backend_pid() AS "pid",
+          pg_advisory_xact_lock(hashtext(${args.orgId}))
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
     if (!holderPid) {
       throw new Error("Expected the admission lock holder pid");
     }
@@ -147,20 +155,24 @@ export async function holdOrgAdmissionLockFixture(args: {
     },
     done,
     waiterCount: async () => {
-      const result = await db().execute<{ readonly waiterCount: number }>(sql`
-        SELECT count(*)::int AS "waiterCount"
-        FROM pg_locks AS waiting
-        WHERE waiting.locktype = 'advisory'
-          AND NOT waiting.granted
-          AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
-            SELECT held.classid, held.objid, held.objsubid
-            FROM pg_locks AS held
-            WHERE held.locktype = 'advisory'
-              AND held.pid = ${holderPid}
-              AND held.granted
-          )
-      `);
-      return result.rows[0]?.waiterCount ?? 0;
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          SELECT count(*)::int AS "waiterCount"
+          FROM pg_locks AS waiting
+          WHERE waiting.locktype = 'advisory'
+            AND NOT waiting.granted
+            AND (waiting.classid, waiting.objid, waiting.objsubid) IN (
+              SELECT held.classid, held.objid, held.objsubid
+              FROM pg_locks AS held
+              WHERE held.locktype = 'advisory'
+                AND held.pid = ${holderPid}
+                AND held.granted
+            )
+        `,
+        waiterCountRowSchema,
+      );
+      return rows[0]?.waiterCount ?? 0;
     },
   };
 }
@@ -181,10 +193,14 @@ export async function holdChatMessageWritesFixture(args: {
   const released = createDeferredPromise<void>(args.signal);
   const done = db().transaction(async (tx) => {
     await tx.execute(sql`LOCK TABLE ${chatMessages} IN SHARE MODE`);
-    const result = await tx.execute<{ readonly pid: number }>(sql`
-      SELECT pg_backend_pid() AS "pid"
-    `);
-    const holderPid = result.rows[0]?.pid;
+    const rows = await executeRawRows(
+      tx,
+      sql`
+        SELECT pg_backend_pid() AS "pid"
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = rows[0]?.pid;
     if (!holderPid) {
       throw new Error("Expected the chat-message lock holder pid");
     }
@@ -201,23 +217,27 @@ export async function holdChatMessageWritesFixture(args: {
     },
     done,
     blockedWaiterCount: async () => {
-      const result = await db().execute<{ readonly waiterCount: number }>(sql`
-        WITH RECURSIVE blocked("pid") AS (
-          SELECT activity.pid
-          FROM pg_stat_activity AS activity
-          WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          WITH RECURSIVE blocked("pid") AS (
+            SELECT activity.pid
+            FROM pg_stat_activity AS activity
+            WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
 
-          UNION
+            UNION
 
-          SELECT activity.pid
-          FROM pg_stat_activity AS activity
-          INNER JOIN blocked AS blocker
-            ON blocker.pid = ANY(pg_blocking_pids(activity.pid))
-        )
-        SELECT count(*)::int AS "waiterCount"
-        FROM blocked
-      `);
-      return result.rows[0]?.waiterCount ?? 0;
+            SELECT activity.pid
+            FROM pg_stat_activity AS activity
+            INNER JOIN blocked AS blocker
+              ON blocker.pid = ANY(pg_blocking_pids(activity.pid))
+          )
+          SELECT count(*)::int AS "waiterCount"
+          FROM blocked
+        `,
+        waiterCountRowSchema,
+      );
+      return rows[0]?.waiterCount ?? 0;
     },
   };
 }

--- a/turbo/apps/api/src/test-fixtures/legacy-goals.ts
+++ b/turbo/apps/api/src/test-fixtures/legacy-goals.ts
@@ -9,7 +9,7 @@ import { db } from "../lib/db";
 export async function seedInvalidLegacyGoalMessages(
   threadId: string,
 ): Promise<void> {
-  const insertedInvalidActiveMarker = await db().execute(sql`
+  const { rowCount: insertedInvalidActiveMarkerCount } = await db().execute(sql`
     INSERT INTO chat_messages (
       chat_thread_id,
       role,
@@ -23,11 +23,11 @@ export async function seedInvalidLegacyGoalMessages(
       '{"objectiveBrief":{"bad":true}}'::jsonb
     )
   `);
-  if (insertedInvalidActiveMarker.rowCount !== 1) {
+  if (insertedInvalidActiveMarkerCount !== 1) {
     throw new Error("Expected one invalid active goal marker fixture");
   }
 
-  const inserted = await db().execute(sql`
+  const { rowCount: insertedCount } = await db().execute(sql`
     INSERT INTO chat_messages (
       chat_thread_id,
       role,
@@ -41,11 +41,12 @@ export async function seedInvalidLegacyGoalMessages(
       '{"objectiveBrief":{"bad":true}}'::jsonb
     )
   `);
-  if (inserted.rowCount !== 1) {
+  if (insertedCount !== 1) {
     throw new Error("Expected one legacy goal marker fixture");
   }
 
-  const insertedMissingSnapshotBrief = await db().execute(sql`
+  const { rowCount: insertedMissingSnapshotBriefCount } = await db().execute(
+    sql`
     INSERT INTO chat_messages (
       chat_thread_id,
       role,
@@ -58,8 +59,9 @@ export async function seedInvalidLegacyGoalMessages(
       'legacy snapshot without objective brief',
       '{"bad":true}'::jsonb
     )
-  `);
-  if (insertedMissingSnapshotBrief.rowCount !== 1) {
+    `,
+  );
+  if (insertedMissingSnapshotBriefCount !== 1) {
     throw new Error("Expected one legacy goal snapshot fixture");
   }
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
@@ -73,6 +73,13 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
         const result = await client.execute<Row>(query());
       `,
     },
+    {
+      code: `
+        async function run(client: Client, query: string) {
+          return await client.execute<Row>(query);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -138,6 +145,54 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
         const result = await database.transaction(async (transaction) => {
           return await transaction.execute(query());
         });
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import type { SQLWrapper } from "drizzle-orm";
+        async function unsafe(executor: Executor, query: SQLWrapper) {
+          const result = await executor.execute(query);
+        }
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import type { SQLWrapper as DrizzleQuery } from "drizzle-orm";
+        type Query = DrizzleQuery;
+        async function unsafe(db: Database, query: Query) {
+          const result = await db.execute<Row>(query);
+        }
+      `,
+      errors: [{ messageId: "rowTypeArgument" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql, type SQL } from "drizzle-orm";
+        function query(): SQL {
+          if (condition) {
+            return sql\`SELECT 1 AS value\`;
+          }
+          return sql\`SELECT 2 AS value\`;
+        }
+        const rows = (await db.execute(query())).rows;
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import type { SQLWrapper } from "drizzle-orm";
+        const result = await db.execute(query as unknown as SQLWrapper);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import type * as drizzle from "drizzle-orm";
+        async function unsafe(db: Database, query: drizzle.SQLWrapper) {
+          return await db.execute(query);
+        }
       `,
       errors: [{ messageId: "rawResult" }],
     },

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
 import { afterAll, describe, it } from "vitest";
 
 import { requireExecuteRowSchema } from "../rules/require-execute-row-schema.ts";
@@ -7,24 +8,56 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester();
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+const drizzlePreamble = `
+    type DrizzleDatabase =
+      import("drizzle-orm/node-postgres").NodePgDatabase;
+    declare const db: DrizzleDatabase;
+    declare const database: DrizzleDatabase;
+    declare const executor: DrizzleDatabase;
+    declare const tx: DrizzleDatabase;
+`;
 
 ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
   valid: [
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         await db.execute(sql\`DELETE FROM jobs\`);
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const holder = { query: sql\`DELETE FROM jobs\` };
+        await db.execute(holder.query);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const { rowCount } = await db.execute(sql\`DELETE FROM jobs\`);
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const { rowCount: deleted } = await db.execute(
           sql\`DELETE FROM jobs\`,
@@ -32,19 +65,35 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const { "rowCount": deleted } = await db.execute(
+          sql\`DELETE FROM jobs\`,
+        );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const { ["rowCount"]: deleted } = await db.execute(
+          sql\`DELETE FROM jobs\`,
+        );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const count = (await db.execute(sql\`DELETE FROM jobs\`)).rowCount;
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import * as drizzle from "drizzle-orm";
         await tx.execute(drizzle.sql\`SELECT pg_advisory_xact_lock(1)\`);
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         await db.execute(lockQuery());
         function lockQuery() {
@@ -53,51 +102,63 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       `,
     },
     {
-      code: `
+      code: `${drizzlePreamble}
+        import { commandQuery } from "./command-query";
+        const { rowCount } = await db.execute(commandQuery());
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        const result = await client.run<Row>("SELECT 1");
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        interface Client {
+          execute<TRow>(query: string): Promise<TRow>;
+        }
+        declare const client: Client;
         const result = await client.execute<Row>("SELECT 1");
       `,
     },
     {
-      code: `
-        import { sql } from "drizzle-orm";
-        function render(sql: (strings: TemplateStringsArray) => string) {
-          return client.execute<Row>(sql\`SELECT 1\`);
+      code: `${drizzlePreamble}
+        interface Contract {
+          execute: { path: string };
         }
+        declare const contract: Contract;
+        const route = contract.execute;
+        const path = contract.execute.path;
       `,
     },
     {
-      code: `
-        function query() {
-          return "SELECT 1";
+      code: `${drizzlePreamble}
+        interface Client {
+          execute<TRow>(query: string): Promise<TRow>;
         }
-        const result = await client.execute<Row>(query());
-      `,
-    },
-    {
-      code: `
-        async function run(client: Client, query: string) {
-          return await client.execute<Row>(query);
-        }
+        declare const client: Client;
+        const { execute: run } = client;
+        const result = await run<Row>("SELECT 1");
       `,
     },
   ],
   invalid: [
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const result = await db.execute<Row>(sql\`SELECT 1 AS value\`);
       `,
       errors: [{ messageId: "rowTypeArgument" }, { messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const result = await db.execute(sql\`SELECT 1 AS value\`);
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const result = await db.execute(sql\`SELECT 1 AS value\`);
         consume(result.rows);
@@ -105,14 +166,14 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const { rows } = await db.execute(sql\`SELECT 1 AS value\`);
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const { rowCount, rows } = await db.execute(
           sql\`DELETE FROM jobs RETURNING id\`,
@@ -121,7 +182,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const query = sql\`SELECT 1 AS value\`;
         return db.execute(query);
@@ -129,7 +190,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const query = () => sql\`SELECT 1 AS value\`;
         const result = await database.execute(query());
@@ -137,7 +198,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         function query() {
           return sql\`SELECT 1 AS value\`;
@@ -149,26 +210,29 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import type { SQLWrapper } from "drizzle-orm";
-        async function unsafe(executor: Executor, query: SQLWrapper) {
+        async function unsafe(
+          executor: DrizzleDatabase,
+          query: SQLWrapper,
+        ) {
           const result = await executor.execute(query);
         }
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import type { SQLWrapper as DrizzleQuery } from "drizzle-orm";
         type Query = DrizzleQuery;
-        async function unsafe(db: Database, query: Query) {
+        async function unsafe(db: DrizzleDatabase, query: Query) {
           const result = await db.execute<Row>(query);
         }
       `,
       errors: [{ messageId: "rowTypeArgument" }, { messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql, type SQL } from "drizzle-orm";
         function query(): SQL {
           if (condition) {
@@ -181,30 +245,33 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import type { SQLWrapper } from "drizzle-orm";
         const result = await db.execute(query as unknown as SQLWrapper);
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import type * as drizzle from "drizzle-orm";
-        async function unsafe(db: Database, query: drizzle.SQLWrapper) {
+        async function unsafe(
+          db: DrizzleDatabase,
+          query: drizzle.SQLWrapper,
+        ) {
           return await db.execute(query);
         }
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql as drizzleSql } from "drizzle-orm";
         const rows = (await tx.execute(drizzleSql.raw("SELECT 1"))).rows;
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const query = condition
           ? sql\`SELECT 1 AS value\`
@@ -214,7 +281,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const query = sql\`SELECT 1\`.append(sql\` AS value\`);
         const rows = (await tx.execute(query)).rows;
@@ -222,7 +289,7 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import * as drizzle from "drizzle-orm";
         const rows = (
           await tx.execute(drizzle.sql\`SELECT 1 AS value\`)
@@ -231,35 +298,35 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         consume(await db.execute(sql\`SELECT 1\`));
       `,
       errors: [{ messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const result = (await db.execute(sql\`SELECT 1\`)) as QueryResult<Row>;
       `,
       errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const row = (await db.execute(sql\`SELECT 1 AS value\`)).rows[0] as Row;
       `,
       errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const rows = (await db.execute(sql\`SELECT 1 AS value\`)).rows as Row[];
       `,
       errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const rowCount = (
           (await db.execute(sql\`DELETE FROM jobs\`)) as QueryResult
@@ -268,18 +335,91 @@ ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
       errors: [{ messageId: "assertedResult" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         await db.execute<Row>(sql\`DELETE FROM jobs\`);
       `,
       errors: [{ messageId: "rowTypeArgument" }],
     },
     {
-      code: `
+      code: `${drizzlePreamble}
         const result = await db.execute(sql\`SELECT 1\`);
         import { sql } from "drizzle-orm";
       `,
       errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const holder = { query: sql\`SELECT NOW() AS value\` };
+        const result = await db.execute<Row>(holder.query);
+      `,
+      errors: [{ messageId: "rowTypeArgument" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const queries = [sql\`SELECT 1 AS value\`];
+        const result = await db.execute(queries[0]);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQLWrapper } from "drizzle-orm";
+        const holder = {
+          query(): SQLWrapper {
+            return sql\`SELECT 1 AS value\`;
+          },
+        };
+        return await db.execute(holder.query());
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { importedQuery } from "./query";
+        const result = await db.execute(importedQuery());
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import type { SQLWrapper } from "drizzle-orm";
+        interface Query extends SQLWrapper {}
+        async function unsafe(db: DrizzleDatabase, query: Query) {
+          return await db.execute(query);
+        }
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import type { SQLWrapper } from "drizzle-orm";
+        type Query = Readonly<SQLWrapper>;
+        async function unsafe(db: DrizzleDatabase, query: Query) {
+          const result = await db.execute(query);
+        }
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const result = await db["execute"](query);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const execute = db.execute.bind(db);
+      `,
+      errors: [{ messageId: "executeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const { execute: run } = db;
+      `,
+      errors: [{ messageId: "executeReference" }],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-execute-row-schema.test.ts
@@ -1,0 +1,230 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { requireExecuteRowSchema } from "../rules/require-execute-row-schema.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("require-execute-row-schema", requireExecuteRowSchema, {
+  valid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        await db.execute(sql\`DELETE FROM jobs\`);
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const { rowCount } = await db.execute(sql\`DELETE FROM jobs\`);
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const { rowCount: deleted } = await db.execute(
+          sql\`DELETE FROM jobs\`,
+        );
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const count = (await db.execute(sql\`DELETE FROM jobs\`)).rowCount;
+      `,
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        await tx.execute(drizzle.sql\`SELECT pg_advisory_xact_lock(1)\`);
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        await db.execute(lockQuery());
+        function lockQuery() {
+          return sql\`SELECT pg_advisory_xact_lock(1)\`;
+        }
+      `,
+    },
+    {
+      code: `
+        const result = await client.execute<Row>("SELECT 1");
+      `,
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        function render(sql: (strings: TemplateStringsArray) => string) {
+          return client.execute<Row>(sql\`SELECT 1\`);
+        }
+      `,
+    },
+    {
+      code: `
+        function query() {
+          return "SELECT 1";
+        }
+        const result = await client.execute<Row>(query());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const result = await db.execute<Row>(sql\`SELECT 1 AS value\`);
+      `,
+      errors: [{ messageId: "rowTypeArgument" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const result = await db.execute(sql\`SELECT 1 AS value\`);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const result = await db.execute(sql\`SELECT 1 AS value\`);
+        consume(result.rows);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const { rows } = await db.execute(sql\`SELECT 1 AS value\`);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const { rowCount, rows } = await db.execute(
+          sql\`DELETE FROM jobs RETURNING id\`,
+        );
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const query = sql\`SELECT 1 AS value\`;
+        return db.execute(query);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const query = () => sql\`SELECT 1 AS value\`;
+        const result = await database.execute(query());
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        function query() {
+          return sql\`SELECT 1 AS value\`;
+        }
+        const result = await database.transaction(async (transaction) => {
+          return await transaction.execute(query());
+        });
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql as drizzleSql } from "drizzle-orm";
+        const rows = (await tx.execute(drizzleSql.raw("SELECT 1"))).rows;
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const query = condition
+          ? sql\`SELECT 1 AS value\`
+          : sql\`SELECT 2 AS value\`;
+        const result = await tx.execute(query);
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const query = sql\`SELECT 1\`.append(sql\` AS value\`);
+        const rows = (await tx.execute(query)).rows;
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        const rows = (
+          await tx.execute(drizzle.sql\`SELECT 1 AS value\`)
+        ).rows;
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        consume(await db.execute(sql\`SELECT 1\`));
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const result = (await db.execute(sql\`SELECT 1\`)) as QueryResult<Row>;
+      `,
+      errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const row = (await db.execute(sql\`SELECT 1 AS value\`)).rows[0] as Row;
+      `,
+      errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const rows = (await db.execute(sql\`SELECT 1 AS value\`)).rows as Row[];
+      `,
+      errors: [{ messageId: "assertedResult" }, { messageId: "rawResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const rowCount = (
+          (await db.execute(sql\`DELETE FROM jobs\`)) as QueryResult
+        ).rowCount;
+      `,
+      errors: [{ messageId: "assertedResult" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        await db.execute<Row>(sql\`DELETE FROM jobs\`);
+      `,
+      errors: [{ messageId: "rowTypeArgument" }],
+    },
+    {
+      code: `
+        const result = await db.execute(sql\`SELECT 1\`);
+        import { sql } from "drizzle-orm";
+      `,
+      errors: [{ messageId: "rawResult" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -6,6 +6,7 @@ import { noNewPromise } from "./rules/no-new-promise.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
+import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
 
 export const apiLintPlugin = {
@@ -22,6 +23,7 @@ export const apiLintPlugin = {
     "no-package-variable": noPackageVariable,
     "no-store-in-params": noStoreInParams,
     "no-test-vi-mocks": noTestViMocks,
+    "require-execute-row-schema": requireExecuteRowSchema,
     "signal-check-await": signalCheckAwait,
   },
 };

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -1,8 +1,9 @@
 import {
   AST_NODE_TYPES,
-  ASTUtils,
+  ESLintUtils,
   type TSESTree,
 } from "@typescript-eslint/utils";
+import type { Declaration } from "typescript";
 
 import { createRule } from "../utils.ts";
 
@@ -12,6 +13,16 @@ function memberName(node: TSESTree.MemberExpression): string | null {
   }
   if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
     return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function propertyName(node: TSESTree.Property): string | null {
+  if (!node.computed && node.key.type === AST_NODE_TYPES.Identifier) {
+    return node.key.name;
+  }
+  if (node.key.type === AST_NODE_TYPES.Literal) {
+    return typeof node.key.value === "string" ? node.key.value : null;
   }
   return null;
 }
@@ -26,11 +37,7 @@ function onlyDestructuresRowCount(pattern: TSESTree.BindingName): boolean {
   const [property] = pattern.properties;
   return (
     property?.type === AST_NODE_TYPES.Property &&
-    !property.computed &&
-    ((property.key.type === AST_NODE_TYPES.Identifier &&
-      property.key.name === "rowCount") ||
-      (property.key.type === AST_NODE_TYPES.Literal &&
-        property.key.value === "rowCount"))
+    propertyName(property) === "rowCount"
   );
 }
 
@@ -132,6 +139,11 @@ function executeUsage(node: TSESTree.CallExpression): ExecuteUsage {
   return { kind: "raw-result", assertion };
 }
 
+function isDrizzleDeclaration(node: Declaration): boolean {
+  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
+  return sourcePath.includes("/node_modules/drizzle-orm/");
+}
+
 export const requireExecuteRowSchema = createRule({
   name: "require-execute-row-schema",
   defaultOptions: [],
@@ -141,7 +153,7 @@ export const requireExecuteRowSchema = createRule({
       description:
         "Require runtime schemas for rows returned by Drizzle execute",
       recommended: true,
-      requiresTypeChecking: false,
+      requiresTypeChecking: true,
     },
     schema: [],
     messages: {
@@ -151,348 +163,41 @@ export const requireExecuteRowSchema = createRule({
         "Do not consume raw rows from Drizzle execute. Use executeRawRows(...) with a runtime schema; direct execute is only for discarded results or rowCount.",
       assertedResult:
         "A TypeScript assertion does not validate a Drizzle execute result. Decode rows with executeRawRows(...) instead.",
+      executeReference:
+        "Do not alias Drizzle execute. Call it directly so result safety can be enforced.",
     },
   },
   create(context) {
-    type DrizzleImportBinding =
-      | {
-          readonly kind: "namespace";
-          readonly typeOnly: boolean;
-        }
-      | {
-          readonly kind: "named";
-          readonly importedName: string;
-          readonly typeOnly: boolean;
-        };
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
 
-    function drizzleImportBinding(
-      identifier: TSESTree.Identifier,
-    ): DrizzleImportBinding | null {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      const definition = variable?.defs.find((candidate) => {
-        return candidate.type === "ImportBinding";
-      });
-      if (
-        !definition ||
-        definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
-        definition.parent.source.value !== "drizzle-orm"
-      ) {
-        return null;
-      }
-
-      const specifier = definition.node;
-      if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
-        return {
-          kind: "namespace",
-          typeOnly: definition.parent.importKind === "type",
-        };
-      }
-      if (specifier.type !== AST_NODE_TYPES.ImportSpecifier) {
-        return null;
-      }
-      return {
-        kind: "named",
-        importedName:
-          specifier.imported.type === AST_NODE_TYPES.Identifier
-            ? specifier.imported.name
-            : specifier.imported.value,
-        typeOnly:
-          definition.parent.importKind === "type" ||
-          specifier.importKind === "type",
-      };
-    }
-
-    function drizzleImportKind(
-      identifier: TSESTree.Identifier,
-    ): "namespace" | "sql" | null {
-      const binding = drizzleImportBinding(identifier);
-      if (!binding || binding.typeOnly) {
-        return null;
-      }
-      if (binding.kind === "namespace") {
-        return "namespace";
-      }
-      return binding.importedName === "sql" ? "sql" : null;
-    }
-
-    function isDrizzleSqlTypeImport(identifier: TSESTree.Identifier): boolean {
-      const binding = drizzleImportBinding(identifier);
-      return (
-        binding?.kind === "named" &&
-        (binding.importedName === "SQL" ||
-          binding.importedName === "SQLWrapper")
-      );
-    }
-
-    function isDrizzleNamespaceImport(
-      identifier: TSESTree.Identifier,
-    ): boolean {
-      return drizzleImportBinding(identifier)?.kind === "namespace";
-    }
-
-    function isDrizzleNamespaceType(
-      typeName: TSESTree.TSQualifiedName,
-    ): boolean {
-      return (
-        typeName.left.type === AST_NODE_TYPES.Identifier &&
-        isDrizzleNamespaceImport(typeName.left) &&
-        (typeName.right.name === "SQL" || typeName.right.name === "SQLWrapper")
-      );
-    }
-
-    function localTypeAlias(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.TypeNode | null {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      const definition = variable?.defs.find((candidate) => {
-        return (
-          candidate.type === "Type" &&
-          candidate.node.type === AST_NODE_TYPES.TSTypeAliasDeclaration
-        );
-      });
-      return definition?.node.type === AST_NODE_TYPES.TSTypeAliasDeclaration
-        ? definition.node.typeAnnotation
-        : null;
-    }
-
-    function isDrizzleSqlType(
-      typeNode: TSESTree.TypeNode,
-      seen: ReadonlySet<TSESTree.Node>,
-    ): boolean {
-      if (seen.has(typeNode)) {
+    function isDrizzleExecuteMember(node: TSESTree.MemberExpression): boolean {
+      if (memberName(node) !== "execute") {
         return false;
       }
-      const nextSeen = new Set(seen);
-      nextSeen.add(typeNode);
-
-      if (typeNode.type === AST_NODE_TYPES.TSTypeReference) {
-        if (typeNode.typeName.type === AST_NODE_TYPES.TSQualifiedName) {
-          return isDrizzleNamespaceType(typeNode.typeName);
-        }
-        if (typeNode.typeName.type !== AST_NODE_TYPES.Identifier) {
-          return false;
-        }
-        if (isDrizzleSqlTypeImport(typeNode.typeName)) {
-          return true;
-        }
-        const alias = localTypeAlias(typeNode.typeName);
-        return alias !== null && isDrizzleSqlType(alias, nextSeen);
-      }
-      if (
-        typeNode.type === AST_NODE_TYPES.TSUnionType ||
-        typeNode.type === AST_NODE_TYPES.TSIntersectionType
-      ) {
-        return typeNode.types.some((member) => {
-          return isDrizzleSqlType(member, nextSeen);
-        });
-      }
-      return false;
-    }
-
-    function isDrizzleSqlTag(tag: TSESTree.Expression): boolean {
-      if (tag.type === AST_NODE_TYPES.Identifier) {
-        return drizzleImportKind(tag) === "sql";
-      }
+      const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
+      const symbol = checker.getSymbolAtLocation(tsProperty);
       return (
-        tag.type === AST_NODE_TYPES.MemberExpression &&
-        tag.object.type === AST_NODE_TYPES.Identifier &&
-        drizzleImportKind(tag.object) === "namespace" &&
-        memberName(tag) === "sql"
+        symbol?.declarations?.some((declaration) => {
+          return isDrizzleDeclaration(declaration);
+        }) === true
       );
     }
 
-    function isDrizzleSqlObject(expression: TSESTree.Expression): boolean {
-      if (expression.type === AST_NODE_TYPES.Identifier) {
-        return drizzleImportKind(expression) === "sql";
-      }
-      return (
-        expression.type === AST_NODE_TYPES.MemberExpression &&
-        expression.object.type === AST_NODE_TYPES.Identifier &&
-        drizzleImportKind(expression.object) === "namespace" &&
-        memberName(expression) === "sql"
-      );
-    }
-
-    function variableInitializer(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.Expression | null {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      const definition = variable?.defs.find((candidate) => {
-        return (
-          candidate.type === "Variable" &&
-          candidate.node.type === AST_NODE_TYPES.VariableDeclarator
-        );
-      });
-      const initializer =
-        definition?.node.type === AST_NODE_TYPES.VariableDeclarator
-          ? definition.node.init
-          : null;
-      return initializer ?? null;
-    }
-
-    function variableDeclaredType(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.TypeNode | null {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      for (const declaration of variable?.identifiers ?? []) {
-        const annotation = declaration.typeAnnotation?.typeAnnotation;
-        if (annotation) {
-          return annotation;
-        }
-      }
-      return null;
-    }
-
-    type LocalFunction =
-      | TSESTree.FunctionDeclaration
-      | TSESTree.FunctionExpression
-      | TSESTree.ArrowFunctionExpression;
-
-    function localFunction(
-      identifier: TSESTree.Identifier,
-    ): LocalFunction | null {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      const definition = variable?.defs.find((candidate) => {
-        return candidate.type === "FunctionName";
-      });
-      const functionNode =
-        definition?.type === "FunctionName" &&
-        (definition.node.type === AST_NODE_TYPES.FunctionDeclaration ||
-          definition.node.type === AST_NODE_TYPES.FunctionExpression)
-          ? definition.node
-          : null;
-      const initializer = variableInitializer(identifier);
-      const variableFunction =
-        initializer?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-        initializer?.type === AST_NODE_TYPES.FunctionExpression
-          ? initializer
-          : null;
-      return functionNode ?? variableFunction;
-    }
-
-    function localFunctionResult(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.Expression | null {
-      const body = localFunction(identifier)?.body;
-      if (!body) {
-        return null;
-      }
-      if (body.type !== AST_NODE_TYPES.BlockStatement) {
-        return body;
-      }
-      const returns = body.body.filter((statement) => {
-        return statement.type === AST_NODE_TYPES.ReturnStatement;
-      });
-      if (returns.length !== 1) {
-        return null;
-      }
-      return returns[0]?.argument ?? null;
-    }
-
-    function localFunctionDeclaredResult(
-      identifier: TSESTree.Identifier,
-    ): TSESTree.TypeNode | null {
-      return localFunction(identifier)?.returnType?.typeAnnotation ?? null;
-    }
-
-    function isDrizzleQueryExpression(
-      expression: TSESTree.Expression,
-      seen: ReadonlySet<TSESTree.Node>,
-    ): boolean {
-      if (seen.has(expression)) {
-        return false;
-      }
-      const nextSeen = new Set(seen);
-      nextSeen.add(expression);
-
-      if (expression.type === AST_NODE_TYPES.TaggedTemplateExpression) {
-        return isDrizzleSqlTag(expression.tag);
-      }
+    function destructuresDrizzleExecute(node: TSESTree.Property): boolean {
       if (
-        expression.type === AST_NODE_TYPES.TSAsExpression ||
-        expression.type === AST_NODE_TYPES.TSTypeAssertion
-      ) {
-        return (
-          isDrizzleSqlType(expression.typeAnnotation, nextSeen) ||
-          isDrizzleQueryExpression(expression.expression, nextSeen)
-        );
-      }
-      if (
-        expression.type === AST_NODE_TYPES.TSNonNullExpression ||
-        expression.type === AST_NODE_TYPES.ChainExpression
-      ) {
-        return isDrizzleQueryExpression(expression.expression, nextSeen);
-      }
-      if (expression.type === AST_NODE_TYPES.Identifier) {
-        const initializer = variableInitializer(expression);
-        if (
-          initializer !== null &&
-          isDrizzleQueryExpression(initializer, nextSeen)
-        ) {
-          return true;
-        }
-        const declaredType = variableDeclaredType(expression);
-        return (
-          declaredType !== null && isDrizzleSqlType(declaredType, nextSeen)
-        );
-      }
-      if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
-        return (
-          isDrizzleQueryExpression(expression.consequent, nextSeen) ||
-          isDrizzleQueryExpression(expression.alternate, nextSeen)
-        );
-      }
-      if (expression.type === AST_NODE_TYPES.LogicalExpression) {
-        return (
-          isDrizzleQueryExpression(expression.left, nextSeen) ||
-          isDrizzleQueryExpression(expression.right, nextSeen)
-        );
-      }
-      if (expression.type === AST_NODE_TYPES.SequenceExpression) {
-        const last = expression.expressions.at(-1);
-        return last !== undefined && isDrizzleQueryExpression(last, nextSeen);
-      }
-      if (
-        expression.type === AST_NODE_TYPES.CallExpression &&
-        expression.callee.type === AST_NODE_TYPES.Identifier
-      ) {
-        const returned = localFunctionResult(expression.callee);
-        if (returned !== null && isDrizzleQueryExpression(returned, nextSeen)) {
-          return true;
-        }
-        const declaredResult = localFunctionDeclaredResult(expression.callee);
-        return (
-          declaredResult !== null && isDrizzleSqlType(declaredResult, nextSeen)
-        );
-      }
-      if (
-        expression.type !== AST_NODE_TYPES.CallExpression ||
-        expression.callee.type !== AST_NODE_TYPES.MemberExpression
+        node.parent.type !== AST_NODE_TYPES.ObjectPattern ||
+        propertyName(node) !== "execute"
       ) {
         return false;
       }
-      const receiver = expression.callee.object;
-      if (receiver.type === AST_NODE_TYPES.Super) {
-        return false;
-      }
+      const tsPattern = services.esTreeNodeToTSNodeMap.get(node.parent);
+      const patternType = checker.getTypeAtLocation(tsPattern);
+      const executeSymbol = checker.getPropertyOfType(patternType, "execute");
       return (
-        isDrizzleSqlObject(receiver) ||
-        isDrizzleQueryExpression(receiver, nextSeen)
+        executeSymbol?.declarations?.some((declaration) => {
+          return isDrizzleDeclaration(declaration);
+        }) === true
       );
     }
 
@@ -500,15 +205,7 @@ export const requireExecuteRowSchema = createRule({
       CallExpression(node: TSESTree.CallExpression): void {
         if (
           node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-          memberName(node.callee) !== "execute"
-        ) {
-          return;
-        }
-        const query = node.arguments[0];
-        if (
-          !query ||
-          query.type === AST_NODE_TYPES.SpreadElement ||
-          !isDrizzleQueryExpression(query, new Set())
+          !isDrizzleExecuteMember(node.callee)
         ) {
           return;
         }
@@ -526,6 +223,21 @@ export const requireExecuteRowSchema = createRule({
         }
         if (usage.kind === "raw-result") {
           context.report({ node, messageId: "rawResult" });
+        }
+      },
+      MemberExpression(node: TSESTree.MemberExpression): void {
+        if (
+          (node.parent.type === AST_NODE_TYPES.CallExpression &&
+            node.parent.callee === node) ||
+          !isDrizzleExecuteMember(node)
+        ) {
+          return;
+        }
+        context.report({ node, messageId: "executeReference" });
+      },
+      Property(node: TSESTree.Property): void {
+        if (destructuresDrizzleExecute(node)) {
+          context.report({ node, messageId: "executeReference" });
         }
       },
     };

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -154,9 +154,20 @@ export const requireExecuteRowSchema = createRule({
     },
   },
   create(context) {
-    function drizzleImportKind(
+    type DrizzleImportBinding =
+      | {
+          readonly kind: "namespace";
+          readonly typeOnly: boolean;
+        }
+      | {
+          readonly kind: "named";
+          readonly importedName: string;
+          readonly typeOnly: boolean;
+        };
+
+    function drizzleImportBinding(
       identifier: TSESTree.Identifier,
-    ): "namespace" | "sql" | null {
+    ): DrizzleImportBinding | null {
       const variable = ASTUtils.findVariable(
         context.sourceCode.getScope(identifier),
         identifier,
@@ -167,69 +178,59 @@ export const requireExecuteRowSchema = createRule({
       if (
         !definition ||
         definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
-        definition.parent.source.value !== "drizzle-orm" ||
-        definition.parent.importKind === "type"
+        definition.parent.source.value !== "drizzle-orm"
       ) {
         return null;
       }
 
       const specifier = definition.node;
       if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
-        return "namespace";
+        return {
+          kind: "namespace",
+          typeOnly: definition.parent.importKind === "type",
+        };
       }
-      if (
-        specifier.type !== AST_NODE_TYPES.ImportSpecifier ||
-        specifier.importKind === "type"
-      ) {
+      if (specifier.type !== AST_NODE_TYPES.ImportSpecifier) {
         return null;
       }
-      const importedName =
-        specifier.imported.type === AST_NODE_TYPES.Identifier
-          ? specifier.imported.name
-          : specifier.imported.value;
-      return importedName === "sql" ? "sql" : null;
+      return {
+        kind: "named",
+        importedName:
+          specifier.imported.type === AST_NODE_TYPES.Identifier
+            ? specifier.imported.name
+            : specifier.imported.value,
+        typeOnly:
+          definition.parent.importKind === "type" ||
+          specifier.importKind === "type",
+      };
+    }
+
+    function drizzleImportKind(
+      identifier: TSESTree.Identifier,
+    ): "namespace" | "sql" | null {
+      const binding = drizzleImportBinding(identifier);
+      if (!binding || binding.typeOnly) {
+        return null;
+      }
+      if (binding.kind === "namespace") {
+        return "namespace";
+      }
+      return binding.importedName === "sql" ? "sql" : null;
     }
 
     function isDrizzleSqlTypeImport(identifier: TSESTree.Identifier): boolean {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
+      const binding = drizzleImportBinding(identifier);
+      return (
+        binding?.kind === "named" &&
+        (binding.importedName === "SQL" ||
+          binding.importedName === "SQLWrapper")
       );
-      const definition = variable?.defs.find((candidate) => {
-        return candidate.type === "ImportBinding";
-      });
-      if (
-        !definition ||
-        definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
-        definition.parent.source.value !== "drizzle-orm" ||
-        definition.node.type !== AST_NODE_TYPES.ImportSpecifier
-      ) {
-        return false;
-      }
-      const importedName =
-        definition.node.imported.type === AST_NODE_TYPES.Identifier
-          ? definition.node.imported.name
-          : definition.node.imported.value;
-      return importedName === "SQL" || importedName === "SQLWrapper";
     }
 
     function isDrizzleNamespaceImport(
       identifier: TSESTree.Identifier,
     ): boolean {
-      const variable = ASTUtils.findVariable(
-        context.sourceCode.getScope(identifier),
-        identifier,
-      );
-      return (
-        variable?.defs.some((candidate) => {
-          return (
-            candidate.type === "ImportBinding" &&
-            candidate.parent.type === AST_NODE_TYPES.ImportDeclaration &&
-            candidate.parent.source.value === "drizzle-orm" &&
-            candidate.node.type === AST_NODE_TYPES.ImportNamespaceSpecifier
-          );
-        }) === true
-      );
+      return drizzleImportBinding(identifier)?.kind === "namespace";
     }
 
     function isDrizzleNamespaceType(

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -1,0 +1,378 @@
+import {
+  AST_NODE_TYPES,
+  ASTUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function onlyDestructuresRowCount(pattern: TSESTree.BindingName): boolean {
+  if (
+    pattern.type !== AST_NODE_TYPES.ObjectPattern ||
+    pattern.properties.length !== 1
+  ) {
+    return false;
+  }
+  const [property] = pattern.properties;
+  return (
+    property?.type === AST_NODE_TYPES.Property &&
+    !property.computed &&
+    ((property.key.type === AST_NODE_TYPES.Identifier &&
+      property.key.name === "rowCount") ||
+      (property.key.type === AST_NODE_TYPES.Literal &&
+        property.key.value === "rowCount"))
+  );
+}
+
+interface ExecuteUsage {
+  readonly kind: "discarded" | "row-count" | "raw-result";
+  readonly assertion: TSESTree.Node | null;
+}
+
+function resultAssertion(node: TSESTree.CallExpression): TSESTree.Node | null {
+  let current: TSESTree.Node = node;
+
+  while (current.parent) {
+    const parent: TSESTree.Node = current.parent;
+    if (
+      (parent.type === AST_NODE_TYPES.AwaitExpression &&
+        parent.argument === current) ||
+      (parent.type === AST_NODE_TYPES.ChainExpression &&
+        parent.expression === current) ||
+      (parent.type === AST_NODE_TYPES.TSNonNullExpression &&
+        parent.expression === current)
+    ) {
+      current = parent;
+      continue;
+    }
+    if (
+      (parent.type === AST_NODE_TYPES.TSAsExpression ||
+        parent.type === AST_NODE_TYPES.TSTypeAssertion) &&
+      parent.expression === current
+    ) {
+      return parent;
+    }
+    if (
+      parent.type === AST_NODE_TYPES.MemberExpression &&
+      parent.object === current
+    ) {
+      current = parent;
+      continue;
+    }
+    if (
+      parent.type === AST_NODE_TYPES.CallExpression &&
+      parent.callee === current
+    ) {
+      current = parent;
+      continue;
+    }
+    break;
+  }
+
+  return null;
+}
+
+function executeUsage(node: TSESTree.CallExpression): ExecuteUsage {
+  let current: TSESTree.Node = node;
+  const assertion = resultAssertion(node);
+
+  while (current.parent) {
+    const parent: TSESTree.Node = current.parent;
+    if (
+      (parent.type === AST_NODE_TYPES.AwaitExpression &&
+        parent.argument === current) ||
+      (parent.type === AST_NODE_TYPES.ChainExpression &&
+        parent.expression === current) ||
+      (parent.type === AST_NODE_TYPES.TSNonNullExpression &&
+        parent.expression === current) ||
+      ((parent.type === AST_NODE_TYPES.TSAsExpression ||
+        parent.type === AST_NODE_TYPES.TSTypeAssertion) &&
+        parent.expression === current)
+    ) {
+      current = parent;
+      continue;
+    }
+    if (
+      parent.type === AST_NODE_TYPES.MemberExpression &&
+      parent.object === current
+    ) {
+      return {
+        kind: memberName(parent) === "rowCount" ? "row-count" : "raw-result",
+        assertion,
+      };
+    }
+    if (
+      parent.type === AST_NODE_TYPES.VariableDeclarator &&
+      parent.init === current
+    ) {
+      return {
+        kind: onlyDestructuresRowCount(parent.id) ? "row-count" : "raw-result",
+        assertion,
+      };
+    }
+    if (
+      parent.type === AST_NODE_TYPES.ExpressionStatement &&
+      parent.expression === current
+    ) {
+      return { kind: "discarded", assertion };
+    }
+    return { kind: "raw-result", assertion };
+  }
+
+  return { kind: "raw-result", assertion };
+}
+
+export const requireExecuteRowSchema = createRule({
+  name: "require-execute-row-schema",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require runtime schemas for rows returned by Drizzle execute",
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      rowTypeArgument:
+        "Drizzle execute row generics are compile-only. Remove the type argument and use executeRawRows(...) with a runtime schema.",
+      rawResult:
+        "Do not consume raw rows from Drizzle execute. Use executeRawRows(...) with a runtime schema; direct execute is only for discarded results or rowCount.",
+      assertedResult:
+        "A TypeScript assertion does not validate a Drizzle execute result. Decode rows with executeRawRows(...) instead.",
+    },
+  },
+  create(context) {
+    function drizzleImportKind(
+      identifier: TSESTree.Identifier,
+    ): "namespace" | "sql" | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return candidate.type === "ImportBinding";
+      });
+      if (
+        !definition ||
+        definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
+        definition.parent.source.value !== "drizzle-orm" ||
+        definition.parent.importKind === "type"
+      ) {
+        return null;
+      }
+
+      const specifier = definition.node;
+      if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+        return "namespace";
+      }
+      if (
+        specifier.type !== AST_NODE_TYPES.ImportSpecifier ||
+        specifier.importKind === "type"
+      ) {
+        return null;
+      }
+      const importedName =
+        specifier.imported.type === AST_NODE_TYPES.Identifier
+          ? specifier.imported.name
+          : specifier.imported.value;
+      return importedName === "sql" ? "sql" : null;
+    }
+
+    function isDrizzleSqlTag(tag: TSESTree.Expression): boolean {
+      if (tag.type === AST_NODE_TYPES.Identifier) {
+        return drizzleImportKind(tag) === "sql";
+      }
+      return (
+        tag.type === AST_NODE_TYPES.MemberExpression &&
+        tag.object.type === AST_NODE_TYPES.Identifier &&
+        drizzleImportKind(tag.object) === "namespace" &&
+        memberName(tag) === "sql"
+      );
+    }
+
+    function isDrizzleSqlObject(expression: TSESTree.Expression): boolean {
+      if (expression.type === AST_NODE_TYPES.Identifier) {
+        return drizzleImportKind(expression) === "sql";
+      }
+      return (
+        expression.type === AST_NODE_TYPES.MemberExpression &&
+        expression.object.type === AST_NODE_TYPES.Identifier &&
+        drizzleImportKind(expression.object) === "namespace" &&
+        memberName(expression) === "sql"
+      );
+    }
+
+    function variableInitializer(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.Expression | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return (
+          candidate.type === "Variable" &&
+          candidate.node.type === AST_NODE_TYPES.VariableDeclarator
+        );
+      });
+      const initializer =
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator
+          ? definition.node.init
+          : null;
+      return initializer ?? null;
+    }
+
+    function localFunctionResult(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.Expression | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return candidate.type === "FunctionName";
+      });
+      const functionNode =
+        definition?.type === "FunctionName" &&
+        (definition.node.type === AST_NODE_TYPES.FunctionDeclaration ||
+          definition.node.type === AST_NODE_TYPES.FunctionExpression)
+          ? definition.node
+          : null;
+      const initializer = variableInitializer(identifier);
+      const variableFunction =
+        initializer?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        initializer?.type === AST_NODE_TYPES.FunctionExpression
+          ? initializer
+          : null;
+      const body = functionNode?.body ?? variableFunction?.body;
+      if (!body) {
+        return null;
+      }
+      if (body.type !== AST_NODE_TYPES.BlockStatement) {
+        return body;
+      }
+      const returns = body.body.filter((statement) => {
+        return statement.type === AST_NODE_TYPES.ReturnStatement;
+      });
+      if (returns.length !== 1) {
+        return null;
+      }
+      return returns[0]?.argument ?? null;
+    }
+
+    function isDrizzleQueryExpression(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      if (seen.has(expression)) {
+        return false;
+      }
+      const nextSeen = new Set(seen);
+      nextSeen.add(expression);
+
+      if (expression.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        return isDrizzleSqlTag(expression.tag);
+      }
+      if (
+        expression.type === AST_NODE_TYPES.TSAsExpression ||
+        expression.type === AST_NODE_TYPES.TSTypeAssertion ||
+        expression.type === AST_NODE_TYPES.TSNonNullExpression ||
+        expression.type === AST_NODE_TYPES.ChainExpression
+      ) {
+        return isDrizzleQueryExpression(expression.expression, nextSeen);
+      }
+      if (expression.type === AST_NODE_TYPES.Identifier) {
+        const initializer = variableInitializer(expression);
+        return (
+          initializer !== null &&
+          isDrizzleQueryExpression(initializer, nextSeen)
+        );
+      }
+      if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
+        return (
+          isDrizzleQueryExpression(expression.consequent, nextSeen) ||
+          isDrizzleQueryExpression(expression.alternate, nextSeen)
+        );
+      }
+      if (expression.type === AST_NODE_TYPES.LogicalExpression) {
+        return (
+          isDrizzleQueryExpression(expression.left, nextSeen) ||
+          isDrizzleQueryExpression(expression.right, nextSeen)
+        );
+      }
+      if (expression.type === AST_NODE_TYPES.SequenceExpression) {
+        const last = expression.expressions.at(-1);
+        return last !== undefined && isDrizzleQueryExpression(last, nextSeen);
+      }
+      if (
+        expression.type === AST_NODE_TYPES.CallExpression &&
+        expression.callee.type === AST_NODE_TYPES.Identifier
+      ) {
+        const returned = localFunctionResult(expression.callee);
+        return (
+          returned !== null && isDrizzleQueryExpression(returned, nextSeen)
+        );
+      }
+      if (
+        expression.type !== AST_NODE_TYPES.CallExpression ||
+        expression.callee.type !== AST_NODE_TYPES.MemberExpression
+      ) {
+        return false;
+      }
+      const receiver = expression.callee.object;
+      if (receiver.type === AST_NODE_TYPES.Super) {
+        return false;
+      }
+      return (
+        isDrizzleSqlObject(receiver) ||
+        isDrizzleQueryExpression(receiver, nextSeen)
+      );
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (
+          node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+          memberName(node.callee) !== "execute"
+        ) {
+          return;
+        }
+        const query = node.arguments[0];
+        if (
+          !query ||
+          query.type === AST_NODE_TYPES.SpreadElement ||
+          !isDrizzleQueryExpression(query, new Set())
+        ) {
+          return;
+        }
+
+        if (node.typeArguments?.params.length) {
+          context.report({ node, messageId: "rowTypeArgument" });
+        }
+
+        const usage = executeUsage(node);
+        if (usage.assertion) {
+          context.report({
+            node: usage.assertion,
+            messageId: "assertedResult",
+          });
+        }
+        if (usage.kind === "raw-result") {
+          context.report({ node, messageId: "rawResult" });
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -190,6 +190,110 @@ export const requireExecuteRowSchema = createRule({
       return importedName === "sql" ? "sql" : null;
     }
 
+    function isDrizzleSqlTypeImport(identifier: TSESTree.Identifier): boolean {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return candidate.type === "ImportBinding";
+      });
+      if (
+        !definition ||
+        definition.parent.type !== AST_NODE_TYPES.ImportDeclaration ||
+        definition.parent.source.value !== "drizzle-orm" ||
+        definition.node.type !== AST_NODE_TYPES.ImportSpecifier
+      ) {
+        return false;
+      }
+      const importedName =
+        definition.node.imported.type === AST_NODE_TYPES.Identifier
+          ? definition.node.imported.name
+          : definition.node.imported.value;
+      return importedName === "SQL" || importedName === "SQLWrapper";
+    }
+
+    function isDrizzleNamespaceImport(
+      identifier: TSESTree.Identifier,
+    ): boolean {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      return (
+        variable?.defs.some((candidate) => {
+          return (
+            candidate.type === "ImportBinding" &&
+            candidate.parent.type === AST_NODE_TYPES.ImportDeclaration &&
+            candidate.parent.source.value === "drizzle-orm" &&
+            candidate.node.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+          );
+        }) === true
+      );
+    }
+
+    function isDrizzleNamespaceType(
+      typeName: TSESTree.TSQualifiedName,
+    ): boolean {
+      return (
+        typeName.left.type === AST_NODE_TYPES.Identifier &&
+        isDrizzleNamespaceImport(typeName.left) &&
+        (typeName.right.name === "SQL" || typeName.right.name === "SQLWrapper")
+      );
+    }
+
+    function localTypeAlias(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.TypeNode | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return (
+          candidate.type === "Type" &&
+          candidate.node.type === AST_NODE_TYPES.TSTypeAliasDeclaration
+        );
+      });
+      return definition?.node.type === AST_NODE_TYPES.TSTypeAliasDeclaration
+        ? definition.node.typeAnnotation
+        : null;
+    }
+
+    function isDrizzleSqlType(
+      typeNode: TSESTree.TypeNode,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      if (seen.has(typeNode)) {
+        return false;
+      }
+      const nextSeen = new Set(seen);
+      nextSeen.add(typeNode);
+
+      if (typeNode.type === AST_NODE_TYPES.TSTypeReference) {
+        if (typeNode.typeName.type === AST_NODE_TYPES.TSQualifiedName) {
+          return isDrizzleNamespaceType(typeNode.typeName);
+        }
+        if (typeNode.typeName.type !== AST_NODE_TYPES.Identifier) {
+          return false;
+        }
+        if (isDrizzleSqlTypeImport(typeNode.typeName)) {
+          return true;
+        }
+        const alias = localTypeAlias(typeNode.typeName);
+        return alias !== null && isDrizzleSqlType(alias, nextSeen);
+      }
+      if (
+        typeNode.type === AST_NODE_TYPES.TSUnionType ||
+        typeNode.type === AST_NODE_TYPES.TSIntersectionType
+      ) {
+        return typeNode.types.some((member) => {
+          return isDrizzleSqlType(member, nextSeen);
+        });
+      }
+      return false;
+    }
+
     function isDrizzleSqlTag(tag: TSESTree.Expression): boolean {
       if (tag.type === AST_NODE_TYPES.Identifier) {
         return drizzleImportKind(tag) === "sql";
@@ -234,9 +338,30 @@ export const requireExecuteRowSchema = createRule({
       return initializer ?? null;
     }
 
-    function localFunctionResult(
+    function variableDeclaredType(
       identifier: TSESTree.Identifier,
-    ): TSESTree.Expression | null {
+    ): TSESTree.TypeNode | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier,
+      );
+      for (const declaration of variable?.identifiers ?? []) {
+        const annotation = declaration.typeAnnotation?.typeAnnotation;
+        if (annotation) {
+          return annotation;
+        }
+      }
+      return null;
+    }
+
+    type LocalFunction =
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression
+      | TSESTree.ArrowFunctionExpression;
+
+    function localFunction(
+      identifier: TSESTree.Identifier,
+    ): LocalFunction | null {
       const variable = ASTUtils.findVariable(
         context.sourceCode.getScope(identifier),
         identifier,
@@ -256,7 +381,13 @@ export const requireExecuteRowSchema = createRule({
         initializer?.type === AST_NODE_TYPES.FunctionExpression
           ? initializer
           : null;
-      const body = functionNode?.body ?? variableFunction?.body;
+      return functionNode ?? variableFunction;
+    }
+
+    function localFunctionResult(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.Expression | null {
+      const body = localFunction(identifier)?.body;
       if (!body) {
         return null;
       }
@@ -270,6 +401,12 @@ export const requireExecuteRowSchema = createRule({
         return null;
       }
       return returns[0]?.argument ?? null;
+    }
+
+    function localFunctionDeclaredResult(
+      identifier: TSESTree.Identifier,
+    ): TSESTree.TypeNode | null {
+      return localFunction(identifier)?.returnType?.typeAnnotation ?? null;
     }
 
     function isDrizzleQueryExpression(
@@ -287,7 +424,14 @@ export const requireExecuteRowSchema = createRule({
       }
       if (
         expression.type === AST_NODE_TYPES.TSAsExpression ||
-        expression.type === AST_NODE_TYPES.TSTypeAssertion ||
+        expression.type === AST_NODE_TYPES.TSTypeAssertion
+      ) {
+        return (
+          isDrizzleSqlType(expression.typeAnnotation, nextSeen) ||
+          isDrizzleQueryExpression(expression.expression, nextSeen)
+        );
+      }
+      if (
         expression.type === AST_NODE_TYPES.TSNonNullExpression ||
         expression.type === AST_NODE_TYPES.ChainExpression
       ) {
@@ -295,9 +439,15 @@ export const requireExecuteRowSchema = createRule({
       }
       if (expression.type === AST_NODE_TYPES.Identifier) {
         const initializer = variableInitializer(expression);
-        return (
+        if (
           initializer !== null &&
           isDrizzleQueryExpression(initializer, nextSeen)
+        ) {
+          return true;
+        }
+        const declaredType = variableDeclaredType(expression);
+        return (
+          declaredType !== null && isDrizzleSqlType(declaredType, nextSeen)
         );
       }
       if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
@@ -321,8 +471,12 @@ export const requireExecuteRowSchema = createRule({
         expression.callee.type === AST_NODE_TYPES.Identifier
       ) {
         const returned = localFunctionResult(expression.callee);
+        if (returned !== null && isDrizzleQueryExpression(returned, nextSeen)) {
+          return true;
+        }
+        const declaredResult = localFunctionDeclaredResult(expression.callee);
         return (
-          returned !== null && isDrizzleQueryExpression(returned, nextSeen)
+          declaredResult !== null && isDrizzleSqlType(declaredResult, nextSeen)
         );
       }
       if (


### PR DESCRIPTION
## Summary

- add a single Zod-derived boundary for irreducible raw Drizzle execute rows
- migrate all 44 compile-only `execute<Row>` consumers: 34 to runtime row schemas and 10 simple lock/read queries to structured Drizzle selections
- make all eight command-metadata consumers explicitly extract `rowCount`, while preserving 38 result-discarding commands
- enable a binding- and type-annotation-aware lint rule that prevents row generics, raw-row consumption, assertions, and typed SQL wrappers from reopening the unchecked boundary

## Migration ledger

| # | Consumer | Treatment | PostgreSQL integration path |
| ---: | --- | --- | --- |
| 1 | planner diagnostic | schema | API benchmark |
| 2 | runner claim run lock | structured `FOR UPDATE` | run lifecycle |
| 3 | runner job lock/expiry | schema | run lifecycle |
| 4 | claimed-job transition CTE | schema | run lifecycle |
| 5 | runtime admission-lock holder PID | schema | chat admission contention |
| 6 | runtime admission-lock state | schema | chat admission contention |
| 7 | artifact URL access | schema | artifacts |
| 8 | message-send active run | schema | chat messages |
| 9 | derived run-persistence lock | structured `FOR UPDATE` | run lifecycle |
| 10 | firewall database clock | schema, lossless bigint | firewall auth |
| 11 | snapshot compaction batch | schema | chat threads |
| 12 | snapshot event pruning | schema | chat threads |
| 13 | callback active run | schema | chat callbacks |
| 14 | queued-dispatch thread lock | structured `FOR UPDATE` | chat messages |
| 15 | queued-dispatch run lock | structured `FOR UPDATE OF agent_runs` | chat messages |
| 16 | competing queued run | schema | chat messages |
| 17 | auto-send marker thread lock | structured `FOR KEY SHARE` | chat callbacks |
| 18 | model rankings | schema, safe int8 | ops/model stats |
| 19 | storage cache pruning | schema | storage cache |
| 20 | incomplete chat frontier | schema | chat messages |
| 21 | queue-marker run lock | structured `FOR UPDATE` | chat messages |
| 22 | queued-message thread lock | structured `FOR UPDATE` | chat messages |
| 23 | paginated artifact list | schema, timestamp/int8 | artifacts |
| 24 | artifact visibility | schema | artifacts |
| 25 | thread-deletion ownership lock | structured `FOR UPDATE` | chat threads |
| 26 | email drain by ID | schema, JSON/array unions | email |
| 27 | email FIFO drain | schema, JSON/array unions | email |
| 28 | managed-usage credit/pricing | schema, lossless bigint | scrape/web search |
| 29 | run-admission credit | schema, safe int8 | run lifecycle |
| 30 | run-cancel lock | structured `FOR UPDATE` | run lifecycle |
| 31 | queue-promotion run lock | structured `FOR UPDATE` | run lifecycle |
| 32 | insight source buckets | schema | usage insights |
| 33 | insight agent buckets | schema | usage insights |
| 34 | insight grand total | schema | usage insights |
| 35 | insight channel totals | schema + enum | usage insights |
| 36 | insight top chats | schema | usage insights |
| 37 | insight overflow count | schema | usage insights |
| 38 | usage-record page | schema + enum/timestamp | usage records |
| 39 | usage-record totals | schema | usage records |
| 40 | usage-record breakdown | schema + enum | usage records |
| 41 | admission fixture PID | schema | run lock contention |
| 42 | admission fixture waiter count | schema | run lock contention |
| 43 | chat-write fixture PID | schema | chat lock contention |
| 44 | chat-write fixture waiter count | schema | chat lock contention |

The raw-row helper executes without a row generic and parses every returned driver row. Output types come only from the supplied schema. Schema transforms replace existing number/timestamp normalization passes, so no query, round trip, join, or avoidable second result-array pass was added.

The lint rule has 34 cases covering named, renamed, namespace, later-declared, and shadowed SQL bindings; SQL/SQLWrapper parameters, aliases, assertions, and function return annotations; variables and local helpers; transactions and chained/conditional SQL; discard and `rowCount`; assignment, return, destructuring, and row access. The schema helper's exact config exception is now exercised by the API lint rather than being implicitly invisible to the rule.

## Explicit exclusions

- no schema, migration, or persisted-data change
- no public API, queue payload, runner protocol, feature switch, or deployment-compatibility change
- structured selected `sql<T>`, contextual `SQL<T>`, and downstream selected-result assertions remain in #22139
- this child does not close parent #22128

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm check-types` (pre-commit; 13 workspaces)
- `pnpm knip`
- `pnpm -F api build`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/require-execute-row-schema.test.ts --silent=passed-only` (34 passed)
- focused `pnpm -F api exec vitest run ... --maxWorkers=1 --silent=passed-only` invocations for run lifecycle, chat messages/callbacks/threads, artifacts, email, firewall auth, storage cache, cron cleanup/compaction, usage records/insights, managed scrape/search usage, model stats, and legacy goals
- `pnpm -F api exec vitest bench --run --outputJson /tmp/issue-22138-bench.json` (all seven routes passed; planner diagnostic retained a hash join and reported 0.783 ms for the seeded 200-row query)

A one-database unsharded API run passed 2,267 tests and had two cross-file database-interference failures: a chat lock fixture observed another file's blocked writer, and cron summarization observed concurrent summaries. Both files passed in isolation after resetting the local database. CI uses fresh databases across eight shards; no test was skipped or weakened.

Closes #22138

Parent objective: #22128

Follow-up: #22139
