### PR TITLE
ci(platform): decouple cloudflare pages release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1448,23 +1448,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
 
-      - name: Install AWS CLI
-        run: |
-          architecture="$(dpkg --print-architecture)"
-          case "$architecture" in
-            amd64) aws_architecture="x86_64" ;;
-            arm64) aws_architecture="aarch64" ;;
-            *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;;
-          esac
-
-          curl -fsSL --retry 3 \
-            "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
-            --output /tmp/awscliv2.zip
-          python3 -m zipfile -e /tmp/awscliv2.zip /tmp/awscli
-          chmod +x /tmp/awscli/aws/install /tmp/awscli/aws/dist/aws
-          /tmp/awscli/aws/install
-          aws --version
-
       - name: Start GitHub Deployment
         id: deployment
         uses: bobheadxi/deployments@v1
@@ -1495,83 +1478,6 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare Cloudflare Pages production deployment
-        id: pages-production
-        env:
-          ARTIFACT_SHA: ${{ needs.build-app-production.outputs.git_sha }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
-          R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
-        run: |
-          set -euo pipefail
-
-          : "${AWS_ACCESS_KEY_ID:?R2_STATIC_ACCESS_KEY_ID secret is required}"
-          : "${AWS_SECRET_ACCESS_KEY:?R2_STATIC_SECRET_ACCESS_KEY secret is required}"
-          : "${ARTIFACT_SHA:?build-app-production git_sha output is required}"
-          : "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID variable is required}"
-          : "${R2_BUCKET_NAME:?R2_STATIC_BUCKET_NAME variable is required}"
-          if [[ ! "$ARTIFACT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Artifact commit must be a full lowercase SHA-1: $ARTIFACT_SHA" >&2
-            exit 1
-          fi
-
-          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          artifact_uri="s3://${R2_BUCKET_NAME}/okou-app/${ARTIFACT_SHA}"
-          ready_key="okou-app/${ARTIFACT_SHA}/ready.json"
-          canonical_dist="$(mktemp -d)"
-          pages_dist="$(mktemp -d)"
-          error_log="$(mktemp)"
-
-          for attempt in $(seq 1 60); do
-            set +e
-            aws s3api head-object \
-              --endpoint-url "$r2_endpoint" \
-              --bucket "$R2_BUCKET_NAME" \
-              --key "$ready_key" \
-              >/dev/null 2>"$error_log"
-            status=$?
-            set -e
-
-            if (( status == 0 )); then
-              break
-            fi
-            if ! grep -Eq '404|NotFound|Not Found|NoSuchKey' "$error_log"; then
-              cat "$error_log" >&2
-              exit "$status"
-            fi
-            if (( attempt == 60 )); then
-              echo "Artifact was not ready after 10 minutes: $artifact_uri" >&2
-              exit 1
-            fi
-            echo "Waiting for artifact: $artifact_uri (attempt $attempt/60)"
-            sleep 10
-          done
-
-          aws s3 cp "$artifact_uri/" "$canonical_dist/" \
-            --endpoint-url "$r2_endpoint" \
-            --recursive
-          bash .github/scripts/verify-okou-app-artifact.sh \
-            "$canonical_dist" \
-            "$ARTIFACT_SHA"
-          bash .github/scripts/prepare-okou-pages-dist.sh \
-            "$canonical_dist" \
-            "$pages_dist"
-
-          echo "canonical-dist=$canonical_dist" >> "$GITHUB_OUTPUT"
-          echo "pages-dist=$pages_dist" >> "$GITHUB_OUTPUT"
-
-      - name: Upload Cloudflare Pages source maps to Sentry
-        env:
-          CANONICAL_DIST: ${{ steps.pages-production.outputs.canonical-dist }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_APP }}
-        working-directory: turbo
-        run: |
-          pnpm --filter @vm0/app exec sentry-cli sourcemaps upload "$CANONICAL_DIST"
-
       - name: Promote App Deployment
         uses: ./.github/actions/vercel-promote
         with:
@@ -1579,35 +1485,6 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
           deployment-url: ${{ needs.build-app-production.outputs.deployment_url }}
-
-      - name: Deploy Cloudflare Pages production
-        env:
-          ARTIFACT_SHA: ${{ needs.build-app-production.outputs.git_sha }}
-          CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
-          PAGES_DIST: ${{ steps.pages-production.outputs.pages-dist }}
-        working-directory: turbo
-        run: |
-          set -euo pipefail
-          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
-          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
-          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
-          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
-            --project-name "$CF_PAGES_PROJECT_NAME" \
-            --branch production \
-            --commit-hash "$ARTIFACT_SHA" \
-            --commit-dirty=false
-
-          production_url="https://${CF_PAGES_PROJECT_NAME}.pages.dev"
-          curl -fsSL \
-            --retry 12 \
-            --retry-delay 5 \
-            --retry-max-time 120 \
-            --retry-all-errors \
-            "$production_url" \
-            --output /dev/null
-          echo "Cloudflare Pages production is serving: $production_url"
 
       - name: Resolve Vercel dashboard URL
         id: vercel-dashboard
@@ -1670,6 +1547,158 @@ jobs:
                 text:
                   type: mrkdwn
                   text: "*App* ❌ Promote failed\n📦 Version: `${{ needs.release-please.outputs.app_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/platform-v${{ needs.release-please.outputs.app_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+
+  # Publish the immutable app artifact to Cloudflare Pages independently from
+  # the Vercel staged build and traffic promotion. If the same release run also
+  # promotes API, wait for API traffic to be live first.
+  deploy-app-cloudflare-production:
+    needs: [release-please, promote-api-production]
+    if: >-
+      always() &&
+      needs.release-please.outputs.app_release_created == 'true' &&
+      (needs.release-please.outputs.api_deploy_required != 'true' ||
+       needs.promote-api-production.result == 'success')
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+    environment: production
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Resolve App Build Commit SHA
+        id: build-commit
+        run: |
+          sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Install AWS CLI
+        run: |
+          architecture="$(dpkg --print-architecture)"
+          case "$architecture" in
+            amd64) aws_architecture="x86_64" ;;
+            arm64) aws_architecture="aarch64" ;;
+            *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;;
+          esac
+
+          curl -fsSL --retry 3 \
+            "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+            --output /tmp/awscliv2.zip
+          python3 -m zipfile -e /tmp/awscliv2.zip /tmp/awscli
+          chmod +x /tmp/awscli/aws/install /tmp/awscli/aws/dist/aws
+          /tmp/awscli/aws/install
+          aws --version
+
+      - name: Prepare Cloudflare Pages production deployment
+        id: pages-production
+        env:
+          ARTIFACT_SHA: ${{ steps.build-commit.outputs.sha }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
+        run: |
+          set -euo pipefail
+
+          : "${AWS_ACCESS_KEY_ID:?R2_STATIC_ACCESS_KEY_ID secret is required}"
+          : "${AWS_SECRET_ACCESS_KEY:?R2_STATIC_SECRET_ACCESS_KEY secret is required}"
+          : "${ARTIFACT_SHA:?resolved app build commit SHA is required}"
+          : "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID variable is required}"
+          : "${R2_BUCKET_NAME:?R2_STATIC_BUCKET_NAME variable is required}"
+          if [[ ! "$ARTIFACT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Artifact commit must be a full lowercase SHA-1: $ARTIFACT_SHA" >&2
+            exit 1
+          fi
+
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          artifact_uri="s3://${R2_BUCKET_NAME}/okou-app/${ARTIFACT_SHA}"
+          ready_key="okou-app/${ARTIFACT_SHA}/ready.json"
+          canonical_dist="$(mktemp -d)"
+          pages_dist="$(mktemp -d)"
+          error_log="$(mktemp)"
+
+          for attempt in $(seq 1 60); do
+            set +e
+            aws s3api head-object \
+              --endpoint-url "$r2_endpoint" \
+              --bucket "$R2_BUCKET_NAME" \
+              --key "$ready_key" \
+              >/dev/null 2>"$error_log"
+            status=$?
+            set -e
+
+            if (( status == 0 )); then
+              break
+            fi
+            if ! grep -Eq '404|NotFound|Not Found|NoSuchKey' "$error_log"; then
+              cat "$error_log" >&2
+              exit "$status"
+            fi
+            if (( attempt == 60 )); then
+              echo "Artifact was not ready after 10 minutes: $artifact_uri" >&2
+              exit 1
+            fi
+            echo "Waiting for artifact: $artifact_uri (attempt $attempt/60)"
+            sleep 10
+          done
+
+          aws s3 cp "$artifact_uri/" "$canonical_dist/" \
+            --endpoint-url "$r2_endpoint" \
+            --recursive
+          bash .github/scripts/verify-okou-app-artifact.sh \
+            "$canonical_dist" \
+            "$ARTIFACT_SHA"
+          bash .github/scripts/prepare-okou-pages-dist.sh \
+            "$canonical_dist" \
+            "$pages_dist"
+
+          echo "canonical-dist=$canonical_dist" >> "$GITHUB_OUTPUT"
+          echo "pages-dist=$pages_dist" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Cloudflare Pages source maps to Sentry
+        env:
+          CANONICAL_DIST: ${{ steps.pages-production.outputs.canonical-dist }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_APP }}
+        working-directory: turbo
+        run: |
+          pnpm --filter @vm0/app exec sentry-cli sourcemaps upload "$CANONICAL_DIST"
+
+      - name: Deploy Cloudflare Pages production
+        env:
+          ARTIFACT_SHA: ${{ steps.build-commit.outputs.sha }}
+          CF_PAGES_PROJECT_NAME: ${{ vars.CF_PAGES_PROJECT_NAME }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
+          PAGES_DIST: ${{ steps.pages-production.outputs.pages-dist }}
+        working-directory: turbo
+        run: |
+          set -euo pipefail
+          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
+          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
+          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
+            --project-name "$CF_PAGES_PROJECT_NAME" \
+            --branch production \
+            --commit-hash "$ARTIFACT_SHA" \
+            --commit-dirty=false
+
+          production_url="https://${CF_PAGES_PROJECT_NAME}.pages.dev"
+          curl -fsSL \
+            --retry 12 \
+            --retry-delay 5 \
+            --retry-max-time 120 \
+            --retry-all-errors \
+            "$production_url" \
+            --output /dev/null
+          echo "Cloudflare Pages production is serving: $production_url"
 
   # Update rollback dashboard issue after deployments
   update-rollback-dashboard:


### PR DESCRIPTION
## Summary

- keep the existing app production promotion job focused on the staged Vercel deployment and its existing GitHub/Slack status reporting
- deploy the immutable okou-app R2 artifact to Cloudflare Pages from a separate production job that resolves the release commit SHA directly
- preserve the existing API-before-app ordering for combined releases without depending on the Vercel app build or promotion
- run the Cloudflare Pages container job explicitly with Bash so pipefail and Bash conditionals work correctly

The Cloudflare job still waits for the exact ready marker, verifies the manifest digest, commit SHA, file sizes, and checksums, uploads source maps, deploys the production branch, and checks the pages.dev endpoint.

No DNS or custom-domain configuration changes are included.

## Verification

- pnpm exec prettier --check ../.github/workflows/release-please.yml
- actionlint .github/workflows/release-please.yml
- git diff --check

No workflow-structure regression test was added; this is a focused job extraction with the existing artifact verification retained.