### PR TITLE
test(runner): retry workspace cache promotion on capacity contention

### DIFF
--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -44,10 +44,12 @@ ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GRO
 set -euo pipefail
 BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
 UNIT="vm0-runner-${SVC}.service"
-SESSION_ID="e2e-workspace-cache-promotion-session"
+MAX_ATTEMPTS=3
+PROMOTION_VERIFIED=false
 SUBMIT_PID=""
 WRITER_EXEC_PID=""
 SANDBOX_ID=""
+INVOCATION_ID=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 wait_for_unit_inactive() {
@@ -76,23 +78,39 @@ cleanup() {
 }
 trap cleanup EXIT
 
-sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-wait_for_unit_inactive
-sudo rm -rf "$GROUP_DIR"
+for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+  SESSION_ID="e2e-workspace-cache-promotion-session-${ATTEMPT}"
+  SUBMIT_PID=""
+  WRITER_EXEC_PID=""
+  SANDBOX_ID=""
+  INVOCATION_ID=""
 
-echo "--- Starting runner ---"
-sudo "$BIN_DIR/runner" service start --name "$SVC" \
-  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+  echo "--- Workspace cache promotion attempt ${ATTEMPT}/${MAX_ATTEMPTS} ---"
+  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+  wait_for_unit_inactive
+  sudo rm -rf "$GROUP_DIR"
 
-# Keep the supervised turn active while an independently owned runner exec
-# creates the live writer. Supervised descendants are reclaimed before
-# promotion, so creating the writer from the turn would not exercise the
-# freeze boundary.
-echo "--- Turn 1: create live workspace state ---"
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --session-id "$SESSION_ID" \
-  --feature-flag sandboxReuse=true \
-  --prompt 'set -eu
+  echo "--- Starting runner ---"
+  sudo "$BIN_DIR/runner" service start --name "$SVC" \
+    --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+
+  for _ in $(seq 1 30); do
+    INVOCATION_ID=$(sudo systemctl show "$UNIT" \
+      --property=InvocationID --value 2>/dev/null) || true
+    [ -n "$INVOCATION_ID" ] && break
+    sleep 1
+  done
+  [ -n "$INVOCATION_ID" ] || fail "runner invocation ID unavailable"
+
+  # Keep the supervised turn active while an independently owned runner exec
+  # creates the live writer. Supervised descendants are reclaimed before
+  # promotion, so creating the writer from the turn would not exercise the
+  # freeze boundary.
+  echo "--- Turn 1: create live workspace state ---"
+  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --session-id "$SESSION_ID" \
+    --feature-flag sandboxReuse=true \
+    --prompt 'set -eu
 rm -f /tmp/vm0-workspace-cache-release
 mkfifo /tmp/vm0-workspace-cache-release
 printf "workspace-cache-marker\n" > /home/user/workspace/cache-marker
@@ -100,90 +118,118 @@ mkdir -p /home/user/workspace/nested
 sudo mount -t tmpfs -o size=1m tmpfs /home/user/workspace/nested
 sudo touch /home/user/workspace/nested/ephemeral
 cat /tmp/vm0-workspace-cache-release >/dev/null' &
-SUBMIT_PID=$!
+  SUBMIT_PID=$!
 
-echo "--- Waiting for active workspace sandbox ---"
-SANDBOX_READY=false
-for _ in $(seq 1 60); do
-  if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
-    wait "$SUBMIT_PID" 2>/dev/null || true
+  echo "--- Waiting for active workspace sandbox ---"
+  SANDBOX_READY=false
+  for _ in $(seq 1 60); do
+    if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
+      wait "$SUBMIT_PID" 2>/dev/null || true
+      SUBMIT_PID=""
+      fail "Workspace cache turn 1 exited before setup completed"
+    fi
+    SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
+      "$RUNNER_DIR/status.json" 2>/dev/null || true)
+    if [ -n "$SANDBOX_ID" ] \
+      && sudo timeout 3 "$BIN_DIR/runner" exec --timeout 2 \
+        --sandbox "$SANDBOX_ID" -- sh -c \
+        'test -p /tmp/vm0-workspace-cache-release && test -f /home/user/workspace/nested/ephemeral' \
+        2>/dev/null; then
+      SANDBOX_READY=true
+      break
+    fi
+    sleep 1
+  done
+  [ "$SANDBOX_READY" = true ] || fail "Active workspace sandbox was not ready after 60s"
+
+  echo "--- Starting independent live workspace writer ---"
+  sudo "$BIN_DIR/runner" exec --timeout 240 --sandbox "$SANDBOX_ID" -- sh -c \
+    'cd /home/user/workspace && exec 3>>live-writer && printf "writer-start\n" >&3 && while :; do printf x >&3; sleep 0.05; done' &
+  WRITER_EXEC_PID=$!
+
+  WRITER_READY=false
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$WRITER_EXEC_PID" 2>/dev/null; then
+      wait "$WRITER_EXEC_PID" 2>/dev/null || true
+      WRITER_EXEC_PID=""
+      fail "Independent workspace writer exited before promotion"
+    fi
+    WRITER_SIZE=$(sudo "$BIN_DIR/runner" exec --timeout 2 \
+      --sandbox "$SANDBOX_ID" -- stat -c %s /home/user/workspace/live-writer \
+      2>/dev/null || true)
+    case "$WRITER_SIZE" in
+      ''|*[!0-9]*) ;;
+      *)
+        if [ "$WRITER_SIZE" -gt 13 ]; then
+          WRITER_READY=true
+          break
+        fi
+        ;;
+    esac
+    sleep 1
+  done
+  [ "$WRITER_READY" = true ] || fail "Independent workspace writer did not become active"
+
+  # Enter draining while both the supervised turn and independent writer are
+  # live. Releasing the turn then drives freeze, stop, and promotion without
+  # allowing a supervised-descendant cleanup to remove the writer first.
+  echo "--- Draining runner to promote the workspace cache ---"
+  sudo "$BIN_DIR/runner" service drain --name "$SVC"
+  kill -0 "$WRITER_EXEC_PID" 2>/dev/null \
+    || fail "Independent workspace writer was not live before the freeze boundary"
+  sudo timeout 20 "$BIN_DIR/runner" exec --timeout 15 \
+    --sandbox "$SANDBOX_ID" -- sh -c \
+    'printf release > /tmp/vm0-workspace-cache-release' \
+    || fail "Failed to release workspace cache turn 1"
+  if ! wait "$SUBMIT_PID"; then
     SUBMIT_PID=""
-    fail "Workspace cache turn 1 exited before setup completed"
+    fail "Workspace cache turn 1 failed"
   fi
-  SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
-    "$RUNNER_DIR/status.json" 2>/dev/null || true)
-  if [ -n "$SANDBOX_ID" ] \
-    && sudo timeout 3 "$BIN_DIR/runner" exec --timeout 2 \
-      --sandbox "$SANDBOX_ID" -- sh -c \
-      'test -p /tmp/vm0-workspace-cache-release && test -f /home/user/workspace/nested/ephemeral' \
-      2>/dev/null; then
-    SANDBOX_READY=true
-    break
-  fi
-  sleep 1
-done
-[ "$SANDBOX_READY" = true ] || fail "Active workspace sandbox was not ready after 60s"
-
-echo "--- Starting independent live workspace writer ---"
-sudo "$BIN_DIR/runner" exec --timeout 240 --sandbox "$SANDBOX_ID" -- sh -c \
-  'cd /home/user/workspace && exec 3>>live-writer && printf "writer-start\n" >&3 && while :; do printf x >&3; sleep 0.05; done' &
-WRITER_EXEC_PID=$!
-
-WRITER_READY=false
-for _ in $(seq 1 30); do
-  if ! kill -0 "$WRITER_EXEC_PID" 2>/dev/null; then
-    wait "$WRITER_EXEC_PID" 2>/dev/null || true
-    WRITER_EXEC_PID=""
-    fail "Independent workspace writer exited before promotion"
-  fi
-  WRITER_SIZE=$(sudo "$BIN_DIR/runner" exec --timeout 2 \
-    --sandbox "$SANDBOX_ID" -- stat -c %s /home/user/workspace/live-writer \
-    2>/dev/null || true)
-  case "$WRITER_SIZE" in
-    ''|*[!0-9]*) ;;
-    *)
-      if [ "$WRITER_SIZE" -gt 13 ]; then
-        WRITER_READY=true
-        break
-      fi
-      ;;
-  esac
-  sleep 1
-done
-[ "$WRITER_READY" = true ] || fail "Independent workspace writer did not become active"
-
-# Enter draining while both the supervised turn and independent writer are
-# live. Releasing the turn then drives freeze, stop, and promotion without
-# allowing a supervised-descendant cleanup to remove the writer first.
-echo "--- Draining runner to promote the workspace cache ---"
-sudo "$BIN_DIR/runner" service drain --name "$SVC"
-kill -0 "$WRITER_EXEC_PID" 2>/dev/null \
-  || fail "Independent workspace writer was not live before the freeze boundary"
-sudo timeout 20 "$BIN_DIR/runner" exec --timeout 15 \
-  --sandbox "$SANDBOX_ID" -- sh -c \
-  'printf release > /tmp/vm0-workspace-cache-release' \
-  || fail "Failed to release workspace cache turn 1"
-if ! wait "$SUBMIT_PID"; then
   SUBMIT_PID=""
-  fail "Workspace cache turn 1 failed"
-fi
-SUBMIT_PID=""
-wait_for_unit_inactive
-wait "$WRITER_EXEC_PID" 2>/dev/null || true
-WRITER_EXEC_PID=""
+  wait_for_unit_inactive
+  wait "$WRITER_EXEC_PID" 2>/dev/null || true
+  WRITER_EXEC_PID=""
 
-# Clear the drain drop-in before starting a fresh transient service.
-sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-sudo "$BIN_DIR/runner" service start --name "$SVC" \
-  --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+  PROMOTION_LOGS=$(sudo journalctl --no-pager \
+    "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+    || fail "failed to read workspace cache promotion runner logs"
+  if grep -F 'workspace image cache promotion skipped: capacity lock busy' \
+    <<<"$PROMOTION_LOGS" >/dev/null; then
+    if [ "$ATTEMPT" -eq "$MAX_ATTEMPTS" ]; then
+      fail "Workspace cache promotion capacity lock remained busy after ${MAX_ATTEMPTS} attempts"
+    fi
+    echo "RETRY: workspace cache promotion capacity lock was busy on attempt ${ATTEMPT}"
+    continue
+  fi
+  if ! grep -F 'workspace image cache promoted' \
+    <<<"$PROMOTION_LOGS" >/dev/null; then
+    echo "--- Workspace cache logs for invocation ${INVOCATION_ID} ---"
+    PROMOTION_LINES=$(grep -F 'workspace image cache' <<<"$PROMOTION_LOGS" || true)
+    if [ -n "$PROMOTION_LINES" ]; then
+      printf '%s\n' "$PROMOTION_LINES"
+    else
+      echo "No workspace image cache logs found"
+    fi
+    fail "Workspace cache turn 1 did not publish a reusable cache entry"
+  fi
 
-echo "--- Turn 2: restore promoted workspace ---"
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --session-id "$SESSION_ID" \
-  --feature-flag sandboxReuse=true \
-  --prompt 'test "$(cat /home/user/workspace/cache-marker)" = workspace-cache-marker && test -s /home/user/workspace/live-writer && test ! -e /home/user/workspace/nested/ephemeral' \
-  || fail "Workspace cache turn 2: promoted workspace state was not restored correctly"
-echo "PASS: workspace cache restored after freeze-based promotion"
+  # Clear the drain drop-in before starting a fresh transient service.
+  sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+  sudo "$BIN_DIR/runner" service start --name "$SVC" \
+    --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+
+  echo "--- Turn 2: restore promoted workspace ---"
+  sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+    --session-id "$SESSION_ID" \
+    --feature-flag sandboxReuse=true \
+    --prompt 'test "$(cat /home/user/workspace/cache-marker)" = workspace-cache-marker && test -s /home/user/workspace/live-writer && test ! -e /home/user/workspace/nested/ephemeral' \
+    || fail "Workspace cache turn 2: promoted workspace state was not restored correctly"
+  echo "PASS: workspace cache restored after freeze-based promotion"
+  PROMOTION_VERIFIED=true
+  break
+done
+
+[ "$PROMOTION_VERIFIED" = true ] || fail "Workspace cache promotion was not verified"
 
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 wait_for_unit_inactive


### PR DESCRIPTION
## Summary

- retry the complete workspace cache promotion behavior scenario up to three times when the exact Turn 1 runner invocation reports host-global capacity lock contention
- isolate attempts with unique session IDs and fresh group state while preserving the generated runner configuration
- require positive publication evidence before running the existing cross-restart marker, live-writer, and nested-mount assertions
- fail immediately for every other unpublished outcome with invocation-scoped workspace cache diagnostics

## Safety and scope

- preserves the runner's intentional best-effort, non-blocking promotion semantics
- does not add fixed waits, increase CI timeouts, or unconditionally rerun failures
- does not change Rust code, workflow YAML, APIs, schemas, cache formats, protocols, or deployment contracts

## Validation

- `bash -n .github/scripts/runner-behavior-workspace-cache-promotion.sh`
- `shellcheck .github/scripts/runner-behavior-*.sh`
- all `.github/scripts/tests/*.sh`
- `git diff --check`
- pre-commit and commit message hooks

Closes #22145
