### PR TITLE
fix(ci): enforce container workflow shell compatibility

### DIFF
--- a/.github/scripts/check-workflow-shell-compatibility.sh
+++ b/.github/scripts/check-workflow-shell-compatibility.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for command in jq shellcheck yq; do
+  if ! command -v "$command" >/dev/null; then
+    echo "${command} is required" >&2
+    exit 2
+  fi
+done
+
+if (( $# > 0 )); then
+  workflows=("$@")
+else
+  shopt -s nullglob
+  workflows=(.github/workflows/*.yml .github/workflows/*.yaml)
+fi
+
+for workflow in "${workflows[@]}"; do
+  if [[ ! -f "$workflow" ]]; then
+    echo "workflow does not exist: ${workflow}" >&2
+    exit 2
+  fi
+done
+
+query="$(
+  cat <<'YQ'
+  (.defaults.run.shell // "sh") as $workflow_shell |
+  .jobs | to_entries[] |
+  select(.value.container != null) |
+  . as $job |
+  ($job.value.defaults.run.shell // $workflow_shell) as $job_shell |
+  $job.value.steps[]? |
+  select(has("run")) |
+  {
+    "job": $job.key,
+    "step": (.name // "<unnamed>"),
+    "shell": (.shell // $job_shell),
+    "script": .run,
+    "line": (.run | line)
+  }
+YQ
+)"
+
+run_shellcheck() {
+  local shell_name="$1"
+  local script="$2"
+  local output
+  local status=0
+
+  output="$(
+    shellcheck \
+      --norc \
+      --format=json \
+      "--shell=${shell_name}" \
+      - <<< "$script"
+  )" || status=$?
+  if (( status > 1 )); then
+    echo "shellcheck failed with exit code ${status}" >&2
+    return "$status"
+  fi
+  printf '%s' "${output:-[]}"
+}
+
+findings=0
+for workflow in "${workflows[@]}"; do
+  records="$(yq -o=json -I=0 "$query" "$workflow")"
+  if [[ -z "$records" ]]; then
+    continue
+  fi
+
+  while IFS= read -r record; do
+    shell="$(jq -r .shell <<< "$record")"
+    shell_command="${shell%% *}"
+    shell_name="${shell_command##*/}"
+    if [[ "$shell_name" != "sh" ]]; then
+      continue
+    fi
+
+    script="$(jq -r .script <<< "$record")"
+    bash_findings="$(run_shellcheck bash "$script")"
+    sh_findings="$(run_shellcheck sh "$script")"
+    compatibility_findings="$(
+      jq -cn \
+        --argjson bash "$bash_findings" \
+        --argjson sh "$sh_findings" \
+        '[
+          $sh[] as $candidate |
+          select(
+            any(
+              $bash[];
+              .code == $candidate.code and
+              .line == $candidate.line and
+              .column == $candidate.column
+            ) | not
+          ) |
+          $candidate
+        ]'
+    )"
+
+    if [[ "$(jq length <<< "$compatibility_findings")" -eq 0 ]]; then
+      continue
+    fi
+
+    job="$(jq -r .job <<< "$record")"
+    step="$(jq -r .step <<< "$record")"
+    run_line="$(jq -r .line <<< "$record")"
+    while IFS=$'\t' read -r code script_line column message; do
+      printf '%s:%d:1: container job %q, step %q uses sh but contains non-POSIX syntax: SC%s at script %s:%s: %s. Declare shell: bash for the step or defaults.run.shell: bash for the job.\n' \
+        "$workflow" \
+        "$run_line" \
+        "$job" \
+        "$step" \
+        "$code" \
+        "$script_line" \
+        "$column" \
+        "$message" \
+        >&2
+      ((findings += 1))
+    done < <(
+      jq -r \
+        '.[] | [.code, .line, .column, .message] | @tsv' \
+        <<< "$compatibility_findings"
+    )
+  done <<< "$records"
+done
+
+if (( findings > 0 )); then
+  echo "workflow shell compatibility check failed with ${findings} finding(s)" >&2
+  exit 1
+fi

--- a/.github/scripts/tests/check-workflow-shell-compatibility-test.sh
+++ b/.github/scripts/tests/check-workflow-shell-compatibility-test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="${SCRIPT_DIR}/check-workflow-shell-compatibility.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+expect_pass() {
+  local workflow="$1"
+  if ! "$CHECKER" "$workflow"; then
+    fail "expected ${workflow} to pass"
+  fi
+}
+
+expect_fail() {
+  local workflow="$1"
+  local expected="$2"
+  local output
+  if output="$("$CHECKER" "$workflow" 2>&1)"; then
+    fail "expected ${workflow} to fail"
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    fail "expected output to contain '${expected}', got: ${output}"
+  fi
+}
+
+cat > "${TMPDIR}/default-sh.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: example.test/toolchain:latest
+    steps:
+      - name: Bash-only script
+        run: |
+          set -euo pipefail
+          if [[ -n "$HOME" ]]; then
+            echo "$HOME"
+          fi
+YAML
+expect_fail "${TMPDIR}/default-sh.yml" "SC3040"
+expect_fail "${TMPDIR}/default-sh.yml" "SC3010"
+
+cat > "${TMPDIR}/job-bash.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: example.test/toolchain:latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Bash-only script
+        run: |
+          set -euo pipefail
+          [[ -n "$HOME" ]]
+YAML
+expect_pass "${TMPDIR}/job-bash.yml"
+
+cat > "${TMPDIR}/step-bash.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: example.test/toolchain:latest
+    steps:
+      - name: Bash-only script
+        shell: bash
+        run: |
+          values=(one two)
+          [[ "${#values[@]}" -eq 2 ]]
+YAML
+expect_pass "${TMPDIR}/step-bash.yml"
+
+cat > "${TMPDIR}/workflow-bash.yml" <<'YAML'
+name: test
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: example.test/toolchain:latest
+    steps:
+      - run: '[[ -n "$HOME" ]]'
+YAML
+expect_pass "${TMPDIR}/workflow-bash.yml"
+
+cat > "${TMPDIR}/step-sh-override.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: example.test/toolchain:latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Explicit sh override
+        run: |
+          function greet() {
+            echo hello
+          }
+          greet
+        shell: sh
+YAML
+expect_fail "${TMPDIR}/step-sh-override.yml" "SC2112"
+
+cat > "${TMPDIR}/posix-sh.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: example.test/toolchain:latest
+    steps:
+      - name: POSIX script
+        run: |
+          set -eu
+          if [ -n "$HOME" ]; then
+            echo "$HOME"
+          fi
+          echo "${{ github.sha }}"
+YAML
+expect_pass "${TMPDIR}/posix-sh.yml"
+
+cat > "${TMPDIR}/host-bash.yml" <<'YAML'
+name: test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Host defaults to Bash
+        run: |
+          set -euo pipefail
+          [[ -n "$HOME" ]]
+YAML
+expect_pass "${TMPDIR}/host-bash.yml"
+
+echo "check-workflow-shell-compatibility-test: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -103,7 +103,7 @@ jobs:
 
           # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
           check_crate() {
-            local rc=0
+            rc=0
             ./scripts/crate-changed.sh "$1" "$BASE_REF" && rc=0 || rc=$?
             if [ $rc -eq 0 ]; then
               echo "$1-changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1437,6 +1437,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    defaults:
+      run:
+        shell: bash
     outputs:
       deployment_url: ${{ needs.build-app-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -273,7 +273,13 @@ jobs:
             .github/scripts/tests/*.sh
           )
           bash -n "${script_files[@]}"
-          shellcheck .github/scripts/runner-behavior-*.sh
+          shellcheck \
+            .github/scripts/check-workflow-shell-compatibility.sh \
+            .github/scripts/runner-behavior-*.sh \
+            .github/scripts/tests/check-workflow-shell-compatibility-test.sh
+          # actionlint assumes Bash when shell is omitted and does not model the
+          # sh default used by container jobs.
+          .github/scripts/check-workflow-shell-compatibility.sh
           for test_script in .github/scripts/tests/*.sh; do
             bash "$test_script"
           done


### PR DESCRIPTION
## Summary

- run the containerized App production promotion job with Bash so its existing `pipefail`, `[[ ... ]]`, and arithmetic syntax executes correctly
- add a workflow shell compatibility check that resolves workflow, job, and step shell precedence, then rejects ShellCheck findings that occur only under a container job's effective `sh`
- run the compatibility check in Workflow Lint and cover container defaults, explicit overrides, POSIX scripts, GitHub expressions, and host jobs
- make the existing crates change detector helper POSIX-compatible so the repository-wide check starts clean

## Why

The App 0.609.1 production promotion failed before accessing R2 or Cloudflare because GitHub Actions executes `run` steps in job containers with `sh` unless a shell is declared. The affected script requires Bash, while actionlint currently assumes Bash when the shell is omitted and therefore did not catch the mismatch.

Failed run: https://github.com/vm0-ai/vm0/actions/runs/29686558154/job/88192851887

## Validation

- `pnpm exec prettier --check ../.github/workflows/crates.yml ../.github/workflows/release-please.yml ../.github/workflows/security.yml`
- `bash -n` for all `.github/scripts/*.sh` and `.github/scripts/tests/*.sh`
- `shellcheck .github/scripts/check-workflow-shell-compatibility.sh .github/scripts/runner-behavior-*.sh .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- all `.github/scripts/tests/*.sh`
- `actionlint`
- repository pre-commit hooks

## Scope

- does not rerun or otherwise recover the failed App 0.609.1 promotion
- does not change application, API, runner, or persisted-data behavior
