### PR TITLE
ci: use default runner for api preview deploys

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -792,7 +792,7 @@ jobs:
 
   # Deploy API application with preview database and E2E bootstrap data
   deploy-api:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
       group: deploy-api-${{ needs.prepare.outputs.job-ref }}


### PR DESCRIPTION
## Summary

- run the `deploy-api` preview job on the standard `ubuntu-latest` GitHub-hosted runner
- preserve the existing timeout, concurrency, container, and deployment behavior

## Impact

- avoids larger-runner charges for API preview deployments while retaining the same workflow behavior

## Verification

- `git diff --check`
- PR CI pending
