### PR TITLE
fix: stop user-deletion s3 cleanup from deleting other users' storage objects via shared prefixes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -458,8 +458,10 @@ describe("GET /api/cron/sync-skills", () => {
     const alphaVersion = buildMockSkillVersion(EXTRA_SKILLS.alphaSkill);
     const alphaArchivePut = s3CallsByName("PutObjectCommand").find(
       (command) => {
+        const key = commandInput(command).Key;
         return (
-          commandInput(command).Key === `${alphaVersion.s3Key}/archive.tar.gz`
+          typeof key === "string" &&
+          key.endsWith(`/${alphaVersion.versionHash}/archive.tar.gz`)
         );
       },
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -4,6 +4,7 @@ import { gzipSync } from "node:zlib";
 import { MEMORY_ARTIFACT_NAME } from "@vm0/core/storage-names";
 
 import type { TestContext } from "../../../../__tests__/test-context";
+import { readStorageS3PrefixFixture } from "../../../../test-fixtures/storage";
 import type { ApiTestUser } from "./api-bdd";
 import { createStoragesBddApi } from "./api-bdd-storages";
 
@@ -55,9 +56,15 @@ export async function commitMemoryVersion(
     files: entries,
   });
 
+  const s3Prefix = await readStorageS3PrefixFixture({
+    orgId: actor.orgId,
+    userId: actor.userId,
+    name: MEMORY_ARTIFACT_NAME,
+    type: "artifact",
+  });
   return {
     versionId: prepared.versionId,
-    s3Key: `${actor.orgId}/artifact/${MEMORY_ARTIFACT_NAME}/${prepared.versionId}`,
+    s3Key: `${s3Prefix}/${prepared.versionId}`,
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -39,6 +39,7 @@ import {
   readOrgPlanEntitlementFixture,
   upsertOrgPlanEntitlementFixture,
 } from "../../../test-fixtures/org-plan-entitlement";
+import { readStorageS3PrefixFixture } from "../../../test-fixtures/storage";
 import {
   createBddApi,
   expectApiError,
@@ -1276,11 +1277,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const memoryPrefix = await readStorageS3PrefixFixture({
+      orgId: actor.orgId,
+      userId: actor.userId,
+      name: "memory",
+      type: "artifact",
+    });
     const emptyArtifactPutCount = context.mocks.s3.send.mock.calls.filter(
       ([command]) => {
         return (
           s3CommandName(command) === "PutObjectCommand" &&
-          s3CommandKey(command)?.includes("/artifact/memory/")
+          s3CommandKey(command)?.startsWith(`${memoryPrefix}/`)
         );
       },
     ).length;
@@ -1667,13 +1677,21 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       },
       files: [artifactFile],
     });
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    const memoryPrefix = await readStorageS3PrefixFixture({
+      orgId: actor.orgId,
+      userId: actor.userId,
+      name: "memory",
+      type: "artifact",
+    });
     const emptyBaseManifestReads = context.mocks.s3.send.mock.calls.filter(
       ([command]) => {
         return (
           s3CommandName(command) === "GetObjectCommand" &&
-          s3CommandKey(command)?.includes(
-            `/artifact/memory/${initialMemoryVersionId}/manifest.json`,
-          ) === true
+          s3CommandKey(command) ===
+            `${memoryPrefix}/${initialMemoryVersionId}/manifest.json`
         );
       },
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
@@ -26,6 +26,8 @@ import { createStoragesBddApi } from "./helpers/api-bdd-storages";
  *   `webhooks-agent-storage.test.ts`.
  */
 
+const UUID_PATTERN =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 const context = testContext();
 const bdd = createBddApi(context);
 const api = createStoragesBddApi(context);
@@ -69,11 +71,15 @@ describe("FILE-01 storage prepare, commit, list, and download", () => {
       files: v1Files,
     });
     expect(prepared.existing).toBeFalsy();
-    expect(prepared.uploads?.archive.key).toBe(
-      `${actor.orgId}/artifact/${name}/${prepared.versionId}/archive.tar.gz`,
+    expect(prepared.uploads?.archive.key).toMatch(
+      new RegExp(
+        `^${actor.orgId}/${UUID_PATTERN}/${prepared.versionId}/archive\\.tar\\.gz$`,
+      ),
     );
-    expect(prepared.uploads?.manifest.key).toBe(
-      `${actor.orgId}/artifact/${name}/${prepared.versionId}/manifest.json`,
+    expect(prepared.uploads?.manifest.key).toMatch(
+      new RegExp(
+        `^${actor.orgId}/${UUID_PATTERN}/${prepared.versionId}/manifest\\.json$`,
+      ),
     );
     expect(prepared.uploads?.archive.presignedUrl).toMatch(/^https?:\/\//);
 
@@ -189,8 +195,10 @@ describe("FILE-01 storage prepare, commit, list, and download", () => {
     expect("url" in headDownload ? headDownload.url : "").toMatch(
       /^https?:\/\//,
     );
-    expect(api.lastPresignedUrlKey()).toBe(
-      `${actor.orgId}/artifact/${name}/${preparedV2.versionId}/archive.tar.gz`,
+    expect(api.lastPresignedUrlKey()).toMatch(
+      new RegExp(
+        `^${actor.orgId}/${UUID_PATTERN}/${preparedV2.versionId}/archive\\.tar\\.gz$`,
+      ),
     );
 
     const ordered = await api.listStorages(actor, "artifact");

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -14,6 +14,11 @@ import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
 import { expireAtomGrantFixture } from "../../../test-fixtures/org-metadata";
 import {
+  readStorageS3PrefixFixture,
+  seedStorageFixture,
+  seedStorageVersionFixture,
+} from "../../../test-fixtures/storage";
+import {
   deleteOrgPlanEntitlementFixture,
   readOrgPlanEntitlementFixture,
 } from "../../../test-fixtures/org-plan-entitlement";
@@ -1721,8 +1726,10 @@ describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in t
       throw new Error("Expected the sandbox storage prepare to succeed");
     }
     expect(prepared.body.existing).toBeFalsy();
-    expect(prepared.body.uploads?.archive.key).toBe(
-      `${orgOf(actor)}/artifact/${storageName}/${prepared.body.versionId}/archive.tar.gz`,
+    expect(prepared.body.uploads?.archive.key).toMatch(
+      new RegExp(
+        `^${orgOf(actor)}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/${prepared.body.versionId}/archive\\.tar\\.gz$`,
+      ),
     );
     expect(prepared.body.uploads?.archive.presignedUrl).toMatch(/^https/);
     expect(prepared.body.uploads?.manifest.presignedUrl).toMatch(/^https/);
@@ -4556,6 +4563,126 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     expect(preserved.subscriptionStatus).toBe("active");
   });
 
+  it("spares other users' objects on legacy shared prefixes during user teardown", async () => {
+    const bdd = createBddApi(context);
+    api.configureClerkWebhookSecret();
+    bdd.acceptAgentStorageWrites();
+
+    const doomed = bdd.user();
+    const orgId = orgOf(doomed);
+    const peer = bdd.user({ orgId, orgRole: "org:member" });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [{ publicUserData: { userId: peer.userId } }],
+      },
+    );
+
+    // Legacy prefixes carry no user segment, so two users' same-named
+    // artifacts share one prefix. Seed that production shape plus an
+    // exclusive legacy prefix for the doomed user.
+    const sharedPrefix = `${orgId}/artifact/memory`;
+    const doomedShared = await seedStorageFixture({
+      orgId,
+      userId: doomed.userId,
+      name: "memory",
+      type: "artifact",
+      s3Prefix: sharedPrefix,
+    });
+    const peerShared = await seedStorageFixture({
+      orgId,
+      userId: peer.userId,
+      name: "memory",
+      type: "artifact",
+      s3Prefix: sharedPrefix,
+    });
+    const doomedVersion = await seedStorageVersionFixture({
+      storageId: doomedShared.storageId,
+      versionId: createHash("sha256").update(randomUUID()).digest("hex"),
+    });
+    const peerVersion = await seedStorageVersionFixture({
+      storageId: peerShared.storageId,
+      versionId: createHash("sha256").update(randomUUID()).digest("hex"),
+    });
+    const exclusivePrefix = `${orgId}/artifact/scratch`;
+    await seedStorageFixture({
+      orgId,
+      userId: doomed.userId,
+      name: "scratch",
+      type: "artifact",
+      s3Prefix: exclusivePrefix,
+    });
+
+    const listedPrefixes: string[] = [];
+    const deletedKeys: string[] = [];
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const input = commandInput(command);
+      if (typeof input.Prefix === "string") {
+        listedPrefixes.push(input.Prefix);
+        return Promise.resolve({
+          Contents: [
+            {
+              Key: `${input.Prefix}stale.bin`,
+              Size: 1,
+              LastModified: nowDate(),
+            },
+          ],
+        });
+      }
+      const removal = input.Delete as
+        | { readonly Objects?: readonly { readonly Key?: string }[] }
+        | undefined;
+      for (const object of removal?.Objects ?? []) {
+        if (object.Key) {
+          deletedKeys.push(object.Key);
+        }
+      }
+      return Promise.resolve({});
+    });
+
+    api.verifyNextClerkWebhook({
+      type: "user.deleted",
+      data: { id: doomed.userId },
+    });
+    const response = await api.requestClerkWebhook("{}", {}, [200]);
+    expect(response.body).toBe("OK");
+    await flushWaitUntilForTest();
+
+    await waitForExpectation(() => {
+      // The exclusive prefix is wiped wholesale (bounded listing), which
+      // also removes orphan objects that never got a version row.
+      expect(listedPrefixes).toContain(`${exclusivePrefix}/`);
+      // The shared prefix falls back to per-version deletion: only the
+      // doomed user's version directory is listed.
+      expect(listedPrefixes).toContain(`${doomedVersion.s3Key}/`);
+    });
+    expect(listedPrefixes).not.toContain(`${sharedPrefix}/`);
+    expect(deletedKeys).toContain(`${exclusivePrefix}/stale.bin`);
+    expect(deletedKeys).toContain(`${doomedVersion.s3Key}/stale.bin`);
+    for (const key of deletedKeys) {
+      expect(key.startsWith(`${peerVersion.s3Key}/`)).toBeFalsy();
+    }
+
+    // The doomed user's rows are gone while the peer's survive untouched.
+    await waitForExpectation(async () => {
+      await expect(
+        readStorageS3PrefixFixture({
+          orgId,
+          userId: doomed.userId,
+          name: "memory",
+          type: "artifact",
+        }),
+      ).rejects.toThrow();
+    });
+    await expect(
+      readStorageS3PrefixFixture({
+        orgId,
+        userId: peer.userId,
+        name: "memory",
+        type: "artifact",
+      }),
+    ).resolves.toBe(sharedPrefix);
+  });
+
   it("does not update a Stripe subscription already canceled upstream", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
@@ -4687,7 +4814,8 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     ).Prefix;
     expect(
       typeof firstCleanupS3Prefix === "string" &&
-        firstCleanupS3Prefix.startsWith(`${orgOf(doomed)}/artifact/`),
+        firstCleanupS3Prefix.startsWith(`${orgOf(doomed)}/`) &&
+        firstCleanupS3Prefix.endsWith("/"),
     ).toBeTruthy();
 
     await waitForExpectation(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
@@ -5,7 +5,10 @@ import type {
   TestWorkflowSkillStoragePresignedUrlCacheStateActionBody,
   TestWorkflowSkillStoragePresignedUrlCacheStateActionResponse,
 } from "@vm0/api-contracts/contracts/test-workflow-skill-storage-presigned-url-cache-state";
-import { getCustomSkillStorageName } from "@vm0/core/storage-names";
+import {
+  getCustomSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -13,6 +16,7 @@ import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
 import { mockNow, nowDate } from "../../../lib/time";
+import { readStorageS3PrefixFixture } from "../../../test-fixtures/storage";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -253,6 +257,12 @@ async function createWorkflowSkillRunFixture(): Promise<{
   if (!actor.orgId) {
     throw new Error("Expected workflow cache test actor to have an org");
   }
+  const objectKeyPrefix = await readStorageS3PrefixFixture({
+    orgId: actor.orgId,
+    userId: VOLUME_ORG_USER_ID,
+    name: storageName,
+    type: "volume",
+  });
   return {
     actor,
     agentId,
@@ -260,7 +270,7 @@ async function createWorkflowSkillRunFixture(): Promise<{
     workflowId,
     workflowName,
     storageName,
-    objectKeyPrefix: `${actor.orgId}/volume/${storageName}`,
+    objectKeyPrefix,
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
@@ -425,13 +425,14 @@ describe("DELETE /api/zero/agents/:id", () => {
 
     await bdd.deleteAgent(actor, agent.agentId);
 
-    const expectedListPrefix = `${actor.orgId}/volume/${
-      instructionsVolume.name
-    }/`;
-    expect(listedPrefix).toBe(expectedListPrefix);
+    expect(listedPrefix).toMatch(
+      new RegExp(
+        `^${actor.orgId}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/$`,
+      ),
+    );
     expect(s3DeletedObjectKeys()).toStrictEqual([
-      `${expectedListPrefix}v1/archive.tar.gz`,
-      `${expectedListPrefix}v1/manifest.json`,
+      `${listedPrefix}v1/archive.tar.gz`,
+      `${listedPrefix}v1/manifest.json`,
     ]);
     const afterVolumes = await storages.listStorages(actor, "volume");
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -386,12 +386,16 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
 
     expect(artifactStorage).toMatchObject({
-      s3Prefix: `${fixture.orgId}/artifact/artifact`,
+      s3Prefix: expect.stringMatching(
+        new RegExp(
+          `^${fixture.orgId}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+        ),
+      ),
       headVersionId: expect.any(String),
       versionId: expect.any(String),
     });
     expect(artifactStorage?.versionS3Key).toBe(
-      `${fixture.orgId}/artifact/artifact/${artifactStorage?.versionId}`,
+      `${artifactStorage?.s3Prefix}/${artifactStorage?.versionId}`,
     );
     expect(context.mocks.s3.send).not.toHaveBeenCalledWith(
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -39,6 +39,7 @@ import {
   type ApiDispatchTimingDimensionsInput,
 } from "./api-dispatch-timing.service";
 import { computeContentHashFromHashes } from "./storage-content-hash.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 type StorageType = "artifact" | "volume";
 type ManifestStorage = StorageManifest["storages"][number];
@@ -1152,14 +1153,16 @@ async function findOrCreateArtifactStorage(
     args.timing,
     "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_storage",
     async () => {
+      const location = newStorageS3Location(args.orgId);
       return await args.db
         .insert(storages)
         .values({
+          id: location.storageId,
           orgId: args.orgId,
           userId: args.userId,
           name: args.name,
           type: "artifact",
-          s3Prefix: `${args.orgId}/artifact/${args.name}`,
+          s3Prefix: location.s3Prefix,
         })
         .onConflictDoNothing()
         .returning({

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -38,6 +38,7 @@ import {
 } from "../external/s3";
 import { createDeferredPromise, safeSync, tapError } from "../utils";
 import type { FileEntryWithHash } from "./storage-content-hash.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 interface SyncSkillsResult {
   readonly commitSha: string;
@@ -74,7 +75,6 @@ interface SkillSyncContext {
 interface SkillArchiveUpload {
   readonly archiveBuffer: Buffer;
   readonly manifestBuffer: Buffer;
-  readonly s3Prefix: string;
   readonly s3Key: string;
 }
 
@@ -339,6 +339,7 @@ async function hasCurrentSkillVersion(args: {
 
 function uploadSkillArchive(
   context: SkillSyncContext,
+  s3Prefix: string,
   signal: AbortSignal,
 ): Computed<Promise<SkillArchiveUpload>> {
   return computed(async (get): Promise<SkillArchiveUpload> => {
@@ -348,7 +349,6 @@ function uploadSkillArchive(
     signal.throwIfAborted();
 
     const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
-    const s3Prefix = `${SYSTEM_ORG_ID}/volume/${context.storageName}`;
     const s3Key = `${s3Prefix}/${context.versionHash}`;
 
     await Promise.all([
@@ -371,25 +371,26 @@ function uploadSkillArchive(
     ]);
     signal.throwIfAborted();
 
-    return { archiveBuffer, manifestBuffer, s3Prefix, s3Key };
+    return { archiveBuffer, manifestBuffer, s3Key };
   });
 }
 
 async function upsertSkillStorage(args: {
   readonly db: Db;
   readonly context: SkillSyncContext;
-  readonly upload: SkillArchiveUpload;
   readonly timestamp: Date;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<{ readonly id: string; readonly s3Prefix: string }> {
+  const location = newStorageS3Location(SYSTEM_ORG_ID);
   const [storage] = await args.db
     .insert(storages)
     .values({
+      id: location.storageId,
       orgId: SYSTEM_ORG_ID,
       userId: VOLUME_ORG_USER_ID,
       name: args.context.storageName,
       type: "volume",
-      s3Prefix: args.upload.s3Prefix,
+      s3Prefix: location.s3Prefix,
       size: args.context.totalSize,
       fileCount: args.context.files.length,
     })
@@ -401,7 +402,7 @@ async function upsertSkillStorage(args: {
         updatedAt: args.timestamp,
       },
     })
-    .returning({ id: storages.id });
+    .returning({ id: storages.id, s3Prefix: storages.s3Prefix });
   args.signal.throwIfAborted();
 
   if (!storage) {
@@ -410,7 +411,7 @@ async function upsertSkillStorage(args: {
     );
   }
 
-  return storage.id;
+  return storage;
 }
 
 async function insertSkillStorageVersion(args: {
@@ -527,14 +528,18 @@ function syncSingleSkill(
     }
 
     const timestamp = nowDate();
-    const upload = await get(uploadSkillArchive(context, signal));
-    const storageId = await upsertSkillStorage({
+    // Upsert the storage row first: objects must land under the row's stored
+    // prefix, which an existing row keeps from its creation time.
+    const storage = await upsertSkillStorage({
       db,
       context,
-      upload,
       timestamp,
       signal,
     });
+    const storageId = storage.id;
+    const upload = await get(
+      uploadSkillArchive(context, storage.s3Prefix, signal),
+    );
     await insertSkillStorageVersion({
       db,
       storageId,

--- a/turbo/apps/api/src/signals/services/storage-s3-prefix.utils.ts
+++ b/turbo/apps/api/src/signals/services/storage-s3-prefix.utils.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Identity and S3 prefix for a new storage row: `{orgId}/{storageId}`.
+ *
+ * The storage id goes into the prefix because it is the only immutable,
+ * globally unique attribute of a storage row. Prefixes that encode mutable
+ * or shared attributes went stale twice already: org slugs broke on rename
+ * (#7186), and `{orgId}/{type}/{name}` collides across users because the
+ * per-user ownership model landed after the user segment was dropped from
+ * the path (#22148). Several historical prefix formats coexist in
+ * production, so a prefix must always be read from `storages.s3_prefix`
+ * and never derived from other columns.
+ */
+export function newStorageS3Location(orgId: string): {
+  readonly storageId: string;
+  readonly s3Prefix: string;
+} {
+  const storageId = randomUUID();
+  return { storageId, s3Prefix: `${orgId}/${storageId}` };
+}

--- a/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
@@ -19,6 +19,7 @@ import {
   hashFileContent,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 interface VolumeFileInput {
   readonly path: string;
@@ -180,12 +181,13 @@ const uploadVolumeServerSideInner$ = command(
 
     const writeDb = set(writeDb$);
     const storageType = "volume";
-    const s3Prefix = `${args.orgId}/${storageType}/${args.storageName}`;
+    const { storageId, s3Prefix } = newStorageS3Location(args.orgId);
     const timestamp = nowDate();
 
     const [storage] = await writeDb
       .insert(storages)
       .values({
+        id: storageId,
         userId: VOLUME_ORG_USER_ID,
         orgId: args.orgId,
         name: args.storageName,
@@ -213,7 +215,9 @@ const uploadVolumeServerSideInner$ = command(
       };
     });
     const versionId = computeContentHashFromHashes(storage.id, fileEntries);
-    const s3Key = `${s3Prefix}/${versionId}`;
+    // On upsert conflict the row keeps its original prefix, which can differ
+    // from the freshly generated one — always key objects off the stored value.
+    const s3Key = `${storage.s3Prefix}/${versionId}`;
     const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
     const manifest: S3StorageManifest = {
       version: versionId,

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -25,6 +25,7 @@ import {
   computeContentHashFromHashes,
   type FileEntryWithHash,
 } from "./storage-content-hash.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 
 const L = logger("storage-write");
 
@@ -307,14 +308,16 @@ async function upsertStorageForPrepare(args: {
   readonly storageOwner: string;
   readonly input: PrepareStorageInput;
 }): Promise<StorageRow | undefined> {
+  const { storageId, s3Prefix } = newStorageS3Location(args.orgId);
   const [storage] = await args.db
     .insert(storages)
     .values({
+      id: storageId,
       userId: args.storageOwner,
       orgId: args.orgId,
       name: args.input.storageName,
       type: args.input.storageType,
-      s3Prefix: `${args.orgId}/${args.input.storageType}/${args.input.storageName}`,
+      s3Prefix,
       size: 0,
       fileCount: 0,
     })

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -24,7 +24,7 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { secrets } from "@vm0/db/schema/secret";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
-import { storages } from "@vm0/db/schema/storage";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
@@ -34,13 +34,17 @@ import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { variables } from "@vm0/db/schema/variable";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command, computed, type Computed } from "ccstate";
-import { and, count, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, count, eq, inArray, isNotNull, ne } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
-import { deleteS3Objects, listS3Objects } from "../external/s3";
+import {
+  deleteS3Objects,
+  listS3Objects,
+  listS3ObjectsUnderPrefix,
+} from "../external/s3";
 import { nowDate } from "../external/time";
 import { publishCancelToRunnerGroup } from "../external/realtime";
 import { deleteWebhook } from "../external/telegram-client";
@@ -610,7 +614,7 @@ function deleteUserObjectsForPrefixesBestEffort(
   return computed(async (get): Promise<void> => {
     for (const prefix of prefixes) {
       const objects = await tapError(
-        get(listS3Objects(bucket, prefix)),
+        get(listS3ObjectsUnderPrefix(bucket, prefix)),
         (error) => {
           L.warn("failed to list user storage objects", {
             userId,
@@ -627,23 +631,20 @@ function deleteUserObjectsForPrefixesBestEffort(
         continue;
       }
 
-      await tapError(
-        get(
-          deleteS3Objects(
-            bucket,
-            objects.map((object) => {
-              return object.key;
-            }),
-          ),
-        ),
-        (error) => {
-          L.warn("failed to delete user storage objects", {
-            userId,
-            prefix,
-            error,
-          });
-        },
-      );
+      const keys = objects.map((object) => {
+        return object.key;
+      });
+      await tapError(get(deleteS3Objects(bucket, keys)), (error) => {
+        // The storage rows (and with them the version keys) are deleted
+        // right after this best-effort pass, so log the full key list to
+        // keep manual re-deletion possible.
+        L.warn("failed to delete user storage objects", {
+          userId,
+          prefix,
+          keys,
+          error,
+        });
+      });
     }
   });
 }
@@ -679,18 +680,67 @@ function deleteUserS3Data(db: Db, userId: string): Computed<Promise<void>> {
   return computed(async (get): Promise<void> => {
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const storageRows = await db
-      .select({ s3Prefix: storages.s3Prefix })
+      .select({ id: storages.id, s3Prefix: storages.s3Prefix })
       .from(storages)
       .where(eq(storages.userId, userId));
-    await get(
-      deleteUserObjectsForPrefixesBestEffort(
-        bucket,
-        storageRows.map((row) => {
-          return row.s3Prefix;
-        }),
-        userId,
-      ),
+
+    // Legacy prefixes like `{orgId}/artifact/{name}` have no user segment,
+    // so another user's storage in the same org can share the prefix.
+    // Deleting a shared prefix wholesale would destroy the other user's
+    // version objects (#22148). Prefixes still exclusive to this user are
+    // deleted wholesale (which also removes orphan objects from uncommitted
+    // prepares); shared prefixes fall back to deleting exactly this user's
+    // version directories.
+    const prefixes = storageRows.map((row) => {
+      return row.s3Prefix;
+    });
+    const sharedRows =
+      prefixes.length > 0
+        ? await db
+            .select({ s3Prefix: storages.s3Prefix })
+            .from(storages)
+            .where(
+              and(
+                inArray(storages.s3Prefix, prefixes),
+                ne(storages.userId, userId),
+              ),
+            )
+        : [];
+    const sharedPrefixes = new Set(
+      sharedRows.map((row) => {
+        return row.s3Prefix;
+      }),
     );
+
+    const exclusivePrefixes = [
+      ...new Set(
+        prefixes.filter((prefix) => {
+          return !sharedPrefixes.has(prefix);
+        }),
+      ),
+    ];
+    await get(
+      deleteUserObjectsForPrefixesBestEffort(bucket, exclusivePrefixes, userId),
+    );
+
+    const sharedStorageIds = storageRows.flatMap((row) => {
+      return sharedPrefixes.has(row.s3Prefix) ? [row.id] : [];
+    });
+    if (sharedStorageIds.length > 0) {
+      const versionRows = await db
+        .select({ s3Key: storageVersions.s3Key })
+        .from(storageVersions)
+        .where(inArray(storageVersions.storageId, sharedStorageIds));
+      await get(
+        deleteUserObjectsForPrefixesBestEffort(
+          bucket,
+          versionRows.map((row) => {
+            return row.s3Key;
+          }),
+          userId,
+        ),
+      );
+    }
 
     const exportRows = await db
       .select({ s3Key: exportJobs.s3Key })

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -50,6 +50,7 @@ import {
   type AgentPhoneChannel,
   type AgentPhoneUserLink,
 } from "./agentphone-shared.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import {
@@ -324,13 +325,15 @@ export const ensureAgentPhoneArtifactStorage$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const writeDb = set(writeDb$);
+    const location = newStorageS3Location(args.orgId);
     const [storage] = await writeDb
       .insert(storages)
       .values({
+        id: location.storageId,
         name: "artifact",
         type: "artifact",
         userId: args.userId,
-        s3Prefix: `${args.orgId}/artifact/artifact`,
+        s3Prefix: location.s3Prefix,
         size: 0,
         fileCount: 0,
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/zero-telegram-link.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-link.service.ts
@@ -16,6 +16,7 @@ import { putS3Object } from "../external/s3";
 import { bestEffort } from "../utils";
 import { computeContentHashFromHashes } from "./storage-content-hash.service";
 import { decryptPersistentSecretValue } from "./crypto.utils";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const PENDING_TELEGRAM_USER_ID = "pending";
@@ -240,13 +241,15 @@ export const ensureTelegramArtifactStorage$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const writeDb = set(writeDb$);
+    const location = newStorageS3Location(args.orgId);
     const [storage] = await writeDb
       .insert(storages)
       .values({
+        id: location.storageId,
         name: "artifact",
         type: "artifact",
         userId: args.userId,
-        s3Prefix: `${args.orgId}/artifact/artifact`,
+        s3Prefix: location.s3Prefix,
         size: 0,
         fileCount: 0,
         orgId: args.orgId,

--- a/turbo/apps/api/src/test-fixtures/storage.ts
+++ b/turbo/apps/api/src/test-fixtures/storage.ts
@@ -1,0 +1,88 @@
+/**
+ * In-process test fixture for `storages` / `storage_versions` rows.
+ *
+ * Legacy prefix formats (`{orgId}/{type}/{name}`, `vm0/...`) cannot be
+ * created through product APIs anymore — new rows always get the
+ * `{orgId}/{storageId}` prefix — but production still holds them, including
+ * prefixes shared by several users' rows in the same org (#22148). The
+ * user-deletion cleanup must keep handling those rows, so tests seed them
+ * here. Reading a storage's stored prefix is equally unreachable through
+ * product APIs because list responses do not expose `s3_prefix`.
+ */
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { writeDb$ } from "../signals/external/db";
+
+export async function seedStorageFixture(values: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly type: string;
+  readonly s3Prefix: string;
+}): Promise<{ readonly storageId: string }> {
+  const db = createStore().set(writeDb$);
+  const [row] = await db
+    .insert(storages)
+    .values(values)
+    .returning({ storageId: storages.id });
+  if (!row) {
+    throw new Error("Failed to seed storage fixture");
+  }
+  return row;
+}
+
+export async function seedStorageVersionFixture(values: {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly size?: number;
+  readonly fileCount?: number;
+}): Promise<{ readonly s3Key: string }> {
+  const db = createStore().set(writeDb$);
+  const [storage] = await db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(eq(storages.id, values.storageId))
+    .limit(1);
+  if (!storage) {
+    throw new Error("Cannot seed a version for a missing storage");
+  }
+  const s3Key = `${storage.s3Prefix}/${values.versionId}`;
+  await db.insert(storageVersions).values({
+    id: values.versionId,
+    storageId: values.storageId,
+    s3Key,
+    size: values.size ?? 1,
+    fileCount: values.fileCount ?? 1,
+    createdBy: "user",
+  });
+  return { s3Key };
+}
+
+export async function readStorageS3PrefixFixture(values: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly type: string;
+}): Promise<string> {
+  const db = createStore().set(writeDb$);
+  const [row] = await db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, values.orgId),
+        eq(storages.userId, values.userId),
+        eq(storages.name, values.name),
+        eq(storages.type, values.type),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    throw new Error(
+      `No storage row for ${values.orgId}/${values.userId}/${values.name}/${values.type}`,
+    );
+  }
+  return row.s3Prefix;
+}


### PR DESCRIPTION
Closes #22148

## Problem

`deleteUserS3Data()` (Clerk `user.deleted` cleanup) lists **every object under each of the user's `storages.s3_prefix` values and deletes them all**. Artifact prefixes carry no user segment (`{orgId}/artifact/{name}`), so two users in the same org who own a same-named artifact — most commonly the automatic `memory` artifact — share one prefix. Deleting user A therefore destroys user B's version objects; B's `storage_versions` rows survive but point at missing objects, breaking B's next pull / resume / memory restore.

Production audit (2026-07-19, 7,062 rows): 6 prefixes are shared across users (27 rows, 2 external orgs), and every multi-member org where two members used memory adds another.

## Fix (per decisions D1–D7 on #22148)

**1. Conditional deletion in user cleanup** (`webhooks-clerk-cleanup.service.ts`)
- A prefix still exclusive to the deleted user is wiped wholesale — now via **bounded** listing (`prefix + "/"`), which also stops a second latent over-deletion (`.../artifact/a` previously matched `.../artifact/ab`) and still removes orphan objects from uncommitted prepares.
- A prefix shared with another user's row falls back to deleting exactly the user's `storage_versions.s3_key` directories.
- Failure logs now include the complete undeleted key list (rows are deleted right after, so this keeps manual re-deletion possible via Axiom).

**2. Collision-free prefixes for new storages**
New rows get `s3_prefix = {orgId}/{storage.id}` through a single helper (`storage-s3-prefix.utils.ts`) used by all 6 creation sites (storage-write, storage-volume-upload, agent-run-storage, cron-sync-skills, zero-telegram-link, zero-agentphone). `storage.id` is the only immutable, globally unique attribute — prefixes encoding slug/type/name went stale twice already (#7186, #22148). Existing rows keep their stored prefixes; readers have used the stored value exclusively since #7186, and no code parses prefix segments.

Two consistency fixes rode along where creation sites computed object keys from a locally rebuilt prefix instead of the stored row value (`storage-volume-upload`, and `cron-sync-skills` now upserts the storage row before uploading so objects land under the row's stored prefix).

## Behavior notes

- Org deletion is unchanged: all shared prefixes are intra-org, so org-level prefix deletion remains correct.
- The 10 dead `type='memory'` rows and existing shared-prefix rows are intentionally not migrated (D4); the legacy fallback path covers them.
- Orphan-object residue on the 6 legacy shared prefixes is an accepted, documented limitation (D1).

## Tests

- New BDD test: two same-org users sharing a legacy prefix — deleting one spares the other's objects and rows, wipes the exclusive prefix wholesale (orphan included), and never lists the shared prefix root.
- Existing storage/webhook/skill-sync/slack-connect assertions updated from exact legacy-format keys to stored-prefix/UUID-pattern assertions.
- Verified locally: `webhooks-callbacks.bdd.test.ts` (42/42), `storages.bdd.test.ts`, `cron-sync-skills.test.ts`, `zero-agents-by-id.test.ts`, `zero-slack-connect.test.ts` all pass. `run-lifecycle.bdd.test.ts` and one `cron-connector-catalog` test fail identically on unmodified `main` in this environment (queue infra unavailable locally) — relying on CI for those.

## Post-deploy verification (non-blocking)

- mask-db spot-check that new rows' prefixes are `{orgId}/{uuid}`.
- Axiom watch on `failed to delete user storage objects` for the new `keys` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
