### PR TITLE
refactor(runner): remove sidecar allocated bytes

### DIFF
--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -11,7 +11,7 @@ use crate::ids::RunId;
 use crate::restored_session_identity::{RestoredSessionIdentity, RestoredSessionIdentityFields};
 
 use super::fs::{
-    allocated_bytes, ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
+    ensure_workspace_cache_entry_dir, remove_workspace_cache_path_if_exists,
     workspace_cache_existing_path_allocated_bytes,
 };
 use super::metadata::WorkspaceImageFileIdentity;
@@ -35,8 +35,6 @@ struct WorkspaceSessionHistorySidecarMetadata {
     representation: WorkspaceSessionHistorySidecarRepresentation,
     encoded_size: u64,
     body_file: WorkspaceImageFileIdentity,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    allocated_bytes: Option<u64>,
 }
 
 impl WorkspaceSessionHistorySidecarMetadata {
@@ -61,7 +59,6 @@ impl WorkspaceSessionHistorySidecarMetadata {
             representation: source.representation,
             encoded_size: source.encoded_size,
             body_file: WorkspaceImageFileIdentity::from_metadata(body_metadata),
-            allocated_bytes: Some(allocated_bytes(body_metadata)),
         })
     }
 

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1675,7 +1675,7 @@ async fn session_history_sidecar_publish_and_probe_hit() {
     let metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
     assert!(metadata.get("historyGenerationRunId").is_none());
-    assert!(metadata["allocatedBytes"].as_u64().is_some());
+    assert!(metadata.get("allocatedBytes").is_none());
     let held_states = cache.held_session_states().await;
     assert_eq!(
         held_states[0].workspace_caches[0].profile,
@@ -1695,14 +1695,14 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 }
 
 #[tokio::test]
-async fn session_history_sidecar_metadata_without_allocated_bytes_remains_restoreable() {
+async fn session_history_sidecar_metadata_with_allocated_bytes_remains_restoreable() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
     let cache = SessionWorkspaceCache::new(paths.clone());
     let run_id = RunId::new_v4();
-    let session_id = "sess-sidecar-without-allocated-bytes";
-    let history = br#"{"type":"message","content":"without allocated bytes"}"#;
+    let session_id = "sess-sidecar-with-allocated-bytes";
+    let history = br#"{"type":"message","content":"with allocated bytes"}"#;
     let cache_key = write_current_cache_entry(
         &cache,
         run_id,
@@ -1723,8 +1723,8 @@ async fn session_history_sidecar_metadata_without_allocated_bytes_remains_restor
         metadata
             .as_object_mut()
             .unwrap()
-            .remove("allocatedBytes")
-            .is_some()
+            .insert("allocatedBytes".into(), 4096_u64.into())
+            .is_none()
     );
     fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
         .await


### PR DESCRIPTION
## Summary

- stop computing and persisting the unused sidecar metadata `allocatedBytes` property
- remove the transitional private metadata member and Serde annotation
- keep both new metadata and old metadata containing the extra property restoreable through the
  real publish/probe boundary

## Compatibility

The reader-first prerequisite shipped in `runner-rs-v0.146.12` and production has advanced to
`v0.146.14`. `v0.146.12` is the documented minimum supported rollback target for this on-disk
transition; `v0.146.11` and earlier require the removed property.

New readers continue accepting old metadata because the private Serde type tolerates unknown
properties. Live sidecar allocation accounting still stats the body and metadata files directly.

## Exclusions

- no metadata format-version bump or cache purge
- no request or body validation, fallback, inspection, or garbage-collection behavior change
- no API contract, database schema, migration, backfill, queue, heartbeat, or guest-protocol change
- no generation-attribution or resource-path telemetry change
- no release-specific logic in the generic runner rollback workflow

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner session_history_sidecar_publish_and_probe_hit`
- `cargo test -p runner --bin runner session_history_sidecar_metadata_with_allocated_bytes_remains_restoreable`
- `cargo test -p runner --bin runner session_history_sidecar_counts_toward_gc_candidate_and_inspection`
- `cargo test -p runner --bin runner` (2764 passed, 0 failed, 12 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- repository pre-commit and commit-message hooks

Closes #22094

Parent: #22028
