### PR TITLE
refactor(api): validate structured sql result rows

### DIFF
--- a/turbo/apps/api/src/lib/db-structured-result.ts
+++ b/turbo/apps/api/src/lib/db-structured-result.ts
@@ -1,11 +1,7 @@
-import type { DriverValueDecoder } from "drizzle-orm";
+import type { Column, DriverValueDecoder } from "drizzle-orm";
 import type { output, ZodEnum, ZodType } from "zod";
 
-import {
-  pgInt8ToBigIntSchema,
-  pgInt8ToSafeIntegerSchema,
-  pgTimestampWithoutTimezoneToDateSchema,
-} from "./db-raw-rows";
+import { pgInt8ToBigIntSchema, pgInt8ToSafeIntegerSchema } from "./db-raw-rows";
 
 function invalidDriverValue(expected: string): never {
   throw new TypeError(`Expected ${expected} from PostgreSQL`);
@@ -81,12 +77,14 @@ export const pgInt8ToSafeIntegerDecoder = zodDriverValueDecoder(
 export const pgInt8ToBigIntDecoder =
   zodDriverValueDecoder(pgInt8ToBigIntSchema);
 
-export const pgTimestampWithoutTimezoneToDateDecoder = zodDriverValueDecoder(
-  pgTimestampWithoutTimezoneToDateSchema,
-);
-
+export function nullableDriverValueDecoder<TColumn extends Column>(
+  decoder: TColumn,
+): DriverValueDecoder<TColumn["_"]["data"] | null, unknown>;
 export function nullableDriverValueDecoder<TData, TDriverParam>(
   decoder: DriverValueDecoder<TData, TDriverParam>,
-): DriverValueDecoder<TData | null, TDriverParam> {
+): DriverValueDecoder<TData | null, TDriverParam>;
+export function nullableDriverValueDecoder(
+  decoder: DriverValueDecoder<unknown, unknown>,
+): DriverValueDecoder<unknown, unknown> {
   return decoder;
 }

--- a/turbo/apps/api/src/lib/db-structured-result.ts
+++ b/turbo/apps/api/src/lib/db-structured-result.ts
@@ -1,0 +1,92 @@
+import type { DriverValueDecoder } from "drizzle-orm";
+import type { output, ZodEnum, ZodType } from "zod";
+
+import {
+  pgInt8ToBigIntSchema,
+  pgInt8ToSafeIntegerSchema,
+  pgTimestampWithoutTimezoneToDateSchema,
+} from "./db-raw-rows";
+
+function invalidDriverValue(expected: string): never {
+  throw new TypeError(`Expected ${expected} from PostgreSQL`);
+}
+
+export function zodDriverValueDecoder<TSchema extends ZodType>(
+  schema: TSchema,
+): DriverValueDecoder<output<TSchema>, unknown> {
+  return Object.freeze({
+    mapFromDriverValue(value: unknown): output<TSchema> {
+      return schema.parse(value);
+    },
+  });
+}
+
+export function zodEnumDriverValueDecoder<
+  TValues extends Readonly<Record<string, string | number>>,
+>(
+  schema: ZodEnum<TValues>,
+): DriverValueDecoder<TValues[keyof TValues], unknown> {
+  const values = new Map<string | number, TValues[keyof TValues]>();
+  for (const option of schema.options) {
+    values.set(option, option);
+  }
+  return Object.freeze({
+    mapFromDriverValue(value: unknown): TValues[keyof TValues] {
+      if (typeof value !== "string" && typeof value !== "number") {
+        return invalidDriverValue("an enum value");
+      }
+      return values.get(value) ?? invalidDriverValue("an enum value");
+    },
+  });
+}
+
+export const pgTextDecoder: DriverValueDecoder<string, unknown> = Object.freeze(
+  {
+    mapFromDriverValue(value: unknown): string {
+      return typeof value === "string"
+        ? value
+        : invalidDriverValue("a text value");
+    },
+  },
+);
+
+export const pgBooleanDecoder: DriverValueDecoder<boolean, unknown> =
+  Object.freeze({
+    mapFromDriverValue(value: unknown): boolean {
+      return typeof value === "boolean"
+        ? value
+        : invalidDriverValue("a boolean value");
+    },
+  });
+
+export const pgIntegerDecoder: DriverValueDecoder<number, unknown> =
+  Object.freeze({
+    mapFromDriverValue(value: unknown): number {
+      return typeof value === "number" && Number.isSafeInteger(value)
+        ? value
+        : invalidDriverValue("an integer value");
+    },
+  });
+
+export const pgNullDecoder: DriverValueDecoder<null, unknown> = Object.freeze({
+  mapFromDriverValue(): null {
+    return invalidDriverValue("null");
+  },
+});
+
+export const pgInt8ToSafeIntegerDecoder = zodDriverValueDecoder(
+  pgInt8ToSafeIntegerSchema,
+);
+
+export const pgInt8ToBigIntDecoder =
+  zodDriverValueDecoder(pgInt8ToBigIntSchema);
+
+export const pgTimestampWithoutTimezoneToDateDecoder = zodDriverValueDecoder(
+  pgTimestampWithoutTimezoneToDateSchema,
+);
+
+export function nullableDriverValueDecoder<TData, TDriverParam>(
+  decoder: DriverValueDecoder<TData, TDriverParam>,
+): DriverValueDecoder<TData | null, TDriverParam> {
+  return decoder;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -996,6 +996,15 @@ describe("CHAT-02: completed chat callback", () => {
     await flushWaitUntilForTest();
 
     expect(followupRequests).toBe(1);
+    expect(sandboxOperationEventsForRun(run.runId)).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "last_event_to_complete",
+          duration_ms: expect.any(Number),
+          success: true,
+        }),
+      ]),
+    );
     const after = await chat.listThreadMessages(actor, run.threadId);
     const marker = lifecycleMarkers(after.messages, run.runId, "completed")[0];
     if (!marker) {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -51,6 +51,10 @@ import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { executeRawRows } from "../../lib/db-raw-rows";
+import {
+  nullableDriverValueDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
@@ -589,9 +593,10 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
       profile: runnerJobQueue.profile,
       cliAgentSessionId: runnerJobQueue.cliAgentSessionId,
-      historyGenerationRunId: sql<
-        string | null
-      >`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`,
+      historyGenerationRunId:
+        sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`.mapWith(
+          nullableDriverValueDecoder(pgTextDecoder),
+        ),
       createdAt: runnerJobQueue.createdAt,
     })
     .from(runnerJobQueue)

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -28,6 +28,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { bodyResultOf, queryOf } from "../context/request";
@@ -516,7 +517,9 @@ function recentSlackRuns(db: ReadonlyDb, orgId: string | null | undefined) {
       triggerSource: zeroRuns.triggerSource,
       userId: agentRuns.userId,
       error: agentRuns.error,
-      promptPreview: sql<string>`substring(${agentRuns.prompt}, 1, 200)`,
+      promptPreview: sql`substring(${agentRuns.prompt}, 1, 200)`.mapWith(
+        pgTextDecoder,
+      ),
     })
     .from(agentRuns)
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -26,6 +26,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { bodyResultOf, queryOf } from "../context/request";
@@ -546,7 +547,9 @@ function recentTeamsRuns(db: ReadonlyDb, orgId: string | null | undefined) {
       triggerSource: zeroRuns.triggerSource,
       userId: agentRuns.userId,
       error: agentRuns.error,
-      promptPreview: sql<string>`substring(${agentRuns.prompt}, 1, 200)`,
+      promptPreview: sql`substring(${agentRuns.prompt}, 1, 200)`.mapWith(
+        pgTextDecoder,
+      ),
     })
     .from(agentRuns)
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -35,6 +35,10 @@ import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
+import {
+  pgIntegerDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { request$ } from "../context/hono";
 import { bodyResultOf, queryOf } from "../context/request";
@@ -153,7 +157,9 @@ function loadRecentRuns(db: ReadonlyDb, orgId: string | undefined) {
       triggerSource: zeroRuns.triggerSource,
       userId: agentRuns.userId,
       error: agentRuns.error,
-      promptPreview: sql<string>`substring(${agentRuns.prompt}, 1, 200)`,
+      promptPreview: sql`substring(${agentRuns.prompt}, 1, 200)`.mapWith(
+        pgTextDecoder,
+      ),
     })
     .from(agentRuns)
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
@@ -237,7 +243,7 @@ async function loadComposeVersion(
 
 async function countMessages(db: ReadonlyDb, botId: string): Promise<number> {
   const [row] = await db
-    .select({ count: sql<number>`count(*)::int` })
+    .select({ count: sql`count(*)::int`.mapWith(pgIntegerDecoder) })
     .from(telegramMessages)
     .where(eq(telegramMessages.installationId, botId));
   return row?.count ?? 0;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -114,9 +114,13 @@ import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { variables } from "@vm0/db/schema/variable";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, count, eq, inArray, or, sql } from "drizzle-orm";
-import type { z } from "zod";
+import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
+import {
+  pgNullDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import {
   badRequestMessage,
   notFound,
@@ -645,7 +649,9 @@ interface PersistedRunEnvironmentSnapshot {
   readonly variables: readonly PersistedRunEnvironmentVariable[];
 }
 
-type PersistedRunEnvironmentRowKind = "variable" | "secret";
+const persistedRunEnvironmentRowKindDecoder = zodEnumDriverValueDecoder(
+  z.enum(["variable", "secret"]),
+);
 
 interface CustomConnectorRuntimeContext {
   readonly firewalls: readonly ExpandedFirewallConfig[];
@@ -1678,7 +1684,7 @@ async function multiAuthModelProviderEnvironment(
     .select({
       name: secretsTable.name,
       encryptedValue: hasFirewallAuth
-        ? sql<string | null>`NULL`
+        ? sql`NULL`.mapWith(pgNullDecoder)
         : secretsTable.encryptedValue,
     })
     .from(secretsTable)
@@ -2058,7 +2064,9 @@ async function loadPersistedRunEnvironmentSnapshot(
   const secretNamesToLoad = [...new Set(referencedSecretNames)];
   const variableQuery = db
     .select({
-      kind: sql<PersistedRunEnvironmentRowKind>`'variable'`.as("kind"),
+      kind: sql`'variable'`
+        .mapWith(persistedRunEnvironmentRowKindDecoder)
+        .as("kind"),
       name: variables.name,
       value: variables.value,
       userId: variables.userId,
@@ -2079,7 +2087,9 @@ async function loadPersistedRunEnvironmentSnapshot(
       ? await variableQuery.unionAll(
           db
             .select({
-              kind: sql<PersistedRunEnvironmentRowKind>`'secret'`.as("kind"),
+              kind: sql`'secret'`
+                .mapWith(persistedRunEnvironmentRowKindDecoder)
+                .as("kind"),
               name: secretsTable.name,
               value: secretsTable.encryptedValue,
               userId: secretsTable.userId,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -61,6 +61,10 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows, pgInt8ToBigIntSchema } from "../../lib/db-raw-rows";
+import {
+  pgInt8ToBigIntDecoder,
+  pgNullDecoder,
+} from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -386,7 +390,7 @@ interface RefreshStateRow {
   readonly tokenExpiresAt: Date | null;
   readonly needsReconnect: boolean;
   readonly lastRefreshErrorCode: string | null;
-  readonly updatedAtMicros: bigint | number | string;
+  readonly updatedAtMicros: bigint;
 }
 
 interface ValidatedRefreshOutput {
@@ -1668,13 +1672,16 @@ async function loadModelProviderRefreshStateRow(
 ): Promise<RefreshStateRow | null> {
   const query = db
     .select({
-      authMethod: sql<string | null>`NULL`,
-      connectorId: sql<string | null>`NULL`,
-      storageVersion: sql<number | null>`NULL`,
+      authMethod: sql`NULL`.mapWith(pgNullDecoder),
+      connectorId: sql`NULL`.mapWith(pgNullDecoder),
+      storageVersion: sql`NULL`.mapWith(pgNullDecoder),
       tokenExpiresAt: modelProviders.tokenExpiresAt,
       needsReconnect: modelProviders.needsReconnect,
       lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
-      updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`,
+      updatedAtMicros:
+        sql`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`.mapWith(
+          pgInt8ToBigIntDecoder,
+        ),
     })
     .from(modelProviders)
     .where(
@@ -1702,8 +1709,11 @@ async function loadConnectorRefreshStateRow(
       storageVersion: connectors.storageVersion,
       tokenExpiresAt: connectors.tokenExpiresAt,
       needsReconnect: connectors.needsReconnect,
-      lastRefreshErrorCode: sql<string | null>`NULL`,
-      updatedAtMicros: sql<string>`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`,
+      lastRefreshErrorCode: sql`NULL`.mapWith(pgNullDecoder),
+      updatedAtMicros:
+        sql`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`.mapWith(
+          pgInt8ToBigIntDecoder,
+        ),
     })
     .from(connectors)
     .where(
@@ -1780,7 +1790,7 @@ async function loadRefreshState(
     tokenExpiresAt: row.tokenExpiresAt,
     needsReconnect: row.needsReconnect,
     lastRefreshErrorCode: row.lastRefreshErrorCode,
-    updatedAtMicros: BigInt(row.updatedAtMicros),
+    updatedAtMicros: row.updatedAtMicros,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -4,6 +4,10 @@ import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { z } from "zod";
 
+import {
+  nullableDriverValueDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { buildArtifactKey, buildFileUrl } from "../../lib/file-url";
 import { logger } from "../../lib/log";
@@ -38,6 +42,7 @@ const PREVIEW_IMAGE_CONTENT_TYPE = "image/webp";
 const PREVIEW_IMAGE_EXTENSION = "webp";
 const PREVIEW_IMAGE_BASENAME = "preview-v2";
 const PREVIEW_WAF_COOKIE_NAME = "vm0_artifact_preview";
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 
 const browserSnapshotSchema = z.object({
   meta: z.object({
@@ -377,9 +382,10 @@ export const generateArtifactPreviews$ = command(
           url: runUploadedFiles.url,
           contentType: runUploadedFiles.contentType,
           createdAt: runUploadedFiles.createdAt,
-          deploymentId: sql<
-            string | null
-          >`${runUploadedFiles.metadata}->>'deploymentId'`,
+          deploymentId:
+            sql`${runUploadedFiles.metadata}->>'deploymentId'`.mapWith(
+              nullableTextDecoder,
+            ),
         })
         .from(runUploadedFiles)
         .where(previewCandidateWhere(cursor))

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -7,6 +7,7 @@ import { variables } from "@vm0/db/schema/variable";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import type { Db, ReadonlyDb } from "../external/db";
@@ -139,7 +140,7 @@ export async function loadConnectorCredentialConnection(args: {
       externalId: connectors.externalId,
       needsReconnect: connectors.needsReconnect,
       oauthScopes: connectors.oauthScopes,
-      stateRevision: sql<string>`${connectors.updatedAt}::text`,
+      stateRevision: sql`${connectors.updatedAt}::text`.mapWith(pgTextDecoder),
       storageVersion: connectors.storageVersion,
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
@@ -344,7 +345,9 @@ async function persistConnectorRefresh(args: {
         externalId: connectors.externalId,
         needsReconnect: connectors.needsReconnect,
         reconnectReason: connectors.reconnectReason,
-        stateRevision: sql<string>`${connectors.updatedAt}::text`,
+        stateRevision: sql`${connectors.updatedAt}::text`.mapWith(
+          pgTextDecoder,
+        ),
         storageVersion: connectors.storageVersion,
       })
       .from(connectors)

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -20,7 +20,6 @@ import {
   pgIntegerDecoder,
   pgInt8ToSafeIntegerDecoder,
   pgTextDecoder,
-  pgTimestampWithoutTimezoneToDateDecoder,
 } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { getDatasetName, queryAxiom } from "../external/axiom";
@@ -792,7 +791,7 @@ async function queryActiveUsers(
         orgId: agentRuns.orgId,
         userId: agentRuns.userId,
         lastActivity: sql`MAX(${agentRuns.completedAt})`
-          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .mapWith(agentRuns.completedAt)
           .as("last_activity"),
       })
       .from(agentRuns)
@@ -808,7 +807,7 @@ async function queryActiveUsers(
         orgId: usageEvent.orgId,
         userId: usageEvent.userId,
         lastActivity: sql`MAX(${usageEvent.processedAt})`
-          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .mapWith(usageEvent.processedAt)
           .as("last_activity"),
       })
       .from(usageEvent)
@@ -1301,7 +1300,7 @@ export const aggregateInsights$ = command(
         orgId: insightsDaily.orgId,
         userId: insightsDaily.userId,
         lastUpdated: sql`MAX(${insightsDaily.updatedAt})`
-          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .mapWith(insightsDaily.updatedAt)
           .as("last_updated"),
       })
       .from(insightsDaily)

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -15,6 +15,13 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command, computed, type Computed } from "ccstate";
 import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
 
+import {
+  nullableDriverValueDecoder,
+  pgIntegerDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+  pgTimestampWithoutTimezoneToDateDecoder,
+} from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { getDatasetName, queryAxiom } from "../external/axiom";
 import { clerk$ } from "../external/clerk";
@@ -30,6 +37,7 @@ const AGGREGATION_REPROCESS_OVERLAP_MS = 5 * 60_000;
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
 const UUID_SHAPE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 
 interface AgentInfo {
   readonly agentId: string | null;
@@ -242,10 +250,6 @@ interface NetworkQueryResult {
 interface CurrentOrgMemberScope {
   readonly orgsWithCurrentMembers: Set<string>;
   readonly memberKeys: Set<string>;
-}
-
-function normalizeDbDate(value: Date | string): Date {
-  return value instanceof Date ? value : new Date(value);
 }
 
 type PermissionLabelResolver = (
@@ -622,7 +626,7 @@ function aggregateOrgCredits(
       agentNames: new Set<string>(),
       agentCredits: new Map<string, number>(),
     };
-    const amount = Number(row.credits);
+    const amount = row.credits;
     existing.credits += amount;
     existing.agentNames.add(row.agentName);
     existing.agentCredits.set(
@@ -768,14 +772,10 @@ async function queryCurrentOrgMembers(
 function mergeActiveUserRows(rows: ActiveUserRow[]): ActiveUserRow[] {
   const byUser = new Map<string, ActiveUserRow>();
   for (const row of rows) {
-    const normalizedRow = {
-      ...row,
-      lastActivity: normalizeDbDate(row.lastActivity),
-    };
     const key = `${row.orgId}:${row.userId}`;
     const existing = byUser.get(key);
-    if (!existing || normalizedRow.lastActivity > existing.lastActivity) {
-      byUser.set(key, normalizedRow);
+    if (!existing || row.lastActivity > existing.lastActivity) {
+      byUser.set(key, row);
     }
   }
   return [...byUser.values()];
@@ -791,9 +791,9 @@ async function queryActiveUsers(
       .select({
         orgId: agentRuns.orgId,
         userId: agentRuns.userId,
-        lastActivity: sql<Date>`MAX(${agentRuns.completedAt})`.as(
-          "last_activity",
-        ),
+        lastActivity: sql`MAX(${agentRuns.completedAt})`
+          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .as("last_activity"),
       })
       .from(agentRuns)
       .where(
@@ -807,9 +807,9 @@ async function queryActiveUsers(
       .select({
         orgId: usageEvent.orgId,
         userId: usageEvent.userId,
-        lastActivity: sql<Date>`MAX(${usageEvent.processedAt})`.as(
-          "last_activity",
-        ),
+        lastActivity: sql`MAX(${usageEvent.processedAt})`
+          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .as("last_activity"),
       })
       .from(usageEvent)
       .where(
@@ -864,7 +864,7 @@ function mergeAgentRows(
     add({ ...row, credits: 0 });
   }
   for (const row of creditRows) {
-    add({ ...row, runs: 0, credits: Number(row.credits) });
+    add({ ...row, runs: 0 });
   }
 
   const result = new Map<string, AgentInfo[]>();
@@ -893,11 +893,12 @@ async function queryCompletedRunCounts(
       orgId: agentRuns.orgId,
       userId: agentRuns.userId,
       agentId: zeroAgents.id,
-      agentName:
-        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
-          "agent_name",
-        ),
-      runs: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as("runs"),
+      agentName: sql`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`
+        .mapWith(pgTextDecoder)
+        .as("agent_name"),
+      runs: sql`COUNT(DISTINCT ${agentRuns.id})::int`
+        .mapWith(pgIntegerDecoder)
+        .as("runs"),
     })
     .from(agentRuns)
     .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
@@ -920,15 +921,7 @@ async function queryCompletedRunCounts(
     );
   signal.throwIfAborted();
 
-  return rows.map((row) => {
-    return {
-      orgId: row.orgId,
-      userId: row.userId,
-      agentId: row.agentId,
-      agentName: row.agentName,
-      runs: Number(row.runs),
-    };
-  });
+  return rows;
 }
 
 async function queryUsageEventCreditRows(
@@ -943,19 +936,18 @@ async function queryUsageEventCreditRows(
     .select({
       orgId: usageEvent.orgId,
       userId: usageEvent.userId,
-      agentId: sql<
-        string | null
-      >`CASE WHEN ${isRunless} THEN NULL ELSE ${zeroAgents.id}::text END`.as(
-        "agent_id",
-      ),
+      agentId:
+        sql`CASE WHEN ${isRunless} THEN NULL ELSE ${zeroAgents.id}::text END`
+          .mapWith(nullableTextDecoder)
+          .as("agent_id"),
       agentName:
-        sql<string>`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`.as(
-          "agent_name",
-        ),
+        sql`CASE WHEN ${isRunless} THEN ${OTHER_USAGE_AGENT_NAME} ELSE COALESCE(${zeroAgents.displayName}, ${zeroAgents.name}, 'Unknown agent') END`
+          .mapWith(pgTextDecoder)
+          .as("agent_name"),
       credits:
-        sql<number>`COALESCE(SUM(COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)), 0)::bigint`.as(
-          "credits",
-        ),
+        sql`COALESCE(SUM(COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)), 0)::bigint`
+          .mapWith(pgInt8ToSafeIntegerDecoder)
+          .as("credits"),
     })
     .from(usageEvent)
     .leftJoin(
@@ -984,9 +976,7 @@ async function queryUsageEventCreditRows(
     );
   signal.throwIfAborted();
 
-  return rows.map((row) => {
-    return { ...row, credits: Number(row.credits) };
-  });
+  return rows;
 }
 
 async function queryNetworkRunAgentRows(
@@ -1006,9 +996,9 @@ async function queryNetworkRunAgentRows(
           orgId: agentRuns.orgId,
           userId: agentRuns.userId,
           agentName:
-            sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
-              "agent_name",
-            ),
+            sql`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`
+              .mapWith(pgTextDecoder)
+              .as("agent_name"),
         })
         .from(agentRuns)
         .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
@@ -1310,9 +1300,9 @@ export const aggregateInsights$ = command(
       .select({
         orgId: insightsDaily.orgId,
         userId: insightsDaily.userId,
-        lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`.as(
-          "last_updated",
-        ),
+        lastUpdated: sql`MAX(${insightsDaily.updatedAt})`
+          .mapWith(pgTimestampWithoutTimezoneToDateDecoder)
+          .as("last_updated"),
       })
       .from(insightsDaily)
       .where(
@@ -1326,7 +1316,7 @@ export const aggregateInsights$ = command(
 
     const lastAggMap = new Map(
       lastAggRows.map((row) => {
-        return [`${row.orgId}:${row.userId}`, normalizeDbDate(row.lastUpdated)];
+        return [`${row.orgId}:${row.userId}`, row.lastUpdated];
       }),
     );
 

--- a/turbo/apps/api/src/signals/services/cron-backfill-storage-archive-sizes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-backfill-storage-archive-sizes.service.ts
@@ -9,6 +9,7 @@ import { storageVersions } from "@vm0/db/schema/storage";
 import { command } from "ccstate";
 import { and, asc, count, eq, isNull, lte, sql } from "drizzle-orm";
 
+import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
@@ -500,35 +501,35 @@ const readStorageArchiveSizeStatusCounts$ = command(
     const [counts] = await db
       .select({
         totalVersions: count(),
-        positiveArchives: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} > 0
-        )::int`,
-        intentionalEmptyArchives: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} = 0
-            AND ${storageVersions.fileCount} = 0
-        )::int`,
-        remaining: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} IS NULL
-        )::int`,
-        negativeArchives: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} < 0
-        )::int`,
-        nonEmptyZeroArchives: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} = 0
-            AND ${storageVersions.fileCount} <> 0
-        )::int`,
-        missing: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} IS NULL
-            AND ${storageArchiveSizeBackfillWork.outcome} = 'missing'
-        )::int`,
-        invalid: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} IS NULL
-            AND ${storageArchiveSizeBackfillWork.outcome} = 'invalid'
-        )::int`,
-        failed: sql<number>`COUNT(*) FILTER (
-          WHERE ${storageVersions.archiveSize} IS NULL
-            AND ${storageArchiveSizeBackfillWork.outcome} = 'failed'
-        )::int`,
+        positiveArchives: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} > 0
+          )::int`.mapWith(pgIntegerDecoder),
+        intentionalEmptyArchives: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} = 0
+              AND ${storageVersions.fileCount} = 0
+          )::int`.mapWith(pgIntegerDecoder),
+        remaining: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} IS NULL
+          )::int`.mapWith(pgIntegerDecoder),
+        negativeArchives: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} < 0
+          )::int`.mapWith(pgIntegerDecoder),
+        nonEmptyZeroArchives: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} = 0
+              AND ${storageVersions.fileCount} <> 0
+          )::int`.mapWith(pgIntegerDecoder),
+        missing: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} IS NULL
+              AND ${storageArchiveSizeBackfillWork.outcome} = 'missing'
+          )::int`.mapWith(pgIntegerDecoder),
+        invalid: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} IS NULL
+              AND ${storageArchiveSizeBackfillWork.outcome} = 'invalid'
+          )::int`.mapWith(pgIntegerDecoder),
+        failed: sql`COUNT(*) FILTER (
+            WHERE ${storageVersions.archiveSize} IS NULL
+              AND ${storageArchiveSizeBackfillWork.outcome} = 'failed'
+          )::int`.mapWith(pgIntegerDecoder),
       })
       .from(storageVersions)
       .leftJoin(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -32,6 +32,10 @@ import { z } from "zod";
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
 import { executeRawRows } from "../../lib/db-raw-rows";
+import {
+  nullableDriverValueDecoder,
+  pgTimestampWithoutTimezoneToDateDecoder,
+} from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
@@ -773,7 +777,9 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 
   const [message] = await db
     .select({
-      lastEventAt: sql<Date | null>`MAX(${chatMessages.createdAt})`,
+      lastEventAt: sql`MAX(${chatMessages.createdAt})`.mapWith(
+        nullableDriverValueDecoder(pgTimestampWithoutTimezoneToDateDecoder),
+      ),
     })
     .from(chatMessages)
     .where(
@@ -787,14 +793,13 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
     return;
   }
 
-  const lastEventMs =
-    message.lastEventAt instanceof Date
-      ? message.lastEventAt.getTime()
-      : new Date(message.lastEventAt).getTime();
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "last_event_to_complete",
-    durationMs: Math.max(0, run.completedAt.getTime() - lastEventMs),
+    durationMs: Math.max(
+      0,
+      run.completedAt.getTime() - message.lastEventAt.getTime(),
+    ),
     success: true,
     runId,
   });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -32,10 +32,7 @@ import { z } from "zod";
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
 import { executeRawRows } from "../../lib/db-raw-rows";
-import {
-  nullableDriverValueDecoder,
-  pgTimestampWithoutTimezoneToDateDecoder,
-} from "../../lib/db-structured-result";
+import { nullableDriverValueDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
@@ -778,7 +775,7 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
   const [message] = await db
     .select({
       lastEventAt: sql`MAX(${chatMessages.createdAt})`.mapWith(
-        nullableDriverValueDecoder(pgTimestampWithoutTimezoneToDateDecoder),
+        nullableDriverValueDecoder(chatMessages.createdAt),
       ),
     })
     .from(chatMessages)

--- a/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
@@ -20,6 +20,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, sql } from "drizzle-orm";
 
+import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { buildAgentResponseMessage } from "../../lib/slack-blocks";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -186,7 +187,10 @@ async function countThreadMentioners(args: {
 }): Promise<number> {
   const [row] = await args.db
     .select({
-      count: sql<number>`count(distinct ${slackOrgThreadSessions.connectionId})::int`,
+      count:
+        sql`count(distinct ${slackOrgThreadSessions.connectionId})::int`.mapWith(
+          pgIntegerDecoder,
+        ),
     })
     .from(slackOrgThreadSessions)
     .innerJoin(

--- a/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
@@ -1,6 +1,7 @@
 import { orgConcurrencySubscriptions } from "@vm0/db/schema/org-concurrency-subscription";
 import { and, eq, gt, inArray, sql } from "drizzle-orm";
 
+import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { nowDate } from "../external/time";
 import type { Db } from "../external/db";
@@ -72,7 +73,10 @@ export async function activePaidConcurrencySlots(
 ): Promise<number> {
   const [row] = await db
     .select({
-      slots: sql<number>`COALESCE(SUM(${orgConcurrencySubscriptions.slots}), 0)::int`,
+      slots:
+        sql`COALESCE(SUM(${orgConcurrencySubscriptions.slots}), 0)::int`.mapWith(
+          pgIntegerDecoder,
+        ),
     })
     .from(orgConcurrencySubscriptions)
     .where(
@@ -89,7 +93,7 @@ export async function activePaidConcurrencySlots(
       ),
     );
 
-  return Number(row?.slots ?? 0);
+  return row?.slots ?? 0;
 }
 
 export async function activeConcurrencySubscriptions(

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -3,6 +3,7 @@ import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import { and, eq, gt, sql, type SQL } from "drizzle-orm";
 
+import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
 
 const RUNNER_SESSION_AFFINITY_PROTECTION_MS = 2000;
@@ -239,9 +240,18 @@ async function runnerSessionAffinityHolders(args: {
     : sql<boolean>`false`;
   const [holders] = await args.db
     .select({
-      hasReusableHolder: sql<boolean>`coalesce(bool_or(${reusableCondition}), false)`,
-      hasWorkspaceHolder: sql<boolean>`coalesce(bool_or(${workspaceCondition}), false)`,
-      hasExactGenerationHolder: sql<boolean>`coalesce(bool_or(${exactGenerationCondition}), false)`,
+      hasReusableHolder:
+        sql`coalesce(bool_or(${reusableCondition}), false)`.mapWith(
+          pgBooleanDecoder,
+        ),
+      hasWorkspaceHolder:
+        sql`coalesce(bool_or(${workspaceCondition}), false)`.mapWith(
+          pgBooleanDecoder,
+        ),
+      hasExactGenerationHolder:
+        sql`coalesce(bool_or(${exactGenerationCondition}), false)`.mapWith(
+          pgBooleanDecoder,
+        ),
     })
     .from(runnerState)
     .where(

--- a/turbo/apps/api/src/signals/services/usage.service.ts
+++ b/turbo/apps/api/src/signals/services/usage.service.ts
@@ -7,6 +7,11 @@ import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
 import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
 
+import {
+  pgIntegerDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { writeDb$, type Db } from "../external/db";
 
 const MS_PER_DAY = 86_400_000;
@@ -56,12 +61,12 @@ async function queryAgentRunsDaily(
 
   const rows = await db
     .select({
-      date: sql<string>`DATE(${agentRuns.createdAt})`.as("date"),
-      run_count: sql<number>`COUNT(*)::int`.as("run_count"),
+      date: sql`DATE(${agentRuns.createdAt})`.mapWith(pgTextDecoder).as("date"),
+      run_count: sql`COUNT(*)::int`.mapWith(pgIntegerDecoder).as("run_count"),
       run_time_ms:
-        sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`.as(
-          "run_time_ms",
-        ),
+        sql`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`
+          .mapWith(pgInt8ToSafeIntegerDecoder)
+          .as("run_time_ms"),
     })
     .from(agentRuns)
     .where(
@@ -75,13 +80,7 @@ async function queryAgentRunsDaily(
     )
     .groupBy(sql`DATE(${agentRuns.createdAt})`);
 
-  return rows.map((row) => {
-    return {
-      date: String(row.date),
-      run_count: Number(row.run_count),
-      run_time_ms: Number(row.run_time_ms),
-    };
-  });
+  return rows;
 }
 
 async function appendAgentRunsDaily(

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -18,6 +18,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import { db$, type ReadonlyDb } from "../external/db";
 import {
@@ -639,7 +640,10 @@ export function zeroBillingStatus(
         .limit(1),
       db
         .select({
-          total: sql<number>`COALESCE(SUM(${creditExpiresRecord.remaining}), 0)::int`,
+          total:
+            sql`COALESCE(SUM(${creditExpiresRecord.remaining}), 0)::int`.mapWith(
+              pgIntegerDecoder,
+            ),
         })
         .from(creditExpiresRecord)
         .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-message.service.ts
@@ -8,6 +8,7 @@ import {
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { and, asc, eq, isNull, sql, type SQL } from "drizzle-orm";
 
+import { pgNullDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
 import {
   deleteChatMessage,
@@ -46,9 +47,9 @@ export async function loadNextUnclaimedQueuedUserMessage(
       attachFiles: chatMessages.attachFiles,
       attachFileMetadata: chatMessages.attachFileMetadata,
       generationTemplate: chatMessages.generationTemplate,
-      modelProviderId: sql<null>`NULL`,
-      modelProviderType: sql<null>`NULL`,
-      modelProviderCredentialScope: sql<null>`NULL`,
+      modelProviderId: sql`NULL`.mapWith(pgNullDecoder),
+      modelProviderType: sql`NULL`.mapWith(pgNullDecoder),
+      modelProviderCredentialScope: sql`NULL`.mapWith(pgNullDecoder),
       selectedModel: chatThreads.selectedModel,
     })
     .from(chatMessageQueue)

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -43,6 +43,7 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { userArtifactFavorites } from "@vm0/db/schema/user-artifact-favorite";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { alias } from "drizzle-orm/pg-core";
 import {
   and,
@@ -71,7 +72,6 @@ import {
   nullableDriverValueDecoder,
   pgBooleanDecoder,
   pgIntegerDecoder,
-  pgTimestampWithoutTimezoneToDateDecoder,
   pgTextDecoder,
   zodEnumDriverValueDecoder,
 } from "../../lib/db-structured-result";
@@ -99,7 +99,7 @@ const nullableTriggerSourceDecoder = nullableDriverValueDecoder(
 const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 const nullableIntegerDecoder = nullableDriverValueDecoder(pgIntegerDecoder);
 const nullableTimestampDecoder = nullableDriverValueDecoder(
-  pgTimestampWithoutTimezoneToDateDecoder,
+  zeroWorkflowAutomations.atTime,
 );
 const TERMINAL_MESSAGE_ORDER_SEQUENCE = 2_147_483_647;
 const matchedChatMessage = alias(chatMessages, "matched_chat_message");

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -12,7 +12,10 @@ import {
   type ResolvedAttachFile,
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import {
+  triggerSourceSchema,
+  type TriggerSource,
+} from "@vm0/api-contracts/contracts/logs";
 import {
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
@@ -40,7 +43,6 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { userArtifactFavorites } from "@vm0/db/schema/user-artifact-favorite";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
 import { alias } from "drizzle-orm/pg-core";
 import {
   and,
@@ -65,6 +67,14 @@ import {
   pgInt8ToSafeIntegerSchema,
   pgTimestampWithoutTimezoneToDateSchema,
 } from "../../lib/db-raw-rows";
+import {
+  nullableDriverValueDecoder,
+  pgBooleanDecoder,
+  pgIntegerDecoder,
+  pgTimestampWithoutTimezoneToDateDecoder,
+  pgTextDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import { type Db, db$, writeDb$ } from "../external/db";
 import {
   inferMimetype,
@@ -83,6 +93,14 @@ import { buildWorkflowScheduleAutomationBrief } from "./zero-workflow-automation
 export { insertAssistantEventMessages$ };
 
 const messageRoleSchema = z.enum(["user", "assistant"]);
+const nullableTriggerSourceDecoder = nullableDriverValueDecoder(
+  zodEnumDriverValueDecoder(triggerSourceSchema),
+);
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
+const nullableIntegerDecoder = nullableDriverValueDecoder(pgIntegerDecoder);
+const nullableTimestampDecoder = nullableDriverValueDecoder(
+  pgTimestampWithoutTimezoneToDateDecoder,
+);
 const TERMINAL_MESSAGE_ORDER_SEQUENCE = 2_147_483_647;
 const matchedChatMessage = alias(chatMessages, "matched_chat_message");
 
@@ -210,18 +228,18 @@ const messageColumns = {
   thinking: chatMessages.thinking,
   runId: effectiveChatMessageRunId(),
   runGroupId: chatMessages.runGroupId,
-  triggerSource: sql<TriggerSource | null>`(
+  triggerSource: sql`(
     SELECT "zero_runs"."trigger_source"
     FROM "zero_runs"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  isGoalRun: sql<boolean>`EXISTS (
+  )`.mapWith(nullableTriggerSourceDecoder),
+  isGoalRun: sql`EXISTS (
     SELECT 1
     FROM ${zeroRuns}
     WHERE ${zeroRuns.id} = ${chatMessages.runId}
       AND ${zeroRuns.goalId} IS NOT NULL
-  )`,
+  )`.mapWith(pgBooleanDecoder),
   usagePayload: chatMessages.usagePayload,
   runEventId: chatMessages.runEventId,
   goalEvent: chatMessages.goalEvent,
@@ -236,7 +254,7 @@ const messageColumns = {
   recommendedFollowups: chatMessages.recommendedFollowups,
   revokesMessageId: chatMessages.revokesMessageId,
   interruptsRunId: chatMessages.interruptsRunId,
-  workflowId: sql<string | null>`(
+  workflowId: sql`(
     SELECT "zero_workflows"."id"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -245,8 +263,8 @@ const messageColumns = {
       ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAgentId: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAgentId: sql`(
     SELECT "zero_workflows"."agent_id"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -255,8 +273,8 @@ const messageColumns = {
       ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowName: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowName: sql`(
     SELECT "zero_workflows"."name"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -265,8 +283,8 @@ const messageColumns = {
       ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowDisplayName: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowDisplayName: sql`(
     SELECT "zero_workflows"."display_name"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -275,8 +293,8 @@ const messageColumns = {
       ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowDescription: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowDescription: sql`(
     SELECT "zero_workflows"."description"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -285,16 +303,16 @@ const messageColumns = {
       ON "zero_workflows"."id" = "zero_workflow_automations"."workflow_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationId: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationId: sql`(
     SELECT "zero_workflow_automations"."id"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationBrief: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationBrief: sql`(
     SELECT COALESCE(
       "zero_runs"."trigger_brief",
       CASE
@@ -324,56 +342,56 @@ const messageColumns = {
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationKind: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationKind: sql`(
     SELECT "zero_workflow_automations"."kind"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationScheduleType: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationScheduleType: sql`(
     SELECT "zero_workflow_automations"."schedule_type"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationCronExpression: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationCronExpression: sql`(
     SELECT "zero_workflow_automations"."cron_expression"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationIntervalSeconds: sql<number | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationIntervalSeconds: sql`(
     SELECT "zero_workflow_automations"."interval_seconds"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationAtTime: sql<Date | null>`(
+  )`.mapWith(nullableIntegerDecoder),
+  workflowAutomationAtTime: sql`(
     SELECT "zero_workflow_automations"."at_time"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`.mapWith(zeroWorkflowAutomations.atTime),
-  workflowAutomationTimezone: sql<string | null>`(
+  )`.mapWith(nullableTimestampDecoder),
+  workflowAutomationTimezone: sql`(
     SELECT "zero_workflow_automations"."timezone"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
       ON "zero_workflow_automations"."id" = "zero_runs"."workflow_automation_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
-  workflowAutomationUserTimezone: sql<string | null>`(
+  )`.mapWith(nullableTextDecoder),
+  workflowAutomationUserTimezone: sql`(
     SELECT "org_members_metadata"."timezone"
     FROM "zero_runs"
     INNER JOIN "zero_workflow_automations"
@@ -383,7 +401,7 @@ const messageColumns = {
       AND "org_members_metadata"."user_id" = "zero_workflow_automations"."owner_user_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
+  )`.mapWith(nullableTextDecoder),
 } as const;
 
 const searchMessageColumns = {

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -16,7 +16,6 @@ import {
   pgIntegerDecoder,
   pgInt8ToSafeIntegerDecoder,
   pgTextDecoder,
-  pgTimestampWithoutTimezoneToDateDecoder,
 } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
@@ -87,7 +86,7 @@ async function loadUsageMessageContext(tx: WriteTx, runId: string) {
         MAX(${usageEvent.createdAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${agentRuns.completedAt}),
         MAX(${agentRuns.createdAt})
-      )`.mapWith(pgTimestampWithoutTimezoneToDateDecoder),
+      )`.mapWith(agentRuns.createdAt),
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -12,6 +12,12 @@ import { usageAllowanceAllocations } from "@vm0/db/schema/org-usage-allowance";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
+import {
+  pgIntegerDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+  pgTimestampWithoutTimezoneToDateDecoder,
+} from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
@@ -28,33 +34,11 @@ const USAGE_CONTEXT_GROUP_BY_COLUMNS = [
   chatThreads.userId,
 ] as const;
 
-function toNumber(value: unknown): number {
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "bigint") {
-    return Number(value);
-  }
-  if (typeof value === "string") {
-    return Number(value);
-  }
-  return 0;
-}
-
-function toIsoString(value: Date | string): string {
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  const normalized = value.replace(" ", "T");
-  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized);
-  return new Date(hasTimezone ? normalized : `${normalized}Z`).toISOString();
-}
-
 function buildUsageBreakdown(
   rows: readonly {
     readonly kind: string;
     readonly provider: string;
-    readonly credits: unknown;
+    readonly credits: number;
   }[],
 ): readonly ChatMessageUsageKindBreakdown[] {
   const byKind = new Map<string, ChatMessageUsageProviderBreakdown[]>();
@@ -62,7 +46,7 @@ function buildUsageBreakdown(
     const providers = byKind.get(row.kind) ?? [];
     providers.push({
       provider: row.provider,
-      credits: Math.max(0, toNumber(row.credits)),
+      credits: Math.max(0, row.credits),
     });
     byKind.set(row.kind, providers);
   }
@@ -86,15 +70,24 @@ async function loadUsageMessageContext(tx: WriteTx, runId: string) {
       chatThreadId: zeroRuns.chatThreadId,
       runGroupId: zeroRuns.runGroupId,
       userId: chatThreads.userId,
-      pendingCount: sql<number>`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'pending')::int`,
-      processedCount: sql<number>`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'processed')::int`,
-      totalCredits: sql<number>`COALESCE(SUM(${usageCreditsExpression()}) FILTER (WHERE ${usageEvent.status} = 'processed'), 0)::bigint`,
-      settledAt: sql<Date>`COALESCE(
+      pendingCount:
+        sql`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'pending')::int`.mapWith(
+          pgIntegerDecoder,
+        ),
+      processedCount:
+        sql`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'processed')::int`.mapWith(
+          pgIntegerDecoder,
+        ),
+      totalCredits:
+        sql`COALESCE(SUM(${usageCreditsExpression()}) FILTER (WHERE ${usageEvent.status} = 'processed'), 0)::bigint`.mapWith(
+          pgInt8ToSafeIntegerDecoder,
+        ),
+      settledAt: sql`COALESCE(
         MAX(${usageEvent.processedAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${usageEvent.createdAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
         MAX(${agentRuns.completedAt}),
         MAX(${agentRuns.createdAt})
-      )`,
+      )`.mapWith(pgTimestampWithoutTimezoneToDateDecoder),
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
@@ -113,8 +106,14 @@ async function loadUsageBreakdownRows(tx: WriteTx, runId: string) {
   return await tx
     .select({
       kind: usageEvent.kind,
-      provider: sql<string>`COALESCE(NULLIF(${usageEvent.provider}, ''), 'unknown')`,
-      credits: sql<number>`COALESCE(SUM(${usageCreditsExpression()}), 0)::bigint`,
+      provider:
+        sql`COALESCE(NULLIF(${usageEvent.provider}, ''), 'unknown')`.mapWith(
+          pgTextDecoder,
+        ),
+      credits:
+        sql`COALESCE(SUM(${usageCreditsExpression()}), 0)::bigint`.mapWith(
+          pgInt8ToSafeIntegerDecoder,
+        ),
     })
     .from(usageEvent)
     .leftJoin(
@@ -152,10 +151,7 @@ export const maybeEmitRunUsageMessage$ = command(
       if (!context.chatThreadId || !context.userId) {
         return null;
       }
-      if (
-        toNumber(context.pendingCount) > 0 ||
-        toNumber(context.processedCount) === 0
-      ) {
+      if (context.pendingCount > 0 || context.processedCount === 0) {
         return null;
       }
 
@@ -180,8 +176,8 @@ export const maybeEmitRunUsageMessage$ = command(
 
       const payload: ChatMessageUsagePayload = {
         version: 1,
-        totalCredits: Math.max(0, toNumber(context.totalCredits)),
-        settledAt: toIsoString(context.settledAt),
+        totalCredits: Math.max(0, context.totalCredits),
+        settledAt: context.settledAt.toISOString(),
         breakdown: buildUsageBreakdown(breakdownRows),
       };
 

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -8,6 +8,11 @@ import { insightsDaily } from "@vm0/db/schema/insights-daily";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { and, desc, eq, gte, sql } from "drizzle-orm";
 
+import {
+  nullableDriverValueDecoder,
+  pgIntegerDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import { clerk$ } from "../external/clerk";
 import { db$ } from "../external/db";
@@ -15,6 +20,7 @@ import { tapError } from "../utils";
 
 type DayInsightData = Partial<Omit<DayInsight, "date">>;
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 
 interface StoredTeamUsageEntry {
   readonly userId?: string;
@@ -198,9 +204,15 @@ export function zeroInsightsRange(args: {
   return computed(async (get): Promise<InsightsRangeResponse> => {
     const [row] = await get(db$)
       .select({
-        minDate: sql<string | null>`MIN(${insightsDaily.date})`.as("min_date"),
-        maxDate: sql<string | null>`MAX(${insightsDaily.date})`.as("max_date"),
-        totalDays: sql<number>`COUNT(*)::int`.as("total_days"),
+        minDate: sql`MIN(${insightsDaily.date})`
+          .mapWith(nullableTextDecoder)
+          .as("min_date"),
+        maxDate: sql`MAX(${insightsDaily.date})`
+          .mapWith(nullableTextDecoder)
+          .as("max_date"),
+        totalDays: sql`COUNT(*)::int`
+          .mapWith(pgIntegerDecoder)
+          .as("total_days"),
       })
       .from(insightsDaily)
       .where(

--- a/turbo/apps/api/src/signals/services/zero-mail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-mail.service.ts
@@ -21,6 +21,7 @@ import { userConnectors } from "@vm0/db/schema/user-connector";
 import { convert } from "html-to-text";
 import { z } from "zod";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
@@ -267,7 +268,7 @@ async function loadMailConnections(args: {
       externalId: connectors.externalId,
       needsReconnect: connectors.needsReconnect,
       oauthScopes: connectors.oauthScopes,
-      stateRevision: sql<string>`${connectors.updatedAt}::text`,
+      stateRevision: sql`${connectors.updatedAt}::text`.mapWith(pgTextDecoder),
       storageVersion: connectors.storageVersion,
       tokenExpiresAt: connectors.tokenExpiresAt,
     })

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -27,7 +27,6 @@ import { z } from "zod";
 
 import {
   nullableDriverValueDecoder,
-  pgTimestampWithoutTimezoneToDateDecoder,
   pgTextDecoder,
   zodDriverValueDecoder,
   zodEnumDriverValueDecoder,
@@ -99,7 +98,7 @@ const nullablePermissionGrantActionDecoder = nullableDriverValueDecoder(
   permissionGrantActionDecoder,
 );
 const nullableTimestampDecoder = nullableDriverValueDecoder(
-  pgTimestampWithoutTimezoneToDateDecoder,
+  zeroWorkflows.createdAt,
 );
 
 interface ExecutionScopeSnapshotQueryRow {

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -1,3 +1,8 @@
+import { userPermissionGrantActionSchema } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  type ZeroWorkflowVisibility,
+  zeroWorkflowVisibilitySchema,
+} from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   isFeatureEnabled,
   type FeatureSwitchContext,
@@ -15,13 +20,18 @@ import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
-import {
-  zeroWorkflows,
-  type ZeroWorkflowVisibility,
-} from "@vm0/db/schema/zero-workflow";
+import { zeroWorkflows } from "@vm0/db/schema/zero-workflow";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { unionAll } from "drizzle-orm/pg-core";
+import { z } from "zod";
 
+import {
+  nullableDriverValueDecoder,
+  pgTimestampWithoutTimezoneToDateDecoder,
+  pgTextDecoder,
+  zodDriverValueDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import type { ReadonlyDb } from "../external/db";
 import {
   agentConnectorScopeFromRows,
@@ -41,7 +51,14 @@ import {
   type RunWorkflowSourceRow,
 } from "./zero-workflow-data.service";
 
-type PromptSnapshotRowKind = "user_info" | "feature_switch";
+const promptSnapshotRowKindSchema = z.enum(["user_info", "feature_switch"]);
+type PromptSnapshotRowKind = z.output<typeof promptSnapshotRowKindSchema>;
+const promptSnapshotRowKindDecoder = zodEnumDriverValueDecoder(
+  promptSnapshotRowKindSchema,
+);
+const promptSnapshotSwitchesDecoder = zodDriverValueDecoder(
+  z.record(z.string(), z.boolean()),
+);
 
 interface PromptSnapshotQueryRow {
   readonly kind: PromptSnapshotRowKind;
@@ -52,12 +69,38 @@ interface PromptSnapshotQueryRow {
   readonly switches: Record<string, boolean> | null;
 }
 
-type ExecutionScopeSnapshotRowKind =
-  | "builtin_connector"
-  | "custom_connector"
-  | "workflow"
-  | "permission_grant"
-  | "trigger_agent";
+const executionScopeSnapshotRowKindSchema = z.enum([
+  "builtin_connector",
+  "custom_connector",
+  "workflow",
+  "permission_grant",
+  "trigger_agent",
+]);
+type ExecutionScopeSnapshotRowKind = z.output<
+  typeof executionScopeSnapshotRowKindSchema
+>;
+const executionScopeSnapshotRowKindDecoder = zodEnumDriverValueDecoder(
+  executionScopeSnapshotRowKindSchema,
+);
+const workflowVisibilityDecoder = zodEnumDriverValueDecoder(
+  zeroWorkflowVisibilitySchema,
+);
+const permissionGrantActionDecoder = zodEnumDriverValueDecoder(
+  userPermissionGrantActionSchema,
+);
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
+const nullablePromptSnapshotSwitchesDecoder = nullableDriverValueDecoder(
+  promptSnapshotSwitchesDecoder,
+);
+const nullableWorkflowVisibilityDecoder = nullableDriverValueDecoder(
+  workflowVisibilityDecoder,
+);
+const nullablePermissionGrantActionDecoder = nullableDriverValueDecoder(
+  permissionGrantActionDecoder,
+);
+const nullableTimestampDecoder = nullableDriverValueDecoder(
+  pgTimestampWithoutTimezoneToDateDecoder,
+);
 
 interface ExecutionScopeSnapshotQueryRow {
   readonly kind: ExecutionScopeSnapshotRowKind;
@@ -117,12 +160,16 @@ export async function loadZeroRunPromptContextSnapshot(
 ): Promise<ZeroRunPromptContext> {
   const userInfoQuery = db
     .select({
-      kind: sql<PromptSnapshotRowKind>`'user_info'`.as("kind"),
+      kind: sql`'user_info'`.mapWith(promptSnapshotRowKindDecoder).as("kind"),
       name: userCache.name,
-      email: sql<string | null>`${userCache.email}`.as("email"),
+      email: sql`${userCache.email}`.mapWith(nullableTextDecoder).as("email"),
       timezone: orgMembersMetadata.timezone,
-      featureUserId: sql<string | null>`NULL::text`.as("feature_user_id"),
-      switches: sql<Record<string, boolean> | null>`NULL::jsonb`.as("switches"),
+      featureUserId: sql`NULL::text`
+        .mapWith(nullableTextDecoder)
+        .as("feature_user_id"),
+      switches: sql`NULL::jsonb`
+        .mapWith(nullablePromptSnapshotSwitchesDecoder)
+        .as("switches"),
     })
     .from(userCache)
     .leftJoin(
@@ -135,17 +182,18 @@ export async function loadZeroRunPromptContextSnapshot(
     .where(eq(userCache.userId, args.userId));
   const featureSwitchQuery = db
     .select({
-      kind: sql<PromptSnapshotRowKind>`'feature_switch'`.as("kind"),
-      name: sql<string | null>`NULL::text`.as("name"),
-      email: sql<string | null>`NULL::text`.as("email"),
-      timezone: sql<string | null>`NULL::text`.as("timezone"),
-      featureUserId: sql<string | null>`${userFeatureSwitches.userId}`.as(
-        "feature_user_id",
-      ),
-      switches: sql<Record<
-        string,
-        boolean
-      > | null>`${userFeatureSwitches.switches}`.as("switches"),
+      kind: sql`'feature_switch'`
+        .mapWith(promptSnapshotRowKindDecoder)
+        .as("kind"),
+      name: sql`NULL::text`.mapWith(nullableTextDecoder).as("name"),
+      email: sql`NULL::text`.mapWith(nullableTextDecoder).as("email"),
+      timezone: sql`NULL::text`.mapWith(nullableTextDecoder).as("timezone"),
+      featureUserId: sql`${userFeatureSwitches.userId}`
+        .mapWith(nullableTextDecoder)
+        .as("feature_user_id"),
+      switches: sql`${userFeatureSwitches.switches}`
+        .mapWith(nullablePromptSnapshotSwitchesDecoder)
+        .as("switches"),
     })
     .from(userFeatureSwitches)
     .where(
@@ -214,14 +262,20 @@ export async function loadZeroRunPromptContextSnapshot(
 
 function emptyExecutionScopeSnapshotFields() {
   return {
-    id: sql<string | null>`NULL::text`.as("id"),
-    name: sql<string | null>`NULL::text`.as("name"),
-    detail: sql<string | null>`NULL::text`.as("detail"),
-    visibility: sql<ZeroWorkflowVisibility | null>`NULL::text`.as("visibility"),
-    ownerUserId: sql<string | null>`NULL::text`.as("owner_user_id"),
-    action: sql<FirewallPermissionGrantAction | null>`NULL::text`.as("action"),
-    createdAt: sql<Date | null>`NULL::timestamp`
-      .mapWith(zeroWorkflows.createdAt)
+    id: sql`NULL::text`.mapWith(nullableTextDecoder).as("id"),
+    name: sql`NULL::text`.mapWith(nullableTextDecoder).as("name"),
+    detail: sql`NULL::text`.mapWith(nullableTextDecoder).as("detail"),
+    visibility: sql`NULL::text`
+      .mapWith(nullableWorkflowVisibilityDecoder)
+      .as("visibility"),
+    ownerUserId: sql`NULL::text`
+      .mapWith(nullableTextDecoder)
+      .as("owner_user_id"),
+    action: sql`NULL::text`
+      .mapWith(nullablePermissionGrantActionDecoder)
+      .as("action"),
+    createdAt: sql`NULL::timestamp`
+      .mapWith(nullableTimestampDecoder)
       .as("created_at"),
   };
 }
@@ -232,9 +286,13 @@ async function queryZeroRunExecutionScopeSnapshot(
 ): Promise<ExecutionScopeSnapshotQueryRow[]> {
   const builtinConnectorQuery = db
     .select({
-      kind: sql<ExecutionScopeSnapshotRowKind>`'builtin_connector'`.as("kind"),
+      kind: sql`'builtin_connector'`
+        .mapWith(executionScopeSnapshotRowKindDecoder)
+        .as("kind"),
       ...emptyExecutionScopeSnapshotFields(),
-      name: sql<string | null>`${userConnectors.connectorType}`.as("name"),
+      name: sql`${userConnectors.connectorType}`
+        .mapWith(nullableTextDecoder)
+        .as("name"),
     })
     .from(userConnectors)
     .where(
@@ -246,11 +304,13 @@ async function queryZeroRunExecutionScopeSnapshot(
     );
   const customConnectorQuery = db
     .select({
-      kind: sql<ExecutionScopeSnapshotRowKind>`'custom_connector'`.as("kind"),
+      kind: sql`'custom_connector'`
+        .mapWith(executionScopeSnapshotRowKindDecoder)
+        .as("kind"),
       ...emptyExecutionScopeSnapshotFields(),
-      id: sql<
-        string | null
-      >`${userCustomConnectors.customConnectorId}::text`.as("id"),
+      id: sql`${userCustomConnectors.customConnectorId}::text`
+        .mapWith(nullableTextDecoder)
+        .as("id"),
     })
     .from(userCustomConnectors)
     .where(
@@ -262,19 +322,20 @@ async function queryZeroRunExecutionScopeSnapshot(
     );
   const workflowQuery = db
     .select({
-      kind: sql<ExecutionScopeSnapshotRowKind>`'workflow'`.as("kind"),
+      kind: sql`'workflow'`
+        .mapWith(executionScopeSnapshotRowKindDecoder)
+        .as("kind"),
       ...emptyExecutionScopeSnapshotFields(),
-      id: sql<string | null>`${zeroWorkflows.id}::text`.as("id"),
-      name: sql<string | null>`${zeroWorkflows.name}`.as("name"),
-      visibility:
-        sql<ZeroWorkflowVisibility | null>`${zeroWorkflows.visibility}`.as(
-          "visibility",
-        ),
-      ownerUserId: sql<string | null>`${zeroWorkflows.ownerUserId}`.as(
-        "owner_user_id",
-      ),
-      createdAt: sql<Date | null>`${zeroWorkflows.createdAt}`
-        .mapWith(zeroWorkflows.createdAt)
+      id: sql`${zeroWorkflows.id}::text`.mapWith(nullableTextDecoder).as("id"),
+      name: sql`${zeroWorkflows.name}`.mapWith(nullableTextDecoder).as("name"),
+      visibility: sql`${zeroWorkflows.visibility}`
+        .mapWith(nullableWorkflowVisibilityDecoder)
+        .as("visibility"),
+      ownerUserId: sql`${zeroWorkflows.ownerUserId}`
+        .mapWith(nullableTextDecoder)
+        .as("owner_user_id"),
+      createdAt: sql`${zeroWorkflows.createdAt}`
+        .mapWith(nullableTimestampDecoder)
         .as("created_at"),
     })
     .from(zeroWorkflows)
@@ -290,16 +351,19 @@ async function queryZeroRunExecutionScopeSnapshot(
     );
   const permissionGrantQuery = db
     .select({
-      kind: sql<ExecutionScopeSnapshotRowKind>`'permission_grant'`.as("kind"),
+      kind: sql`'permission_grant'`
+        .mapWith(executionScopeSnapshotRowKindDecoder)
+        .as("kind"),
       ...emptyExecutionScopeSnapshotFields(),
-      name: sql<string | null>`${userPermissionGrants.connectorRef}`.as("name"),
-      detail: sql<string | null>`${userPermissionGrants.permission}`.as(
-        "detail",
-      ),
-      action:
-        sql<FirewallPermissionGrantAction | null>`${userPermissionGrants.action}`.as(
-          "action",
-        ),
+      name: sql`${userPermissionGrants.connectorRef}`
+        .mapWith(nullableTextDecoder)
+        .as("name"),
+      detail: sql`${userPermissionGrants.permission}`
+        .mapWith(nullableTextDecoder)
+        .as("detail"),
+      action: sql`${userPermissionGrants.action}`
+        .mapWith(nullablePermissionGrantActionDecoder)
+        .as("action"),
     })
     .from(userPermissionGrants)
     .where(
@@ -312,9 +376,13 @@ async function queryZeroRunExecutionScopeSnapshot(
     );
   const triggerAgentQuery = db
     .select({
-      kind: sql<ExecutionScopeSnapshotRowKind>`'trigger_agent'`.as("kind"),
+      kind: sql`'trigger_agent'`
+        .mapWith(executionScopeSnapshotRowKindDecoder)
+        .as("kind"),
       ...emptyExecutionScopeSnapshotFields(),
-      id: sql<string | null>`${agentSessions.agentComposeId}::text`.as("id"),
+      id: sql`${agentSessions.agentComposeId}::text`
+        .mapWith(nullableTextDecoder)
+        .as("id"),
     })
     .from(agentRuns)
     .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -2,6 +2,11 @@ import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
 import { usageAllowanceAllocations } from "@vm0/db/schema/org-usage-allowance";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 
+import {
+  nullableDriverValueDecoder,
+  pgInt8ToSafeIntegerDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
 
 const MODEL_USAGE_KIND = "model";
@@ -36,6 +41,7 @@ const ALL_CACHE_TOKEN_CATEGORIES = [
   ...CACHE_READ_TOKEN_CATEGORIES,
   ...CACHE_CREATION_TOKEN_CATEGORIES,
 ] as const;
+const nullableTextDecoder = nullableDriverValueDecoder(pgTextDecoder);
 
 interface BillingWindow {
   readonly start: Date;
@@ -122,12 +128,11 @@ export function buildUsageEventRunUsageTotalsSubquery(db: Db, orgId: string) {
       "cache_tokens_sum",
     ),
     creditsCharged: usageCreditsSum("credits_sum"),
-    model: sql<
-      string | null
-    >`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`.as(
-      "model",
-    ),
-    userId: sql<string>`MAX(${usageEvent.userId})`.as("user_id"),
+    model:
+      sql`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`
+        .mapWith(nullableTextDecoder)
+        .as("model"),
+    userId: sql`MAX(${usageEvent.userId})`.mapWith(pgTextDecoder).as("user_id"),
   } satisfies Record<keyof UsageRunTotalsRow, unknown>;
 
   return db
@@ -177,7 +182,7 @@ export function mergedRunCreditsCharged(
 }
 
 export function mergedRunModel(events: UsageEventRunUsageTotalsSubquery) {
-  return sql<string | null>`${events.model}`.as("model");
+  return sql`${events.model}`.mapWith(nullableTextDecoder).as("model");
 }
 
 function usageEventTokenSum(categories: readonly string[], alias: string) {
@@ -187,17 +192,19 @@ function usageEventTokenSum(categories: readonly string[], alias: string) {
     }),
     sql.raw(", "),
   );
-  return sql<number>`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`.as(
-    alias,
-  );
+  return sql`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
+    .mapWith(pgInt8ToSafeIntegerDecoder)
+    .as(alias);
 }
 
 function coalesceRunTotal(column: unknown, alias: string) {
-  return sql<number>`COALESCE(${column}, 0)::bigint`.as(alias);
+  return sql`COALESCE(${column}, 0)::bigint`
+    .mapWith(pgInt8ToSafeIntegerDecoder)
+    .as(alias);
 }
 
 function usageCreditsSum(alias: string) {
-  return sql<number>`COALESCE(SUM(COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)), 0)::bigint`.as(
-    alias,
-  );
+  return sql`COALESCE(SUM(COALESCE(${usageEvent.creditsCharged}, 0) + COALESCE(${usageAllowanceAllocations.unitsApplied}, 0)), 0)::bigint`
+    .mapWith(pgInt8ToSafeIntegerDecoder)
+    .as(alias);
 }

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -83,11 +83,11 @@ export const zeroUsageMembers$ = command(
       return {
         userId: row.userId,
         email: emailMap.get(row.userId) ?? "unknown",
-        inputTokens: Number(row.inputTokens),
-        outputTokens: Number(row.outputTokens),
-        cacheReadInputTokens: Number(row.cacheReadInputTokens),
-        cacheCreationInputTokens: Number(row.cacheCreationInputTokens),
-        creditsCharged: Number(row.creditsCharged),
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+        cacheReadInputTokens: row.cacheReadInputTokens,
+        cacheCreationInputTokens: row.cacheCreationInputTokens,
+        creditsCharged: row.creditsCharged,
       };
     });
 
@@ -222,10 +222,10 @@ export const zeroUsageRuns$ = command(
           startedAt,
           completedAt,
           durationMs,
-          inputTokens: Number(row.inputTokens),
-          outputTokens: Number(row.outputTokens),
-          cacheTokens: Number(row.cacheTokens),
-          creditsCharged: Number(row.creditsCharged),
+          inputTokens: row.inputTokens,
+          outputTokens: row.outputTokens,
+          cacheTokens: row.cacheTokens,
+          creditsCharged: row.creditsCharged,
           createdAt: row.createdAt.toISOString(),
         };
       }),


### PR DESCRIPTION
## Summary

- add runtime-inferred Drizzle decoders for structured raw SQL result values
- map all 112 result-producing `sql<T>` expressions across 23 query owners while preserving their SQL
- remove redundant downstream representation normalization and cover asynchronous callback timestamp decoding

## Inventory

| Cohort | Count | Result |
| --- | ---: | --- |
| All tagged SQL expressions inspected | 449 | classified |
| Structured result expressions | 112 | runtime-mapped in this PR |
| Explicit non-result `sql<T>` expressions | 36 | tracked by #22157 |
| Contextual non-result `SQL<T>` expressions | 13 | tracked by #22157 |

The latest rebase onto `6af9b4ba0e` incorporated 11 tagged SQL templates from `main`: eight structured `int4` storage-backfill status aggregates are runtime-mapped, while three DDL/write fragments remain non-result expressions. All 196 tagged templates in the 23 changed query-owner files retain identical normalized SQL text and interpolation order against the rebased base.

Timestamp expressions reuse their exact Drizzle schema-column decoders. Shared decoders are limited to representations without an exact column contract.

## Compatibility

- no database schema, migration, or persisted-data changes
- no API shape, queue payload, runner protocol, or feature-switch changes
- #22139 remains open; lint and non-result enforcement remain in #22157

## Performance

- controlled fresh-database message benchmark: 16.343 ms mapped versus 16.293 ms compile-only control (about 0.3%, within measurement error)
- query text, query count, execution order, joins, locks, aliases, and casts are unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected real-PostgreSQL integration files in serial isolation after the latest rebase (8 files, 239 tests)
- full API suite on the pre-rebase base (161 files, 2,269 tests)
- fresh-database parity check: this head and current `origin/main` reproduce the same local cross-worker test interference at four workers; all affected files pass in serial isolation, tracked separately by #22161
- `pnpm -F api build`
- `pnpm knip --workspace api`
- pre-commit repository-wide Knip and TypeScript checks
- normalized SQL template AST comparison (23 query owners, 196 identical templates)
- controlled API benchmark

Closes #22156
Relates to #22139
