### PR TITLE
refactor: reduce fallback slop in slack oauth

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
@@ -99,6 +99,26 @@ describe("connector/providers/slack", () => {
         ),
       ).rejects.toThrow("No user access token");
     });
+
+    it("throws when no authenticated user id is returned", async () => {
+      const handler = http.post("https://slack.com/api/oauth.v2.access", () => {
+        return HttpResponse.json({
+          ok: true,
+          authed_user: { access_token: "xoxp-test-token" },
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        exchangeSlackCode(
+          authCodeGrant(),
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No authenticated user id");
+    });
   });
 
   describe("fetchSlackUserInfo", () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
@@ -88,11 +88,14 @@ export async function exchangeSlackCode(
   if (!data.authed_user?.access_token) {
     throw new Error("No user access token in Slack response");
   }
+  if (!data.authed_user.id) {
+    throw new Error("No authenticated user id in Slack response");
+  }
 
   return {
     accessToken: data.authed_user.access_token,
     scopes: data.authed_user.scope?.split(",") ?? [],
-    userId: data.authed_user.id ?? "",
+    userId: data.authed_user.id,
   };
 }
 


### PR DESCRIPTION
## Summary

- Reject a successful Slack connector OAuth response when it omits the authenticated user ID.
- Prevent the connector flow from querying `users.info` with an empty user key and from persisting an invalid external identity.

## Scan

- Scan timestamp: `2026-07-19T20:02:59.616Z`
- Base commit: `6c88936f3a4047dbb33c722b214263e4b8b034b9`
- Tracked source files scanned: `4,288`
- Total matches: `19,455`
- Scanner initial high-confidence production actionable total: `220`
- Scanner initial suggested 5% budget: `11`
- Manually confirmed `actionable_total`: `1`
- Final `edit_budget`: `1` (`max(1, ceil(1 * 0.05))`), reduced after surrounding-code review excluded duplicate category hits, tests/comments, external payload variation without a proven vm0 requirement, and intentional presentation/precedence fallbacks
- Candidates changed: `1`

Total matches by category:

```json
{
  "nullish": 5914,
  "nullish-chain": 127,
  "field-fallback-chain": 103,
  "optional-prop": 6024,
  "zod-optional": 2264,
  "zod-loose-optional": 2,
  "loose-record": 1180,
  "loose-index-signature": 3,
  "as-any": 0,
  "as-unknown-as": 32,
  "empty-fallback": 705,
  "string-fallback": 764,
  "null-undefined-fallback": 1552,
  "empty-catch": 3,
  "promise-catch-swallow": 14,
  "rust-unwrap-or": 633,
  "rust-ok-discard": 135
}
```

## Files changed

- `turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts`: fail fast when Slack returns a user access token without `authed_user.id`, then pass the validated ID downstream without an empty-string fallback. This is safe because the provider immediately uses the value as the required `users.info` lookup key, and the resulting identity is persisted as the connector external ID.
- `turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts`: cover the malformed successful response with a missing authenticated user ID.

## Verification

- `pnpm exec vitest run src/auth-providers/connectors/__tests__/slack.test.ts`: 1 file passed, 10 tests passed
- `pnpm run check-types` in `@vm0/connectors`: passed
- Type-aware Oxlint on both touched files: 0 warnings, 0 errors
- ESLint on both touched files: passed
- Prettier check on both touched files: passed
- `git diff --check`: passed
- Follow-up full scan: targeted `nullish` and `string-fallback` totals each decreased by one; all high-confidence totals were unchanged because this specific scanner rule is medium-confidence until downstream contract review

This workflow intentionally leaves the remaining candidates for later daily runs.
