### PR TITLE
perf(platform): render branded skeleton before app bundle loads

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -472,7 +472,8 @@
         }
       })();
     </script>
-    <div id="root">
+    <div id="root"></div>
+    <div id="app-bootstrap-skeleton">
       <style>
         :root {
           --zero-viewport-height: 100dvh;
@@ -502,17 +503,298 @@
           right: 0;
           left: 0;
         }
-        .sk {
+        #app-bootstrap-skeleton {
+          position: fixed;
+          inset: 0;
+          z-index: 60;
+          box-sizing: border-box;
+          display: none;
+          align-items: center;
+          justify-content: center;
           height: var(--zero-viewport-height);
           min-height: var(--zero-viewport-height);
           background: #fdfdfe;
+          color: rgba(20, 23, 29, 0.7);
+          font-family:
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            "Segoe UI",
+            sans-serif;
+          opacity: 1;
+          transition: opacity 300ms ease;
         }
-        [data-theme="dark"] .sk {
+        [data-browser-supported="true"] #app-bootstrap-skeleton {
+          display: flex;
+        }
+        [data-theme="dark"] #app-bootstrap-skeleton {
           background: #19191b;
+          color: rgba(232, 233, 237, 0.7);
+        }
+        #app-bootstrap-skeleton.app-bootstrap-skeleton--hidden {
+          pointer-events: none;
+          opacity: 0;
+        }
+        .app-bootstrap-skeleton__content {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 20px;
+        }
+        .app-bootstrap-skeleton__avatar {
+          position: relative;
+          width: 64px;
+          height: 64px;
+          overflow: hidden;
+          border-radius: 9999px;
+        }
+        .app-bootstrap-skeleton__avatar-layers {
+          position: absolute;
+          inset: 0;
+          transform: scale(1.25);
+        }
+        .app-bootstrap-skeleton__avatar img {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+        }
+        .app-bootstrap-skeleton__message {
+          position: relative;
+          height: 24px;
+          font-size: 16px;
+          font-weight: 500;
+          line-height: 24px;
+        }
+        .app-bootstrap-skeleton__message p {
+          margin: 0;
+          white-space: nowrap;
+        }
+        .app-bootstrap-skeleton__message-spacer {
+          visibility: hidden;
+        }
+        .app-bootstrap-skeleton__message-static {
+          position: absolute;
+          top: 0;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+        .app-bootstrap-skeleton__message-typewriter {
+          position: absolute;
+          inset: 0;
+          width: 0;
+          overflow: hidden;
+          border-right: 2px solid currentColor;
+          visibility: hidden;
+        }
+        @keyframes app-bootstrap-skeleton-hide-static {
+          0%,
+          99.9% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0;
+          }
+        }
+        @keyframes app-bootstrap-skeleton-show-typewriter {
+          0%,
+          99.9% {
+            visibility: hidden;
+          }
+          100% {
+            visibility: visible;
+          }
+        }
+        @keyframes app-bootstrap-skeleton-type {
+          from {
+            width: 0;
+          }
+          to {
+            width: 100%;
+          }
+        }
+        @keyframes app-bootstrap-skeleton-blink {
+          0%,
+          100% {
+            border-color: transparent;
+          }
+          50% {
+            border-color: currentColor;
+          }
         }
       </style>
-      <div class="sk"></div>
+      <div class="app-bootstrap-skeleton__content">
+        <div class="app-bootstrap-skeleton__avatar" aria-hidden="true">
+          <div class="app-bootstrap-skeleton__avatar-layers">
+            <img data-app-bootstrap-avatar-layer="head" alt="" />
+            <img data-app-bootstrap-avatar-layer="face" alt="" />
+            <img data-app-bootstrap-avatar-layer="hair" alt="" />
+          </div>
+        </div>
+        <div class="app-bootstrap-skeleton__message">
+          <p class="app-bootstrap-skeleton__message-spacer" aria-hidden="true">
+            Brewing some ideas...
+          </p>
+          <p class="app-bootstrap-skeleton__message-static">
+            Warming up the neurons...
+          </p>
+          <p class="app-bootstrap-skeleton__message-typewriter">
+            Brewing some ideas...
+          </p>
+        </div>
+      </div>
     </div>
+    <script>
+      (function () {
+        if (window.__vm0BrowserSupported !== true) return;
+
+        var skeleton = document.getElementById("app-bootstrap-skeleton");
+        var messages = [
+          "Warming up the neurons...",
+          "Brewing some ideas...",
+          "Getting things ready...",
+          "Almost there...",
+          "Loading your workspace...",
+          "Tuning the instruments...",
+          "Connecting the dots...",
+          "Spinning up the team...",
+        ];
+        var avatarPresets = [
+          {
+            rotation: 1,
+            skin: 0,
+            hairStyle: 1,
+            hairColor: 5,
+            expression: 1,
+            intensity: "h",
+          },
+          {
+            rotation: 2,
+            skin: 1,
+            hairStyle: 3,
+            hairColor: 3,
+            expression: 1,
+            intensity: "m",
+          },
+          {
+            rotation: 4,
+            skin: 2,
+            hairStyle: 5,
+            hairColor: 4,
+            expression: 3,
+            intensity: "d",
+          },
+          {
+            rotation: 3,
+            skin: 3,
+            hairStyle: 4,
+            hairColor: 1,
+            expression: 4,
+            intensity: "h",
+          },
+          {
+            rotation: 5,
+            skin: 4,
+            hairStyle: 2,
+            hairColor: 2,
+            expression: 5,
+            intensity: "m",
+          },
+        ];
+        var avatarAssetBase =
+          "https://static.vm0.io/platform/views/zero-page/assets/avatar-svg/";
+        var avatar =
+          avatarPresets[Math.floor(Math.random() * avatarPresets.length)];
+        var messageIndex = Math.floor(Math.random() * messages.length);
+        var staticMessage = skeleton.querySelector(
+          ".app-bootstrap-skeleton__message-static",
+        );
+        var spacerMessage = skeleton.querySelector(
+          ".app-bootstrap-skeleton__message-spacer",
+        );
+        var typewriterMessage = skeleton.querySelector(
+          ".app-bootstrap-skeleton__message-typewriter",
+        );
+
+        skeleton.querySelector('[data-app-bootstrap-avatar-layer="head"]').src =
+          avatarAssetBase +
+          "head-r" +
+          avatar.rotation +
+          "-s" +
+          avatar.skin +
+          ".svg";
+        skeleton.querySelector('[data-app-bootstrap-avatar-layer="face"]').src =
+          avatarAssetBase +
+          "face-r" +
+          avatar.rotation +
+          "-f" +
+          avatar.expression +
+          "-" +
+          avatar.intensity +
+          ".svg";
+        skeleton.querySelector('[data-app-bootstrap-avatar-layer="hair"]').src =
+          avatarAssetBase +
+          "hair-r" +
+          avatar.rotation +
+          "-h" +
+          avatar.hairStyle +
+          "-c" +
+          avatar.hairColor +
+          ".svg";
+
+        function typewriterAnimation(message, delay) {
+          return (
+            "app-bootstrap-skeleton-show-typewriter " +
+            delay +
+            "ms forwards, app-bootstrap-skeleton-type 1.5s steps(" +
+            message.length +
+            ") " +
+            delay +
+            "ms forwards, app-bootstrap-skeleton-blink 0.6s step-end " +
+            delay +
+            "ms infinite"
+          );
+        }
+
+        function setMessages(isFirst) {
+          var currentMessage = messages[messageIndex % messages.length];
+          var nextMessage = messages[(messageIndex + 1) % messages.length];
+          var nextTypewriterMessage = typewriterMessage.cloneNode(true);
+
+          staticMessage.textContent = currentMessage;
+          staticMessage.style.display = isFirst ? "block" : "none";
+          staticMessage.style.animation = isFirst
+            ? "app-bootstrap-skeleton-hide-static 800ms forwards"
+            : "none";
+          spacerMessage.textContent = nextMessage;
+          nextTypewriterMessage.textContent = nextMessage;
+          nextTypewriterMessage.style.animation = typewriterAnimation(
+            nextMessage,
+            isFirst ? 800 : 0,
+          );
+          typewriterMessage.replaceWith(nextTypewriterMessage);
+          typewriterMessage = nextTypewriterMessage;
+        }
+
+        setMessages(true);
+
+        var cycles = 0;
+        var interval = window.setInterval(function () {
+          if (!document.getElementById("app-bootstrap-skeleton")) {
+            window.clearInterval(interval);
+            return;
+          }
+
+          messageIndex += 1;
+          setMessages(false);
+          cycles += 1;
+          if (cycles >= 3) {
+            window.clearInterval(interval);
+          }
+        }, 4000);
+      })();
+    </script>
     <script
       src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
       integrity="sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3"

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -12,23 +12,58 @@ const internalVisible$ = state(true);
 const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
 const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
   "vm0AppSkeletonVisibleEventQueued";
+const APP_BOOTSTRAP_SKELETON_ID = "app-bootstrap-skeleton";
+const APP_BOOTSTRAP_SKELETON_HIDDEN_CLASS = "app-bootstrap-skeleton--hidden";
+
+const internalBootstrapSkeletonActive$ = state(false);
+
+export const bootstrapSkeletonActive$ = computed((get) => {
+  return get(internalBootstrapSkeletonActive$);
+});
+
+export const initBootstrapSkeleton$ = command(({ set }) => {
+  const active = document.getElementById(APP_BOOTSTRAP_SKELETON_ID) !== null;
+  if (active) {
+    queueAppSkeletonVisibleEvent();
+  }
+  set(internalBootstrapSkeletonActive$, active);
+});
+
+function queueAppSkeletonVisibleEvent(): void {
+  if (
+    document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] ===
+    "true"
+  ) {
+    return;
+  }
+  document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] =
+    "true";
+  queueMicrotask(() => {
+    window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
+  });
+}
 
 export const appSkeletonVisibleEventRef$ = onRef(
   command((_visitor, _element: HTMLDivElement, _signal: AbortSignal) => {
-    if (
-      document.documentElement.dataset[
-        APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY
-      ] === "true"
-    ) {
-      return;
-    }
-    document.documentElement.dataset[APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY] =
-      "true";
-    queueMicrotask(() => {
-      window.dispatchEvent(new Event(APP_SKELETON_VISIBLE_EVENT));
-    });
+    queueAppSkeletonVisibleEvent();
   }),
 );
+
+function hideBootstrapSkeleton(): void {
+  const skeleton = document.getElementById(APP_BOOTSTRAP_SKELETON_ID);
+  if (!skeleton) {
+    return;
+  }
+  skeleton.setAttribute("aria-hidden", "true");
+  skeleton.addEventListener(
+    "transitionend",
+    () => {
+      skeleton.remove();
+    },
+    { once: true },
+  );
+  skeleton.classList.add(APP_BOOTSTRAP_SKELETON_HIDDEN_CLASS);
+}
 
 // ---------------------------------------------------------------------------
 // Avatar – picked once at module load so remounts don't flicker
@@ -122,6 +157,8 @@ export const showAppSkeleton$ = command(({ set }) => {
 export const hideAppSkeleton$ = command(({ set }, _signal: AbortSignal) => {
   set(resetSkeletonCycling$);
 
+  set(internalBootstrapSkeletonActive$, false);
   set(internalVisible$, false);
+  hideBootstrapSkeleton();
   set(captureFirstSkeletonHide$);
 });

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -59,7 +59,11 @@ import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
 import { setupExportPage$ } from "./export-page/export-page-setup.ts";
 import { initSlackOrg$ as handleSlackRedirect$ } from "./zero-page/zero-slack.ts";
 import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
-import { hideAppSkeleton$, startSkeletonCycling$ } from "./app-skeleton.ts";
+import {
+  hideAppSkeleton$,
+  initBootstrapSkeleton$,
+  startSkeletonCycling$,
+} from "./app-skeleton.ts";
 import { setupRedeemCampaignPage$ } from "./redeem-campaign/redeem-campaign-page-setup.ts";
 import { updatePage$ } from "./react-router.ts";
 import { NotFoundPage } from "../views/not-found-page.tsx";
@@ -428,6 +432,7 @@ export const bootstrap$ = command(
   async ({ set }, render: () => void, signal: AbortSignal) => {
     set(initTheme$);
     set(setRootSignal$, signal);
+    set(initBootstrapSkeleton$);
 
     set(setupLoggers$);
 

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -55,28 +55,6 @@ describe("platform entrypoint safe area behavior", () => {
     );
   });
 
-  it("renders the loading surface before the application bundle executes", () => {
-    const doc = new DOMParser().parseFromString(indexHtml, "text/html");
-    const root = doc.getElementById("root");
-    const skeleton = doc.getElementById("app-bootstrap-skeleton");
-
-    if (!root || !skeleton) {
-      throw new Error("Unable to locate the platform bootstrap skeleton");
-    }
-    expect(root.compareDocumentPosition(skeleton)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(
-      skeleton.querySelectorAll("[data-app-bootstrap-avatar-layer]"),
-    ).toHaveLength(3);
-    expect(indexHtml).toMatch(
-      /\[data-theme="dark"\]\s+#app-bootstrap-skeleton\s*{/,
-    );
-    expect(indexHtml).toMatch(
-      /#app-bootstrap-skeleton\.app-bootstrap-skeleton--hidden\s*{[\s\S]*opacity:\s*0;/,
-    );
-  });
-
   it("suppresses the bottom safe-area inset only while the keyboard is open", () => {
     const globalCss = readGlobalCss();
 

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -51,7 +51,29 @@ describe("platform entrypoint safe area behavior", () => {
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100dvh;/);
     expect(indexHtml).toMatch(/--zero-viewport-height:\s*100lvh;/);
     expect(indexHtml).toMatch(
-      /\.sk\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);/,
+      /#app-bootstrap-skeleton\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);/,
+    );
+  });
+
+  it("renders the loading surface before the application bundle executes", () => {
+    const doc = new DOMParser().parseFromString(indexHtml, "text/html");
+    const root = doc.getElementById("root");
+    const skeleton = doc.getElementById("app-bootstrap-skeleton");
+
+    if (!root || !skeleton) {
+      throw new Error("Unable to locate the platform bootstrap skeleton");
+    }
+    expect(root.compareDocumentPosition(skeleton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(
+      skeleton.querySelectorAll("[data-app-bootstrap-avatar-layer]"),
+    ).toHaveLength(3);
+    expect(indexHtml).toMatch(
+      /\[data-theme="dark"\]\s+#app-bootstrap-skeleton\s*{/,
+    );
+    expect(indexHtml).toMatch(
+      /#app-bootstrap-skeleton\.app-bootstrap-skeleton--hidden\s*{[\s\S]*opacity:\s*0;/,
     );
   });
 

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { useGet } from "ccstate-react";
 import { page$, pageLayout$ } from "../signals/react-router.ts";
-import { appSkeletonVisible$ } from "../signals/app-skeleton.ts";
+import {
+  appSkeletonVisible$,
+  bootstrapSkeletonActive$,
+} from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./zero-page/app-skeleton.tsx";
 import { SidebarLayout } from "./zero-page/sidebar-layout.tsx";
 import { MinimalSidebarLayout } from "./zero-page/zero-directed-shared.tsx";
@@ -25,7 +28,12 @@ function LayoutHost({ children }: { children: ReactNode }) {
 export function AppSkeletonOverlay() {
   const page = useGet(page$);
   const skeletonVisible = useGet(appSkeletonVisible$);
-  return <AppSkeleton visible={!page || skeletonVisible} />;
+  const bootstrapSkeletonActive = useGet(bootstrapSkeletonActive$);
+  return (
+    <AppSkeleton
+      visible={!bootstrapSkeletonActive && (!page || skeletonVisible)}
+    />
+  );
 }
 
 export function Router() {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
@@ -41,4 +41,21 @@ describe("app skeleton", () => {
     });
     expect(skeletonMountedAtDispatch).toBeTruthy();
   });
+
+  it("removes the inline loading surface after the page is ready", async () => {
+    const bootstrapSkeleton = document.createElement("div");
+    bootstrapSkeleton.id = "app-bootstrap-skeleton";
+    document.body.append(bootstrapSkeleton);
+
+    detachedSetupPage({ context, path: "/_/error" });
+
+    await waitFor(() => {
+      expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
+    });
+    expect(bootstrapSkeleton).toHaveAttribute("aria-hidden", "true");
+
+    bootstrapSkeleton.dispatchEvent(new Event("transitionend"));
+
+    expect(document.getElementById("app-bootstrap-skeleton")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Render the full branded avatar and typewriter loading surface directly from index.html so first paint does not wait for the application bundle.
- Match the existing loading messages and avatar presets with library-free JavaScript, including light and dark theme colors and self-cleaning message rotation.
- Keep the inline overlay visible through application bootstrap, suppress the duplicate initial React skeleton, then fade and remove the fixed DOM node when hideAppSkeleton$ marks the page ready.

## User impact
First-load users see the branded Zero loading surface while the main JavaScript and CSS are still downloading and parsing, instead of seeing only a blank background. Later in-app loading states continue using the existing React skeleton.

## Verification
- pnpm exec prettier --check on all changed files
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts src/views/zero-page/__tests__/app-skeleton.test.tsx (2 files, 8 tests)
- pnpm -F @vm0/app build
- Browser-verified the built dist/index.html with the main bundle blocked: the skeleton remained visible, all three avatar layers loaded, the message rotated after four seconds, and light/dark computed colors matched the intended themes.

The production build completed with the existing undefined local Clerk environment, CSS ::highlight, and large-chunk warnings.