### PR TITLE
refactor: decouple device auth startup from dialog mount

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -121,8 +121,8 @@ import {
   personalModelProvider$,
   selectedModelAvailable$,
 } from "../zero-page/model-first-personal-oauth.ts";
-import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/claude-code-device-auth.ts";
-import { setCodexDeviceAuthDialogStatePersonal$ } from "../zero-page/settings/codex-device-auth.ts";
+import { openClaudeCodeDeviceAuthDialogPersonal$ } from "../zero-page/settings/claude-code-device-auth.ts";
+import { openCodexDeviceAuthDialogPersonal$ } from "../zero-page/settings/codex-device-auth.ts";
 import type {
   ChatThreadSignals,
   ComposerSendButtonStatus,
@@ -711,13 +711,10 @@ function createModelSelection(
       const mode =
         status.status === "needs_reconnect" ? "reconnect" : "connect";
       if (status.providerType === "claude-code-oauth-token") {
-        set(setClaudeCodeDeviceAuthDialogStatePersonal$, {
-          open: true,
-          mode,
-        });
+        await set(openClaudeCodeDeviceAuthDialogPersonal$, mode, signal);
         return;
       }
-      set(setCodexDeviceAuthDialogStatePersonal$, { open: true, mode });
+      await set(openCodexDeviceAuthDialogPersonal$, mode, signal);
     },
   );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -9,13 +9,7 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import {
-  bestEffort,
-  onRef,
-  resetSignal,
-  settle,
-  tapError,
-} from "../../utils.ts";
+import { bestEffort, resetSignal, settle, tapError } from "../../utils.ts";
 import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
@@ -172,18 +166,6 @@ interface ClaudeCodeDeviceAuthSignalContext {
   resetFlowSignal$: ReturnType<typeof resetSignal>;
 }
 
-function createClaudeCodeSetDialogState$(
-  ctx: ClaudeCodeDeviceAuthSignalContext,
-) {
-  return command(({ set }, next: ClaudeCodeDeviceAuthDialogState) => {
-    set(ctx.internalDialogState$, next);
-    if (!next.open) {
-      set(ctx.resetFlowSignal$);
-      set(ctx.internalFlowState$, createIdleFlowState());
-    }
-  });
-}
-
 function createClaudeCodeRunFlow$(ctx: ClaudeCodeDeviceAuthSignalContext) {
   return command(
     async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
@@ -225,10 +207,37 @@ function createClaudeCodeRun$(
   ctx: ClaudeCodeDeviceAuthSignalContext,
   runFlow$: ReturnType<typeof createClaudeCodeRunFlow$>,
 ) {
-  return command(async ({ set }, signal: AbortSignal): Promise<boolean> => {
-    const flowSignal = set(ctx.resetFlowSignal$, signal);
-    return await set(runFlow$, flowSignal);
-  });
+  return command(
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+      const flowSignal = set(ctx.resetFlowSignal$, signal);
+      flowSignal.addEventListener(
+        "abort",
+        () => {
+          if (get(ctx.internalFlowState$).status === "starting") {
+            set(ctx.internalFlowState$, createIdleFlowState());
+          }
+        },
+        { once: true },
+      );
+      return await set(runFlow$, flowSignal);
+    },
+  );
+}
+
+function createClaudeCodeOpen$(
+  ctx: ClaudeCodeDeviceAuthSignalContext,
+  run$: ReturnType<typeof createClaudeCodeRun$>,
+) {
+  return command(
+    async (
+      { set },
+      mode: ClaudeCodeDeviceAuthDialogMode,
+      signal: AbortSignal,
+    ): Promise<boolean> => {
+      set(ctx.internalDialogState$, { open: true, mode });
+      return await set(run$, signal);
+    },
+  );
 }
 
 function createClaudeCodeOpenApprovalPage$(
@@ -361,31 +370,6 @@ function createClaudeCodeClose$(ctx: ClaudeCodeDeviceAuthSignalContext) {
   });
 }
 
-function createClaudeCodeAutoStartRef(
-  ctx: ClaudeCodeDeviceAuthSignalContext,
-  runFlow$: ReturnType<typeof createClaudeCodeRunFlow$>,
-) {
-  const autoStart$ = command(
-    async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
-      if (get(ctx.internalFlowState$).status !== "idle") {
-        return;
-      }
-      const flowSignal = set(ctx.resetFlowSignal$, signal);
-      signal.addEventListener(
-        "abort",
-        () => {
-          if (get(ctx.internalFlowState$).status === "starting") {
-            set(ctx.internalFlowState$, createIdleFlowState());
-          }
-        },
-        { once: true },
-      );
-      await set(runFlow$, flowSignal);
-    },
-  );
-  return onRef(autoStart$);
-}
-
 function createClaudeCodeDeviceAuthSignals(
   scope: ClaudeCodeDeviceAuthScope,
   reloadProviders$: Command<void, []>,
@@ -400,6 +384,7 @@ function createClaudeCodeDeviceAuthSignals(
     resetFlowSignal$: resetSignal(),
   };
   const runFlow$ = createClaudeCodeRunFlow$(ctx);
+  const run$ = createClaudeCodeRun$(ctx, runFlow$);
 
   return {
     dialogState$: computed((get) => {
@@ -408,38 +393,35 @@ function createClaudeCodeDeviceAuthSignals(
     flowState$: computed((get) => {
       return get(ctx.internalFlowState$);
     }),
-    setDialogState$: createClaudeCodeSetDialogState$(ctx),
+    open$: createClaudeCodeOpen$(ctx, run$),
     openApprovalPage$: createClaudeCodeOpenApprovalPage$(ctx),
     setAuthorizationCode$: createClaudeCodeSetAuthorizationCode$(ctx),
     submit$: createClaudeCodeSubmit$(ctx),
     close$: createClaudeCodeClose$(ctx),
-    run$: createClaudeCodeRun$(ctx, runFlow$),
-    autoStartRef$: createClaudeCodeAutoStartRef(ctx, runFlow$),
+    run$,
   };
 }
 
 export const {
   dialogState$: claudeCodeDeviceAuthDialogState$,
   flowState$: claudeCodeDeviceAuthFlowState$,
-  setDialogState$: setClaudeCodeDeviceAuthDialogState$,
+  open$: openClaudeCodeDeviceAuthDialog$,
   openApprovalPage$: openClaudeCodeDeviceAuthApprovalPage$,
   setAuthorizationCode$: setClaudeCodeDeviceAuthAuthorizationCode$,
   submit$: submitClaudeCodeDeviceAuth$,
   close$: closeClaudeCodeDeviceAuthDialog$,
   run$: runClaudeCodeDeviceAuth$,
-  autoStartRef$: claudeCodeDeviceAuthAutoStartRef$,
 } = createClaudeCodeDeviceAuthSignals("org", reloadOrgModelProviders$);
 
 export const {
   dialogState$: claudeCodeDeviceAuthDialogStatePersonal$,
   flowState$: claudeCodeDeviceAuthFlowStatePersonal$,
-  setDialogState$: setClaudeCodeDeviceAuthDialogStatePersonal$,
+  open$: openClaudeCodeDeviceAuthDialogPersonal$,
   openApprovalPage$: openClaudeCodeDeviceAuthApprovalPagePersonal$,
   setAuthorizationCode$: setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
   submit$: submitClaudeCodeDeviceAuthPersonal$,
   close$: closeClaudeCodeDeviceAuthDialogPersonal$,
   run$: runClaudeCodeDeviceAuthPersonal$,
-  autoStartRef$: claudeCodeDeviceAuthAutoStartRefPersonal$,
 } = createClaudeCodeDeviceAuthSignals("personal", reloadPersonalModelProvider$);
 
 export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -12,7 +12,6 @@ import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
 import {
   bestEffort,
-  onRef,
   resetSignal,
   settle,
   setLoop,
@@ -207,16 +206,6 @@ interface CodexDeviceAuthSignalContext {
   resetFlowSignal$: ReturnType<typeof resetSignal>;
 }
 
-function createCodexSetDialogState$(ctx: CodexDeviceAuthSignalContext) {
-  return command(({ set }, next: CodexDeviceAuthDialogState) => {
-    set(ctx.internalDialogState$, next);
-    if (!next.open) {
-      set(ctx.resetFlowSignal$);
-      set(ctx.internalFlowState$, createIdleFlowState());
-    }
-  });
-}
-
 function createCodexPollFlow$(ctx: CodexDeviceAuthSignalContext) {
   return command(
     async ({ get, set }, requestId: string, signal: AbortSignal) => {
@@ -352,10 +341,37 @@ function createCodexRun$(
   ctx: CodexDeviceAuthSignalContext,
   runFlow$: ReturnType<typeof createCodexRunFlow$>,
 ) {
-  return command(async ({ set }, signal: AbortSignal): Promise<boolean> => {
-    const flowSignal = set(ctx.resetFlowSignal$, signal);
-    return await set(runFlow$, flowSignal);
-  });
+  return command(
+    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+      const flowSignal = set(ctx.resetFlowSignal$, signal);
+      flowSignal.addEventListener(
+        "abort",
+        () => {
+          if (get(ctx.internalFlowState$).status === "starting") {
+            set(ctx.internalFlowState$, createIdleFlowState());
+          }
+        },
+        { once: true },
+      );
+      return await set(runFlow$, flowSignal);
+    },
+  );
+}
+
+function createCodexOpen$(
+  ctx: CodexDeviceAuthSignalContext,
+  run$: ReturnType<typeof createCodexRun$>,
+) {
+  return command(
+    async (
+      { set },
+      mode: CodexDeviceAuthDialogMode,
+      signal: AbortSignal,
+    ): Promise<boolean> => {
+      set(ctx.internalDialogState$, { open: true, mode });
+      return await set(run$, signal);
+    },
+  );
 }
 
 function createCodexOpenApprovalPage$(ctx: CodexDeviceAuthSignalContext) {
@@ -399,31 +415,6 @@ function createCodexClose$(ctx: CodexDeviceAuthSignalContext) {
   });
 }
 
-function createCodexAutoStartRef(
-  ctx: CodexDeviceAuthSignalContext,
-  runFlow$: ReturnType<typeof createCodexRunFlow$>,
-) {
-  const autoStart$ = command(
-    async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
-      if (get(ctx.internalFlowState$).status !== "idle") {
-        return;
-      }
-      const flowSignal = set(ctx.resetFlowSignal$, signal);
-      signal.addEventListener(
-        "abort",
-        () => {
-          if (get(ctx.internalFlowState$).status === "starting") {
-            set(ctx.internalFlowState$, createIdleFlowState());
-          }
-        },
-        { once: true },
-      );
-      await set(runFlow$, flowSignal);
-    },
-  );
-  return onRef(autoStart$);
-}
-
 function createCodexDeviceAuthSignals(
   scope: CodexDeviceAuthScope,
   reloadProviders$: Command<void, []>,
@@ -437,6 +428,7 @@ function createCodexDeviceAuthSignals(
   };
   const pollFlow$ = createCodexPollFlow$(ctx);
   const runFlow$ = createCodexRunFlow$(ctx, pollFlow$);
+  const run$ = createCodexRun$(ctx, runFlow$);
 
   return {
     dialogState$: computed((get) => {
@@ -445,32 +437,29 @@ function createCodexDeviceAuthSignals(
     flowState$: computed((get) => {
       return get(ctx.internalFlowState$);
     }),
-    setDialogState$: createCodexSetDialogState$(ctx),
+    open$: createCodexOpen$(ctx, run$),
     openApprovalPage$: createCodexOpenApprovalPage$(ctx),
     close$: createCodexClose$(ctx),
-    run$: createCodexRun$(ctx, runFlow$),
-    autoStartRef$: createCodexAutoStartRef(ctx, runFlow$),
+    run$,
   };
 }
 
 export const {
   dialogState$: codexDeviceAuthDialogState$,
   flowState$: codexDeviceAuthFlowState$,
-  setDialogState$: setCodexDeviceAuthDialogState$,
+  open$: openCodexDeviceAuthDialog$,
   openApprovalPage$: openCodexDeviceAuthApprovalPage$,
   close$: closeCodexDeviceAuthDialog$,
   run$: runCodexDeviceAuth$,
-  autoStartRef$: codexDeviceAuthAutoStartRef$,
 } = createCodexDeviceAuthSignals("org", reloadOrgModelProviders$);
 
 export const {
   dialogState$: codexDeviceAuthDialogStatePersonal$,
   flowState$: codexDeviceAuthFlowStatePersonal$,
-  setDialogState$: setCodexDeviceAuthDialogStatePersonal$,
+  open$: openCodexDeviceAuthDialogPersonal$,
   openApprovalPage$: openCodexDeviceAuthApprovalPagePersonal$,
   close$: closeCodexDeviceAuthDialogPersonal$,
   run$: runCodexDeviceAuthPersonal$,
-  autoStartRef$: codexDeviceAuthAutoStartRefPersonal$,
 } = createCodexDeviceAuthSignals("personal", reloadPersonalModelProvider$);
 
 export type { CodexDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -21,8 +21,8 @@ import {
   setCodexFastModeLocalDefault$,
 } from "./codex-fast-local-default.ts";
 import { personalModelProvider$ } from "./model-first-personal-oauth.ts";
-import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "./settings/claude-code-device-auth.ts";
-import { setCodexDeviceAuthDialogStatePersonal$ } from "./settings/codex-device-auth.ts";
+import { openClaudeCodeDeviceAuthDialogPersonal$ } from "./settings/claude-code-device-auth.ts";
+import { openCodexDeviceAuthDialogPersonal$ } from "./settings/codex-device-auth.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -138,10 +138,10 @@ export const configureChatPageSelectedModel$ = command(
     }
     const mode = status.status === "needs_reconnect" ? "reconnect" : "connect";
     if (status.providerType === "claude-code-oauth-token") {
-      set(setClaudeCodeDeviceAuthDialogStatePersonal$, { open: true, mode });
+      await set(openClaudeCodeDeviceAuthDialogPersonal$, mode, signal);
       return;
     }
-    set(setCodexDeviceAuthDialogStatePersonal$, { open: true, mode });
+    await set(openCodexDeviceAuthDialogPersonal$, mode, signal);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -1,11 +1,13 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useSet, useLoadable } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { orgConfiguredProviders$ } from "../../../../signals/zero-page/settings/org-model-providers.ts";
-import { setClaudeCodeDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
-import { setCodexDeviceAuthDialogState$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
+import { openClaudeCodeDeviceAuthDialog$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
+import { openCodexDeviceAuthDialog$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
 import {
   ClaudeCodeDeviceAuthDialog,
   PersonalClaudeCodeDeviceAuthDialog,
@@ -56,8 +58,9 @@ function StaleProviderBanner({
 }: {
   providers: ModelProviderResponse[];
 }) {
-  const setClaudeCodeDeviceDialog = useSet(setClaudeCodeDeviceAuthDialogState$);
-  const setDeviceDialog = useSet(setCodexDeviceAuthDialogState$);
+  const openClaudeCodeDeviceDialog = useSet(openClaudeCodeDeviceAuthDialog$);
+  const openDeviceDialog = useSet(openCodexDeviceAuthDialog$);
+  const pageSignal = useGet(pageSignal$);
   const stale = providers.find((p) => {
     return (
       (p.type === "claude-code-oauth-token" ||
@@ -88,9 +91,13 @@ function StaleProviderBanner({
         type="button"
         onClick={() => {
           if (isClaudeCode) {
-            return setClaudeCodeDeviceDialog({ open: true, mode: "reconnect" });
+            detach(
+              openClaudeCodeDeviceDialog("reconnect", pageSignal),
+              Reason.DomCallback,
+            );
+            return;
           }
-          return setDeviceDialog({ open: true, mode: "reconnect" });
+          detach(openDeviceDialog("reconnect", pageSignal), Reason.DomCallback);
         }}
         className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
       >

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -22,8 +22,8 @@ import {
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { modelPlanCapabilities$ } from "../../../../signals/zero-page/model-plan-capabilities.ts";
 import { openSettingsBillingPlans$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
-import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
-import { setCodexDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
+import { openClaudeCodeDeviceAuthDialogPersonal$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
+import { openCodexDeviceAuthDialogPersonal$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ProviderIcon } from "../settings/provider-icons.tsx";
@@ -58,11 +58,9 @@ function OAuthCredentialsSection() {
   const modelCapabilitiesLoadable = useLastLoadable(modelPlanCapabilities$);
   const openBillingPlans = useSet(openSettingsBillingPlans$);
   const openClaudeCodeDeviceAuthDialog = useSet(
-    setClaudeCodeDeviceAuthDialogStatePersonal$,
+    openClaudeCodeDeviceAuthDialogPersonal$,
   );
-  const openCodexDeviceAuthDialog = useSet(
-    setCodexDeviceAuthDialogStatePersonal$,
-  );
+  const openCodexDeviceAuthDialog = useSet(openCodexDeviceAuthDialogPersonal$);
   const disconnectCredential = useSet(disconnectPersonalOAuthCredential$);
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
@@ -91,22 +89,19 @@ function OAuthCredentialsSection() {
       openBillingPlans();
       return;
     }
-    const next = {
-      open: true,
-      mode: claudeCode?.needsReconnect ? "reconnect" : "connect",
-    } as const;
-    openClaudeCodeDeviceAuthDialog(next);
+    const mode = claudeCode?.needsReconnect ? "reconnect" : "connect";
+    detach(
+      openClaudeCodeDeviceAuthDialog(mode, pageSignal),
+      Reason.DomCallback,
+    );
   };
   const connectOpenAI = () => {
     if (!supportByok) {
       openBillingPlans();
       return;
     }
-    const next = {
-      open: true,
-      mode: openAI?.needsReconnect ? "reconnect" : "connect",
-    } as const;
-    openCodexDeviceAuthDialog(next);
+    const mode = openAI?.needsReconnect ? "reconnect" : "connect";
+    detach(openCodexDeviceAuthDialog(mode, pageSignal), Reason.DomCallback);
   };
 
   const confirmCodexReset = () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -13,8 +13,6 @@ import { IconLoader2 } from "@tabler/icons-react";
 import {
   claudeCodeDeviceAuthDialogState$,
   claudeCodeDeviceAuthDialogStatePersonal$,
-  claudeCodeDeviceAuthAutoStartRef$,
-  claudeCodeDeviceAuthAutoStartRefPersonal$,
   claudeCodeDeviceAuthFlowState$,
   claudeCodeDeviceAuthFlowStatePersonal$,
   closeClaudeCodeDeviceAuthDialog$,
@@ -25,8 +23,6 @@ import {
   runClaudeCodeDeviceAuthPersonal$,
   setClaudeCodeDeviceAuthAuthorizationCode$,
   setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
-  setClaudeCodeDeviceAuthDialogState$,
-  setClaudeCodeDeviceAuthDialogStatePersonal$,
   submitClaudeCodeDeviceAuth$,
   submitClaudeCodeDeviceAuthPersonal$,
   type ClaudeCodeDeviceAuthFlowState,
@@ -40,13 +36,9 @@ type ClaudeCodeDeviceAuthDialogState = {
   mode: "connect" | "reconnect";
 };
 
-type AutoStartRef = (element: HTMLDivElement | null) => void;
-
 interface ClaudeCodeDeviceAuthScopeBundle {
   dialog: ClaudeCodeDeviceAuthDialogState;
   flow: ClaudeCodeDeviceAuthFlowState;
-  autoStartRef: AutoStartRef;
-  setDialog: (next: ClaudeCodeDeviceAuthDialogState) => void;
   close: (signal: AbortSignal) => Promise<void>;
   openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
   run: (signal: AbortSignal) => Promise<boolean>;
@@ -67,8 +59,6 @@ export function PersonalClaudeCodeDeviceAuthDialog() {
 function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   const dialog = useGet(claudeCodeDeviceAuthDialogState$);
   const flow = useGet(claudeCodeDeviceAuthFlowState$);
-  const autoStartRef = useSet(claudeCodeDeviceAuthAutoStartRef$);
-  const setDialog = useSet(setClaudeCodeDeviceAuthDialogState$);
   const close = useSet(closeClaudeCodeDeviceAuthDialog$);
   const openApprovalPage = useSet(openClaudeCodeDeviceAuthApprovalPage$);
   const [, run] = useLoadableSet(runClaudeCodeDeviceAuth$);
@@ -79,8 +69,6 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   return {
     dialog,
     flow,
-    autoStartRef,
-    setDialog,
     close,
     openApprovalPage,
     run,
@@ -92,8 +80,6 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
 function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   const dialog = useGet(claudeCodeDeviceAuthDialogStatePersonal$);
   const flow = useGet(claudeCodeDeviceAuthFlowStatePersonal$);
-  const autoStartRef = useSet(claudeCodeDeviceAuthAutoStartRefPersonal$);
-  const setDialog = useSet(setClaudeCodeDeviceAuthDialogStatePersonal$);
   const close = useSet(closeClaudeCodeDeviceAuthDialogPersonal$);
   const openApprovalPage = useSet(
     openClaudeCodeDeviceAuthApprovalPagePersonal$,
@@ -106,8 +92,6 @@ function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundl
   return {
     dialog,
     flow,
-    autoStartRef,
-    setDialog,
     close,
     openApprovalPage,
     run,
@@ -125,8 +109,6 @@ function ClaudeCodeDeviceAuthDialogView({
   const {
     dialog,
     flow,
-    autoStartRef,
-    setDialog,
     close,
     openApprovalPage,
     run,
@@ -140,7 +122,6 @@ function ClaudeCodeDeviceAuthDialogView({
 
   function handleOpenChange(nextOpen: boolean): void {
     if (nextOpen) {
-      setDialog({ ...dialog, open: true });
       return;
     }
     detach(close(pageSignal), Reason.DomCallback);
@@ -157,26 +138,24 @@ function ClaudeCodeDeviceAuthDialogView({
   return (
     <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md" aria-describedby={undefined}>
-        <div ref={autoStartRef} className="contents">
-          <DialogHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-                <ProviderIcon type="claude-code-oauth-token" size={20} />
-              </div>
-              <DialogTitle>{title}</DialogTitle>
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+              <ProviderIcon type="claude-code-oauth-token" size={20} />
             </div>
-          </DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </div>
+        </DialogHeader>
 
-          <ClaudeCodeDeviceAuthBody
-            flow={flow}
-            mode={dialog.mode}
-            onStart={handleStart}
-            onSubmit={handleSubmit}
-            openApprovalPage={openApprovalPage}
-            pageSignal={pageSignal}
-            setAuthorizationCode={setAuthorizationCode}
-          />
-        </div>
+        <ClaudeCodeDeviceAuthBody
+          flow={flow}
+          mode={dialog.mode}
+          onStart={handleStart}
+          onSubmit={handleSubmit}
+          openApprovalPage={openApprovalPage}
+          pageSignal={pageSignal}
+          setAuthorizationCode={setAuthorizationCode}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
@@ -13,8 +13,6 @@ import { IconLoader2 } from "@tabler/icons-react";
 import {
   closeCodexDeviceAuthDialog$,
   closeCodexDeviceAuthDialogPersonal$,
-  codexDeviceAuthAutoStartRef$,
-  codexDeviceAuthAutoStartRefPersonal$,
   codexDeviceAuthDialogState$,
   codexDeviceAuthDialogStatePersonal$,
   codexDeviceAuthFlowState$,
@@ -23,8 +21,6 @@ import {
   openCodexDeviceAuthApprovalPagePersonal$,
   runCodexDeviceAuth$,
   runCodexDeviceAuthPersonal$,
-  setCodexDeviceAuthDialogState$,
-  setCodexDeviceAuthDialogStatePersonal$,
   type CodexDeviceAuthFlowState,
 } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -36,13 +32,9 @@ type CodexDeviceAuthDialogState = {
   mode: "connect" | "reconnect";
 };
 
-type AutoStartRef = (element: HTMLDivElement | null) => void;
-
 interface CodexDeviceAuthScopeBundle {
   dialog: CodexDeviceAuthDialogState;
   flow: CodexDeviceAuthFlowState;
-  autoStartRef: AutoStartRef;
-  setDialog: (next: CodexDeviceAuthDialogState) => void;
   close: (signal: AbortSignal) => Promise<void>;
   openApprovalPage: (signal: AbortSignal) => Promise<boolean>;
   run: (signal: AbortSignal) => Promise<boolean>;
@@ -61,16 +53,12 @@ export function PersonalCodexDeviceAuthDialog() {
 function useOrgCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   const dialog = useGet(codexDeviceAuthDialogState$);
   const flow = useGet(codexDeviceAuthFlowState$);
-  const autoStartRef = useSet(codexDeviceAuthAutoStartRef$);
-  const setDialog = useSet(setCodexDeviceAuthDialogState$);
   const close = useSet(closeCodexDeviceAuthDialog$);
   const openApprovalPage = useSet(openCodexDeviceAuthApprovalPage$);
   const [, run] = useLoadableSet(runCodexDeviceAuth$);
   return {
     dialog,
     flow,
-    autoStartRef,
-    setDialog,
     close,
     openApprovalPage,
     run,
@@ -80,16 +68,12 @@ function useOrgCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
 function usePersonalCodexDeviceAuthBundle(): CodexDeviceAuthScopeBundle {
   const dialog = useGet(codexDeviceAuthDialogStatePersonal$);
   const flow = useGet(codexDeviceAuthFlowStatePersonal$);
-  const autoStartRef = useSet(codexDeviceAuthAutoStartRefPersonal$);
-  const setDialog = useSet(setCodexDeviceAuthDialogStatePersonal$);
   const close = useSet(closeCodexDeviceAuthDialogPersonal$);
   const openApprovalPage = useSet(openCodexDeviceAuthApprovalPagePersonal$);
   const [, run] = useLoadableSet(runCodexDeviceAuthPersonal$);
   return {
     dialog,
     flow,
-    autoStartRef,
-    setDialog,
     close,
     openApprovalPage,
     run,
@@ -102,21 +86,12 @@ function CodexDeviceAuthDialogView({
   bundle: CodexDeviceAuthScopeBundle;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const {
-    dialog,
-    flow,
-    autoStartRef,
-    setDialog,
-    close,
-    openApprovalPage,
-    run,
-  } = bundle;
+  const { dialog, flow, close, openApprovalPage, run } = bundle;
   const title =
     dialog.mode === "reconnect" ? "Re-connect Codex" : "Connect Codex";
 
   function handleOpenChange(nextOpen: boolean): void {
     if (nextOpen) {
-      setDialog({ ...dialog, open: true });
       return;
     }
     detach(close(pageSignal), Reason.DomCallback);
@@ -129,24 +104,22 @@ function CodexDeviceAuthDialogView({
   return (
     <Dialog open={dialog.open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md" aria-describedby={undefined}>
-        <div ref={autoStartRef} className="contents">
-          <DialogHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-                <ProviderIcon type="codex-oauth-token" size={20} />
-              </div>
-              <DialogTitle>{title}</DialogTitle>
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+              <ProviderIcon type="codex-oauth-token" size={20} />
             </div>
-          </DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </div>
+        </DialogHeader>
 
-          <CodexDeviceAuthBody
-            flow={flow}
-            mode={dialog.mode}
-            onStart={handleStart}
-            openApprovalPage={openApprovalPage}
-            pageSignal={pageSignal}
-          />
-        </div>
+        <CodexDeviceAuthBody
+          flow={flow}
+          mode={dialog.mode}
+          onStart={handleStart}
+          openApprovalPage={openApprovalPage}
+          pageSignal={pageSignal}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

- start Codex and Claude Code device authentication from explicit ccstate `open` commands bound to the caller's page signal
- remove the DOM-only `autoStartRef` lifecycle bridge and keep dialog rendering as a pure projection of auth state
- preserve explicit retry, close, cancellation, and provider reload behavior across personal, organization, and routed-model entry points

## User impact

Connect and reconnect flows now begin directly from the user's action instead of waiting for the dialog content to mount. The dialog UI and authorization steps are unchanged.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/personal-providers-tab.test.tsx src/views/zero-page/__tests__/org-providers-tab.test.tsx` (28 passed)
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t 'blocks routed model sends|opens reconnect login|completes personal Claude Code auth'` (3 passed)
