### PR TITLE
refactor(platform): route connector auth failures through accept

### DIFF
--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -1,4 +1,5 @@
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { isAbortError, onRejection } from "../signals/utils.ts";
 
 class ApiError extends Error {
   readonly code: string;
@@ -34,6 +35,10 @@ function extractError(
   return { message: `HTTP ${status}`, code: "UNKNOWN" };
 }
 
+function requestErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
  * Otherwise shows a toast and throws an `ApiError`.
@@ -53,7 +58,11 @@ async function accept<
   codes: S[],
   options?: { toast?: boolean },
 ): Promise<Extract<T, { status: S }>> {
-  const result = await promise;
+  const result = await onRejection(promise, (error) => {
+    if (!isAbortError(error) && options?.toast !== false) {
+      toast.error(requestErrorMessage(error));
+    }
+  });
   if ((codes as number[]).includes(result.status)) {
     return result as Extract<T, { status: S }>;
   }

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -144,6 +144,19 @@ export function userPermissionGrantsByAgent(
   });
 }
 
+export function userPermissionGrantsByAgentIfExists(
+  params: UserPermissionGrantsByAgentParams,
+): Computed<Promise<readonly UserPermissionGrantResponse[] | null>> {
+  return computed(async (get) => {
+    get(internalUserPermissionGrantsReload$);
+    const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
+    const result = await retryTransientLoad(() => {
+      return accept(client.list({ query: params }), [200, 404]);
+    });
+    return result.status === 404 ? null : result.body;
+  });
+}
+
 export const permissionAllowUserPermissionGrants$ = computed(async (get) => {
   const agentId = get(permissionAllowAgentId$);
   if (!agentId) {

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -121,7 +121,7 @@ export async function clearAllDetached() {
   return settledResult;
 }
 
-const isAbortError = (error: unknown): boolean => {
+export const isAbortError = (error: unknown): boolean => {
   if (
     (error instanceof Error || error instanceof DOMException) &&
     error.name === "AbortError"
@@ -371,6 +371,7 @@ export async function setLoop(
   loopBody: (signal: AbortSignal) => Promise<boolean> | boolean,
   interval: number,
   signal: AbortSignal,
+  options: { retryTransientErrors?: boolean } = {},
 ): Promise<void> {
   let fibIndex = 0;
   let loopCount = 0;
@@ -401,6 +402,9 @@ export async function setLoop(
         : delay(interval, { signal }));
     } catch (error) {
       throwIfAbort(error);
+      if (options.retryTransientErrors === false) {
+        throw error;
+      }
       const backoff =
         FIB_DELAYS_MS[Math.min(fibIndex, FIB_DELAYS_MS.length - 1)] ?? 60_000;
       L.warn(

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -5,17 +5,11 @@ import {
   type ClaudeCodeDeviceAuthScope,
 } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
 
-import { ApiError, accept } from "../../../lib/accept.ts";
+import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import {
-  bestEffort,
-  onRef,
-  resetSignal,
-  settle,
-  tapError,
-} from "../../utils.ts";
+import { bestEffort, onRef, resetSignal, tapError } from "../../utils.ts";
 import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
@@ -26,7 +20,7 @@ interface ClaudeCodeDeviceAuthDialogState {
 }
 
 type ActiveClaudeCodeDeviceAuthFlowState = {
-  readonly status: "pending" | "submitting";
+  readonly status: "pending";
   readonly requestId: string;
   readonly sessionToken: string;
   readonly browserUrl: string;
@@ -62,15 +56,6 @@ function secondsToMilliseconds(seconds: number): number {
   return seconds * 1000;
 }
 
-function claudeCodeDeviceAuthErrorMessage(error: unknown): string {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-  return error instanceof Error
-    ? error.message
-    : "Claude Code connection failed";
-}
-
 function openApprovalPage(browserUrl: string): boolean {
   const approvalWindow = window.open(browserUrl, "_blank");
   if (!approvalWindow) {
@@ -91,16 +76,13 @@ function isCurrentActive(
   stateValue: ClaudeCodeDeviceAuthFlowState,
   requestId: string,
 ): stateValue is ActiveClaudeCodeDeviceAuthFlowState {
-  return (
-    (stateValue.status === "pending" || stateValue.status === "submitting") &&
-    stateValue.requestId === requestId
-  );
+  return stateValue.status === "pending" && stateValue.requestId === requestId;
 }
 
 function isActive(
   stateValue: ClaudeCodeDeviceAuthFlowState,
 ): stateValue is ActiveClaudeCodeDeviceAuthFlowState {
-  return stateValue.status === "pending" || stateValue.status === "submitting";
+  return stateValue.status === "pending";
 }
 
 const startClaudeCodeDeviceAuth$ = command(
@@ -138,11 +120,10 @@ const completeClaudeCodeDeviceAuth$ = command(
         },
         fetchOptions: { signal },
       }),
-      [200],
-      { toast: false },
+      [200, 400],
     );
     signal.throwIfAborted();
-    return result.body;
+    return result;
   },
 );
 
@@ -295,18 +276,11 @@ function createClaudeCodeSubmit$(ctx: ClaudeCodeDeviceAuthSignalContext) {
         return false;
       }
 
-      set(ctx.internalFlowState$, {
-        ...current,
-        status: "submitting",
-        errorMessage: null,
-      });
-      const completed = await settle(
-        set(
-          completeClaudeCodeDeviceAuth$,
-          current.sessionToken,
-          current.authorizationCode,
-          signal,
-        ),
+      set(ctx.internalFlowState$, { ...current, errorMessage: null });
+      const completed = await set(
+        completeClaudeCodeDeviceAuth$,
+        current.sessionToken,
+        current.authorizationCode,
         signal,
       );
       signal.throwIfAborted();
@@ -315,20 +289,11 @@ function createClaudeCodeSubmit$(ctx: ClaudeCodeDeviceAuthSignalContext) {
       if (!isCurrentActive(latest, current.requestId)) {
         return false;
       }
-      if (!completed.ok) {
-        const message = claudeCodeDeviceAuthErrorMessage(completed.error);
-        if (
-          completed.error instanceof ApiError &&
-          completed.error.status === 400
-        ) {
-          set(ctx.internalFlowState$, {
-            ...latest,
-            status: "pending",
-            errorMessage: message,
-          });
-          return false;
-        }
-        set(ctx.internalFlowState$, { status: "error", message });
+      if (completed.status === 400) {
+        set(ctx.internalFlowState$, {
+          ...latest,
+          errorMessage: completed.body.error.message,
+        });
         return false;
       }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -5,13 +5,13 @@ import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroClient$ } from "../../api-client.ts";
 import { agents$ } from "../../agent.ts";
-import { ApiError, accept } from "../../../lib/accept.ts";
-import { userPermissionGrantsByAgent } from "../../permission-allow/permission-allow-signals.ts";
+import { accept } from "../../../lib/accept.ts";
+import { userPermissionGrantsByAgentIfExists } from "../../permission-allow/permission-allow-signals.ts";
 import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
 } from "../agent-connector-authorizations.ts";
-import { settle, withCleanup } from "../../utils.ts";
+import { withCleanup } from "../../utils.ts";
 import { firewallPermissionMetadataByConnector } from "../../firewall-permission-metadata.ts";
 
 export interface ConnectorAgentAccessRow {
@@ -146,19 +146,13 @@ export const managedConnectorAgentAccessRows$ = computed(
           const authorized = enabledTypes.includes(connectorType);
           let grants: readonly UserPermissionGrantResponse[] = [];
           if (authorized) {
-            const grantsResult = await settle(
-              get(userPermissionGrantsByAgent({ agentId: agent.id })),
+            const loadedGrants = await get(
+              userPermissionGrantsByAgentIfExists({ agentId: agent.id }),
             );
-            if (!grantsResult.ok) {
-              if (
-                grantsResult.error instanceof ApiError &&
-                grantsResult.error.status === 404
-              ) {
-                return null;
-              }
-              throw grantsResult.error;
+            if (loadedGrants === null) {
+              return null;
             }
-            grants = grantsResult.value;
+            grants = loadedGrants;
           }
           return {
             agent,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1425,19 +1425,14 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
           status: "polling",
         });
 
-        const pollResponse = await tapError(
-          accept(
-            client.poll({
-              params: { type, sessionId: current.sessionId },
-              body: { sessionToken: current.sessionToken },
-              fetchOptions: { signal },
-            }),
-            [200],
-          ),
+        const pollResponse = await accept(
+          client.poll({
+            params: { type, sessionId: current.sessionId },
+            body: { sessionToken: current.sessionToken },
+            fetchOptions: { signal },
+          }),
+          [200],
         );
-        if (!pollResponse) {
-          return { stop: true };
-        }
         const pollResult = pollResponse.body;
         if (pollResult.status === "complete") {
           connectorStateChanged = true;
@@ -1553,6 +1548,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
       },
       0,
       signal,
+      { retryTransientErrors: false },
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -54,7 +54,6 @@ import {
 import {
   jsonParseOr,
   resetSignal,
-  settle,
   setLoop,
   tapError,
   withCleanup,
@@ -698,7 +697,7 @@ export type ConnectorExternalCodeState =
       readonly requestId: string;
     }
   | (ActiveConnectorExternalCodeState & {
-      readonly status: "pending" | "completing";
+      readonly status: "pending";
     })
   | {
       readonly status: "expired" | "error";
@@ -784,11 +783,7 @@ function connectorOAuthDeviceAuthStateIsActive(
 function connectorExternalCodeStateIsActive(
   state: ConnectorExternalCodeState,
 ): boolean {
-  return (
-    state.status === "starting" ||
-    state.status === "pending" ||
-    state.status === "completing"
-  );
+  return state.status === "starting" || state.status === "pending";
 }
 
 function connectorConnectOperationIsActive({
@@ -1301,10 +1296,6 @@ function createConnectorOAuthDeviceAuthRequestId(type: ConnectorType): string {
   return `${type}-oauth-device-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function oauthDeviceAuthErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Connection failed";
-}
-
 function getOAuthDeviceAuthTerminalMessage(
   result: Extract<
     ConnectorOauthDeviceAuthSessionPollResponse,
@@ -1434,27 +1425,23 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
           status: "polling",
         });
 
-        const acceptPoll = async () => {
-          const response = await accept(
+        const pollResponse = await tapError(
+          accept(
             client.poll({
               params: { type, sessionId: current.sessionId },
               body: { sessionToken: current.sessionToken },
               fetchOptions: { signal },
             }),
             [200],
-          );
-          if (response.body.status === "complete") {
-            connectorStateChanged = true;
-          }
-          return response;
-        };
-        const pollSettled = await settle(acceptPoll(), signal);
-        const pollResult = pollSettled.ok
-          ? pollSettled.value.body
-          : {
-              status: "error" as const,
-              errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
-            };
+          ),
+        );
+        if (!pollResponse) {
+          return { stop: true };
+        }
+        const pollResult = pollResponse.body;
+        if (pollResult.status === "complete") {
+          connectorStateChanged = true;
+        }
 
         const latest = get(internalConnectorOAuthDeviceAuthState$);
         if (
@@ -1687,7 +1674,6 @@ const connectConnectorOAuthDeviceAuth$ = command(
         });
         set(internalConnectorOAuthDeviceAuthState$, (current) => {
           if (
-            !signal.aborted ||
             requestId === null ||
             current.connectorType !== type ||
             (current.status !== "starting" &&
@@ -1754,20 +1740,16 @@ function createConnectorExternalCodeRequestId(type: ConnectorType): string {
   return `${type}-external-code-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function externalCodeErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Connection failed";
-}
-
 function isCurrentConnectorExternalCodeRequest(
   state: ConnectorExternalCodeState,
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
   requestId: string,
 ): state is ActiveConnectorExternalCodeState & {
-  readonly status: "pending" | "completing";
+  readonly status: "pending";
 } {
   return (
-    (state.status === "pending" || state.status === "completing") &&
+    state.status === "pending" &&
     state.connectorType === type &&
     state.authMethod === authMethod &&
     state.requestId === requestId
@@ -1793,7 +1775,7 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
   ) => {
     const current = get(internalConnectorExternalCodeState$);
     if (
-      (current.status !== "pending" && current.status !== "completing") ||
+      current.status !== "pending" ||
       current.connectorType !== args.type ||
       current.authMethod !== args.authMethod
     ) {
@@ -1931,9 +1913,7 @@ export const connectConnectorExternalCode$ = command(
             !signal.aborted ||
             requestId === null ||
             current.connectorType !== type ||
-            (current.status !== "starting" &&
-              current.status !== "pending" &&
-              current.status !== "completing") ||
+            (current.status !== "starting" && current.status !== "pending") ||
             current.authMethod !== authMethod ||
             current.requestId !== requestId
           ) {
@@ -1982,7 +1962,6 @@ const completeConnectorExternalCode$ = command(
 
     set(internalConnectorExternalCodeState$, {
       ...current,
-      status: "completing",
       code,
       errorMessage: null,
     });
@@ -1995,21 +1974,18 @@ const completeConnectorExternalCode$ = command(
         const client = createClient(zeroConnectorExternalCodeSessionContract, {
           apiBase: OAUTH_WEB_API_BASE,
         });
-        const completeSettled = await settle(
-          accept(
-            client.complete({
-              params: { type, sessionId: current.sessionId },
-              body: {
-                sessionToken: current.sessionToken,
-                code,
-              },
-              fetchOptions: { signal: flowSignal },
-            }),
-            [200],
-            { toast: false },
-          ),
+        const completeResult = await accept(
+          client.complete({
+            params: { type, sessionId: current.sessionId },
+            body: {
+              sessionToken: current.sessionToken,
+              code,
+            },
+            fetchOptions: { signal: flowSignal },
+          }),
+          [200, 400],
         );
-        if (completeSettled.ok) {
+        if (completeResult.status === 200) {
           connectorStateChanged = true;
         }
         signal.throwIfAborted();
@@ -2026,14 +2002,10 @@ const completeConnectorExternalCode$ = command(
           return false;
         }
 
-        if (!completeSettled.ok) {
-          if (flowSignal.aborted) {
-            return false;
-          }
+        if (completeResult.status === 400) {
           set(internalConnectorExternalCodeState$, {
             ...latest,
-            status: "pending",
-            errorMessage: externalCodeErrorMessage(completeSettled.error),
+            errorMessage: completeResult.body.error.message,
           });
           return false;
         }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { screen, waitFor, within } from "@testing-library/react";
+import { HttpResponse } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -435,6 +436,20 @@ describe("personal model providers settings", () => {
     click(submit);
     await expect(
       screen.findByText("Claude authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(submit).toBeEnabled();
+    });
+
+    context.mocks.http.post(
+      "*/api/zero/model-providers/claude-code/device-auth/sessions/complete",
+      () => {
+        return HttpResponse.error();
+      },
+    );
+    click(submit);
+    await expect(
+      screen.findByText("Failed to fetch"),
     ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(submit).toBeEnabled();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -454,7 +454,7 @@ describe("personal model providers settings", () => {
     await waitFor(() => {
       expect(submit).toBeEnabled();
     });
-  }, 10_000);
+  });
 
   it("shows available subscription details in the connected status", async () => {
     mockBrowserTimeZone("America/New_York");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -373,6 +373,74 @@ describe("personal model providers settings", () => {
     });
   });
 
+  it("keeps Claude Code validation inline and toasts unexpected errors", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "member",
+    });
+    context.mocks.data.personalModelProviders([]);
+    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+      return respond(200, {
+        sessionToken: "mock-personal-claude-code-session",
+        type: "claude-code",
+        status: "pending",
+        scope: "personal",
+        browserUrl: "https://claude.ai/oauth/authorize",
+        expiresIn: 30,
+      });
+    });
+    let completeCount = 0;
+    context.mocks.api(
+      zeroClaudeCodeDeviceAuthContract.complete,
+      ({ respond }) => {
+        completeCount += 1;
+        if (completeCount === 1) {
+          return respond(400, {
+            error: {
+              message: "Invalid Claude authorization code",
+              code: "BAD_REQUEST",
+            },
+          });
+        }
+        return respond(503, {
+          error: {
+            message: "Claude authorization is unavailable",
+            code: "UNAVAILABLE",
+          },
+        });
+      },
+    );
+
+    await openModelSettings();
+
+    const claudeCodeRow = await screen.findByTestId(
+      "oauth-card-claude-code-oauth-token",
+    );
+    click(connectButtonInRow(claudeCodeRow, "Connect Claude Code OAuth"));
+    const codeInput = await findLatestClaudeCodeInput();
+    const dialog = dialogContaining(codeInput);
+    await fill(codeInput, "invalid-claude-code");
+    const submit = within(dialog).getByTestId("claude-code-device-auth-submit");
+    click(submit);
+
+    await expect(
+      within(dialog).findByText("Invalid Claude authorization code"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(submit).toBeEnabled();
+    });
+
+    click(submit);
+    await expect(
+      screen.findByText("Claude authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(submit).toBeEnabled();
+    });
+  });
+
   it("shows available subscription details in the connected status", async () => {
     mockBrowserTimeZone("America/New_York");
     mockNow(new Date("2030-01-01T00:48:00.000Z"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1267,7 +1267,7 @@ describe("connectors page", () => {
     expect(
       within(dialog).queryByText("Loading agents..."),
     ).not.toBeInTheDocument();
-  }, 10_000);
+  });
 
   it("shows authorized agent names with an overflow count on connector cards", async () => {
     const agentIds = [
@@ -2006,7 +2006,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(buttonByText("Connect Stripe", dialog)).toBeEnabled();
     });
-  }, 10_000);
+  });
 
   it("connects a manual token connector", async () => {
     mockConnectors([]);
@@ -2775,7 +2775,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(complete).toBeEnabled();
     });
-  }, 10_000);
+  });
 
   it("toasts external-code transport errors and restores a retryable state", async () => {
     context.mocks.http.post(
@@ -2793,7 +2793,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(complete).toBeEnabled();
     });
-  }, 10_000);
+  });
 
   it("uses auth method help text for PlayStation external-code connection", async () => {
     mockConnectors([]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -5,6 +5,7 @@ import {
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
+  zeroConnectorExternalCodeSessionContract,
   zeroConnectorOpenIdStartContract,
   zeroConnectorOauthStartContract,
   zeroConnectorManualGrantContract,
@@ -1916,6 +1917,53 @@ describe("connectors page", () => {
     expect(startCount).toBe(1);
   });
 
+  it("returns device auth to a retryable state after an unexpected poll error", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Stripe",
+        authMethods: [
+          {
+            id: "cli",
+            label: "Stripe CLI",
+            description: "Approve access with Stripe CLI.",
+            grantKind: "device-auth",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    context.mocks.browser.open(createMockAuthWindow());
+    context.mocks.api(
+      zeroConnectorOauthDeviceAuthSessionContract.poll,
+      ({ respond }) => {
+        return respond(500, {
+          error: {
+            message: "Stripe device authorization is unavailable",
+            code: "UNAVAILABLE",
+          },
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "stripe");
+    click(await screen.findByLabelText("Connect Stripe"));
+    const dialog = await screen.findByRole("dialog", { name: "Stripe" });
+    click(buttonByText("Connect Stripe", dialog));
+    click(await within(dialog).findByTestId("connector-oauth-device-open"));
+
+    await expect(
+      screen.findByText("Stripe device authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(buttonByText("Connect Stripe", dialog)).toBeEnabled();
+    });
+  });
+
   it("connects a manual token connector", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([
@@ -2643,6 +2691,63 @@ describe("connectors page", () => {
           /@arn:aws:iam::000000000000:user\/mock-aws/u,
         ),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("keeps external-code validation inline and toasts unexpected errors", async () => {
+    mockConnectors([]);
+    context.mocks.browser.open(createMockAuthWindow());
+    let completeCount = 0;
+    context.mocks.api(
+      zeroConnectorExternalCodeSessionContract.complete,
+      ({ respond }) => {
+        completeCount += 1;
+        if (completeCount === 1) {
+          return respond(400, {
+            error: { message: "Invalid AWS code", code: "BAD_REQUEST" },
+          });
+        }
+        return respond(500, {
+          error: {
+            message: "AWS authorization is unavailable",
+            code: "UNAVAILABLE",
+          },
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.AwsConnector]: true },
+    });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "aws");
+    click(await screen.findByLabelText("Connect AWS"));
+    const dialog = await screen.findByRole("dialog", { name: "AWS" });
+    click(buttonByText("Start AWS sign-in", dialog));
+    await fill(
+      await within(dialog).findByTestId("connector-external-code-input"),
+      "INVALID-CODE",
+    );
+    const complete = within(dialog).getByTestId(
+      "connector-external-code-complete",
+    );
+    click(complete);
+
+    await expect(
+      within(dialog).findByText("Invalid AWS code"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(complete).toBeEnabled();
+    });
+
+    click(complete);
+    await expect(
+      screen.findByText("AWS authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(complete).toBeEnabled();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -30,6 +30,7 @@ import type {
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -1936,15 +1937,23 @@ describe("connectors page", () => {
       }),
     ]);
     context.mocks.browser.open(createMockAuthWindow());
-    context.mocks.api(
-      zeroConnectorOauthDeviceAuthSessionContract.poll,
-      ({ respond }) => {
-        return respond(500, {
-          error: {
-            message: "Stripe device authorization is unavailable",
-            code: "UNAVAILABLE",
-          },
-        });
+    let pollCount = 0;
+    context.mocks.http.post(
+      "*/api/zero/connectors/stripe/oauth/device/sessions/:sessionId/poll",
+      () => {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Stripe device authorization is unavailable",
+                code: "UNAVAILABLE",
+              },
+            },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.error();
       },
     );
 
@@ -1958,6 +1967,15 @@ describe("connectors page", () => {
 
     await expect(
       screen.findByText("Stripe device authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(buttonByText("Connect Stripe", dialog)).toBeEnabled();
+    });
+
+    click(buttonByText("Connect Stripe", dialog));
+    click(await within(dialog).findByTestId("connector-oauth-device-open"));
+    await expect(
+      screen.findByText("Failed to fetch"),
     ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(buttonByText("Connect Stripe", dialog)).toBeEnabled();
@@ -2745,6 +2763,20 @@ describe("connectors page", () => {
     click(complete);
     await expect(
       screen.findByText("AWS authorization is unavailable"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(complete).toBeEnabled();
+    });
+
+    context.mocks.http.post(
+      "*/api/zero/connectors/aws/external-code/sessions/:sessionId/complete",
+      () => {
+        return HttpResponse.error();
+      },
+    );
+    click(complete);
+    await expect(
+      screen.findByText("Failed to fetch"),
     ).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(complete).toBeEnabled();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -167,6 +167,7 @@ type ConnectMethodContentProps = ConnectModalContentProps & {
   completeExternalCodeAndSettle: CompleteExternalCodeAndSettleFn;
   connectNoAuthAndSettle: ConnectNoAuthAndSettleFn;
   submitManualGrant: SubmitManualGrantFn;
+  externalCodeCompleting: boolean;
   manualGrantSubmitting: boolean;
   noAuthSubmitting: boolean;
   signal: AbortSignal;
@@ -205,9 +206,7 @@ function connectorExternalCodeFlowIsActive(
 ): boolean {
   return (
     state.connectorType === type &&
-    (state.status === "starting" ||
-      state.status === "pending" ||
-      state.status === "completing")
+    (state.status === "starting" || state.status === "pending")
   );
 }
 
@@ -732,7 +731,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
 
 type PendingConnectorExternalCodeState = Extract<
   ConnectorExternalCodeState,
-  { readonly status: "pending" | "completing" }
+  { readonly status: "pending" }
 >;
 type ExternalCodeButtonHandler = (event: unknown) => void;
 type ExternalCodeSubmitHandler = (event: FormEvent<HTMLFormElement>) => void;
@@ -779,6 +778,7 @@ function ExternalCodePendingContent({
   connectorLabel,
   method,
   current,
+  completing,
   onOpen,
   onCodeChange,
   onComplete,
@@ -786,11 +786,11 @@ function ExternalCodePendingContent({
   connectorLabel: string;
   method: ConnectorStatusAuthMethodDetail;
   current: PendingConnectorExternalCodeState;
+  completing: boolean;
   onOpen: ExternalCodeButtonHandler;
   onCodeChange: (code: string) => void;
   onComplete: ExternalCodeSubmitHandler;
 }) {
-  const completing = current.status === "completing";
   return (
     <form className="flex flex-col gap-3" onSubmit={onComplete}>
       {method.description && <ConnectorHelpText text={method.description} />}
@@ -892,12 +892,13 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
     );
   }
 
-  if (current?.status === "pending" || current?.status === "completing") {
+  if (current?.status === "pending") {
     return (
       <ExternalCodePendingContent
         connectorLabel={props.item.label}
         method={props.method}
         current={current}
+        completing={props.externalCodeCompleting}
         onOpen={() => {
           openAuthorizationPage(props.item.type, props.authMethod);
         }}
@@ -1099,6 +1100,7 @@ function StandardConnectMethodsContent({
   completeExternalCodeAndSettle,
   connectNoAuthAndSettle,
   submitManualGrant,
+  externalCodeCompleting,
   manualGrantSubmitting,
   noAuthSubmitting,
   signal,
@@ -1110,6 +1112,7 @@ function StandardConnectMethodsContent({
   completeExternalCodeAndSettle: CompleteExternalCodeAndSettleFn;
   connectNoAuthAndSettle: ConnectNoAuthAndSettleFn;
   submitManualGrant: SubmitManualGrantFn;
+  externalCodeCompleting: boolean;
   manualGrantSubmitting: boolean;
   noAuthSubmitting: boolean;
   signal: AbortSignal;
@@ -1131,6 +1134,7 @@ function StandardConnectMethodsContent({
           completeExternalCodeAndSettle,
           connectNoAuthAndSettle,
           submitManualGrant,
+          externalCodeCompleting,
           manualGrantSubmitting,
           noAuthSubmitting,
           signal,
@@ -1155,9 +1159,8 @@ function ConnectModalContent({
   const [, connectExternalCodeCommand] = useLoadableSet(
     connectConnectorExternalCode$,
   );
-  const [, completeExternalCodeAndSettleCommand] = useLoadableSet(
-    completeConnectorExternalCodeAndSettle$,
-  );
+  const [completeExternalCodeLoadable, completeExternalCodeAndSettleCommand] =
+    useLoadableSet(completeConnectorExternalCodeAndSettle$);
   const [manualGrantLoadable, submitManualGrantCommand] =
     useLoadableSet(submitManualGrant$);
   const [noAuthLoadable, connectNoAuthAndSettleCommand] = useLoadableSet(
@@ -1179,6 +1182,8 @@ function ConnectModalContent({
   const pageSignal = useGet(pageSignal$);
   const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const settling = settleLoadable.state === "loading";
+  const externalCodeCompleting =
+    completeExternalCodeLoadable.state === "loading";
   const manualGrantSubmitting = manualGrantLoadable.state === "loading";
   const noAuthSubmitting = noAuthLoadable.state === "loading";
   const isPolling = pollingType === item.type;
@@ -1254,6 +1259,7 @@ function ConnectModalContent({
       completeExternalCodeAndSettle={completeExternalCodeAndSettle}
       connectNoAuthAndSettle={connectNoAuthAndSettle}
       submitManualGrant={submitManualGrant}
+      externalCodeCompleting={externalCodeCompleting}
       manualGrantSubmitting={manualGrantSubmitting}
       noAuthSubmitting={noAuthSubmitting}
       signal={pageSignal}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -51,6 +51,7 @@ interface ClaudeCodeDeviceAuthScopeBundle {
   openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
   run: (signal: AbortSignal) => Promise<boolean>;
   submit: (signal: AbortSignal) => Promise<boolean>;
+  submitting: boolean;
   setAuthorizationCode: (value: string) => void;
 }
 
@@ -72,7 +73,7 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
   const close = useSet(closeClaudeCodeDeviceAuthDialog$);
   const openApprovalPage = useSet(openClaudeCodeDeviceAuthApprovalPage$);
   const [, run] = useLoadableSet(runClaudeCodeDeviceAuth$);
-  const [, submit] = useLoadableSet(submitClaudeCodeDeviceAuth$);
+  const [submitLoadable, submit] = useLoadableSet(submitClaudeCodeDeviceAuth$);
   const setAuthorizationCode = useSet(
     setClaudeCodeDeviceAuthAuthorizationCode$,
   );
@@ -85,6 +86,7 @@ function useOrgClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundle {
     openApprovalPage,
     run,
     submit,
+    submitting: submitLoadable.state === "loading",
     setAuthorizationCode,
   };
 }
@@ -99,7 +101,9 @@ function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundl
     openClaudeCodeDeviceAuthApprovalPagePersonal$,
   );
   const [, run] = useLoadableSet(runClaudeCodeDeviceAuthPersonal$);
-  const [, submit] = useLoadableSet(submitClaudeCodeDeviceAuthPersonal$);
+  const [submitLoadable, submit] = useLoadableSet(
+    submitClaudeCodeDeviceAuthPersonal$,
+  );
   const setAuthorizationCode = useSet(
     setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
   );
@@ -112,6 +116,7 @@ function usePersonalClaudeCodeDeviceAuthBundle(): ClaudeCodeDeviceAuthScopeBundl
     openApprovalPage,
     run,
     submit,
+    submitting: submitLoadable.state === "loading",
     setAuthorizationCode,
   };
 }
@@ -131,6 +136,7 @@ function ClaudeCodeDeviceAuthDialogView({
     openApprovalPage,
     run,
     submit,
+    submitting,
     setAuthorizationCode,
   } = bundle;
   const title =
@@ -175,6 +181,7 @@ function ClaudeCodeDeviceAuthDialogView({
             openApprovalPage={openApprovalPage}
             pageSignal={pageSignal}
             setAuthorizationCode={setAuthorizationCode}
+            submitting={submitting}
           />
         </div>
       </DialogContent>
@@ -190,6 +197,7 @@ function ClaudeCodeDeviceAuthBody({
   openApprovalPage,
   pageSignal,
   setAuthorizationCode,
+  submitting,
 }: {
   flow: ClaudeCodeDeviceAuthFlowState;
   mode: "connect" | "reconnect";
@@ -198,6 +206,7 @@ function ClaudeCodeDeviceAuthBody({
   openApprovalPage: (signal: AbortSignal) => boolean | Promise<boolean>;
   pageSignal: AbortSignal;
   setAuthorizationCode: (value: string) => void;
+  submitting: boolean;
 }) {
   switch (flow.status) {
     case "idle": {
@@ -206,8 +215,7 @@ function ClaudeCodeDeviceAuthBody({
     case "starting": {
       return <ClaudeCodeDeviceAuthLoadingContent />;
     }
-    case "pending":
-    case "submitting": {
+    case "pending": {
       return (
         <form
           className="space-y-3"
@@ -245,7 +253,7 @@ function ClaudeCodeDeviceAuthBody({
               id="claude-code-device-auth-code"
               value={flow.authorizationCode}
               placeholder="Paste code from Claude"
-              readOnly={flow.status === "submitting"}
+              readOnly={submitting}
               onChange={(event) => {
                 setAuthorizationCode(event.target.value);
               }}
@@ -260,13 +268,11 @@ function ClaudeCodeDeviceAuthBody({
           <Button
             type="submit"
             className="w-full gap-2"
-            disabled={flow.status === "submitting"}
+            disabled={submitting}
             data-testid="claude-code-device-auth-submit"
           >
-            {flow.status === "submitting" && (
-              <IconLoader2 size={14} className="animate-spin" />
-            )}
-            {flow.status === "submitting" ? "Connecting..." : "Connect"}
+            {submitting && <IconLoader2 size={14} className="animate-spin" />}
+            {submitting ? "Connecting..." : "Connect"}
           </Button>
         </form>
       );


### PR DESCRIPTION
## Summary

- accept stale-agent grant `404` responses as an expected absence while preserving the existing transient retry and grant reload behavior
- accept invalid Claude Code and external connector codes as inline `400` validation results, with request loading owned by `useLoadableSet`
- let unexpected authorization failures use the default `accept` toast and restore each flow to a retryable state
- remove four production `settle()` calls from Platform, reducing the scoped remainder from seven to three

## User impact

Invalid authorization codes stay next to the input that needs correction. Unexpected service failures now use the standard toast behavior, and the dialog no longer gets stuck in a submitting or polling state after an error.

## Verification

- `pnpm format`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `zero-connectors-page.test.tsx`: 49 passed
- `personal-providers-tab.test.tsx`: 9 passed

Per repository PR guidance, I did not run the full Vitest suite or start a local dev server.