### PR TITLE
refactor: make accepted http errors explicit

### DIFF
--- a/turbo/apps/platform/src/lib/ably-auth.ts
+++ b/turbo/apps/platform/src/lib/ably-auth.ts
@@ -48,9 +48,7 @@ export function createAblyAuthCallback(
       (async () => {
         // eslint-disable-next-line no-restricted-syntax -- bridging Ably's node-style auth callback into our promise-based `accept()` helper; justified per eslint.config.js "If genuinely needed (JSON.parse, clipboard, polling), add an inline eslint-disable with justification"
         try {
-          const res = await accept(client.create({ body: {} }), [200], {
-            toast: false,
-          });
+          const res = await accept(client.create({ body: {} }), [200]);
           // The fetch above does not accept our signal, so check it
           // explicitly per ccstate skill ("AbortSignal Lifecycle"): aborts
           // surface as an AbortError that the catch re-throws to detach.

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -37,30 +37,17 @@ function extractError(
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
  * Otherwise shows a toast and throws an `ApiError`.
- *
- * Toast behavior:
- * - Write-path commands (mutations): omit `options` or pass `{}` — the toast
- *   fires automatically. The thrown `ApiError` is swallowed by `detach()`, so
- *   there is no double-notification.
- * - Use `{ toast: false }` only when the caller deliberately handles the error
- *   in a non-toast UI flow or in a non-user-facing integration callback.
  */
 async function accept<
   T extends { status: number; body: unknown },
   S extends number,
->(
-  promise: Promise<T>,
-  codes: S[],
-  options?: { toast?: boolean },
-): Promise<Extract<T, { status: S }>> {
+>(promise: Promise<T>, codes: S[]): Promise<Extract<T, { status: S }>> {
   const result = await promise;
   if ((codes as number[]).includes(result.status)) {
     return result as Extract<T, { status: S }>;
   }
   const { message, code } = extractError(result.body, result.status);
-  if (options?.toast !== false) {
-    toast.error(message);
-  }
+  toast.error(message);
   throw new ApiError(message, code, result.status);
 }
 

--- a/turbo/apps/platform/src/signals/activity-page/activity-download.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-download.ts
@@ -32,7 +32,6 @@ export const fetchDownloadExtra$ = command(
           fetchOptions: { signal: _signal },
         }),
         [200, 404],
-        { toast: false },
       );
       return result.status === 200 ? result.body : undefined;
     };
@@ -43,7 +42,6 @@ export const fetchDownloadExtra$ = command(
         get(zeroClient$)(zeroRunNetworkLogsContract),
         runId,
         _signal,
-        { toast: false },
       ),
     ]);
     _signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -34,10 +34,6 @@ interface ZeroActivityNetworkLogs {
   loading: boolean;
 }
 
-interface NetworkLogsRequestOptions {
-  toast?: boolean;
-}
-
 /**
  * Fetch a single page of network logs.
  */
@@ -46,7 +42,6 @@ async function fetchPage(
   runId: string,
   signal?: AbortSignal,
   cursor?: string,
-  options?: NetworkLogsRequestOptions,
 ): Promise<NetworkLogsPage> {
   const result = await accept(
     client.getNetworkLogs({
@@ -59,7 +54,6 @@ async function fetchPage(
       fetchOptions: signal ? { signal } : undefined,
     }),
     [200],
-    options,
   );
   const nextCursor = result.body.nextCursor ?? null;
   return {
@@ -76,7 +70,6 @@ export async function fetchAllNetworkLogs(
   client: NetworkLogsClient,
   runId: string,
   signal: AbortSignal,
-  options?: NetworkLogsRequestOptions,
 ): Promise<NetworkLogEntry[]> {
   const all: NetworkLogEntry[] = [];
   let cursor: string | undefined;
@@ -88,7 +81,6 @@ export async function fetchAllNetworkLogs(
       runId,
       signal,
       cursor,
-      options,
     );
     all.push(...logs);
 

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -89,13 +89,14 @@ async function syncArtifactFilesToGoogleDrive(
             },
             fetchOptions: params.signal ? { signal: params.signal } : undefined,
           }),
-          [200],
-          { toast: false },
+          [200, 400, 401, 403, 404, 503],
         ),
         params.signal,
       );
       const result: ArtifactGoogleDriveSyncResult = settled.ok
-        ? { ok: true }
+        ? settled.value.status === 200
+          ? { ok: true }
+          : { ok: false, message: settled.value.body.error.message }
         : {
             ok: false,
             message: googleDriveSyncErrorMessage(settled.error),

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -25,7 +25,7 @@ import {
   type ZeroWorkflowUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 
-import { accept, ApiError } from "../../lib/accept.ts";
+import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { activeRoute$ } from "../active-route.ts";
 import {
@@ -43,7 +43,6 @@ import {
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { currentAgentId$ } from "../agent.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
-import { onRejection } from "../utils.ts";
 import {
   reloadWorkflowData$,
   workflowReloadVersion$,
@@ -734,38 +733,29 @@ export const checkWorkflowConnectorReadiness$ = command(
       status: "pending",
     });
     const client = get(zeroClient$)(zeroWorkflowsDetailContract);
-    const result = await onRejection(
-      accept(
-        client.connectorReadiness({
-          params: { workflowId },
-          fetchOptions: { signal },
-        }),
-        [200],
-        { toast: false },
-      ),
-      (error) => {
-        if (
-          !signal.aborted &&
-          get(internalWorkflowConnectorReadiness$)?.requestId === requestId
-        ) {
-          set(internalWorkflowConnectorReadiness$, {
-            workflowId,
-            requestId,
-            status: "error",
-            errorKind:
-              error instanceof ApiError &&
-              (error.status === 413 || error.code === "PAYLOAD_TOO_LARGE")
-                ? "input-too-long"
-                : error instanceof ApiError &&
-                    error.code === "CONNECTOR_READINESS_TIMEOUT"
-                  ? "timeout"
-                  : "retry",
-          });
-        }
-      },
+    const result = await accept(
+      client.connectorReadiness({
+        params: { workflowId },
+        fetchOptions: { signal },
+      }),
+      [200, 413, 503],
     );
     signal.throwIfAborted();
     if (get(internalWorkflowConnectorReadiness$)?.requestId !== requestId) {
+      return;
+    }
+    if (result.status !== 200) {
+      set(internalWorkflowConnectorReadiness$, {
+        workflowId,
+        requestId,
+        status: "error",
+        errorKind:
+          result.status === 413
+            ? "input-too-long"
+            : result.body.error.code === "CONNECTOR_READINESS_TIMEOUT"
+              ? "timeout"
+              : "retry",
+      });
       return;
     }
     set(internalWorkflowConnectorReadiness$, {

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -8,7 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-host";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { accept } from "../../lib/accept.ts";
+import { accept, ApiError } from "../../lib/accept.ts";
 import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { onRef, resetSignal, settle, tapError, withCleanup } from "../utils.ts";
@@ -386,7 +386,6 @@ async function requestHtmlEditDraft(params: {
       fetchOptions: { signal: params.signal },
     }),
     [200],
-    { toast: false },
   );
   params.signal.throwIfAborted();
 
@@ -3263,9 +3262,11 @@ export const sendHtmlDomEditRequest$ = command(
             signal,
           }),
           (error) => {
-            toast.error(
-              htmlDomEditErrorMessage(error, "Failed to generate edit"),
-            );
+            if (!(error instanceof ApiError)) {
+              toast.error(
+                htmlDomEditErrorMessage(error, "Failed to generate edit"),
+              );
+            }
           },
         );
         signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -5,17 +5,11 @@ import {
   type ClaudeCodeDeviceAuthScope,
 } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
 
-import { ApiError, accept } from "../../../lib/accept.ts";
+import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import {
-  bestEffort,
-  onRef,
-  resetSignal,
-  settle,
-  tapError,
-} from "../../utils.ts";
+import { bestEffort, onRef, resetSignal, tapError } from "../../utils.ts";
 import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
@@ -60,15 +54,6 @@ function createRequestId(scope: ClaudeCodeDeviceAuthScope): string {
 
 function secondsToMilliseconds(seconds: number): number {
   return seconds * 1000;
-}
-
-function claudeCodeDeviceAuthErrorMessage(error: unknown): string {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-  return error instanceof Error
-    ? error.message
-    : "Claude Code connection failed";
 }
 
 function openApprovalPage(browserUrl: string): boolean {
@@ -138,11 +123,10 @@ const completeClaudeCodeDeviceAuth$ = command(
         },
         fetchOptions: { signal },
       }),
-      [200],
-      { toast: false },
+      [200, 400, 404, 503],
     );
     signal.throwIfAborted();
-    return result.body;
+    return result;
   },
 );
 
@@ -157,7 +141,6 @@ const cancelClaudeCodeDeviceAuth$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     return result.body;
@@ -300,13 +283,10 @@ function createClaudeCodeSubmit$(ctx: ClaudeCodeDeviceAuthSignalContext) {
         status: "submitting",
         errorMessage: null,
       });
-      const completed = await settle(
-        set(
-          completeClaudeCodeDeviceAuth$,
-          current.sessionToken,
-          current.authorizationCode,
-          signal,
-        ),
+      const completed = await set(
+        completeClaudeCodeDeviceAuth$,
+        current.sessionToken,
+        current.authorizationCode,
         signal,
       );
       signal.throwIfAborted();
@@ -315,12 +295,9 @@ function createClaudeCodeSubmit$(ctx: ClaudeCodeDeviceAuthSignalContext) {
       if (!isCurrentActive(latest, current.requestId)) {
         return false;
       }
-      if (!completed.ok) {
-        const message = claudeCodeDeviceAuthErrorMessage(completed.error);
-        if (
-          completed.error instanceof ApiError &&
-          completed.error.status === 400
-        ) {
+      if (completed.status !== 200) {
+        const message = completed.body.error.message;
+        if (completed.status === 400) {
           set(ctx.internalFlowState$, {
             ...latest,
             status: "pending",

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -6,7 +6,7 @@ import {
   type CodexDeviceAuthScope,
 } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 
-import { ApiError, accept } from "../../../lib/accept.ts";
+import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
@@ -14,7 +14,6 @@ import {
   bestEffort,
   onRef,
   resetSignal,
-  settle,
   setLoop,
   tapError,
 } from "../../utils.ts";
@@ -69,17 +68,17 @@ function secondsToMilliseconds(seconds: number): number {
   return seconds * 1000;
 }
 
-function codexDeviceAuthErrorMessage(error: unknown): string {
-  if (error instanceof ApiError) {
-    if (error.code === "CODEX_AUTH_JSON_SHAPE_INVALID") {
-      return "Codex produced a login token format vm0 does not recognize. Update Codex and try again.";
-    }
-    if (error.code === "CODEX_FREE_PLAN_REJECTED") {
-      return "Free ChatGPT plans cannot use Codex via vm0. Upgrade to Plus or Pro and try again.";
-    }
-    return error.message;
+function codexDeviceAuthErrorMessage(error: {
+  readonly code: string;
+  readonly message: string;
+}): string {
+  if (error.code === "CODEX_AUTH_JSON_SHAPE_INVALID") {
+    return "Codex produced a login token format vm0 does not recognize. Update Codex and try again.";
   }
-  return error instanceof Error ? error.message : "Codex connection failed";
+  if (error.code === "CODEX_FREE_PLAN_REJECTED") {
+    return "Free ChatGPT plans cannot use Codex via vm0. Upgrade to Plus or Pro and try again.";
+  }
+  return error.message;
 }
 
 function openApprovalPage(browserUrl: string): boolean {
@@ -173,11 +172,10 @@ const completeCodexDeviceAuth$ = command(
         body: { sessionToken },
         fetchOptions: { signal },
       }),
-      [200],
-      { toast: false },
+      [200, 400, 404, 503],
     );
     signal.throwIfAborted();
-    return result.body;
+    return result;
   },
 );
 
@@ -192,7 +190,6 @@ const cancelCodexDeviceAuth$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     return result.body;
@@ -238,8 +235,9 @@ function createCodexPollFlow$(ctx: CodexDeviceAuthSignalContext) {
           }
 
           set(ctx.internalFlowState$, { ...current, status: "polling" });
-          const completion = await settle(
-            set(completeCodexDeviceAuth$, current.sessionToken, loopSignal),
+          const completion = await set(
+            completeCodexDeviceAuth$,
+            current.sessionToken,
             loopSignal,
           );
           loopSignal.throwIfAborted();
@@ -249,15 +247,15 @@ function createCodexPollFlow$(ctx: CodexDeviceAuthSignalContext) {
             return true;
           }
 
-          if (!completion.ok) {
+          if (completion.status !== 200) {
             set(ctx.internalFlowState$, {
               status: "error",
-              message: codexDeviceAuthErrorMessage(completion.error),
+              message: codexDeviceAuthErrorMessage(completion.body.error),
             });
             return true;
           }
 
-          if (completion.value.status === "complete") {
+          if (completion.body.status === "complete") {
             set(ctx.reloadProviders$);
             toast.success("ChatGPT connected");
             set(ctx.internalDialogState$, createInitialDialogState());
@@ -269,7 +267,7 @@ function createCodexPollFlow$(ctx: CodexDeviceAuthSignalContext) {
           set(ctx.internalFlowState$, {
             ...latest,
             status: "pending",
-            errorMessage: completion.value.errorMessage,
+            errorMessage: completion.body.errorMessage,
           });
 
           const nextRemainingMs = latest.expiresAtMs - now();

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1754,10 +1754,6 @@ function createConnectorExternalCodeRequestId(type: ConnectorType): string {
   return `${type}-external-code-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function externalCodeErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Connection failed";
-}
-
 function isCurrentConnectorExternalCodeRequest(
   state: ConnectorExternalCodeState,
   type: ConnectorType,
@@ -1995,21 +1991,18 @@ const completeConnectorExternalCode$ = command(
         const client = createClient(zeroConnectorExternalCodeSessionContract, {
           apiBase: OAUTH_WEB_API_BASE,
         });
-        const completeSettled = await settle(
-          accept(
-            client.complete({
-              params: { type, sessionId: current.sessionId },
-              body: {
-                sessionToken: current.sessionToken,
-                code,
-              },
-              fetchOptions: { signal: flowSignal },
-            }),
-            [200],
-            { toast: false },
-          ),
+        const completeResult = await accept(
+          client.complete({
+            params: { type, sessionId: current.sessionId },
+            body: {
+              sessionToken: current.sessionToken,
+              code,
+            },
+            fetchOptions: { signal: flowSignal },
+          }),
+          [200, 400, 404],
         );
-        if (completeSettled.ok) {
+        if (completeResult.status === 200) {
           connectorStateChanged = true;
         }
         signal.throwIfAborted();
@@ -2026,14 +2019,14 @@ const completeConnectorExternalCode$ = command(
           return false;
         }
 
-        if (!completeSettled.ok) {
+        if (completeResult.status !== 200) {
           if (flowSignal.aborted) {
             return false;
           }
           set(internalConnectorExternalCodeState$, {
             ...latest,
             status: "pending",
-            errorMessage: externalCodeErrorMessage(completeSettled.error),
+            errorMessage: completeResult.body.error.message,
           });
           return false;
         }

--- a/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
@@ -13,7 +13,7 @@ import {
   searchParams$,
   updateSearchParams$,
 } from "../route.ts";
-import { accept } from "../../lib/accept.ts";
+import { accept, ApiError } from "../../lib/accept.ts";
 import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import {
@@ -224,11 +224,10 @@ export const loadPersistedEditableImageCanvasSnapshot$ = command(
         query: { url: args.url },
         fetchOptions: { signal },
       }),
-      [200, 404],
-      { toast: false },
+      [200],
     );
     signal.throwIfAborted();
-    if (loaded.status === 404 || loaded.body.snapshot === null) {
+    if (loaded.body.snapshot === null) {
       set(internalPersistedImageCanvasSnapshotPresentByKey$, (current) => {
         return { ...current, [args.key]: false };
       });
@@ -305,8 +304,7 @@ export const persistEditableImageCanvasSnapshot$ = command(
           query: { url: args.url },
           fetchOptions: { signal },
         }),
-        [204, 404],
-        { toast: false },
+        [204],
       );
       signal.throwIfAborted();
       set(internalPersistedImageCanvasSnapshotPresentByKey$, (current) => {
@@ -315,7 +313,7 @@ export const persistEditableImageCanvasSnapshot$ = command(
       return;
     }
 
-    const saved = await accept(
+    await accept(
       client.upsertImageEditSnapshot({
         body: {
           snapshot: {
@@ -328,19 +326,12 @@ export const persistEditableImageCanvasSnapshot$ = command(
         },
         fetchOptions: { signal },
       }),
-      [200, 204, 404],
-      { toast: false },
+      [200],
     );
     signal.throwIfAborted();
-    if (saved.status === 200) {
-      set(internalPersistedImageCanvasSnapshotPresentByKey$, (current) => {
-        return { ...current, [args.key]: true };
-      });
-    } else if (saved.status === 204) {
-      set(internalPersistedImageCanvasSnapshotPresentByKey$, (current) => {
-        return { ...current, [args.key]: false };
-      });
-    }
+    set(internalPersistedImageCanvasSnapshotPresentByKey$, (current) => {
+      return { ...current, [args.key]: true };
+    });
   },
 );
 
@@ -685,9 +676,6 @@ async function interpretRegionMarks({
       fetchOptions: { signal: requestSignal(signal) },
     }),
     [200],
-    // run() surfaces a single generic toast via tapError; suppress accept's own
-    // toast so an interpret failure isn't reported twice.
-    { toast: false },
   );
   signal.throwIfAborted();
 
@@ -956,8 +944,10 @@ export const runImageEdit$ = command(
     };
 
     await withCleanup(
-      tapError(run(), () => {
-        toast.error("Couldn't edit the image, try again");
+      tapError(run(), (error) => {
+        if (!(error instanceof ApiError)) {
+          toast.error("Couldn't edit the image, try again");
+        }
         // A thrown run (e.g. the source-image load timed out mid-sequence) also
         // has to release the region toggle so it isn't left stuck on.
         if (editRegion) {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -2210,7 +2210,7 @@ describe("activity detail polling", () => {
     expect(extra.networkLogs).toStrictEqual([]);
   });
 
-  it("silences optional activity extra fetch failures during download", async () => {
+  it("toasts optional activity extra fetch failures during download", async () => {
     const runId = "a0000000-0000-4000-a000-000000000396";
     const toastError = vi.spyOn(toast, "error");
 
@@ -2242,7 +2242,7 @@ describe("activity detail polling", () => {
       );
 
       expect(extra).toStrictEqual({});
-      expect(toastError).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Network logs unavailable");
     } finally {
       toastError.mockRestore();
     }

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/require-accept.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/require-accept.test.ts
@@ -36,7 +36,7 @@ ruleTester.run("require-accept", rule, {
       code: `
         const createClient = get(zeroClient$);
         const client = createClient(someContract);
-        const result = await accept(client.create({ body }), [201], { toast: false });
+        const result = await accept(client.create({ body }), [201]);
       `,
     },
     // Test file — rule not applied


### PR DESCRIPTION
## Summary

- remove the `toast` option from `accept`, so every unaccepted HTTP status now produces the standard error toast and throws `ApiError`
- migrate all 15 `{ toast: false }` call sites to express expected errors through typed accepted-status unions
- preserve inline and aggregate error flows for workflow readiness, device authentication, connector external-code auth, and Google Drive sync while allowing unexpected errors to surface consistently
- remove obsolete status branches from image-edit snapshot persistence and prevent caller-owned fallback toasts from duplicating `accept` errors

## User-visible impact

Expected HTTP errors remain part of their designed inline or aggregate UI flows. Unexpected errors in background and best-effort requests are no longer silent and now use the same toast behavior as the rest of the platform.

## Verification

- Prettier 3.8.1 on all changed files
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/eslint-rules lint`
- `pnpm --filter @vm0/eslint-rules check-types`
- `pnpm knip --workspace @vm0/app --workspace @vm0/eslint-rules`
- 43 targeted Vitest cases across accept lint rules, activity downloads, workflow readiness, device auth, external-code auth, HTML/image editing, and Google Drive sync
