### PR TITLE
refactor(platform): load html editor document reactively

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -11,7 +11,8 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept, ApiError } from "../../lib/accept.ts";
 import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import { onRef, resetSignal, settle, tapError, withCleanup } from "../utils.ts";
+import { pageSignal$ } from "../page-signal.ts";
+import { onRef, resetSignal, tapError, withCleanup } from "../utils.ts";
 import {
   createHtmlDomEditPayload,
   HTML_DOM_EDIT_HOVER_ATTR,
@@ -30,16 +31,14 @@ import {
   publicAttachmentUrl,
   readableAttachmentResourceUrl,
 } from "../../views/zero-page/zero-attachment-url.ts";
+import {
+  artifactHtmlEditMode$,
+  currentArtifactRef$,
+} from "./zero-artifact-sidebar.ts";
 
-export type EditorLoadState =
-  | { readonly status: "loading" }
-  | {
-      readonly html: string;
-      readonly nodeIds: readonly string[];
-      readonly sourceUrl: string;
-      readonly status: "ready";
-    }
-  | { readonly message: string; readonly status: "error" };
+export interface HtmlDomEditDocument {
+  readonly html: string;
+}
 
 interface CommentPopoverAnchor {
   readonly left: number;
@@ -104,7 +103,6 @@ export interface HtmlDomCommentEditorModel {
   readonly imageLinkOpen: boolean;
   readonly imageLinkValue: string;
   readonly imagePendingAction: HtmlDomImagePendingAction | null;
-  readonly loadState: EditorLoadState;
   readonly pendingFrameKey: number | null;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
@@ -205,7 +203,6 @@ const SUPPORTED_IMAGE_UPLOAD_CONTENT_TYPES = [
   "image/png",
   "image/webp",
 ] as const;
-const internalLoadState$ = state<EditorLoadState>({ status: "loading" });
 const internalActiveFrameKey$ = state(0);
 const internalPendingFrameKey$ = state<number | null>(null);
 const internalStageElement$ = state<HTMLDivElement | null>(null);
@@ -398,7 +395,7 @@ function htmlDomEditErrorMessage(error: unknown, fallback: string): string {
 
 async function fetchHtmlDomEditDocument(
   params: LoadHtmlDocumentParams,
-): Promise<EditorLoadState> {
+): Promise<HtmlDomEditDocument> {
   const response = await fetch(
     readableAttachmentResourceUrl(params.sourceUrl),
     {
@@ -418,24 +415,22 @@ async function fetchHtmlDomEditDocument(
   });
   return {
     html: instrumented.html,
-    nodeIds: instrumented.nodeIds,
-    sourceUrl: params.sourceUrl,
-    status: "ready",
   };
 }
 
-async function loadHtmlDomEditDocument(
-  params: LoadHtmlDocumentParams,
-): Promise<EditorLoadState> {
-  const loaded = await settle(fetchHtmlDomEditDocument(params), params.signal);
-  if (loaded.ok) {
-    return loaded.value;
+export const currentHtmlDomEditDocument$ = computed(async (get) => {
+  if (!get(artifactHtmlEditMode$)) {
+    throw new Error("HTML editor is unavailable");
   }
-  return {
-    message: htmlDomEditErrorMessage(loaded.error, "Failed to load HTML"),
-    status: "error",
-  };
-}
+  const artifact = get(currentArtifactRef$);
+  if (!artifact || artifact.kind !== "html") {
+    throw new Error("HTML editor URL is unavailable");
+  }
+  return await fetchHtmlDomEditDocument({
+    signal: get(pageSignal$),
+    sourceUrl: publicAttachmentUrl(artifact.url),
+  });
+});
 
 function nodeSelector(nodeId: string): string {
   return `[${HTML_DOM_NODE_ID_ATTR}="${nodeId}"]`;
@@ -1283,14 +1278,9 @@ function canDiscardHtmlDomEditorDraft(params: {
   readonly hasPendingImageEdits: boolean;
   readonly hasPendingStyleEdits: boolean;
   readonly imageBusy: boolean;
-  readonly loadState: EditorLoadState;
   readonly submitting: boolean;
 }): boolean {
-  if (
-    params.loadState.status !== "ready" ||
-    params.submitting ||
-    params.imageBusy
-  ) {
+  if (params.submitting || params.imageBusy) {
     return false;
   }
   return (
@@ -2176,7 +2166,6 @@ const cleanupCurrentFrameBinding$ = command(({ get, set }) => {
 const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(cleanupCurrentFrameBinding$);
   set(resetHtmlDomImageEditSignal$);
-  set(internalLoadState$, { status: "loading" });
   set(internalActiveFrameKey$, 0);
   set(internalPendingFrameKey$, null);
   set(internalStageElement$, null);
@@ -2202,12 +2191,7 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
 });
 
 export const setHtmlDomCommentStageRef$ = onRef(
-  command(async ({ set }, el: HTMLDivElement, signal: AbortSignal) => {
-    const url = el.dataset.htmlDomCommentUrl;
-    if (!url) {
-      return;
-    }
-
+  command(({ set }, el: HTMLDivElement, signal: AbortSignal) => {
     set(resetHtmlDomCommentEditor$);
     set(internalStageElement$, el);
     signal.addEventListener(
@@ -2218,14 +2202,6 @@ export const setHtmlDomCommentStageRef$ = onRef(
       },
       { once: true },
     );
-
-    const sourceUrl = publicAttachmentUrl(url);
-    const nextState = await loadHtmlDomEditDocument({
-      signal,
-      sourceUrl,
-    });
-    signal.throwIfAborted();
-    set(internalLoadState$, nextState);
   }),
 );
 
@@ -3171,9 +3147,6 @@ export const setHtmlDomImagePendingAction$ = command(
 );
 
 export const discardHtmlDomComments$ = command(({ get, set }) => {
-  const readyLoadState = get(internalLoadState$);
-  const doc = currentFrameDocument(get(internalIframeElement$));
-
   set(resetHtmlDomImageEditSignal$);
   set(internalComments$, []);
   set(internalCommentsOpen$, false);
@@ -3186,17 +3159,11 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   set(internalImageLinkOpen$, false);
   set(internalImageLinkValue$, "");
   set(internalImagePendingAction$, null);
-  if (readyLoadState.status === "ready") {
-    set(
-      internalPendingFrameKey$,
-      Math.max(
-        get(internalActiveFrameKey$),
-        get(internalPendingFrameKey$) ?? 0,
-      ) + 1,
-    );
-  } else {
-    syncFrameCommentMarkers(doc, []);
-  }
+  set(
+    internalPendingFrameKey$,
+    Math.max(get(internalActiveFrameKey$), get(internalPendingFrameKey$) ?? 0) +
+      1,
+  );
   set(resetHtmlDomCommentDraft$);
 });
 
@@ -3230,15 +3197,12 @@ export const sendHtmlDomEditRequest$ = command(
   async (
     { get, set },
     params: SendHtmlDomEditRequestParams,
-    _parentSignal: AbortSignal,
+    parentSignal: AbortSignal,
   ) => {
-    const readyLoadState = get(internalLoadState$);
+    const editDocument = await get(currentHtmlDomEditDocument$);
+    parentSignal.throwIfAborted();
     const comments = get(internalComments$);
-    if (
-      readyLoadState.status !== "ready" ||
-      comments.length === 0 ||
-      get(internalSubmitting$)
-    ) {
+    if (comments.length === 0 || get(internalSubmitting$)) {
       return;
     }
 
@@ -3248,7 +3212,7 @@ export const sendHtmlDomEditRequest$ = command(
 
     const submit = async () => {
       const html = htmlWithEditOverlaysRemoved({
-        fallbackHtml: readyLoadState.html,
+        fallbackHtml: editDocument.html,
         frameDocument: currentFrameDocument(get(internalIframeElement$)),
       });
       params.onStarted?.();
@@ -3328,14 +3292,14 @@ export const applyHtmlDomStyleEdits$ = command(
   async (
     { get, set },
     params: ApplyHtmlDomStyleEditsParams,
-    _parentSignal: AbortSignal,
+    parentSignal: AbortSignal,
   ) => {
-    const readyLoadState = get(internalLoadState$);
+    const editDocument = await get(currentHtmlDomEditDocument$);
+    parentSignal.throwIfAborted();
     const hasPendingDomEdits =
       hasStyleEdits(get(internalStyleEditsByNodeId$)) ||
       hasImageEdits(get(internalImageEditsByNodeId$));
     if (
-      readyLoadState.status !== "ready" ||
       get(internalComments$).length > 0 ||
       !hasPendingDomEdits ||
       get(internalSubmitting$)
@@ -3349,7 +3313,7 @@ export const applyHtmlDomStyleEdits$ = command(
 
     const apply = async () => {
       const html = htmlWithEditOverlaysRemoved({
-        fallbackHtml: readyLoadState.html,
+        fallbackHtml: editDocument.html,
         frameDocument: currentFrameDocument(get(internalIframeElement$)),
       });
       params.onStarted?.();
@@ -3386,7 +3350,6 @@ export const htmlDomCommentEditorModel$ = computed(
     const commentText = get(internalCommentText$);
     const editingCommentId = get(internalEditingCommentId$);
     const selectedNodeIds = get(internalSelectedNodeIds$);
-    const loadState = get(internalLoadState$);
     const submitting = get(internalSubmitting$);
     const styleEditsByNodeId = get(internalStyleEditsByNodeId$);
     const imageEditsByNodeId = get(internalImageEditsByNodeId$);
@@ -3407,7 +3370,6 @@ export const htmlDomCommentEditorModel$ = computed(
       activeColorPanelProperty: get(internalActiveColorPanelProperty$),
       activeFrameKey: get(internalActiveFrameKey$),
       canApplyStyleEdits:
-        loadState.status === "ready" &&
         comments.length === 0 &&
         (hasPendingStyleEdits || hasPendingImageEdits) &&
         !submitting &&
@@ -3425,15 +3387,10 @@ export const htmlDomCommentEditorModel$ = computed(
         hasPendingImageEdits,
         hasPendingStyleEdits,
         imageBusy,
-        loadState,
         submitting,
       }),
       canEditSelectedStyle: editableStyleProperties.length > 0,
-      canSend:
-        loadState.status === "ready" &&
-        comments.length > 0 &&
-        !submitting &&
-        !imageBusy,
+      canSend: comments.length > 0 && !submitting && !imageBusy,
       colorPopoverOffset: get(internalColorPopoverOffset$),
       commentsOpen: get(internalCommentsOpen$),
       commentText,
@@ -3446,7 +3403,6 @@ export const htmlDomCommentEditorModel$ = computed(
       imageLinkOpen: get(internalImageLinkOpen$),
       imageLinkValue: get(internalImageLinkValue$),
       imagePendingAction: get(internalImagePendingAction$),
-      loadState,
       pendingFrameKey: get(internalPendingFrameKey$),
       popoverTextAreaKey: [
         selectedNodeIds.join(":"),

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -418,17 +418,25 @@ async function fetchHtmlDomEditDocument(
   };
 }
 
-export const currentHtmlDomEditDocument$ = computed(async (get) => {
+const currentHtmlDomEditSourceUrl$ = computed((get) => {
   if (!get(artifactHtmlEditMode$)) {
-    throw new Error("HTML editor is unavailable");
+    return null;
   }
   const artifact = get(currentArtifactRef$);
-  if (!artifact || artifact.kind !== "html") {
+  if (!artifact || artifact.source !== "url" || artifact.kind !== "html") {
+    return null;
+  }
+  return publicAttachmentUrl(artifact.url);
+});
+
+export const currentHtmlDomEditDocument$ = computed(async (get) => {
+  const sourceUrl = get(currentHtmlDomEditSourceUrl$);
+  if (!sourceUrl) {
     throw new Error("HTML editor URL is unavailable");
   }
   return await fetchHtmlDomEditDocument({
     signal: get(pageSignal$),
-    sourceUrl: publicAttachmentUrl(artifact.url),
+    sourceUrl,
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -17,7 +17,7 @@ import {
   IconTrash,
   IconUpload,
 } from "@tabler/icons-react";
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import {
   createDeferredPromise,
   detach,
@@ -36,6 +36,7 @@ import {
   deleteHtmlDomComment$,
   discardHtmlDomComments$,
   focusHtmlDomComment$,
+  currentHtmlDomEditDocument$,
   htmlDomCommentEditorModel$,
   sendHtmlDomEditRequest$,
   setHtmlDomColorPopoverOffset$,
@@ -53,6 +54,7 @@ import {
   type HtmlDomImageLayout,
   type HtmlDomStyleProperty,
   type HtmlDomCommentEditorModel,
+  type HtmlDomEditDocument,
   type HtmlDomSelectedImage,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
 import type {
@@ -71,7 +73,6 @@ interface HtmlDomCommentEditorProps {
   readonly onSubmitEditRequest?: (payload: HtmlDomEditPayload) => Promise<void>;
   readonly pageSignal: AbortSignal;
   readonly status?: "working";
-  readonly url: string;
 }
 
 function waitForIframePaint(
@@ -127,6 +128,7 @@ function waitForIframePaint(
 }
 
 function HtmlDomCommentStage({
+  editDocument,
   filename,
   model,
   onApplyEditDraft,
@@ -136,8 +138,8 @@ function HtmlDomCommentStage({
   onSubmitEditRequest,
   pageSignal,
   status,
-  url,
 }: {
+  readonly editDocument: HtmlDomEditDocument;
   readonly filename: string;
   readonly model: HtmlDomCommentEditorModel;
   readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => void | Promise<void>;
@@ -147,77 +149,60 @@ function HtmlDomCommentStage({
   readonly onSubmitEditRequest?: (payload: HtmlDomEditPayload) => Promise<void>;
   readonly pageSignal: AbortSignal;
   readonly status?: "working";
-  readonly url: string;
 }) {
   const bindFrame = useSet(bindHtmlDomCommentFrame$);
   const activatePendingFrame = useSet(activatePendingHtmlDomCommentFrame$);
   const setIframeRef = useSet(setHtmlDomCommentIframeRef$);
   const setStageRef = useSet(setHtmlDomCommentStageRef$);
-  const loadState = model.loadState;
   const working = status === "working" || model.submitting;
   const frameKeys =
-    loadState.status === "ready"
-      ? model.pendingFrameKey === null
-        ? [model.activeFrameKey]
-        : [model.activeFrameKey, model.pendingFrameKey]
-      : [];
+    model.pendingFrameKey === null
+      ? [model.activeFrameKey]
+      : [model.activeFrameKey, model.pendingFrameKey];
 
   return (
     <div
       ref={setStageRef}
       className="relative min-h-[260px] flex-1 overflow-hidden bg-muted/20"
-      data-html-dom-comment-url={url}
     >
-      {loadState.status === "loading" && (
-        <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-          <IconLoader2 size={16} className="animate-spin" />
-          Loading page
-        </div>
-      )}
-      {loadState.status === "error" && (
-        <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
-          {loadState.message}
-        </div>
-      )}
-      {loadState.status === "ready" &&
-        frameKeys.map((frameKey) => {
-          const active = frameKey === model.activeFrameKey;
-          return (
-            <iframe
-              key={frameKey}
-              ref={active ? setIframeRef : undefined}
-              srcDoc={loadState.html}
-              title={`${filename} comment preview`}
-              sandbox="allow-same-origin allow-scripts"
-              className={
-                active
-                  ? "block h-full w-full border-0 bg-background"
-                  : "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0"
+      {frameKeys.map((frameKey) => {
+        const active = frameKey === model.activeFrameKey;
+        return (
+          <iframe
+            key={frameKey}
+            ref={active ? setIframeRef : undefined}
+            srcDoc={editDocument.html}
+            title={`${filename} comment preview`}
+            sandbox="allow-same-origin allow-scripts"
+            className={
+              active
+                ? "block h-full w-full border-0 bg-background"
+                : "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0"
+            }
+            aria-hidden={active ? undefined : true}
+            data-testid={
+              active
+                ? "html-dom-comment-frame"
+                : "html-dom-comment-frame-pending"
+            }
+            onLoad={(event) => {
+              const iframe = event.currentTarget;
+              if (active) {
+                bindFrame(iframe);
+                return;
               }
-              aria-hidden={active ? undefined : true}
-              data-testid={
-                active
-                  ? "html-dom-comment-frame"
-                  : "html-dom-comment-frame-pending"
-              }
-              onLoad={(event) => {
-                const iframe = event.currentTarget;
-                if (active) {
-                  bindFrame(iframe);
-                  return;
-                }
-                detach(
-                  (async () => {
-                    await waitForIframePaint(iframe, pageSignal);
-                    activatePendingFrame({ frameKey, iframe });
-                  })(),
-                  Reason.DomCallback,
-                  "activatePendingHtmlDomCommentFrame",
-                );
-              }}
-            />
-          );
-        })}
+              detach(
+                (async () => {
+                  await waitForIframePaint(iframe, pageSignal);
+                  activatePendingFrame({ frameKey, iframe });
+                })(),
+                Reason.DomCallback,
+                "activatePendingHtmlDomCommentFrame",
+              );
+            }}
+          />
+        );
+      })}
       {!working && (
         <HtmlDomCommentPopover model={model} pageSignal={pageSignal} />
       )}
@@ -1440,8 +1425,8 @@ export function HtmlDomCommentEditor({
   onSubmitEditRequest,
   pageSignal,
   status,
-  url,
 }: HtmlDomCommentEditorProps) {
+  const editDocument = useLoadable(currentHtmlDomEditDocument$);
   const model = useGet(htmlDomCommentEditorModel$);
 
   return (
@@ -1449,18 +1434,33 @@ export function HtmlDomCommentEditor({
       className="flex h-full min-h-0 flex-col bg-background"
       data-testid="html-dom-comment-editor"
     >
-      <HtmlDomCommentStage
-        filename={filename}
-        model={model}
-        onApplyEditDraft={onApplyEditDraft}
-        onEditRequestFailed={onEditRequestFailed}
-        onEditRequestStarted={onEditRequestStarted}
-        onSubmitEditRequest={onSubmitEditRequest}
-        pageSignal={pageSignal}
-        status={status}
-        url={url}
-        onApplyStyleEdits={onApplyStyleEdits}
-      />
+      {editDocument.state === "loading" && (
+        <div className="relative flex min-h-[260px] flex-1 items-center justify-center gap-2 overflow-hidden bg-muted/20 text-sm text-muted-foreground">
+          <IconLoader2 size={16} className="animate-spin" />
+          Loading page
+        </div>
+      )}
+      {editDocument.state === "hasError" && (
+        <div className="relative flex min-h-[260px] flex-1 items-center justify-center overflow-hidden bg-muted/20 px-6 text-center text-sm text-muted-foreground">
+          {editDocument.error instanceof Error
+            ? editDocument.error.message
+            : "Failed to load HTML"}
+        </div>
+      )}
+      {editDocument.state === "hasData" && (
+        <HtmlDomCommentStage
+          editDocument={editDocument.data}
+          filename={filename}
+          model={model}
+          onApplyEditDraft={onApplyEditDraft}
+          onEditRequestFailed={onEditRequestFailed}
+          onEditRequestStarted={onEditRequestStarted}
+          onSubmitEditRequest={onSubmitEditRequest}
+          pageSignal={pageSignal}
+          status={status}
+          onApplyStyleEdits={onApplyStyleEdits}
+        />
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1665,7 +1665,6 @@ function ArtifactBody({
           onEditRequestStarted={onHtmlEditRequestStarted}
           pageSignal={pageSignal}
           status={htmlEditStatus}
-          url={url}
         />
       );
     }


### PR DESCRIPTION
## Summary

- load the hosted-site HTML editor document through a route-owned async computed resource
- render loading and error states with `useLoadable` instead of copying request state into mutable editor state
- keep stage and iframe refs limited to mounted DOM lifecycle work
- stabilize the resource on the active editor URL so fullscreen and other sidebar state changes preserve the current iframe
- reuse the resolved document resource when submitting comments or applying style edits

## User impact

Hosted-site editing keeps the same loading, error, comment, discard, apply, and fullscreen behavior while document fetching is no longer triggered by a callback ref. Direct links and restored edit-mode routes load from the same route state as the rendered editor.

## Verification

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx --reporter=verbose` (51 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "keeps direct hosted-site edit controls consistent while exiting and toggling fullscreen" --reporter=verbose` (1 passed)
- GitHub CI: 54 checks passed, 21 intentionally skipped