### PR TITLE
docs(rust): document write_files entry-count limits

### DIFF
--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -116,8 +116,12 @@ pub fn encode_private_write_file_frame_into(
 /// Encode write_files payload:
 /// `[2B file_count]` followed by `[2B path_len][path][4B content_len][content]` for each file.
 ///
-/// Returns `Err` if the batch is empty, any path exceeds 65535 bytes, or the
-/// payload cannot fit in one protocol frame.
+/// # Errors
+///
+/// Returns [`ProtocolError`] if the batch is empty, contains more than 65,535
+/// entries because `file_count` is encoded as `u16`, any path exceeds the
+/// `u16` length-field limit, any content exceeds the `u32` length-field limit,
+/// or the encoded payload cannot fit in one protocol frame.
 pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, ProtocolError> {
     let encoded = validate_write_files_payload(files)?;
 
@@ -128,6 +132,8 @@ pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, 
 }
 
 /// Validate a write_files payload without encoding it.
+///
+/// This applies the same input constraints documented by [`encode_write_files`].
 pub fn validate_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<(), ProtocolError> {
     validate_write_files_payload(files).map(|_| ())
 }
@@ -137,6 +143,8 @@ pub fn validate_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<(), Pro
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_WRITE_FILES, seq, &encode_write_files(...))` without allocating
 /// separate payload and frame vectors.
+///
+/// This applies the same input constraints documented by [`encode_write_files`].
 pub fn encode_write_files_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,


### PR DESCRIPTION
## Summary

- Document the independent 65,535-entry limit enforced by the `u16 file_count` field in `encode_write_files`.
- Define the shared batch validation contract in one `# Errors` section and link `validate_write_files` and `encode_write_files_frame_into` to it.
- Keep wire bytes, runtime validation, error ordering, public signatures, and tests unchanged.

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --no-deps`

Closes #22171
