### PR TITLE
docs(rust): run nbd-cow integration binary through sudo

### DIFF
--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -8,7 +8,9 @@
 //!
 //! ```sh
 //! sudo modprobe nbd nbds_max=4096
-//! cargo test -p nbd-cow --test integration -- --ignored --test-threads=1
+//! cargo test \
+//!   --config 'target."cfg(target_os = \"linux\")".runner = "sudo"' \
+//!   -p nbd-cow --test integration -- --ignored --test-threads=1
 //! ```
 
 use std::fs;


### PR DESCRIPTION
## Summary

- run the root-required `nbd-cow` integration test executable through a per-command Cargo `sudo` runner
- keep Cargo compilation unprivileged while preserving `--ignored --test-threads=1`
- let Cargo select the exact freshly built executable instead of relying on hashed artifact discovery

## Scope

- updates only the module-level local run instructions
- does not change integration-test behavior, NBD device handling, dependencies, or CI configuration

## Validation

- `cargo fmt -p nbd-cow -- --check`
- `cargo test --config 'target."cfg(target_os = \"linux\")".runner = "sudo"' -p nbd-cow --test integration --no-run`
- `cargo test --config 'target."cfg(target_os = \"linux\")".runner = "echo"' -p nbd-cow --test integration -- --ignored --test-threads=1 create_and_destroy`
- `cargo clippy -p nbd-cow --tests -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p nbd-cow --no-deps`

Privileged NBD execution remains covered by the existing metal `nbd-cow-test` PR job, which loads the module and runs the compiled test binary under `sudo`.

Closes #22172
