### PR TITLE
feat(chat): add feedback message cards

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -1,5 +1,6 @@
 import type { Command } from "ccstate";
 import type {
+  ChatMessageFeedbackPayload,
   ChatRunOptionsRequest,
   CodexServiceTier,
   GenerationTemplateRequest,
@@ -23,6 +24,7 @@ export interface ChatThreadRealtimeHandlers {
 export interface PatchDraftArgs {
   threadId: string;
   content: string | null;
+  feedbackPayload?: ChatMessageFeedbackPayload | null;
   attachments: PersistedAttachment[] | null;
 }
 
@@ -43,6 +45,8 @@ export interface AppendQueuedMessageArgs {
   threadId: string;
   agentId: string;
   content: string | null;
+  textContent?: string;
+  feedbackPayload?: ChatMessageFeedbackPayload;
   attachments: PersistedAttachment[] | null;
   clientMessageId: string;
   chatThreadSortEventId: string;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -82,10 +82,16 @@ const loadDraft$ = command(
     }
 
     const hasDraftContent = threadDraft.draftContent !== null;
+    const feedbackMessageCardsEnabled =
+      thread.workflowComposer.feedback.feedbackMessageCardsEnabled;
+    const draftFeedbackItems = feedbackMessageCardsEnabled
+      ? (threadDraft.draftFeedbackPayload?.items ?? [])
+      : [];
+    const hasDraftFeedback = draftFeedbackItems.length > 0;
     const draftAttachments = threadDraft.draftAttachments;
     const hasDraftAttachments =
       draftAttachments !== null && draftAttachments.length > 0;
-    if (isNew && (hasDraftContent || hasDraftAttachments)) {
+    if (isNew && (hasDraftContent || hasDraftFeedback || hasDraftAttachments)) {
       const restoredAttachments = createRestoredDraftAttachments(
         threadDraft.draftContent ?? "",
         draftAttachments ?? [],
@@ -94,6 +100,7 @@ const loadDraft$ = command(
         thread.draft.seed$,
         threadDraft.draftContent ?? "",
         restoredAttachments,
+        draftFeedbackItems,
       );
     }
   },
@@ -151,6 +158,8 @@ const setupPaneThread$ = command(
         inlineAttachmentReferences:
           features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ??
           false,
+        feedbackMessageCards:
+          features[FeatureSwitchKey.FeedbackMessageCards] ?? false,
       },
     );
     set(spec.setPaneThread$, thread);

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -1,5 +1,6 @@
 import type { Command, Computed } from "ccstate";
 import type {
+  ChatMessageFeedbackPayload,
   PagedChatMessage,
   ChatThreadArtifactRun,
   ChatThreadDraft,
@@ -30,6 +31,7 @@ export interface RecommendedFollowupSource {
 export interface QueuedChatMessageItem {
   readonly id: string;
   readonly text: string;
+  readonly quoteCount?: number;
 }
 
 export type ThinkingIndicatorMode =
@@ -53,6 +55,12 @@ export interface SendMessageOptions {
   readonly revokesMessageId?: string;
   readonly includeDraftAttachments?: boolean;
   readonly computerUseHostId?: string | null;
+  readonly feedbackMessage?: FeedbackMessageInput;
+}
+
+export interface FeedbackMessageInput {
+  readonly textContent: string;
+  readonly feedbackPayload: ChatMessageFeedbackPayload;
 }
 
 export interface ChatThreadSignals {
@@ -88,7 +96,12 @@ export interface ChatThreadSignals {
   composerSendButtonStatus$: Computed<Promise<ComposerSendButtonStatus>>;
   queueMessage$: Command<
     Promise<boolean>,
-    [string, string | null | undefined, AbortSignal]
+    [
+      string,
+      string | null | undefined,
+      FeedbackMessageInput | undefined,
+      AbortSignal,
+    ]
   >;
   recallMessage$: Command<Promise<void>, [string, AbortSignal]>;
   cancelRun$: Command<Promise<void>, [AbortSignal]>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -127,6 +127,7 @@ import { openCodexDeviceAuthDialogPersonal$ } from "../zero-page/settings/codex-
 import type {
   ChatThreadSignals,
   ComposerSendButtonStatus,
+  FeedbackMessageInput,
   MessageImageGroupProjection,
   QueuedChatMessageItem,
   RecommendedFollowupSource,
@@ -1002,6 +1003,7 @@ function createDraftSync(
   threadId: string,
   draft: DraftSignals,
   dataSource: ChatThreadRemote,
+  feedbackMessageCards: boolean,
 ) {
   const optimisticCreateUnsettled$ =
     optimisticChatThreadCreateUnsettled(threadId);
@@ -1022,6 +1024,19 @@ function createDraftSync(
 
       const input = get(draft.input$);
       const content = input.trim() || null;
+      const feedbackItems = feedbackMessageCards
+        ? get(draft.feedbackItems$)
+        : [];
+      const feedbackPayload = !feedbackMessageCards
+        ? undefined
+        : feedbackItems.length > 0
+          ? {
+              version: 1 as const,
+              items: feedbackItems.map((item) => {
+                return { ...item };
+              }),
+            }
+          : null;
       const attachments = get(draft.attachments$);
 
       const infos = await Promise.allSettled(
@@ -1048,6 +1063,7 @@ function createDraftSync(
         {
           threadId,
           content,
+          feedbackPayload,
           attachments: persisted.length > 0 ? persisted : null,
         },
         signal,
@@ -1076,7 +1092,12 @@ function createDraftSync(
       }
       await set(
         dataSource.patchDraft$,
-        { threadId, content: null, attachments: null },
+        {
+          threadId,
+          content: null,
+          feedbackPayload: null,
+          attachments: null,
+        },
         signal,
       );
     },
@@ -1900,6 +1921,7 @@ function latestRecommendedFollowupsFromGroups(
 function createMessageSemanticSignals(
   semanticMessages$: Computed<SemanticChatMessage[]>,
   messageRunIndicatorState$: Computed<Promise<RunIndicatorState>>,
+  feedbackMessageCards: boolean,
 ) {
   const semanticGroups$ = computed((get): SemanticChatGroups => {
     return groupSemanticChatMessages(get(semanticMessages$));
@@ -1930,7 +1952,15 @@ function createMessageSemanticSignals(
     (get): Promise<readonly QueuedChatMessageItem[]> => {
       return Promise.resolve(
         get(queuedMessages$).map((message) => {
-          return { id: message.id, text: (message.content ?? "").trim() };
+          const content = (message.content ?? "").trim();
+          if (!feedbackMessageCards || !message.feedbackPayload) {
+            return { id: message.id, text: content };
+          }
+          return {
+            id: message.id,
+            text: content || "Feedback",
+            quoteCount: message.feedbackPayload.items.length,
+          };
         }),
       );
     },
@@ -2332,6 +2362,7 @@ function createPagedMessages(
   threadId: string,
   dataSource: ChatThreadRemote,
   initialOptimisticEntries: readonly OptimisticChatMessageEntry[],
+  feedbackMessageCards: boolean,
 ) {
   const mailDraftCardSignals = createMailDraftCardSignalsRegistry();
   const artifactCardSignals = createArtifactCardSignalsRegistry();
@@ -2378,6 +2409,7 @@ function createPagedMessages(
   const semanticSignals = createMessageSemanticSignals(
     semanticMessages$,
     messageRunIndicatorState$,
+    feedbackMessageCards,
   );
 
   // The thread's active goal, folded from the (goal-marker) message stream so
@@ -2475,6 +2507,7 @@ function createChatThreadMessagePipeline({
   threadId,
   dataSource,
   initialOptimisticEntries,
+  feedbackMessageCards,
   recordScrollHeightForPrepend$,
   clearScrollHeightForPrepend$,
   awayFromBottom$,
@@ -2482,6 +2515,7 @@ function createChatThreadMessagePipeline({
   threadId: string;
   dataSource: ChatThreadRemote;
   initialOptimisticEntries: readonly OptimisticChatMessageEntry[];
+  feedbackMessageCards: boolean;
   recordScrollHeightForPrepend$: Command<
     PrependScrollCompensationToken | null,
     []
@@ -2496,6 +2530,7 @@ function createChatThreadMessagePipeline({
     threadId,
     dataSource,
     initialOptimisticEntries,
+    feedbackMessageCards,
   );
   const renderWindow = createChatRenderWindow({
     threadId,
@@ -3001,7 +3036,8 @@ function createSendOptimisticMessageEntry({
     message: {
       id: clientMessageId,
       role: "user",
-      content: result.prompt,
+      content: options?.feedbackMessage?.textContent ?? result.prompt,
+      feedbackPayload: options?.feedbackMessage?.feedbackPayload,
       attachFiles: result.attachments,
       generationTemplate,
       ...sendMessageRevocationPatch(options),
@@ -3037,6 +3073,8 @@ function sendMessageRequestBody(params: {
   return {
     agentId: params.agentId,
     prompt: params.result.prompt,
+    textContent: params.options?.feedbackMessage?.textContent,
+    feedbackPayload: params.options?.feedbackMessage?.feedbackPayload,
     threadId: params.threadId,
     hasTextContent: params.result.hasTextContent,
     clientMessageId: params.clientMessageId,
@@ -3348,6 +3386,29 @@ interface QueueMessageDeps {
   dataSource: ChatThreadRemote;
 }
 
+function createQueueOptimisticMessageEntry(params: {
+  readonly threadId: string;
+  readonly clientMessageId: string;
+  readonly createdAt: string;
+  readonly result: PreparedSendMessageResult;
+  readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly feedbackMessage: FeedbackMessageInput | undefined;
+}): OptimisticChatMessageInput {
+  return {
+    threadId: params.threadId,
+    optimisticUserMessageAssociation: "queue",
+    message: {
+      id: params.clientMessageId,
+      role: "user",
+      content: params.feedbackMessage?.textContent ?? params.result.prompt,
+      feedbackPayload: params.feedbackMessage?.feedbackPayload,
+      attachFiles: params.result.attachments,
+      generationTemplate: params.generationTemplate,
+      createdAt: params.createdAt,
+    },
+  };
+}
+
 function createQueueMessage(deps: QueueMessageDeps) {
   const {
     threadId,
@@ -3369,6 +3430,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
       { get, set },
       prompt: string,
       computerUseHostId: string | null | undefined,
+      feedbackMessage: FeedbackMessageInput | undefined,
       signal: AbortSignal,
     ): Promise<boolean> => {
       L.debug("queueMessage$ start", { threadId, promptLen: prompt.length });
@@ -3426,18 +3488,17 @@ function createQueueMessage(deps: QueueMessageDeps) {
         agentId: meta.agentId,
         createdAt: nowIso,
       });
-      set(appendOptimisticMessage$, {
-        threadId,
-        optimisticUserMessageAssociation: "queue",
-        message: {
-          id: clientMessageId,
-          role: "user",
-          content: result.prompt,
-          attachFiles: result.attachments,
-          generationTemplate,
+      set(
+        appendOptimisticMessage$,
+        createQueueOptimisticMessageEntry({
+          threadId,
+          clientMessageId,
           createdAt: nowIso,
-        },
-      });
+          result,
+          generationTemplate,
+          feedbackMessage,
+        }),
+      );
       animationFrame(
         () => {
           set(scrollToBottom$);
@@ -3445,13 +3506,11 @@ function createQueueMessage(deps: QueueMessageDeps) {
         { signal },
       );
 
-      const codexFastModeEnabled =
-        features[FeatureSwitchKey.CodexFastMode] ?? false;
       const realAgentInPreviewEnabled =
         features[FeatureSwitchKey.RealAgentInPreview] ?? false;
       const runOptions = runOptionsFromModelProviderSelection(
         modelSelection,
-        codexFastModeEnabled,
+        features[FeatureSwitchKey.CodexFastMode] ?? false,
       );
       const [, persistedMessage] = await Promise.all([
         set(flushDraftClear$, signal),
@@ -3461,6 +3520,8 @@ function createQueueMessage(deps: QueueMessageDeps) {
             threadId,
             agentId: meta.agentId,
             content: result.prompt,
+            textContent: feedbackMessage?.textContent,
+            feedbackPayload: feedbackMessage?.feedbackPayload,
             attachments: result.attachments ?? null,
             clientMessageId,
             chatThreadSortEventId,
@@ -3488,6 +3549,7 @@ interface RecallMessageDeps {
   threadMeta$: Computed<Promise<ThreadMeta | null>>;
   rawMessages$: Computed<ChatMessageProjectionEntry[]>;
   draft: DraftSignals;
+  feedbackMessageCards: boolean;
   writePersistentMessages$: Command<
     Promise<void>,
     [PagedChatMessage[], AbortSignal]
@@ -3502,6 +3564,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
     threadMeta$,
     rawMessages$,
     draft,
+    feedbackMessageCards,
     writePersistentMessages$,
     appendOptimisticMessage$,
     dataSource,
@@ -3541,6 +3604,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
         (message.attachFiles ?? []).map((attachment) => {
           return createRestoredAttachment(attachment);
         }),
+        feedbackMessageCards ? (message.feedbackPayload?.items ?? []) : [],
       );
 
       const persistedMessage = await set(
@@ -4112,6 +4176,7 @@ function publicChatThreadMessageSignals(
 interface ChatThreadComposerFeatureModes {
   inlinePromptItems?: boolean;
   inlineAttachmentReferences?: boolean;
+  feedbackMessageCards?: boolean;
 }
 
 function createThreadComposer(
@@ -4120,13 +4185,17 @@ function createThreadComposer(
   featureModes: ChatThreadComposerFeatureModes,
   agentId$: Computed<Promise<string | null>>,
 ) {
-  const { inlinePromptItems = false, inlineAttachmentReferences = false } =
-    featureModes;
+  const {
+    inlinePromptItems = false,
+    inlineAttachmentReferences = false,
+    feedbackMessageCards = false,
+  } = featureModes;
   const workflowComposer = createWorkflowComposerSignals(
     draft,
     threadId,
     inlinePromptItems,
     inlineAttachmentReferences,
+    feedbackMessageCards,
   );
   return {
     workflowComposer,
@@ -4142,6 +4211,8 @@ export function createChatThreadSignals(
   initialOptimisticEntries: readonly OptimisticChatMessageEntry[] = [],
   composerFeatureModes: ChatThreadComposerFeatureModes = {},
 ): ChatThreadSignals {
+  const feedbackMessageCards =
+    composerFeatureModes.feedbackMessageCards ?? false;
   const { remoteThreadDetail$, threadDraft$, reloadThread$ } =
     createRemoteThreadDetail(dataSource);
   const threadMeta$ = createThreadMeta(threadId);
@@ -4176,12 +4247,13 @@ export function createChatThreadSignals(
     threadId,
     dataSource,
     initialOptimisticEntries,
+    feedbackMessageCards,
     recordScrollHeightForPrepend$,
     clearScrollHeightForPrepend$,
     awayFromBottom$,
   });
   const { queueDraftSync$, cancelDraftSync$, flushDraftClear$ } =
-    createDraftSync(threadId, draft, dataSource);
+    createDraftSync(threadId, draft, dataSource, feedbackMessageCards);
   const composerSendButton = createComposerSendButtonSignals(messages);
   const artifact = createArtifacts(threadId);
   const runTracking = createRunTracking({
@@ -4205,6 +4277,7 @@ export function createChatThreadSignals(
     modelSelectionForSend$,
     rawMessages$: messages.rawMessages$,
     draft,
+    feedbackMessageCards,
     cancelDraftSync$,
     flushDraftClear$,
     scrollToBottom$: scrollSignals.scrollToBottom$,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -67,14 +67,20 @@ type ChatRealtimeSubscription =
 const patchDraft$ = command(
   async (
     { get, set },
-    { threadId, content, attachments }: PatchDraftArgs,
+    { threadId, content, feedbackPayload, attachments }: PatchDraftArgs,
     signal: AbortSignal,
   ) => {
     const client = get(zeroClient$)(chatThreadByIdContract);
     await accept(
       client.patch({
         params: { id: threadId },
-        body: { draftContent: content, draftAttachments: attachments },
+        body: {
+          draftContent: content,
+          ...(feedbackPayload === undefined
+            ? {}
+            : { draftFeedbackPayload: feedbackPayload }),
+          draftAttachments: attachments,
+        },
         fetchOptions: { signal },
       }),
       [200, 204],
@@ -146,6 +152,8 @@ const appendQueuedMessage$ = command(
       threadId,
       agentId,
       content,
+      textContent,
+      feedbackPayload,
       attachments,
       clientMessageId,
       chatThreadSortEventId,
@@ -163,6 +171,8 @@ const appendQueuedMessage$ = command(
         body: {
           agentId,
           prompt: content ?? "",
+          textContent,
+          feedbackPayload,
           threadId,
           hasTextContent,
           clientMessageId,
@@ -181,7 +191,8 @@ const appendQueuedMessage$ = command(
     return {
       id: clientMessageId,
       role: "user" as const,
-      content,
+      content: feedbackPayload ? (textContent ?? "") : content,
+      feedbackPayload,
       attachFiles: attachments ?? undefined,
       generationTemplate,
       createdAt: result.body.createdAt ?? nowDate().toISOString(),

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -76,6 +76,10 @@ export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   );
 });
 
+export const feedbackMessageCardsEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.FeedbackMessageCards] ?? false;
+});
+
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const identity = await get(authenticatedIdentity$);

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -42,6 +42,8 @@ const internalStream$ = state<MediaStream | null>(null);
 const internalRecorder$ = state<MediaRecorder | null>(null);
 const internalRecordingSession$ = state<VoiceRecordingSession | null>(null);
 const internalAudioActivityMonitor$ = state<AudioActivityMonitor | null>(null);
+export type VoiceInputOwner = "composer" | "feedback";
+const internalVoiceInputOwner$ = state<VoiceInputOwner | null>(null);
 const audioInputQuotaReload$ = state(0);
 
 // ---------------------------------------------------------------------------
@@ -66,6 +68,10 @@ export const sttSpeechDetected$ = computed((get) => {
 
 export const sttVoiceLevel$ = computed((get) => {
   return get(internalVoiceLevel$);
+});
+
+export const sttVoiceInputOwner$ = computed((get) => {
+  return get(internalVoiceInputOwner$);
 });
 
 export const audioInputAvailable$ = computed(() => {
@@ -423,6 +429,7 @@ const resetState$ = command(({ set }) => {
   set(internalRecordingSession$, null);
   set(internalAudioActivityMonitor$, null);
   set(internalStream$, null);
+  set(internalVoiceInputOwner$, null);
 });
 
 const prepareRecordingStart$ = command(({ set }) => {
@@ -883,6 +890,7 @@ function createVoiceSegmentSession(
 export const startRecording$ = command(
   async (
     { get, set },
+    owner: VoiceInputOwner,
     onSegmentTranscribed: VoiceSegmentTranscribedCallback,
     autoSegment: boolean,
     parentSignal: AbortSignal,
@@ -903,6 +911,7 @@ export const startRecording$ = command(
       },
       { once: true },
     );
+    set(internalVoiceInputOwner$, owner);
     set(prepareRecordingStart$);
 
     await waitForBrowserPaint(signal);
@@ -914,10 +923,12 @@ export const startRecording$ = command(
     });
     if (stream === undefined) {
       set(internalStarting$, false);
+      set(internalVoiceInputOwner$, null);
       return;
     }
     if (!stream) {
       set(internalStarting$, false);
+      set(internalVoiceInputOwner$, null);
       return;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -11,6 +11,7 @@ import { currentChatThreadId$ } from "../agent-chat.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import type {
+  ChatMessageFeedbackPayload,
   GenerationTemplateRequest,
   PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -215,6 +216,8 @@ function createChatAttachment(file: File): ZeroChatAttachment {
 // DraftSignals — encapsulates per-thread composer state
 // ---------------------------------------------------------------------------
 
+export type DraftFeedbackItem = ChatMessageFeedbackPayload["items"][number];
+
 export interface DraftSignals {
   input$: Computed<string>;
   hasInput$: Computed<boolean>;
@@ -238,12 +241,21 @@ export interface DraftSignals {
   restoreAttachments$: Command<ZeroChatAttachment[], [PersistedAttachment[]]>;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
   removeAttachmentByClientId$: Command<void, [string]>;
+  feedbackItems$: Computed<readonly DraftFeedbackItem[]>;
+  setFeedbackItems$: Command<void, [readonly DraftFeedbackItem[]]>;
   dragOver$: Computed<boolean>;
   setDragOver$: Command<void, [boolean]>;
-  /** Reset all draft state (input, template, attachments). Called after send. */
+  /** Reset all draft state (input, template, attachments, feedback). Called after send. */
   clear$: Command<void, []>;
   /** Seed draft from persisted server data. Only called when local cache was empty. */
-  seed$: Command<void, [content: string, attachments: ZeroChatAttachment[]]>;
+  seed$: Command<
+    void,
+    [
+      content: string,
+      attachments: ZeroChatAttachment[],
+      feedbackItems?: readonly DraftFeedbackItem[],
+    ]
+  >;
 }
 
 export interface DraftInputSyncTarget {
@@ -466,6 +478,7 @@ export function createDraftSignals(): DraftSignals {
     GenerationTemplateRequest | undefined
   >(undefined);
   const internalAttachments$ = state<ZeroChatAttachment[]>([]);
+  const internalFeedbackItems$ = state<readonly DraftFeedbackItem[]>([]);
   const internalDragOver$ = state(false);
   const draftAttachments = createDraftAttachmentSignals(internalAttachments$);
 
@@ -475,6 +488,15 @@ export function createDraftSignals(): DraftSignals {
   const setGenerationTemplate$ = command(
     ({ set }, value: GenerationTemplateRequest | undefined) => {
       set(internalGenerationTemplate$, value);
+    },
+  );
+
+  const feedbackItems$ = computed((get) => {
+    return get(internalFeedbackItems$);
+  });
+  const setFeedbackItems$ = command(
+    ({ set }, items: readonly DraftFeedbackItem[]) => {
+      set(internalFeedbackItems$, items);
     },
   );
 
@@ -496,13 +518,20 @@ export function createDraftSignals(): DraftSignals {
     if (attachments.length > 0) {
       set(internalAttachments$, []);
     }
+    set(internalFeedbackItems$, []);
     set(internalDragOver$, false);
   });
 
   const seed$ = command(
-    ({ set }, content: string, attachments: ZeroChatAttachment[]) => {
+    (
+      { set },
+      content: string,
+      attachments: ZeroChatAttachment[],
+      feedbackItems: readonly DraftFeedbackItem[] = [],
+    ) => {
       set(draftInput.setInput$, content);
       set(internalAttachments$, attachments);
+      set(internalFeedbackItems$, feedbackItems);
     },
   );
 
@@ -511,6 +540,8 @@ export function createDraftSignals(): DraftSignals {
     generationTemplate$,
     setGenerationTemplate$,
     ...draftAttachments,
+    feedbackItems$,
+    setFeedbackItems$,
     dragOver$,
     setDragOver$,
     clear$,

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -21,6 +21,9 @@ const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
 // read it off the selection so a feedback draft stays bound to its own thread.
 const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
 const CHAT_COMPOSER_SELECTOR = "[data-chat-composer]";
+// The Codex-style inline feedback input; interacting with it must not dismiss
+// the quoted passage it is anchored to.
+const FEEDBACK_INPUT_SELECTOR = "[data-feedback-input]";
 
 export interface FeedbackSelectionRect {
   readonly top: number;
@@ -54,12 +57,32 @@ export interface FeedbackEditorAdapter {
   removeItem(id: number): void;
 }
 
+export interface FeedbackDraftSignals {
+  readonly items$: Computed<readonly FeedbackItem[]>;
+  readonly setItems$: Command<void, [readonly FeedbackItem[]]>;
+}
+
 export interface FeedbackSignals {
   readonly items$: Computed<readonly FeedbackItem[]>;
   readonly active$: Computed<boolean>;
+  readonly feedbackMessageCardsEnabled: boolean;
   readonly selection$: Computed<FeedbackSelection | null>;
   readonly startFeedback$: Command<void, []>;
+  // Insert a feedback item whose note is already written — used by the
+  // Codex-style inline input that collects the comment beside the selection
+  // before the item lands in the composer.
+  readonly startFeedbackWithNote$: Command<void, [string]>;
+  // Draft state for that inline input: whether it is open for the current
+  // selection and the note being typed.
+  readonly draftOpen$: Computed<boolean>;
+  readonly draftNote$: Computed<string>;
+  readonly openFeedbackDraft$: Command<void, []>;
+  readonly setFeedbackDraftNote$: Command<void, [string]>;
+  readonly submitFeedbackDraft$: Command<void, []>;
+  readonly cancelFeedbackDraft$: Command<void, []>;
+  readonly dismissFeedbackDraft$: Command<void, []>;
   readonly replaceFromEditor$: Command<void, [readonly FeedbackItem[]]>;
+  readonly updateFeedbackNote$: Command<void, [id: number, note: string]>;
   readonly removeFeedback$: Command<void, [number]>;
   readonly closeSelectionToolbar$: Command<void, []>;
   readonly copySelection$: Command<Promise<void>, [AbortSignal]>;
@@ -276,10 +299,22 @@ function shouldIgnoreTextShortcut(event: KeyboardEvent): boolean {
   return isEditableTarget(event.target);
 }
 
+function isFeedbackInputTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest(FEEDBACK_INPUT_SELECTOR) !== null
+  );
+}
+
 function shouldDismissSelectionForInteractionTarget(
   target: EventTarget | null,
 ): boolean {
   if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  // Typing the comment in the inline feedback input must keep the passage
+  // selected, otherwise the input would dismiss its own anchor.
+  if (isFeedbackInputTarget(target)) {
     return false;
   }
   return (
@@ -290,17 +325,52 @@ function shouldDismissSelectionForInteractionTarget(
 function createFeedbackSelectionState(threadId: string) {
   const selectionState$ = state<FeedbackSelection | null>(null);
   const resetSelectionToolbarSignal$ = resetSignal();
+  // Inline-input draft: open while the user is typing a comment beside the
+  // selected passage, cleared whenever the toolbar is dismissed.
+  const draftOpenState$ = state(false);
+  const draftNoteState$ = state("");
+  const draftOpen$ = computed((get) => {
+    return get(draftOpenState$);
+  });
+  const draftNote$ = computed((get) => {
+    return get(draftNoteState$);
+  });
+  const resetDraft$ = command(({ set }) => {
+    set(draftOpenState$, false);
+    set(draftNoteState$, "");
+  });
+  const openFeedbackDraft$ = command(({ set }) => {
+    set(draftNoteState$, "");
+    set(draftOpenState$, true);
+  });
+  const setFeedbackDraftNote$ = command(({ set }, note: string) => {
+    set(draftNoteState$, note);
+  });
   const selection$ = computed((get) => {
     return get(selectionState$);
   });
-  const closeSelectionToolbar$ = command(({ set }) => {
+  const hideSelectionToolbar$ = command(({ set }) => {
     set(resetSelectionToolbarSignal$);
     set(selectionState$, null);
+    set(resetDraft$);
   });
-  const captureSelection$ = command(({ set }) => {
+  const closeSelectionToolbar$ = command(({ get, set }) => {
+    if (get(selectionState$) === null || get(draftOpenState$)) {
+      return;
+    }
+    set(hideSelectionToolbar$);
+  });
+  const captureSelection$ = command(({ get, set }) => {
     const selection = readFeedbackSelection();
     if (!selection || selection.threadId !== threadId) {
-      set(closeSelectionToolbar$);
+      // While the inline input is open the native selection legitimately moves
+      // into the textarea, so keep the anchored passage instead of dismissing.
+      if (get(draftOpenState$)) {
+        return;
+      }
+      if (get(selectionState$) !== null) {
+        set(hideSelectionToolbar$);
+      }
       return;
     }
     set(selectionState$, selection);
@@ -323,36 +393,62 @@ function createFeedbackSelectionState(threadId: string) {
       toast.success("Copied");
     }
   });
+  const cancelFeedbackDraft$ = command(({ set }) => {
+    set(resetDraft$);
+  });
+  const dismissFeedbackDraft$ = command(({ set }) => {
+    set(hideSelectionToolbar$);
+    window.getSelection()?.removeAllRanges();
+  });
   return {
     selectionState$,
     resetSelectionToolbarSignal$,
     selection$,
+    hideSelectionToolbar$,
     closeSelectionToolbar$,
     captureSelection$,
     dismissSelectionOnScroll$,
     copySelection$,
+    draftOpen$,
+    draftNote$,
+    openFeedbackDraft$,
+    setFeedbackDraftNote$,
+    cancelFeedbackDraft$,
+    dismissFeedbackDraft$,
   };
 }
 
 function createFeedbackItemSignals({
   threadId,
   editor,
+  syncEditor,
+  draft,
   selectionState$,
-  closeSelectionToolbar$,
+  hideSelectionToolbar$,
 }: {
   threadId: string;
   editor: FeedbackEditorAdapter;
+  syncEditor: boolean;
+  draft: FeedbackDraftSignals | undefined;
   selectionState$: State<FeedbackSelection | null>;
-  closeSelectionToolbar$: Command<void, []>;
+  hideSelectionToolbar$: Command<void, []>;
 }) {
   const itemsState$ = state<readonly FeedbackItem[]>([]);
   const rangesState$ = state<ReadonlyMap<number, Range>>(new Map());
   const nextIdState$ = state(1);
-  const items$ = computed((get) => {
+  const localItems$ = computed((get) => {
     return get(itemsState$);
   });
+  const items$ = draft?.items$ ?? localItems$;
+  const setItems$ = command(({ set }, nextItems: readonly FeedbackItem[]) => {
+    if (draft) {
+      set(draft.setItems$, nextItems);
+      return;
+    }
+    set(itemsState$, nextItems);
+  });
   const active$ = computed((get) => {
-    return get(itemsState$).length > 0;
+    return get(items$).length > 0;
   });
   const replaceFromEditor$ = command(
     ({ get, set }, items: readonly FeedbackItem[]) => {
@@ -368,44 +464,79 @@ function createFeedbackItemSignals({
       );
       set(rangesState$, ranges);
       set(setFeedbackHighlight$, threadId, ranges);
-      set(itemsState$, items);
+      set(setItems$, items);
+      set(
+        nextIdState$,
+        items.reduce((nextId, item) => {
+          return Math.max(nextId, item.id + 1);
+        }, 1),
+      );
     },
   );
-  const startFeedback$ = command(({ get, set }) => {
+  const startFeedbackWithNote$ = command(({ get, set }, note: string) => {
     const selection = get(selectionState$);
     if (!selection) {
       return;
     }
-    const id = get(nextIdState$);
-    const item = { id, quote: selection.text, note: "" };
-    const items = [...get(itemsState$), item];
+    const currentItems = get(items$);
+    const id = draft
+      ? currentItems.reduce((nextId, item) => {
+          return Math.max(nextId, item.id + 1);
+        }, 1)
+      : get(nextIdState$);
+    const item = { id, quote: selection.text, note };
     set(nextIdState$, id + 1);
-    set(itemsState$, items);
+    set(setItems$, [...currentItems, item]);
     const ranges = new Map<number, Range>(get(rangesState$));
     if (selection.range) {
       ranges.set(id, selection.range);
     }
     set(rangesState$, ranges);
     set(setFeedbackHighlight$, threadId, ranges);
-    editor.insertItem(item);
-    set(closeSelectionToolbar$);
+    if (syncEditor) {
+      editor.insertItem(item);
+    }
+    set(hideSelectionToolbar$);
   });
+  const startFeedback$ = command(({ set }) => {
+    set(startFeedbackWithNote$, "");
+  });
+  const updateFeedbackNote$ = command(
+    ({ get, set }, id: number, note: string) => {
+      const item = get(items$).find((candidate) => {
+        return candidate.id === id;
+      });
+      if (!item) {
+        return;
+      }
+      set(
+        setItems$,
+        get(items$).map((candidate) => {
+          return candidate.id === id ? { ...item, note } : candidate;
+        }),
+      );
+    },
+  );
   const removeFeedback$ = command(({ get, set }, id: number) => {
-    const items = get(itemsState$).filter((item) => {
+    const items = get(items$).filter((item) => {
       return item.id !== id;
     });
     const ranges = new Map<number, Range>(get(rangesState$));
     ranges.delete(id);
     set(rangesState$, ranges);
     set(setFeedbackHighlight$, threadId, ranges);
-    set(itemsState$, items);
-    editor.removeItem(id);
+    set(setItems$, items);
+    if (syncEditor) {
+      editor.removeItem(id);
+    }
   });
   return {
     items$,
     active$,
     startFeedback$,
+    startFeedbackWithNote$,
     replaceFromEditor$,
+    updateFeedbackNote$,
     removeFeedback$,
   };
 }
@@ -414,12 +545,14 @@ function createSelectionToolbarRef({
   resetSelectionToolbarSignal$,
   closeSelectionToolbar$,
   copySelection$,
-  startFeedback$,
+  provideFeedback$,
+  feedbackMessageCardsEnabled,
 }: {
   resetSelectionToolbarSignal$: ReturnType<typeof resetSignal>;
   closeSelectionToolbar$: Command<void, []>;
   copySelection$: Command<Promise<void>, [AbortSignal]>;
-  startFeedback$: Command<void, []>;
+  provideFeedback$: Command<void, []>;
+  feedbackMessageCardsEnabled: boolean;
 }) {
   return onRef(
     command(({ set }, el: HTMLElement, signal: AbortSignal) => {
@@ -431,6 +564,9 @@ function createSelectionToolbarRef({
             return;
           }
           if (matchShortcut("mod+c", event)) {
+            if (shouldIgnoreTextShortcut(event)) {
+              return;
+            }
             // Preserve the browser's native copy action, then dismiss only the
             // feedback state without changing the document selection.
             await delay(0, { signal: toolbarSignal });
@@ -445,6 +581,19 @@ function createSelectionToolbarRef({
             set(closeSelectionToolbar$);
             return;
           }
+          const feedbackShortcutMatches =
+            matchShortcut("f", event) ||
+            (feedbackMessageCardsEnabled && matchShortcut("q", event));
+          if (feedbackShortcutMatches && !isFeedbackInputTarget(event.target)) {
+            // Selecting assistant text does not move focus away from the main
+            // composer. Treat the feedback shortcuts before the generic
+            // editable-target guard so that stale composer focus does not make
+            // them inert. F remains supported for users without browser-level
+            // link-hint shortcuts; Q is the conflict-free visible shortcut.
+            event.preventDefault();
+            set(provideFeedback$);
+            return;
+          }
           if (shouldIgnoreTextShortcut(event)) {
             return;
           }
@@ -452,10 +601,6 @@ function createSelectionToolbarRef({
             event.preventDefault();
             await set(copySelection$, signal);
             return;
-          }
-          if (matchShortcut("f", event)) {
-            event.preventDefault();
-            set(startFeedback$);
           }
         }),
         { signal: toolbarSignal },
@@ -466,20 +611,31 @@ function createSelectionToolbarRef({
 
 function createPointerSelectionListeners({
   selectionState$,
-  closeSelectionToolbar$,
+  draftOpen$,
+  hideSelectionToolbar$,
 }: {
   selectionState$: State<FeedbackSelection | null>;
-  closeSelectionToolbar$: Command<void, []>;
+  draftOpen$: Computed<boolean>;
+  hideSelectionToolbar$: Command<void, []>;
 }) {
   return command(({ get, set }, doc: Document, signal: AbortSignal) => {
     doc.addEventListener(
       "pointerdown",
       (event) => {
+        const target = event.target;
+        if (
+          get(draftOpen$) &&
+          target instanceof HTMLElement &&
+          target.closest(FEEDBACK_INPUT_SELECTOR) === null
+        ) {
+          set(hideSelectionToolbar$);
+          return;
+        }
         if (
           get(selectionState$) !== null &&
-          shouldDismissSelectionForInteractionTarget(event.target)
+          shouldDismissSelectionForInteractionTarget(target)
         ) {
-          set(closeSelectionToolbar$);
+          set(hideSelectionToolbar$);
         }
       },
       { capture: true, signal },
@@ -546,23 +702,36 @@ function createSelectionListenersRef({
 export function createFeedbackSignals(
   threadId: string,
   editor: FeedbackEditorAdapter,
+  feedbackMessageCardsEnabled = false,
+  draft?: FeedbackDraftSignals,
 ): FeedbackSignals {
   const selection = createFeedbackSelectionState(threadId);
   const items = createFeedbackItemSignals({
     threadId,
     editor,
+    syncEditor: !feedbackMessageCardsEnabled,
+    draft: feedbackMessageCardsEnabled ? draft : undefined,
     selectionState$: selection.selectionState$,
-    closeSelectionToolbar$: selection.closeSelectionToolbar$,
+    hideSelectionToolbar$: selection.hideSelectionToolbar$,
+  });
+  const provideFeedback$ = command(({ set }) => {
+    if (feedbackMessageCardsEnabled) {
+      set(selection.openFeedbackDraft$);
+      return;
+    }
+    set(items.startFeedback$);
   });
   const setSelectionToolbarRef$ = createSelectionToolbarRef({
     resetSelectionToolbarSignal$: selection.resetSelectionToolbarSignal$,
     closeSelectionToolbar$: selection.closeSelectionToolbar$,
     copySelection$: selection.copySelection$,
-    startFeedback$: items.startFeedback$,
+    provideFeedback$,
+    feedbackMessageCardsEnabled,
   });
   const pointerListeners$ = createPointerSelectionListeners({
     selectionState$: selection.selectionState$,
-    closeSelectionToolbar$: selection.closeSelectionToolbar$,
+    draftOpen$: selection.draftOpen$,
+    hideSelectionToolbar$: selection.hideSelectionToolbar$,
   });
   const documentListeners$ = createDocumentSelectionListeners({
     threadId,
@@ -573,13 +742,28 @@ export function createFeedbackSignals(
     pointerListeners$,
     documentListeners$,
   });
+  const submitFeedbackDraft$ = command(({ get, set }) => {
+    const note = get(selection.draftNote$);
+    if (note.trim().length === 0) {
+      return;
+    }
+    set(items.startFeedbackWithNote$, note);
+  });
 
   return {
     ...items,
+    feedbackMessageCardsEnabled,
     selection$: selection.selection$,
     closeSelectionToolbar$: selection.closeSelectionToolbar$,
     copySelection$: selection.copySelection$,
     setSelectionListenersRef$,
     setSelectionToolbarRef$,
+    draftOpen$: selection.draftOpen$,
+    draftNote$: selection.draftNote$,
+    openFeedbackDraft$: selection.openFeedbackDraft$,
+    setFeedbackDraftNote$: selection.setFeedbackDraftNote$,
+    submitFeedbackDraft$,
+    cancelFeedbackDraft$: selection.cancelFeedbackDraft$,
+    dismissFeedbackDraft$: selection.dismissFeedbackDraft$,
   };
 }

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -131,7 +131,7 @@ export interface WorkflowComposerSignals {
   readonly insertText$: Command<void, [string]>;
   readonly appendText$: Command<void, [string]>;
   readonly readInputForSubmission$: Command<
-    Promise<string>,
+    Promise<WorkflowComposerSubmission>,
     [
       attachmentReferenceClientIds: ReadonlySet<string> | null,
       signal: AbortSignal,
@@ -143,6 +143,11 @@ export interface WorkflowComposerSignals {
   >;
   readonly setEventHandlers$: Command<void, [WorkflowComposerEventHandlers]>;
   readonly feedback: FeedbackSignals;
+}
+
+export interface WorkflowComposerSubmission {
+  readonly text: string;
+  readonly feedbackItems: readonly FeedbackItem[];
 }
 
 export type ComposerTemplateAttachmentType =
@@ -1968,7 +1973,7 @@ function workflowComposerDocumentForValue(
   if (!templateAttachment) {
     return textDocument;
   }
-  const content = [templateAttachment];
+  const content: ProseMirrorNode[] = [templateAttachment];
   for (let index = 0; index < textDocument.childCount; index++) {
     content.push(textDocument.child(index));
   }
@@ -2024,6 +2029,7 @@ function createMountEditorCommand({
   featureModes,
   autoFocus,
   singleLineOnMobile,
+  feedbackMessageCards,
 }: {
   editor: Editor;
   draft: DraftSignals;
@@ -2036,6 +2042,7 @@ function createMountEditorCommand({
   featureModes: WorkflowComposerFeatureModes;
   autoFocus: boolean;
   singleLineOnMobile: boolean;
+  feedbackMessageCards: boolean;
 }) {
   return onRef(
     command(({ get, set }, element: HTMLElement, signal: AbortSignal) => {
@@ -2047,9 +2054,11 @@ function createMountEditorCommand({
             set(draft.removeAttachmentByClientId$, clientId);
           },
         );
-        runtime.replaceFeedbackItems(
-          feedbackItemsFromWorkflowComposer(updatedEditor),
-        );
+        if (!feedbackMessageCards) {
+          runtime.replaceFeedbackItems(
+            feedbackItemsFromWorkflowComposer(updatedEditor),
+          );
+        }
         set(draft.setInput$, workflowComposerDocToString(updatedEditor));
         runtime.input();
         set(selectedSuggestionIndexState$, 0);
@@ -2074,7 +2083,10 @@ function createMountEditorCommand({
       };
       setWorkflowComposerEditorOptions(editor, runtime, singleLineOnMobile);
       const input = get(draft.input$);
-      if (feedbackItemsFromWorkflowComposer(editor).length === 0) {
+      if (
+        feedbackMessageCards ||
+        feedbackItemsFromWorkflowComposer(editor).length === 0
+      ) {
         setWorkflowComposerDocument(
           editor,
           workflowComposerDocumentForValue(editor, input, featureModes),
@@ -2100,7 +2112,7 @@ function createMountEditorCommand({
             editor,
             workflowComposerDocumentForValue(editor, value, featureModes),
           );
-          if (changed) {
+          if (changed && !feedbackMessageCards) {
             runtime.replaceFeedbackItems(
               feedbackItemsFromWorkflowComposer(editor),
             );
@@ -2299,23 +2311,33 @@ function createTemplateAttachmentControls(
   return { active$, setLifecycleRef$ };
 }
 
-function createComposerFeedback(
+function createFeedback(
   editor: Editor,
+  draft: DraftSignals,
   threadId: string | undefined,
   inlinePromptItems: boolean,
+  feedbackMessageCards: boolean,
 ): FeedbackSignals {
-  return createFeedbackSignals(threadId ?? "", {
-    insertItem(item) {
-      if (inlinePromptItems) {
-        insertPromptFeedbackItem(editor, item);
-      } else {
-        insertFeedbackItem(editor, item);
-      }
+  return createFeedbackSignals(
+    threadId ?? "",
+    {
+      insertItem(item) {
+        if (inlinePromptItems) {
+          insertPromptFeedbackItem(editor, item);
+        } else {
+          insertFeedbackItem(editor, item);
+        }
+      },
+      removeItem(id) {
+        removeFeedbackItem(editor, id);
+      },
     },
-    removeItem(id) {
-      removeFeedbackItem(editor, id);
+    feedbackMessageCards,
+    {
+      items$: draft.feedbackItems$,
+      setItems$: draft.setFeedbackItems$,
     },
-  });
+  );
 }
 
 function createInlinePromptItemCommands(editor: Editor) {
@@ -2361,47 +2383,47 @@ function createInlinePromptItemCommands(editor: Editor) {
   };
 }
 
-function createReadInputForSubmissionCommand(
-  editor: Editor,
-  compositionGate: CompositionGate,
-) {
-  return command(
+function createFeedbackSubmissionControls({
+  editor,
+  draft,
+  feedback,
+  compositionGate,
+  feedbackMessageCards,
+}: {
+  editor: Editor;
+  draft: DraftSignals;
+  feedback: FeedbackSignals;
+  compositionGate: CompositionGate;
+  feedbackMessageCards: boolean;
+}) {
+  const readInputForSubmission$ = command(
     (
-      _context,
+      { get },
       attachmentReferenceClientIds: ReadonlySet<string> | null,
       signal: AbortSignal,
     ) => {
       return compositionGate.runWhenSettled(() => {
-        return workflowComposerDocToString(
-          editor,
-          attachmentReferenceClientIds,
-        );
+        return {
+          text: workflowComposerDocToString(
+            editor,
+            attachmentReferenceClientIds,
+          ),
+          feedbackItems: feedbackMessageCards ? get(feedback.items$) : [],
+        };
       }, signal);
     },
   );
+  const hasInput$ = computed((get) => {
+    return get(draft.hasInput$) || get(feedback.active$);
+  });
+  return { readInputForSubmission$, hasInput$ };
 }
 
-export function createWorkflowComposerSignals(
-  draft: DraftSignals,
-  threadId?: string,
-  inlinePromptItems = false,
-  inlineAttachmentReferences = false,
-): WorkflowComposerSignals {
-  const caretIndex$ = state(-1);
-  const editorFocusedState$ = state(false);
-  const selectedSuggestionIndexState$ = state(0);
-  const runtime = createWorkflowComposerRuntime();
-  const templatePreview = createTemplatePreviewRuntime();
-  const compositionGate = createCompositionGate();
-  const featureModes = { inlinePromptItems, inlineAttachmentReferences };
-
-  const editor = createWorkflowEditor(runtime);
-  const templateAttachment = createTemplateAttachmentControls(editor, runtime);
-  const feedback = createComposerFeedback(editor, threadId, inlinePromptItems);
-
-  const selectedSuggestionIndex$ = computed((get) => {
-    return get(selectedSuggestionIndexState$);
-  });
+function createComposerSuggestionState(
+  editor: Editor,
+  caretIndex$: State<number>,
+  editorFocusedState$: State<boolean>,
+) {
   const activeSlashRange$ = computed((get) => {
     const caretIndex = get(caretIndex$);
     if (caretIndex < 0 || !get(editorFocusedState$)) {
@@ -2428,6 +2450,44 @@ export function createWorkflowComposerSignals(
   const chatThreadSuggestions$ = createComposerChatThreadSuggestions(
     activeChatThreadSuggestionRange$,
   );
+  return {
+    activeSlashRange$,
+    activeChatThreadSuggestionRange$,
+    chatThreadSuggestions$,
+  };
+}
+
+export function createWorkflowComposerSignals(
+  draft: DraftSignals,
+  threadId?: string,
+  inlinePromptItems = false,
+  inlineAttachmentReferences = false,
+  feedbackMessageCards = false,
+): WorkflowComposerSignals {
+  const caretIndex$ = state(-1);
+  const editorFocusedState$ = state(false);
+  const selectedSuggestionIndexState$ = state(0);
+  const runtime = createWorkflowComposerRuntime();
+  const templatePreview = createTemplatePreviewRuntime();
+  const compositionGate = createCompositionGate();
+  const featureModes = { inlinePromptItems, inlineAttachmentReferences };
+  const editor = createWorkflowEditor(runtime);
+  const templateAttachment = createTemplateAttachmentControls(editor, runtime);
+  const feedback = createFeedback(
+    editor,
+    draft,
+    threadId,
+    inlinePromptItems,
+    feedbackMessageCards,
+  );
+  const {
+    activeSlashRange$,
+    activeChatThreadSuggestionRange$,
+    chatThreadSuggestions$,
+  } = createComposerSuggestionState(editor, caretIndex$, editorFocusedState$);
+  const selectedSuggestionIndex$ = computed((get) => {
+    return get(selectedSuggestionIndexState$);
+  });
   const setSelectedSuggestionIndex$ = command(({ set }, index: number) => {
     set(selectedSuggestionIndexState$, index);
   });
@@ -2463,6 +2523,7 @@ export function createWorkflowComposerSignals(
       featureModes,
       autoFocus,
       singleLineOnMobile,
+      feedbackMessageCards,
     });
   };
   const insertWorkflow$ = createInsertWorkflowCommand(
@@ -2476,14 +2537,14 @@ export function createWorkflowComposerSignals(
   const { insertText$, insertPromptMarkdown$, appendText$ } =
     createInsertTextCommands(editor, featureModes);
   const inlinePromptItemCommands = createInlinePromptItemCommands(editor);
-  const readInputForSubmission$ = createReadInputForSubmissionCommand(
-    editor,
-    compositionGate,
-  );
-  const hasInput$ = computed((get) => {
-    return get(draft.hasInput$) || get(feedback.active$);
-  });
-
+  const { readInputForSubmission$, hasInput$ } =
+    createFeedbackSubmissionControls({
+      editor,
+      draft,
+      feedback,
+      compositionGate,
+      feedbackMessageCards,
+    });
   return {
     editor,
     templatePreview,

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -45,6 +45,7 @@ export const chatPageWorkflowComposer$ = computed((get) => {
     undefined,
     composerInlinePromptItemsEnabled(features),
     features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ?? false,
+    features[FeatureSwitchKey.FeedbackMessageCards] ?? false,
   );
 });
 

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
+  type ChatMessageFeedbackPayload,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { StoreProvider } from "ccstate-react";
 import { describe, expect, it } from "vitest";
 
@@ -16,7 +19,11 @@ import { Markdown } from "../markdown.tsx";
 
 const context = testContext();
 
-function mockThread(content: string): void {
+function mockThread(
+  content: string,
+  role: "assistant" | "user" = "assistant",
+  feedbackPayload?: ChatMessageFeedbackPayload,
+): void {
   context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
     if (query.sinceId) {
       return respond(200, { messages: [] });
@@ -26,8 +33,10 @@ function mockThread(content: string): void {
       messages: [
         {
           id: "msg-1",
-          role: "assistant",
+          role,
           content,
+          ...(feedbackPayload ? { feedbackPayload } : {}),
+          ...(role === "user" ? { runId: "run-markdown" } : {}),
           createdAt: "2026-01-01T00:00:00Z",
         },
       ],
@@ -51,6 +60,16 @@ function getButtonByText(container: ParentNode, text: string): HTMLElement {
     throw new Error(`Could not find button: ${text}`);
   }
 
+  return button;
+}
+
+function getButtonByLabel(label: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!button) {
+    throw new Error(`Could not find button: ${label}`);
+  }
   return button;
 }
 
@@ -156,5 +175,103 @@ describe("assistant markdown", () => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
+  });
+});
+
+describe("feedback message cards", () => {
+  it("keeps a structured feedback message as a chip after reload", async () => {
+    const feedbackPayload = {
+      version: 1 as const,
+      items: [{ id: 1, quote: "Persisted quote", note: "Persisted note" }],
+    };
+    mockThread("Keep the opening concise.", "user", feedbackPayload);
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    const chip = await waitFor(() => {
+      return getButtonByLabel("Show 1 quote");
+    });
+    expect(chip).toBeInTheDocument();
+    expect(document.querySelector(".zero-chat-bubble-user")).toHaveTextContent(
+      "Keep the opening concise.",
+    );
+
+    await userEvent.setup({ delay: null }).click(chip);
+    await expect(
+      screen.findByText("Persisted quote"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Persisted note")).toBeInTheDocument();
+  });
+
+  it("renders one sent-message chip with all feedback details on hover", async () => {
+    const user = userEvent.setup({ delay: null });
+    const feedbackPayload = {
+      version: 1 as const,
+      items: [
+        { id: 1, quote: "First quoted passage", note: "first note" },
+        { id: 2, quote: "Second quoted passage", note: "second note" },
+      ],
+    };
+    mockThread("Follow up on these points.", "user", feedbackPayload);
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-markdown",
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    const chip = await waitFor(() => {
+      return getButtonByLabel("Show 2 quotes");
+    });
+    expect(document.querySelectorAll("[data-feedback-chip]")).toHaveLength(1);
+    const userBubble = document.querySelector(".zero-chat-bubble-user");
+    expect(userBubble).toHaveTextContent("Follow up on these points.");
+    expect(userBubble).not.toContainElement(chip);
+    expect(screen.queryByText("first note")).not.toBeInTheDocument();
+
+    await user.hover(chip);
+    await waitFor(() => {
+      expect(screen.getAllByText("first note").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("second note").length).toBeGreaterThan(0);
+    });
+    const hoverDetails = document.querySelector<HTMLElement>(
+      '[data-feedback-details="hover"]',
+    );
+    expect(hoverDetails).toHaveStyle({
+      width: "min(22rem, calc(100vw - 1.5rem))",
+    });
+    const quoteList = document.querySelector("[data-feedback-comment-list]");
+    expect(quoteList?.querySelectorAll("[data-feedback-item]")).toHaveLength(2);
+    expect(screen.getAllByText("First quoted passage").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText("Second quoted passage").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText("Selected text 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quotes")).not.toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryAllByText("first note")).toHaveLength(0);
+    });
+    await user.click(chip);
+    await waitFor(() => {
+      expect(screen.getAllByText("first note").length).toBeGreaterThan(0);
+    });
+    const clickDetails = document.querySelector<HTMLElement>(
+      '[data-feedback-details="click"]',
+    );
+    expect(clickDetails).toHaveStyle({
+      width: "min(22rem, calc(100vw - 1.5rem))",
+    });
+    // The raw intro line is not shown as literal text.
+    expect(
+      screen.queryByText("Feedback on 2 parts of your reply:"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -850,6 +850,7 @@ describe("chat drafts", () => {
       expect(textarea().textContent ?? "").toBe("");
       expect(draftPatches).toContainEqual({
         draftContent: null,
+        draftFeedbackPayload: null,
         draftAttachments: null,
       });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  chatThreadByIdContract,
+  chatThreadDraftContract,
+  type GenerationTemplateRequest,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
@@ -10,7 +14,9 @@ import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  click,
   detachedSetupPage,
+  fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
@@ -18,6 +24,7 @@ import { mockChatLifecycle } from "./chat-test-helpers.ts";
 const context = testContext();
 
 const FEEDBACK_THREAD_ID = "b0000000-0000-4000-a000-000000000703";
+const SECOND_FEEDBACK_THREAD_ID = "b0000000-0000-4000-a000-000000000704";
 
 interface ModelSelectionRequest {
   readonly modelProviderId: string;
@@ -26,6 +33,11 @@ interface ModelSelectionRequest {
 
 interface RunCreateCapture {
   prompt?: string;
+  textContent?: string;
+  feedbackPayload?: {
+    version: 1;
+    items: { id: number; quote: string; note: string }[];
+  };
   attachFiles?: {
     id: string;
     filename: string;
@@ -58,6 +70,7 @@ function selectTextRangeForInlineFeedback(element: HTMLElement): void {
 }
 
 function selectTextForInlineFeedback(element: HTMLElement): void {
+  document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
   selectTextRangeForInlineFeedback(element);
   document.dispatchEvent(new Event("selectionchange"));
 }
@@ -122,12 +135,24 @@ function buttonByText(text: string): HTMLElement {
       label === text ||
       label === `${text}C` ||
       label === `${text} C` ||
+      label === `${text}Q` ||
+      label === `${text} Q` ||
       label === `${text}F` ||
       label === `${text} F`
     );
   });
   if (!button) {
     throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
+function buttonByLabel(label: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!button) {
+    throw new Error(`${label} button not found`);
   }
   return button;
 }
@@ -142,6 +167,18 @@ async function findComposerEditor(): Promise<HTMLElement> {
     }
     return editor;
   });
+}
+
+async function navigateToThread(threadId: string): Promise<void> {
+  const link = await waitFor(() => {
+    return document.querySelector<HTMLAnchorElement>(
+      `a[href="/chats/${threadId}"]`,
+    );
+  });
+  if (!link) {
+    throw new Error(`Thread link not found: ${threadId}`);
+  }
+  click(link);
 }
 
 function feedbackNotes(): HTMLElement[] {
@@ -212,6 +249,21 @@ function dispatchDocumentShortcut(
   return event;
 }
 
+function dispatchElementShortcut(
+  target: HTMLElement,
+  key: string,
+  init?: Omit<KeyboardEventInit, "key">,
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+    key,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe("chat inline feedback", () => {
   it("keeps the composer caret after inserting atomic block feedback", async () => {
     const user = userEvent.setup({ delay: null });
@@ -257,6 +309,13 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
+    expect(buttonByText("Provide feedback")).toHaveAttribute(
+      "aria-keyshortcuts",
+      "f",
+    );
+    const disabledCardsShortcutEvent = dispatchDocumentShortcut("q");
+    expect(disabledCardsShortcutEvent.defaultPrevented).toBeFalsy();
+    expect(composerEditor.querySelector("[data-composer-feedback]")).toBeNull();
     const shortcutEvent = dispatchDocumentShortcut("f");
     expect(shortcutEvent.defaultPrevented).toBeTruthy();
     expect(window.getSelection()?.rangeCount).toBe(1);
@@ -389,6 +448,357 @@ describe("chat inline feedback", () => {
 
     expect(feedbackNotes()).toHaveLength(0);
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
+  });
+
+  it("submits feedback cards as structured quote comments", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+    const sentBodies: RunCreateCapture[] = [];
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentBodies.push(body);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.FeedbackMessageCards]: true,
+      },
+    });
+
+    const composerEditor = await findComposerEditor();
+    await user.click(composerEditor);
+    expect(composerEditor).toHaveFocus();
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+    expect(buttonByText("Provide feedback")).toHaveAttribute(
+      "aria-keyshortcuts",
+      "q f",
+    );
+    // Selecting non-focusable reply text leaves the composer focused in the
+    // browser, so the real keydown originates from the editable composer.
+    const shortcutEvent = dispatchElementShortcut(composerEditor, "q");
+    expect(shortcutEvent.defaultPrevented).toBeTruthy();
+
+    // The inline input opens beside the selection; no empty note is inserted
+    // into the composer until it is submitted.
+    const inlineInput = await screen.findByLabelText("Add an optional comment");
+    expect(feedbackNotes()).toHaveLength(0);
+    expect(screen.queryByLabelText("Send feedback")).not.toBeInTheDocument();
+    fireEvent.keyDown(inlineInput, {
+      key: "Enter",
+      keyCode: 229,
+      isComposing: true,
+    });
+    fireEvent.keyDown(inlineInput, { key: "c", metaKey: true });
+    fireEvent.paste(inlineInput, {
+      clipboardData: {
+        getData: () => {
+          return "pasted comment";
+        },
+      },
+    });
+    expect(screen.getByLabelText("Add an optional comment")).toBe(inlineInput);
+    fireEvent.focusOut(inlineInput, { relatedTarget: null });
+    fireEvent.pointerDown(document.body);
+    fireEvent.pointerUp(document.body, { pointerType: "mouse" });
+    fireEvent.mouseUp(document.body);
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Add an optional comment"),
+      ).not.toBeInTheDocument();
+    });
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+    await user.click(buttonByText("Provide feedback"));
+    const reopenedInput = await screen.findByLabelText(
+      "Add an optional comment",
+    );
+    Object.defineProperty(reopenedInput, "scrollHeight", {
+      configurable: true,
+      value: 80,
+    });
+    fireEvent.change(reopenedInput, {
+      target: {
+        value:
+          "This is a long feedback comment that should wrap onto several visible lines.",
+      },
+    });
+    expect(reopenedInput).toHaveStyle({ height: "80px" });
+    expect(reopenedInput).toHaveAttribute("data-multiline", "true");
+    await fill(reopenedInput, "Make the dates explicit.");
+    await user.click(screen.getByLabelText("Send feedback"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Add an optional comment"),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByLabelText("Feedback comment 1"),
+    ).not.toBeInTheDocument();
+    const feedbackChip = buttonByLabel("Open 1 quote");
+    await user.click(feedbackChip);
+    const firstComment = screen.getByLabelText("Feedback comment 1");
+    expect(firstComment).toHaveValue("Make the dates explicit.");
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+    dispatchDocumentShortcut("f");
+    const secondInput = await screen.findByLabelText("Add an optional comment");
+    await user.type(secondInput, "Name the owners.");
+    await user.click(screen.getByLabelText("Send feedback"));
+
+    expect(
+      screen.queryByLabelText("Feedback comment 1"),
+    ).not.toBeInTheDocument();
+    expect(document.querySelectorAll("[data-feedback-chip]")).toHaveLength(1);
+    await user.click(buttonByLabel("Open 2 quotes"));
+    expect(screen.getAllByLabelText(/Feedback comment \d/)).toHaveLength(2);
+    expect(screen.getAllByText(assistantReply)).toHaveLength(3);
+    expect(screen.queryByText("Selected text 1")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Feedback comment 2")).toHaveValue(
+      "Name the owners.",
+    );
+
+    const editableComment = screen.getByLabelText("Feedback comment 1");
+    expect(editableComment).toHaveValue("Make the dates explicit.");
+    await fill(editableComment, "Use exact dates.");
+    await user.click(screen.getByLabelText("Remove comment 2"));
+
+    await waitFor(() => {
+      expect(buttonByLabel("Open 1 quote")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(sentBodies).toHaveLength(1);
+    });
+    const sentBody = sentBodies[0];
+    expect(sentBody?.prompt).toContain(
+      "> The rollout dates are unclear in this summary.",
+    );
+    expect(sentBody?.prompt).toContain("Use exact dates.");
+    expect(sentBody?.prompt).not.toContain("Name the owners.");
+    expect(sentBody).toMatchObject({
+      textContent: "",
+      feedbackPayload: {
+        version: 1,
+        items: [
+          {
+            quote: assistantReply,
+            note: "Use exact dates.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("restores a saved feedback chip and its comments from the thread draft", async () => {
+    const assistantReply = "The rollout plan needs owners and exact dates.";
+    const savedFeedbackPayload = {
+      version: 1 as const,
+      items: [
+        { id: 4, quote: "Assign every risk.", note: "Name the owner." },
+        { id: 7, quote: "The schedule is vague.", note: "Use exact dates." },
+      ],
+    };
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-draft-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-draft",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftContent: "Add a short summary.",
+        draftFeedbackPayload: savedFeedbackPayload,
+        draftAttachments: null,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    const composerEditor = await findComposerEditor();
+    await waitFor(() => {
+      expect(composerEditor).toHaveTextContent("Add a short summary.");
+      expect(buttonByLabel("Open 2 quotes")).toBeInTheDocument();
+    });
+    expect(composerEditor).not.toHaveTextContent(
+      "Feedback on 2 parts of your reply:",
+    );
+
+    await userEvent
+      .setup({ delay: null })
+      .click(buttonByLabel("Open 2 quotes"));
+    expect(screen.getByLabelText("Feedback comment 1")).toHaveValue(
+      "Name the owner.",
+    );
+    expect(screen.getByLabelText("Feedback comment 2")).toHaveValue(
+      "Use exact dates.",
+    );
+  });
+
+  it("ignores saved feedback and preserves it during text sync when cards are disabled", async () => {
+    const draftPatches: Record<string, unknown>[] = [];
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [],
+    });
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftContent: "Visible draft text",
+        draftFeedbackPayload: {
+          version: 1,
+          items: [
+            {
+              id: 1,
+              quote: "Hidden saved quote",
+              note: "Hidden saved comment",
+            },
+          ],
+        },
+        draftAttachments: null,
+      });
+    });
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: false },
+    });
+
+    const composerEditor = await findComposerEditor();
+    await waitFor(() => {
+      expect(composerEditor).toHaveTextContent("Visible draft text");
+    });
+    expect(
+      document.querySelector("[data-feedback-chip]"),
+    ).not.toBeInTheDocument();
+    expect(composerEditor).not.toHaveTextContent("Hidden saved quote");
+
+    await fill(composerEditor, "Updated visible draft");
+    await waitFor(() => {
+      expect(draftPatches).toContainEqual({
+        draftContent: "Updated visible draft",
+        draftAttachments: null,
+      });
+    });
+  });
+
+  it("shows voice input state only on the feedback input that started it", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+    context.mocks.browser.voiceInput({ rms: 0.1 });
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-voice-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-voice",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+    context.mocks.http.post("*/api/zero/voice-io/stt", () => {
+      return new Response(JSON.stringify({ text: "Use exact dates." }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    await findComposerEditor();
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement);
+    await user.click(await screen.findByText("Provide feedback"));
+    const feedbackInput = await screen.findByLabelText(
+      "Add an optional comment",
+    );
+    const feedbackInputRoot = feedbackInput.closest("[data-feedback-input]");
+    if (!(feedbackInputRoot instanceof HTMLElement)) {
+      throw new Error("Feedback input root not found");
+    }
+    Object.defineProperty(feedbackInput, "scrollHeight", {
+      configurable: true,
+      value: 80,
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Voice input")).toHaveLength(2);
+    });
+    const feedbackVoiceInput = feedbackInputRoot.querySelector(
+      'button[aria-label="Voice input"]',
+    );
+    if (!(feedbackVoiceInput instanceof HTMLButtonElement)) {
+      throw new Error("Feedback voice input not found");
+    }
+    await user.click(feedbackVoiceInput);
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Stop recording")).toHaveLength(1);
+    });
+    expect(
+      feedbackInputRoot.querySelector('button[aria-label="Stop recording"]'),
+    ).not.toBeNull();
+    expect(screen.getByLabelText("Voice input")).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Stop recording"));
+    await waitFor(() => {
+      expect(feedbackInput).toHaveValue("Use exact dates.");
+      expect(feedbackInput).toHaveStyle({ height: "80px" });
+      expect(feedbackInput).toHaveAttribute("data-multiline", "true");
+      expect(screen.getAllByLabelText("Voice input")).toHaveLength(2);
+    });
   });
 
   it("uses slash workflow suggestions inside an inline feedback note", async () => {
@@ -1394,5 +1804,109 @@ describe("chat inline feedback", () => {
     );
     expect(sentPrompts[0]).toContain("Name owners.");
     expect(sentPrompts[0]).toContain("Add dates.");
+  });
+
+  it("preserves feedback drafts while switching threads and syncs them to the server", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout plan needs owners and exact dates.";
+    const draftPatches: Record<string, unknown>[] = [];
+    const lifecycle = mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-navigation-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-navigation",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+    lifecycle.setThreadList([
+      {
+        id: FEEDBACK_THREAD_ID,
+        title: "Feedback review",
+        agent: {
+          id: "c0000000-0000-4000-a000-000000000001",
+          avatarUrl: null,
+        },
+        createdAt: "2026-06-09T10:00:00Z",
+        updatedAt: "2026-06-09T10:01:00Z",
+      },
+      {
+        id: SECOND_FEEDBACK_THREAD_ID,
+        title: "Other review",
+        agent: {
+          id: "c0000000-0000-4000-a000-000000000001",
+          avatarUrl: null,
+        },
+        createdAt: "2026-06-09T10:00:00Z",
+        updatedAt: "2026-06-09T10:00:00Z",
+      },
+    ]);
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    await findComposerEditor();
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Provide feedback"));
+    await user.type(
+      await screen.findByLabelText("Add an optional comment"),
+      "Name the owner.",
+    );
+    await user.click(screen.getByLabelText("Send feedback"));
+
+    await waitFor(() => {
+      expect(buttonByLabel("Open 1 quote")).toBeInTheDocument();
+      expect(draftPatches).toContainEqual({
+        draftContent: null,
+        draftFeedbackPayload: {
+          version: 1,
+          items: [
+            {
+              id: 1,
+              quote: assistantReply,
+              note: "Name the owner.",
+            },
+          ],
+        },
+        draftAttachments: null,
+      });
+    });
+
+    await navigateToThread(SECOND_FEEDBACK_THREAD_ID);
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          `[data-chat-thread-container-id="${SECOND_FEEDBACK_THREAD_ID}"]`,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector("[data-feedback-chip]"),
+      ).not.toBeInTheDocument();
+    });
+
+    await navigateToThread(FEEDBACK_THREAD_ID);
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          `[data-chat-thread-container-id="${FEEDBACK_THREAD_ID}"]`,
+        ),
+      ).toBeInTheDocument();
+      expect(buttonByLabel("Open 1 quote")).toBeInTheDocument();
+    });
+    await user.click(buttonByLabel("Open 1 quote"));
+    expect(screen.getByLabelText("Feedback comment 1")).toHaveValue(
+      "Name the owner.",
+    );
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -136,6 +136,133 @@ function mockActiveRunThread(
 }
 
 describe("chat run queue", () => {
+  it("shows queued feedback as a readable summary", async () => {
+    const user = userEvent.setup({ delay: null });
+    const feedbackPayload = {
+      version: 1 as const,
+      items: [
+        {
+          id: 1,
+          quote: "你好你好你好呀",
+          note: "Use a shorter greeting.",
+        },
+      ],
+    };
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: `${THREAD_ID}-active-user`,
+          role: "user",
+          content: "Start the active run",
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: `${THREAD_ID}-queue-marker`,
+          role: "assistant",
+          content: null,
+          runId: "run-active",
+          runEventId: "queue:queued",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: `${THREAD_ID}-queued-feedback`,
+          role: "user",
+          content: "额外",
+          feedbackPayload,
+          runId: undefined,
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+      activeRunIds: ["run-active"],
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: true },
+    });
+
+    await expect(
+      screen.findByText("1 message waiting to send"),
+    ).resolves.toBeInTheDocument();
+    const queuedMessage = await screen.findByLabelText("Queued message");
+    expect(queuedMessage).toHaveTextContent("额外");
+    expect(queuedMessage).toHaveTextContent("1 quote");
+
+    await user.click(screen.getByLabelText("About this queued message"));
+    await expect(
+      screen.findByText(
+        "Waits in line and sends once the current run finishes.",
+      ),
+    ).resolves.toBeInTheDocument();
+
+    const composer = await activeRunComposer();
+    await user.click(screen.getByLabelText("Remove queued message"));
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+      expect(composer).toHaveTextContent("额外");
+      expect(screen.getByLabelText("Open 1 quote")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Open 1 quote"));
+    expect(screen.getByLabelText("Feedback comment 1")).toHaveValue(
+      "Use a shorter greeting.",
+    );
+  });
+
+  it("hides queued feedback metadata when feedback cards are disabled", async () => {
+    const feedbackPayload = {
+      version: 1 as const,
+      items: [
+        {
+          id: 1,
+          quote: "The rollout starts soon.",
+          note: "Replace soon with a date.",
+        },
+      ],
+    };
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: `${THREAD_ID}-active-user`,
+          role: "user",
+          content: "Start the active run",
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: `${THREAD_ID}-queue-marker`,
+          role: "assistant",
+          content: null,
+          runId: "run-active",
+          runEventId: "queue:queued",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: `${THREAD_ID}-queued-feedback`,
+          role: "user",
+          content: "Revise the rollout.",
+          feedbackPayload,
+          runId: undefined,
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+      activeRunIds: ["run-active"],
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.FeedbackMessageCards]: false },
+    });
+
+    const queuedMessage = await screen.findByLabelText("Queued message");
+    expect(queuedMessage).toHaveTextContent("Revise the rollout.");
+    expect(queuedMessage).not.toHaveTextContent("1 quote");
+  });
+
   it("shows a sent message and stop control while a new chat run is active", async () => {
     const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -437,6 +437,15 @@ export function mockChatLifecycle(
     afterInitialMessagesList?: () => void;
     onRunCreate?: (body: {
       prompt?: string;
+      textContent?: string;
+      feedbackPayload?: {
+        version: 1;
+        items: {
+          id: number;
+          quote: string;
+          note: string;
+        }[];
+      };
       clientMessageId?: string;
       clientThreadId?: string;
       attachFiles?: {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -4,9 +4,16 @@ import {
   useLastResolved,
   useSet,
 } from "ccstate-react";
+import { IconQuote, IconX } from "@tabler/icons-react";
 import type { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
-import { Popover, PopoverAnchor, type KeyboardEventLike } from "@vm0/ui";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+  type KeyboardEventLike,
+} from "@vm0/ui";
 import { currentChatAgentRecordId$ } from "../../signals/agent-chat.ts";
 import type { ComposerChatThreadSuggestion } from "../../signals/zero-page/chat-thread-suggestion-domain.ts";
 import { composerChatThreadSuggestionsEnabled$ } from "../../signals/zero-page/composer-chat-thread-suggestions.ts";
@@ -153,6 +160,96 @@ function WorkflowComposerPlaceholder({
       aria-hidden="true"
     >
       {workflowComposerPlaceholder(sending)}
+    </div>
+  );
+}
+
+function FeedbackChipStrip({
+  composer,
+  onDraftChange,
+}: {
+  composer: WorkflowComposerSignals;
+  onDraftChange: (() => void) | undefined;
+}) {
+  const items = useGet(composer.feedback.items$);
+  const updateNote = useSet(composer.feedback.updateFeedbackNote$);
+  const removeFeedback = useSet(composer.feedback.removeFeedback$);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const label = `${String(items.length)} ${items.length === 1 ? "quote" : "quotes"}`;
+
+  return (
+    <div
+      className="flex flex-wrap gap-1.5 px-4 pt-4"
+      data-feedback-chip-strip=""
+    >
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Open ${label}`}
+            data-feedback-chip=""
+            className="inline-flex h-9 max-w-56 items-center gap-2 rounded-xl border border-border bg-background px-3 text-sm font-medium shadow-sm transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <IconQuote size={16} stroke={1.7} className="shrink-0" />
+            <span className="truncate">{label}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="max-h-[min(28rem,70vh)] w-[min(32rem,calc(100vw-1.5rem))] max-w-none overflow-y-auto rounded-xl p-3 shadow-lg"
+        >
+          <div
+            className="flex flex-col divide-y divide-border/60"
+            data-feedback-comment-list=""
+          >
+            {items.map((item, index) => {
+              return (
+                <div
+                  key={item.id}
+                  data-feedback-item=""
+                  className="py-3 first:pt-1 last:pb-1"
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="whitespace-pre-wrap break-words border-l-2 border-foreground/15 pl-3 text-sm leading-5 text-muted-foreground">
+                        {item.quote}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Remove comment ${String(index + 1)}`}
+                      onClick={() => {
+                        removeFeedback(item.id);
+                        onDraftChange?.();
+                      }}
+                      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <IconX size={15} stroke={1.7} />
+                    </button>
+                  </div>
+                  <textarea
+                    value={item.note}
+                    onChange={(event) => {
+                      updateNote(item.id, event.target.value);
+                      onDraftChange?.();
+                    }}
+                    aria-label={`Feedback comment ${String(index + 1)}`}
+                    placeholder="Add an optional comment..."
+                    rows={2}
+                    className="mt-2 max-h-28 min-h-10 w-full resize-none rounded-md border-0 bg-transparent px-2 py-1.5 text-sm leading-5 outline-none transition-colors placeholder:text-muted-foreground/50 hover:bg-muted/25 focus:bg-muted/40 focus:ring-1 focus:ring-primary/30"
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }
@@ -403,6 +500,7 @@ export function TiptapWorkflowComposer({
       ? composer.setAutoFocusContainerRef$
       : composer.setContainerRef$;
   const setContainerRef = useSet(containerRefSignal);
+  const feedbackChipsEnabled = composer.feedback.feedbackMessageCardsEnabled;
 
   function handlePaste(
     event: ClipboardEvent,
@@ -461,6 +559,12 @@ export function TiptapWorkflowComposer({
       <div
         className={`relative ${singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]"}`}
       >
+        {feedbackChipsEnabled ? (
+          <FeedbackChipStrip
+            composer={composer}
+            onDraftChange={onDraftChange}
+          />
+        ) : null}
         <WorkflowComposerPlaceholder composer={composer} sending={sending} />
         <div ref={setContainerRef} />
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -38,6 +38,7 @@ import {
   IconPlug,
   IconPhoto,
   IconPlus,
+  IconQuote,
   IconRoute,
   IconSearch,
   IconTarget,
@@ -97,6 +98,7 @@ import type {
 } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import { hasSubmittableInlinePromptContent } from "../../signals/zero-page/composer-inline-prompt-items.ts";
+import type { FeedbackItem } from "../../signals/zero-page/chat-feedback.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
 import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { Command, Computed } from "ccstate";
@@ -216,9 +218,11 @@ import {
   sttRecording$,
   sttStarting$,
   sttTranscribing$,
+  sttVoiceInputOwner$,
   sttVoiceLevel$,
   startRecording$,
   stopAndTranscribe$,
+  type VoiceInputOwner,
 } from "../../signals/voice-io/voice-io-stt.ts";
 import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.ts";
 import { Markdown } from "../components/markdown.tsx";
@@ -251,10 +255,12 @@ export interface ZeroChatComposerProps {
   onSend: (
     message: string,
     generationTemplate: GenerationTemplateRequest | undefined,
+    feedbackItems: readonly FeedbackItem[],
   ) => void;
   onQueue?: (
     message: string,
     generationTemplate: GenerationTemplateRequest | undefined,
+    feedbackItems: readonly FeedbackItem[],
   ) => void;
   sending?: boolean;
   queueWhileSending?: boolean;
@@ -345,6 +351,7 @@ export interface ZeroChatComposerProps {
 export interface QueuedComposerItem {
   id: string;
   text: string;
+  quoteCount?: number;
 }
 
 interface ActiveGoalComposerItem {
@@ -525,12 +532,14 @@ function ComposerQueueGlyph() {
 function ComposerStripRow({
   kind,
   text,
+  quoteCount,
   onRemove,
   onOpenDetail,
   removeAriaLabel,
 }: {
   kind: "queued" | "goal";
   text: string;
+  quoteCount?: number;
   onRemove?: () => void;
   onOpenDetail?: () => void;
   removeAriaLabel: string;
@@ -588,12 +597,24 @@ function ComposerStripRow({
                   ? "Runs after the queue drains and keeps running until you cancel it."
                   : "Waits in line and sends once the current run finishes."}
               </p>
+              {quoteCount ? (
+                <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-foreground">
+                  <IconQuote size={13} stroke={1.6} aria-hidden="true" />
+                  {String(quoteCount)} {quoteCount === 1 ? "quote" : "quotes"}
+                </p>
+              ) : null}
               <div className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
                 {text}
               </div>
             </PopoverContent>
           </Popover>
           <span className="min-w-0 flex-1 truncate">{text}</span>
+          {quoteCount ? (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-background/70 px-1.5 py-0.5 text-xs text-muted-foreground">
+              <IconQuote size={13} stroke={1.6} aria-hidden="true" />
+              {String(quoteCount)} {quoteCount === 1 ? "quote" : "quotes"}
+            </span>
+          ) : null}
         </>
       )}
       <button
@@ -713,6 +734,7 @@ function QueuedMessagesStrip({
               key={item.id}
               kind="queued"
               text={item.text}
+              quoteCount={item.quoteCount}
               onRemove={() => {
                 onRemove?.(item.id);
               }}
@@ -6027,9 +6049,25 @@ function micButtonTooltip(status: MicButtonStatus): string {
   return "Voice input";
 }
 
-function MicButton({
+function micButtonDisabled(
+  status: MicButtonStatus,
+  ownsVoiceInput: boolean,
+  quotaResolved: boolean,
+  voiceInputBusy: boolean,
+): boolean {
+  return (
+    (voiceInputBusy && !ownsVoiceInput) ||
+    status.starting ||
+    status.transcribing ||
+    (!status.recording && !quotaResolved)
+  );
+}
+
+export function MicButton({
+  owner,
   onTranscribed,
 }: {
+  owner: VoiceInputOwner;
   onTranscribed: (text: string) => void;
 }) {
   const available = useLastResolved(audioInputAvailable$) ?? false;
@@ -6039,29 +6077,40 @@ function MicButton({
   const recording = useGet(sttRecording$);
   const starting = useGet(sttStarting$);
   const transcribing = useGet(sttTranscribing$);
+  const voiceInputOwner = useGet(sttVoiceInputOwner$);
   const voiceLevel = useGet(sttVoiceLevel$);
   const voiceLevelFill = `${Math.round((voiceLevel / 3) * 100)}%`;
   const startRec = useSet(startRecording$);
   const stopAndTranscribe = useSet(stopAndTranscribe$);
   const openQuotaRecovery = useSet(openAudioInputQuotaRecovery$);
   const signal = useGet(pageSignal$);
-  const disabled = starting || transcribing || (!recording && !quotaResolved);
+  const ownsVoiceInput = voiceInputOwner === owner;
+  const ownedRecording = ownsVoiceInput && recording;
+  const ownedStarting = ownsVoiceInput && starting;
+  const ownedTranscribing = ownsVoiceInput && transcribing;
   const status = {
-    recording,
-    starting,
-    transcribing,
+    recording: ownedRecording,
+    starting: ownedStarting,
+    transcribing: ownedTranscribing,
     quotaLoading: quotaState === "loading" && !quotaResolved,
   };
+  const voiceInputBusy = recording || starting || transcribing;
+  const disabled = micButtonDisabled(
+    status,
+    ownsVoiceInput,
+    quotaResolved,
+    voiceInputBusy,
+  );
 
   if (!available) {
     return null;
   }
 
   const handleClick = () => {
-    if (starting || transcribing) {
+    if (ownedStarting || ownedTranscribing) {
       return;
     }
-    if (recording) {
+    if (ownedRecording) {
       detach(
         (async () => {
           const text = await stopAndTranscribe(signal);
@@ -6081,7 +6130,7 @@ function MicButton({
       return;
     }
     detach(
-      startRec(onTranscribed, quota.limit === null, signal),
+      startRec(owner, onTranscribed, quota.limit === null, signal),
       Reason.DomCallback,
     );
   };
@@ -6095,7 +6144,7 @@ function MicButton({
             className={cn(
               "relative inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-colors",
               COMPOSER_CONTROL_FOCUS_CLASS,
-              recording || starting || transcribing
+              ownedRecording || ownedStarting || ownedTranscribing
                 ? "bg-[#2E9E9F] text-white hover:bg-[#279394]"
                 : "text-muted-foreground hover:bg-accent hover:text-foreground",
             )}
@@ -6103,9 +6152,9 @@ function MicButton({
             disabled={disabled}
             aria-label={micButtonAriaLabel(status)}
           >
-            {starting || transcribing ? (
+            {ownedStarting || ownedTranscribing ? (
               <span className="mic-starting-spinner" aria-hidden="true" />
-            ) : recording ? (
+            ) : ownedRecording ? (
               <>
                 <span
                   className="mic-volume-icon-meter"
@@ -6445,6 +6494,7 @@ function ComposerSendButton({
 function ComposerSendControl({
   draft,
   attachmentReferenceClientIds,
+  hasFeedback,
   visibleAttachmentCount,
   uploadsReady,
   submitBlocked,
@@ -6458,6 +6508,7 @@ function ComposerSendControl({
 }: {
   draft: DraftSignals;
   attachmentReferenceClientIds: ReadonlySet<string> | null;
+  hasFeedback: boolean;
   visibleAttachmentCount: number;
   uploadsReady: boolean;
   submitBlocked: boolean;
@@ -6470,10 +6521,9 @@ function ComposerSendControl({
   onSend: () => void;
 }) {
   const input = useGet(draft.input$);
-  const hasInput = hasSubmittableInlinePromptContent(
-    input,
-    attachmentReferenceClientIds,
-  );
+  const hasInput =
+    hasSubmittableInlinePromptContent(input, attachmentReferenceClientIds) ||
+    hasFeedback;
   const canSend = resolveComposerCanSend({
     hasInput,
     visibleAttachmentCount,
@@ -6675,6 +6725,7 @@ export function useZeroChatComposer({
   const [inputForSubmissionLoadable, readInputForSubmission] = useLoadableSet(
     composer.readInputForSubmission$,
   );
+  const hasFeedback = useGet(composer.feedback.active$);
 
   const ensurePushSubscription = useSet(ensurePushSubscription$);
   const rootSignal = useGet(rootSignal$);
@@ -6997,10 +7048,9 @@ export function useZeroChatComposer({
 
   const handleSend = () => {
     const input = readInput();
-    const hasInput = hasSubmittableInlinePromptContent(
-      input,
-      attachmentReferenceClientIds,
-    );
+    const hasInput =
+      hasSubmittableInlinePromptContent(input, attachmentReferenceClientIds) ||
+      hasFeedback;
     const sendAction = resolveKeyboardSendAction({
       canSend:
         !actionsLoading &&
@@ -7021,20 +7071,29 @@ export function useZeroChatComposer({
       detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
     }
     const submitCurrentInput = async () => {
-      const currentInput = await readInputForSubmission(
+      const submission = await readInputForSubmission(
         attachmentReferenceClientIds,
         pageSignal,
       );
-      const prompt = currentInput.trim();
-      if (prompt.length === 0 && visibleAttachments.length === 0) {
+      const prompt = submission.text.trim();
+      if (
+        prompt.length === 0 &&
+        submission.feedbackItems.length === 0 &&
+        visibleAttachments.length === 0
+      ) {
         return;
       }
       if (sendAction === "send") {
-        onSend(prompt, inlinePromptItems ? undefined : templatePicker?.value);
+        onSend(
+          prompt,
+          inlinePromptItems ? undefined : templatePicker?.value,
+          submission.feedbackItems,
+        );
       } else {
         onQueue?.(
           prompt,
           inlinePromptItems ? undefined : templatePicker?.value,
+          submission.feedbackItems,
         );
       }
     };
@@ -7235,6 +7294,7 @@ export function useZeroChatComposer({
                   />
                   <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
                   <MicButton
+                    owner="composer"
                     onTranscribed={(text) => {
                       appendComposerText(text);
                       onDraftChange?.();
@@ -7243,6 +7303,7 @@ export function useZeroChatComposer({
                   <ComposerSendControl
                     draft={draft}
                     attachmentReferenceClientIds={attachmentReferenceClientIds}
+                    hasFeedback={hasFeedback}
                     visibleAttachmentCount={visibleAttachments.length}
                     uploadsReady={uploadsReady}
                     submitBlocked={submitBlocker !== undefined}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { IconCopy, IconMessageCircle } from "@tabler/icons-react";
+import { IconArrowUp, IconCopy, IconMessageCircle } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
   getShortcutParts,
@@ -13,6 +13,7 @@ import type {
   FeedbackSelection,
   FeedbackSignals,
 } from "../../signals/zero-page/chat-feedback.ts";
+import { MicButton } from "./zero-chat-composer.tsx";
 
 function anchorStyle(selection: FeedbackSelection): CSSProperties {
   return {
@@ -45,10 +46,13 @@ function ShortcutHint({ shortcut }: { readonly shortcut: string }) {
 function FeedbackToolbar({
   onCopy,
   onProvideFeedback,
+  feedbackMessageCardsEnabled,
 }: {
   onCopy: () => void;
   onProvideFeedback: () => void;
+  feedbackMessageCardsEnabled: boolean;
 }) {
+  const feedbackShortcut = feedbackMessageCardsEnabled ? "q" : "f";
   return (
     <PopoverContent
       side="top"
@@ -77,29 +81,126 @@ function FeedbackToolbar({
         <button
           type="button"
           onClick={onProvideFeedback}
-          aria-keyshortcuts="f"
+          aria-keyshortcuts={
+            feedbackMessageCardsEnabled ? "q f" : feedbackShortcut
+          }
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
           <IconMessageCircle size={14} stroke={2} />
           Provide feedback
-          <ShortcutHint shortcut="f" />
+          <ShortcutHint shortcut={feedbackShortcut} />
         </button>
       </div>
     </PopoverContent>
   );
 }
 
+// Codex-style inline input, shown beside the selection after "Provide feedback"
+// so the comment is written next to the quoted passage before it becomes a chip
+// in the composer. Gated behind the feedbackMessageCards switch.
+function FeedbackInputPopover({
+  note,
+  onChange,
+  onSubmit,
+  onCancel,
+}: {
+  note: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <PopoverContent
+      side="bottom"
+      align="start"
+      sideOffset={8}
+      data-feedback-input=""
+      onCloseAutoFocus={(event) => {
+        return event.preventDefault();
+      }}
+      onEscapeKeyDown={(event) => {
+        event.preventDefault();
+        onCancel();
+      }}
+      className="group/feedback-input w-[min(20rem,calc(100vw-2rem))] rounded-2xl border border-border bg-card px-3 py-1 text-foreground shadow-md has-[textarea[data-multiline=true]]:rounded-[1.75rem] has-[textarea[data-multiline=true]]:px-5 has-[textarea[data-multiline=true]]:py-4"
+    >
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-end gap-1 group-has-[textarea[data-multiline=true]]/feedback-input:min-h-40 group-has-[textarea[data-multiline=true]]/feedback-input:grid-rows-[auto_1fr_auto] [&_button]:h-8 [&_button]:w-8">
+        <textarea
+          autoFocus
+          ref={(element) => {
+            resizeFeedbackTextarea(element);
+          }}
+          rows={1}
+          value={note}
+          onChange={(event) => {
+            onChange(event.target.value);
+          }}
+          onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing || event.keyCode === 229) {
+              return;
+            }
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              onSubmit();
+            }
+          }}
+          placeholder="Add an optional comment..."
+          aria-label="Add an optional comment"
+          className="col-start-1 row-start-1 max-h-32 min-h-8 min-w-0 resize-none overflow-y-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 text-sm leading-5 outline-none placeholder:text-muted-foreground/45 group-has-[textarea[data-multiline=true]]/feedback-input:col-span-3 group-has-[textarea[data-multiline=true]]/feedback-input:w-full group-has-[textarea[data-multiline=true]]/feedback-input:py-0"
+        />
+        <div className="col-start-2 row-start-1 group-has-[textarea[data-multiline=true]]/feedback-input:row-start-3">
+          <MicButton
+            owner="feedback"
+            onTranscribed={(text) => {
+              onChange([note.trim(), text.trim()].filter(Boolean).join(" "));
+            }}
+          />
+        </div>
+        {note.trim() ? (
+          <button
+            type="button"
+            onClick={onSubmit}
+            aria-label="Send feedback"
+            className="col-start-3 row-start-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-has-[textarea[data-multiline=true]]/feedback-input:row-start-3"
+          >
+            <IconArrowUp size={18} stroke={2} />
+          </button>
+        ) : null}
+      </div>
+    </PopoverContent>
+  );
+}
+
+function resizeFeedbackTextarea(element: HTMLTextAreaElement | null): void {
+  if (!element) {
+    return;
+  }
+  const maxHeight = 128;
+  element.style.height = "auto";
+  const height = Math.min(Math.max(element.scrollHeight, 32), maxHeight);
+  element.dataset.multiline = height > 32 ? "true" : "false";
+  element.style.height = `${height}px`;
+  element.style.overflowY =
+    element.scrollHeight > maxHeight ? "auto" : "hidden";
+}
+
 // Mounts the selection listeners and the floating Copy / Provide feedback
-// toolbar anchored to the highlighted passage. Picking "Provide feedback"
-// drops the quoted passage straight into the composer (see ComposerFeedbackRows
-// in zero-chat-composer.tsx) — there is no separate feedback panel.
+// toolbar anchored to the highlighted passage. With the feedbackMessageCards
+// switch off, "Provide feedback" drops the quoted passage straight into the
+// composer; with it on, it opens the inline input above before the passage
+// becomes a chip.
 export function ChatFeedbackSelection({
   feedback,
+  onDraftChange,
 }: {
   readonly feedback: FeedbackSignals;
+  readonly onDraftChange?: () => void;
 }) {
   const selection = useGet(feedback.selection$);
   const rootSignal = useGet(rootSignal$);
+  const inlineInputEnabled = feedback.feedbackMessageCardsEnabled;
+  const draftOpen = useGet(feedback.draftOpen$);
+  const draftNote = useGet(feedback.draftNote$);
   const setFeedbackSelectionListenersRef = useSet(
     feedback.setSelectionListenersRef$,
   );
@@ -107,8 +208,19 @@ export function ChatFeedbackSelection({
     feedback.setSelectionToolbarRef$,
   );
   const startFeedback = useSet(feedback.startFeedback$);
+  const openDraft = useSet(feedback.openFeedbackDraft$);
+  const setDraftNote = useSet(feedback.setFeedbackDraftNote$);
+  const submitDraft = useSet(feedback.submitFeedbackDraft$);
+  const cancelDraft = useSet(feedback.cancelFeedbackDraft$);
+  const dismissDraft = useSet(feedback.dismissFeedbackDraft$);
   const closeSelectionToolbar = useSet(feedback.closeSelectionToolbar$);
   const copy = useSet(feedback.copySelection$);
+
+  const showInlineInput = inlineInputEnabled && draftOpen;
+  const handleSubmitDraft = () => {
+    submitDraft();
+    onDraftChange?.();
+  };
 
   return (
     <>
@@ -118,7 +230,11 @@ export function ChatFeedbackSelection({
           open
           onOpenChange={(next) => {
             if (!next) {
-              closeSelectionToolbar();
+              if (showInlineInput) {
+                dismissDraft();
+              } else {
+                closeSelectionToolbar();
+              }
             }
           }}
         >
@@ -126,12 +242,22 @@ export function ChatFeedbackSelection({
             <div style={anchorStyle(selection)} aria-hidden />
           </PopoverAnchor>
           <span ref={setFeedbackSelectionToolbarRef} hidden />
-          <FeedbackToolbar
-            onCopy={() => {
-              return detach(copy(rootSignal), Reason.DomCallback);
-            }}
-            onProvideFeedback={startFeedback}
-          />
+          {showInlineInput ? (
+            <FeedbackInputPopover
+              note={draftNote}
+              onChange={setDraftNote}
+              onSubmit={handleSubmitDraft}
+              onCancel={cancelDraft}
+            />
+          ) : (
+            <FeedbackToolbar
+              onCopy={() => {
+                return detach(copy(rootSignal), Reason.DomCallback);
+              }}
+              onProvideFeedback={inlineInputEnabled ? openDraft : startFeedback}
+              feedbackMessageCardsEnabled={inlineInputEnabled}
+            />
+          )}
         </Popover>
       ) : null}
     </>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -46,6 +46,7 @@ import {
   IconLoader2,
   IconMessageCircle,
   IconMoodPlus,
+  IconQuote,
   IconPackage,
   IconPresentation,
   IconRoute,
@@ -109,6 +110,11 @@ import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/
 import { emptyArtifactImg, emptyChatImg } from "./platform-assets.ts";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 import { Markdown } from "../components/markdown.tsx";
+import { feedbackMessageCardsEnabled$ } from "../../signals/external/feature-switch.ts";
+import {
+  formatFeedbackPrompt,
+  type FeedbackItem,
+} from "../../signals/zero-page/chat-feedback.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   captureRecommendedFollowupSelected,
@@ -250,6 +256,7 @@ import {
 } from "../../signals/chat-page/chat-message.ts";
 import type {
   ChatThreadSignals,
+  FeedbackMessageInput,
   QueuedChatMessageItem,
   RecommendedFollowupSource,
   ThinkingIndicatorMode,
@@ -3678,6 +3685,12 @@ function ChatThreadMessagesPane({ thread }: { thread: ChatThreadSignals }) {
 }
 
 function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
+  const queueDraftSync = useSet(thread.queueDraftSync$);
+  const pageSignal = useGet(pageSignal$);
+  const handleDraftChange = () => {
+    detach(queueDraftSync(pageSignal), Reason.DomCallback);
+  };
+
   return (
     <>
       <ChatThreadHeader thread={thread} />
@@ -3689,7 +3702,10 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
         </div>
       </div>
 
-      <ChatFeedbackSelection feedback={thread.workflowComposer.feedback} />
+      <ChatFeedbackSelection
+        feedback={thread.workflowComposer.feedback}
+        onDraftChange={handleDraftChange}
+      />
     </>
   );
 }
@@ -3955,6 +3971,7 @@ function useChatComposerQueue(
     return {
       id: message.id,
       text: message.text,
+      quoteCount: message.quoteCount,
     };
   });
 
@@ -4070,15 +4087,69 @@ function useChatThreadComposerSendState({
   const rootSignal = useGet(rootSignal$);
   const generationTemplate = useGet(thread.draft.generationTemplate$);
   const setGenerationTemplate = useSet(thread.draft.setGenerationTemplate$);
+  const feedbackCardsEnabled =
+    thread.workflowComposer.feedback.feedbackMessageCardsEnabled;
 
-  const handleSend = (text: string) => {
+  const feedbackMessageFromSubmission = (
+    textContent: string,
+    feedbackItems: readonly FeedbackItem[],
+  ): FeedbackMessageInput | undefined => {
+    if (!feedbackCardsEnabled || feedbackItems.length === 0) {
+      return undefined;
+    }
+    return {
+      textContent,
+      feedbackPayload: {
+        version: 1,
+        items: feedbackItems.map((item) => {
+          return { ...item };
+        }),
+      },
+    };
+  };
+
+  const prepareFeedbackSubmission = (
+    prompt: string,
+    feedbackItems: readonly FeedbackItem[],
+  ) => {
+    const feedbackMessage = feedbackMessageFromSubmission(
+      prompt,
+      feedbackItems,
+    );
+    if (!feedbackMessage) {
+      return { prompt, feedbackMessage };
+    }
+    const formattedFeedback = formatFeedbackPrompt(
+      feedbackMessage.feedbackPayload.items,
+    );
+    return {
+      prompt: [feedbackMessage.textContent.trim(), formattedFeedback]
+        .filter(Boolean)
+        .join("\n\n"),
+      feedbackMessage,
+    };
+  };
+
+  const handleSend = (
+    text: string,
+    _generationTemplate: GenerationTemplateRequest | undefined,
+    feedbackItems: readonly FeedbackItem[],
+  ) => {
     detach(
       (async () => {
+        const submission = prepareFeedbackSubmission(text, feedbackItems);
         const computerUsePatch =
           computerUseHostIdForSend === undefined
             ? {}
             : { computerUseHostId: computerUseHostIdForSend };
-        const sent = await send(text, { ...computerUsePatch }, rootSignal);
+        const sent = await send(
+          submission.prompt,
+          {
+            ...computerUsePatch,
+            feedbackMessage: submission.feedbackMessage,
+          },
+          rootSignal,
+        );
         if (sent) {
           clearComputerUseHostOverride();
         }
@@ -4087,11 +4158,21 @@ function useChatThreadComposerSendState({
     );
   };
 
-  const handleQueue = (text: string) => {
+  const handleQueue = (
+    text: string,
+    _generationTemplate: GenerationTemplateRequest | undefined,
+    feedbackItems: readonly FeedbackItem[],
+  ) => {
     detach(
       (async () => {
+        const submission = prepareFeedbackSubmission(text, feedbackItems);
         const computerUseHostId = computerUseHostIdForSend;
-        const queued = await queueMessage(text, computerUseHostId, rootSignal);
+        const queued = await queueMessage(
+          submission.prompt,
+          computerUseHostId,
+          submission.feedbackMessage,
+          rootSignal,
+        );
         if (queued) {
           clearComputerUseHostOverride();
         }
@@ -6475,6 +6556,86 @@ function GoalUserMessage({
   );
 }
 
+function FeedbackQuotesDetails({ items }: { items: readonly FeedbackItem[] }) {
+  return (
+    <div className="flex flex-col" data-feedback-comment-list="">
+      {items.map((item) => {
+        return (
+          <div
+            key={item.id}
+            data-feedback-item=""
+            className="border-b border-border/60 px-1 py-3 first:pt-1 last:border-b-0 last:pb-1"
+          >
+            <div className="whitespace-pre-wrap break-words border-l-2 border-foreground/15 pl-3 text-sm leading-5 text-muted-foreground">
+              {item.quote}
+            </div>
+            {item.note ? (
+              <div className="mt-2 whitespace-pre-wrap break-words text-sm leading-5 text-foreground">
+                {item.note}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function FeedbackQuotesChip({ items }: { items: readonly FeedbackItem[] }) {
+  const detailsClassName =
+    "max-h-[min(28rem,70vh)] max-w-none overflow-y-auto rounded-xl border border-border p-3 shadow-lg";
+  const detailsStyle: CSSProperties = {
+    width: "min(22rem, calc(100vw - 1.5rem))",
+    backgroundColor: "hsl(var(--card))",
+    color: "hsl(var(--foreground))",
+  };
+  return (
+    <Popover>
+      <TooltipProvider delayDuration={150}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                data-feedback-chip=""
+                aria-label={`Show ${String(items.length)} ${items.length === 1 ? "quote" : "quotes"}`}
+                className="inline-flex h-9 w-fit max-w-56 items-center gap-2 rounded-xl border border-border bg-background px-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <IconQuote size={16} stroke={1.7} className="shrink-0" />
+                <span className="truncate">
+                  {String(items.length)}{" "}
+                  {items.length === 1 ? "quote" : "quotes"}
+                </span>
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent
+            data-feedback-details="hover"
+            side="top"
+            align="end"
+            sideOffset={8}
+            collisionPadding={12}
+            className={detailsClassName}
+            style={detailsStyle}
+          >
+            <FeedbackQuotesDetails items={items} />
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PopoverContent
+        data-feedback-details="click"
+        side="top"
+        align="end"
+        sideOffset={8}
+        className={detailsClassName}
+        style={detailsStyle}
+      >
+        <FeedbackQuotesDetails items={items} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function PagedUserMessage({
   message,
   thread,
@@ -6483,6 +6644,7 @@ function PagedUserMessage({
   thread: ChatThreadSignals;
 }) {
   const content = message.content ?? "";
+  const feedbackCardsEnabled = useGet(feedbackMessageCardsEnabled$);
   // Two attachment sources coexist: the structured `attachFiles` field
   // (current flow) and legacy `[Attached file: ...](url)` inline lines left
   // over from messages sent before #10243 split the flows. Use the structured
@@ -6490,14 +6652,18 @@ function PagedUserMessage({
   const { cleanContent, parsed } = parseInlineAttachments(content);
   const hasStructuredAttachments =
     message.attachFiles !== undefined && message.attachFiles.length > 0;
-  const copyText =
+  const unfilteredCopyText =
     !hasStructuredAttachments && parsed.length === 0
       ? content
       : hasStructuredAttachments &&
           cleanContent.trim() === ATTACH_ONLY_PLACEHOLDER
         ? ""
         : cleanContent;
+  const feedbackItems = feedbackCardsEnabled
+    ? message.feedbackPayload?.items
+    : undefined;
   const bodyBlocks = message.blocks;
+  const copyText = feedbackItems ? content : unfilteredCopyText;
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openLightbox = (url: string) => {
@@ -6550,6 +6716,14 @@ function PagedUserMessage({
             attachments={allAttachments}
             onImageClick={openLightbox}
           />
+          {feedbackItems ? (
+            <div
+              data-feedback-message=""
+              className="mb-2 flex max-w-[85%] justify-end"
+            >
+              <FeedbackQuotesChip items={feedbackItems} />
+            </div>
+          ) : null}
           {bodyBlocks.length > 0 && (
             <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
               <div className="px-4 py-3">


### PR DESCRIPTION
## Summary
- show one quote chip per feedback message in the composer and sent user messages
- support hover/click quote details, comment editing/removal, keyboard shortcuts, and isolated voice input
- persist quote drafts across refresh and chat switches
- restore quote chips when a queued message is recalled
- keep all quote behavior behind `FeedbackMessageCards`

## Depends on
- #22270

## Test plan
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- feedback card scenarios: 5 passed
- chat draft suite: 14 passed
- chat queue/recall suite: 11 passed
- markdown message rendering suite: 7 passed

## Existing test note
The complete legacy inline-feedback test file has pre-existing ProseMirror timing failures on the base commit as well (4 failures on the base versus 2 with this PR). The five new feedback-card scenarios pass independently.