### PR TITLE
chore(rust): update fastrand and syn lockfile versions

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -2970,7 +2970,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3198,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3303,7 +3303,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update `fastrand` from 2.4.1 to 2.5.0.
- Update `syn` from 3.0.0 to 3.0.2.
- Keep the maintenance change lockfile-only; no Rust source or manifest constraints changed.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available. `crypto-common` 0.1.7 pins `generic-array = "=0.14.7"` through the `digest` → `crc-fast` → `aws-smithy-checksums` → `aws-sdk-s3` → `runner` dependency path.

## Manual version bumps

- None. Both updates resolve within the existing `Cargo.toml` constraints.

## Verification

- `cargo test --workspace -j 1 -- --test-threads=1` passed on the final branch, including unit, integration, and doc tests.
- The local run used umask 0022, disabled test-profile debug info and incremental compilation, and placed the target directory on workspace storage to fit the constrained runner. No default tests were excluded; repository-defined ignored tests remained ignored.
