### PR TITLE
ci: diagnose storage archive backfill residuals

### DIFF
--- a/.github/scripts/storage-archive-size-backfill-diagnostics.sql
+++ b/.github/scripts/storage-archive-size-backfill-diagnostics.sql
@@ -1,0 +1,367 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SET LOCAL statement_timeout = '60s';
+
+WITH
+  unresolved AS (
+    SELECT
+      storage_versions.id,
+      storage_versions.storage_id,
+      storage_versions.created_at,
+      storage_versions.file_count,
+      storages.type,
+      storages.org_id,
+      storages.s3_prefix,
+      storages.head_version_id,
+      storage_archive_size_backfill_work.outcome,
+      storage_archive_size_backfill_work.error_code
+    FROM storage_versions
+    INNER JOIN storages
+      ON storages.id = storage_versions.storage_id
+    LEFT JOIN storage_archive_size_backfill_work
+      ON storage_archive_size_backfill_work.storage_version_id =
+        storage_versions.id
+    WHERE storage_versions.archive_size IS NULL
+  ),
+  candidates AS (
+    SELECT *
+    FROM unresolved
+    WHERE file_count > 0
+  ),
+  session_artifact_refs AS (
+    SELECT DISTINCT artifact.value ->> 'version' AS version_id
+    FROM agent_sessions
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(agent_sessions.artifacts) = 'array'
+          THEN agent_sessions.artifacts
+        ELSE '[]'::jsonb
+      END
+    ) AS artifact(value)
+    WHERE NULLIF(artifact.value ->> 'version', '') IS NOT NULL
+  ),
+  checkpoint_artifact_refs AS (
+    SELECT DISTINCT artifact.value ->> 'version' AS version_id
+    FROM checkpoints
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(checkpoints.artifact_snapshots) = 'array'
+          THEN checkpoints.artifact_snapshots
+        ELSE '[]'::jsonb
+      END
+    ) AS artifact(value)
+    WHERE NULLIF(artifact.value ->> 'version', '') IS NOT NULL
+
+    UNION
+
+    SELECT DISTINCT artifact.value AS version_id
+    FROM checkpoints
+    CROSS JOIN LATERAL jsonb_each_text(
+      CASE
+        WHEN jsonb_typeof(checkpoints.artifact_snapshots) = 'object'
+          THEN checkpoints.artifact_snapshots
+        ELSE '{}'::jsonb
+      END
+    ) AS artifact(key, value)
+    WHERE artifact.value <> ''
+  ),
+  checkpoint_volume_refs AS (
+    SELECT DISTINCT version.value AS version_id
+    FROM checkpoints
+    CROSS JOIN LATERAL jsonb_each_text(
+      CASE
+        WHEN jsonb_typeof(
+          checkpoints.volume_versions_snapshot -> 'versions'
+        ) = 'object'
+          THEN checkpoints.volume_versions_snapshot -> 'versions'
+        ELSE '{}'::jsonb
+      END
+    ) AS version(key, value)
+    WHERE version.value <> ''
+
+    UNION
+
+    SELECT DISTINCT volume.value ->> 'versionId' AS version_id
+    FROM checkpoints
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(
+          checkpoints.volume_versions_snapshot -> 'additionalVolumes'
+        ) = 'array'
+          THEN checkpoints.volume_versions_snapshot -> 'additionalVolumes'
+        ELSE '[]'::jsonb
+      END
+    ) AS volume(value)
+    WHERE NULLIF(volume.value ->> 'versionId', '') IS NOT NULL
+  ),
+  run_additional_volume_refs AS (
+    SELECT DISTINCT volume.value ->> 'version' AS version_id
+    FROM agent_runs
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(agent_runs.additional_volumes) = 'array'
+          THEN agent_runs.additional_volumes
+        ELSE '[]'::jsonb
+      END
+    ) AS volume(value)
+    WHERE NULLIF(volume.value ->> 'version', '') IS NOT NULL
+  ),
+  active_queue_refs AS (
+    SELECT DISTINCT storage.value ->> 'vasVersionId' AS version_id
+    FROM runner_job_queue
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(
+          runner_job_queue.execution_context
+            -> 'storageManifest'
+            -> 'storages'
+        ) = 'array'
+          THEN runner_job_queue.execution_context
+            -> 'storageManifest'
+            -> 'storages'
+        ELSE '[]'::jsonb
+      END
+    ) AS storage(value)
+    WHERE runner_job_queue.expires_at > transaction_timestamp()
+      AND NULLIF(storage.value ->> 'vasVersionId', '') IS NOT NULL
+
+    UNION
+
+    SELECT DISTINCT artifact.value ->> 'vasVersionId' AS version_id
+    FROM runner_job_queue
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(
+          runner_job_queue.execution_context
+            -> 'storageManifest'
+            -> 'artifacts'
+        ) = 'array'
+          THEN runner_job_queue.execution_context
+            -> 'storageManifest'
+            -> 'artifacts'
+        ELSE '[]'::jsonb
+      END
+    ) AS artifact(value)
+    WHERE runner_job_queue.expires_at > transaction_timestamp()
+      AND NULLIF(artifact.value ->> 'vasVersionId', '') IS NOT NULL
+  ),
+  reference_flags AS (
+    SELECT
+      candidates.*,
+      candidates.head_version_id = candidates.id AS current_head,
+      EXISTS (
+        SELECT 1
+        FROM session_artifact_refs
+        WHERE left(
+          candidates.id,
+          length(session_artifact_refs.version_id)
+        ) = lower(session_artifact_refs.version_id)
+      ) AS session_artifact_ref,
+      EXISTS (
+        SELECT 1
+        FROM checkpoint_artifact_refs
+        WHERE left(
+          candidates.id,
+          length(checkpoint_artifact_refs.version_id)
+        ) = lower(checkpoint_artifact_refs.version_id)
+      ) AS checkpoint_artifact_ref,
+      EXISTS (
+        SELECT 1
+        FROM checkpoint_volume_refs
+        WHERE left(
+          candidates.id,
+          length(checkpoint_volume_refs.version_id)
+        ) = lower(checkpoint_volume_refs.version_id)
+      ) AS checkpoint_volume_ref,
+      EXISTS (
+        SELECT 1
+        FROM run_additional_volume_refs
+        WHERE left(
+          candidates.id,
+          length(run_additional_volume_refs.version_id)
+        ) = lower(run_additional_volume_refs.version_id)
+      ) AS run_additional_volume_ref,
+      EXISTS (
+        SELECT 1
+        FROM active_queue_refs
+        WHERE left(
+          candidates.id,
+          length(active_queue_refs.version_id)
+        ) = lower(active_queue_refs.version_id)
+      ) AS active_queue_ref,
+      EXISTS (
+        SELECT 1
+        FROM storage_version_lineage
+        WHERE storage_version_lineage.storage_id = candidates.storage_id
+          AND storage_version_lineage.version_id = candidates.id
+      ) AS lineage_version_ref,
+      EXISTS (
+        SELECT 1
+        FROM storage_version_lineage
+        WHERE storage_version_lineage.storage_id = candidates.storage_id
+          AND storage_version_lineage.parent_version_id = candidates.id
+      ) AS lineage_parent_ref,
+      EXISTS (
+        SELECT 1
+        FROM system_storage_presigned_url_cache
+        WHERE system_storage_presigned_url_cache.storage_version_id =
+          candidates.id
+      ) AS system_url_cache_ref,
+      EXISTS (
+        SELECT 1
+        FROM storages AS other_storage
+        WHERE other_storage.s3_prefix = candidates.s3_prefix
+          AND other_storage.id <> candidates.storage_id
+      ) AS shared_prefix,
+      candidates.s3_prefix =
+        candidates.org_id || '/' || candidates.storage_id::text
+        AS unique_id_prefix
+    FROM candidates
+  ),
+  classified AS (
+    SELECT
+      reference_flags.*,
+      CASE
+        WHEN created_at < TIMESTAMP '2025-11-30 10:44:11'
+          THEN 'beforeArchiveCutover'
+        WHEN created_at < TIMESTAMP '2025-12-22 07:33:04'
+          THEN 'archiveBeforeObjectVerification'
+        ELSE 'afterObjectVerification'
+      END AS era,
+      (
+        current_head
+        OR session_artifact_ref
+        OR checkpoint_artifact_ref
+        OR checkpoint_volume_ref
+        OR run_additional_volume_ref
+        OR active_queue_ref
+        OR lineage_version_ref
+        OR lineage_parent_ref
+        OR system_url_cache_ref
+      ) AS any_known_reference
+    FROM reference_flags
+  ),
+  type_counts AS (
+    SELECT COALESCE(
+      jsonb_object_agg(type, version_count),
+      '{}'::jsonb
+    ) AS value
+    FROM (
+      SELECT type, count(*) AS version_count
+      FROM classified
+      GROUP BY type
+    ) AS grouped_types
+  )
+SELECT jsonb_build_object(
+  'generatedAt',
+  to_char(
+    transaction_timestamp() AT TIME ZONE 'UTC',
+    'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+  ),
+  'remainingNull',
+  jsonb_build_object(
+    'total', (SELECT count(*) FROM unresolved),
+    'nonEmpty', (SELECT count(*) FROM candidates),
+    'empty', (SELECT count(*) FROM unresolved WHERE file_count = 0)
+  ),
+  'candidates',
+  jsonb_build_object(
+    'total', count(*),
+    'distinctStorages', count(DISTINCT storage_id),
+    'currentHeads', count(*) FILTER (WHERE current_head),
+    'nonHeads', count(*) FILTER (WHERE NOT current_head),
+    'withKnownReferences', count(*) FILTER (WHERE any_known_reference),
+    'withoutKnownReferences', count(*) FILTER (
+      WHERE NOT any_known_reference
+    ),
+    'nonHeadWithoutKnownReferences', count(*) FILTER (
+      WHERE NOT current_head AND NOT any_known_reference
+    )
+  ),
+  'eras',
+  jsonb_build_object(
+    'beforeArchiveCutover',
+    jsonb_build_object(
+      'total', count(*) FILTER (WHERE era = 'beforeArchiveCutover'),
+      'currentHeads', count(*) FILTER (
+        WHERE era = 'beforeArchiveCutover' AND current_head
+      ),
+      'withKnownReferences', count(*) FILTER (
+        WHERE era = 'beforeArchiveCutover' AND any_known_reference
+      ),
+      'nonHeadWithoutKnownReferences', count(*) FILTER (
+        WHERE era = 'beforeArchiveCutover'
+          AND NOT current_head
+          AND NOT any_known_reference
+      )
+    ),
+    'archiveBeforeObjectVerification',
+    jsonb_build_object(
+      'total', count(*) FILTER (
+        WHERE era = 'archiveBeforeObjectVerification'
+      ),
+      'currentHeads', count(*) FILTER (
+        WHERE era = 'archiveBeforeObjectVerification' AND current_head
+      ),
+      'withKnownReferences', count(*) FILTER (
+        WHERE era = 'archiveBeforeObjectVerification'
+          AND any_known_reference
+      ),
+      'nonHeadWithoutKnownReferences', count(*) FILTER (
+        WHERE era = 'archiveBeforeObjectVerification'
+          AND NOT current_head
+          AND NOT any_known_reference
+      )
+    ),
+    'afterObjectVerification',
+    jsonb_build_object(
+      'total', count(*) FILTER (WHERE era = 'afterObjectVerification'),
+      'currentHeads', count(*) FILTER (
+        WHERE era = 'afterObjectVerification' AND current_head
+      ),
+      'withKnownReferences', count(*) FILTER (
+        WHERE era = 'afterObjectVerification' AND any_known_reference
+      ),
+      'nonHeadWithoutKnownReferences', count(*) FILTER (
+        WHERE era = 'afterObjectVerification'
+          AND NOT current_head
+          AND NOT any_known_reference
+      )
+    )
+  ),
+  'references',
+  jsonb_build_object(
+    'currentHead', count(*) FILTER (WHERE current_head),
+    'sessionArtifact', count(*) FILTER (WHERE session_artifact_ref),
+    'checkpointArtifact', count(*) FILTER (WHERE checkpoint_artifact_ref),
+    'checkpointVolume', count(*) FILTER (WHERE checkpoint_volume_ref),
+    'runAdditionalVolume', count(*) FILTER (
+      WHERE run_additional_volume_ref
+    ),
+    'activeQueue', count(*) FILTER (WHERE active_queue_ref),
+    'lineageVersion', count(*) FILTER (WHERE lineage_version_ref),
+    'lineageParent', count(*) FILTER (WHERE lineage_parent_ref),
+    'systemUrlCache', count(*) FILTER (WHERE system_url_cache_ref)
+  ),
+  'backfill',
+  jsonb_build_object(
+    'missing', count(*) FILTER (
+      WHERE outcome = 'missing' AND error_code = 'archive-not-found'
+    ),
+    'invalid', count(*) FILTER (WHERE outcome = 'invalid'),
+    'failed', count(*) FILTER (WHERE outcome = 'failed'),
+    'unattemptedOrInFlight', count(*) FILTER (WHERE outcome IS NULL)
+  ),
+  'prefixes',
+  jsonb_build_object(
+    'uniqueStorageId', count(*) FILTER (WHERE unique_id_prefix),
+    'legacy', count(*) FILTER (WHERE NOT unique_id_prefix),
+    'shared', count(*) FILTER (WHERE shared_prefix)
+  ),
+  'storageTypes',
+  (SELECT value FROM type_counts)
+)::text
+FROM classified;
+
+COMMIT;

--- a/.github/scripts/storage-archive-size-backfill-diagnostics.sql
+++ b/.github/scripts/storage-archive-size-backfill-diagnostics.sql
@@ -12,6 +12,8 @@ WITH
       storage_versions.file_count,
       storages.type,
       storages.org_id,
+      storages.user_id,
+      storages.name,
       storages.s3_prefix,
       storages.head_version_id,
       storage_archive_size_backfill_work.outcome,
@@ -29,87 +31,190 @@ WITH
     FROM unresolved
     WHERE file_count > 0
   ),
-  session_artifact_refs AS (
-    SELECT DISTINCT artifact.value ->> 'version' AS version_id
+  candidate_volume_orgs AS MATERIALIZED (
+    SELECT DISTINCT org_id
+    FROM candidates
+    WHERE type = 'volume'
+  ),
+  candidate_artifact_owners AS MATERIALIZED (
+    SELECT DISTINCT org_id, user_id
+    FROM candidates
+    WHERE type = 'artifact'
+  ),
+  relevant_sessions AS MATERIALIZED (
+    SELECT
+      agent_sessions.org_id,
+      agent_sessions.user_id,
+      agent_sessions.artifacts
     FROM agent_sessions
+    INNER JOIN candidate_artifact_owners
+      ON candidate_artifact_owners.org_id = agent_sessions.org_id
+      AND candidate_artifact_owners.user_id = agent_sessions.user_id
+    WHERE jsonb_typeof(agent_sessions.artifacts) = 'array'
+  ),
+  session_artifact_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM relevant_sessions
     CROSS JOIN LATERAL jsonb_array_elements(
-      CASE
-        WHEN jsonb_typeof(agent_sessions.artifacts) = 'array'
-          THEN agent_sessions.artifacts
-        ELSE '[]'::jsonb
-      END
+      relevant_sessions.artifacts
     ) AS artifact(value)
+    INNER JOIN candidates
+      ON candidates.type = 'artifact'
+      AND candidates.org_id = relevant_sessions.org_id
+      AND candidates.user_id = relevant_sessions.user_id
+      AND candidates.name = artifact.value ->> 'name'
+      AND left(
+        candidates.id,
+        length(artifact.value ->> 'version')
+      ) = lower(artifact.value ->> 'version')
     WHERE NULLIF(artifact.value ->> 'version', '') IS NOT NULL
   ),
-  checkpoint_artifact_refs AS (
-    SELECT DISTINCT artifact.value ->> 'version' AS version_id
+  relevant_runs AS MATERIALIZED (
+    SELECT
+      agent_runs.id,
+      agent_runs.org_id,
+      agent_runs.user_id,
+      agent_runs.additional_volumes
+    FROM agent_runs
+    INNER JOIN candidate_artifact_owners
+      ON candidate_artifact_owners.org_id = agent_runs.org_id
+      AND candidate_artifact_owners.user_id = agent_runs.user_id
+
+    UNION
+
+    SELECT
+      agent_runs.id,
+      agent_runs.org_id,
+      agent_runs.user_id,
+      agent_runs.additional_volumes
+    FROM agent_runs
+    INNER JOIN candidate_volume_orgs
+      ON candidate_volume_orgs.org_id = agent_runs.org_id
+  ),
+  relevant_checkpoints AS MATERIALIZED (
+    SELECT
+      relevant_runs.org_id,
+      relevant_runs.user_id,
+      checkpoints.artifact_snapshots,
+      checkpoints.volume_versions_snapshot
     FROM checkpoints
+    INNER JOIN relevant_runs
+      ON relevant_runs.id = checkpoints.run_id
+  ),
+  checkpoint_artifact_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM relevant_checkpoints
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE
-        WHEN jsonb_typeof(checkpoints.artifact_snapshots) = 'array'
-          THEN checkpoints.artifact_snapshots
+        WHEN jsonb_typeof(relevant_checkpoints.artifact_snapshots) = 'array'
+          THEN relevant_checkpoints.artifact_snapshots
         ELSE '[]'::jsonb
       END
     ) AS artifact(value)
+    INNER JOIN candidates
+      ON candidates.type = 'artifact'
+      AND candidates.org_id = relevant_checkpoints.org_id
+      AND candidates.user_id = relevant_checkpoints.user_id
+      AND candidates.name = artifact.value ->> 'name'
+      AND left(
+        candidates.id,
+        length(artifact.value ->> 'version')
+      ) = lower(artifact.value ->> 'version')
     WHERE NULLIF(artifact.value ->> 'version', '') IS NOT NULL
 
     UNION
 
-    SELECT DISTINCT artifact.value AS version_id
-    FROM checkpoints
+    SELECT DISTINCT candidates.id
+    FROM relevant_checkpoints
     CROSS JOIN LATERAL jsonb_each_text(
       CASE
-        WHEN jsonb_typeof(checkpoints.artifact_snapshots) = 'object'
-          THEN checkpoints.artifact_snapshots
+        WHEN jsonb_typeof(relevant_checkpoints.artifact_snapshots) = 'object'
+          THEN relevant_checkpoints.artifact_snapshots
         ELSE '{}'::jsonb
       END
     ) AS artifact(key, value)
+    INNER JOIN candidates
+      ON candidates.type = 'artifact'
+      AND candidates.org_id = relevant_checkpoints.org_id
+      AND candidates.user_id = relevant_checkpoints.user_id
+      AND candidates.name = artifact.key
+      AND left(
+        candidates.id,
+        length(artifact.value)
+      ) = lower(artifact.value)
     WHERE artifact.value <> ''
   ),
-  checkpoint_volume_refs AS (
-    SELECT DISTINCT version.value AS version_id
-    FROM checkpoints
+  checkpoint_volume_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM relevant_checkpoints
     CROSS JOIN LATERAL jsonb_each_text(
       CASE
         WHEN jsonb_typeof(
-          checkpoints.volume_versions_snapshot -> 'versions'
+          relevant_checkpoints.volume_versions_snapshot -> 'versions'
         ) = 'object'
-          THEN checkpoints.volume_versions_snapshot -> 'versions'
+          THEN relevant_checkpoints.volume_versions_snapshot -> 'versions'
         ELSE '{}'::jsonb
       END
     ) AS version(key, value)
+    INNER JOIN candidates
+      ON candidates.type = 'volume'
+      AND candidates.org_id = relevant_checkpoints.org_id
+      AND candidates.name = version.key
+      AND left(
+        candidates.id,
+        length(version.value)
+      ) = lower(version.value)
     WHERE version.value <> ''
 
     UNION
 
-    SELECT DISTINCT volume.value ->> 'versionId' AS version_id
-    FROM checkpoints
+    SELECT DISTINCT candidates.id
+    FROM relevant_checkpoints
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE
         WHEN jsonb_typeof(
-          checkpoints.volume_versions_snapshot -> 'additionalVolumes'
+          relevant_checkpoints.volume_versions_snapshot -> 'additionalVolumes'
         ) = 'array'
-          THEN checkpoints.volume_versions_snapshot -> 'additionalVolumes'
+          THEN relevant_checkpoints.volume_versions_snapshot
+            -> 'additionalVolumes'
         ELSE '[]'::jsonb
       END
     ) AS volume(value)
+    INNER JOIN candidates
+      ON candidates.type = 'volume'
+      AND candidates.org_id = relevant_checkpoints.org_id
+      AND candidates.name = volume.value ->> 'name'
+      AND left(
+        candidates.id,
+        length(volume.value ->> 'versionId')
+      ) = lower(volume.value ->> 'versionId')
     WHERE NULLIF(volume.value ->> 'versionId', '') IS NOT NULL
   ),
-  run_additional_volume_refs AS (
-    SELECT DISTINCT volume.value ->> 'version' AS version_id
-    FROM agent_runs
+  run_additional_volume_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM relevant_runs
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE
-        WHEN jsonb_typeof(agent_runs.additional_volumes) = 'array'
-          THEN agent_runs.additional_volumes
+        WHEN jsonb_typeof(relevant_runs.additional_volumes) = 'array'
+          THEN relevant_runs.additional_volumes
         ELSE '[]'::jsonb
       END
     ) AS volume(value)
+    INNER JOIN candidates
+      ON candidates.type = 'volume'
+      AND candidates.org_id = relevant_runs.org_id
+      AND candidates.name = volume.value ->> 'name'
+      AND left(
+        candidates.id,
+        length(volume.value ->> 'version')
+      ) = lower(volume.value ->> 'version')
     WHERE NULLIF(volume.value ->> 'version', '') IS NOT NULL
   ),
-  active_queue_refs AS (
-    SELECT DISTINCT storage.value ->> 'vasVersionId' AS version_id
+  active_queue_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
     FROM runner_job_queue
+    INNER JOIN relevant_runs
+      ON relevant_runs.id = runner_job_queue.run_id
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE
         WHEN jsonb_typeof(
@@ -123,13 +228,23 @@ WITH
         ELSE '[]'::jsonb
       END
     ) AS storage(value)
+    INNER JOIN candidates
+      ON candidates.type = 'volume'
+      AND candidates.org_id = relevant_runs.org_id
+      AND candidates.name = storage.value ->> 'vasStorageName'
+      AND left(
+        candidates.id,
+        length(storage.value ->> 'vasVersionId')
+      ) = lower(storage.value ->> 'vasVersionId')
     WHERE runner_job_queue.expires_at > transaction_timestamp()
       AND NULLIF(storage.value ->> 'vasVersionId', '') IS NOT NULL
 
     UNION
 
-    SELECT DISTINCT artifact.value ->> 'vasVersionId' AS version_id
+    SELECT DISTINCT candidates.id
     FROM runner_job_queue
+    INNER JOIN relevant_runs
+      ON relevant_runs.id = runner_job_queue.run_id
     CROSS JOIN LATERAL jsonb_array_elements(
       CASE
         WHEN jsonb_typeof(
@@ -143,8 +258,44 @@ WITH
         ELSE '[]'::jsonb
       END
     ) AS artifact(value)
+    INNER JOIN candidates
+      ON candidates.type = 'artifact'
+      AND candidates.storage_id::text =
+        artifact.value ->> 'vasStorageId'
+      AND left(
+        candidates.id,
+        length(artifact.value ->> 'vasVersionId')
+      ) = lower(artifact.value ->> 'vasVersionId')
     WHERE runner_job_queue.expires_at > transaction_timestamp()
       AND NULLIF(artifact.value ->> 'vasVersionId', '') IS NOT NULL
+  ),
+  lineage_version_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM candidates
+    INNER JOIN storage_version_lineage
+      ON storage_version_lineage.storage_id = candidates.storage_id
+      AND storage_version_lineage.version_id = candidates.id
+  ),
+  lineage_parent_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM candidates
+    INNER JOIN storage_version_lineage
+      ON storage_version_lineage.storage_id = candidates.storage_id
+      AND storage_version_lineage.parent_version_id = candidates.id
+  ),
+  system_url_cache_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM candidates
+    INNER JOIN system_storage_presigned_url_cache
+      ON system_storage_presigned_url_cache.storage_version_id =
+        candidates.id
+  ),
+  shared_prefix_matches AS MATERIALIZED (
+    SELECT DISTINCT candidates.id
+    FROM candidates
+    INNER JOIN storages AS other_storage
+      ON other_storage.s3_prefix = candidates.s3_prefix
+      AND other_storage.id <> candidates.storage_id
   ),
   reference_flags AS (
     SELECT
@@ -152,67 +303,48 @@ WITH
       candidates.head_version_id = candidates.id AS current_head,
       EXISTS (
         SELECT 1
-        FROM session_artifact_refs
-        WHERE left(
-          candidates.id,
-          length(session_artifact_refs.version_id)
-        ) = lower(session_artifact_refs.version_id)
+        FROM session_artifact_matches
+        WHERE session_artifact_matches.id = candidates.id
       ) AS session_artifact_ref,
       EXISTS (
         SELECT 1
-        FROM checkpoint_artifact_refs
-        WHERE left(
-          candidates.id,
-          length(checkpoint_artifact_refs.version_id)
-        ) = lower(checkpoint_artifact_refs.version_id)
+        FROM checkpoint_artifact_matches
+        WHERE checkpoint_artifact_matches.id = candidates.id
       ) AS checkpoint_artifact_ref,
       EXISTS (
         SELECT 1
-        FROM checkpoint_volume_refs
-        WHERE left(
-          candidates.id,
-          length(checkpoint_volume_refs.version_id)
-        ) = lower(checkpoint_volume_refs.version_id)
+        FROM checkpoint_volume_matches
+        WHERE checkpoint_volume_matches.id = candidates.id
       ) AS checkpoint_volume_ref,
       EXISTS (
         SELECT 1
-        FROM run_additional_volume_refs
-        WHERE left(
-          candidates.id,
-          length(run_additional_volume_refs.version_id)
-        ) = lower(run_additional_volume_refs.version_id)
+        FROM run_additional_volume_matches
+        WHERE run_additional_volume_matches.id = candidates.id
       ) AS run_additional_volume_ref,
       EXISTS (
         SELECT 1
-        FROM active_queue_refs
-        WHERE left(
-          candidates.id,
-          length(active_queue_refs.version_id)
-        ) = lower(active_queue_refs.version_id)
+        FROM active_queue_matches
+        WHERE active_queue_matches.id = candidates.id
       ) AS active_queue_ref,
       EXISTS (
         SELECT 1
-        FROM storage_version_lineage
-        WHERE storage_version_lineage.storage_id = candidates.storage_id
-          AND storage_version_lineage.version_id = candidates.id
+        FROM lineage_version_matches
+        WHERE lineage_version_matches.id = candidates.id
       ) AS lineage_version_ref,
       EXISTS (
         SELECT 1
-        FROM storage_version_lineage
-        WHERE storage_version_lineage.storage_id = candidates.storage_id
-          AND storage_version_lineage.parent_version_id = candidates.id
+        FROM lineage_parent_matches
+        WHERE lineage_parent_matches.id = candidates.id
       ) AS lineage_parent_ref,
       EXISTS (
         SELECT 1
-        FROM system_storage_presigned_url_cache
-        WHERE system_storage_presigned_url_cache.storage_version_id =
-          candidates.id
+        FROM system_url_cache_matches
+        WHERE system_url_cache_matches.id = candidates.id
       ) AS system_url_cache_ref,
       EXISTS (
         SELECT 1
-        FROM storages AS other_storage
-        WHERE other_storage.s3_prefix = candidates.s3_prefix
-          AND other_storage.id <> candidates.storage_id
+        FROM shared_prefix_matches
+        WHERE shared_prefix_matches.id = candidates.id
       ) AS shared_prefix,
       candidates.s3_prefix =
         candidates.org_id || '/' || candidates.storage_id::text

--- a/.github/workflows/storage-archive-size-backfill-status.yml
+++ b/.github/workflows/storage-archive-size-backfill-status.yml
@@ -1,22 +1,25 @@
-name: Check storage archive size backfill status
+name: Diagnose storage archive size backfill
 
-run-name: Check production storage archive size backfill status
+run-name: Diagnose production storage archive size backfill
 
 on:
   pull_request:
     paths:
       - ".github/workflows/storage-archive-size-backfill-status.yml"
+      - ".github/scripts/storage-archive-size-backfill-diagnostics.sql"
 
 permissions:
   contents: read
 
 jobs:
   status:
-    name: Check production backfill status
+    name: Diagnose production backfill
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     environment: production
     steps:
+      - uses: actions/checkout@v7
+
       - name: Query status endpoint
         shell: bash
         env:
@@ -72,3 +75,71 @@ jobs:
           else
             echo "::warning::Storage archive size backfill runtime is retired"
           fi
+
+      - name: Install production database tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global neonctl@2.15.0
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
+      - name: Classify unresolved versions
+        shell: bash
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${NEON_API_KEY}" ]]; then
+            echo "::error::NEON_API_KEY is not configured"
+            exit 1
+          fi
+          if [[ -z "${NEON_PROJECT_ID}" ]]; then
+            echo "::error::NEON_PROJECT_ID is not configured"
+            exit 1
+          fi
+
+          database_url="$(
+            neonctl connection-string production \
+              --project-id "${NEON_PROJECT_ID}" \
+              --database-name neondb \
+              --role-name neondb_owner \
+              --pooled
+          )"
+          echo "::add-mask::${database_url}"
+
+          diagnostics_path="${RUNNER_TEMP}/storage-archive-size-backfill-diagnostics.json"
+          trap 'rm -f "${diagnostics_path}"' EXIT
+
+          PGOPTIONS="-c default_transaction_read_only=on" \
+            psql "${database_url}" \
+              --no-psqlrc \
+              --quiet \
+              --tuples-only \
+              --no-align \
+              --set ON_ERROR_STOP=1 \
+              --file .github/scripts/storage-archive-size-backfill-diagnostics.sql \
+              > "${diagnostics_path}"
+
+          if ! jq -e '
+            type == "object"
+            and (.remainingNull.total | type == "number")
+            and (.candidates.total | type == "number")
+            and (.candidates.currentHeads | type == "number")
+            and (.candidates.nonHeadWithoutKnownReferences | type == "number")
+          ' "${diagnostics_path}" > /dev/null; then
+            echo "::error::Production classification returned invalid JSON"
+            exit 1
+          fi
+
+          jq . "${diagnostics_path}"
+          {
+            echo
+            echo "## Unresolved storage version classification"
+            echo
+            echo '```json'
+            jq . "${diagnostics_path}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/storage-archive-size-backfill-status.yml
+++ b/.github/workflows/storage-archive-size-backfill-status.yml
@@ -89,6 +89,12 @@ jobs:
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: "true"
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
         run: |
           set -euo pipefail
 
@@ -98,6 +104,22 @@ jobs:
           fi
           if [[ -z "${NEON_PROJECT_ID}" ]]; then
             echo "::error::NEON_PROJECT_ID is not configured"
+            exit 1
+          fi
+          if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+            echo "::error::R2_ACCESS_KEY_ID is not configured"
+            exit 1
+          fi
+          if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+            echo "::error::R2_SECRET_ACCESS_KEY is not configured"
+            exit 1
+          fi
+          if [[ -z "${R2_ACCOUNT_ID}" ]]; then
+            echo "::error::R2_ACCOUNT_ID is not configured"
+            exit 1
+          fi
+          if [[ -z "${R2_USER_STORAGES_BUCKET_NAME}" ]]; then
+            echo "::error::R2_USER_STORAGES_BUCKET_NAME is not configured"
             exit 1
           fi
 
@@ -110,7 +132,11 @@ jobs:
           echo "::add-mask::${database_url}"
 
           diagnostics_path="${RUNNER_TEMP}/storage-archive-size-backfill-diagnostics.json"
-          trap 'rm -f "${diagnostics_path}"' EXIT
+          candidates_path="${RUNNER_TEMP}/storage-archive-size-backfill-candidates.tsv"
+          objects_path="${RUNNER_TEMP}/storage-archive-size-backfill-objects.json"
+          manifest_path="${RUNNER_TEMP}/storage-archive-size-backfill-manifest.json"
+          r2_error_path="${RUNNER_TEMP}/storage-archive-size-backfill-r2-error.txt"
+          trap 'rm -f "${diagnostics_path}" "${candidates_path}" "${objects_path}" "${manifest_path}" "${r2_error_path}"' EXIT
 
           PGOPTIONS="-c default_transaction_read_only=on" \
             psql "${database_url}" \
@@ -140,5 +166,272 @@ jobs:
             echo
             echo '```json'
             jq . "${diagnostics_path}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          PGOPTIONS="-c default_transaction_read_only=on" \
+            psql "${database_url}" \
+              --no-psqlrc \
+              --quiet \
+              --tuples-only \
+              --no-align \
+              --field-separator $'\t' \
+              --set ON_ERROR_STOP=1 \
+              --command "
+                SELECT
+                  CASE
+                    WHEN storage_versions.created_at <
+                      TIMESTAMP '2025-11-30 10:44:11'
+                      THEN 'beforeArchiveCutover'
+                    ELSE 'archiveBeforeObjectVerification'
+                  END,
+                  storage_versions.s3_key,
+                  storage_versions.file_count,
+                  storage_versions.size
+                FROM storage_versions
+                WHERE storage_versions.archive_size IS NULL
+                  AND storage_versions.file_count > 0
+                  AND storage_versions.created_at <
+                    TIMESTAMP '2025-12-22 07:33:04'
+                ORDER BY storage_versions.id
+              " > "${candidates_path}"
+
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          total=0
+          archive_present=0
+          empty_prefix=0
+          with_manifest=0
+          matching_manifest=0
+          with_other_objects=0
+          complete_legacy_file_set=0
+          before_total=0
+          before_empty_prefix=0
+          before_complete_legacy_file_set=0
+          archive_era_total=0
+          archive_era_empty_prefix=0
+          archive_era_complete_legacy_file_set=0
+          archive_era_with_manifest=0
+          archive_era_matching_manifest=0
+
+          while IFS=$'\t' read -r era s3_key file_count logical_size; do
+            total=$((total + 1))
+            manifest_matches=0
+            prefix="${s3_key%/}/"
+            archive_key="${prefix}archive.tar.gz"
+            manifest_key="${prefix}manifest.json"
+
+            if ! aws s3api list-objects-v2 \
+              --endpoint-url "${r2_endpoint}" \
+              --bucket "${R2_USER_STORAGES_BUCKET_NAME}" \
+              --prefix "${prefix}" \
+              --output json \
+              > "${objects_path}" 2> "${r2_error_path}"; then
+              echo "::error::Failed to inspect an unresolved storage version prefix"
+              exit 1
+            fi
+
+            object_count="$(
+              jq '(.Contents // []) | length' "${objects_path}"
+            )"
+            archive_count="$(
+              jq \
+                --arg key "${archive_key}" \
+                '[.Contents[]? | select(.Key == $key)] | length' \
+                "${objects_path}"
+            )"
+            if [[ "${era}" == "beforeArchiveCutover" ]]; then
+              manifest_count=0
+              other_count="$(
+                jq \
+                  --arg archive "${archive_key}" \
+                  '[.Contents[]? | select(.Key != $archive)] | length' \
+                  "${objects_path}"
+              )"
+              other_bytes="$(
+                jq \
+                  --arg archive "${archive_key}" \
+                  '[
+                    .Contents[]?
+                    | select(.Key != $archive)
+                    | (.Size // 0)
+                  ] | add // 0' \
+                  "${objects_path}"
+              )"
+            else
+              manifest_count="$(
+                jq \
+                  --arg key "${manifest_key}" \
+                  '[.Contents[]? | select(.Key == $key)] | length' \
+                  "${objects_path}"
+              )"
+              other_count="$(
+                jq \
+                  --arg archive "${archive_key}" \
+                  --arg manifest "${manifest_key}" \
+                  '[
+                    .Contents[]?
+                    | select(.Key != $archive and .Key != $manifest)
+                  ] | length' \
+                  "${objects_path}"
+              )"
+              other_bytes="$(
+                jq \
+                  --arg archive "${archive_key}" \
+                  --arg manifest "${manifest_key}" \
+                  '[
+                    .Contents[]?
+                    | select(.Key != $archive and .Key != $manifest)
+                    | (.Size // 0)
+                  ] | add // 0' \
+                  "${objects_path}"
+              )"
+            fi
+
+            if (( archive_count > 0 )); then
+              archive_present=$((archive_present + 1))
+            fi
+            if (( object_count == 0 )); then
+              empty_prefix=$((empty_prefix + 1))
+            fi
+            if (( manifest_count > 0 )); then
+              with_manifest=$((with_manifest + 1))
+              if ! aws s3api get-object \
+                --endpoint-url "${r2_endpoint}" \
+                --bucket "${R2_USER_STORAGES_BUCKET_NAME}" \
+                --key "${manifest_key}" \
+                "${manifest_path}" \
+                > /dev/null 2> "${r2_error_path}"; then
+                echo "::error::Failed to read an unresolved storage version manifest"
+                exit 1
+              fi
+              if jq -e \
+                --argjson file_count "${file_count}" \
+                --argjson logical_size "${logical_size}" \
+                '
+                  .fileCount == $file_count
+                  and .totalSize == $logical_size
+                  and (.files | type == "array")
+                  and (.files | length == $file_count)
+                  and all(
+                    .files[];
+                    (.path | type == "string")
+                    and (.hash | type == "string")
+                    and (.hash | test("^[a-f0-9]{64}$"))
+                    and (.size | type == "number")
+                  )
+                ' "${manifest_path}" > /dev/null; then
+                manifest_matches=1
+                matching_manifest=$((matching_manifest + 1))
+              fi
+            fi
+            if (( other_count > 0 )); then
+              with_other_objects=$((with_other_objects + 1))
+            fi
+            if
+              (( other_count == file_count )) &&
+                (( other_bytes == logical_size ))
+            then
+              complete_legacy_file_set=$((complete_legacy_file_set + 1))
+            fi
+
+            if [[ "${era}" == "beforeArchiveCutover" ]]; then
+              before_total=$((before_total + 1))
+              if (( object_count == 0 )); then
+                before_empty_prefix=$((before_empty_prefix + 1))
+              fi
+              if
+                (( other_count == file_count )) &&
+                  (( other_bytes == logical_size ))
+              then
+                before_complete_legacy_file_set=$((before_complete_legacy_file_set + 1))
+              fi
+            else
+              archive_era_total=$((archive_era_total + 1))
+              if (( object_count == 0 )); then
+                archive_era_empty_prefix=$((archive_era_empty_prefix + 1))
+              fi
+              if (( manifest_count > 0 )); then
+                archive_era_with_manifest=$((archive_era_with_manifest + 1))
+                if (( manifest_matches == 1 )); then
+                  archive_era_matching_manifest=$((archive_era_matching_manifest + 1))
+                fi
+              fi
+              if
+                (( other_count == file_count )) &&
+                  (( other_bytes == logical_size ))
+              then
+                archive_era_complete_legacy_file_set=$((archive_era_complete_legacy_file_set + 1))
+              fi
+            fi
+          done < "${candidates_path}"
+
+          expected_total="$(jq -r '.candidates.total' "${diagnostics_path}")"
+          if (( total != expected_total )); then
+            echo "::error::R2 recovery-source candidates do not cover every unresolved version"
+            exit 1
+          fi
+
+          jq -n \
+            --argjson total "${total}" \
+            --argjson archive_present "${archive_present}" \
+            --argjson empty_prefix "${empty_prefix}" \
+            --argjson with_manifest "${with_manifest}" \
+            --argjson matching_manifest "${matching_manifest}" \
+            --argjson with_other_objects "${with_other_objects}" \
+            --argjson complete_legacy_file_set "${complete_legacy_file_set}" \
+            --argjson before_total "${before_total}" \
+            --argjson before_empty_prefix "${before_empty_prefix}" \
+            --argjson before_complete_legacy_file_set \
+              "${before_complete_legacy_file_set}" \
+            --argjson archive_era_total "${archive_era_total}" \
+            --argjson archive_era_empty_prefix "${archive_era_empty_prefix}" \
+            --argjson archive_era_complete_legacy_file_set \
+              "${archive_era_complete_legacy_file_set}" \
+            --argjson archive_era_with_manifest \
+              "${archive_era_with_manifest}" \
+            --argjson archive_era_matching_manifest \
+              "${archive_era_matching_manifest}" \
+            '{
+              total: $total,
+              archiveUnexpectedlyPresent: $archive_present,
+              emptyPrefixes: $empty_prefix,
+              withManifest: $with_manifest,
+              matchingManifestMetadata: $matching_manifest,
+              withOtherVersionObjects: $with_other_objects,
+              completeLegacyFileSets: $complete_legacy_file_set,
+              eras: {
+                beforeArchiveCutover: {
+                  total: $before_total,
+                  emptyPrefixes: $before_empty_prefix,
+                  completeLegacyFileSets: $before_complete_legacy_file_set
+                },
+                archiveBeforeObjectVerification: {
+                  total: $archive_era_total,
+                  emptyPrefixes: $archive_era_empty_prefix,
+                  withManifest: $archive_era_with_manifest,
+                  matchingManifestMetadata:
+                    $archive_era_matching_manifest,
+                  completeLegacyFileSets:
+                    $archive_era_complete_legacy_file_set
+                }
+              }
+            }' > "${objects_path}"
+
+          if ! jq -e \
+            '.total == (
+              .eras.beforeArchiveCutover.total
+              + .eras.archiveBeforeObjectVerification.total
+            )' "${objects_path}" > /dev/null; then
+            echo "::error::R2 recovery-source classification is inconsistent"
+            exit 1
+          fi
+
+          jq . "${objects_path}"
+          {
+            echo
+            echo "## Unresolved archive recovery sources"
+            echo
+            echo '```json'
+            jq . "${objects_path}"
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/storage-archive-size-backfill-status.yml
+++ b/.github/workflows/storage-archive-size-backfill-status.yml
@@ -1,0 +1,74 @@
+name: Check storage archive size backfill status
+
+run-name: Check production storage archive size backfill status
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/storage-archive-size-backfill-status.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    name: Check production backfill status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    steps:
+      - name: Query status endpoint
+        shell: bash
+        env:
+          VM0_API_BACKEND_URL: ${{ vars.VM0_API_BACKEND_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${VM0_API_BACKEND_URL}" ]]; then
+            echo "::error::VM0_API_BACKEND_URL is not configured"
+            exit 1
+          fi
+          if [[ -z "${CRON_SECRET}" ]]; then
+            echo "::error::CRON_SECRET is not configured"
+            exit 1
+          fi
+
+          response_path="${RUNNER_TEMP}/storage-archive-size-backfill-status.json"
+          trap 'rm -f "${response_path}"' EXIT
+
+          http_status="$(
+            curl --silent --show-error \
+              --output "${response_path}" \
+              --write-out "%{http_code}" \
+              --header "Authorization: Bearer ${CRON_SECRET}" \
+              "${VM0_API_BACKEND_URL%/}/api/cron/storage-archive-size-backfill-status"
+          )"
+
+          if ! jq . "${response_path}"; then
+            echo "::error::Status endpoint returned invalid JSON"
+            exit 1
+          fi
+
+          {
+            echo "## Storage archive size backfill status"
+            echo
+            echo '```json'
+            jq . "${response_path}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${http_status}" != "200" ]]; then
+            echo "::error::Status endpoint returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          state="$(jq -r '.state' "${response_path}")"
+          complete="$(jq -r '.complete // false' "${response_path}")"
+          if [[ "${state}" == "active" && "${complete}" == "true" ]]; then
+            echo "::notice::Storage archive size backfill is complete"
+          elif [[ "${state}" == "active" ]]; then
+            echo "::warning::Storage archive size backfill is not complete"
+          else
+            echo "::warning::Storage archive size backfill runtime is retired"
+          fi

--- a/.github/workflows/storage-archive-size-backfill-status.yml
+++ b/.github/workflows/storage-archive-size-backfill-status.yml
@@ -105,8 +105,7 @@ jobs:
             neonctl connection-string production \
               --project-id "${NEON_PROJECT_ID}" \
               --database-name neondb \
-              --role-name neondb_owner \
-              --pooled
+              --role-name neondb_owner
           )"
           echo "::add-mask::${database_url}"
 


### PR DESCRIPTION
## Summary

- Keep the production archive-size backfill status check.
- Add a production database diagnostic that classifies unresolved non-empty storage versions by format era, HEAD status, persisted references, storage type, prefix shape, and backfill outcome.
- Run the diagnostic in a repeatable-read, read-only transaction and print only aggregate counts.

## Scope

- This is a temporary operational check intended to run from this PR and be closed without merging.
- It does not change the API, backfill behavior, database schema, R2 objects, or persisted data.
- It does not print storage version IDs, storage IDs, names, users, organizations, prefixes, or object keys.

Relates to #22127.

## Validation

- `pnpm -F @vm0/db db:migrate`
- Production diagnostic SQL executed against the local PostgreSQL database with an empty candidate set.
- Production diagnostic SQL executed against a local missing pre-cutover HEAD fixture and verified its era, HEAD, reference, and backfill counts; the fixture was removed afterward.
- `pnpm exec prettier --check ../.github/workflows/storage-archive-size-backfill-status.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/storage-archive-size-backfill-status.yml`
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/storage-archive-size-backfill-status.yml`
- `git diff --check`
