### PR TITLE
refactor(api): enforce structured sql result mapping

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -73,7 +73,8 @@ PostgreSQL driver values. Never use them to declare a database result contract.
 ### Structured Selections
 
 For every raw expression selected by `select`, `selectDistinct`,
-`selectDistinctOn`, or `returning`, choose the first applicable runtime boundary:
+`selectDistinctOn`, `returning`, or relational-query `extras`, choose the first
+applicable runtime boundary:
 
 1. Prefer a schema column or a Drizzle helper such as `count()` that already
    owns the correct decoder.
@@ -108,6 +109,15 @@ not add or replace its decoder. A PostgreSQL cast such as `::int` changes the
 server-side value representation, while `.mapWith(...)` defines the client-side
 runtime decoder. A TypeScript assertion changes neither one.
 
+The same rule applies to `db.query.<table>.findMany(...)` and
+`findFirst(...)`, including callback-form `extras` and `extras` nested below
+`with`. Keep relational configs inline or in inspectable local variables so
+lint can follow every selected extra. Call `select`, `selectDistinct`,
+`selectDistinctOn`, `returning`, `findMany`, and `findFirst` directly; do not
+alias, destructure, or bind these methods, and do not spread their invocation
+arguments, because those forms hide the result boundary from static
+enforcement.
+
 For set operations, every branch must expose a compatible, concretely mapped
 output. Drizzle uses the leftmost branch's decoder for returned rows, so the
 leftmost expression owns the runtime contract; mapping later branches does not
@@ -125,7 +135,9 @@ expression, write value, discarded command, or `rowCount` command result does
 not produce a structured field and needs no result decoder. Leave those
 expressions as unparameterized `sql` and `SQL`. If a write query adds
 `.returning({...})`, map raw SQL in the returned fields independently of
-`.set({...})`.
+`.set({...})`. Likewise, raw SQL passed to `insert(...).select(...)` is the
+write source rather than a returned field; only a subsequent `returning(...)`
+introduces a result-mapping boundary.
 
 ### Raw Execute Rows
 

--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -64,6 +64,98 @@ Pure data transforms that only touch the database should use regular SQL migrati
 - **Excluded from CI**: completed scripts that reference deleted schemas are excluded
   from `tsconfig.json` and `eslint.config.js` to avoid build errors
 
+## Database Result Boundaries
+
+Drizzle's `sql<T>`, `SQL<T>`, generic `.as<T>()`, `execute<Row>`, and TypeScript
+assertions only change compile-time types. They do not validate or decode
+PostgreSQL driver values. Never use them to declare a database result contract.
+
+### Structured Selections
+
+For every raw expression selected by `select`, `selectDistinct`,
+`selectDistinctOn`, or `returning`, choose the first applicable runtime boundary:
+
+1. Prefer a schema column or a Drizzle helper such as `count()` that already
+   owns the correct decoder.
+2. Use `.mapWith(column)` when the expression has exactly the same PostgreSQL
+   runtime representation as that column.
+3. Use `.mapWith(decoder)` for a dedicated runtime contract. Shared decoders
+   live in `turbo/apps/api/src/lib/db-structured-result.ts`.
+4. If the expression can return SQL `NULL`, wrap the column or decoder with
+   `nullableDriverValueDecoder(...)`. Drizzle preserves `null` and applies the
+   wrapped decoder only to non-null values.
+
+```typescript
+// Correct: LOWER(text) has the same driver representation as the text column.
+const normalizedEmail =
+  sql`LOWER(${users.email})`.mapWith(users.email).as("normalized_email");
+
+// Correct: the explicit decoder owns the runtime number contract.
+const total = sql`COUNT(*)::int`.mapWith(pgIntegerDecoder).as("total");
+
+// Correct: nullable SQL result with the column's non-null decoder.
+const latestName = sql`MAX(${users.name})`
+  .mapWith(nullableDriverValueDecoder(users.name))
+  .as("latest_name");
+
+// Incorrect: these only restate a TypeScript type.
+const unsafeEmail = sql<string>`LOWER(${users.email})`;
+const unsafeAlias = sql`LOWER(${users.email})`.as<string>("email");
+```
+
+Apply `.mapWith(...)` before `.as("alias")`; aliasing names a SQL field but does
+not add or replace its decoder. A PostgreSQL cast such as `::int` changes the
+server-side value representation, while `.mapWith(...)` defines the client-side
+runtime decoder. A TypeScript assertion changes neither one.
+
+For set operations, every branch must expose a compatible, concretely mapped
+output. Drizzle uses the leftmost branch's decoder for returned rows, so the
+leftmost expression owns the runtime contract; mapping later branches does not
+repair an unmapped leftmost branch.
+
+PostgreSQL `int8` and `numeric` commonly arrive from `pg` as strings to avoid
+precision loss. Use `pgInt8ToSafeIntegerDecoder` only when the value is required
+to fit a JavaScript safe integer, and `pgInt8ToBigIntDecoder` when lossless
+integer precision is required. Do not coerce arbitrary `numeric` values with
+`Number` unless the domain contract explicitly permits the resulting precision;
+use a dedicated decoder that preserves or validates the required representation.
+
+Raw SQL used only as a predicate, join condition, ordering or grouping
+expression, write value, discarded command, or `rowCount` command result does
+not produce a structured field and needs no result decoder. Leave those
+expressions as unparameterized `sql` and `SQL`. If a write query adds
+`.returning({...})`, map raw SQL in the returned fields independently of
+`.set({...})`.
+
+### Raw Execute Rows
+
+Prefer structured Drizzle selections whenever they can express the query.
+Direct `db.execute(...)` is allowed when rows are discarded or only `rowCount`
+is consumed. When an irreducible raw query returns rows, use
+`executeRawRows(executor, query, rowSchema)` from
+`turbo/apps/api/src/lib/db-raw-rows.ts`:
+
+```typescript
+const rowSchema = z.object({
+  id: z.string().uuid(),
+  size_bytes: pgInt8ToSafeIntegerSchema,
+});
+
+const rows = await executeRawRows(
+  db,
+  sql`SELECT id, size_bytes FROM artifacts`,
+  rowSchema,
+);
+```
+
+`executeRawRows` executes without a row generic and parses every returned driver
+row with the supplied schema; its TypeScript output is inferred from that schema.
+Use schema transforms such as `pgInt8ToSafeIntegerSchema`,
+`pgInt8ToBigIntSchema`, and `pgTimestampWithoutTimezoneToDateSchema` when the
+driver representation differs from the application value. Never replace this
+boundary with `execute<Row>`, a typed wrapper around `db.execute`, or a
+downstream assertion.
+
 ## Checklist
 
 Before committing:

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -281,6 +281,7 @@ export default [
       "api/no-new-promise": "error",
       "api/no-store-in-params": "error",
       "api/require-execute-row-schema": "error",
+      "api/require-sql-result-mapping": "error",
       "api/signal-check-await": "error",
     },
   },

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -526,7 +526,7 @@ function runnerPollPriorityOrder(args: {
   readonly runnerId: string | undefined;
   readonly runnerGroup: string;
   readonly currentDate: Date;
-}): SQL<unknown>[] {
+}): SQL[] {
   if (!args.runnerId) {
     return [];
   }
@@ -556,7 +556,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const { group, supportedProfiles } = body.data;
-  const whereConditions: SQL<unknown>[] = [
+  const whereConditions: SQL[] = [
     eq(runnerJobQueue.runnerGroup, group),
     gt(runnerJobQueue.expiresAt, sql`now()`),
     eq(agentRuns.status, "pending"),

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -45,7 +45,7 @@ function lastRunFinishMessageSubquery(db: Pick<Db, "select">) {
 }
 
 function latestRunFinishCreatedAtSql() {
-  return sql<Date>`(
+  return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
     WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -14,7 +14,7 @@ import { zeroChatThreadUnreads } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route-entry";
 
 function latestRunFinishCreatedAtSql() {
-  return sql<Date>`(
+  return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
     WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-chat-assistant.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-chat-assistant.service.ts
@@ -219,11 +219,11 @@ export const processChatAssistantEvents$ = command(
       .onConflictDoUpdate({
         target: chatOutputMaterializations.runId,
         set: {
-          processedThroughSequence: sql<number>`greatest(${chatOutputMaterializations.processedThroughSequence}, ${processedThroughSequence})`,
+          processedThroughSequence: sql`greatest(${chatOutputMaterializations.processedThroughSequence}, ${processedThroughSequence})`,
           latestResultSequence:
             resultSequence === null
               ? chatOutputMaterializations.latestResultSequence
-              : sql<number>`greatest(coalesce(${chatOutputMaterializations.latestResultSequence}, -1), ${resultSequence})`,
+              : sql`greatest(coalesce(${chatOutputMaterializations.latestResultSequence}, -1), ${resultSequence})`,
           updatedAt,
         },
       });

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -156,7 +156,7 @@ async function persistLastEventSequence(
   await db
     .update(agentRuns)
     .set({
-      lastEventSequence: sql<number>`greatest(coalesce(${agentRuns.lastEventSequence}, -1), ${lastEventSequence})`,
+      lastEventSequence: sql`greatest(coalesce(${agentRuns.lastEventSequence}, -1), ${lastEventSequence})`,
     })
     .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)));
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -641,7 +641,7 @@ async function latestEventBackedAssistantMessage(
         eq(chatMessages.role, "assistant"),
         isNotNull(chatMessages.sequenceNumber),
         isNotNull(chatMessages.content),
-        sql<boolean>`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
+        sql`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
         ...(options.maxSequenceNumber === undefined
           ? []
           : [lte(chatMessages.sequenceNumber, options.maxSequenceNumber)]),

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -140,7 +140,7 @@ function parseModelRankingPeriod(
 
 function modelUsageObservationModelExpression() {
   const modelColumn = sql.raw('"model_usage_observation"."model"');
-  return sql<string>`CASE ${sql.join(
+  return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
       return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
     }),
@@ -150,7 +150,7 @@ function modelUsageObservationModelExpression() {
 
 function modelStatModelExpression() {
   const modelColumn = sql.raw('"model_stat"."model"');
-  return sql<string>`CASE ${sql.join(
+  return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
       return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
     }),

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -1669,7 +1669,7 @@ async function claimNotionPendingEvent(args: {
     .update(notionWorkflowPendingEvents)
     .set({
       status: "running",
-      attempts: sql<number>`${notionWorkflowPendingEvents.attempts} + 1`,
+      attempts: sql`${notionWorkflowPendingEvents.attempts} + 1`,
       updatedAt: args.currentTime,
     })
     .where(

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -19,22 +19,22 @@ function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
   );
 }
 
-type SessionIdSqlValue = string | SQL<string | null>;
-type ProfileSqlValue = string | SQL<string>;
-type GenerationSqlValue = string | SQL<string | null>;
+type SessionIdSqlValue = string | SQL;
+type ProfileSqlValue = string | SQL;
+type GenerationSqlValue = string | SQL;
 
 function reusableSandboxCondition(args: {
   readonly sessionId: SessionIdSqlValue;
   readonly profile: ProfileSqlValue;
   readonly historyGenerationRunId?: GenerationSqlValue;
-}): SQL<boolean> {
+}): SQL {
   const reusableSandbox = args.historyGenerationRunId
     ? sql`jsonb_build_object(
         'profile', cast(${args.profile} as text),
         'historyGenerationRunId', cast(${args.historyGenerationRunId} as text)
       )`
     : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
-  return sql<boolean>`${runnerState.heldSessionStates} @> jsonb_build_array(
+  return sql`${runnerState.heldSessionStates} @> jsonb_build_array(
     jsonb_build_object(
       'sessionId', cast(${args.sessionId} as text),
       'reusableSandbox', ${reusableSandbox}
@@ -45,8 +45,8 @@ function reusableSandboxCondition(args: {
 function capableWorkspaceCondition(args: {
   readonly sessionId: SessionIdSqlValue;
   readonly profile: ProfileSqlValue;
-}): SQL<boolean> {
-  return sql<boolean>`(
+}): SQL {
+  return sql`(
     ${runnerState.heldSessionStates} @> jsonb_build_array(
       jsonb_build_object(
         'sessionId', cast(${args.sessionId} as text),
@@ -68,12 +68,12 @@ function runnerStateHas(args: {
   readonly runnerId?: string;
   readonly runnerGroup: string;
   readonly freshAfter: Date;
-  readonly resourceCondition: SQL<boolean>;
-}): SQL<boolean> {
+  readonly resourceCondition: SQL;
+}): SQL {
   const runnerCondition = args.runnerId
     ? sql`AND ${runnerState.runnerId} = ${args.runnerId}`
     : sql``;
-  return sql<boolean>`EXISTS (
+  return sql`EXISTS (
     SELECT 1
     FROM ${runnerState}
     WHERE ${runnerState.runnerGroup} = ${args.runnerGroup}
@@ -88,7 +88,7 @@ export function runnerSessionAffinityPollPriority(args: {
   readonly runnerId: string;
   readonly runnerGroup: string;
   readonly currentDate: Date;
-}): SQL<number> {
+}): SQL {
   const protectedAfter = new Date(
     args.currentDate.getTime() - RUNNER_SESSION_AFFINITY_PROTECTION_MS,
   );
@@ -97,11 +97,9 @@ export function runnerSessionAffinityPollPriority(args: {
       RUNNER_HISTORY_GENERATION_AFFINITY_PROTECTION_MS,
   );
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
-  const targetGenerationRunId = sql<
-    string | null
-  >`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
-  const sessionId = sql<string | null>`${runnerJobQueue.cliAgentSessionId}`;
-  const profile = sql<string>`${runnerJobQueue.profile}`;
+  const targetGenerationRunId = sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`;
+  const sessionId = sql`${runnerJobQueue.cliAgentSessionId}`;
+  const profile = sql`${runnerJobQueue.profile}`;
   const exactCondition = reusableSandboxCondition({
     sessionId,
     profile,
@@ -109,14 +107,14 @@ export function runnerSessionAffinityPollPriority(args: {
   });
   const reusableCondition = reusableSandboxCondition({ sessionId, profile });
   const workspaceCondition = capableWorkspaceCondition({ sessionId, profile });
-  const global = (resourceCondition: SQL<boolean>) => {
+  const global = (resourceCondition: SQL) => {
     return runnerStateHas({
       runnerGroup: args.runnerGroup,
       freshAfter,
       resourceCondition,
     });
   };
-  const local = (resourceCondition: SQL<boolean>) => {
+  const local = (resourceCondition: SQL) => {
     return runnerStateHas({
       runnerId: args.runnerId,
       runnerGroup: args.runnerGroup,
@@ -130,7 +128,7 @@ export function runnerSessionAffinityPollPriority(args: {
   const hasLocalReusable = local(reusableCondition);
   const hasGlobalWorkspace = global(workspaceCondition);
   const hasLocalWorkspace = local(workspaceCondition);
-  return sql<number>`CASE
+  return sql`CASE
     WHEN ${runnerJobQueue.createdAt} > ${generationProtectedAfter}
     AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
     AND ${targetGenerationRunId} IS NOT NULL
@@ -237,7 +235,7 @@ async function runnerSessionAffinityHolders(args: {
         profile: args.profile,
         historyGenerationRunId: args.historyGenerationRunId,
       })
-    : sql<boolean>`false`;
+    : sql`false`;
   const [holders] = await args.db
     .select({
       hasReusableHolder:

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -3281,7 +3281,7 @@ async function expireActiveUsageAllowanceWindows(
       return db
         .update(orgUsageAllowanceWindows)
         .set({
-          expiresAt: sql<Date>`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
+          expiresAt: sql`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
           updatedAt: args.updatedAt,
         })
         .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -44,7 +44,7 @@ async function selectIncompleteRoundFrontier(
   readonly rounds: readonly IncompleteRoundSelection[];
   readonly successfulRunId: string | null;
 }> {
-  const isSuccessfulRun = sql<boolean>`COALESCE(
+  const isSuccessfulRun = sql`COALESCE(
     ${agentRuns.result} ? 'agentSessionId'
     AND jsonb_typeof(${agentRuns.result}->'agentSessionId') = 'string',
     FALSE
@@ -132,7 +132,7 @@ async function selectIncompleteRoundFrontier(
 }
 
 function afterSuccessfulRunBoundary(threadId: string, successfulRunId: string) {
-  return sql<boolean>`${chatMessages.createdAt} > COALESCE(
+  return sql`${chatMessages.createdAt} > COALESCE(
     (
       SELECT MAX(boundary_message.created_at)
       FROM chat_messages boundary_message

--- a/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
@@ -104,7 +104,7 @@ export async function touchChatThreadLastMessageAt(
 }
 
 export function visibleChatMessageCondition() {
-  return sql<boolean>`NOT EXISTS (
+  return sql`NOT EXISTS (
       SELECT 1
       FROM ${chatMessages} AS revoker
       WHERE revoker.revokes_message_id = ${chatMessages.id}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -105,14 +105,14 @@ const TERMINAL_MESSAGE_ORDER_SEQUENCE = 2_147_483_647;
 const matchedChatMessage = alias(chatMessages, "matched_chat_message");
 
 function chatMessageOrderSequenceSql() {
-  return sql<number>`CASE
+  return sql`CASE
     WHEN ${chatMessages.runLifecycleEvent} IS NOT NULL THEN ${TERMINAL_MESSAGE_ORDER_SEQUENCE}
     ELSE COALESCE(${chatMessages.sequenceNumber}, -1)
   END`;
 }
 
 function matchedMessageCreatedAtSql(messageId: string) {
-  return sql<Date>`(
+  return sql`(
     SELECT ${matchedChatMessage.createdAt}
     FROM ${chatMessages} AS matched_chat_message
     WHERE ${matchedChatMessage.id} = ${messageId}
@@ -717,7 +717,7 @@ function activeRunStatusSqlList() {
 }
 
 function noActiveRunsForCurrentThreadCondition() {
-  return sql<boolean>`NOT EXISTS (
+  return sql`NOT EXISTS (
     SELECT 1
     FROM ${zeroRuns}
     INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
@@ -727,7 +727,7 @@ function noActiveRunsForCurrentThreadCondition() {
 }
 
 function noActiveGoalsForCurrentThreadCondition() {
-  return sql<boolean>`NOT EXISTS (
+  return sql`NOT EXISTS (
     SELECT 1
     FROM ${threadGoals}
     WHERE ${threadGoals.chatThreadId} = ${chatThreads.id}

--- a/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-bootstrap-context.service.ts
@@ -386,9 +386,7 @@ async function queryZeroRunExecutionScopeSnapshot(
     .from(agentRuns)
     .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(
-      args.triggerRunId
-        ? eq(agentRuns.id, args.triggerRunId)
-        : sql<boolean>`FALSE`,
+      args.triggerRunId ? eq(agentRuns.id, args.triggerRunId) : sql`FALSE`,
     );
   return await unionAll(
     builtinConnectorQuery,

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -617,7 +617,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
           and(
             eq(agentRuns.status, "queued"),
             lt(agentRuns.createdAt, cutoff),
-            sql<boolean>`NOT EXISTS (
+            sql`NOT EXISTS (
               SELECT 1
               FROM ${agentRunQueue}
               WHERE ${agentRunQueue.runId} = ${agentRuns.id}
@@ -650,7 +650,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
           and(
             eq(agentRuns.status, "queued"),
             inArray(agentRuns.id, candidateRunIds),
-            sql<boolean>`NOT EXISTS (
+            sql`NOT EXISTS (
               SELECT 1
               FROM ${agentRunQueue}
               WHERE ${agentRunQueue.runId} = ${agentRuns.id}

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -159,9 +159,9 @@ async function estimatedTimePerRun(
   const recentRuns = db
     .select({
       durationMs:
-        sql<number>`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`.as(
-          "duration_ms",
-        ),
+        sql`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`
+          .mapWith(Number)
+          .as("duration_ms"),
     })
     .from(agentRuns)
     .where(

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -326,6 +326,9 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         const LocalConstructor = SQL<string>;
         const instantiatedLocalConstructor = new LocalConstructor("value");
         class LocalSubclass extends SQL<string> {}
+        class LocalImplementation implements SQL<string> {
+          constructor(readonly value: string) {}
+        }
         interface LocalInterface extends SQL<string> {}
         declare const localInterfaceValue: LocalInterface;
         void localValue;
@@ -337,6 +340,7 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         void constructedLocalAlias;
         void instantiatedLocalConstructor;
         void LocalSubclass;
+        void LocalImplementation;
         void localInterfaceValue;
       `,
     },
@@ -440,6 +444,30 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         const mapped = new TypedSql([]).mapWith(String);
         await db.select().from(users).where(predicate);
         db.select({ value: mapped });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const mapped = sql\`upper(\${users.name})\`.mapWith(users.name);
+        declare function mappedFields(): {
+          readonly value: typeof mapped;
+        };
+        db.select(mappedFields());
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        let mapped = sql\`upper(\${users.name})\`.mapWith(users.name);
+        let column = users.name;
+        db.select({ mapped, column });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        const emptyFields = {};
+        db.select(emptyFields);
       `,
     },
   ],
@@ -616,6 +644,22 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     },
     {
       code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class TypedSql extends SQL implements SQL<string> {
+          override _: { brand: "SQL"; type: string } = {
+            brand: "SQL",
+            type: "",
+          };
+          override as(): never {
+            throw new Error("not implemented");
+          }
+        }
+        await db.select().from(users).where(new TypedSql([]));
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
         declare const value: import("drizzle-orm").SQL<string>;
         db.select({ value });
       `,
@@ -642,6 +686,101 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         db.select({ value: new TypedSql([]) });
       `,
       errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const source = { value: sql\`SELECT 1\` };
+        const fields: Omit<typeof source, "value"> = source;
+        db.select(fields);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const source = {
+          name: users.name,
+          value: sql\`SELECT 1\`,
+        };
+        const fields: Pick<typeof source, "name"> = source;
+        const alias = fields;
+        db.select((void 0, alias));
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const source = {
+          name: users.name,
+          value: sql\`SELECT 1\`,
+        };
+        let fields: Pick<typeof source, "name"> = source;
+        db.select(fields);
+      `,
+      errors: [{ messageId: "uninspectableResultSelection" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        declare function opaqueFields(): Record<never, never>;
+        db.select(opaqueFields());
+      `,
+      errors: [{ messageId: "uninspectableResultSelection" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        type DatabaseMethod = typeof db.select;
+        type QueryMethod = DatabaseMethod;
+        declare const runQuery: QueryMethod;
+        runQuery({
+          value: sql\`upper(\${users.name})\`.mapWith(users.name),
+        });
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const runQuery = Reflect.get(db, "select");
+        runQuery({
+          value: sql\`upper(\${users.name})\`.mapWith(users.name),
+        });
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        interface QueryExecutor {
+          readonly run: typeof db.select;
+        }
+        declare const selector: QueryExecutor;
+        selector.run({
+          value: sql\`upper(\${users.name})\`.mapWith(users.name),
+        });
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${relationalPreamble}
+        type FindUsers = typeof db.query.users.findMany;
+        declare const runQuery: FindUsers;
+        runQuery({ columns: { id: true } });
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fields = Object.defineProperty({}, "value", {
+          enumerable: true,
+          value: sql\`SELECT 1\`,
+        });
+        db.select(fields);
+      `,
+      errors: [{ messageId: "uninspectableResultSelection" }],
     },
     {
       code: `${drizzlePreamble}

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -1,0 +1,467 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, it } from "vitest";
+
+import { requireSqlResultMapping } from "../rules/require-sql-result-mapping.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+const drizzlePreamble = `
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase;
+  declare const db: DrizzleDatabase;
+
+  import { integer, pgTable, text } from "drizzle-orm/pg-core";
+  const users = pgTable("users", {
+    id: integer("id").notNull(),
+    name: text("name").notNull(),
+  });
+`;
+
+ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
+  valid: [
+    {
+      code: `${drizzlePreamble}
+        db.select();
+        db.select({ name: users.name });
+        db.selectDistinct({ name: users.name });
+        db.selectDistinctOn([users.id], { name: users.name });
+        db.update(users).set({ name: "updated" }).returning();
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          value: sql\`upper(\${users.name})\`.mapWith(users.name),
+          aliased: sql\`lower(\${users.name})\`.mapWith(users.name).as("value"),
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function mappedValue() {
+          return sql\`upper(\${users.name})\`.mapWith(users.name);
+        }
+        const messageColumns = {
+          direct: sql\`lower(\${users.name})\`.mapWith(users.name),
+          helper: mappedValue(),
+        } as const;
+        db.select(messageColumns);
+        db.select({ nested: messageColumns });
+        db.select({ ...messageColumns });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type DriverValueDecoder } from "drizzle-orm";
+        declare const nullableTextDecoder:
+          DriverValueDecoder<string | null, unknown>;
+        db.select({
+          nullableValue: sql\`NULLIF(\${users.name}, '')\`
+            .mapWith(nullableTextDecoder),
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { count, sql } from "drizzle-orm";
+        db.select({
+          count: count(sql\`CASE WHEN \${users.id} > 0 THEN 1 END\`),
+          nested: sql\`coalesce(\${sql\`nullif(\${users.name}, '')\`}, '')\`
+            .mapWith(users.name),
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const left = db.select({
+          value: sql\`'left'\`.mapWith(users.name),
+        });
+        const right = db.select({
+          value: sql\`'right'\`.mapWith(users.name),
+        });
+        left.unionAll(right);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const condition: boolean;
+        db.select({
+          value: condition
+            ? sql\`'left'\`.mapWith(users.name)
+            : sql\`'right'\`.mapWith(users.name),
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.selectDistinct({
+          value: sql\`upper(\${users.name})\`.mapWith(users.name),
+        });
+        db.selectDistinctOn(
+          [sql\`lower(\${users.name})\`],
+          { value: sql\`upper(\${users.name})\`.mapWith(users.name) },
+        );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.update(users)
+          .set({ name: sql\`upper(\${users.name})\` })
+          .returning({ name: users.name });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        await db.select()
+          .from(users)
+          .where(sql\`\${users.id} > 0\`)
+          .groupBy(sql\`\${users.id}\`)
+          .orderBy(sql\`\${users.name}\`);
+        await db.update(users).set({
+          name: sql\`upper(\${users.name})\`,
+        });
+        await db.execute(sql\`DELETE FROM users\`);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, or, sql, type SQL } from "drizzle-orm";
+        function condition(): SQL {
+          return sql\`\${users.id} > 0\`;
+        }
+        const narrowed = or(
+          eq(users.id, 1),
+          eq(users.id, 2),
+        ) as SQL;
+        await db.select().from(users).where(condition());
+        await db.select().from(users).where(narrowed);
+      `,
+    },
+    {
+      code: `
+        function sql<T>(strings: TemplateStringsArray): T {
+          throw new Error(strings[0]);
+        }
+        interface SQL<T> {
+          readonly value: T;
+        }
+        const localValue = sql<string>\`value\`;
+        const localTyped: SQL<string> = { value: "value" };
+        void localValue;
+        void localTyped;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as drizzleSql } from "drizzle-orm";
+        function localTag() {
+          function sql<T>(strings: TemplateStringsArray): T {
+            throw new Error(strings[0]);
+          }
+          return sql<string>\`local\`;
+        }
+        db.select({
+          value: drizzleSql\`upper(\${users.name})\`.mapWith(users.name),
+        });
+        void localTag;
+      `,
+    },
+    {
+      code: `
+        interface Builder {
+          as<T>(alias: string): T;
+        }
+        interface Repository {
+          select<T>(fields: T): T;
+        }
+        declare const builder: Builder;
+        declare const repository: Repository;
+        const value = builder.as<string>("value");
+        repository.select({ value });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const fields = { value: sql\`upper(\${users.name})\` } as const;
+        const preserved = fields as { readonly value: SQL };
+        void fields;
+        void preserved;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        interface Repository {
+          select<T>(fields: T): T;
+        }
+        declare const repository: Repository;
+        repository.select({
+          value: sql\`upper(\${users.name})\`,
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = sql<string>\`upper(\${users.name})\`;
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as drizzleSql } from "drizzle-orm";
+        const value = drizzleSql<string>\`upper(\${users.name})\`;
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        const value = drizzle.sql<string>\`upper(\${users.name})\`;
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const value = sql<string>\`upper(\${users.name})\`;
+        import { sql } from "drizzle-orm";
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `
+        import type { SQL } from "drizzle-orm";
+        declare const value: SQL<string>;
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `
+        import type { SQL as DrizzleSql } from "drizzle-orm";
+        type Value = DrizzleSql<string>;
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `
+        import type * as drizzle from "drizzle-orm";
+        interface Holder {
+          readonly value: drizzle.SQL<string>;
+        }
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `
+        import type { SQL } from "drizzle-orm";
+        declare const value: SQL.Aliased<string>;
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = sql\`upper(\${users.name})\`.as<string>("value");
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = sql\`upper(\${users.name})\`.as<string>();
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const hidden = { value: sql\`upper(\${users.name})\` } as unknown;
+      `,
+      errors: [{ messageId: "sqlAssertion" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fields = { value: sql\`upper(\${users.name})\` };
+        const hidden = fields as { readonly value: string };
+        db.select(hidden);
+      `,
+      errors: [{ messageId: "sqlAssertion" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({ value: sql\`upper(\${users.name})\`.as("value") });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const messageColumns = {
+          value: sql\`upper(\${users.name})\`,
+        };
+        db.select(messageColumns);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const fields = { value: sql\`upper(\${users.name})\` };
+        db.select({ ...fields });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          nested: { value: sql\`upper(\${users.name})\` },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function value() {
+          return sql\`upper(\${users.name})\`;
+        }
+        db.select({ value: value() });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function fields() {
+          return { value: sql\`upper(\${users.name})\` };
+        }
+        db.select(fields());
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const condition: boolean;
+        db.select({
+          value: condition
+            ? sql\`'left'\`.mapWith(users.name)
+            : sql\`'right'\`,
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.selectDistinct({
+          value: sql\`upper(\${users.name})\`,
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.selectDistinctOn(
+          [sql\`lower(\${users.name})\`],
+          { value: sql\`upper(\${users.name})\` },
+        );
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.update(users)
+          .set({ name: sql\`upper(\${users.name})\` })
+          .returning({ value: sql\`lower(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const left = db.select({ value: sql\`'left'\` });
+        const right = db.select({
+          value: sql\`'right'\`.mapWith(users.name),
+        });
+        left.unionAll(right);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const left = db.select({
+          value: sql\`'left'\`.mapWith(users.name),
+        });
+        const right = db.select({ value: sql\`'right'\` });
+        left.unionAll(right);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const query = db.select({
+          value: sql\`upper(\${users.name})\`,
+        });
+        const rows = await query as { readonly value: string }[];
+        void rows;
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const fields: { readonly value: SQL<string> } = {
+          value: sql\`upper(\${users.name})\`,
+        };
+        void fields;
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -142,6 +142,7 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         import { sql } from "drizzle-orm";
         await db.select()
           .from(users)
+          .leftJoin(users, sql\`\${users.id} > 0\`)
           .where(sql\`\${users.id} > 0\`)
           .groupBy(sql\`\${users.id}\`)
           .orderBy(sql\`\${users.name}\`);
@@ -149,6 +150,8 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
           name: sql\`upper(\${users.name})\`,
         });
         await db.execute(sql\`DELETE FROM users\`);
+        const { rowCount } = await db.execute(sql\`DELETE FROM users\`);
+        void rowCount;
       `,
     },
     {

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -305,16 +305,39 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         function sql<T>(strings: TemplateStringsArray): T {
           throw new Error(strings[0]);
         }
-        interface SQL<T> {
-          readonly value: T;
+        declare const strings: TemplateStringsArray;
+        class SQL<T> {
+          constructor(readonly value: T) {}
+        }
+        namespace SQL {
+          export class Aliased<T> {
+            constructor(readonly value: T) {}
+          }
         }
         const localValue = sql<string>\`value\`;
         const localTag = sql<string>;
         const instantiatedLocalValue = localTag\`value\`;
-        const localTyped: SQL<string> = { value: "value" };
+        const calledLocalValue = sql<string>(strings);
+        const localCall = sql;
+        const aliasedCalledLocalValue = localCall<string>(strings);
+        const localTyped: SQL<string> = new SQL("value");
+        const constructedLocalValue = new SQL<string>("value");
+        const constructedLocalAlias = new SQL.Aliased<string>("value");
+        const LocalConstructor = SQL<string>;
+        const instantiatedLocalConstructor = new LocalConstructor("value");
+        class LocalSubclass extends SQL<string> {}
+        interface LocalInterface extends SQL<string> {}
+        declare const localInterfaceValue: LocalInterface;
         void localValue;
         void instantiatedLocalValue;
+        void calledLocalValue;
+        void aliasedCalledLocalValue;
         void localTyped;
+        void constructedLocalValue;
+        void constructedLocalAlias;
+        void instantiatedLocalConstructor;
+        void LocalSubclass;
+        void localInterfaceValue;
       `,
     },
     {
@@ -381,6 +404,42 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         repository.select(
           ...[{ value: sql\`upper(\${users.name})\` }] as const,
         );
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        function mapped<T>(value: T) {
+          return sql\`upper(\${users.name})\`.mapWith(() => value);
+        }
+        db.select({ value: mapped<string>("value") });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class MetadataSql<T> extends SQL {
+          constructor(readonly metadata: T) {
+            super([]);
+          }
+        }
+        const predicate = new MetadataSql<string>("metadata");
+        await db.select().from(users).where(predicate);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class TypedSql extends SQL {
+          override _: { brand: "SQL"; type: string } = {
+            brand: "SQL",
+            type: "",
+          };
+        }
+        const predicate = new TypedSql([]);
+        const mapped = new TypedSql([]).mapWith(String);
+        await db.select().from(users).where(predicate);
+        db.select({ value: mapped });
       `,
     },
   ],
@@ -463,7 +522,141 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
+        declare const strings: TemplateStringsArray;
+        db.select({ value: sql<string>(strings) });
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const strings: TemplateStringsArray;
+        const tag = sql;
+        db.select({ value: tag<string>(strings) });
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const strings: TemplateStringsArray;
+        const tag = sql.bind(undefined);
+        db.select({ value: tag<string>(strings) });
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        db.select({ value: new SQL<string>([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        db.select({
+          value: new drizzle.SQL.Aliased<string>(
+            drizzle.sql\`value\`,
+            "value",
+          ),
+        });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        const SqlConstructor = SQL;
+        db.select({ value: new SqlConstructor<string>([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        const SqlConstructor = SQL.bind(null);
+        db.select({ value: new SqlConstructor<string>([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        const TypedSql = SQL<string>;
+        db.select({ value: new TypedSql([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        const SqlConstructor = SQL;
+        const TypedSql = SqlConstructor<string>;
+        db.select({ value: new TypedSql([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class TypedSql extends SQL<string> {}
+        db.select({ value: new TypedSql([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        const SqlConstructor = SQL;
+        const TypedSql = class extends SqlConstructor<string> {};
+        db.select({ value: new TypedSql([]) });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        declare const value: import("drizzle-orm").SQL<string>;
+        db.select({ value });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        interface TypedSql extends SQL<string> {}
+        declare const value: TypedSql;
+        db.select({ value });
+      `,
+      errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { SQL } from "drizzle-orm";
+        class TypedSql extends SQL {
+          override _: { brand: "SQL"; type: string } = {
+            brand: "SQL",
+            type: "",
+          };
+        }
+        db.select({ value: new TypedSql([]) });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
         const value = sql\`upper(\${users.name})\`.as<string>("value");
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const expression = sql\`upper(\${users.name})\`;
+        const alias = expression.as.bind(expression);
+        const value = alias<string>("value");
+        db.select({ value });
       `,
       errors: [{ messageId: "sqlAliasTypeArgument" }],
     },

--- a/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/require-sql-result-mapping.test.ts
@@ -38,6 +38,39 @@ const drizzlePreamble = `
   });
 `;
 
+const relationalPreamble = `
+  import { relations } from "drizzle-orm";
+  import { integer, pgTable, text } from "drizzle-orm/pg-core";
+
+  const users = pgTable("users", {
+    id: integer("id").notNull(),
+    name: text("name").notNull(),
+  });
+  const posts = pgTable("posts", {
+    id: integer("id").notNull(),
+    authorId: integer("author_id").notNull(),
+    title: text("title").notNull(),
+  });
+  const usersRelations = relations(users, ({ many }) => ({
+    posts: many(posts),
+  }));
+  const postsRelations = relations(posts, ({ one }) => ({
+    author: one(users, {
+      fields: [posts.authorId],
+      references: [users.id],
+    }),
+  }));
+
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      users: typeof users;
+      posts: typeof posts;
+      usersRelations: typeof usersRelations;
+      postsRelations: typeof postsRelations;
+    }>;
+  declare const db: DrizzleDatabase;
+`;
+
 ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
   valid: [
     {
@@ -56,6 +89,96 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
           value: sql\`upper(\${users.name})\`.mapWith(users.name),
           aliased: sql\`lower(\${users.name})\`.mapWith(users.name).as("value"),
         });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          get value() {
+            return sql\`upper(\${users.name})\`.mapWith(users.name);
+          },
+        });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.insert(users).select(sql\`SELECT 1, 'name'\`);
+        db.insert(users).select(...[sql\`SELECT 1, 'name'\`] as const);
+        const insertSelect = db.insert(users).select;
+        const method = "select" as const;
+        db.insert(users)[method](sql\`SELECT 1, 'name'\`);
+        void insertSelect;
+      `,
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.id} > 0\`,
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`
+              .mapWith(users.name)
+              .as("normalized_name"),
+          },
+          with: {
+            posts: {
+              extras: (fields, operators) => ({
+                normalizedTitle: operators.sql\`upper(\${fields.title})\`
+                  .mapWith(fields.title)
+                  .as("normalized_title"),
+              }),
+            },
+          },
+        });
+        db.query.users.findFirst({
+          extras: (fields, operators) => ({
+            normalizedName: operators.sql\`upper(\${fields.name})\`
+              .mapWith(fields.name)
+              .as("normalized_name"),
+          }),
+        });
+        db.query.users.findMany({ with: { posts: true } });
+        db.query.users.findMany(undefined);
+        db.query.users.findFirst({
+          extras: (fields, operators) => {
+            return {
+              normalizedName: operators.sql\`upper(\${fields.name})\`
+                .mapWith(fields.name)
+                .as("normalized_name"),
+            };
+          },
+        });
+      `,
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        type UsersQueryConfig = NonNullable<
+          Parameters<typeof db.query.users.findMany>[0]
+        >;
+        const columnsOnly: UsersQueryConfig = {
+          columns: { id: true },
+        };
+        const mapped: UsersQueryConfig = {
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`
+              .mapWith(users.name)
+              .as("normalized_name"),
+          },
+        };
+        const nested = {
+          extras: {
+            normalizedTitle: sql\`upper(\${posts.title})\`
+              .mapWith(posts.title)
+              .as("normalized_title"),
+          },
+        };
+        db.query.users.findMany(columnsOnly);
+        db.query.users.findMany(mapped);
+        db.query.users.findMany({ with: { posts: nested } });
       `,
     },
     {
@@ -104,6 +227,15 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
           value: sql\`'right'\`.mapWith(users.name),
         });
         left.unionAll(right);
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        const subquery = db
+          .select({ name: users.name })
+          .from(users)
+          .as<"named_users">("named_users");
+        void subquery;
       `,
     },
     {
@@ -177,8 +309,11 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
           readonly value: T;
         }
         const localValue = sql<string>\`value\`;
+        const localTag = sql<string>;
+        const instantiatedLocalValue = localTag\`value\`;
         const localTyped: SQL<string> = { value: "value" };
         void localValue;
+        void instantiatedLocalValue;
         void localTyped;
       `,
     },
@@ -208,7 +343,20 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         declare const builder: Builder;
         declare const repository: Repository;
         const value = builder.as<string>("value");
+        const alias = builder.as<string>;
+        const instantiatedValue = alias("value");
         repository.select({ value });
+        void instantiatedValue;
+      `,
+    },
+    {
+      code: `
+        interface Repository {
+          findMany(config: object): readonly unknown[];
+        }
+        declare const repository: Repository;
+        const findMany = repository.findMany;
+        void findMany;
       `,
     },
     {
@@ -230,6 +378,9 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         repository.select({
           value: sql\`upper(\${users.name})\`,
         });
+        repository.select(
+          ...[{ value: sql\`upper(\${users.name})\` }] as const,
+        );
       `,
     },
   ],
@@ -245,6 +396,23 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
       code: `${drizzlePreamble}
         import { sql as drizzleSql } from "drizzle-orm";
         const value = drizzleSql<string>\`upper(\${users.name})\`;
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const tag = sql;
+        const value = tag<string>\`upper(\${users.name})\`;
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const typedSql = sql<string>;
+        const value = typedSql\`value\`;
+        void value;
       `,
       errors: [{ messageId: "sqlTypeArgument" }],
     },
@@ -308,6 +476,34 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
     },
     {
       code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const expression: Pick<SQL, "as"> = sql\`upper(\${users.name})\`;
+        const value = expression.as<string>("value");
+        db.select({ value });
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const expression = sql\`upper(\${users.name})\`;
+        const alias = expression.as;
+        const value = alias<string>("value");
+        db.select({ value });
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const expression = sql\`value\`;
+        const alias = expression.as<string>;
+        void alias;
+      `,
+      errors: [{ messageId: "sqlAliasTypeArgument" }],
+    },
+    {
+      code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         const hidden = { value: sql\`upper(\${users.name})\` } as unknown;
       `,
@@ -326,6 +522,38 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";
         db.select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        db.select({
+          get value() {
+            return sql\`upper(\${users.name})\`;
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        type Fields = NonNullable<
+          Parameters<DrizzleDatabase["select"]>[0]
+        >;
+        function select<TFields extends Fields>(fields: TFields) {
+          return db.select(fields);
+        }
+        select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const method = "select" as const;
+        db[method]({ value: sql\`upper(\${users.name})\` });
       `,
       errors: [{ messageId: "unmappedResult" }],
     },
@@ -465,6 +693,253 @@ ruleTester.run("require-sql-result-mapping", requireSqlResultMapping, {
         void fields;
       `,
       errors: [{ messageId: "sqlTypeReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const select = db.select.bind(db);
+        select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const args = [
+          { value: sql\`upper(\${users.name})\` },
+        ] as const;
+        db.select(...args);
+      `,
+      errors: [{ messageId: "uninspectableResultArguments" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const method = "select" as const;
+        const select = db[method].bind(db);
+        void select;
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const database: Pick<DrizzleDatabase, "select"> = db;
+        database.select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        interface Selector {
+          readonly select: DrizzleDatabase["select"];
+        }
+        const database: Selector = db;
+        database.select({ value: sql\`upper(\${users.name})\` });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const update = db.update(users).set({ name: "updated" });
+        const writer: Pick<typeof update, "returning"> = update;
+        writer.returning({
+          value: sql\`upper(\${users.name})\`,
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const { selectDistinct: select } = db;
+        void select;
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        const returning = db.update(users).set({ name: "updated" }).returning;
+        void returning;
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        db.query.users.findMany({
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const extras = "extras" as const;
+        db.query.users.findMany({
+          [extras]: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        type UsersQueryConfig = NonNullable<
+          Parameters<typeof db.query.users.findMany>[0]
+        >;
+        const config: UsersQueryConfig = {
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        };
+        db.query.users.findMany(config);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const unsafe = {
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        };
+        db.query.users.findMany({ ...unsafe });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        db.query.users.findFirst({
+          extras: (fields, operators) => ({
+            normalizedName:
+              operators.sql\`upper(\${fields.name})\`.as("normalized_name"),
+          }),
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        db.query.users.findFirst({
+          extras: (fields, operators) => ({
+            normalizedName:
+              operators.sql<string>\`upper(\${fields.name})\`
+                .as("normalized_name"),
+          }),
+        });
+      `,
+      errors: [{ messageId: "sqlTypeArgument" }],
+    },
+    {
+      code: `${relationalPreamble}
+        db.query.users.findFirst({
+          extras: (fields, operators) => {
+            return {
+              normalizedName:
+                operators.sql\`upper(\${fields.name})\`.as("normalized_name"),
+            };
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const config = {
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        };
+        db.query.users.findMany(config);
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        db.query.users.findMany({
+          with: {
+            posts: {
+              extras: {
+                normalizedTitle:
+                  sql\`upper(\${posts.title})\`.as("normalized_title"),
+              },
+            },
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        const findMany = db.query.users.findMany.bind(db.query.users);
+        void findMany;
+      `,
+      errors: [{ messageId: "resultMethodReference" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const args = [{
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        }] as const;
+        db.query.users.findMany(...args);
+      `,
+      errors: [{ messageId: "uninspectableResultArguments" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const shared = {
+          normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+        };
+        db.query.users.findMany({
+          with: { posts: shared },
+          extras: shared,
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
+    },
+    {
+      code: `${relationalPreamble}
+        declare function config(): {};
+        db.query.users.findMany(config());
+      `,
+      errors: [{ messageId: "uninspectableRelationalConfig" }],
+    },
+    {
+      code: `${relationalPreamble}
+        function query(undefined: {}) {
+          return db.query.users.findMany(undefined);
+        }
+        void query;
+      `,
+      errors: [{ messageId: "uninspectableRelationalConfig" }],
+    },
+    {
+      code: `${relationalPreamble}
+        import { sql } from "drizzle-orm";
+        const usersQuery: Pick<
+          typeof db.query.users,
+          "findMany"
+        > = db.query.users;
+        usersQuery.findMany({
+          extras: {
+            normalizedName: sql\`upper(\${users.name})\`.as("normalized_name"),
+          },
+        });
+      `,
+      errors: [{ messageId: "unmappedResult" }],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -8,6 +8,7 @@ import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
 import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
+import { requireSqlResultMapping } from "./rules/require-sql-result-mapping.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
 
 export const apiLintPlugin = {
@@ -26,6 +27,7 @@ export const apiLintPlugin = {
     "no-store-in-params": noStoreInParams,
     "no-test-vi-mocks": noTestViMocks,
     "require-execute-row-schema": requireExecuteRowSchema,
+    "require-sql-result-mapping": requireSqlResultMapping,
     "signal-check-await": signalCheckAwait,
   },
 };

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -116,9 +116,12 @@ function sqlOutputType(
   location: Node,
 ): Type | null {
   const metadataSymbol = checker.getPropertyOfType(type, "_");
+  const metadataDeclarations = metadataSymbol?.declarations;
   if (
     metadataSymbol === undefined ||
-    metadataSymbol.declarations?.some(isDrizzleDeclaration) !== true
+    metadataDeclarations === undefined ||
+    metadataDeclarations.length === 0 ||
+    !metadataDeclarations.every(isDrizzleDeclaration)
   ) {
     return null;
   }
@@ -147,6 +150,28 @@ function isDrizzleWrapper(checker: TypeChecker, type: Type): boolean {
   return isDrizzleSymbol(checker, checker.getPropertyOfType(type, "getSQL"));
 }
 
+function hasUntrustedSqlMetadata(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  if (
+    checker.getPropertyOfType(type, "_") === undefined ||
+    !isDrizzleWrapper(checker, type)
+  ) {
+    return false;
+  }
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return false;
+  }
+  const brandType = propertyType(checker, metadataType, "brand", location);
+  return (
+    brandType?.isStringLiteral() === true &&
+    (brandType.value === "SQL" || brandType.value === "SQL.Aliased")
+  );
+}
+
 function containsUntrustedSql(
   checker: TypeChecker,
   type: Type,
@@ -167,6 +192,9 @@ function containsUntrustedSql(
   const outputType = sqlOutputType(checker, type, location);
   if (outputType !== null) {
     return isUntrustedOutput(outputType);
+  }
+  if (hasUntrustedSqlMetadata(checker, type, location)) {
+    return true;
   }
 
   if (
@@ -346,6 +374,32 @@ export const requireSqlResultMapping = createRule({
         checker.getTypeAtLocation(tsNode),
         tsNode,
         new Set<Type>(),
+      );
+    }
+
+    function isDrizzleSqlConstructor(node: TSESTree.Expression): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return checker
+        .getTypeAtLocation(tsNode)
+        .getConstructSignatures()
+        .some((signature) => {
+          return (
+            signature.declaration !== undefined &&
+            isDrizzleDeclaration(signature.declaration) &&
+            sqlOutputType(
+              checker,
+              checker.getReturnTypeOfSignature(signature),
+              tsNode,
+            ) !== null
+          );
+        });
+    }
+
+    function isDrizzleSqlTypeName(node: TSESTree.Node): boolean {
+      const symbol = resolvedSymbol(checker, symbolAt(node));
+      return (
+        (symbol?.getName() === "SQL" || symbol?.getName() === "Aliased") &&
+        isDrizzleSymbol(checker, symbol)
       );
     }
 
@@ -706,6 +760,18 @@ export const requireSqlResultMapping = createRule({
       );
     }
 
+    function checkGenericSqlSuperclass(
+      node: TSESTree.ClassDeclaration | TSESTree.ClassExpression,
+    ): void {
+      if (
+        node.superTypeArguments?.params.length &&
+        node.superClass !== null &&
+        isDrizzleSqlConstructor(node.superClass)
+      ) {
+        context.report({ node, messageId: "sqlTypeReference" });
+      }
+    }
+
     function checkAssertion(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
     ): void {
@@ -741,11 +807,26 @@ export const requireSqlResultMapping = createRule({
         }
       },
       TSTypeReference(node: TSESTree.TSTypeReference): void {
-        const symbol = resolvedSymbol(checker, symbolAt(node.typeName));
         if (
           node.typeArguments?.params.length &&
-          (symbol?.getName() === "SQL" || symbol?.getName() === "Aliased") &&
-          isDrizzleSymbol(checker, symbol)
+          isDrizzleSqlTypeName(node.typeName)
+        ) {
+          context.report({ node, messageId: "sqlTypeReference" });
+        }
+      },
+      TSImportType(node: TSESTree.TSImportType): void {
+        if (
+          node.typeArguments?.params.length &&
+          node.qualifier !== null &&
+          isDrizzleSqlTypeName(node.qualifier)
+        ) {
+          context.report({ node, messageId: "sqlTypeReference" });
+        }
+      },
+      TSInterfaceHeritage(node: TSESTree.TSInterfaceHeritage): void {
+        if (
+          node.typeArguments?.params.length &&
+          isDrizzleSqlTypeName(node.expression)
         ) {
           context.report({ node, messageId: "sqlTypeReference" });
         }
@@ -760,10 +841,17 @@ export const requireSqlResultMapping = createRule({
           context.report({ node, messageId: "sqlTypeArgument" });
         } else if (isDrizzleSqlAliasCallee(node.expression)) {
           context.report({ node, messageId: "sqlAliasTypeArgument" });
+        } else if (isDrizzleSqlConstructor(node.expression)) {
+          context.report({ node, messageId: "sqlTypeReference" });
         }
       },
       CallExpression(node: TSESTree.CallExpression): void {
-        if (isGenericDrizzleSqlAlias(node)) {
+        if (
+          node.typeArguments?.params.length === 1 &&
+          isDrizzleSqlTag(node.callee)
+        ) {
+          context.report({ node, messageId: "sqlTypeArgument" });
+        } else if (isGenericDrizzleSqlAlias(node)) {
           context.report({ node, messageId: "sqlAliasTypeArgument" });
         }
 
@@ -839,6 +927,20 @@ export const requireSqlResultMapping = createRule({
         for (const field of unmapped) {
           context.report({ node: field, messageId: "unmappedResult" });
         }
+      },
+      NewExpression(node: TSESTree.NewExpression): void {
+        if (
+          node.typeArguments?.params.length &&
+          isDrizzleSqlConstructor(node.callee)
+        ) {
+          context.report({ node, messageId: "sqlTypeReference" });
+        }
+      },
+      ClassDeclaration(node: TSESTree.ClassDeclaration): void {
+        checkGenericSqlSuperclass(node);
+      },
+      ClassExpression(node: TSESTree.ClassExpression): void {
+        checkGenericSqlSuperclass(node);
       },
       "MemberExpression[computed=false][property.name='findFirst']":
         checkResultMethodReference,

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -2,10 +2,13 @@ import {
   AST_NODE_TYPES,
   ESLintUtils,
   type TSESTree,
+  type TSESLint,
 } from "@typescript-eslint/utils";
 import {
   IndexKind,
   isVariableDeclaration,
+  isVariableDeclarationList,
+  NodeFlags,
   SymbolFlags,
   TypeFlags,
   type Declaration,
@@ -14,6 +17,7 @@ import {
   type Symbol as TypeScriptSymbol,
   type Type,
   type TypeChecker,
+  type VariableDeclaration,
 } from "typescript";
 
 import { createRule } from "../utils.ts";
@@ -26,6 +30,16 @@ const RESULT_FIELD_ARGUMENT = new Map<string, number>([
 ]);
 
 const RELATIONAL_RESULT_METHODS = new Set(["findFirst", "findMany"]);
+
+const RESULT_METHOD_NAMES = [
+  ...RESULT_FIELD_ARGUMENT.keys(),
+  ...RELATIONAL_RESULT_METHODS,
+];
+const RESULT_METHOD_HINTS = RESULT_METHOD_NAMES.map((name) => {
+  return name.toLowerCase();
+});
+
+type SelectionTypeStatus = "safe" | "unmapped" | "uninspectable";
 
 const TERMINAL_TYPE_FLAGS =
   TypeFlags.Any |
@@ -228,36 +242,123 @@ function containsUntrustedSql(
   );
 }
 
-function containsUntrustedSqlResult(
+function combineSelectionTypeStatus(
+  current: SelectionTypeStatus,
+  next: SelectionTypeStatus,
+): SelectionTypeStatus {
+  if (current === "unmapped" || next === "unmapped") {
+    return "unmapped";
+  }
+  if (current === "uninspectable" || next === "uninspectable") {
+    return "uninspectable";
+  }
+  return "safe";
+}
+
+function selectionTypeStatus(
   checker: TypeChecker,
   type: Type,
   location: Node,
   visited: Set<Type>,
-): boolean {
+): SelectionTypeStatus {
   if (visited.has(type)) {
-    return false;
+    return "safe";
   }
   visited.add(type);
 
-  if (type.isUnionOrIntersection()) {
-    return type.types.some((member) => {
-      return containsUntrustedSqlResult(checker, member, location, visited);
-    });
+  if (type.isUnion()) {
+    return type.types.reduce<SelectionTypeStatus>((status, member) => {
+      return combineSelectionTypeStatus(
+        status,
+        selectionTypeStatus(checker, member, location, visited),
+      );
+    }, "safe");
   }
 
+  const outputType = sqlOutputType(checker, type, location);
+  if (outputType !== null) {
+    return isUntrustedOutput(outputType) ? "unmapped" : "safe";
+  }
+  if (hasUntrustedSqlMetadata(checker, type, location)) {
+    return "unmapped";
+  }
+  if (isDrizzleWrapper(checker, type)) {
+    return "safe";
+  }
+
+  if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
+    return "uninspectable";
+  }
+  if ((type.flags & TERMINAL_TYPE_FLAGS) !== 0) {
+    return "safe";
+  }
+
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return constraint === undefined
+      ? "uninspectable"
+      : selectionTypeStatus(checker, constraint, location, visited);
+  }
+
+  if (
+    checker.isArrayType(type) ||
+    checker.isTupleType(type) ||
+    type.getCallSignatures().length > 0
+  ) {
+    return "uninspectable";
+  }
+
+  let status: SelectionTypeStatus = "safe";
+  let inspectedMember = false;
+  for (const property of checker.getPropertiesOfType(type)) {
+    inspectedMember = true;
+    const propertyType = checker.getTypeOfSymbolAtLocation(property, location);
+    status = combineSelectionTypeStatus(
+      status,
+      selectionTypeStatus(checker, propertyType, location, visited),
+    );
+  }
+
+  const stringValueType = checker.getIndexTypeOfType(type, IndexKind.String);
+  if (stringValueType !== undefined) {
+    inspectedMember = true;
+    status = combineSelectionTypeStatus(
+      status,
+      selectionTypeStatus(checker, stringValueType, location, visited),
+    );
+  }
+  const numberValueType = checker.getIndexTypeOfType(type, IndexKind.Number);
+  if (numberValueType !== undefined) {
+    inspectedMember = true;
+    status = combineSelectionTypeStatus(
+      status,
+      selectionTypeStatus(checker, numberValueType, location, visited),
+    );
+  }
+
+  return inspectedMember ? status : "uninspectable";
+}
+
+function selectionResultTypeStatus(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): SelectionTypeStatus {
   const signatures = type.getCallSignatures();
-  if (signatures.length > 0) {
-    return signatures.some((signature) => {
-      return containsUntrustedSql(
+  if (signatures.length === 0) {
+    return selectionTypeStatus(checker, type, location, new Set<Type>());
+  }
+  return signatures.reduce<SelectionTypeStatus>((status, signature) => {
+    return combineSelectionTypeStatus(
+      status,
+      selectionTypeStatus(
         checker,
         checker.getReturnTypeOfSignature(signature),
         location,
         new Set<Type>(),
-      );
-    });
-  }
-
-  return containsUntrustedSql(checker, type, location, new Set<Type>());
+      ),
+    );
+  }, "safe");
 }
 
 export const requireSqlResultMapping = createRule({
@@ -285,6 +386,8 @@ export const requireSqlResultMapping = createRule({
         "Do not alias or bind a Drizzle structured-result method. Call it directly so raw SQL result mapping can be enforced.",
       uninspectableResultArguments:
         "Do not spread arguments into a Drizzle structured-result method. Pass them explicitly so raw SQL result mapping can be enforced.",
+      uninspectableResultSelection:
+        "Structured-result fields must be inspectable so raw SQL runtime mapping can be enforced. Use an inline object, a local const selection, or a type with concrete selected-field members.",
       uninspectableRelationalConfig:
         "Relational query config must be an inline object or a local variable so raw SQL extras can be inspected.",
       unmappedResult:
@@ -294,6 +397,10 @@ export const requireSqlResultMapping = createRule({
   create(context) {
     const services = ESLintUtils.getParserServices(context);
     const checker = services.program.getTypeChecker();
+    const resultMethodNameByType = new Map<Type, string | null>();
+    const resultMethodHintVariables = new Set<TSESLint.Scope.Variable>();
+    const resultMethodHintVariablesInProgress =
+      new Set<TSESLint.Scope.Variable>();
 
     function symbolAt(node: TSESTree.Node): TypeScriptSymbol | undefined {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
@@ -322,9 +429,9 @@ export const requireSqlResultMapping = createRule({
       );
     }
 
-    function localVariableInitializer(
+    function localVariableDeclaration(
       node: TSESTree.Node,
-    ): TSESTree.Node | null {
+    ): VariableDeclaration | null {
       if (node.type !== AST_NODE_TYPES.Identifier) {
         return null;
       }
@@ -336,12 +443,57 @@ export const requireSqlResultMapping = createRule({
       if (
         declaration === undefined ||
         !isVariableDeclaration(declaration) ||
-        declaration.initializer === undefined ||
         declaration.getSourceFile() !== tsNode.getSourceFile()
       ) {
         return null;
       }
+      return declaration;
+    }
+
+    function isConstVariable(declaration: VariableDeclaration): boolean {
+      return (
+        isVariableDeclarationList(declaration.parent) &&
+        (declaration.parent.flags & NodeFlags.Const) !== 0
+      );
+    }
+
+    function localVariableInitializer(
+      node: TSESTree.Node,
+    ): TSESTree.Node | null {
+      const declaration = localVariableDeclaration(node);
+      if (
+        declaration === null ||
+        !isConstVariable(declaration) ||
+        declaration.initializer === undefined
+      ) {
+        return null;
+      }
       return services.tsNodeToESTreeNodeMap.get(declaration.initializer);
+    }
+
+    function isSelectionContainerType(type: Type, location: Node): boolean {
+      if (type.isUnionOrIntersection()) {
+        return type.types.some((member) => {
+          return isSelectionContainerType(member, location);
+        });
+      }
+      return (
+        (type.flags & TypeFlags.Object) !== 0 &&
+        sqlOutputType(checker, type, location) === null &&
+        !isDrizzleWrapper(checker, type)
+      );
+    }
+
+    function isMutableLocalSelectionContainer(node: TSESTree.Node): boolean {
+      const declaration = localVariableDeclaration(node);
+      if (declaration === null || isConstVariable(declaration)) {
+        return false;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return isSelectionContainerType(
+        checker.getTypeAtLocation(tsNode),
+        tsNode,
+      );
     }
 
     function isDrizzleSqlTag(node: TSESTree.Expression): boolean {
@@ -403,9 +555,9 @@ export const requireSqlResultMapping = createRule({
       );
     }
 
-    function nodeContainsUntrustedSqlResult(node: TSESTree.Node): boolean {
+    function nodeSelectionTypeStatus(node: TSESTree.Node): SelectionTypeStatus {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      return containsUntrustedSqlResult(
+      return selectionTypeStatus(
         checker,
         checker.getTypeAtLocation(tsNode),
         tsNode,
@@ -413,27 +565,121 @@ export const requireSqlResultMapping = createRule({
       );
     }
 
+    function nodeSelectionResultTypeStatus(
+      node: TSESTree.Node,
+    ): SelectionTypeStatus {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return selectionResultTypeStatus(
+        checker,
+        checker.getTypeAtLocation(tsNode),
+        tsNode,
+      );
+    }
+
     function collectUnmappedSelections(
       node: TSESTree.Node,
       unmapped: TSESTree.Node[],
+      uninspectable: TSESTree.Node[],
+      visited: Set<TSESTree.Node>,
     ): void {
+      if (visited.has(node)) {
+        return;
+      }
+      visited.add(node);
+
+      if (
+        (node.type === AST_NODE_TYPES.TSAsExpression ||
+          node.type === AST_NODE_TYPES.TSTypeAssertion) &&
+        isUnsafeSqlAssertion(node)
+      ) {
+        return;
+      }
+
+      const initializer = localVariableInitializer(node);
+      if (initializer !== null) {
+        collectUnmappedSelections(
+          initializer,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        return;
+      }
+      const expression = transparentExpression(node);
+      if (expression !== null) {
+        collectUnmappedSelections(expression, unmapped, uninspectable, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        collectUnmappedSelections(
+          node.consequent,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        collectUnmappedSelections(
+          node.alternate,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.LogicalExpression) {
+        collectUnmappedSelections(node.left, unmapped, uninspectable, visited);
+        collectUnmappedSelections(node.right, unmapped, uninspectable, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.SequenceExpression) {
+        const selectedExpression = node.expressions.at(-1);
+        if (selectedExpression !== undefined) {
+          collectUnmappedSelections(
+            selectedExpression,
+            unmapped,
+            uninspectable,
+            visited,
+          );
+        }
+        return;
+      }
       if (node.type === AST_NODE_TYPES.ObjectExpression) {
         for (const property of node.properties) {
           if (property.type === AST_NODE_TYPES.SpreadElement) {
-            collectUnmappedSelections(property.argument, unmapped);
-          } else if (
-            property.kind === "get" &&
-            nodeContainsUntrustedSqlResult(property.value)
-          ) {
-            unmapped.push(property.value);
+            collectUnmappedSelections(
+              property.argument,
+              unmapped,
+              uninspectable,
+              visited,
+            );
+          } else if (property.kind === "get") {
+            const status = nodeSelectionResultTypeStatus(property.value);
+            if (status === "unmapped") {
+              unmapped.push(property.value);
+            } else if (status === "uninspectable") {
+              uninspectable.push(property.value);
+            }
           } else {
-            collectUnmappedSelections(property.value, unmapped);
+            collectUnmappedSelections(
+              property.value,
+              unmapped,
+              uninspectable,
+              visited,
+            );
           }
         }
         return;
       }
-      if (nodeContainsUntrustedSql(node)) {
+
+      if (isMutableLocalSelectionContainer(node)) {
+        uninspectable.push(node);
+        return;
+      }
+
+      const status = nodeSelectionTypeStatus(node);
+      if (status === "unmapped") {
         unmapped.push(node);
+      } else if (status === "uninspectable") {
+        uninspectable.push(node);
       }
     }
 
@@ -472,6 +718,7 @@ export const requireSqlResultMapping = createRule({
     function collectUnmappedExtras(
       node: TSESTree.Node,
       unmapped: TSESTree.Node[],
+      uninspectable: TSESTree.Node[],
       visited: Set<TSESTree.Node>,
     ): void {
       if (visited.has(node)) {
@@ -481,32 +728,66 @@ export const requireSqlResultMapping = createRule({
 
       const initializer = localVariableInitializer(node);
       if (initializer !== null) {
-        collectUnmappedExtras(initializer, unmapped, visited);
+        collectUnmappedExtras(initializer, unmapped, uninspectable, visited);
         return;
       }
       const expression = transparentExpression(node);
       if (expression !== null) {
-        collectUnmappedExtras(expression, unmapped, visited);
+        collectUnmappedExtras(expression, unmapped, uninspectable, visited);
         return;
       }
       if (node.type === AST_NODE_TYPES.ConditionalExpression) {
-        collectUnmappedExtras(node.consequent, unmapped, visited);
-        collectUnmappedExtras(node.alternate, unmapped, visited);
+        collectUnmappedExtras(
+          node.consequent,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        collectUnmappedExtras(node.alternate, unmapped, uninspectable, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.LogicalExpression) {
+        collectUnmappedExtras(node.left, unmapped, uninspectable, visited);
+        collectUnmappedExtras(node.right, unmapped, uninspectable, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.SequenceExpression) {
+        const selectedExpression = node.expressions.at(-1);
+        if (selectedExpression !== undefined) {
+          collectUnmappedExtras(
+            selectedExpression,
+            unmapped,
+            uninspectable,
+            visited,
+          );
+        }
         return;
       }
       if (node.type === AST_NODE_TYPES.ObjectExpression) {
-        collectUnmappedSelections(node, unmapped);
+        collectUnmappedSelections(
+          node,
+          unmapped,
+          uninspectable,
+          new Set<TSESTree.Node>(),
+        );
         return;
       }
       if (
         node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
         node.body.type !== AST_NODE_TYPES.BlockStatement
       ) {
-        collectUnmappedExtras(node.body, unmapped, visited);
+        collectUnmappedExtras(node.body, unmapped, uninspectable, visited);
         return;
       }
-      if (nodeContainsUntrustedSqlResult(node)) {
+      if (isMutableLocalSelectionContainer(node)) {
+        uninspectable.push(node);
+        return;
+      }
+      const status = nodeSelectionResultTypeStatus(node);
+      if (status === "unmapped") {
         unmapped.push(node);
+      } else if (status === "uninspectable") {
+        uninspectable.push(node);
       }
     }
 
@@ -598,7 +879,12 @@ export const requireSqlResultMapping = createRule({
 
         const name = resolvedPropertyName(property);
         if (name === "extras") {
-          collectUnmappedExtras(property.value, unmapped, visited.extras);
+          collectUnmappedExtras(
+            property.value,
+            unmapped,
+            uninspectable,
+            visited.extras,
+          );
         } else if (name === "with") {
           collectUnmappedRelationalNode(
             property.value,
@@ -613,14 +899,8 @@ export const requireSqlResultMapping = createRule({
 
     function resultFieldArgument(
       node: TSESTree.CallExpression,
+      name: string,
     ): TSESTree.Expression | null {
-      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
-        return null;
-      }
-      const name = resolvedMemberName(node.callee);
-      if (name === null) {
-        return null;
-      }
       const argumentIndex = RESULT_FIELD_ARGUMENT.get(name);
       if (argumentIndex === undefined) {
         return null;
@@ -674,23 +954,200 @@ export const requireSqlResultMapping = createRule({
       );
     }
 
-    function isResultMethodMember(node: TSESTree.MemberExpression): boolean {
-      const name = resolvedMemberName(node);
+    function isResultMethod(
+      name: string,
+      symbol: TypeScriptSymbol | undefined,
+      type: Type,
+    ): boolean {
+      return (
+        isRelationalResultMethod(name, symbol, type) ||
+        isStructuredSelectionMethod(name, symbol, type)
+      );
+    }
+
+    function hasResultMethodHint(text: string): boolean {
+      const normalizedText = text.toLowerCase();
+      return RESULT_METHOD_HINTS.some((hint) => {
+        return normalizedText.includes(hint);
+      });
+    }
+
+    function isReflectedResultMethod(node: TSESTree.Node): boolean {
       if (
-        name === null ||
-        (!RESULT_FIELD_ARGUMENT.has(name) &&
-          !RELATIONAL_RESULT_METHODS.has(name))
+        node.type !== AST_NODE_TYPES.CallExpression ||
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        node.callee.object.type !== AST_NODE_TYPES.Identifier ||
+        node.callee.object.name !== "Reflect" ||
+        resolvedMemberName(node.callee) !== "get"
       ) {
         return false;
       }
+      const key = node.arguments[1];
+      if (key === undefined || key.type === AST_NODE_TYPES.SpreadElement) {
+        return false;
+      }
+      const name =
+        key.type === AST_NODE_TYPES.Literal && typeof key.value === "string"
+          ? key.value
+          : staticStringValue(key);
+      return (
+        name !== null &&
+        (RESULT_FIELD_ARGUMENT.has(name) || RELATIONAL_RESULT_METHODS.has(name))
+      );
+    }
 
-      const symbol = symbolAt(node.property);
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      const type = checker.getTypeAtLocation(tsNode);
-      if (isRelationalResultMethod(name, symbol, type)) {
+    function variableInScope(
+      node: TSESTree.Node,
+      name: string,
+    ): TSESLint.Scope.Variable | null {
+      let scope: TSESLint.Scope.Scope | null =
+        context.sourceCode.getScope(node);
+      while (scope !== null) {
+        const variable = scope.variables.find((candidate) => {
+          return candidate.name === name;
+        });
+        if (variable !== undefined) {
+          return variable;
+        }
+        scope = scope.upper;
+      }
+      return null;
+    }
+
+    function variableHasResultMethodHint(
+      variable: TSESLint.Scope.Variable,
+    ): boolean {
+      if (resultMethodHintVariables.has(variable)) {
         return true;
       }
-      return isStructuredSelectionMethod(name, symbol, type);
+      if (resultMethodHintVariablesInProgress.has(variable)) {
+        return false;
+      }
+      resultMethodHintVariablesInProgress.add(variable);
+
+      for (const definition of variable.defs) {
+        if (
+          definition.node.type !== AST_NODE_TYPES.TSTypeAliasDeclaration &&
+          definition.node.type !== AST_NODE_TYPES.TSInterfaceDeclaration &&
+          definition.node.type !== AST_NODE_TYPES.VariableDeclarator
+        ) {
+          continue;
+        }
+        if (hasResultMethodHint(context.sourceCode.getText(definition.node))) {
+          resultMethodHintVariables.add(variable);
+          resultMethodHintVariablesInProgress.delete(variable);
+          return true;
+        }
+        for (const token of context.sourceCode.getTokens(definition.node)) {
+          const referencedVariable = variableInScope(
+            definition.node,
+            token.value,
+          );
+          if (
+            referencedVariable !== null &&
+            variableHasResultMethodHint(referencedVariable)
+          ) {
+            resultMethodHintVariables.add(variable);
+            resultMethodHintVariablesInProgress.delete(variable);
+            return true;
+          }
+        }
+      }
+      resultMethodHintVariablesInProgress.delete(variable);
+      return false;
+    }
+
+    function typeAnnotationHasResultMethodHint(node: TSESTree.Node): boolean {
+      if (hasResultMethodHint(context.sourceCode.getText(node))) {
+        return true;
+      }
+      return context.sourceCode.getTokens(node).some((token) => {
+        const variable = variableInScope(node, token.value);
+        return variable !== null && variableHasResultMethodHint(variable);
+      });
+    }
+
+    function identifierCanBeResultMethodAlias(
+      node: TSESTree.Identifier,
+    ): boolean {
+      const variable = variableInScope(node, node.name);
+      if (variable === null) {
+        return false;
+      }
+      return variable.defs.some((definition) => {
+        const typeAnnotation =
+          "typeAnnotation" in definition.name
+            ? definition.name.typeAnnotation
+            : undefined;
+        if (
+          typeAnnotation !== undefined &&
+          typeAnnotationHasResultMethodHint(typeAnnotation)
+        ) {
+          return true;
+        }
+        return (
+          definition.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init !== null &&
+          isReflectedResultMethod(definition.node.init)
+        );
+      });
+    }
+
+    function canBeResultMethodAlias(node: TSESTree.Expression): boolean {
+      if (node.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          node.object.type === AST_NODE_TYPES.Identifier &&
+          identifierCanBeResultMethodAlias(node.object)
+        );
+      }
+      if (node.type !== AST_NODE_TYPES.Identifier) {
+        return isReflectedResultMethod(node);
+      }
+      return identifierCanBeResultMethodAlias(node);
+    }
+
+    function resultMethodName(node: TSESTree.Expression): string | null {
+      if (node.type === AST_NODE_TYPES.MemberExpression) {
+        const name = resolvedMemberName(node);
+        if (
+          name !== null &&
+          (RESULT_FIELD_ARGUMENT.has(name) ||
+            RELATIONAL_RESULT_METHODS.has(name))
+        ) {
+          const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+          const type = checker.getTypeAtLocation(tsNode);
+          return isResultMethod(name, symbolAt(node.property), type)
+            ? name
+            : null;
+        }
+      }
+      if (!canBeResultMethodAlias(node)) {
+        return null;
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const type = checker.getTypeAtLocation(tsNode);
+      const cachedName = resultMethodNameByType.get(type);
+      if (cachedName !== undefined) {
+        return cachedName;
+      }
+      for (const name of RESULT_METHOD_NAMES) {
+        if (
+          type.getCallSignatures().some((signature) => {
+            return isNamedDrizzleSignature(signature, name);
+          }) &&
+          isResultMethod(name, undefined, type)
+        ) {
+          resultMethodNameByType.set(type, name);
+          return name;
+        }
+      }
+      resultMethodNameByType.set(type, null);
+      return null;
+    }
+
+    function isResultMethodMember(node: TSESTree.MemberExpression): boolean {
+      return resultMethodName(node) !== null;
     }
 
     function destructuresResultMethod(node: TSESTree.Property): boolean {
@@ -772,15 +1229,86 @@ export const requireSqlResultMapping = createRule({
       }
     }
 
+    function isUnsafeSqlAssertion(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      return (
+        nodeContainsUntrustedSql(node.expression) &&
+        !nodeContainsUntrustedSql(node)
+      );
+    }
+
     function checkAssertion(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
     ): void {
-      if (
-        nodeContainsUntrustedSql(node.expression) &&
-        !nodeContainsUntrustedSql(node)
-      ) {
+      if (isUnsafeSqlAssertion(node)) {
         context.report({ node, messageId: "sqlAssertion" });
       }
+    }
+
+    function containsReportedResultMethodReference(
+      node: TSESTree.Node,
+      visited: Set<TSESTree.Node>,
+    ): boolean {
+      if (visited.has(node)) {
+        return false;
+      }
+      visited.add(node);
+
+      const initializer = localVariableInitializer(node);
+      if (initializer !== null) {
+        return containsReportedResultMethodReference(initializer, visited);
+      }
+      const expression = transparentExpression(node);
+      if (expression !== null) {
+        return containsReportedResultMethodReference(expression, visited);
+      }
+      if (node.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          isResultMethodMember(node) ||
+          containsReportedResultMethodReference(node.object, visited) ||
+          (node.computed &&
+            containsReportedResultMethodReference(node.property, visited))
+        );
+      }
+      if (node.type === AST_NODE_TYPES.CallExpression) {
+        if (containsReportedResultMethodReference(node.callee, visited)) {
+          return true;
+        }
+        return node.arguments.some((argument) => {
+          return containsReportedResultMethodReference(
+            argument.type === AST_NODE_TYPES.SpreadElement
+              ? argument.argument
+              : argument,
+            visited,
+          );
+        });
+      }
+      if (
+        node.type === AST_NODE_TYPES.ConditionalExpression ||
+        node.type === AST_NODE_TYPES.LogicalExpression
+      ) {
+        return (
+          containsReportedResultMethodReference(
+            node.type === AST_NODE_TYPES.ConditionalExpression
+              ? node.consequent
+              : node.left,
+            visited,
+          ) ||
+          containsReportedResultMethodReference(
+            node.type === AST_NODE_TYPES.ConditionalExpression
+              ? node.alternate
+              : node.right,
+            visited,
+          )
+        );
+      }
+      if (node.type === AST_NODE_TYPES.SequenceExpression) {
+        return node.expressions.some((item) => {
+          return containsReportedResultMethodReference(item, visited);
+        });
+      }
+      return false;
     }
 
     function checkResultMethodReference(node: TSESTree.MemberExpression): void {
@@ -831,6 +1359,14 @@ export const requireSqlResultMapping = createRule({
           context.report({ node, messageId: "sqlTypeReference" });
         }
       },
+      TSClassImplements(node: TSESTree.TSClassImplements): void {
+        if (
+          node.typeArguments?.params.length &&
+          isDrizzleSqlTypeName(node.expression)
+        ) {
+          context.report({ node, messageId: "sqlTypeReference" });
+        }
+      },
       TSInstantiationExpression(
         node: TSESTree.TSInstantiationExpression,
       ): void {
@@ -855,14 +1391,54 @@ export const requireSqlResultMapping = createRule({
           context.report({ node, messageId: "sqlAliasTypeArgument" });
         }
 
+        let methodName: string;
+        if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
+          const directName = resolvedMemberName(node.callee);
+          if (
+            directName !== null &&
+            (RESULT_FIELD_ARGUMENT.has(directName) ||
+              RELATIONAL_RESULT_METHODS.has(directName))
+          ) {
+            methodName = directName;
+          } else {
+            const aliasName = resultMethodName(node.callee);
+            if (aliasName === null) {
+              return;
+            }
+            context.report({
+              node: node.callee,
+              messageId: "resultMethodReference",
+            });
+            return;
+          }
+        } else {
+          const aliasName = resultMethodName(node.callee);
+          if (aliasName === null) {
+            return;
+          }
+          const initializer = localVariableInitializer(node.callee);
+          if (
+            initializer === null ||
+            !containsReportedResultMethodReference(
+              initializer,
+              new Set<TSESTree.Node>(),
+            )
+          ) {
+            context.report({
+              node: node.callee,
+              messageId: "resultMethodReference",
+            });
+          }
+          return;
+        }
+
         const hasSpreadArgument = node.arguments.some(
           (argument) => argument.type === AST_NODE_TYPES.SpreadElement,
         );
-        if (
-          hasSpreadArgument &&
-          node.callee.type === AST_NODE_TYPES.MemberExpression &&
-          isResultMethodMember(node.callee)
-        ) {
+        if (hasSpreadArgument) {
+          if (!isResultMethodMember(node.callee)) {
+            return;
+          }
           for (const argument of node.arguments) {
             if (argument.type === AST_NODE_TYPES.SpreadElement) {
               context.report({
@@ -874,13 +1450,10 @@ export const requireSqlResultMapping = createRule({
           return;
         }
 
-        if (
-          node.callee.type === AST_NODE_TYPES.MemberExpression &&
-          RELATIONAL_RESULT_METHODS.has(
-            resolvedMemberName(node.callee) ?? "",
-          ) &&
-          isResultMethodMember(node.callee)
-        ) {
+        if (RELATIONAL_RESULT_METHODS.has(methodName)) {
+          if (!isResultMethodMember(node.callee)) {
+            return;
+          }
           const config = node.arguments[0];
           if (
             config !== undefined &&
@@ -911,21 +1484,32 @@ export const requireSqlResultMapping = createRule({
           }
         }
 
-        const fields = resultFieldArgument(node);
+        const fields = resultFieldArgument(node, methodName);
         if (fields === null) {
           return;
         }
         const unmapped: TSESTree.Node[] = [];
-        collectUnmappedSelections(fields, unmapped);
+        const uninspectable: TSESTree.Node[] = [];
+        collectUnmappedSelections(
+          fields,
+          unmapped,
+          uninspectable,
+          new Set<TSESTree.Node>(),
+        );
         if (
-          unmapped.length === 0 ||
-          node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+          (unmapped.length === 0 && uninspectable.length === 0) ||
           !isResultMethodMember(node.callee)
         ) {
           return;
         }
         for (const field of unmapped) {
           context.report({ node: field, messageId: "unmappedResult" });
+        }
+        for (const field of uninspectable) {
+          context.report({
+            node: field,
+            messageId: "uninspectableResultSelection",
+          });
         }
       },
       NewExpression(node: TSESTree.NewExpression): void {

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -1,0 +1,357 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  IndexKind,
+  SymbolFlags,
+  TypeFlags,
+  type Declaration,
+  type Node,
+  type Symbol as TypeScriptSymbol,
+  type Type,
+  type TypeChecker,
+} from "typescript";
+
+import { createRule } from "../utils.ts";
+
+const RESULT_FIELD_ARGUMENT = new Map<string, number>([
+  ["returning", 0],
+  ["select", 0],
+  ["selectDistinct", 0],
+  ["selectDistinctOn", 1],
+]);
+
+const TERMINAL_TYPE_FLAGS =
+  TypeFlags.Any |
+  TypeFlags.Unknown |
+  TypeFlags.StringLike |
+  TypeFlags.NumberLike |
+  TypeFlags.BigIntLike |
+  TypeFlags.BooleanLike |
+  TypeFlags.ESSymbolLike |
+  TypeFlags.Null |
+  TypeFlags.Undefined |
+  TypeFlags.Void |
+  TypeFlags.Never;
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function isDrizzleDeclaration(node: Declaration): boolean {
+  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
+  return sourcePath.includes("/node_modules/drizzle-orm/");
+}
+
+function resolvedSymbol(
+  checker: TypeChecker,
+  symbol: TypeScriptSymbol | undefined,
+): TypeScriptSymbol | undefined {
+  if (symbol === undefined) {
+    return undefined;
+  }
+  return (symbol.flags & SymbolFlags.Alias) === 0
+    ? symbol
+    : checker.getAliasedSymbol(symbol);
+}
+
+function isDrizzleSymbol(
+  checker: TypeChecker,
+  symbol: TypeScriptSymbol | undefined,
+): boolean {
+  return (
+    resolvedSymbol(checker, symbol)?.declarations?.some(
+      isDrizzleDeclaration,
+    ) === true
+  );
+}
+
+function propertyType(
+  checker: TypeChecker,
+  type: Type,
+  name: string,
+  location: Node,
+): Type | undefined {
+  const symbol = checker.getPropertyOfType(type, name);
+  return symbol === undefined
+    ? undefined
+    : checker.getTypeOfSymbolAtLocation(symbol, location);
+}
+
+function sqlOutputType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): Type | null {
+  const metadataSymbol = checker.getPropertyOfType(type, "_");
+  if (
+    metadataSymbol === undefined ||
+    metadataSymbol.declarations?.some(isDrizzleDeclaration) !== true
+  ) {
+    return null;
+  }
+
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return null;
+  }
+  const brandType = propertyType(checker, metadataType, "brand", location);
+  if (
+    brandType === undefined ||
+    !brandType.isStringLiteral() ||
+    (brandType.value !== "SQL" && brandType.value !== "SQL.Aliased")
+  ) {
+    return null;
+  }
+
+  return propertyType(checker, metadataType, "type", location) ?? null;
+}
+
+function isUntrustedOutput(type: Type): boolean {
+  return (type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0;
+}
+
+function isDrizzleWrapper(checker: TypeChecker, type: Type): boolean {
+  return isDrizzleSymbol(checker, checker.getPropertyOfType(type, "getSQL"));
+}
+
+function containsUntrustedSql(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+  visited: Set<Type>,
+): boolean {
+  if (visited.has(type)) {
+    return false;
+  }
+  visited.add(type);
+
+  if (type.isUnionOrIntersection()) {
+    return type.types.some((member) => {
+      return containsUntrustedSql(checker, member, location, visited);
+    });
+  }
+
+  const outputType = sqlOutputType(checker, type, location);
+  if (outputType !== null) {
+    return isUntrustedOutput(outputType);
+  }
+
+  if (
+    (type.flags & TERMINAL_TYPE_FLAGS) !== 0 ||
+    isDrizzleWrapper(checker, type) ||
+    checker.isArrayType(type) ||
+    checker.isTupleType(type) ||
+    type.getCallSignatures().length > 0
+  ) {
+    return false;
+  }
+
+  for (const property of checker.getPropertiesOfType(type)) {
+    const propertyType = checker.getTypeOfSymbolAtLocation(property, location);
+    if (containsUntrustedSql(checker, propertyType, location, visited)) {
+      return true;
+    }
+  }
+
+  const stringValueType = checker.getIndexTypeOfType(type, IndexKind.String);
+  if (
+    stringValueType !== undefined &&
+    containsUntrustedSql(checker, stringValueType, location, visited)
+  ) {
+    return true;
+  }
+  const numberValueType = checker.getIndexTypeOfType(type, IndexKind.Number);
+  return (
+    numberValueType !== undefined &&
+    containsUntrustedSql(checker, numberValueType, location, visited)
+  );
+}
+
+export const requireSqlResultMapping = createRule({
+  name: "require-sql-result-mapping",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require runtime mapping for raw SQL values in structured Drizzle results",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      sqlTypeArgument:
+        "Drizzle sql<T> is compile-only. Remove the type argument; map selected values with a matching runtime decoder.",
+      sqlTypeReference:
+        "A generic Drizzle SQL type is compile-only. Use unparameterized SQL for composition and derive selected output from runtime mapping.",
+      sqlAliasTypeArgument:
+        'Generic SQL .as<T>(...) changes only the TypeScript type. Use .as("alias") after runtime mapping.',
+      sqlAssertion:
+        "A TypeScript assertion cannot establish a raw SQL runtime result contract.",
+      unmappedResult:
+        "Raw SQL in a structured Drizzle result must derive a concrete output from .mapWith(...) or a trusted schema-aware helper.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function symbolAt(node: TSESTree.Node): TypeScriptSymbol | undefined {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return checker.getSymbolAtLocation(tsNode);
+    }
+
+    function isDrizzleSqlTag(node: TSESTree.Expression): boolean {
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        const symbol = resolvedSymbol(checker, symbolAt(node));
+        return symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol);
+      }
+      if (
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(node) === "sql"
+      ) {
+        const symbol = resolvedSymbol(checker, symbolAt(node.property));
+        return symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol);
+      }
+      return false;
+    }
+
+    function nodeContainsUntrustedSql(node: TSESTree.Node): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return containsUntrustedSql(
+        checker,
+        checker.getTypeAtLocation(tsNode),
+        tsNode,
+        new Set<Type>(),
+      );
+    }
+
+    function collectUnmappedSelections(
+      node: TSESTree.Node,
+      unmapped: TSESTree.Node[],
+    ): void {
+      if (node.type === AST_NODE_TYPES.ObjectExpression) {
+        for (const property of node.properties) {
+          if (property.type === AST_NODE_TYPES.SpreadElement) {
+            collectUnmappedSelections(property.argument, unmapped);
+          } else {
+            collectUnmappedSelections(property.value, unmapped);
+          }
+        }
+        return;
+      }
+      if (nodeContainsUntrustedSql(node)) {
+        unmapped.push(node);
+      }
+    }
+
+    function resultFieldArgument(
+      node: TSESTree.CallExpression,
+    ): TSESTree.Expression | null {
+      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+        return null;
+      }
+      const name = memberName(node.callee);
+      if (name === null) {
+        return null;
+      }
+      const argumentIndex = RESULT_FIELD_ARGUMENT.get(name);
+      if (argumentIndex === undefined) {
+        return null;
+      }
+      const argument = node.arguments[argumentIndex];
+      if (
+        argument === undefined ||
+        argument.type === AST_NODE_TYPES.SpreadElement
+      ) {
+        return null;
+      }
+      return argument;
+    }
+
+    function isGenericDrizzleSqlAlias(node: TSESTree.CallExpression): boolean {
+      if (
+        node.typeArguments?.params.length !== 1 ||
+        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(node.callee) !== "as" ||
+        !isDrizzleSymbol(checker, symbolAt(node.callee.property))
+      ) {
+        return false;
+      }
+      const receiver = node.callee.object;
+      const tsReceiver = services.esTreeNodeToTSNodeMap.get(receiver);
+      return (
+        sqlOutputType(
+          checker,
+          checker.getTypeAtLocation(tsReceiver),
+          tsReceiver,
+        ) !== null
+      );
+    }
+
+    function checkAssertion(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): void {
+      if (
+        !nodeContainsUntrustedSql(node) &&
+        nodeContainsUntrustedSql(node.expression)
+      ) {
+        context.report({ node, messageId: "sqlAssertion" });
+      }
+    }
+
+    return {
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
+        if (node.typeArguments?.params.length && isDrizzleSqlTag(node.tag)) {
+          context.report({ node, messageId: "sqlTypeArgument" });
+        }
+      },
+      TSTypeReference(node: TSESTree.TSTypeReference): void {
+        const symbol = resolvedSymbol(checker, symbolAt(node.typeName));
+        if (
+          node.typeArguments?.params.length &&
+          (symbol?.getName() === "SQL" || symbol?.getName() === "Aliased") &&
+          isDrizzleSymbol(checker, symbol)
+        ) {
+          context.report({ node, messageId: "sqlTypeReference" });
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (isGenericDrizzleSqlAlias(node)) {
+          context.report({ node, messageId: "sqlAliasTypeArgument" });
+        }
+        const fields = resultFieldArgument(node);
+        if (fields === null) {
+          return;
+        }
+        const unmapped: TSESTree.Node[] = [];
+        collectUnmappedSelections(fields, unmapped);
+        if (
+          unmapped.length === 0 ||
+          node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+          !isDrizzleSymbol(checker, symbolAt(node.callee.property))
+        ) {
+          return;
+        }
+        for (const field of unmapped) {
+          context.report({ node: field, messageId: "unmappedResult" });
+        }
+      },
+      TSAsExpression(node: TSESTree.TSAsExpression): void {
+        checkAssertion(node);
+      },
+      TSTypeAssertion(node: TSESTree.TSTypeAssertion): void {
+        checkAssertion(node);
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -5,10 +5,12 @@ import {
 } from "@typescript-eslint/utils";
 import {
   IndexKind,
+  isVariableDeclaration,
   SymbolFlags,
   TypeFlags,
   type Declaration,
   type Node,
+  type Signature,
   type Symbol as TypeScriptSymbol,
   type Type,
   type TypeChecker,
@@ -22,6 +24,8 @@ const RESULT_FIELD_ARGUMENT = new Map<string, number>([
   ["selectDistinct", 0],
   ["selectDistinctOn", 1],
 ]);
+
+const RELATIONAL_RESULT_METHODS = new Set(["findFirst", "findMany"]);
 
 const TERMINAL_TYPE_FLAGS =
   TypeFlags.Any |
@@ -46,9 +50,29 @@ function memberName(node: TSESTree.MemberExpression): string | null {
   return null;
 }
 
+function propertyName(node: TSESTree.Property): string | null {
+  if (!node.computed && node.key.type === AST_NODE_TYPES.Identifier) {
+    return node.key.name;
+  }
+  if (node.key.type === AST_NODE_TYPES.Literal) {
+    return typeof node.key.value === "string" ? node.key.value : null;
+  }
+  return null;
+}
+
 function isDrizzleDeclaration(node: Declaration): boolean {
   const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
   return sourcePath.includes("/node_modules/drizzle-orm/");
+}
+
+function isNamedDrizzleSignature(signature: Signature, name: string): boolean {
+  const declaration = signature.declaration;
+  return (
+    declaration !== undefined &&
+    "name" in declaration &&
+    declaration.name?.getText() === name &&
+    isDrizzleDeclaration(declaration)
+  );
 }
 
 function resolvedSymbol(
@@ -176,6 +200,38 @@ function containsUntrustedSql(
   );
 }
 
+function containsUntrustedSqlResult(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+  visited: Set<Type>,
+): boolean {
+  if (visited.has(type)) {
+    return false;
+  }
+  visited.add(type);
+
+  if (type.isUnionOrIntersection()) {
+    return type.types.some((member) => {
+      return containsUntrustedSqlResult(checker, member, location, visited);
+    });
+  }
+
+  const signatures = type.getCallSignatures();
+  if (signatures.length > 0) {
+    return signatures.some((signature) => {
+      return containsUntrustedSql(
+        checker,
+        checker.getReturnTypeOfSignature(signature),
+        location,
+        new Set<Type>(),
+      );
+    });
+  }
+
+  return containsUntrustedSql(checker, type, location, new Set<Type>());
+}
+
 export const requireSqlResultMapping = createRule({
   name: "require-sql-result-mapping",
   defaultOptions: [],
@@ -197,6 +253,12 @@ export const requireSqlResultMapping = createRule({
         'Generic SQL .as<T>(...) changes only the TypeScript type. Use .as("alias") after runtime mapping.',
       sqlAssertion:
         "A TypeScript assertion cannot establish a raw SQL runtime result contract.",
+      resultMethodReference:
+        "Do not alias or bind a Drizzle structured-result method. Call it directly so raw SQL result mapping can be enforced.",
+      uninspectableResultArguments:
+        "Do not spread arguments into a Drizzle structured-result method. Pass them explicitly so raw SQL result mapping can be enforced.",
+      uninspectableRelationalConfig:
+        "Relational query config must be an inline object or a local variable so raw SQL extras can be inspected.",
       unmappedResult:
         "Raw SQL in a structured Drizzle result must derive a concrete output from .mapWith(...) or a trusted schema-aware helper.",
     },
@@ -210,24 +272,86 @@ export const requireSqlResultMapping = createRule({
       return checker.getSymbolAtLocation(tsNode);
     }
 
-    function isDrizzleSqlTag(node: TSESTree.Expression): boolean {
-      if (node.type === AST_NODE_TYPES.Identifier) {
-        const symbol = resolvedSymbol(checker, symbolAt(node));
-        return symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol);
+    function staticStringValue(node: TSESTree.Node): string | null {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const type = checker.getTypeAtLocation(tsNode);
+      return type.isStringLiteral() ? type.value : null;
+    }
+
+    function resolvedMemberName(
+      node: TSESTree.MemberExpression,
+    ): string | null {
+      return (
+        memberName(node) ??
+        (node.computed ? staticStringValue(node.property) : null)
+      );
+    }
+
+    function resolvedPropertyName(node: TSESTree.Property): string | null {
+      return (
+        propertyName(node) ??
+        (node.computed ? staticStringValue(node.key) : null)
+      );
+    }
+
+    function localVariableInitializer(
+      node: TSESTree.Node,
+    ): TSESTree.Node | null {
+      if (node.type !== AST_NODE_TYPES.Identifier) {
+        return null;
       }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const declaration = resolvedSymbol(
+        checker,
+        symbolAt(node),
+      )?.valueDeclaration;
       if (
-        node.type === AST_NODE_TYPES.MemberExpression &&
-        memberName(node) === "sql"
+        declaration === undefined ||
+        !isVariableDeclaration(declaration) ||
+        declaration.initializer === undefined ||
+        declaration.getSourceFile() !== tsNode.getSourceFile()
       ) {
-        const symbol = resolvedSymbol(checker, symbolAt(node.property));
-        return symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol);
+        return null;
       }
-      return false;
+      return services.tsNodeToESTreeNodeMap.get(declaration.initializer);
+    }
+
+    function isDrizzleSqlTag(node: TSESTree.Expression): boolean {
+      let symbol: TypeScriptSymbol | undefined;
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        symbol = resolvedSymbol(checker, symbolAt(node));
+      } else if (
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        resolvedMemberName(node) === "sql"
+      ) {
+        symbol = resolvedSymbol(checker, symbolAt(node.property));
+      }
+      if (symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol)) {
+        return true;
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return checker
+        .getTypeAtLocation(tsNode)
+        .getCallSignatures()
+        .some((signature) => {
+          return isNamedDrizzleSignature(signature, "sql");
+        });
     }
 
     function nodeContainsUntrustedSql(node: TSESTree.Node): boolean {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
       return containsUntrustedSql(
+        checker,
+        checker.getTypeAtLocation(tsNode),
+        tsNode,
+        new Set<Type>(),
+      );
+    }
+
+    function nodeContainsUntrustedSqlResult(node: TSESTree.Node): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return containsUntrustedSqlResult(
         checker,
         checker.getTypeAtLocation(tsNode),
         tsNode,
@@ -243,6 +367,11 @@ export const requireSqlResultMapping = createRule({
         for (const property of node.properties) {
           if (property.type === AST_NODE_TYPES.SpreadElement) {
             collectUnmappedSelections(property.argument, unmapped);
+          } else if (
+            property.kind === "get" &&
+            nodeContainsUntrustedSqlResult(property.value)
+          ) {
+            unmapped.push(property.value);
           } else {
             collectUnmappedSelections(property.value, unmapped);
           }
@@ -254,13 +383,187 @@ export const requireSqlResultMapping = createRule({
       }
     }
 
+    function transparentExpression(node: TSESTree.Node): TSESTree.Node | null {
+      if (
+        node.type === AST_NODE_TYPES.TSAsExpression ||
+        node.type === AST_NODE_TYPES.TSTypeAssertion ||
+        node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        node.type === AST_NODE_TYPES.TSNonNullExpression ||
+        node.type === AST_NODE_TYPES.ChainExpression
+      ) {
+        return node.expression;
+      }
+      return null;
+    }
+
+    function isSafeRelationalLeaf(node: TSESTree.Node): boolean {
+      let isUndefined = false;
+      if (
+        node.type === AST_NODE_TYPES.Identifier &&
+        node.name === "undefined"
+      ) {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        isUndefined =
+          (checker.getTypeAtLocation(tsNode).flags & TypeFlags.Undefined) !== 0;
+      }
+      return (
+        isUndefined ||
+        (node.type === AST_NODE_TYPES.Literal &&
+          (node.value === null || typeof node.value === "boolean")) ||
+        (node.type === AST_NODE_TYPES.UnaryExpression &&
+          node.operator === "void")
+      );
+    }
+
+    function collectUnmappedExtras(
+      node: TSESTree.Node,
+      unmapped: TSESTree.Node[],
+      visited: Set<TSESTree.Node>,
+    ): void {
+      if (visited.has(node)) {
+        return;
+      }
+      visited.add(node);
+
+      const initializer = localVariableInitializer(node);
+      if (initializer !== null) {
+        collectUnmappedExtras(initializer, unmapped, visited);
+        return;
+      }
+      const expression = transparentExpression(node);
+      if (expression !== null) {
+        collectUnmappedExtras(expression, unmapped, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        collectUnmappedExtras(node.consequent, unmapped, visited);
+        collectUnmappedExtras(node.alternate, unmapped, visited);
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ObjectExpression) {
+        collectUnmappedSelections(node, unmapped);
+        return;
+      }
+      if (
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+        node.body.type !== AST_NODE_TYPES.BlockStatement
+      ) {
+        collectUnmappedExtras(node.body, unmapped, visited);
+        return;
+      }
+      if (nodeContainsUntrustedSqlResult(node)) {
+        unmapped.push(node);
+      }
+    }
+
+    // DBQueryConfig is recursive, so inspect bounded local syntax instead of
+    // expanding its full contextual type.
+    function collectUnmappedRelationalNode(
+      node: TSESTree.Node,
+      kind: "config" | "with",
+      unmapped: TSESTree.Node[],
+      uninspectable: TSESTree.Node[],
+      visited: {
+        config: Set<TSESTree.Node>;
+        extras: Set<TSESTree.Node>;
+        with: Set<TSESTree.Node>;
+      },
+    ): void {
+      if (visited[kind].has(node)) {
+        return;
+      }
+      visited[kind].add(node);
+
+      const initializer = localVariableInitializer(node);
+      if (initializer !== null) {
+        collectUnmappedRelationalNode(
+          initializer,
+          kind,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        return;
+      }
+      const expression = transparentExpression(node);
+      if (expression !== null) {
+        collectUnmappedRelationalNode(
+          expression,
+          kind,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        return;
+      }
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        collectUnmappedRelationalNode(
+          node.consequent,
+          kind,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        collectUnmappedRelationalNode(
+          node.alternate,
+          kind,
+          unmapped,
+          uninspectable,
+          visited,
+        );
+        return;
+      }
+      if (node.type !== AST_NODE_TYPES.ObjectExpression) {
+        if (!isSafeRelationalLeaf(node)) {
+          uninspectable.push(node);
+        }
+        return;
+      }
+
+      for (const property of node.properties) {
+        if (property.type === AST_NODE_TYPES.SpreadElement) {
+          collectUnmappedRelationalNode(
+            property.argument,
+            kind,
+            unmapped,
+            uninspectable,
+            visited,
+          );
+          continue;
+        }
+        if (kind === "with") {
+          collectUnmappedRelationalNode(
+            property.value,
+            "config",
+            unmapped,
+            uninspectable,
+            visited,
+          );
+          continue;
+        }
+
+        const name = resolvedPropertyName(property);
+        if (name === "extras") {
+          collectUnmappedExtras(property.value, unmapped, visited.extras);
+        } else if (name === "with") {
+          collectUnmappedRelationalNode(
+            property.value,
+            "with",
+            unmapped,
+            uninspectable,
+            visited,
+          );
+        }
+      }
+    }
+
     function resultFieldArgument(
       node: TSESTree.CallExpression,
     ): TSESTree.Expression | null {
       if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
         return null;
       }
-      const name = memberName(node.callee);
+      const name = resolvedMemberName(node.callee);
       if (name === null) {
         return null;
       }
@@ -278,23 +581,128 @@ export const requireSqlResultMapping = createRule({
       return argument;
     }
 
-    function isGenericDrizzleSqlAlias(node: TSESTree.CallExpression): boolean {
+    function isStructuredSelectionMethod(
+      name: string,
+      symbol: TypeScriptSymbol | undefined,
+      type: Type,
+    ): boolean {
+      if (!RESULT_FIELD_ARGUMENT.has(name)) {
+        return false;
+      }
+      if (name === "returning") {
+        return (
+          isDrizzleSymbol(checker, symbol) ||
+          methodReturnsDrizzleType(type, "execute")
+        );
+      }
+      return methodReturnsDrizzleType(type, "from");
+    }
+
+    function methodReturnsDrizzleType(type: Type, property: string): boolean {
+      return type.getCallSignatures().some((signature) => {
+        const returnType = checker.getReturnTypeOfSignature(signature);
+        return isDrizzleSymbol(
+          checker,
+          checker.getPropertyOfType(returnType, property),
+        );
+      });
+    }
+
+    function isRelationalResultMethod(
+      name: string,
+      symbol: TypeScriptSymbol | undefined,
+      type: Type,
+    ): boolean {
+      return (
+        RELATIONAL_RESULT_METHODS.has(name) &&
+        (isDrizzleSymbol(checker, symbol) ||
+          methodReturnsDrizzleType(type, "execute"))
+      );
+    }
+
+    function isResultMethodMember(node: TSESTree.MemberExpression): boolean {
+      const name = resolvedMemberName(node);
       if (
-        node.typeArguments?.params.length !== 1 ||
-        node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-        memberName(node.callee) !== "as" ||
-        !isDrizzleSymbol(checker, symbolAt(node.callee.property))
+        name === null ||
+        (!RESULT_FIELD_ARGUMENT.has(name) &&
+          !RELATIONAL_RESULT_METHODS.has(name))
       ) {
         return false;
       }
-      const receiver = node.callee.object;
-      const tsReceiver = services.esTreeNodeToTSNodeMap.get(receiver);
+
+      const symbol = symbolAt(node.property);
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const type = checker.getTypeAtLocation(tsNode);
+      if (isRelationalResultMethod(name, symbol, type)) {
+        return true;
+      }
+      return isStructuredSelectionMethod(name, symbol, type);
+    }
+
+    function destructuresResultMethod(node: TSESTree.Property): boolean {
+      if (node.parent.type !== AST_NODE_TYPES.ObjectPattern) {
+        return false;
+      }
+      const name = resolvedPropertyName(node);
+      if (
+        name === null ||
+        (!RESULT_FIELD_ARGUMENT.has(name) &&
+          !RELATIONAL_RESULT_METHODS.has(name))
+      ) {
+        return false;
+      }
+
+      const tsPattern = services.esTreeNodeToTSNodeMap.get(node.parent);
+      const patternType = checker.getTypeAtLocation(tsPattern);
+      const symbol = checker.getPropertyOfType(patternType, name);
+      if (symbol === undefined) {
+        return false;
+      }
+      const type = checker.getTypeOfSymbolAtLocation(symbol, tsPattern);
       return (
-        sqlOutputType(
-          checker,
-          checker.getTypeAtLocation(tsReceiver),
-          tsReceiver,
-        ) !== null
+        isRelationalResultMethod(name, symbol, type) ||
+        isStructuredSelectionMethod(name, symbol, type)
+      );
+    }
+
+    function isDrizzleSqlAliasCallee(node: TSESTree.Expression): boolean {
+      if (
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        resolvedMemberName(node) === "as" &&
+        isDrizzleSymbol(checker, symbolAt(node.property))
+      ) {
+        const tsReceiver = services.esTreeNodeToTSNodeMap.get(node.object);
+        if (
+          sqlOutputType(
+            checker,
+            checker.getTypeAtLocation(tsReceiver),
+            tsReceiver,
+          ) !== null
+        ) {
+          return true;
+        }
+      }
+
+      const tsCallee = services.esTreeNodeToTSNodeMap.get(node);
+      return checker
+        .getTypeAtLocation(tsCallee)
+        .getCallSignatures()
+        .some((signature) => {
+          return (
+            isNamedDrizzleSignature(signature, "as") &&
+            sqlOutputType(
+              checker,
+              checker.getReturnTypeOfSignature(signature),
+              tsCallee,
+            ) !== null
+          );
+        });
+    }
+
+    function isGenericDrizzleSqlAlias(node: TSESTree.CallExpression): boolean {
+      return (
+        node.typeArguments?.params.length === 1 &&
+        isDrizzleSqlAliasCallee(node.callee)
       );
     }
 
@@ -302,10 +710,27 @@ export const requireSqlResultMapping = createRule({
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
     ): void {
       if (
-        !nodeContainsUntrustedSql(node) &&
-        nodeContainsUntrustedSql(node.expression)
+        nodeContainsUntrustedSql(node.expression) &&
+        !nodeContainsUntrustedSql(node)
       ) {
         context.report({ node, messageId: "sqlAssertion" });
+      }
+    }
+
+    function checkResultMethodReference(node: TSESTree.MemberExpression): void {
+      if (
+        (node.parent.type === AST_NODE_TYPES.CallExpression &&
+          node.parent.callee === node) ||
+        !isResultMethodMember(node)
+      ) {
+        return;
+      }
+      context.report({ node, messageId: "resultMethodReference" });
+    }
+
+    function checkDestructuredResultMethod(node: TSESTree.Property): void {
+      if (destructuresResultMethod(node)) {
+        context.report({ node, messageId: "resultMethodReference" });
       }
     }
 
@@ -325,10 +750,79 @@ export const requireSqlResultMapping = createRule({
           context.report({ node, messageId: "sqlTypeReference" });
         }
       },
+      TSInstantiationExpression(
+        node: TSESTree.TSInstantiationExpression,
+      ): void {
+        if (node.typeArguments.params.length !== 1) {
+          return;
+        }
+        if (isDrizzleSqlTag(node.expression)) {
+          context.report({ node, messageId: "sqlTypeArgument" });
+        } else if (isDrizzleSqlAliasCallee(node.expression)) {
+          context.report({ node, messageId: "sqlAliasTypeArgument" });
+        }
+      },
       CallExpression(node: TSESTree.CallExpression): void {
         if (isGenericDrizzleSqlAlias(node)) {
           context.report({ node, messageId: "sqlAliasTypeArgument" });
         }
+
+        const hasSpreadArgument = node.arguments.some(
+          (argument) => argument.type === AST_NODE_TYPES.SpreadElement,
+        );
+        if (
+          hasSpreadArgument &&
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          isResultMethodMember(node.callee)
+        ) {
+          for (const argument of node.arguments) {
+            if (argument.type === AST_NODE_TYPES.SpreadElement) {
+              context.report({
+                node: argument,
+                messageId: "uninspectableResultArguments",
+              });
+            }
+          }
+          return;
+        }
+
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          RELATIONAL_RESULT_METHODS.has(
+            resolvedMemberName(node.callee) ?? "",
+          ) &&
+          isResultMethodMember(node.callee)
+        ) {
+          const config = node.arguments[0];
+          if (
+            config !== undefined &&
+            config.type !== AST_NODE_TYPES.SpreadElement
+          ) {
+            const unmapped: TSESTree.Node[] = [];
+            const uninspectable: TSESTree.Node[] = [];
+            collectUnmappedRelationalNode(
+              config,
+              "config",
+              unmapped,
+              uninspectable,
+              {
+                config: new Set<TSESTree.Node>(),
+                extras: new Set<TSESTree.Node>(),
+                with: new Set<TSESTree.Node>(),
+              },
+            );
+            for (const field of unmapped) {
+              context.report({ node: field, messageId: "unmappedResult" });
+            }
+            for (const field of uninspectable) {
+              context.report({
+                node: field,
+                messageId: "uninspectableRelationalConfig",
+              });
+            }
+          }
+        }
+
         const fields = resultFieldArgument(node);
         if (fields === null) {
           return;
@@ -338,7 +832,7 @@ export const requireSqlResultMapping = createRule({
         if (
           unmapped.length === 0 ||
           node.callee.type !== AST_NODE_TYPES.MemberExpression ||
-          !isDrizzleSymbol(checker, symbolAt(node.callee.property))
+          !isResultMethodMember(node.callee)
         ) {
           return;
         }
@@ -346,6 +840,20 @@ export const requireSqlResultMapping = createRule({
           context.report({ node: field, messageId: "unmappedResult" });
         }
       },
+      "MemberExpression[computed=false][property.name='findFirst']":
+        checkResultMethodReference,
+      "MemberExpression[computed=false][property.name='findMany']":
+        checkResultMethodReference,
+      "MemberExpression[computed=false][property.name='returning']":
+        checkResultMethodReference,
+      "MemberExpression[computed=false][property.name='select']":
+        checkResultMethodReference,
+      "MemberExpression[computed=false][property.name='selectDistinct']":
+        checkResultMethodReference,
+      "MemberExpression[computed=false][property.name='selectDistinctOn']":
+        checkResultMethodReference,
+      "MemberExpression[computed=true]": checkResultMethodReference,
+      "ObjectPattern > Property": checkDestructuredResultMethod,
       TSAsExpression(node: TSESTree.TSAsExpression): void {
         checkAssertion(node);
       },


### PR DESCRIPTION
## Summary

- add and enable one type-aware API ESLint rule that rejects compile-only
  Drizzle SQL result types and unmapped raw SQL at structured result boundaries
- remove the 29 remaining `sql<T>` and 12 contextual `SQL<T>` annotations
  present on current `main`; map the sole selected intermediate field that
  requires a runtime decoder
- enforce the same invariant for reusable selections, helper returns,
  assertions, set-operation branches, relational-query `extras`, and hidden
  result-method calls
- extend the existing database-development skill with structured mapping,
  nullable and precision handling, set-operation ownership, and raw
  `executeRawRows` guidance

The rule resolves actual Drizzle declarations and checks `select`,
`selectDistinct`, `selectDistinctOn`, `returning`, `findMany`, and `findFirst`
result boundaries. It accepts mapped SQL, schema columns, and trusted
schema-aware helpers while leaving predicates, joins, ordering, grouping,
writes, discarded commands, and `rowCount` SQL untyped.

Structured selections fail closed when their runtime mapping cannot be
inspected. Reusable selection containers must be local `const` values, and
relational configs must remain inline or in inspectable local variables. The
rule has no allowlist, baseline, suppression, autofix, or production runtime
component.

## Final SQL ledger

- rebased onto `main` at `c73d40f593`
- 445 tagged API SQL templates reconciled on the current head
- 29 explicit and 12 contextual output generics removed from the current diff;
  zero `sql<T>`, contextual `SQL<T>`, or generic SQL `.as<T>` remains under
  `turbo/apps/api/src`
- all 144 templates in the 16 current cleanup owners retain identical template
  text and interpolation order relative to the rebased base

## Explicit exclusions

- no database schema, migration, or persisted-data change
- no public API, queue payload, runner protocol, or deployment-compatibility
  change
- no feature switch
- no SQL text, parameter order, query count, join, lock, ordering, or write
  change
- no production query or result-array runtime pass
- this child does not close parent #22139 or umbrella #22128

## Validation

- `pnpm prettier --check` for the changed rule, tests, config, exports, and
  existing skill
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test -- --silent=passed-only`
  (44 files, 644 tests; 111 targeted rule cases)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts --silent=passed-only`
  (19 tests)
- `pnpm knip --workspace @vm0/eslint-rules`
- current-base tagged-SQL inventory and normalized template comparison
- `git diff --check`

Closes #22157

Parent: #22139

Umbrella: #22128
