### PR TITLE
test(mitm-addon): cover auth base worker start failure

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -996,6 +996,41 @@ class TestForwardRequestAsyncWrapper:
         assert body == b"ok"
         assert list(headers.items(multi=True)) == []
 
+    async def test_worker_start_failure_releases_tracking_and_capacity(self):
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            fake_forwarder_upstream(),
+        ):
+            with (
+                patch.object(
+                    forwarder.threading.Thread,
+                    "start",
+                    side_effect=RuntimeError("can't start new thread"),
+                ),
+                pytest.raises(RuntimeError, match="can't start new thread"),
+            ):
+                await forwarder.forward_request(
+                    "https://example.com",
+                    "POST",
+                    [],
+                    b"request body",
+                )
+
+            assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+            with forwarder._forward_request_pending_futures_lock:
+                assert not forwarder._forward_request_pending_futures
+            with forwarder._forward_request_workers_lock:
+                assert not forwarder._forward_request_workers
+
+            status, body, headers = await asyncio.wait_for(
+                forwarder.forward_request("https://example.com", "GET", [], None),
+                timeout=2,
+            )
+
+        assert status == 200
+        assert body == b"ok"
+        assert list(headers.items(multi=True)) == []
+
     async def test_limits_concurrent_forwarding_work(self):
         active = 0
         max_active = 0


### PR DESCRIPTION
## Summary

- cover auth.base worker thread startup failure through the public forwarding lifecycle
- verify failed submission releases admission count, body-byte budget, pending-future tracking, and worker tracking
- prove the concurrency permit is reusable by completing a subsequent request with a limit of one

## Scope

- test-only change in `crates/runner/mitm-addon/tests/test_auth_base_forwarder.py`
- no production behavior, schema, API, persisted state, protocol, deployment compatibility, or documentation changes

## Validation

- `.venv/bin/pytest tests/test_auth_base_forwarder.py -k worker_start` — 2 passed
- `.venv/bin/pytest tests/test_auth_base_forwarder.py` — 98 passed
- `.venv/bin/ruff format --check tests/test_auth_base_forwarder.py`
- `.venv/bin/ruff check tests/test_auth_base_forwarder.py`
- `.venv/bin/basedpyright -p .` — 0 errors, 0 warnings
- `.venv/bin/pytest` — 4098 passed

Closes #22175
