### PR TITLE
perf(mitm-addon): avoid repeated idna normalization in x billing

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -345,10 +345,10 @@ def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: s
         simple_ascii_candidate = candidate.lower()
         # Canonical A-label validation remains owned by the shared IDNA path.
         use_simple_ascii_labels = "xn--" not in simple_ascii_candidate
+        labels = (simple_ascii_candidate if use_simple_ascii_labels else candidate).split(".")
     else:
-        simple_ascii_candidate = candidate
         use_simple_ascii_labels = False
-    labels = (simple_ascii_candidate if use_simple_ascii_labels else candidate).split(".")
+        labels = candidate.split(".")
     last_label_index = len(labels) - 1
     for index, label in enumerate(labels):
         if use_simple_ascii_labels:

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -341,22 +341,32 @@ def _label_has_tld_prefix_before_unicode(label: str) -> bool:
 
 
 def _bare_domain_candidate_likely_contains_url(candidate: str, following_char: str) -> bool:
-    labels = tuple(candidate.split("."))
+    if candidate.isascii():
+        simple_ascii_candidate = candidate.lower()
+        # Canonical A-label validation remains owned by the shared IDNA path.
+        use_simple_ascii_labels = "xn--" not in simple_ascii_candidate
+    else:
+        simple_ascii_candidate = candidate
+        use_simple_ascii_labels = False
+    labels = (simple_ascii_candidate if use_simple_ascii_labels else candidate).split(".")
     last_label_index = len(labels) - 1
     for index, label in enumerate(labels):
-        if index > 0 and _label_has_tld_prefix_before_unicode(label):
-            return True
+        if use_simple_ascii_labels:
+            normalized_label = label
+        else:
+            if index > 0 and _label_has_tld_prefix_before_unicode(label):
+                return True
 
-        try:
-            normalized_label = normalize_idna_label(label)
-        except UnsafeIdnaCompatibilityMappingError:
-            # Keep billing conservative for URL-like compatibility aliases,
-            # but do not fold them into unrelated ASCII domains.
-            if index == last_label_index:
-                return _is_twitter_text_tld_boundary(following_char)
-            continue
-        except UnicodeError:
-            return False
+            try:
+                normalized_label = normalize_idna_label(label)
+            except UnsafeIdnaCompatibilityMappingError:
+                # Keep billing conservative for URL-like compatibility aliases,
+                # but do not fold them into unrelated ASCII domains.
+                if index == last_label_index:
+                    return _is_twitter_text_tld_boundary(following_char)
+                continue
+            except UnicodeError:
+                return False
 
         if not _label_is_billing_domain_label(normalized_label):
             return False

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -18,6 +18,7 @@ from tests.x_flow_helpers import (
     json_body_that_exceeds_decoder_recursion,
     json_body_that_exceeds_integer_digit_limit,
 )
+from usage.providers.connectors import x_billing
 
 
 def _raw_deflate_body(payload: bytes) -> bytes:
@@ -404,6 +405,7 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
         "Open example.com/path/to/resource?search=foo&lang=en",
         "Open example.com:443/path",
         "Open xn--r8jz45g.xn--q9jyb4c",
+        "Uppercase IDN XN--R8JZ45G.XN--Q9JYB4C",
         "IDN 例え.みんな",
         "Accent mañana.com",
         "Sharp S faß.de",
@@ -453,6 +455,7 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
         "Leading hyphen -bad.com",
         "Trailing hyphen bad-.com",
         "Invalid prefix bad-.com.notatld",
+        "Invalid A-label xn--a.com",
     ],
 )
 def test_tweet_create_url_like_non_links_downgrade_to_content_create(
@@ -472,6 +475,38 @@ def test_tweet_create_url_like_non_links_downgrade_to_content_create(
     flow.request.method = "POST"
     flow.request.content = json.dumps({"text": text}).encode()
     p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_long_dotted_ascii_candidate_skips_idna_normalization(
+    x_usage, tmp_path, real_flow
+):
+    """Long ordinary ASCII candidates avoid generic IDNA work."""
+    text = ("a." * 12_500)[:25_000]
+    request_body = json.dumps({"text": text}).encode()
+    assert len(text) == 25_000
+    assert len(request_body) < REQUEST_BODY_BILLING_INSPECTION_LIMIT
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.content = request_body
+
+    with patch.object(
+        x_billing,
+        "normalize_idna_label",
+        wraps=x_billing.normalize_idna_label,
+    ) as normalize_idna_label:
+        p = x_usage.call_and_get_single_billing(flow)
+
+    normalize_idna_label.assert_not_called()
     assert p["category"] == "content.create"
     assert p["quantity"] == 1
 

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -456,6 +456,7 @@ def test_tweet_create_with_url_stays_on_with_url_bucket(x_usage, tmp_path, real_
         "Trailing hyphen bad-.com",
         "Invalid prefix bad-.com.notatld",
         "Invalid A-label xn--a.com",
+        "Invalid uppercase A-label XN--A.com",
     ],
 )
 def test_tweet_create_url_like_non_links_downgrade_to_content_create(


### PR DESCRIPTION
## Summary

- bypass per-label IDNA normalization for ordinary ASCII X post candidates
- preserve the existing Unicode and A-label validation path, including case-insensitive `xn--` candidates
- cover uppercase canonical/invalid A-labels, lowercase invalid A-labels, and a 25,000-character dotted ASCII post through the connector usage flow

## Performance

The 25,000-character dotted ASCII case now performs zero IDNA normalization calls and improves from 22.320 ms to 3.277 ms in the local benchmark (about 6.8x faster). A 50,000-case differential corpus found no billing classification differences from `main`.

## Compatibility

- no schema or migration changes
- no persisted-data changes
- no API, protocol, dependency, or deployment-order changes
- Unicode and canonical/invalid A-label behavior remains on the existing normalization path

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/pytest tests/x_connector_usage/test_writes.py` (88 passed)
- `.venv/bin/pytest` (4101 passed)

Closes #22177
