### PR TITLE
refactor(runner): remove generation claim attribution

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -37,7 +37,6 @@ use crate::ids::RunId;
 use crate::paths::short_digest;
 use crate::provider::{
     ClaimedJob, JobCandidate, LocalAdmissionResourceKind, SessionAffinityLocalResource,
-    SessionHistoryGenerationRelationship,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
@@ -83,27 +82,6 @@ impl LocalAdmissionResource {
         match self {
             Self::Fresh(_) => LocalAdmissionResourceKind::Fresh,
             Self::Reusable(_) => LocalAdmissionResourceKind::ReusableSandbox,
-        }
-    }
-
-    fn session_history_generation_relationship(
-        &self,
-        target_generation_run_id: Option<RunId>,
-    ) -> SessionHistoryGenerationRelationship {
-        let Some(target_generation_run_id) = target_generation_run_id else {
-            return SessionHistoryGenerationRelationship::UnknownTarget;
-        };
-        match self {
-            Self::Fresh(_) => SessionHistoryGenerationRelationship::Fresh,
-            Self::Reusable(reservation) => match reservation.history_generation_run_id() {
-                Some(reserved_generation_run_id)
-                    if reserved_generation_run_id == target_generation_run_id =>
-                {
-                    SessionHistoryGenerationRelationship::Exact
-                }
-                Some(_) => SessionHistoryGenerationRelationship::Different,
-                None => SessionHistoryGenerationRelationship::UnknownReserved,
-            },
         }
     }
 }
@@ -554,11 +532,6 @@ async fn claim_with_local_admission(
             return None;
         }
     }
-    let target_generation_run_id = candidate.history_generation_run_id();
-    let relationship = admission
-        .resource
-        .session_history_generation_relationship(target_generation_run_id);
-    candidate.set_session_history_generation_relationship(relationship);
     // claim() runs in the branch handler: non-interruptible, so a valid
     // successful claim is always paired with complete().
     let Some(claimed) = ctx.spawn_ctx.provider.claim(candidate).await else {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -926,7 +926,10 @@ mod tests {
             let reservation = idle_pool
                 .reserve_reusable("sess-network-log-park", "vm0/default", &None)
                 .expect("finalized sandbox should be reusable");
-            assert_eq!(reservation.history_generation_run_id(), Some(run_id));
+            assert_eq!(
+                reservation.history_generation_run_id_for_test(),
+                Some(run_id)
+            );
             assert!(matches!(
                 idle_pool.restore_reserved(reservation),
                 RestoreReservedIdleResult::Restored

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -187,16 +187,6 @@ async fn claim_failure_rolls_back_budget() {
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id_1, Duration::from_secs(5)).await;
     assert_eq!(budget.allocated().2, 0);
-    let claim_candidates = env.handle.claim_candidates();
-    let unavailable_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id_1)
-        .expect("unavailable candidate should reach claim");
-    assert_eq!(
-        unavailable_candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::Fresh)
-    );
-
     // Second job: claim succeeds — budget should have been freed.
     let run_id_2 = RunId::new_v4();
     push_job(
@@ -214,16 +204,6 @@ async fn claim_failure_rolls_back_budget() {
         completion.is_some(),
         "second job should complete (budget freed after unavailable claim)"
     );
-    let claim_candidates = env.handle.claim_candidates();
-    let followup_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id_2)
-        .expect("follow-up candidate should reach claim");
-    assert_eq!(
-        followup_candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::UnknownTarget)
-    );
-
     shutdown(&env, run_handle).await;
 }
 
@@ -323,16 +303,6 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         (2, 4096, 1),
         "restored reservation should retain its original budget lease"
     );
-    let claim_candidates = env.handle.claim_candidates();
-    let conflict_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == conflict_run_id)
-        .expect("claim conflict candidate should reach claim");
-    assert_eq!(
-        conflict_candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::Exact)
-    );
-
     let followup_run_id = RunId::new_v4();
     let followup_target_generation_run_id = RunId::new_v4();
     env.provider.set_claim_result(
@@ -352,16 +322,6 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
         .await
         .expect("restored idle reservation should serve the next claim");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    let claim_candidates = env.handle.claim_candidates();
-    let followup_candidate = claim_candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == followup_run_id)
-        .expect("follow-up candidate should reach claim");
-    assert_eq!(
-        followup_candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::Different)
-    );
-
     shutdown(&env, run_handle).await;
 }
 
@@ -446,10 +406,6 @@ async fn reusable_claim_without_generation_target_reports_selected_resources() {
         .iter()
         .find(|candidate| candidate.run_id() == run_id)
         .expect("missing-target reusable candidate should reach claim");
-    assert_eq!(
-        candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::UnknownTarget)
-    );
     assert_eq!(
         candidate.session_affinity_resource(),
         Some(SessionAffinityResource::ReusableSandbox)
@@ -828,10 +784,6 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     assert_eq!(
         claimed_candidate.local_admission_resource(),
         Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
-    );
-    assert_eq!(
-        claimed_candidate.session_history_generation_relationship(),
-        Some(crate::provider::SessionHistoryGenerationRelationship::UnknownReserved)
     );
     assert!(
         claimed_candidate

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -935,7 +935,8 @@ impl ReservedIdleSandbox {
         self.entry.cli_agent_session_id()
     }
 
-    pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
+    #[cfg(test)]
+    pub(crate) fn history_generation_run_id_for_test(&self) -> Option<RunId> {
         self.entry.metadata.history_generation_run_id
     }
 
@@ -1521,7 +1522,7 @@ mod tests {
             .reserve_reusable(session_id, profile_name, &None)
             .expect("idle entry should be reserved");
         assert_eq!(
-            reservation.history_generation_run_id(),
+            reservation.history_generation_run_id_for_test(),
             Some(history_generation_run_id)
         );
 
@@ -1685,7 +1686,7 @@ mod tests {
             )
             .expect("the exact generation should reserve");
         assert_eq!(
-            reservation.history_generation_run_id(),
+            reservation.history_generation_run_id_for_test(),
             Some(held_generation_run_id)
         );
         assert_eq!(pool.len(), 0);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -25,7 +25,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    LocalAdmissionResourceKind, SessionAffinityLocalResource, SessionHistoryGenerationRelationship,
+    LocalAdmissionResourceKind, SessionAffinityLocalResource,
 };
 use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
@@ -66,8 +66,6 @@ struct ClaimRequestTelemetry {
     session_affinity_local_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     local_admission_resource: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    session_history_generation_relationship: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -855,9 +853,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             local_admission_resource: candidate
                 .local_admission_resource()
                 .map(LocalAdmissionResourceKind::as_str),
-            session_history_generation_relationship: candidate
-                .session_history_generation_relationship()
-                .map(SessionHistoryGenerationRelationship::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1660,9 +1655,6 @@ mod tests {
         .with_history_generation_run_id(Some(target_generation_run_id))
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
-        candidate.set_session_history_generation_relationship(
-            SessionHistoryGenerationRelationship::Exact,
-        );
         candidate
             .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
         candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
@@ -1695,9 +1687,10 @@ mod tests {
             body["telemetry"]["localAdmissionResource"],
             "reusableSandbox"
         );
-        assert_eq!(
-            body["telemetry"]["sessionHistoryGenerationRelationship"],
-            "exact"
+        assert!(
+            body["telemetry"]
+                .get("sessionHistoryGenerationRelationship")
+                .is_none()
         );
         assert!(
             !body

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -75,27 +75,6 @@ impl LocalAdmissionResourceKind {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum SessionHistoryGenerationRelationship {
-    Exact,
-    Different,
-    Fresh,
-    UnknownTarget,
-    UnknownReserved,
-}
-
-impl SessionHistoryGenerationRelationship {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Exact => "exact",
-            Self::Different => "different",
-            Self::Fresh => "fresh",
-            Self::UnknownTarget => "unknown_target",
-            Self::UnknownReserved => "unknown_reserved",
-        }
-    }
-}
-
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -119,7 +98,6 @@ pub struct JobCandidate {
     session_affinity_local_resource: Option<SessionAffinityLocalResource>,
     local_admission_resource: Option<LocalAdmissionResourceKind>,
     history_generation_run_id: Option<RunId>,
-    session_history_generation_relationship: Option<SessionHistoryGenerationRelationship>,
     history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
@@ -155,7 +133,6 @@ impl JobCandidate {
             session_affinity_local_resource: None,
             local_admission_resource: None,
             history_generation_run_id: None,
-            session_history_generation_relationship: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
         }
@@ -263,12 +240,6 @@ impl JobCandidate {
         self.history_generation_run_id
     }
 
-    pub(crate) fn session_history_generation_relationship(
-        &self,
-    ) -> Option<SessionHistoryGenerationRelationship> {
-        self.session_history_generation_relationship
-    }
-
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
         protection_remaining(self.affinity_protected_until)
     }
@@ -327,13 +298,6 @@ impl JobCandidate {
             .as_deref()
             .and_then(parse_affinity_protected_until);
         self
-    }
-
-    pub(crate) fn set_session_history_generation_relationship(
-        &mut self,
-        relationship: SessionHistoryGenerationRelationship,
-    ) {
-        self.session_history_generation_relationship = Some(relationship);
     }
 
     pub(crate) fn set_session_affinity_local_resource(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2099,12 +2099,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const claims = await Promise.all([
-      api.requestClaimRunnerJob(true, run.runId, [200, 404], {
-        telemetry: { sessionHistoryGenerationRelationship: "different" },
-      }),
-      api.requestClaimRunnerJob(true, run.runId, [200, 404], {
-        telemetry: { sessionHistoryGenerationRelationship: "different" },
-      }),
+      api.requestClaimRunnerJob(true, run.runId, [200, 404]),
+      api.requestClaimRunnerJob(true, run.runId, [200, 404]),
     ]);
     expect(
       claims
@@ -2115,27 +2111,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           return left - right;
         }),
     ).toStrictEqual([200, 404]);
-    const claimAttemptEvents = sandboxOperationEventsForRunByAction(
-      run.runId,
-      "runner_session_history_generation_claim_attempt",
-    );
-    expect(claimAttemptEvents).toHaveLength(2);
-    expect(
-      claimAttemptEvents
-        .map((event) => {
-          return event.claim_outcome;
-        })
-        .sort(),
-    ).toStrictEqual(["accepted", "unavailable"]);
-    for (const event of claimAttemptEvents) {
-      expect(event).toStrictEqual(
-        expect.objectContaining({
-          generation_relationship: "different",
-          auth_type: "official-runner",
-        }),
-      );
-    }
-
     const running = await api.readRun(actor, run.runId);
     expect(running.status).toBe("running");
     expect(running.startedAt).toBeDefined();
@@ -6227,9 +6202,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       true,
       missingRun.runId,
       [400],
-      {
-        telemetry: { sessionHistoryGenerationRelationship: "unknown_target" },
-      },
     );
     expectApiError(missingClaim.body);
     expect(missingClaim.body.error.message).toBe(
@@ -6243,21 +6215,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(failedMissingRun.error).toBe(
       "Runner job missing valid execution context",
     );
-    expect(
-      sandboxOperationEventsForRunByAction(
-        missingRun.runId,
-        "runner_session_history_generation_claim_attempt",
-      ),
-    ).toStrictEqual([
-      expect.objectContaining({
-        success: false,
-        duration_ms: 0,
-        generation_relationship: "unknown_target",
-        claim_outcome: "preclaim_error",
-        auth_type: "official-runner",
-      }),
-    ]);
-
     const invalidRun = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "materialize invalid masking metadata",
@@ -8044,178 +8001,33 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 });
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
-  it("records trusted terminal generation claim attempts without user-token pollution", async () => {
-    const bdd = createBddApi(context);
+  it("accepts retired runner claim attribution telemetry", async () => {
     const api = createRunsApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
-    const actorRunnerKey = await api.createApiKey(actor);
-    const actorBearer = `Bearer ${actorRunnerKey.token}`;
+    const { actor, agentId } = await entitledRunActor();
 
-    const attributed = await api.createRun(actor, {
+    const run = await api.createRun(actor, {
       agentId,
-      prompt: "attribute terminal generation claims",
+      prompt: "accept retired claim attribution telemetry",
       modelProvider: "anthropic-api-key",
     });
-    const accepted = await api.requestRawClaimRunnerJob(
-      true,
-      attributed.runId,
-      [200],
-      {
-        telemetry: {
-          sessionHistoryGenerationRelationship: "different",
-          sessionHistoryGenerationLocalAvailability:
-            "parked_before_discovery_lt_heartbeat_period",
-          workspaceSessionHistorySidecarRelationship: "different",
-          workspaceSessionHistorySidecarRawSizeBucket: "256_kib_1_mib",
-        },
+    const claim = await api.requestRawClaimRunnerJob(true, run.runId, [200], {
+      telemetry: {
+        sessionHistoryGenerationRelationship: "different",
+        sessionHistoryGenerationLocalAvailability:
+          "parked_before_discovery_lt_heartbeat_period",
+        workspaceSessionHistorySidecarRelationship: "different",
+        workspaceSessionHistorySidecarRawSizeBucket: "256_kib_1_mib",
       },
-    );
-    expect(accepted.status).toBe(200);
-
-    const lateUser = await api.requestRawClaimRunnerJobAs(
-      actorBearer,
-      attributed.runId,
-      [404],
-      {
-        telemetry: {
-          sessionHistoryGenerationRelationship: "exact",
-          sessionHistoryGenerationLocalAvailability: "parked_after_discovery",
-          workspaceSessionHistorySidecarRelationship: "exact",
-          workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
-        },
-      },
-    );
-    expectApiError(lateUser.body);
-    expect(
-      sandboxOperationEventsForRunByAction(
-        attributed.runId,
-        "runner_session_history_generation_claim_attempt",
-      ),
-    ).toHaveLength(1);
-
-    const lateOfficial = await api.requestRawClaimRunnerJob(
-      true,
-      attributed.runId,
-      [404],
-      {
-        telemetry: {
-          sessionHistoryGenerationRelationship: "exact",
-          sessionHistoryGenerationLocalAvailability: "parked_after_discovery",
-          workspaceSessionHistorySidecarRelationship: "exact",
-          workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
-        },
-      },
-    );
-    expectApiError(lateOfficial.body);
-    const attributedEvents = sandboxOperationEventsForRunByAction(
-      attributed.runId,
-      "runner_session_history_generation_claim_attempt",
-    );
-    expect(attributedEvents).toStrictEqual([
-      expect.objectContaining({
-        success: true,
-        duration_ms: 0,
-        generation_relationship: "different",
-        claim_outcome: "accepted",
-        auth_type: "official-runner",
-        runner_group: runnerGroup,
-        profile: "vm0/default",
-      }),
-      expect.objectContaining({
-        success: false,
-        duration_ms: 0,
-        generation_relationship: "exact",
-        claim_outcome: "unavailable",
-        auth_type: "official-runner",
-      }),
-    ]);
-    for (const event of attributedEvents) {
-      expect(event).not.toHaveProperty("history_generation_run_id");
-      expect(event).not.toHaveProperty("session_id");
-      expect(event).not.toHaveProperty("history_hash");
-      expect(event).not.toHaveProperty("parked_at");
-      expect(event).not.toHaveProperty("discovered_at");
-      expect(event).not.toHaveProperty("generation_local_availability");
-      expect(event).not.toHaveProperty("generation_local_availability_ms");
-      expect(event).not.toHaveProperty("workspace_sidecar_generation_run_id");
-      expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bytes");
-      expect(event).not.toHaveProperty("workspace_sidecar_relationship");
-      expect(event).not.toHaveProperty("workspace_sidecar_raw_size_bucket");
-      expect(JSON.stringify(event)).not.toContain(actorRunnerKey.token);
-    }
-    const guarded = await api.createRun(actor, {
-      agentId,
-      prompt: "reject untrusted generation attribution",
-      modelProvider: "anthropic-api-key",
     });
-    const outsider = bdd.user();
-    const outsiderKey = await api.createApiKey(outsider);
-    const forbiddenClaim = await api.requestClaimRunnerJobAs(
-      `Bearer ${outsiderKey.token}`,
-      guarded.runId,
-      [403],
-      {
-        telemetry: { sessionHistoryGenerationRelationship: "exact" },
-      },
-    );
-    expectApiError(forbiddenClaim.body);
-    expect(
-      sandboxOperationEventsForRunByAction(
-        guarded.runId,
-        "runner_session_history_generation_claim_attempt",
-      ),
-    ).toHaveLength(0);
+    expect(claim.status).toBe(200);
 
-    const oldRunnerClaim = await api.requestClaimRunnerJob(
-      true,
-      guarded.runId,
-      [200],
-    );
-    expect(oldRunnerClaim.status).toBe(200);
-    expect(
-      sandboxOperationEventsForRunByAction(
-        guarded.runId,
-        "runner_session_history_generation_claim_attempt",
-      ),
-    ).toHaveLength(0);
-    await api.requestCancelRun(actor, attributed.runId, [200]);
-    await api.requestCancelRun(actor, guarded.runId, [200]);
-
-    const previousRunner = await api.createRun(actor, {
-      agentId,
-      prompt: "accept prior generation attribution without local availability",
-      modelProvider: "anthropic-api-key",
-    });
-    const previousRunnerClaim = await api.requestClaimRunnerJob(
-      true,
-      previousRunner.runId,
-      [200],
-      {
-        telemetry: { sessionHistoryGenerationRelationship: "fresh" },
-      },
-    );
-    expect(previousRunnerClaim.status).toBe(200);
-    const previousRunnerEvents = sandboxOperationEventsForRunByAction(
-      previousRunner.runId,
-      "runner_session_history_generation_claim_attempt",
-    );
-    expect(previousRunnerEvents).toStrictEqual([
-      expect.objectContaining({
-        generation_relationship: "fresh",
-        claim_outcome: "accepted",
-      }),
-    ]);
-    expect(previousRunnerEvents[0]).not.toHaveProperty(
-      "generation_local_availability",
-    );
-
-    await api.requestCancelRun(actor, previousRunner.runId, [200]);
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("records generic preclaim response construction failures", async () => {
+  it("returns 500 when claim response construction fails", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { actor, agentId } = await entitledRunActor();
 
     const source = await api.createRun(actor, {
       agentId,
@@ -8251,42 +8063,12 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     context.mocks.s3.send.mockRejectedValueOnce(
       new Error("session history metadata unavailable"),
     );
-    const failedClaim = await api.requestRawClaimRunnerJob(
+    const failedClaim = await api.requestClaimRunnerJob(
       true,
       resumed.runId,
       [500],
-      {
-        telemetry: {
-          sessionHistoryGenerationRelationship: "exact",
-          sessionHistoryGenerationLocalAvailability:
-            "parked_before_discovery_ge_heartbeat_period",
-          workspaceSessionHistorySidecarRelationship: "legacy",
-          workspaceSessionHistorySidecarRawSizeBucket: "1_4_mib",
-        },
-      },
     );
     expect(failedClaim.status).toBe(500);
-
-    const events = sandboxOperationEventsForRunByAction(
-      resumed.runId,
-      "runner_session_history_generation_claim_attempt",
-    );
-    expect(events).toStrictEqual([
-      expect.objectContaining({
-        success: false,
-        duration_ms: 0,
-        generation_relationship: "exact",
-        claim_outcome: "preclaim_error",
-        auth_type: "official-runner",
-        runner_group: runnerGroup,
-        profile: "vm0/default",
-      }),
-    ]);
-    expect(JSON.stringify(events)).not.toContain(source.runId);
-    expect(JSON.stringify(events)).not.toContain(historyHash);
-    expect(events[0]).not.toHaveProperty("generation_local_availability");
-    expect(events[0]).not.toHaveProperty("workspace_sidecar_relationship");
-    expect(events[0]).not.toHaveProperty("workspace_sidecar_raw_size_bucket");
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -11,7 +11,6 @@ import {
   type ExecutionContext,
   type HeldSessionState,
   type SessionHistoryDownloadSource,
-  type SessionHistoryGenerationRelationship,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import {
@@ -711,62 +710,6 @@ interface ActiveRunNetworkPolicyScope {
 }
 
 type ClaimLookupResult = ClaimableJob | ReturnType<typeof notFound>;
-
-type SessionHistoryGenerationClaimOutcome =
-  | "accepted"
-  | "unavailable"
-  | "preclaim_error";
-
-function recordSessionHistoryGenerationClaimAttempt(args: {
-  readonly runId: string;
-  readonly relationship: SessionHistoryGenerationRelationship | undefined;
-  readonly outcome: SessionHistoryGenerationClaimOutcome;
-  readonly authType: RunnerAuthContext["type"];
-  readonly runnerGroup?: string;
-  readonly profile?: string;
-}): void {
-  if (!args.relationship) {
-    return;
-  }
-  const dimensions: Record<string, string> = {
-    generation_relationship: args.relationship,
-    claim_outcome: args.outcome,
-    auth_type: args.authType,
-  };
-  if (args.runnerGroup) {
-    dimensions.runner_group = args.runnerGroup;
-  }
-  if (args.profile) {
-    dimensions.profile = args.profile;
-  }
-  recordSandboxOperations([
-    {
-      sandboxType: "runner",
-      actionType: "runner_session_history_generation_claim_attempt",
-      durationMs: 0,
-      success: args.outcome === "accepted",
-      runId: args.runId,
-      dimensions,
-    },
-  ]);
-}
-
-function recordSessionHistoryGenerationClaimAttemptForJob(args: {
-  readonly runId: string;
-  readonly relationship: SessionHistoryGenerationRelationship | undefined;
-  readonly outcome: SessionHistoryGenerationClaimOutcome;
-  readonly authType: RunnerAuthContext["type"];
-  readonly job: ClaimableJob["job"];
-}): void {
-  recordSessionHistoryGenerationClaimAttempt({
-    runId: args.runId,
-    relationship: args.relationship,
-    outcome: args.outcome,
-    authType: args.authType,
-    runnerGroup: args.job.runnerGroup,
-    profile: args.job.profile,
-  });
-}
 
 function isClaimableJob(value: ClaimLookupResult): value is ClaimableJob {
   return "job" in value;
@@ -2068,9 +2011,6 @@ const claimAuthorizedJob$ = command(
       readonly runId: string;
       readonly authType: RunnerAuthContext["type"];
       readonly jobWithRun: ClaimableJob;
-      readonly generationRelationship:
-        | SessionHistoryGenerationRelationship
-        | undefined;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;
       readonly claimRouteTiming: ClaimRouteTimingCollector;
@@ -2079,15 +2019,6 @@ const claimAuthorizedJob$ = command(
   ) => {
     const { db, runId, jobWithRun, claimRouteTiming, signal } = args;
     const run = jobWithRun.run;
-    const recordAttempt = (outcome: SessionHistoryGenerationClaimOutcome) => {
-      recordSessionHistoryGenerationClaimAttemptForJob({
-        runId,
-        relationship: args.generationRelationship,
-        outcome,
-        authType: args.authType,
-        job: jobWithRun.job,
-      });
-    };
 
     const contextParseStartedAt = now();
     const storedContextResult = storedExecutionContextSchema.safeParse(
@@ -2104,7 +2035,7 @@ const claimAuthorizedJob$ = command(
         runId,
         storedContextResult.error.issues,
       );
-      const response = await failClaimForInvalidStoredExecutionContext({
+      return await failClaimForInvalidStoredExecutionContext({
         db,
         runId,
         userId: run.userId,
@@ -2114,8 +2045,6 @@ const claimAuthorizedJob$ = command(
           set(scheduleClaimFailedSideEffects$, failedArgs);
         },
       });
-      recordAttempt("preclaim_error");
-      return response;
     }
     const storedContext = storedContextResult.data;
 
@@ -2130,8 +2059,7 @@ const claimAuthorizedJob$ = command(
       signal,
     );
     if (!responseBodyResult.ok) {
-      recordAttempt("preclaim_error");
-      const response = await claimResponseBuildErrorResponse({
+      return await claimResponseBuildErrorResponse({
         db,
         run,
         runId,
@@ -2141,7 +2069,6 @@ const claimAuthorizedJob$ = command(
           set(scheduleClaimFailedSideEffects$, failedArgs);
         },
       });
-      return response;
     }
     signal.throwIfAborted();
 
@@ -2159,11 +2086,9 @@ const claimAuthorizedJob$ = command(
     );
     signal.throwIfAborted();
     if (claimResult.status !== "claimed") {
-      recordAttempt("unavailable");
       return claimTransitionErrorResponse(claimResult);
     }
 
-    recordAttempt("accepted");
     scheduleSuccessfulClaimSideEffects({
       jobWithRun,
       authType: args.authType,
@@ -2194,8 +2119,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const runId = get(pathParamsOf(runnersJobClaimContract.claim)).id;
-  const generationRelationship =
-    body.data.telemetry?.sessionHistoryGenerationRelationship;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -2206,14 +2129,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const lookupAuthorizationStartedAt = now();
   const jobWithRun = await getClaimableJob(db, runId, signal);
   if (!isClaimableJob(jobWithRun)) {
-    if (auth.type === "official-runner") {
-      recordSessionHistoryGenerationClaimAttempt({
-        runId,
-        relationship: generationRelationship,
-        outcome: "unavailable",
-        authType: auth.type,
-      });
-    }
     return jobWithRun;
   }
   const authError = claimAuthorizationError(auth, jobWithRun);
@@ -2231,7 +2146,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     runId,
     authType: auth.type,
     jobWithRun,
-    generationRelationship,
     telemetry: body.data.telemetry,
     claimRequestStartedAtMs,
     claimRouteTiming,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -723,7 +723,6 @@ describe("runner claim capability contract", () => {
         sessionAffinityResource: "workspaceCache",
         sessionAffinityLocalResource: "workspaceCache",
         localAdmissionResource: "fresh",
-        sessionHistoryGenerationRelationship: "exact",
       },
     });
 
@@ -742,9 +741,7 @@ describe("runner claim capability contract", () => {
       },
     });
 
-    expect(body.telemetry).toEqual({
-      sessionHistoryGenerationRelationship: "fresh",
-    });
+    expect(body.telemetry).toEqual({});
   });
 
   it("accepts old claim bodies without generation telemetry", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -88,13 +88,6 @@ const sessionAffinityLocalResourceSchema = z.enum([
 const runnerLocalAdmissionResourceSchema = z.enum(["reusableSandbox", "fresh"]);
 
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
-export const sessionHistoryGenerationRelationshipSchema = z.enum([
-  "exact",
-  "different",
-  "fresh",
-  "unknown_target",
-  "unknown_reserved",
-]);
 const runnerClaimTelemetrySchema = z.object({
   discoverySource: runnerClaimDiscoverySourceSchema.optional(),
   jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
@@ -110,8 +103,6 @@ const runnerClaimTelemetrySchema = z.object({
   sessionAffinityResource: sessionAffinityResourceSchema.optional(),
   sessionAffinityLocalResource: sessionAffinityLocalResourceSchema.optional(),
   localAdmissionResource: runnerLocalAdmissionResourceSchema.optional(),
-  sessionHistoryGenerationRelationship:
-    sessionHistoryGenerationRelationshipSchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),
@@ -738,9 +729,6 @@ export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
 export type SessionHistoryDownloadSource = z.infer<
   typeof sessionHistoryDownloadSourceSchema
->;
-export type SessionHistoryGenerationRelationship = z.infer<
-  typeof sessionHistoryGenerationRelationshipSchema
 >;
 export type SessionHistorySizeBucket = z.infer<
   typeof sessionHistorySizeBucketSchema


### PR DESCRIPTION
## Summary

- remove runner-side session history generation relationship classification, candidate state, and claim serialization
- remove the optional API contract field, exported telemetry-only type, and dedicated claim-attribution operation event
- retain route-level coverage that previous runners can send the retired field and have it accepted and stripped

## Compatibility and scope

- old runner to new API remains compatible because unknown claim telemetry properties are accepted and stripped
- new runner to old API remains compatible because the retired field was optional
- affinity selection, local admission, claim ownership, workspace checkout, sidecar restore, remote fallback, and sandbox reuse behavior are unchanged
- no database schema, migration, persisted state, queue payload, heartbeat payload, or guest protocol changes
- `sessionAffinityResource`, `sessionAffinityLocalResource`, `localAdmissionResource`, generation IDs, and affinity deadlines remain intact

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner` (2,764 passed, 12 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts` (47 passed)
- `env -u DATABASE_URL pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (107 passed)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/api-contracts`
- `pnpm knip --workspace api`
- full pre-commit hook, including repository-wide Turbo type checking and Knip

Closes #22093

Parent context: #22028
