### PR TITLE
test(runner): stabilize completion retry event capture

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3247,25 +3247,28 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let complete_task = tokio::spawn(async move {
-            capture_api_provider_events(provider.complete(
-                run_id,
-                1,
-                Some("boom"),
-                None,
-                None,
-                CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
-            ))
-            .await
-        });
+        let completion = capture_api_provider_events(provider.complete(
+            run_id,
+            1,
+            Some("boom"),
+            None,
+            None,
+            CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+        ));
+        let observe_requests = async {
+            let first_request = next_request(&mut requests).await;
+            assert_complete_authorization(&first_request, "sandbox-token");
+            tokio::task::yield_now().await;
+            assert!(
+                requests.try_recv().is_err(),
+                "completion should wait before the retry"
+            );
+            tokio::time::advance(Duration::from_secs(2)).await;
+            let second_request = next_request(&mut requests).await;
+            assert_complete_authorization(&second_request, "sandbox-token");
+        };
 
-        let first_request = next_request(&mut requests).await;
-        assert_complete_authorization(&first_request, "sandbox-token");
-        tokio::time::advance(Duration::from_secs(2)).await;
-        let second_request = next_request(&mut requests).await;
-        assert_complete_authorization(&second_request, "sandbox-token");
-
-        let ((), events) = complete_task.await.unwrap();
+        let (((), events), ()) = tokio::join!(completion, observe_requests);
         server_task.await.unwrap();
         assert!(
             requests.recv().await.is_none(),


### PR DESCRIPTION
## Summary

- keep completion retry tracing capture on the test task instead of a detached task
- let the first transient failure finish processing before advancing paused Tokio time
- assert that the retry does not start before the configured delay

## Why

The Rust coverage job intermittently captured only the final completion failure event because the test could advance virtual time while the first 500 response and its warning event were still being processed. The production retry completed correctly, but the event-count assertion became scheduler-sensitive.

This change makes the test drive the completion future and request observer together on the same task, preserving the tracing subscriber for every poll and establishing the retry timer before advancing time.

Failure example: https://github.com/vm0-ai/vm0/actions/runs/29718271375/job/88275790704

## Scope

- test-only change in the runner API provider
- no production retry behavior or timing changes

## Validation

- `cargo fmt --all -- --check`
- `CARGO_PROFILE_TEST_DEBUG=line-tables-only CARGO_BUILD_JOBS=1 cargo test -p runner provider::api::tests::api_provider_complete_stops_after_two_transient_failures -- --nocapture`
- targeted test repeated successfully 20 consecutive times
- `CARGO_PROFILE_TEST_DEBUG=line-tables-only CARGO_BUILD_JOBS=1 cargo clippy -p runner --tests -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo doc -p runner --no-deps`
