### PR TITLE
test: remove expired affinity cleanup residue

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -924,12 +924,8 @@ mod tests {
         {
             let mut idle_pool = fixture.idle_pool.lock().await;
             let reservation = idle_pool
-                .reserve_reusable("sess-network-log-park", "vm0/default", &None)
-                .expect("finalized sandbox should be reusable");
-            assert_eq!(
-                reservation.history_generation_run_id_for_test(),
-                Some(run_id)
-            );
+                .reserve_reusable_generation("sess-network-log-park", "vm0/default", &None, run_id)
+                .expect("finalized sandbox should be reusable for its generation");
             assert!(matches!(
                 idle_pool.restore_reserved(reservation),
                 RestoreReservedIdleResult::Restored

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -935,11 +935,6 @@ impl ReservedIdleSandbox {
         self.entry.cli_agent_session_id()
     }
 
-    #[cfg(test)]
-    pub(crate) fn history_generation_run_id_for_test(&self) -> Option<RunId> {
-        self.entry.metadata.history_generation_run_id
-    }
-
     pub fn validate_workspace_promotion_identity(
         &self,
         cache: &SessionWorkspaceCache,
@@ -1521,10 +1516,6 @@ mod tests {
         let reservation = pool
             .reserve_reusable(session_id, profile_name, &None)
             .expect("idle entry should be reserved");
-        assert_eq!(
-            reservation.history_generation_run_id_for_test(),
-            Some(history_generation_run_id)
-        );
 
         let IdleUnparkResult::Reused {
             sandbox,
@@ -1677,7 +1668,7 @@ mod tests {
         assert_eq!(pool.len(), 1);
         assert_eq!(pool.status_snapshot().revision, parked_revision);
 
-        let reservation = pool
+        let _reservation = pool
             .reserve_reusable_generation(
                 "session-generation",
                 "vm0/default",
@@ -1685,10 +1676,6 @@ mod tests {
                 held_generation_run_id,
             )
             .expect("the exact generation should reserve");
-        assert_eq!(
-            reservation.history_generation_run_id_for_test(),
-            Some(held_generation_run_id)
-        );
         assert_eq!(pool.len(), 0);
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1688,11 +1688,6 @@ mod tests {
             "reusableSandbox"
         );
         assert!(
-            body["telemetry"]
-                .get("sessionHistoryGenerationRelationship")
-                .is_none()
-        );
-        assert!(
             !body
                 .to_string()
                 .contains(&target_generation_run_id.to_string())

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8001,22 +8001,18 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 });
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
-  it("accepts retired runner claim attribution telemetry", async () => {
+  it("accepts a previous runner generation relationship", async () => {
     const api = createRunsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
     const run = await api.createRun(actor, {
       agentId,
-      prompt: "accept retired claim attribution telemetry",
+      prompt: "accept previous runner generation relationship",
       modelProvider: "anthropic-api-key",
     });
     const claim = await api.requestRawClaimRunnerJob(true, run.runId, [200], {
       telemetry: {
         sessionHistoryGenerationRelationship: "different",
-        sessionHistoryGenerationLocalAvailability:
-          "parked_before_discovery_lt_heartbeat_period",
-        workspaceSessionHistorySidecarRelationship: "different",
-        workspaceSessionHistorySidecarRawSizeBucket: "256_kib_1_mib",
       },
     });
     expect(claim.status).toBe(200);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -729,35 +729,14 @@ describe("runner claim capability contract", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts and strips previous attribution telemetry", () => {
+  it("accepts and strips a previous runner generation relationship", () => {
     const body = runnersJobClaimContract.claim.body.parse({
       telemetry: {
-        preLocalAdmissionOutcome: "local_holder",
         sessionHistoryGenerationRelationship: "fresh",
-        sessionHistoryGenerationLocalAvailability:
-          "parked_before_discovery_ge_heartbeat_period",
-        workspaceSessionHistorySidecarRelationship: "exact",
-        workspaceSessionHistorySidecarRawSizeBucket: "64_256_kib",
       },
     });
 
     expect(body.telemetry).toEqual({});
-  });
-
-  it("accepts old claim bodies without generation telemetry", () => {
-    expect(runnersJobClaimContract.claim.body.safeParse({}).success).toBe(true);
-  });
-
-  it("rejects the removed legacy local resource value", () => {
-    const result = runnersJobClaimContract.claim.body.safeParse({
-      telemetry: {
-        sessionAffinityResource: "workspaceCache",
-        sessionAffinityLocalResource: "legacySession",
-        localAdmissionResource: "fresh",
-      },
-    });
-
-    expect(result.success).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- remove the test-only idle-pool generation accessor and assertions against private state
- keep generation reuse coverage through the public exact-generation reservation behavior
- remove expired runner-claim compatibility fixtures while retaining the one field still sent by the current production runner at both the contract and route boundaries

## Compatibility

This changes tests only. It does not change production code, API schemas, or persisted data. `sessionHistoryGenerationRelationship` remains accepted and stripped for compatibility with the current production runner.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `env -u DATABASE_URL pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- scoped lint, type-check, and Knip checks for `api` and `@vm0/api-contracts`
- repository pre-commit hooks

Closes #22205

Parent issue: #22028
