### PR TITLE
feat: add composer attachment references

### DIFF
--- a/turbo/apps/platform/src/lib/composer-feature-switches.ts
+++ b/turbo/apps/platform/src/lib/composer-feature-switches.ts
@@ -1,0 +1,16 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+
+type ComposerFeatureSwitches =
+  | Partial<Record<FeatureSwitchKey, boolean>>
+  | undefined;
+
+export function composerInlinePromptItemsEnabled(
+  features: ComposerFeatureSwitches,
+): boolean {
+  return (
+    !(
+      features?.[FeatureSwitchKey.ComposerInlineAttachmentReferences] ?? false
+    ) &&
+    (features?.[FeatureSwitchKey.ComposerInlinePromptItems] ?? false)
+  );
+}

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
@@ -51,18 +51,4 @@ describe("generationTemplateForFeatureSwitches", () => {
       }),
     ).toBeUndefined();
   });
-
-  it("keeps structured templates when attachment references override inline prompt items", () => {
-    const template: GenerationTemplateRequest = {
-      type: "illustration",
-      selection: { illustrationStyleId: "image-style:ink-studio" },
-    };
-
-    expect(
-      generationTemplateForFeatureSwitches(template, {
-        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
-        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
-      }),
-    ).toBe(template);
-  });
 });

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
@@ -51,4 +51,18 @@ describe("generationTemplateForFeatureSwitches", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("keeps structured templates when attachment references override inline prompt items", () => {
+    const template: GenerationTemplateRequest = {
+      type: "illustration",
+      selection: { illustrationStyleId: "image-style:ink-studio" },
+    };
+
+    expect(
+      generationTemplateForFeatureSwitches(template, {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      }),
+    ).toBe(template);
+  });
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -9,6 +9,7 @@ import {
 import { ROUTES } from "../route-paths.ts";
 import { resetSignal } from "../utils.ts";
 import { createRestoredAttachment } from "../zero-page/chat-draft.ts";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import { clearArtifactPreview$ } from "../zero-page/zero-artifact-sidebar.ts";
 import { closeMailDraftSidebar$ } from "../zero-page/mail-draft-sidebar.ts";
 import { createChatThreadSignals, ensureDraft$ } from "./create-chat-thread.ts";
@@ -19,7 +20,6 @@ import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-sour
 import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 export const SIDEBAR_PARAM = "sidebar";
 
@@ -143,7 +143,7 @@ const setupPaneThread$ = command(
       draft,
       dataSource,
       initialOptimisticEntries,
-      get(featureSwitch$)[FeatureSwitchKey.ComposerInlinePromptItems] ?? false,
+      composerInlinePromptItemsEnabled(get(featureSwitch$)),
     );
     set(spec.setPaneThread$, thread);
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -20,6 +20,7 @@ import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-sour
 import { setupChatThreadInitScroll$ } from "./setup-chat-thread-signals.ts";
 import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 export const SIDEBAR_PARAM = "sidebar";
 
@@ -139,12 +140,18 @@ const setupPaneThread$ = command(
     const initialOptimisticEntries = get(
       createOptimisticChatMessagesForThread(threadId),
     );
+    const features = get(featureSwitch$);
     const thread = createChatThreadSignals(
       threadId,
       draft,
       dataSource,
       initialOptimisticEntries,
-      composerInlinePromptItemsEnabled(get(featureSwitch$)),
+      {
+        inlinePromptItems: composerInlinePromptItemsEnabled(features),
+        inlineAttachmentReferences:
+          features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ??
+          false,
+      },
     );
     set(spec.setPaneThread$, thread);
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -8,7 +8,7 @@ import {
 } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 import { resetSignal } from "../utils.ts";
-import { createRestoredAttachment } from "../zero-page/chat-draft.ts";
+import { createRestoredDraftAttachments } from "../zero-page/chat-draft.ts";
 import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import { clearArtifactPreview$ } from "../zero-page/zero-artifact-sidebar.ts";
 import { closeMailDraftSidebar$ } from "../zero-page/mail-draft-sidebar.ts";
@@ -85,8 +85,9 @@ const loadDraft$ = command(
     const hasDraftAttachments =
       draftAttachments !== null && draftAttachments.length > 0;
     if (isNew && (hasDraftContent || hasDraftAttachments)) {
-      const restoredAttachments = (draftAttachments ?? []).map(
-        createRestoredAttachment,
+      const restoredAttachments = createRestoredDraftAttachments(
+        threadDraft.draftContent ?? "",
+        draftAttachments ?? [],
       );
       set(
         thread.draft.seed$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -4108,15 +4108,23 @@ function publicChatThreadMessageSignals(
   };
 }
 
+interface ChatThreadComposerFeatureModes {
+  inlinePromptItems?: boolean;
+  inlineAttachmentReferences?: boolean;
+}
+
 function createThreadComposer(
   draft: DraftSignals,
   threadId: string,
-  inlinePromptItems: boolean,
+  featureModes: ChatThreadComposerFeatureModes,
 ) {
+  const { inlinePromptItems = false, inlineAttachmentReferences = false } =
+    featureModes;
   const workflowComposer = createWorkflowComposerSignals(
     draft,
     threadId,
     inlinePromptItems,
+    inlineAttachmentReferences,
   );
   return { workflowComposer, focusInput$: workflowComposer.focus$ };
 }
@@ -4126,7 +4134,7 @@ export function createChatThreadSignals(
   draft: DraftSignals,
   dataSource: ChatThreadRemote = createRemoteChatThreadDataSource(threadId),
   initialOptimisticEntries: readonly OptimisticChatMessageEntry[] = [],
-  inlinePromptItems = false,
+  composerFeatureModes: ChatThreadComposerFeatureModes = {},
 ): ChatThreadSignals {
   const { remoteThreadDetail$, threadDraft$, reloadThread$ } =
     createRemoteThreadDetail(dataSource);
@@ -4199,7 +4207,7 @@ export function createChatThreadSignals(
     appendOptimisticMessage$: messages.appendOptimisticMessage$,
     dataSource,
   });
-  const composer = createThreadComposer(draft, threadId, inlinePromptItems);
+  const composer = createThreadComposer(draft, threadId, composerFeatureModes);
   return {
     threadId,
     remoteThreadDetail$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -29,6 +29,7 @@ import {
   createRestoredAttachment,
   type DraftSignals,
 } from "../zero-page/chat-draft.ts";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
@@ -2960,7 +2961,7 @@ interface PreparedSendMessageResult {
 function shouldIncludeDraftAttachments(
   features: Partial<Record<FeatureSwitchKey, boolean>>,
 ): boolean {
-  return !(features[FeatureSwitchKey.ComposerInlinePromptItems] ?? false);
+  return !composerInlinePromptItemsEnabled(features);
 }
 
 function prepareTextOnlyUserMessage(

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3537,7 +3537,9 @@ function createRecallMessage(deps: RecallMessageDeps) {
       set(
         draft.seed$,
         message.content ?? "",
-        (message.attachFiles ?? []).map(createRestoredAttachment),
+        (message.attachFiles ?? []).map((attachment) => {
+          return createRestoredAttachment(attachment);
+        }),
       );
 
       const persistedMessage = await set(

--- a/turbo/apps/platform/src/signals/chat-page/generation-template-feature-switch.ts
+++ b/turbo/apps/platform/src/signals/chat-page/generation-template-feature-switch.ts
@@ -1,5 +1,6 @@
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 
 type GenerationTemplateFeatureSwitches =
   | Partial<Record<FeatureSwitchKey, boolean>>
@@ -9,7 +10,7 @@ export function generationTemplateForFeatureSwitches(
   value: GenerationTemplateRequest | undefined,
   features: GenerationTemplateFeatureSwitches,
 ): GenerationTemplateRequest | undefined {
-  if (features?.[FeatureSwitchKey.ComposerInlinePromptItems] ?? false) {
+  if (composerInlinePromptItemsEnabled(features)) {
     return undefined;
   }
   if (

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -24,6 +24,7 @@ import {
   clearMailDraftSidebarParams,
 } from "../zero-page/right-sidebar-search-params.ts";
 import { talkDraft$ } from "../zero-page/chat-draft.ts";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import { clearAgentDraftById$ } from "../zero-page/agent-draft.ts";
 import {
   prepareUserMessageFromDraft$,
@@ -448,9 +449,8 @@ const sendNewThreadMessage$ = command(
       draft,
       prompt,
       {
-        includeAttachments: !(
-          get(featureSwitch$)[FeatureSwitchKey.ComposerInlinePromptItems] ??
-          false
+        includeAttachments: !composerInlinePromptItemsEnabled(
+          get(featureSwitch$),
         ),
         excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
           resolvedModelSelection.selectedModel,

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -8,7 +8,7 @@ import { collectSuccessfulAttachmentInfos } from "../chat-page/resolve-draft-att
 import { resetSignal } from "../utils.ts";
 import {
   createDraftSignals,
-  createRestoredAttachment,
+  createRestoredDraftAttachments,
   type DraftSignals,
 } from "./chat-draft.ts";
 
@@ -159,7 +159,10 @@ export const loadAgentDraft$ = command(
     set(
       draft.seed$,
       result.body.draftContent ?? "",
-      attachments.map(createRestoredAttachment),
+      createRestoredDraftAttachments(
+        result.body.draftContent ?? "",
+        attachments,
+      ),
     );
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -234,7 +234,7 @@ export interface DraftSignals {
     [ZeroChatAttachment, AbortSignal]
   >;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
-  restoreAttachments$: Command<void, [PersistedAttachment[]]>;
+  restoreAttachments$: Command<ZeroChatAttachment[], [PersistedAttachment[]]>;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
   removeAttachmentByClientId$: Command<void, [string]>;
   dragOver$: Computed<boolean>;
@@ -391,12 +391,13 @@ function createDraftAttachmentSignals(
   const restoreAttachments$ = command(
     ({ set }, persisted: PersistedAttachment[]) => {
       if (persisted.length === 0) {
-        return;
+        return [];
       }
       const restored = persisted.map(createRestoredAttachment);
       set(internalAttachments$, (prev) => {
         return [...prev, ...restored];
       });
+      return restored;
     },
   );
   const removeAttachment$ = command(

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -16,6 +16,7 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { splitInlinePromptLine } from "./composer-inline-prompt-items.ts";
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)
@@ -255,8 +256,8 @@ export interface DraftInputSyncTarget {
  */
 export function createRestoredAttachment(
   persisted: PersistedAttachment,
+  clientId: string = crypto.randomUUID(),
 ): ZeroChatAttachment {
-  const clientId = crypto.randomUUID();
   const fileInfo$ = computed(
     (): Promise<{ id: string; url: string } | null> => {
       return Promise.resolve({ id: persisted.id, url: persisted.url });
@@ -282,6 +283,31 @@ export function createRestoredAttachment(
     cancel$,
     upload$,
   };
+}
+
+export function createRestoredDraftAttachments(
+  content: string,
+  persisted: readonly PersistedAttachment[],
+): ZeroChatAttachment[] {
+  const referenceClientIdsByUrl = new Map<string, string[]>();
+  for (const line of content.split("\n")) {
+    for (const segment of splitInlinePromptLine(line)) {
+      if (
+        segment.type !== "file" ||
+        segment.promptReference === undefined ||
+        segment.clientId === undefined
+      ) {
+        continue;
+      }
+      const clientIds = referenceClientIdsByUrl.get(segment.url) ?? [];
+      clientIds.push(segment.clientId);
+      referenceClientIdsByUrl.set(segment.url, clientIds);
+    }
+  }
+  return persisted.map((attachment) => {
+    const clientId = referenceClientIdsByUrl.get(attachment.url)?.shift();
+    return createRestoredAttachment(attachment, clientId);
+  });
 }
 
 function createDraftInputSignals() {
@@ -393,7 +419,9 @@ function createDraftAttachmentSignals(
       if (persisted.length === 0) {
         return [];
       }
-      const restored = persisted.map(createRestoredAttachment);
+      const restored = persisted.map((attachment) => {
+        return createRestoredAttachment(attachment);
+      });
       set(internalAttachments$, (prev) => {
         return [...prev, ...restored];
       });

--- a/turbo/apps/platform/src/signals/zero-page/composer-inline-prompt-items.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-inline-prompt-items.ts
@@ -31,6 +31,8 @@ export type InlinePromptLineSegment =
       readonly type: "file";
       readonly filename: string;
       readonly url: string;
+      readonly promptReference?: string;
+      readonly clientId?: string;
     }
   | {
       readonly type: "thread";
@@ -42,6 +44,9 @@ const INLINE_TEMPLATE_COMMENT_PATTERN =
   /<!-- zero-template:v1 type="([^"]+)" id="([^"]+)"(?: color="([^"]+)")?; .*? -->/g;
 const MARKDOWN_LINK_PATTERN =
   /\[((?:\\[\\[\]]|[^[\]\\])+)\]\((https:\/\/cdn\.(?:vm0|vm7)\.io\/artifacts\/[^)\s]+)\)/g;
+const INLINE_ATTACHMENT_REFERENCE_FRAGMENT = "#vm0-attachment-reference=";
+const INLINE_ATTACHMENT_REFERENCE_CLIENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function inlineTemplateMetadataFromRequest(
   request: GenerationTemplateRequest,
@@ -253,6 +258,36 @@ export function serializeInlineFilePromptItem(
   return `[${escapedFilename}](${url})`;
 }
 
+export function serializeInlineAttachmentReferencePromptItem(
+  promptReference: string,
+  url: string,
+  clientId: string,
+): string {
+  if (!INLINE_ATTACHMENT_REFERENCE_CLIENT_ID_PATTERN.test(clientId)) {
+    throw new Error("Inline attachment reference client ID is invalid");
+  }
+  const referenceUrl = new URL(url);
+  referenceUrl.hash = `vm0-attachment-reference=${clientId}`;
+  return serializeInlineFilePromptItem(promptReference, referenceUrl.href);
+}
+
+function inlineAttachmentReferenceFromUrl(url: string): {
+  readonly url: string;
+  readonly clientId: string;
+} | null {
+  const markerIndex = url.lastIndexOf(INLINE_ATTACHMENT_REFERENCE_FRAGMENT);
+  if (markerIndex === -1) {
+    return null;
+  }
+  const clientId = url.slice(
+    markerIndex + INLINE_ATTACHMENT_REFERENCE_FRAGMENT.length,
+  );
+  if (!INLINE_ATTACHMENT_REFERENCE_CLIENT_ID_PATTERN.test(clientId)) {
+    return null;
+  }
+  return { url: url.slice(0, markerIndex), clientId };
+}
+
 function isVm0ArtifactUrl(url: string): boolean {
   if (!URL.canParse(url)) {
     return false;
@@ -296,10 +331,18 @@ function appendFileAndThreadSegments(
       continue;
     }
     appendChatThreadSegments(segments, value.slice(lastIndex, index));
+    const filename = (match[1] ?? "").replace(/\\([\\[\]])/g, "$1");
+    const reference = inlineAttachmentReferenceFromUrl(url);
     segments.push({
       type: "file",
-      filename: (match[1] ?? "").replace(/\\([\\[\]])/g, "$1"),
-      url,
+      filename,
+      url: reference?.url ?? url,
+      ...(reference
+        ? {
+            promptReference: filename,
+            clientId: reference.clientId,
+          }
+        : {}),
     });
     lastIndex = index + match[0].length;
   }

--- a/turbo/apps/platform/src/signals/zero-page/composer-inline-prompt-items.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-inline-prompt-items.ts
@@ -393,3 +393,37 @@ export function splitInlinePromptLine(
   appendTemplateFreeSegments(segments, line.slice(lastIndex));
   return segments;
 }
+
+export function hasSubmittableInlinePromptContent(
+  value: string,
+  attachmentReferenceClientIds: ReadonlySet<string> | null,
+): boolean {
+  for (const line of value.split("\n")) {
+    for (const segment of splitInlinePromptLine(line)) {
+      switch (segment.type) {
+        case "text": {
+          if (segment.text.trim().length > 0) {
+            return true;
+          }
+          break;
+        }
+        case "file": {
+          if (
+            segment.promptReference === undefined ||
+            attachmentReferenceClientIds === null ||
+            (segment.clientId !== undefined &&
+              attachmentReferenceClientIds.has(segment.clientId))
+          ) {
+            return true;
+          }
+          break;
+        }
+        case "template":
+        case "thread": {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -48,6 +48,7 @@ import {
 } from "./template-preview-runtime.ts";
 import {
   inlineTemplateMetadataFromRequest,
+  serializeInlineAttachmentReferencePromptItem,
   serializeInlineFilePromptItem,
   serializeInlineTemplatePromptItem,
   splitInlinePromptLine,
@@ -747,6 +748,13 @@ function inlineFileNodeAttributes(
 function inlineFileNodeText(node: ProseMirrorNode): string {
   const attributes = inlineFileNodeAttributes(node);
   const label = attributes.promptReference ?? attributes.filename;
+  if (attributes.promptReference && attributes.url) {
+    return serializeInlineAttachmentReferencePromptItem(
+      label,
+      attributes.url,
+      attributes.clientId,
+    );
+  }
   return attributes.url
     ? serializeInlineFilePromptItem(label, attributes.url)
     : label;
@@ -1377,19 +1385,16 @@ function inlinePromptSegmentToJson(
       };
     }
     case "file": {
-      const promptReference = /^(?:image|file)\d+$/.test(segment.filename)
-        ? segment.filename
-        : null;
       return {
         type: INLINE_FILE_NODE_NAME,
         attrs: {
-          clientId: segment.url,
+          clientId: segment.clientId ?? segment.url,
           filename: segment.filename,
           contentType: "application/octet-stream",
           size: 0,
           fileId: null,
           url: segment.url,
-          promptReference,
+          promptReference: segment.promptReference ?? null,
         },
       };
     }

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -132,7 +132,10 @@ export interface WorkflowComposerSignals {
   readonly appendText$: Command<void, [string]>;
   readonly readInputForSubmission$: Command<
     Promise<string>,
-    [includeAttachmentReferences: boolean, signal: AbortSignal]
+    [
+      attachmentReferenceClientIds: ReadonlySet<string> | null,
+      signal: AbortSignal,
+    ]
   >;
   readonly setTemplateAttachmentLifecycleRef$: Command<
     (() => void) | undefined,
@@ -760,9 +763,17 @@ function inlineFileNodeText(node: ProseMirrorNode): string {
     : label;
 }
 
-function inlineFileSubmissionText(node: ProseMirrorNode): string {
+function inlineFileSubmissionText(
+  node: ProseMirrorNode,
+  attachmentReferenceClientIds: ReadonlySet<string>,
+): string {
   const attributes = inlineFileNodeAttributes(node);
-  return attributes.promptReference ?? inlineFileNodeText(node);
+  if (!attributes.promptReference) {
+    return inlineFileNodeText(node);
+  }
+  return attachmentReferenceClientIds.has(attributes.clientId)
+    ? attributes.promptReference
+    : "";
 }
 
 function createInlineFileReferenceNodeView(node: ProseMirrorNode): NodeView {
@@ -1431,7 +1442,7 @@ function valueToWorkflowComposerDoc(value: string): JSONContent {
 function nodeText(
   node: ProseMirrorNode,
   to: number = node.content.size,
-  forSubmission = false,
+  attachmentReferenceClientIds: ReadonlySet<string> | null = null,
 ): string {
   return node.textBetween(0, to, "\n", (leafNode) => {
     if (leafNode.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
@@ -1441,8 +1452,8 @@ function nodeText(
       return inlineTemplateNodeText(leafNode);
     }
     if (leafNode.type.name === INLINE_FILE_NODE_NAME) {
-      return forSubmission
-        ? inlineFileSubmissionText(leafNode)
+      return attachmentReferenceClientIds
+        ? inlineFileSubmissionText(leafNode, attachmentReferenceClientIds)
         : inlineFileNodeText(leafNode);
     }
     return leafNode.type.name === "hardBreak" ? "\n" : "";
@@ -1451,7 +1462,7 @@ function nodeText(
 
 function workflowComposerDocToString(
   editor: Editor,
-  forSubmission = false,
+  attachmentReferenceClientIds: ReadonlySet<string> | null = null,
 ): string {
   const sections: string[] = [];
   let textBlocks: string[] = [];
@@ -1494,7 +1505,9 @@ function workflowComposerDocToString(
       continue;
     }
     flushFeedbackItems();
-    textBlocks.push(nodeText(node, node.content.size, forSubmission));
+    textBlocks.push(
+      nodeText(node, node.content.size, attachmentReferenceClientIds),
+    );
   }
   flushTextBlocks();
   flushFeedbackItems();
@@ -2305,6 +2318,26 @@ function createInlinePromptItemCommands(editor: Editor) {
   };
 }
 
+function createReadInputForSubmissionCommand(
+  editor: Editor,
+  compositionGate: CompositionGate,
+) {
+  return command(
+    (
+      _context,
+      attachmentReferenceClientIds: ReadonlySet<string> | null,
+      signal: AbortSignal,
+    ) => {
+      return compositionGate.runWhenSettled(() => {
+        return workflowComposerDocToString(
+          editor,
+          attachmentReferenceClientIds,
+        );
+      }, signal);
+    },
+  );
+}
+
 export function createWorkflowComposerSignals(
   draft: DraftSignals,
   threadId?: string,
@@ -2397,12 +2430,9 @@ export function createWorkflowComposerSignals(
   const { insertText$, insertPromptMarkdown$, appendText$ } =
     createInsertTextCommands(editor);
   const inlinePromptItemCommands = createInlinePromptItemCommands(editor);
-  const readInputForSubmission$ = command(
-    (_context, includeAttachmentReferences: boolean, signal: AbortSignal) => {
-      return compositionGate.runWhenSettled(() => {
-        return workflowComposerDocToString(editor, includeAttachmentReferences);
-      }, signal);
-    },
+  const readInputForSubmission$ = createReadInputForSubmissionCommand(
+    editor,
+    compositionGate,
   );
   const hasInput$ = computed((get) => {
     return get(draft.hasInput$) || get(feedback.active$);

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -1384,6 +1384,7 @@ function removeInlineFile(editor: Editor, clientId: string): void {
 
 function inlinePromptSegmentToJson(
   segment: ReturnType<typeof splitInlinePromptLine>[number],
+  featureModes: WorkflowComposerFeatureModes,
 ): JSONContent {
   switch (segment.type) {
     case "text": {
@@ -1396,6 +1397,26 @@ function inlinePromptSegmentToJson(
       };
     }
     case "file": {
+      if (
+        segment.promptReference !== undefined &&
+        !featureModes.inlineAttachmentReferences
+      ) {
+        if (!featureModes.inlinePromptItems) {
+          return { type: "text", text: segment.promptReference };
+        }
+        return {
+          type: INLINE_FILE_NODE_NAME,
+          attrs: {
+            clientId: segment.clientId ?? segment.url,
+            filename: segment.promptReference,
+            contentType: "application/octet-stream",
+            size: 0,
+            fileId: null,
+            url: segment.url,
+            promptReference: null,
+          },
+        };
+      }
       return {
         type: INLINE_FILE_NODE_NAME,
         attrs: {
@@ -1426,14 +1447,25 @@ function inlinePromptSegmentToJson(
   }
 }
 
-function valueToWorkflowComposerDoc(value: string): JSONContent {
+interface WorkflowComposerFeatureModes {
+  readonly inlinePromptItems: boolean;
+  readonly inlineAttachmentReferences: boolean;
+}
+
+function valueToWorkflowComposerDoc(
+  value: string,
+  featureModes: WorkflowComposerFeatureModes = {
+    inlinePromptItems: false,
+    inlineAttachmentReferences: false,
+  },
+): JSONContent {
   const content: JSONContent[] = value.split("\n").map((line) => {
     if (line.length === 0) {
       return { type: "paragraph" };
     }
-    const inlineContent = splitInlinePromptLine(line).map(
-      inlinePromptSegmentToJson,
-    );
+    const inlineContent = splitInlinePromptLine(line).map((segment) => {
+      return inlinePromptSegmentToJson(segment, featureModes);
+    });
     return { type: "paragraph", content: inlineContent };
   });
   return { type: "doc", content };
@@ -1924,9 +1956,10 @@ function setWorkflowComposerDocument(
 function workflowComposerDocumentForValue(
   editor: Editor,
   value: string,
+  featureModes: WorkflowComposerFeatureModes,
 ): ProseMirrorNode {
   const textDocument = editor.schema.nodeFromJSON(
-    valueToWorkflowComposerDoc(value),
+    valueToWorkflowComposerDoc(value, featureModes),
   );
   const templateAttachment = locateTemplateAttachment(editor.state.doc)?.node;
   if (!templateAttachment) {
@@ -1985,6 +2018,7 @@ function createMountEditorCommand({
   selectedSuggestionIndexState$,
   feedback,
   compositionGate,
+  featureModes,
   autoFocus,
   singleLineOnMobile,
 }: {
@@ -1996,6 +2030,7 @@ function createMountEditorCommand({
   selectedSuggestionIndexState$: State<number>;
   feedback: FeedbackSignals;
   compositionGate: CompositionGate;
+  featureModes: WorkflowComposerFeatureModes;
   autoFocus: boolean;
   singleLineOnMobile: boolean;
 }) {
@@ -2039,7 +2074,7 @@ function createMountEditorCommand({
       if (feedbackItemsFromWorkflowComposer(editor).length === 0) {
         setWorkflowComposerDocument(
           editor,
-          workflowComposerDocumentForValue(editor, input),
+          workflowComposerDocumentForValue(editor, input, featureModes),
         );
       }
       editor.mount(element);
@@ -2060,7 +2095,7 @@ function createMountEditorCommand({
           }
           const changed = setWorkflowComposerDocument(
             editor,
-            workflowComposerDocumentForValue(editor, value),
+            workflowComposerDocumentForValue(editor, value, featureModes),
           );
           if (changed) {
             runtime.replaceFeedbackItems(
@@ -2160,12 +2195,17 @@ function createInsertChatThreadCommand(
   });
 }
 
-function createInsertTextCommands(editor: Editor) {
+function createInsertTextCommands(
+  editor: Editor,
+  featureModes: WorkflowComposerFeatureModes,
+) {
   const insertText$ = command((_context, value: string) => {
     editor.chain().focus().insertContent(value).run();
   });
   const insertPromptMarkdown$ = command((_context, value: string) => {
-    const doc = editor.schema.nodeFromJSON(valueToWorkflowComposerDoc(value));
+    const doc = editor.schema.nodeFromJSON(
+      valueToWorkflowComposerDoc(value, featureModes),
+    );
     const slice = Slice.maxOpen(doc.content, true);
     editor
       .chain()
@@ -2342,6 +2382,7 @@ export function createWorkflowComposerSignals(
   draft: DraftSignals,
   threadId?: string,
   inlinePromptItems = false,
+  inlineAttachmentReferences = false,
 ): WorkflowComposerSignals {
   const caretIndex$ = state(-1);
   const editorFocusedState$ = state(false);
@@ -2349,6 +2390,7 @@ export function createWorkflowComposerSignals(
   const runtime = createWorkflowComposerRuntime();
   const templatePreview = createTemplatePreviewRuntime();
   const compositionGate = createCompositionGate();
+  const featureModes = { inlinePromptItems, inlineAttachmentReferences };
 
   const editor = createWorkflowEditor(runtime);
   const templateAttachment = createTemplateAttachmentControls(editor, runtime);
@@ -2415,6 +2457,7 @@ export function createWorkflowComposerSignals(
       selectedSuggestionIndexState$,
       feedback,
       compositionGate,
+      featureModes,
       autoFocus,
       singleLineOnMobile,
     });
@@ -2428,7 +2471,7 @@ export function createWorkflowComposerSignals(
     activeChatThreadSuggestionRange$,
   );
   const { insertText$, insertPromptMarkdown$, appendText$ } =
-    createInsertTextCommands(editor);
+    createInsertTextCommands(editor, featureModes);
   const inlinePromptItemCommands = createInlinePromptItemCommands(editor);
   const readInputForSubmission$ = createReadInputForSubmissionCommand(
     editor,

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -976,8 +976,11 @@ function feedbackNoteContent(note: string): JSONContent[] {
   });
 }
 
-function feedbackNoteFromNode(node: ProseMirrorNode): string {
-  return nodeText(node);
+function feedbackNoteFromNode(
+  node: ProseMirrorNode,
+  attachmentReferenceClientIds: ReadonlySet<string> | null = null,
+): string {
+  return nodeText(node, node.content.size, attachmentReferenceClientIds);
 }
 
 function feedbackItemNode(editor: Editor, item: FeedbackItem): ProseMirrorNode {
@@ -1527,7 +1530,7 @@ function workflowComposerDocToString(
       feedbackItems.push({
         id: attributes.feedbackId,
         quote: attributes.quote,
-        note: feedbackNoteFromNode(node),
+        note: feedbackNoteFromNode(node, attachmentReferenceClientIds),
       });
       continue;
     }

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -120,6 +120,7 @@ export interface WorkflowComposerSignals {
     [GenerationTemplateRequest, ComposerTemplateAttachment]
   >;
   readonly insertFile$: Command<void, [ComposerInlineFileAttachment]>;
+  readonly insertReferencedFile$: Command<void, [ComposerInlineFileAttachment]>;
   readonly resolveFile$: Command<
     void,
     [clientId: string, fileId: string, url: string]
@@ -128,7 +129,10 @@ export interface WorkflowComposerSignals {
   readonly insertPromptMarkdown$: Command<void, [string]>;
   readonly insertText$: Command<void, [string]>;
   readonly appendText$: Command<void, [string]>;
-  readonly readInputForSubmission$: Command<Promise<string>, [AbortSignal]>;
+  readonly readInputForSubmission$: Command<
+    Promise<string>,
+    [includeAttachmentReferences: boolean, signal: AbortSignal]
+  >;
   readonly setTemplateAttachmentLifecycleRef$: Command<
     (() => void) | undefined,
     [HTMLButtonElement | null]
@@ -158,6 +162,7 @@ export interface ComposerInlineFileAttachment {
   readonly size: number;
   readonly fileId?: string;
   readonly url?: string;
+  readonly promptReference?: string;
 }
 
 export interface WorkflowComposerEventHandlers {
@@ -716,13 +721,15 @@ function inlineFileNodeAttributes(
   const size: unknown = node.attrs.size;
   const fileId: unknown = node.attrs.fileId;
   const url: unknown = node.attrs.url;
+  const promptReference: unknown = node.attrs.promptReference;
   if (
     typeof clientId !== "string" ||
     typeof filename !== "string" ||
     typeof contentType !== "string" ||
     typeof size !== "number" ||
     (fileId !== null && typeof fileId !== "string") ||
-    (url !== null && typeof url !== "string")
+    (url !== null && typeof url !== "string") ||
+    (promptReference !== null && typeof promptReference !== "string")
   ) {
     throw new Error("Inline file node attributes are invalid");
   }
@@ -733,20 +740,62 @@ function inlineFileNodeAttributes(
     size,
     ...(fileId === null ? {} : { fileId }),
     ...(url === null ? {} : { url }),
+    ...(promptReference === null ? {} : { promptReference }),
   };
 }
 
 function inlineFileNodeText(node: ProseMirrorNode): string {
   const attributes = inlineFileNodeAttributes(node);
+  const label = attributes.promptReference ?? attributes.filename;
   return attributes.url
-    ? serializeInlineFilePromptItem(attributes.filename, attributes.url)
-    : attributes.filename;
+    ? serializeInlineFilePromptItem(label, attributes.url)
+    : label;
+}
+
+function inlineFileSubmissionText(node: ProseMirrorNode): string {
+  const attributes = inlineFileNodeAttributes(node);
+  return attributes.promptReference ?? inlineFileNodeText(node);
+}
+
+function createInlineFileReferenceNodeView(node: ProseMirrorNode): NodeView {
+  const dom = document.createElement("span");
+  dom.dataset.composerInlineFile = "";
+  dom.className = "text-foreground";
+  dom.contentEditable = "false";
+
+  let currentNode = node;
+  function render(nextNode: ProseMirrorNode): boolean {
+    const reference = inlineFileNodeAttributes(nextNode).promptReference;
+    if (!reference) {
+      return false;
+    }
+    dom.textContent = reference;
+    return true;
+  }
+  render(currentNode);
+
+  return {
+    dom,
+    update(nextNode) {
+      if (nextNode.type !== currentNode.type || !render(nextNode)) {
+        return false;
+      }
+      currentNode = nextNode;
+      return true;
+    },
+    ignoreMutation() {
+      return true;
+    },
+  };
 }
 
 function createInlineFileNodeView(
   node: ProseMirrorNode,
   removeFile: () => void,
 ): NodeView {
+  if (inlineFileNodeAttributes(node).promptReference) {
+    return createInlineFileReferenceNodeView(node);
+  }
   const dom = document.createElement("span");
   dom.dataset.composerInlineFile = "";
   dom.className =
@@ -772,11 +821,9 @@ function createInlineFileNodeView(
   let currentNode = node;
   function render(nextNode: ProseMirrorNode): void {
     const attributes = inlineFileNodeAttributes(nextNode);
-    title.textContent = attributes.filename;
-    removeButton.setAttribute(
-      "aria-label",
-      `Remove file ${attributes.filename}`,
-    );
+    const label = attributes.promptReference ?? attributes.filename;
+    title.textContent = label;
+    removeButton.setAttribute("aria-label", `Remove file ${label}`);
     icon.replaceChildren();
     const fileIcon = createComposerIcon(12, 1.5, [
       "M15 7l-6.5 6.5a2.121 2.121 0 0 0 3 3l6.5-6.5a4.243 4.243 0 0 0-6-6l-6.5 6.5a6.364 6.364 0 0 0 9 9l6.5-6.5",
@@ -1218,11 +1265,32 @@ function insertInlineFile(
           size: attachment.size,
           fileId: attachment.fileId ?? null,
           url: attachment.url ?? null,
+          promptReference: attachment.promptReference ?? null,
         },
       },
       { type: "text", text: " " },
     ])
     .run();
+}
+
+function nextInlineFilePromptReference(
+  document: ProseMirrorNode,
+  contentType: string,
+): string {
+  const prefix = contentType.startsWith("image/") ? "image" : "file";
+  let nextIndex = 1;
+  document.descendants((node) => {
+    if (node.type.name !== INLINE_FILE_NODE_NAME) {
+      return true;
+    }
+    const reference = inlineFileNodeAttributes(node).promptReference;
+    const match = reference?.match(new RegExp(`^${prefix}(\\d+)$`));
+    if (match) {
+      nextIndex = Math.max(nextIndex, Number(match[1]) + 1);
+    }
+    return true;
+  });
+  return `${prefix}${nextIndex}`;
 }
 
 interface LocatedInlineFile {
@@ -1251,7 +1319,10 @@ function locateInlineFile(
 function inlineFileClientIds(document: ProseMirrorNode): ReadonlySet<string> {
   const clientIds = new Set<string>();
   document.descendants((node) => {
-    if (node.type.name === INLINE_FILE_NODE_NAME) {
+    if (
+      node.type.name === INLINE_FILE_NODE_NAME &&
+      !inlineFileNodeAttributes(node).promptReference
+    ) {
       clientIds.add(inlineFileNodeAttributes(node).clientId);
     }
     return true;
@@ -1306,6 +1377,9 @@ function inlinePromptSegmentToJson(
       };
     }
     case "file": {
+      const promptReference = /^(?:image|file)\d+$/.test(segment.filename)
+        ? segment.filename
+        : null;
       return {
         type: INLINE_FILE_NODE_NAME,
         attrs: {
@@ -1315,6 +1389,7 @@ function inlinePromptSegmentToJson(
           size: 0,
           fileId: null,
           url: segment.url,
+          promptReference,
         },
       };
     }
@@ -1351,6 +1426,7 @@ function valueToWorkflowComposerDoc(value: string): JSONContent {
 function nodeText(
   node: ProseMirrorNode,
   to: number = node.content.size,
+  forSubmission = false,
 ): string {
   return node.textBetween(0, to, "\n", (leafNode) => {
     if (leafNode.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
@@ -1360,13 +1436,18 @@ function nodeText(
       return inlineTemplateNodeText(leafNode);
     }
     if (leafNode.type.name === INLINE_FILE_NODE_NAME) {
-      return inlineFileNodeText(leafNode);
+      return forSubmission
+        ? inlineFileSubmissionText(leafNode)
+        : inlineFileNodeText(leafNode);
     }
     return leafNode.type.name === "hardBreak" ? "\n" : "";
   });
 }
 
-function workflowComposerDocToString(editor: Editor): string {
+function workflowComposerDocToString(
+  editor: Editor,
+  forSubmission = false,
+): string {
   const sections: string[] = [];
   let textBlocks: string[] = [];
   let feedbackItems: FeedbackItem[] = [];
@@ -1408,7 +1489,7 @@ function workflowComposerDocToString(editor: Editor): string {
       continue;
     }
     flushFeedbackItems();
-    textBlocks.push(nodeText(node));
+    textBlocks.push(nodeText(node, node.content.size, forSubmission));
   }
   flushTextBlocks();
   flushFeedbackItems();
@@ -1678,6 +1759,7 @@ function createInlineFileNode(): Node<undefined, unknown> {
         size: { default: 0 },
         fileId: { default: null },
         url: { default: null },
+        promptReference: { default: null },
       };
     },
     parseHTML() {
@@ -2190,6 +2272,17 @@ function createInlinePromptItemCommands(editor: Editor) {
       insertInlineFile(editor, attachment);
     },
   );
+  const insertReferencedFile$ = command(
+    (_context, attachment: ComposerInlineFileAttachment) => {
+      insertInlineFile(editor, {
+        ...attachment,
+        promptReference: nextInlineFilePromptReference(
+          editor.state.doc,
+          attachment.contentType,
+        ),
+      });
+    },
+  );
   const resolveFile$ = command(
     (_context, clientId: string, fileId: string, url: string) => {
       resolveInlineFile(editor, clientId, fileId, url);
@@ -2198,7 +2291,13 @@ function createInlinePromptItemCommands(editor: Editor) {
   const removeFile$ = command((_context, clientId: string) => {
     removeInlineFile(editor, clientId);
   });
-  return { insertTemplate$, insertFile$, resolveFile$, removeFile$ };
+  return {
+    insertTemplate$,
+    insertFile$,
+    insertReferencedFile$,
+    resolveFile$,
+    removeFile$,
+  };
 }
 
 export function createWorkflowComposerSignals(
@@ -2293,11 +2392,13 @@ export function createWorkflowComposerSignals(
   const { insertText$, insertPromptMarkdown$, appendText$ } =
     createInsertTextCommands(editor);
   const inlinePromptItemCommands = createInlinePromptItemCommands(editor);
-  const readInputForSubmission$ = command((_context, signal: AbortSignal) => {
-    return compositionGate.runWhenSettled(() => {
-      return workflowComposerDocToString(editor);
-    }, signal);
-  });
+  const readInputForSubmission$ = command(
+    (_context, includeAttachmentReferences: boolean, signal: AbortSignal) => {
+      return compositionGate.runWhenSettled(() => {
+        return workflowComposerDocToString(editor, includeAttachmentReferences);
+      }, signal);
+    },
+  );
   const hasInput$ = computed((get) => {
     return get(draft.hasInput$) || get(feedback.active$);
   });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { talkDraft$ } from "./chat-draft.ts";
 import { createWorkflowComposerSignals } from "./tiptap-workflow-composer.ts";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
 import {
   codexFastModeEnabled$,
@@ -39,7 +40,7 @@ export const chatPageWorkflowComposer$ = computed((get) => {
   return createWorkflowComposerSignals(
     get(talkDraft$),
     undefined,
-    get(featureSwitch$)[FeatureSwitchKey.ComposerInlinePromptItems] ?? false,
+    composerInlinePromptItemsEnabled(get(featureSwitch$)),
   );
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -37,10 +37,12 @@ export const setChatPageInput$ = command(({ get, set }, value: string) => {
 });
 
 export const chatPageWorkflowComposer$ = computed((get) => {
+  const features = get(featureSwitch$);
   return createWorkflowComposerSignals(
     get(talkDraft$),
     undefined,
-    composerInlinePromptItemsEnabled(get(featureSwitch$)),
+    composerInlinePromptItemsEnabled(features),
+    features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ?? false,
   );
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -3327,19 +3327,40 @@ describe("chat composer models", () => {
 
   it("hides an accepted visual attachment after switching to a text-only model", async () => {
     const user = userEvent.setup({ delay: null });
+    let submitted:
+      | {
+          prompt?: string;
+          attachFiles?: readonly { id?: string }[];
+        }
+      | undefined;
     mockOrgModelRoutes("claude-sonnet-4-6");
     mockAgent();
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
     context.mocks.upload.success({
       id: "visual-model-switch",
       filename: "storyboard.png",
       contentType: "image/png",
       size: 128,
-      url: "https://example.com/storyboard.png",
+      url: "https://cdn.vm0.io/artifacts/user_1/visual-model-switch/storyboard.png",
     });
 
-    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
 
     await expectComposerModel("Claude Sonnet 4.6");
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Describe ");
     const fileInput =
       document.querySelector<HTMLInputElement>('input[type="file"]')!;
     await user.upload(
@@ -3350,6 +3371,7 @@ describe("chat composer models", () => {
     await expect(
       screen.findByLabelText("Open image preview for storyboard.png"),
     ).resolves.toBeInTheDocument();
+    expect(editor).toHaveTextContent("Describe image1");
 
     await user.click(
       screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
@@ -3365,6 +3387,14 @@ describe("chat composer models", () => {
         screen.queryByLabelText("Open image preview for storyboard.png"),
       ).not.toBeInTheDocument();
     });
+
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toBe("Describe");
+    expect(submitted?.attachFiles).toBeUndefined();
   });
 
   it("shows agent connector access from the composer", async () => {
@@ -3674,6 +3704,47 @@ describe("chat composer templates", () => {
       expect(
         screen.queryByLabelText(`Remove template ${template.title}`),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps templates structured when attachment references override inline prompt items", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    let submitted:
+      | {
+          prompt?: string;
+          generationTemplate?: GenerationTemplateRequest;
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    await selectTemplate(user, template);
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Create a launch deck{Enter}");
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toBe("Create a launch deck");
+    expect(submitted?.prompt).not.toContain("zero-template:v1");
+    expect(submitted?.generationTemplate).toMatchObject({
+      type: "presentation",
+      selection: { templateId: template.templateId },
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -3397,6 +3397,64 @@ describe("chat composer models", () => {
     expect(submitted?.attachFiles).toBeUndefined();
   });
 
+  it("disables send when only a hidden visual attachment reference remains", async () => {
+    const user = userEvent.setup({ delay: null });
+    let submitted = false;
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    mockChatLifecycle(context, {
+      onRunCreate: () => {
+        submitted = true;
+      },
+    });
+    context.mocks.upload.success({
+      id: "visual-only-model-switch",
+      filename: "visual-only.png",
+      contentType: "image/png",
+      size: 128,
+      url: "https://cdn.vm0.io/artifacts/user_1/visual-only-model-switch/visual-only.png",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    await expectComposerModel("Claude Sonnet 4.6");
+    const editor = await findComposerEditor();
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      fileInput,
+      new File(["image"], "visual-only.png", { type: "image/png" }),
+    );
+
+    await expect(
+      screen.findByLabelText("Open image preview for visual-only.png"),
+    ).resolves.toBeInTheDocument();
+    expect(editor).toHaveTextContent("image1");
+    expect(screen.getByLabelText("Send")).toBeEnabled();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByRole("option", { name: /GLM-5\.1/ }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Open image preview for visual-only.png"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeDisabled();
+    });
+    await user.click(editor);
+    await user.keyboard("{Enter}");
+    expect(submitted).toBeFalsy();
+  });
+
   it("shows agent connector access from the composer", async () => {
     mockOrgModelRoutes("claude-sonnet-4-6");
     mockAgent();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -612,6 +612,108 @@ describe("chat drafts", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "structured attachment mode",
+      threadId: "b1000000-0000-4000-a000-000000000107",
+      inlinePromptItems: false,
+      expectedPrompt: "Review image1",
+      expectedAttachmentId: "rollback-reference-image",
+      expectedInlineFileCount: 0,
+      expectedAttachmentChip: true,
+    },
+    {
+      name: "legacy inline prompt mode",
+      threadId: "b1000000-0000-4000-a000-000000000108",
+      inlinePromptItems: true,
+      expectedPrompt:
+        "Review [image1](https://cdn.vm7.io/artifacts/test/drafts/rollback-reference.png)",
+      expectedAttachmentId: undefined,
+      expectedInlineFileCount: 1,
+      expectedAttachmentChip: false,
+    },
+  ])(
+    "normalizes restored references when the switch is off in $name",
+    async ({
+      threadId,
+      inlinePromptItems,
+      expectedPrompt,
+      expectedAttachmentId,
+      expectedInlineFileCount,
+      expectedAttachmentChip,
+    }) => {
+      const user = userEvent.setup({ delay: null });
+      const imageUrl =
+        "https://cdn.vm7.io/artifacts/test/drafts/rollback-reference.png";
+      const imageClientId = "33333333-3333-4333-8333-333333333333";
+      let submitted:
+        | {
+            prompt?: string;
+            attachFiles?: readonly { id?: string }[];
+          }
+        | undefined;
+      mockChatLifecycle(context, {
+        threadId,
+        onRunCreate: (body) => {
+          submitted = body;
+        },
+      });
+      context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+        return respond(200, {
+          draftContent: `Review [image1](${imageUrl}#vm0-attachment-reference=${imageClientId})`,
+          draftAttachments: [
+            {
+              id: "rollback-reference-image",
+              filename: "rollback-reference.png",
+              contentType: "image/png",
+              size: 10,
+              url: imageUrl,
+            },
+          ],
+        });
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/chats/${threadId}`,
+        featureSwitches: {
+          [FeatureSwitchKey.ComposerInlinePromptItems]: inlinePromptItems,
+          [FeatureSwitchKey.ComposerInlineAttachmentReferences]: false,
+        },
+      });
+
+      await waitFor(() => {
+        expect(textarea()).toHaveTextContent("Review image1");
+        expect(
+          textarea().querySelectorAll("[data-composer-inline-file]"),
+        ).toHaveLength(expectedInlineFileCount);
+        const attachmentChip = screen.queryByLabelText(
+          "Remove rollback-reference.png",
+        );
+        if (expectedAttachmentChip) {
+          expect(attachmentChip).toBeInTheDocument();
+        } else {
+          expect(attachmentChip).not.toBeInTheDocument();
+        }
+        expect(screen.getByLabelText("Send")).toBeEnabled();
+      });
+      await user.click(screen.getByLabelText("Send"));
+
+      await waitFor(() => {
+        expect(submitted).toBeDefined();
+      });
+      expect(submitted?.prompt).toBe(expectedPrompt);
+      expect(submitted?.prompt).not.toContain("vm0-attachment-reference");
+      if (expectedAttachmentId === undefined) {
+        expect(submitted?.attachFiles).toBeUndefined();
+      } else {
+        expect(submitted?.attachFiles).toStrictEqual([
+          expect.objectContaining({ id: expectedAttachmentId }),
+        ]);
+      }
+    },
+  );
+
   it("keeps a legacy inline attachment named like a numbered reference", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "b1000000-0000-4000-a000-000000000106";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -173,6 +174,18 @@ async function findComposerEditor(): Promise<HTMLElement> {
   });
 }
 
+function composerFileInput(editor: HTMLElement): HTMLInputElement {
+  const fileInput = Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[type="file"]'),
+  ).find((candidate) => {
+    return candidate.parentElement?.contains(editor) ?? false;
+  });
+  if (!fileInput) {
+    throw new Error("File input not found");
+  }
+  return fileInput;
+}
+
 async function navigateToThread(threadId: string): Promise<void> {
   const link = await waitFor(() => {
     return document.querySelector<HTMLAnchorElement>(
@@ -328,6 +341,241 @@ describe("chat drafts", () => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
       expect(screen.getByLabelText("Remove brief.md")).toBeInTheDocument();
     });
+  });
+
+  it("shows numbered text references and attachment chips", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b1000000-0000-4000-a000-000000000103";
+    const uploadResults = [
+      {
+        id: "upload-image-one",
+        filename: "first.png",
+        contentType: "image/png",
+        size: 3,
+        url: "https://cdn.vm0.io/artifacts/user_1/upload-image-one/first.png",
+      },
+      {
+        id: "upload-image-two",
+        filename: "second.png",
+        contentType: "image/png",
+        size: 3,
+        url: "https://cdn.vm0.io/artifacts/user_1/upload-image-two/second.png",
+      },
+      {
+        id: "upload-file-one",
+        filename: "first.pdf",
+        contentType: "application/pdf",
+        size: 3,
+        url: "https://cdn.vm0.io/artifacts/user_1/upload-file-one/first.pdf",
+      },
+      {
+        id: "upload-file-two",
+        filename: "second.pdf",
+        contentType: "application/pdf",
+        size: 3,
+        url: "https://cdn.vm0.io/artifacts/user_1/upload-file-two/second.pdf",
+      },
+    ] as const;
+    let submitted:
+      | {
+          prompt?: string;
+          attachFiles?: readonly { id?: string }[];
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("Compare ");
+    const fileInput = composerFileInput(editor);
+    for (const upload of uploadResults) {
+      context.mocks.upload.success(upload);
+      await user.upload(
+        fileInput,
+        new File([upload.filename], upload.filename, {
+          type: upload.contentType,
+        }),
+      );
+      await screen.findByLabelText(`Remove ${upload.filename}`);
+      await waitFor(() => {
+        expect(screen.getByLabelText("Send")).toBeEnabled();
+      });
+    }
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent("Compare");
+      expect(editor).toHaveTextContent("image1 image2 file1 file2");
+      expect(
+        editor.querySelectorAll("[data-composer-inline-file]"),
+      ).toHaveLength(4);
+      expect(editor.querySelector("button")).toBeNull();
+      expect(screen.getByLabelText("Remove first.png")).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove second.png")).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove first.pdf")).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove second.pdf")).toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeEnabled();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toContain("Compare");
+    for (const reference of ["image1", "image2", "file1", "file2"]) {
+      expect(submitted?.prompt).toContain(reference);
+    }
+    expect(submitted?.attachFiles).toHaveLength(4);
+  });
+
+  it("keeps the attachment chip when its text reference is deleted", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b1000000-0000-4000-a000-000000000104";
+    const uploadUrl =
+      "https://cdn.vm0.io/artifacts/user_1/upload-empty/empty-composer.pdf";
+    let submitted:
+      | {
+          prompt?: string;
+          attachFiles?: readonly { id?: string }[];
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-empty-composer",
+      filename: "empty-composer.pdf",
+      contentType: "application/pdf",
+      size: 8,
+      url: uploadUrl,
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    const fileInput = composerFileInput(editor);
+    await user.upload(
+      fileInput,
+      new File(["document"], "empty-composer.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    await expect(
+      screen.findByLabelText("Remove empty-composer.pdf"),
+    ).resolves.toBeInTheDocument();
+    expect(editor).toHaveTextContent("file1");
+    expect(editor.querySelectorAll("[data-composer-inline-file]")).toHaveLength(
+      1,
+    );
+    expect(editor.querySelector("button")).toBeNull();
+    await user.click(editor);
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+    await waitFor(() => {
+      expect(editor).not.toHaveTextContent("file1");
+      expect(
+        screen.getByLabelText("Remove empty-composer.pdf"),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeEnabled();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toBe("(see attached files)");
+    expect(submitted?.attachFiles?.[0]?.id).toBe("upload-empty-composer");
+  });
+
+  it("restores numbered attachment references and their attachment chips", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b1000000-0000-4000-a000-000000000105";
+    const imageUrl =
+      "https://cdn.vm7.io/artifacts/test/drafts/reference-image.png";
+    const fileUrl = "https://cdn.vm7.io/artifacts/test/drafts/reference.pdf";
+    let submitted:
+      | {
+          prompt?: string;
+          attachFiles?: readonly { id?: string }[];
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftContent: `Compare [image1](${imageUrl}) with [file1](${fileUrl})`,
+        draftAttachments: [
+          {
+            id: "draft-image-reference",
+            filename: "reference-image.png",
+            contentType: "image/png",
+            size: 10,
+            url: imageUrl,
+          },
+          {
+            id: "draft-file-reference",
+            filename: "reference.pdf",
+            contentType: "application/pdf",
+            size: 20,
+            url: fileUrl,
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(textarea()).toHaveTextContent("Compare image1 with file1");
+      expect(
+        textarea().querySelectorAll("[data-composer-inline-file]"),
+      ).toHaveLength(2);
+      expect(textarea().querySelector("button")).toBeNull();
+      expect(
+        screen.getByLabelText("Remove reference-image.png"),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove reference.pdf")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toBe("Compare image1 with file1");
+    expect(submitted?.attachFiles).toHaveLength(2);
   });
 
   it("persists edited draft attachments and clears the server draft after sending", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -346,6 +346,7 @@ describe("chat drafts", () => {
   it("shows numbered text references and attachment chips", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "b1000000-0000-4000-a000-000000000103";
+    const draftPatches: Record<string, unknown>[] = [];
     const uploadResults = [
       {
         id: "upload-image-one",
@@ -388,6 +389,10 @@ describe("chat drafts", () => {
         submitted = body;
       },
     });
+    context.mocks.api(chatThreadByIdContract.patch, ({ body, respond }) => {
+      draftPatches.push(body as Record<string, unknown>);
+      return respond(204);
+    });
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
@@ -427,6 +432,18 @@ describe("chat drafts", () => {
       expect(screen.getByLabelText("Remove first.pdf")).toBeInTheDocument();
       expect(screen.getByLabelText("Remove second.pdf")).toBeInTheDocument();
       expect(screen.getByLabelText("Send")).toBeEnabled();
+    });
+    await waitFor(() => {
+      const persistedContent = draftPatches.find((patch) => {
+        return (
+          typeof patch.draftContent === "string" &&
+          patch.draftContent.includes("#vm0-attachment-reference=")
+        );
+      })?.draftContent;
+      expect(persistedContent).toBeTypeOf("string");
+      expect(
+        (persistedContent as string).match(/#vm0-attachment-reference=/g),
+      ).toHaveLength(4);
     });
     await user.click(screen.getByLabelText("Send"));
 
@@ -515,6 +532,8 @@ describe("chat drafts", () => {
     const imageUrl =
       "https://cdn.vm7.io/artifacts/test/drafts/reference-image.png";
     const fileUrl = "https://cdn.vm7.io/artifacts/test/drafts/reference.pdf";
+    const imageClientId = "11111111-1111-4111-8111-111111111111";
+    const fileClientId = "22222222-2222-4222-8222-222222222222";
     let submitted:
       | {
           prompt?: string;
@@ -529,7 +548,9 @@ describe("chat drafts", () => {
     });
     context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
       return respond(200, {
-        draftContent: `Compare [image1](${imageUrl}) with [file1](${fileUrl})`,
+        draftContent:
+          `Compare [image1](${imageUrl}#vm0-attachment-reference=${imageClientId}) with ` +
+          `[file1](${fileUrl}#vm0-attachment-reference=${fileClientId})`,
         draftAttachments: [
           {
             id: "draft-image-reference",
@@ -569,13 +590,73 @@ describe("chat drafts", () => {
       ).toBeInTheDocument();
       expect(screen.getByLabelText("Remove reference.pdf")).toBeInTheDocument();
     });
+    await user.click(screen.getByLabelText("Remove reference.pdf"));
+    await waitFor(() => {
+      expect(textarea()).toHaveTextContent("Compare image1 with");
+      expect(textarea()).not.toHaveTextContent("file1");
+      expect(
+        screen.queryByLabelText("Remove reference.pdf"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Remove reference-image.png"),
+      ).toBeInTheDocument();
+    });
     await user.click(screen.getByLabelText("Send"));
 
     await waitFor(() => {
       expect(submitted).toBeDefined();
     });
-    expect(submitted?.prompt).toBe("Compare image1 with file1");
-    expect(submitted?.attachFiles).toHaveLength(2);
+    expect(submitted?.prompt).toBe("Compare image1 with");
+    expect(submitted?.attachFiles).toStrictEqual([
+      expect.objectContaining({ id: "draft-image-reference" }),
+    ]);
+  });
+
+  it("keeps a legacy inline attachment named like a numbered reference", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "b1000000-0000-4000-a000-000000000106";
+    const fileUrl =
+      "https://cdn.vm7.io/artifacts/test/drafts/legacy-file-one.pdf";
+    let submitted:
+      | {
+          prompt?: string;
+          attachFiles?: readonly { id?: string }[];
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        submitted = body;
+      },
+    });
+    context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftContent: `[file1](${fileUrl})`,
+        draftAttachments: null,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(textarea()).toHaveTextContent("file1");
+      expect(screen.getByLabelText("Remove file file1")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Remove file1")).not.toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submitted).toBeDefined();
+    });
+    expect(submitted?.prompt).toBe(`[file1](${fileUrl})`);
+    expect(submitted?.attachFiles).toBeUndefined();
   });
 
   it("persists edited draft attachments and clears the server draft after sending", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1036,14 +1036,14 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
 
-    await user.click(await screen.findByLabelText("Template"));
-    await user.click(
+    fireEvent.click(await screen.findByLabelText("Template"));
+    fireEvent.click(
       await screen.findByLabelText(
         `Preview ${template.title} at current slide`,
       ),
     );
-    await user.click(await screen.findByLabelText("Select style Gold Luxe"));
-    await user.click(
+    fireEvent.click(await screen.findByLabelText("Select style Gold Luxe"));
+    fireEvent.click(
       await screen.findByLabelText(`Select template ${template.title}`),
     );
     await waitFor(() => {
@@ -1073,10 +1073,13 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    fireEvent.click(buttonByText("Provide feedback"));
 
-    await findFeedbackNote();
-    await user.keyboard("Use the attached brief as supporting context.");
+    const feedbackNote = await findFeedbackNote();
+    pastePlainText(
+      feedbackNote,
+      "Use the attached brief as supporting context.",
+    );
     expect(
       screen.getByLabelText(`Remove template ${templateChipLabel}`),
     ).toBeInTheDocument();
@@ -1084,7 +1087,7 @@ describe("chat inline feedback", () => {
       screen.getByLabelText("Remove feedback-brief.txt"),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText("Send"));
+    fireEvent.click(screen.getByLabelText("Send"));
 
     await waitFor(() => {
       expect(sentBodies[0]).toMatchObject({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1118,6 +1118,126 @@ describe("chat inline feedback", () => {
     );
   });
 
+  it("filters hidden attachment references from inline feedback sends", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The launch summary needs visual context.";
+    let sentBody: RunCreateCapture | undefined;
+    const imageUrl =
+      "https://cdn.vm0.io/artifacts/user_1/feedback-model-switch/diagram.png";
+
+    context.mocks.data.orgModelPolicies([
+      {
+        id: "00000000-0000-4000-a000-000000000705",
+        model: "claude-sonnet-4-6",
+        modelLabel: "Claude Sonnet 4.6",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+        routeStatus: "valid",
+        routeStatusReason: null,
+        createdAt: "2026-07-14T00:00:00.000Z",
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      },
+      {
+        id: "00000000-0000-4000-a000-000000000706",
+        model: "glm-5.1",
+        modelLabel: "GLM-5.1",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+        routeStatus: "valid",
+        routeStatusReason: null,
+        createdAt: "2026-07-14T00:00:00.000Z",
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      },
+    ]);
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      selectedModel: "claude-sonnet-4-6",
+      chatMessages: [
+        {
+          id: "msg-feedback-model-switch-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-model-switch",
+          createdAt: "2026-07-20T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-model-switch-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-model-switch",
+          createdAt: "2026-07-20T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentBody = body;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-feedback-model-switch",
+      filename: "diagram.png",
+      contentType: "image/png",
+      size: 128,
+      url: imageUrl,
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerInlinePromptItems]: true,
+        [FeatureSwitchKey.ComposerInlineAttachmentReferences]: true,
+      },
+    });
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Provide feedback"));
+    const feedbackNote = await findFeedbackNote();
+    await user.click(feedbackNote);
+    await user.keyboard("Review ");
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
+    await user.upload(
+      fileInput,
+      new File(["image"], "diagram.png", { type: "image/png" }),
+    );
+
+    await waitFor(() => {
+      expect(feedbackNote).toHaveTextContent("Review image1");
+      expect(
+        screen.getByLabelText("Open image preview for diagram.png"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+    );
+    await user.click(await screen.findByRole("option", { name: /GLM-5\.1/ }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText("Open image preview for diagram.png"),
+      ).not.toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(sentBody).toBeDefined();
+    });
+    expect(sentBody?.prompt).toContain("Review");
+    expect(sentBody?.prompt).not.toContain("image1");
+    expect(sentBody?.prompt).not.toContain(imageUrl);
+    expect(sentBody?.prompt).not.toContain("vm0-attachment-reference");
+    expect(sentBody?.attachFiles).toBeUndefined();
+  });
+
   it("keeps committed inline feedback while drafting another selected comment", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The launch summary needs clearer risk ownership.";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -94,6 +94,7 @@ import type {
   WorkflowComposerSignals,
 } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
+import { hasSubmittableInlinePromptContent } from "../../signals/zero-page/composer-inline-prompt-items.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
 import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { Command, Computed } from "ccstate";
@@ -425,6 +426,20 @@ function resolveComposerModelForSelection(
     return selection;
   }
   return null;
+}
+
+function createAttachmentReferenceClientIds<T extends { clientId: string }>(
+  inlineAttachmentReferences: boolean,
+  visibleAttachments: readonly T[],
+): ReadonlySet<string> | null {
+  if (!inlineAttachmentReferences) {
+    return null;
+  }
+  return new Set(
+    visibleAttachments.map((attachment) => {
+      return attachment.clientId;
+    }),
+  );
 }
 
 interface VisualAttachmentUnsupportedState {
@@ -6336,6 +6351,7 @@ function ComposerSendButton({
 
 function ComposerSendControl({
   draft,
+  attachmentReferenceClientIds,
   visibleAttachmentCount,
   uploadsReady,
   submitBlocked,
@@ -6348,6 +6364,7 @@ function ComposerSendControl({
   onSend,
 }: {
   draft: DraftSignals;
+  attachmentReferenceClientIds: ReadonlySet<string> | null;
   visibleAttachmentCount: number;
   uploadsReady: boolean;
   submitBlocked: boolean;
@@ -6359,7 +6376,11 @@ function ComposerSendControl({
   submissionLoading: boolean;
   onSend: () => void;
 }) {
-  const hasInput = useGet(draft.hasInput$);
+  const input = useGet(draft.input$);
+  const hasInput = hasSubmittableInlinePromptContent(
+    input,
+    attachmentReferenceClientIds,
+  );
   const canSend = resolveComposerCanSend({
     hasInput,
     visibleAttachmentCount,
@@ -6564,6 +6585,10 @@ export function useZeroChatComposer({
   const visibleAttachments = resolveVisibleAttachments(
     attachments,
     visualAttachmentUnsupported,
+  );
+  const attachmentReferenceClientIds = createAttachmentReferenceClientIds(
+    inlineAttachmentReferences,
+    visibleAttachments,
   );
   const uploadsReady = attachmentUploadsState === "hasData";
 
@@ -6862,13 +6887,17 @@ export function useZeroChatComposer({
 
   const handleSend = () => {
     const input = readInput();
+    const hasInput = hasSubmittableInlinePromptContent(
+      input,
+      attachmentReferenceClientIds,
+    );
     const sendAction = resolveKeyboardSendAction({
       canSend:
         !actionsLoading &&
         !submissionLoading &&
         inputForSubmissionLoadable.state !== "loading" &&
         uploadsReady &&
-        (input.trim().length > 0 || visibleAttachments.length > 0) &&
+        (hasInput || visibleAttachments.length > 0) &&
         !submitBlocker,
       sending,
       queueWhileSending,
@@ -6882,13 +6911,6 @@ export function useZeroChatComposer({
       detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
     }
     const submitCurrentInput = async () => {
-      const attachmentReferenceClientIds = inlineAttachmentReferences
-        ? new Set(
-            visibleAttachments.map((attachment) => {
-              return attachment.clientId;
-            }),
-          )
-        : null;
       const currentInput = await readInputForSubmission(
         attachmentReferenceClientIds,
         pageSignal,
@@ -7107,6 +7129,7 @@ export function useZeroChatComposer({
                   />
                   <ComposerSendControl
                     draft={draft}
+                    attachmentReferenceClientIds={attachmentReferenceClientIds}
                     visibleAttachmentCount={visibleAttachments.length}
                     uploadsReady={uploadsReady}
                     submitBlocked={submitBlocker !== undefined}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6916,8 +6916,15 @@ export function useZeroChatComposer({
       detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
     }
     const submitCurrentInput = async () => {
+      const attachmentReferenceClientIds = inlineAttachmentReferences
+        ? new Set(
+            visibleAttachments.map((attachment) => {
+              return attachment.clientId;
+            }),
+          )
+        : null;
       const currentInput = await readInputForSubmission(
-        inlineAttachmentReferences,
+        attachmentReferenceClientIds,
         pageSignal,
       );
       const prompt = currentInput.trim();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -93,6 +93,7 @@ import type {
   ComposerTemplateAttachment,
   WorkflowComposerSignals,
 } from "../../signals/zero-page/tiptap-workflow-composer.ts";
+import { composerInlinePromptItemsEnabled } from "../../lib/composer-feature-switches.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
 import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { Command, Computed } from "ccstate";
@@ -6578,6 +6579,7 @@ export function useZeroChatComposer({
   const insertPromptMarkdown = useSet(composer.insertPromptMarkdown$);
   const insertTemplate = useSet(composer.insertTemplate$);
   const insertFile = useSet(composer.insertFile$);
+  const insertReferencedFile = useSet(composer.insertReferencedFile$);
   const resolveFile = useSet(composer.resolveFile$);
   const removeFile = useSet(composer.removeFile$);
   const appendComposerText = useSet(composer.appendText$);
@@ -6588,8 +6590,9 @@ export function useZeroChatComposer({
   const ensurePushSubscription = useSet(ensurePushSubscription$);
   const rootSignal = useGet(rootSignal$);
   const features = useGet(featureSwitch$);
-  const inlinePromptItems =
-    features[FeatureSwitchKey.ComposerInlinePromptItems] ?? false;
+  const inlineAttachmentReferences =
+    features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ?? false;
+  const inlinePromptItems = composerInlinePromptItemsEnabled(features);
   const visualAttachmentUnsupported =
     getVisualAttachmentUnsupportedState(modelPicker);
   const visibleAttachments = resolveVisibleAttachments(
@@ -6598,10 +6601,11 @@ export function useZeroChatComposer({
   );
   const uploadsReady = attachmentUploadsState === "hasData";
 
-  const uploadInlineFile = (file: File) => {
+  const uploadInlineFile = (file: File, usePromptReference: boolean) => {
     const started = startAttachmentUpload(file, rootSignal);
     const { clientId } = started.attachment;
-    insertFile({
+    const insert = usePromptReference ? insertReferencedFile : insertFile;
+    insert({
       clientId,
       filename: started.attachment.filename,
       contentType: started.attachment.contentType,
@@ -6622,14 +6626,20 @@ export function useZeroChatComposer({
         return;
       }
       resolveFile(clientId, info.id, info.url);
-      removeAttachment(started.attachment);
+      if (!usePromptReference) {
+        removeAttachment(started.attachment);
+      }
     };
     detach(settleUpload(), Reason.DomCallback);
   };
 
-  const uploadComposerFile = (file: File) => {
-    if (inlinePromptItems) {
-      uploadInlineFile(file);
+  const shouldInsertInlineAttachment = (): boolean => {
+    return inlineAttachmentReferences || inlinePromptItems;
+  };
+
+  const uploadComposerFile = (file: File, insertInline: boolean) => {
+    if (insertInline) {
+      uploadInlineFile(file, inlineAttachmentReferences);
       return;
     }
     detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
@@ -6638,8 +6648,27 @@ export function useZeroChatComposer({
   const insertClipboardAttachments = (
     clipboardAttachments: PersistedAttachment[],
   ) => {
-    if (!inlinePromptItems) {
+    const insertInline = shouldInsertInlineAttachment();
+    if (!insertInline) {
       restoreAttachments(clipboardAttachments);
+      return;
+    }
+    if (inlineAttachmentReferences) {
+      const restoredAttachments = restoreAttachments(clipboardAttachments);
+      for (const [index, attachment] of clipboardAttachments.entries()) {
+        const restoredAttachment = restoredAttachments[index];
+        if (!restoredAttachment) {
+          continue;
+        }
+        insertReferencedFile({
+          clientId: restoredAttachment.clientId,
+          filename: attachment.filename,
+          contentType: attachment.contentType,
+          size: attachment.size,
+          fileId: attachment.id,
+          url: attachment.url,
+        });
+      }
       return;
     }
     for (const attachment of clipboardAttachments) {
@@ -6729,7 +6758,7 @@ export function useZeroChatComposer({
       }
       e.preventDefault();
       applyPlainText();
-      uploadComposerFile(file);
+      uploadComposerFile(file, shouldInsertInlineAttachment());
       onDraftChange?.();
     }
   };
@@ -6742,6 +6771,7 @@ export function useZeroChatComposer({
       return;
     }
     let uploaded = false;
+    const insertInline = shouldInsertInlineAttachment();
     for (const file of files) {
       if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
         showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
@@ -6752,7 +6782,7 @@ export function useZeroChatComposer({
         toast.error(`${file.name} exceeds the 1 GB limit`);
         continue;
       }
-      uploadComposerFile(file);
+      uploadComposerFile(file, insertInline);
       uploaded = true;
     }
     if (uploaded) {
@@ -6886,7 +6916,10 @@ export function useZeroChatComposer({
       detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
     }
     const submitCurrentInput = async () => {
-      const currentInput = await readInputForSubmission(pageSignal);
+      const currentInput = await readInputForSubmission(
+        inlineAttachmentReferences,
+        pageSignal,
+      );
       const prompt = currentInput.trim();
       if (prompt.length === 0 && visibleAttachments.length === 0) {
         return;
@@ -6946,6 +6979,7 @@ export function useZeroChatComposer({
       return;
     }
     let uploaded = false;
+    const insertInline = shouldInsertInlineAttachment();
     for (const file of files) {
       if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
         showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
@@ -6956,7 +6990,7 @@ export function useZeroChatComposer({
         toast.error(`${file.name} exceeds the 1 GB limit`);
         continue;
       }
-      uploadComposerFile(file);
+      uploadComposerFile(file, insertInline);
       uploaded = true;
     }
     if (uploaded) {
@@ -7047,6 +7081,7 @@ export function useZeroChatComposer({
                 <AttachmentChips
                   attachments={visibleAttachments}
                   onRemove={(attachment) => {
+                    removeFile(attachment.clientId);
                     removeAttachment(attachment);
                     onDraftChange?.();
                   }}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -57,6 +57,7 @@ export enum FeatureSwitchKey {
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",
   ComposerInlinePromptItems = "composerInlinePromptItems",
+  ComposerInlineAttachmentReferences = "composerInlineAttachmentReferences",
 
   ZapierConnector = "zapierConnector",
   MemoryViewer = "memoryViewer",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -45,6 +45,9 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.ComposerInlinePromptItems, {}),
     ).toBe(false);
     expect(
+      isFeatureEnabled(FeatureSwitchKey.ComposerInlineAttachmentReferences, {}),
+    ).toBe(false);
+    expect(
       isFeatureEnabled(FeatureSwitchKey.PresentationElementDragging, {}),
     ).toBe(false);
   });
@@ -153,6 +156,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       true,
     );
+    expect(
+      staffOrgStates[FeatureSwitchKey.ComposerInlineAttachmentReferences],
+    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationElementDragging]).toBe(
       true,
@@ -193,6 +199,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       false,
     );
+    expect(
+      otherOrgStates[FeatureSwitchKey.ComposerInlineAttachmentReferences],
+    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -331,6 +331,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerInlineAttachmentReferences]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Keep attachments in chips, insert numbered image or file text references, and override composerInlinePromptItems.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the composerInlineAttachmentReferences feature switch and make it override composerInlinePromptItems behavior
- keep uploaded files in AttachmentChips while inserting numbered image and file references into the composer
- keep templates on the structured path, send clean reference text without URL JSON, and make reference deletion preserve the attachment
- persist and restore reference nodes alongside draft attachments

## Testing

- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-draft.test.tsx --silent=passed-only
- pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts src/signals/zero-page/__tests__/composer-inline-prompt-items.test.ts --silent=passed-only
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only
- pnpm -F @vm0/app lint
- pnpm -F @vm0/core lint
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors check-types
- pnpm knip --workspace @vm0/app
- Prettier check for all changed files

## Local environment note

- pnpm -F @vm0/db db:migrate could not run because the local DATABASE_URL is invalid; this PR does not change the database.