### PR TITLE
refactor: graduate website templates to always-on

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3215,13 +3215,6 @@ describe("CHAT-02: generation templates and attachments", () => {
     const agent = await bdd.createAgent(actor, {
       displayName: "Invalid template agent",
     });
-    if (!actor.orgId) {
-      throw new Error("Expected test actor to belong to an org");
-    }
-    const actorWithOrg = { ...actor, orgId: actor.orgId };
-    await updateFeatureSwitchesForUser(context, actorWithOrg, {
-      [FeatureSwitchKey.WebsiteTemplates]: true,
-    });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
     if (!template) {
       throw new Error("Expected a registered presentation runbook item");

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -238,7 +238,6 @@ function shouldTouchThreadSortFromNormalSend(
 
 interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
-  readonly websiteTemplatesEnabled: boolean;
 }
 
 interface ResolvedComputerUseHostGrant {
@@ -1128,24 +1127,7 @@ async function resolveNormalSendFeatureSwitches(
       FeatureSwitchKey.CodexFastMode,
       context,
     ),
-    websiteTemplatesEnabled: isFeatureEnabled(
-      FeatureSwitchKey.WebsiteTemplates,
-      context,
-    ),
   };
-}
-
-function validateGenerationTemplateFeatureSwitches(params: {
-  readonly body: NormalSendBody;
-  readonly featureSwitches: NormalSendFeatureSwitches;
-}): NormalSendFailure | undefined {
-  if (
-    params.body.generationTemplate?.type === "website" &&
-    !params.featureSwitches.websiteTemplatesEnabled
-  ) {
-    return badRequestMessage("Website templates are not enabled");
-  }
-  return undefined;
 }
 
 function validateGenerationTemplatePrompt(
@@ -1160,16 +1142,6 @@ function validateGenerationTemplatePrompt(
     return badRequestMessage(validation.message);
   }
   return undefined;
-}
-
-function validateGenerationTemplateForNormalSend(params: {
-  readonly body: NormalSendBody;
-  readonly featureSwitches: NormalSendFeatureSwitches;
-}): NormalSendFailure | undefined {
-  return (
-    validateGenerationTemplateFeatureSwitches(params) ??
-    validateGenerationTemplatePrompt(params.body)
-  );
 }
 
 async function updateUserModelPreference(
@@ -2345,10 +2317,7 @@ const prepareNormalSend$ = command(
     if (codexServiceTierError) {
       return codexServiceTierError;
     }
-    const generationTemplateError = validateGenerationTemplateForNormalSend({
-      body: args.body,
-      featureSwitches,
-    });
+    const generationTemplateError = validateGenerationTemplatePrompt(args.body);
     if (generationTemplateError) {
       return generationTemplateError;
     }

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
@@ -4,15 +4,6 @@ import { describe, expect, it } from "vitest";
 import { generationTemplateForFeatureSwitches } from "../generation-template-feature-switch.ts";
 
 describe("generationTemplateForFeatureSwitches", () => {
-  it("keeps website templates when inline prompt items are off", () => {
-    const template: GenerationTemplateRequest = {
-      type: "website",
-      selection: { websiteTemplateId: "warm-cards" },
-    };
-
-    expect(generationTemplateForFeatureSwitches(template, {})).toBe(template);
-  });
-
   it("drops structured templates when inline prompt items are on", () => {
     const template: GenerationTemplateRequest = {
       type: "illustration",

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts
@@ -4,39 +4,13 @@ import { describe, expect, it } from "vitest";
 import { generationTemplateForFeatureSwitches } from "../generation-template-feature-switch.ts";
 
 describe("generationTemplateForFeatureSwitches", () => {
-  it("keeps non-website templates independent of the website switch", () => {
+  it("keeps website templates when inline prompt items are off", () => {
     const template: GenerationTemplateRequest = {
-      type: "workflow",
-      selection: { workflowTemplateId: "workflow:auto-inbox" },
+      type: "website",
+      selection: { websiteTemplateId: "warm-cards" },
     };
 
     expect(generationTemplateForFeatureSwitches(template, {})).toBe(template);
-  });
-
-  it("drops website templates when the website template switch is off", () => {
-    const template: GenerationTemplateRequest = {
-      type: "website",
-      selection: { websiteTemplateId: "warm-cards" },
-    };
-
-    expect(
-      generationTemplateForFeatureSwitches(template, {
-        [FeatureSwitchKey.WebsiteTemplates]: false,
-      }),
-    ).toBeUndefined();
-  });
-
-  it("keeps website templates when the website template switch is on", () => {
-    const template: GenerationTemplateRequest = {
-      type: "website",
-      selection: { websiteTemplateId: "warm-cards" },
-    };
-
-    expect(
-      generationTemplateForFeatureSwitches(template, {
-        [FeatureSwitchKey.WebsiteTemplates]: true,
-      }),
-    ).toBe(template);
   });
 
   it("drops structured templates when inline prompt items are on", () => {

--- a/turbo/apps/platform/src/signals/chat-page/generation-template-feature-switch.ts
+++ b/turbo/apps/platform/src/signals/chat-page/generation-template-feature-switch.ts
@@ -12,11 +12,5 @@ export function generationTemplateForFeatureSwitches(
   if (features?.[FeatureSwitchKey.ComposerInlinePromptItems] ?? false) {
     return undefined;
   }
-  if (
-    value?.type === "website" &&
-    !(features?.[FeatureSwitchKey.WebsiteTemplates] ?? false)
-  ) {
-    return undefined;
-  }
   return value;
 }

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -7,10 +7,8 @@ import {
   findWebsiteTemplateItem,
   findVideoTemplateItem,
 } from "@vm0/core";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { sendNewThread$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { defaultAgentId$ } from "../agent.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
@@ -33,62 +31,6 @@ function templateIdFromSearchParam(
     return undefined;
   }
   return id;
-}
-
-function legacyGenerationTemplateFromSearchParam(
-  template: string | null,
-): GenerationTemplateRequest | undefined {
-  const id = templateIdFromSearchParam(template);
-  if (!id) {
-    return undefined;
-  }
-  const videoTemplate = findVideoTemplateItem(id);
-  if (!videoTemplate) {
-    const presentationTemplateId = id.replace(/^presentation-template:/, "");
-    const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS.find(
-      (item) => {
-        return (
-          item.slug === presentationTemplateId ||
-          item.templateId === id ||
-          item.templateId === presentationTemplateId
-        );
-      },
-    );
-    if (!presentationTemplate) {
-      const illustrationTemplateId = id
-        .replace(/^illustration-template:/, "")
-        .replace(/^image-template:/, "");
-      const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
-        return (
-          item.slug === illustrationTemplateId ||
-          item.illustrationStyleId === id ||
-          item.illustrationStyleId === illustrationTemplateId
-        );
-      });
-      if (!illustrationTemplate) {
-        return undefined;
-      }
-      return {
-        type: "illustration",
-        selection: {
-          illustrationStyleId: illustrationTemplate.illustrationStyleId,
-        },
-      };
-    }
-    return {
-      type: "presentation",
-      selection: {
-        templateId: presentationTemplate.templateId,
-        colorSystemId:
-          presentationTemplate.colorSystemId ?? "color-system:warm-sand",
-        previewUrl: presentationTemplate.embedUrl,
-      },
-    };
-  }
-  return {
-    type: "video",
-    selection: { stylePresetId: videoTemplate.id },
-  };
 }
 
 function websiteGenerationTemplateFromId(
@@ -209,11 +151,7 @@ export const setupPromptPage$ = command(
     const prompt = params.get("prompt")?.trim();
     const requestedModel = params.get("model")?.trim();
     const template = params.get("template");
-    const generationTemplate = get(featureSwitch$)[
-      FeatureSwitchKey.WebsiteTemplates
-    ]
-      ? generationTemplateFromSearchParam(template)
-      : legacyGenerationTemplateFromSearchParam(template);
+    const generationTemplate = generationTemplateFromSearchParam(template);
     if (!prompt) {
       set(detachedNavigateTo$, "/", { replace: true });
       return;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -5695,7 +5695,7 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("selects and sends a website template behind the feature switch", async () => {
+  it("selects and sends a website template", async () => {
     const user = userEvent.setup({ delay: null });
     const websiteTemplate = WEBSITE_TEMPLATE_ITEMS[0]!;
     const websiteTemplatePreviewImageUrl = r2ImageTransformUrl(
@@ -5712,7 +5712,6 @@ describe("chat composer templates", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.WebsiteTemplates]: true },
       path: `/chats/${THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -228,7 +228,7 @@ describe("prompt query parameter injection", () => {
     });
   });
 
-  it("starts an optimistic website template chat from the prompt route when enabled", async () => {
+  it("starts an optimistic website template chat from the prompt route", async () => {
     const websiteTemplate = WEBSITE_TEMPLATE_ITEMS.find((item) => {
       return item.id === "website-template:warm-cards";
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -6,7 +6,6 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   WEBSITE_TEMPLATE_ITEMS,
 } from "@vm0/core";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { OrgModelPolicy } from "@vm0/api-contracts/contracts/model-providers";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
@@ -249,7 +248,6 @@ describe("prompt query parameter injection", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.WebsiteTemplates]: true },
       path: "/prompt?prompt=Make%20a%20warm%20website&template=website-template%3Awarm-cards",
     });
 
@@ -257,30 +255,6 @@ describe("prompt query parameter injection", () => {
       expect(screen.getByText("Make a warm website")).toBeInTheDocument();
       expect(runPrompt).toBe("Make a warm website");
       expect(websiteTemplateId).toBe(websiteTemplate?.id);
-    });
-  });
-
-  it("ignores website template prompt params while the website template switch is off", async () => {
-    let generationTemplate:
-      | {
-          type: string;
-        }
-      | undefined;
-    mockChatLifecycle(context, {
-      onRunCreate: (body) => {
-        generationTemplate = body.generationTemplate;
-      },
-    });
-
-    detachedSetupPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.WebsiteTemplates]: false },
-      path: "/prompt?prompt=Make%20a%20warm%20website&template=website-template%3Awarm-cards",
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Make a warm website")).toBeInTheDocument();
-      expect(generationTemplate).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1600,14 +1600,12 @@ function websitePreviewImageUrlsForItems(
 function initialTemplatePreviewImageUrlsForCategory({
   category,
   hasPptTab,
-  hasWebsiteTab,
   hasIllustrationTab,
   hasVideoTab,
   presentationThemeIdBySlug,
 }: {
   category: string;
   hasPptTab: boolean;
-  hasWebsiteTab?: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
   presentationThemeIdBySlug?: Readonly<Record<string, string>>;
@@ -1627,7 +1625,7 @@ function initialTemplatePreviewImageUrlsForCategory({
   if (category === "video" && hasVideoTab) {
     return videoPreviewImageUrlsForItems(VIDEO_TEMPLATE_ITEMS);
   }
-  if (category === "website" && hasWebsiteTab) {
+  if (category === "website") {
     return websitePreviewImageUrlsForItems(WEBSITE_TEMPLATE_ITEMS);
   }
   return [];
@@ -4185,14 +4183,12 @@ function IllustrationTemplateCard({
 function resolveTemplatePickerCategory({
   category,
   hasPptTab,
-  hasWebsiteTab,
   hasIllustrationTab,
   hasVideoTab,
   hasWorkflowTab,
 }: {
   category: string;
   hasPptTab: boolean;
-  hasWebsiteTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
   hasWorkflowTab: boolean;
@@ -4201,9 +4197,7 @@ function resolveTemplatePickerCategory({
   if (hasPptTab) {
     categories.push("slides");
   }
-  if (hasWebsiteTab) {
-    categories.push("website");
-  }
+  categories.push("website");
   if (hasIllustrationTab) {
     categories.push("illustration");
   }
@@ -4250,7 +4244,6 @@ function templatePickerCategoryMeta(category: string): {
 function TemplatePickerCategoryNav({
   selectedCategory,
   hasPptTab,
-  hasWebsiteTab,
   hasIllustrationTab,
   hasVideoTab,
   hasWorkflowTab,
@@ -4258,7 +4251,6 @@ function TemplatePickerCategoryNav({
 }: {
   selectedCategory: string;
   hasPptTab: boolean;
-  hasWebsiteTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
   hasWorkflowTab: boolean;
@@ -4276,13 +4268,11 @@ function TemplatePickerCategoryNav({
       Icon: IconPresentation,
     });
   }
-  if (hasWebsiteTab) {
-    categoryOptions.push({
-      value: "website",
-      label: "Website",
-      Icon: IconWorld,
-    });
-  }
+  categoryOptions.push({
+    value: "website",
+    label: "Website",
+    Icon: IconWorld,
+  });
   if (hasIllustrationTab) {
     categoryOptions.push({
       value: "illustration",
@@ -4523,7 +4513,6 @@ function TemplatePickerDialog({
   onClose,
   hasPptTab,
   presentationItems,
-  hasWebsiteTab,
   hasIllustrationTab,
   hasVideoTab,
   hasWorkflowTab,
@@ -4534,7 +4523,6 @@ function TemplatePickerDialog({
   onClose: () => void;
   hasPptTab: boolean;
   presentationItems: readonly PresentationTemplateItem[];
-  hasWebsiteTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
   hasWorkflowTab: boolean;
@@ -4590,7 +4578,6 @@ function TemplatePickerDialog({
   const selectedCategory = resolveTemplatePickerCategory({
     category,
     hasPptTab,
-    hasWebsiteTab,
     hasIllustrationTab,
     hasVideoTab,
     hasWorkflowTab,
@@ -4612,7 +4599,7 @@ function TemplatePickerDialog({
     if (targetCategory === "video" && hasVideoTab) {
       return videoPreviewImageUrlsForItems(VIDEO_TEMPLATE_ITEMS);
     }
-    if (targetCategory === "website" && hasWebsiteTab) {
+    if (targetCategory === "website") {
       return websitePreviewImageUrlsForItems(WEBSITE_TEMPLATE_ITEMS);
     }
     return [];
@@ -4820,7 +4807,6 @@ function TemplatePickerDialog({
               <TemplatePickerCategoryNav
                 selectedCategory={selectedCategory}
                 hasPptTab={hasPptTab}
-                hasWebsiteTab={hasWebsiteTab}
                 hasIllustrationTab={hasIllustrationTab}
                 hasVideoTab={hasVideoTab}
                 hasWorkflowTab={hasWorkflowTab}
@@ -4838,7 +4824,6 @@ function TemplatePickerDialog({
                 <TemplatePickerCategoryContent
                   selectedCategory={selectedCategory}
                   hasPptTab={hasPptTab}
-                  hasWebsiteTab={hasWebsiteTab}
                   hasVideoTab={hasVideoTab}
                   hasWorkflowTab={hasWorkflowTab}
                   filteredPptItems={filteredPptItems}
@@ -4875,7 +4860,6 @@ function TemplatePickerDialog({
 function TemplatePickerCategoryContent({
   selectedCategory,
   hasPptTab,
-  hasWebsiteTab,
   hasVideoTab,
   hasWorkflowTab,
   filteredPptItems,
@@ -4900,7 +4884,6 @@ function TemplatePickerCategoryContent({
 }: {
   selectedCategory: string;
   hasPptTab: boolean;
-  hasWebsiteTab: boolean;
   hasVideoTab: boolean;
   hasWorkflowTab: boolean;
   filteredPptItems: readonly PresentationTemplateItem[];
@@ -4957,7 +4940,7 @@ function TemplatePickerCategoryContent({
     );
   }
 
-  if (selectedCategory === "website" && hasWebsiteTab) {
+  if (selectedCategory === "website") {
     return (
       <div
         data-website-template-grid-scroll=""
@@ -5076,7 +5059,6 @@ function TemplatePickerCategoryContent({
 
 function selectedComposerTemplateAttachment(
   value: GenerationTemplateRequest | undefined,
-  hasWebsiteTab: boolean,
 ): ComposerTemplateAttachment | undefined {
   const presentationItem = selectedPresentationTemplateItem(value);
   if (presentationItem && value?.type === "presentation") {
@@ -5120,9 +5102,7 @@ function selectedComposerTemplateAttachment(
       category: "workflow",
     };
   }
-  const websiteItem = hasWebsiteTab
-    ? selectedWebsiteTemplateItem(value)
-    : undefined;
+  const websiteItem = selectedWebsiteTemplateItem(value);
   return websiteItem
     ? { type: "website", title: websiteItem.title, category: "website" }
     : undefined;
@@ -5158,19 +5138,13 @@ function ComposerTemplateAttachmentSync({
   const setSearch = useSet(setTemplatePickerSearch$);
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
   const cardThemeIdBySlug = useGet(templateCardThemeIdBySlug$);
-  const features = useLastResolved(featureSwitch$);
-  const hasWebsiteTab = features?.[FeatureSwitchKey.WebsiteTemplates] ?? false;
-  const attachment = selectedComposerTemplateAttachment(
-    picker?.value,
-    hasWebsiteTab,
-  );
+  const attachment = selectedComposerTemplateAttachment(picker?.value);
   const openPicker = (category: string) => {
     prewarmTemplatePreviewImages(
       runtime,
       initialTemplatePreviewImageUrlsForCategory({
         category,
         hasPptTab: true,
-        hasWebsiteTab,
         hasIllustrationTab: true,
         hasVideoTab: true,
         presentationThemeIdBySlug: cardThemeIdBySlug,
@@ -5210,7 +5184,6 @@ function TemplatePickerButton({
   picker,
   hasPptTab,
   presentationItems,
-  hasWebsiteTab,
   hasIllustrationTab,
   hasVideoTab,
   hasWorkflowTab,
@@ -5219,7 +5192,6 @@ function TemplatePickerButton({
   picker: ComposerTemplatePicker;
   hasPptTab: boolean;
   presentationItems: readonly PresentationTemplateItem[];
-  hasWebsiteTab: boolean;
   hasIllustrationTab: boolean;
   hasVideoTab: boolean;
   hasWorkflowTab: boolean;
@@ -5235,7 +5207,6 @@ function TemplatePickerButton({
   const selectedCategory = resolveTemplatePickerCategory({
     category,
     hasPptTab,
-    hasWebsiteTab,
     hasIllustrationTab,
     hasVideoTab,
     hasWorkflowTab,
@@ -5246,7 +5217,6 @@ function TemplatePickerButton({
       initialTemplatePreviewImageUrlsForCategory({
         category: selectedCategory,
         hasPptTab,
-        hasWebsiteTab,
         hasIllustrationTab,
         hasVideoTab,
         presentationThemeIdBySlug: cardThemeIdBySlug,
@@ -5296,7 +5266,6 @@ function TemplatePickerButton({
           }}
           hasPptTab={hasPptTab}
           presentationItems={presentationItems}
-          hasWebsiteTab={hasWebsiteTab}
           hasIllustrationTab={hasIllustrationTab}
           hasVideoTab={hasVideoTab}
           hasWorkflowTab={hasWorkflowTab}
@@ -5315,8 +5284,6 @@ function ComposerTemplatePickerSlot({
   picker: ComposerTemplatePicker | undefined;
 }) {
   const hasPptTab = true;
-  const features = useLastResolved(featureSwitch$);
-  const hasWebsiteTab = features?.[FeatureSwitchKey.WebsiteTemplates] ?? false;
   const hasIllustrationTab = true;
   const hasVideoTab = true;
   const hasWorkflowTab = true;
@@ -5329,7 +5296,6 @@ function ComposerTemplatePickerSlot({
       picker={picker}
       hasPptTab={hasPptTab}
       presentationItems={presentationItems}
-      hasWebsiteTab={hasWebsiteTab}
       hasIllustrationTab={hasIllustrationTab}
       hasVideoTab={hasVideoTab}
       hasWorkflowTab={hasWorkflowTab}
@@ -6991,10 +6957,7 @@ export function useZeroChatComposer({
             if (!value) {
               return;
             }
-            const attachment = selectedComposerTemplateAttachment(
-              value,
-              features[FeatureSwitchKey.WebsiteTemplates] ?? false,
-            );
+            const attachment = selectedComposerTemplateAttachment(value);
             if (attachment) {
               insertTemplate(value, attachment);
             }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -76,7 +76,6 @@ export enum FeatureSwitchKey {
   Artifacts = "artifacts",
   ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
-  WebsiteTemplates = "websiteTemplates",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ConnectorActionCallback = "connectorActionCallback",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -148,7 +148,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       true,
@@ -188,7 +187,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactPreviewImage]).toBe(true);
-    expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -462,12 +462,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Render a static preview image (screenshot) for HTML/website artifacts on deploy so the artifacts grid shows an image instead of a live iframe.",
     enabled: true,
   },
-  [FeatureSwitchKey.WebsiteTemplates]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Enable the built-in R2-backed website template picker and generation-template flow.",
-    enabled: true,
-  },
   [FeatureSwitchKey.OrgPlanEntitlementReads]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Retire the globally enabled `WebsiteTemplates` feature switch from the shared registry.
- Make the Website template picker, template attachments, and `/prompt` deep links permanently available.
- Remove the API feature-gate rejection while retaining website template ID validation and the existing Open Design CLI registry path.

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm --filter @vm0/connectors lint`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter api lint`
- `pnpm --filter @vm0/connectors check-types`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/app exec vitest run src/signals/chat-page/__tests__/generation-template-feature-switch.test.ts src/views/zero-page/__tests__/prompt-param-injection.test.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --reporter=dot`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "renders generation template guidance|rejects unknown generation template selections" --reporter=dot`
- `pnpm knip --workspace @vm0/connectors --workspace @vm0/core --workspace @vm0/app --workspace api`
