### PR TITLE
test(sandbox-fc): cover zero device rate dimensions

### DIFF
--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -194,6 +194,32 @@ mod tests {
         NonZeroU64::new(value).expect("test rate must be non-zero")
     }
 
+    fn positive_device_rate_limits() -> sandbox::DeviceRateLimits {
+        sandbox::DeviceRateLimits {
+            block: sandbox::BlockRateLimits {
+                bandwidth_bytes_per_sec: 100 * 1024 * 1024,
+                ops_per_sec: 10_000,
+            },
+            network: sandbox::NetworkRateLimits {
+                rx_bytes_per_sec: 50 * 1024 * 1024,
+                tx_bytes_per_sec: 25 * 1024 * 1024,
+            },
+        }
+    }
+
+    fn assert_zero_rate_rejected(limits: &sandbox::DeviceRateLimits, expected_dimension: &str) {
+        let err = FirecrackerDeviceRateLimits::try_from(limits).unwrap_err();
+
+        assert!(
+            err.contains(expected_dimension),
+            "error does not identify {expected_dimension}: {err}"
+        );
+        assert!(
+            err.contains("positive"),
+            "error does not require a positive rate: {err}"
+        );
+    }
+
     #[test]
     fn token_bucket_uses_100ms_refill_window() {
         let bucket = token_bucket(nonzero(100 * 1024 * 1024));
@@ -296,21 +322,34 @@ mod tests {
     }
 
     #[test]
-    fn device_limits_reject_zero_rates() {
-        let limits = sandbox::DeviceRateLimits {
-            block: sandbox::BlockRateLimits {
-                bandwidth_bytes_per_sec: 0,
-                ops_per_sec: 10_000,
-            },
-            network: sandbox::NetworkRateLimits {
-                rx_bytes_per_sec: 50 * 1024 * 1024,
-                tx_bytes_per_sec: 25 * 1024 * 1024,
-            },
-        };
+    fn device_limits_reject_zero_block_bandwidth() {
+        let mut limits = positive_device_rate_limits();
+        limits.block.bandwidth_bytes_per_sec = 0;
 
-        let err = FirecrackerDeviceRateLimits::try_from(&limits).unwrap_err();
+        assert_zero_rate_rejected(&limits, "block bandwidth_bytes_per_sec");
+    }
 
-        assert!(err.contains("block bandwidth_bytes_per_sec"));
-        assert!(err.contains("positive"));
+    #[test]
+    fn device_limits_reject_zero_block_ops() {
+        let mut limits = positive_device_rate_limits();
+        limits.block.ops_per_sec = 0;
+
+        assert_zero_rate_rejected(&limits, "block ops_per_sec");
+    }
+
+    #[test]
+    fn device_limits_reject_zero_network_rx_bandwidth() {
+        let mut limits = positive_device_rate_limits();
+        limits.network.rx_bytes_per_sec = 0;
+
+        assert_zero_rate_rejected(&limits, "network rx_bytes_per_sec");
+    }
+
+    #[test]
+    fn device_limits_reject_zero_network_tx_bandwidth() {
+        let mut limits = positive_device_rate_limits();
+        limits.network.tx_bytes_per_sec = 0;
+
+        assert_zero_rate_rejected(&limits, "network tx_bytes_per_sec");
     }
 }


### PR DESCRIPTION
## Summary

- cover zero-value rejection for block bandwidth, block operations, network receive bandwidth, and network transmit bandwidth
- start each case from a shared all-positive fixture so validation order cannot mask later dimensions
- assert each error identifies the rejected dimension and the positive-value requirement

## Scope

- test-only change in `crates/sandbox-fc/src/config.rs`
- no production behavior, API, dependency, compatibility, migration, or documentation changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc config::tests::device_limits_reject_zero -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc` (734 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- isolated mutation verification confirmed that bypassing each of the four validation branches fails its corresponding test

Closes #22186
