### PR TITLE
test(runner): cover zero-memory profile validation

### DIFF
--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -511,6 +511,22 @@ async fn load_rejects_zero_vcpu_in_profile() {
 }
 
 #[tokio::test]
+async fn load_rejects_zero_memory_mb_in_profile() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml_with_profile(
+        "vm0/default",
+        ProfileConfig {
+            memory_mb: 0,
+            ..default_profile_config()
+        },
+        "",
+    );
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(err.to_string().contains("non-zero"), "got: {err}");
+}
+
+#[tokio::test]
 async fn load_rejects_zero_rootfs_disk_mb_in_profile() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml_with_profile(


### PR DESCRIPTION
## Summary

- add file-backed runner config coverage for a profile with zero memory
- keep vCPU and both disk resources valid and positive to isolate the memory invariant
- preserve production validation behavior and the existing non-zero error contract

## Scope

This is a test-only change. It does not change runner config parsing, validation limits, runtime errors, APIs, protocols, persisted data, or deployment behavior.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner config::tests::load_rejects_zero_memory_mb_in_profile`
- mutation check: temporarily removed only `memory_mb == 0`, confirmed the new test failed, then restored production code
- `cargo test --manifest-path crates/Cargo.toml -p runner config::tests` (87 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2766 passed, 12 ignored; guest inventory 1 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- staged pre-commit hooks and commitlint

Closes #22187
