### PR TITLE
test: remove expired runner protocol fixtures

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1632,7 +1632,6 @@ mod tests {
             body["supportedProfiles"][0],
             crate::profile::DEFAULT_PROFILE
         );
-        assert!(body.get("profiles").is_none());
         assert_eq!(body["telemetry"]["pollReason"], "immediate");
         assert!(body.get("heldSessionStates").is_none());
     }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1795,36 +1795,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_target_runner_id_is_ignored_for_direct_candidate() {
-        let tokens = Mutex::new(HashMap::new());
-        let wakeups = PollWakeups::new(true);
-        let direct_candidates = direct_candidate_inbox();
-        let profiles = default_profiles();
-        let _ = wakeups
-            .wait_for_poll_due(
-                &CancellationToken::new(),
-                Duration::from_secs(30),
-                Duration::from_secs(5),
-            )
-            .await;
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000001",
-                "profile": "vm0/default",
-                "targetRunnerId": "runner-1"
-            }),
-        );
-
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
-
-        let candidate = pop_direct_candidate(&direct_candidates).await;
-        assert_eq!(candidate.profile_name(), "vm0/default");
-        assert_no_direct_candidate(&direct_candidates).await;
-        assert!(!wakeups.snapshot().await.poll_now);
-    }
-
-    #[tokio::test]
     async fn unsupported_profile_job_notification_is_ignored() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
@@ -1880,47 +1850,6 @@ mod tests {
         let snapshot = wakeups.snapshot().await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
-    }
-
-    #[tokio::test]
-    async fn legacy_target_runner_id_does_not_override_profile_routing() {
-        for (data, should_wake_poll) in [
-            (
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000001",
-                    "profile": "vm0/large",
-                    "targetRunnerId": "runner-1"
-                }),
-                false,
-            ),
-            (
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000001",
-                    "targetRunnerId": "runner-1"
-                }),
-                true,
-            ),
-        ] {
-            let tokens = Mutex::new(HashMap::new());
-            let wakeups = PollWakeups::new(true);
-            let direct_candidates = direct_candidate_inbox();
-            let profiles = default_profiles();
-            let _ = wakeups
-                .wait_for_poll_due(
-                    &CancellationToken::new(),
-                    Duration::from_secs(30),
-                    Duration::from_secs(5),
-                )
-                .await;
-            let msg = make_message(Some("job"), data);
-
-            handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
-
-            let snapshot = wakeups.snapshot().await;
-            assert_no_direct_candidate(&direct_candidates).await;
-            assert_eq!(snapshot.poll_now, should_wake_poll);
-            assert!(snapshot.deferred_poll_at.is_none());
-        }
     }
 
     #[tokio::test]
@@ -2064,79 +1993,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_target_runner_id_does_not_defer_poll() {
-        let tokens = Mutex::new(HashMap::new());
-        let wakeups = PollWakeups::new(true);
-        let direct_candidates = direct_candidate_inbox();
-        let profiles = default_profiles();
-        let _ = wakeups
-            .wait_for_poll_due(
-                &CancellationToken::new(),
-                Duration::from_secs(30),
-                Duration::from_secs(5),
-            )
-            .await;
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000001",
-                "profile": "vm0/default",
-                "targetRunnerId": "runner-2"
-            }),
-        );
-
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
-
-        let candidate = pop_direct_candidate(&direct_candidates).await;
-        assert_eq!(candidate.profile_name(), "vm0/default");
-        let snapshot = wakeups.snapshot().await;
-        assert_no_direct_candidate(&direct_candidates).await;
-        assert!(!snapshot.poll_now);
-        assert!(snapshot.deferred_poll_at.is_none());
-    }
-
-    #[tokio::test]
-    async fn legacy_target_runner_id_is_ignored_before_profile_routing() {
-        for (data, should_wake_poll) in [
-            (
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000001",
-                    "profile": "vm0/large",
-                    "targetRunnerId": "runner-2"
-                }),
-                false,
-            ),
-            (
-                serde_json::json!({
-                    "runId": "00000000-0000-0000-0000-000000000001",
-                    "targetRunnerId": "runner-2"
-                }),
-                true,
-            ),
-        ] {
-            let tokens = Mutex::new(HashMap::new());
-            let wakeups = PollWakeups::new(true);
-            let direct_candidates = direct_candidate_inbox();
-            let profiles = default_profiles();
-            let _ = wakeups
-                .wait_for_poll_due(
-                    &CancellationToken::new(),
-                    Duration::from_secs(30),
-                    Duration::from_secs(5),
-                )
-                .await;
-            let msg = make_message(Some("job"), data);
-
-            handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
-
-            let snapshot = wakeups.snapshot().await;
-            assert_no_direct_candidate(&direct_candidates).await;
-            assert_eq!(snapshot.poll_now, should_wake_poll);
-            assert!(snapshot.deferred_poll_at.is_none());
-        }
-    }
-
-    #[tokio::test]
     async fn invalid_job_notification_does_not_mutate_wakeup_state() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
@@ -2227,42 +2083,6 @@ mod tests {
             .await
             .expect("dropping supervisor should cancel the task")
             .unwrap();
-    }
-
-    #[test]
-    fn parse_job_notification_ignores_target_runner_id() {
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000001",
-                "profile": "vm0/default",
-                "targetRunnerId": "00000000-0000-0000-0000-000000000099",
-                "cliAgentSessionId": "sess-target",
-                "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
-                "historyGenerationAffinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "affinityProtectedUntil": "2999-01-01T00:00:00.000Z",
-                "sessionAffinityResource": "reusableSandbox"
-            }),
-        );
-        let notif = parse_job_notification(&msg).unwrap();
-        assert_eq!(notif.profile, Some("vm0/default"));
-        assert_eq!(notif.cli_agent_session_id, Some("sess-target"));
-        assert_eq!(
-            notif.session_affinity_resource,
-            Some(SessionAffinityResource::ReusableSandbox)
-        );
-        assert_eq!(
-            notif.history_generation_run_id,
-            Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
-        );
-        assert_eq!(
-            notif.history_generation_affinity_protected_until,
-            Some("2999-01-01T00:00:00.000Z")
-        );
-        assert_eq!(
-            notif.affinity_protected_until,
-            Some("2999-01-01T00:00:00.000Z")
-        );
     }
 
     #[test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1784,6 +1784,10 @@ mod tests {
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
+        assert_eq!(
+            candidate.history_generation_run_id(),
+            Some("00000000-0000-0000-0000-000000000098".parse().unwrap())
+        );
         assert!(candidate.is_affinity_protected());
         assert!(candidate.is_history_generation_affinity_protected());
         assert_eq!(

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -2074,8 +2074,6 @@ mod tests {
         assert_eq!(json["allocatedMemoryMb"], 6144);
         assert_eq!(json["runningCount"], 2);
         assert_eq!(json["admittableProfiles"], json!(["vm0/default"]));
-        assert!(json.get("profiles").is_none());
-        assert!(json.get("availableProfiles").is_none());
         assert_eq!(
             json["heldSessionStates"],
             json!([{
@@ -2095,9 +2093,9 @@ mod tests {
     }
 
     #[test]
-    fn held_session_state_accepts_legacy_shape_and_omits_absent_capability() {
+    fn held_session_state_accepts_minimal_shape_and_omits_absent_capability() {
         let state: HeldSessionState = serde_json::from_value(json!({
-            "sessionId": "session-legacy",
+            "sessionId": "session-minimal",
             "lastCompletedAt": "2026-05-28T00:00:00.000Z",
             "reusableSandbox": {
                 "profile": "vm0/default"

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1746,14 +1746,14 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 }
 
 #[tokio::test]
-async fn session_history_sidecar_metadata_with_allocated_bytes_remains_restoreable() {
+async fn previous_session_history_sidecar_metadata_remains_restoreable() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
     let cache = SessionWorkspaceCache::new(paths.clone());
     let run_id = RunId::new_v4();
-    let session_id = "sess-sidecar-with-allocated-bytes";
-    let history = br#"{"type":"message","content":"with allocated bytes"}"#;
+    let session_id = "sess-sidecar-previous";
+    let history = br#"{"type":"message","content":"previous"}"#;
     let cache_key = write_current_cache_entry(
         &cache,
         run_id,
@@ -1770,11 +1770,15 @@ async fn session_history_sidecar_metadata_with_allocated_bytes_remains_restoreab
         .join("session-history.metadata.json");
     let mut metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
+    let metadata = metadata.as_object_mut().unwrap();
     assert!(
         metadata
-            .as_object_mut()
-            .unwrap()
             .insert("allocatedBytes".into(), 4096_u64.into())
+            .is_none()
+    );
+    assert!(
+        metadata
+            .insert("historyGenerationRunId".into(), run_id.to_string().into(),)
             .is_none()
     );
     fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
@@ -1792,47 +1796,6 @@ async fn session_history_sidecar_metadata_with_allocated_bytes_remains_restoreab
     );
     assert_eq!(sidecar.encoded_size, history.len() as u64);
     assert_eq!(fs::read(sidecar.path).await.unwrap(), history);
-}
-
-#[tokio::test]
-async fn previous_session_history_sidecar_metadata_remains_restoreable() {
-    let dir = tempfile::tempdir().unwrap();
-    let paths = RunnerPaths::new(dir.path().join("runner"));
-    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let run_id = RunId::new_v4();
-    let session_id = "sess-sidecar-legacy";
-    let history = br#"{"type":"message","content":"legacy"}"#;
-    let cache_key = write_current_cache_entry(
-        &cache,
-        run_id,
-        session_id,
-        CANONICAL_WORKING_DIR,
-        "2026-05-01T00:00:00.000Z",
-        "2026-05-01T00:00:00.000Z",
-    )
-    .await;
-    let identity =
-        publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let metadata_path = paths
-        .session_workspace_cache_entry_dir(&cache_key)
-        .join("session-history.metadata.json");
-    let mut metadata: serde_json::Value =
-        serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
-    metadata
-        .as_object_mut()
-        .unwrap()
-        .insert("historyGenerationRunId".into(), run_id.to_string().into());
-    fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap())
-        .await
-        .unwrap();
-
-    assert!(
-        cache
-            .probe_session_history_sidecar(&cache_key, &identity)
-            .await
-            .is_ok()
-    );
 }
 
 #[tokio::test]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2131,12 +2131,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       [400],
     );
     expectApiError(missingSupport.body);
-    const legacySupport = await api.requestRawPollRunner(
-      true,
-      { group: runnerGroup, profiles: ["vm0/default"] },
-      [400],
-    );
-    expectApiError(legacySupport.body);
     const emptySupport = await api.requestPollRunner(
       true,
       { group: runnerGroup, supportedProfiles: [] },
@@ -2165,12 +2159,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
     expect(incompatiblePoll.body.job).toBeNull();
 
-    const compatiblePoll = await api.requestRawPollRunner(
+    const compatiblePoll = await api.requestPollRunner(
       true,
       {
         group: runnerGroup,
         supportedProfiles: ["vm0/default"],
-        profiles: ["vm0/large"],
       },
       [200],
     );
@@ -2361,42 +2354,31 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expectApiError(missingProfileListHeartbeat.body);
 
-    const legacyAvailableHeartbeat = await api.requestRawHeartbeatRunner(
+    const canonicalHeartbeat = await api.requestRawHeartbeatRunner(
       true,
-      [400],
-      rawHeartbeatBody({ availableProfiles: ["vm0/default"] }),
+      [200],
+      rawHeartbeatBody({
+        admittableProfiles: ["vm0/default"],
+      }),
     );
-    expectApiError(legacyAvailableHeartbeat.body);
-
-    const legacyStaticHeartbeat = await api.requestRawHeartbeatRunner(
-      true,
-      [400],
-      rawHeartbeatBody({ profiles: ["vm0/default"] }),
-    );
-    expectApiError(legacyStaticHeartbeat.body);
-
-    const finalHeartbeatWithExtraLegacyFields =
-      await api.requestRawHeartbeatRunner(
-        true,
-        [200],
-        rawHeartbeatBody({
-          admittableProfiles: ["vm0/default"],
-          availableProfiles: ["vm0/large"],
-          profiles: ["vm0/large"],
-        }),
-      );
-    expect(finalHeartbeatWithExtraLegacyFields.body).toStrictEqual({
+    expect(canonicalHeartbeat.body).toStrictEqual({
       ok: true,
     });
-    const finalHeartbeatHolder = await pollFollowUp(
-      "continue when final heartbeat includes extra legacy fields",
+    const canonicalHeartbeatHolder = await pollFollowUp(
+      "continue with a canonical heartbeat",
     );
-    expect(finalHeartbeatHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(sessionAffinityProtectedUntil(finalHeartbeatHolder.job)).toBeNull();
+    expect(canonicalHeartbeatHolder.job?.cliAgentSessionId).toBe(
+      cliAgentSessionId,
+    );
     expect(
-      historyGenerationAffinityProtectedUntil(finalHeartbeatHolder.job),
+      sessionAffinityProtectedUntil(canonicalHeartbeatHolder.job),
     ).toBeNull();
-    expect(sessionAffinityResource(finalHeartbeatHolder.job)).toBeUndefined();
+    expect(
+      historyGenerationAffinityProtectedUntil(canonicalHeartbeatHolder.job),
+    ).toBeNull();
+    expect(
+      sessionAffinityResource(canonicalHeartbeatHolder.job),
+    ).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -2480,11 +2462,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         },
       ],
     });
-    const duplicateLegacyParent = await pollFollowUp(
-      "continue with a duplicate legacy parent beside a capable mismatch",
+    const duplicateBareParent = await pollFollowUp(
+      "continue with a duplicate bare parent beside a capable mismatch",
     );
-    expect(sessionAffinityProtectedUntil(duplicateLegacyParent.job)).toBeNull();
-    expect(sessionAffinityResource(duplicateLegacyParent.job)).toBeUndefined();
+    expect(sessionAffinityProtectedUntil(duplicateBareParent.job)).toBeNull();
+    expect(sessionAffinityResource(duplicateBareParent.job)).toBeUndefined();
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -2536,66 +2518,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "reusableSandbox",
     );
 
-    const previousSidecarRunnerId = randomUUID();
-    const previousSidecarHeartbeat = await api.requestRawHeartbeatRunner(
-      true,
-      [200],
-      rawHeartbeatBody({
-        runnerId: previousSidecarRunnerId,
-        admittableProfiles: ["vm0/default"],
-        heldSessionStates: [
-          {
-            sessionId: cliAgentSessionId,
-            lastCompletedAt: nowDate().toISOString(),
-            workspaceCaches: [
-              {
-                profile: "vm0/default",
-                workspaceAffinityVersion: 1,
-                sessionHistorySidecar: {
-                  historyGenerationRunId: first.runId,
-                  rawSizeBucket: "64_256_kib",
-                },
-              },
-            ],
-          },
-        ],
-      }),
-    );
-    expect(previousSidecarHeartbeat.body).toStrictEqual({ ok: true });
-    const reusableWithPreviousSidecarHeartbeat = await pollFollowUp(
-      "accept a previous heartbeat while preferring reusable affinity",
-    );
-    expect(
-      sessionAffinityProtectedUntil(reusableWithPreviousSidecarHeartbeat.job),
-    ).toStrictEqual(expect.any(String));
-    expect(
-      historyGenerationAffinityProtectedUntil(
-        reusableWithPreviousSidecarHeartbeat.job,
-      ),
-    ).toStrictEqual(expect.any(String));
-    expect(
-      sessionAffinityResource(reusableWithPreviousSidecarHeartbeat.job),
-    ).toBe("reusableSandbox");
-
-    await heartbeatHolder({ admittableProfiles: [], mode: "stopping" });
-    const workspaceFromPreviousHeartbeat = await pollFollowUp(
-      "use typed workspace affinity from a previous heartbeat",
-    );
-    expect(sessionAffinityResource(workspaceFromPreviousHeartbeat.job)).toBe(
-      "workspaceCache",
-    );
-    expect(
-      historyGenerationAffinityProtectedUntil(
-        workspaceFromPreviousHeartbeat.job,
-      ),
-    ).toBeNull();
     for (const { runId, resource } of [
       {
-        runId: reusableWithPreviousSidecarHeartbeat.run.runId,
+        runId: reusableOverWorkspace.run.runId,
         resource: "reusableSandbox",
       },
       {
-        runId: workspaceFromPreviousHeartbeat.run.runId,
+        runId: capableWorkspaceHolder.run.runId,
         resource: "workspaceCache",
       },
     ]) {
@@ -2610,21 +2539,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
             session_affinity_resource: resource,
           }),
         );
-        expect(events[0]).not.toHaveProperty("workspace_sidecar_exact_holder");
-        expect(events[0]).not.toHaveProperty(
-          "workspace_sidecar_different_holder",
-        );
-        expect(events[0]).not.toHaveProperty("workspace_sidecar_legacy_holder");
-        expect(events[0]).not.toHaveProperty("workspace_sidecar_absent_holder");
       }
     }
-    await api.requestHeartbeatRunner(true, [200], {
-      runnerId: previousSidecarRunnerId,
-      group: runnerGroup,
-      admittableProfiles: [],
-      heldSessionStates: [],
-      mode: "stopping",
-    });
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -3091,15 +3007,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
     });
 
-    const legacyPriorityPoll = await api.requestPollRunner(
+    const genericPriorityPoll = await api.requestPollRunner(
       true,
       { group: runnerGroup, supportedProfiles: ["vm0/default"] },
       [200],
     );
-    if (legacyPriorityPoll.status !== 200) {
-      throw new Error("Expected legacy FIFO poll to return 200");
+    if (genericPriorityPoll.status !== 200) {
+      throw new Error("Expected generic FIFO poll to return 200");
     }
-    expect(legacyPriorityPoll.body.job?.runId).toBe(olderGeneric.runId);
+    expect(genericPriorityPoll.body.job?.runId).toBe(olderGeneric.runId);
 
     const reusablePriorityPoll = await api.requestPollRunner(
       true,
@@ -3127,7 +3043,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         },
       ],
     });
-    const legacyReusablePriorityPoll = await api.requestPollRunner(
+    const genericReusablePriorityPoll = await api.requestPollRunner(
       true,
       {
         runnerId: affinityRunnerId,
@@ -3136,10 +3052,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       },
       [200],
     );
-    if (legacyReusablePriorityPoll.status !== 200) {
-      throw new Error("Expected legacy reusable-priority poll to return 200");
+    if (genericReusablePriorityPoll.status !== 200) {
+      throw new Error("Expected generic reusable-priority poll to return 200");
     }
-    expect(legacyReusablePriorityPoll.body.job?.runId).toBe(
+    expect(genericReusablePriorityPoll.body.job?.runId).toBe(
       newerReusable.runId,
     );
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -380,10 +380,6 @@ describe("runner resume session contract", () => {
         {
           profile: "vm0/default",
           workspaceAffinityVersion: 1,
-          sessionHistorySidecar: {
-            historyGenerationRunId,
-            rawSizeBucket: "64_256_kib",
-          },
         },
         { profile: "vm0/large" },
       ],


### PR DESCRIPTION
## Summary

- remove runner protocol fixtures for retired profile aliases, `targetRunnerId`, and sidecar heartbeat metadata
- keep current profile routing, affinity telemetry, and malformed-input coverage focused on supported protocol shapes
- consolidate persisted sidecar metadata compatibility into one real publish/probe integration test
- preserve explicit Ably generation metadata propagation coverage in the current-protocol test

## Scope

This is a test-only cleanup after the supported runner rollback floor moved past the retired wire
shapes. Durable on-disk sidecar metadata compatibility remains covered.

No production code, API, schema, migration, persisted-data format, queue payload, runner protocol,
or deployment behavior changes are included.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner` (2,759 passed, 12 ignored; guest inventory passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_ably_supervisor::tests::broadcast_supported_job_notification_enqueues_direct_candidate`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- API contract runner tests (45 passed)
- API run lifecycle integration tests (107 passed)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- affected-workspace TypeScript checks
- `pnpm knip`
- staged pre-commit hooks and commitlint

Closes #22207

Parent: #22028
