### PR TITLE
style(platform): highlight matching slash workflow prefixes

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1092,7 +1092,9 @@ describe("chat composer models", () => {
     await waitFor(() => {
       expect(screen.queryByText("support-escalation")).not.toBeInTheDocument();
     });
-    expect(screen.getByText("sales-research")).toBeInTheDocument();
+    const matchedPrefix = screen.getByText("sales", { selector: "span" });
+    expect(matchedPrefix).toHaveClass("text-primary/60");
+    expect(screen.getByText("-research")).toBeInTheDocument();
 
     await user.keyboard("{Enter}");
 

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -64,12 +64,14 @@ export function scrollSlashWorkflowIntoView(
 
 export function SlashWorkflowMenu({
   workflows,
+  query,
   loading,
   selectedIndex,
   showWorkflowsPageLink,
   onSelect,
 }: {
   readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly query: string;
   readonly loading: boolean;
   readonly selectedIndex: number;
   readonly showWorkflowsPageLink: boolean;
@@ -117,7 +119,12 @@ export function SlashWorkflowMenu({
               >
                 <span className="w-full truncate font-mono text-sm text-foreground">
                   <span className="text-primary">/</span>
-                  {workflow.name}
+                  {query && (
+                    <span className="text-primary/60">
+                      {workflow.name.slice(0, query.length)}
+                    </span>
+                  )}
+                  {workflow.name.slice(query.length)}
                 </span>
                 {workflow.description && (
                   <span className="w-full truncate text-xs text-muted-foreground/70">

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -251,6 +251,7 @@ interface ComposerSuggestionMenuState {
   readonly close: () => void;
   readonly workflowNames: readonly string[];
   readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly workflowQuery: string;
   readonly workflowsLoading: boolean;
   readonly showWorkflows: boolean;
   readonly chatThreads: readonly ComposerChatThreadSuggestion[];
@@ -368,6 +369,7 @@ function useComposerSuggestionMenu({
       return workflow.name;
     }),
     workflows: workflowSuggestions,
+    workflowQuery: slashRange?.query ?? "",
     workflowsLoading: workflowsLoadable.state === "loading",
     showWorkflows,
     chatThreads,
@@ -465,6 +467,7 @@ export function TiptapWorkflowComposer({
       {suggestionMenu.showWorkflows && (
         <SlashWorkflowMenu
           workflows={suggestionMenu.workflows}
+          query={suggestionMenu.workflowQuery}
           loading={suggestionMenu.workflowsLoading}
           selectedIndex={suggestionMenu.selectedIndex}
           showWorkflowsPageLink


### PR DESCRIPTION
## Summary

- Keep the leading slash in the full brand primary color while tinting the typed workflow prefix with a lighter primary color.
- Keep the unmatched workflow suffix neutral so similar slash commands remain easy to scan.
- Pass the active slash query into the existing workflow menu without changing filtering or insertion behavior.

## User-visible impact

Typing /pr now renders the slash in the current theme color, the matched pr prefix in a lighter theme color, and the remaining workflow name in the normal foreground color. Empty queries remain neutral, and selected workflow tokens keep their existing full-primary treatment after insertion.

## Verification

- Targeted chat composer Vitest passed.
- Prettier check passed for all changed files.
- Platform lint passed with zero warnings and errors.
- Platform production and test type checks passed.
- Platform Knip check passed.
- Browser-verified matched, exact-match, empty-query, no-result, and hover states.