### PR TITLE
refactor(api-contracts): type guest checkpoint requests

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -85,6 +85,54 @@ pub mod runners {
 pub mod webhooks {
     /// Agent webhook DTOs exchanged between sandboxes and the API.
     pub mod agent {
+        /// DTOs for creating recoverable agent checkpoints.
+        pub mod checkpoints {
+            /// Artifact version captured by an agent checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestArtifactSnapshot {
+                /// User-facing artifact name referenced by the run.
+                pub name: String,
+                /// Artifact version selected for the checkpoint.
+                pub version: String,
+                /// Guest filesystem path where the artifact is mounted.
+                pub mount_path: String,
+                /// Optional policy retained when the artifact mount root is missing.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub missing_root_policy: Option<
+                    crate::generated::types::runners::storage::ArtifactEntryMissingRootPolicy,
+                >,
+            }
+
+            /// Volume versions captured by an agent checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestVolumeVersionsSnapshot {
+                /// Volume names mapped to their captured versions.
+                pub versions: std::collections::BTreeMap<String, String>,
+            }
+
+            /// Request body for creating a recoverable agent checkpoint.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct Request {
+                /// Agent run identifier bound to the sandbox token.
+                pub run_id: String,
+                /// CLI agent implementation that produced the session.
+                pub cli_agent_type: String,
+                /// CLI agent session identifier being checkpointed.
+                pub cli_agent_session_id: String,
+                /// SHA-256 hash of the uploaded CLI agent session history.
+                pub cli_agent_session_history_hash: String,
+                /// Optional artifact versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub artifact_snapshots: Option<Vec<RequestArtifactSnapshot>>,
+                /// Optional volume versions captured by the checkpoint.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub volume_versions_snapshot: Option<RequestVolumeVersionsSnapshot>,
+            }
+        }
+
         /// Sandbox storage upload DTOs shared by guest agents and webhook handlers.
         pub mod storages {
             /// File metadata entry used to compute and commit content-addressed storage uploads.

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,8 +1,76 @@
 use api_contracts::generated::types::{
     runners::storage as runner_storage,
-    webhooks::agent::storages::{FileEntryWithHash, commit, prepare},
+    webhooks::agent::{
+        checkpoints,
+        storages::{FileEntryWithHash, commit, prepare},
+    },
 };
 use serde_json::json;
+
+#[test]
+fn generated_checkpoint_request_omits_absent_snapshots() {
+    let history_hash = "a".repeat(64);
+    let request = checkpoints::Request {
+        run_id: "run-1".to_string(),
+        cli_agent_type: "claude-code".to_string(),
+        cli_agent_session_id: "session-1".to_string(),
+        cli_agent_session_history_hash: history_hash.clone(),
+        artifact_snapshots: None,
+        volume_versions_snapshot: None,
+    };
+
+    let value = serde_json::to_value(request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "runId": "run-1",
+            "cliAgentType": "claude-code",
+            "cliAgentSessionId": "session-1",
+            "cliAgentSessionHistoryHash": history_hash,
+        })
+    );
+    assert!(value.get("artifactSnapshots").is_none());
+    assert!(value.get("volumeVersionsSnapshot").is_none());
+}
+
+#[test]
+fn generated_checkpoint_request_round_trips_preserve_parent_snapshot() {
+    let request = checkpoints::Request {
+        run_id: "run-1".to_string(),
+        cli_agent_type: "codex".to_string(),
+        cli_agent_session_id: "session-1".to_string(),
+        cli_agent_session_history_hash: "b".repeat(64),
+        artifact_snapshots: Some(vec![checkpoints::RequestArtifactSnapshot {
+            name: "memory".to_string(),
+            version: "version-1".to_string(),
+            mount_path: "/memory".to_string(),
+            missing_root_policy: Some(
+                runner_storage::ArtifactEntryMissingRootPolicy::PreserveParentVersion,
+            ),
+        }]),
+        volume_versions_snapshot: None,
+    };
+
+    let value = serde_json::to_value(&request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "runId": "run-1",
+            "cliAgentType": "codex",
+            "cliAgentSessionId": "session-1",
+            "cliAgentSessionHistoryHash": "b".repeat(64),
+            "artifactSnapshots": [{
+                "name": "memory",
+                "version": "version-1",
+                "mountPath": "/memory",
+                "missingRootPolicy": "preserveParentVersion",
+            }],
+        })
+    );
+
+    let round_trip: checkpoints::Request = serde_json::from_value(value).unwrap();
+    assert_eq!(round_trip, request);
+}
 
 #[test]
 fn generated_prepare_request_serializes_wire_shape() {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -16,7 +16,9 @@ use api_contracts::generated::constants::runners::{
     SESSION_HISTORY_ENCODING_IDENTITY, SESSION_HISTORY_ENCODING_ZSTD,
     SESSION_HISTORY_GZIP_MIN_BYTES,
 };
-use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
+use api_contracts::generated::types::{
+    runners::storage::ArtifactEntryMissingRootPolicy, webhooks::agent::checkpoints,
+};
 use bytes::Bytes;
 use flate2::{Compression, write::GzEncoder};
 use guest_common::telemetry::record_sandbox_op;
@@ -307,25 +309,20 @@ fn fail(
     AgentError::Checkpoint(msg)
 }
 
-/// Shape one entry of the `artifactSnapshots` payload. Keys are the
-/// camelCase names the web Zod receiver (`artifactSnapshotsSchema`) expects.
+/// Build an artifact snapshot using the type generated from the canonical
+/// checkpoint webhook contract.
 fn build_artifact_snapshot_entry(
     name: &str,
     version: &str,
     mount_path: &str,
     missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
-) -> serde_json::Value {
-    let mut entry = json!({
-        "name": name,
-        "version": version,
-        "mountPath": mount_path,
-    });
-    if let Some(policy) = missing_root_policy
-        && let Some(object) = entry.as_object_mut()
-    {
-        object.insert("missingRootPolicy".to_string(), json!(policy));
+) -> checkpoints::RequestArtifactSnapshot {
+    checkpoints::RequestArtifactSnapshot {
+        name: name.to_string(),
+        version: version.to_string(),
+        mount_path: mount_path.to_string(),
+        missing_root_policy,
     }
-    entry
 }
 
 enum ArtifactSnapshotPlan<'a> {
@@ -524,14 +521,14 @@ async fn build_and_upload_session_history(
 }
 
 /// Snapshot artifact entries. Memory rides in `VM0_ARTIFACTS` post-#10602, so
-/// there is no longer a separate memory arm. Payload shape is
-/// `Array<{name, version, mountPath}>`, matching the webhook
-/// receiver's canonical artifact snapshot schema.
+/// there is no longer a separate memory arm. The generated checkpoint
+/// contract preserves the optional missing-root policy for every snapshot
+/// path.
 async fn snapshot_artifact_entries(
     http: &HttpClient,
     run_id: &str,
     entries: &[env::ArtifactEnv],
-) -> Result<Option<serde_json::Value>, AgentError> {
+) -> Result<Option<Vec<checkpoints::RequestArtifactSnapshot>>, AgentError> {
     if entries.is_empty() {
         log_info!(
             LOG_TAG,
@@ -657,7 +654,7 @@ async fn snapshot_artifact_entries(
             entry.missing_root_policy,
         ));
     }
-    Ok(Some(serde_json::Value::Array(results)))
+    Ok(Some(results))
 }
 
 /// Create a checkpoint after a successful run using the explicit runtime snapshot.
@@ -1060,18 +1057,14 @@ async fn create_checkpoint_impl(
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)
     let cli_agent_type = inputs.framework.agent_type();
-    let mut payload = json!({
-        "runId": inputs.run_id,
-        "cliAgentType": cli_agent_type,
-        "cliAgentSessionId": cli_agent_session_id,
-        "cliAgentSessionHistoryHash": history_hash,
-    });
-
-    if let Some(snaps) = artifact_snapshots
-        && let Some(obj) = payload.as_object_mut()
-    {
-        obj.insert("artifactSnapshots".to_string(), snaps);
-    }
+    let payload = checkpoints::Request {
+        run_id: inputs.run_id.to_string(),
+        cli_agent_type: cli_agent_type.to_string(),
+        cli_agent_session_id,
+        cli_agent_session_history_hash: history_hash,
+        artifact_snapshots,
+        volume_versions_snapshot: None,
+    };
 
     log_info!(LOG_TAG, "Calling checkpoint API...");
     let api_start = std::time::Instant::now();
@@ -1096,8 +1089,8 @@ async fn create_checkpoint_impl(
     if let Some(id) = checkpoint_id {
         write_final_session_history_identity(
             mode,
-            &cli_agent_session_id,
-            &history_hash,
+            &payload.cli_agent_session_id,
+            &payload.cli_agent_session_history_hash,
             history_size,
             &history_marker_payload,
             inputs.framework,
@@ -1273,8 +1266,9 @@ mod tests {
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
         let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
+        let value = serde_json::to_value(entry).unwrap();
         assert_eq!(
-            entry,
+            value,
             json!({
                 "name": "workspace",
                 "version": "v-abc-123",
@@ -1291,7 +1285,8 @@ mod tests {
             "/m",
             Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         );
-        let obj = entry.as_object().expect("entry must be a JSON object");
+        let value = serde_json::to_value(entry).unwrap();
+        let obj = value.as_object().expect("entry must be a JSON object");
         // Contract-boundary invariant: the web Zod receiver requires camelCase
         // `mountPath` and `missingRootPolicy`; a snake_case slip would
         // silently cause a 400 on the webhook side.
@@ -1481,7 +1476,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            snapshots,
+            serde_json::to_value(snapshots).unwrap(),
             json!([
                 {
                     "name": "memory",

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -492,9 +492,8 @@ export const webhookCheckpointsContract = c.router({
         cliAgentType: z.string().min(1, "cliAgentType is required"),
         cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
         cliAgentSessionHistoryHash: sha256HexSchema,
-        // Multi-artifact snapshot payload. Canonical
-        // `Array<{name, version, mountPath}>` form persisted verbatim to
-        // checkpoints.artifact_snapshots.
+        // Multi-artifact snapshots validated by artifactSnapshotsSchema and
+        // persisted to checkpoints.artifact_snapshots.
         artifactSnapshots: artifactSnapshotsSchema.optional(),
         volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
       })

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../contracts/runners";
 import { fileEntryWithHashSchema } from "../../contracts/storages";
 import {
+  webhookCheckpointsContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../../contracts/webhooks";
@@ -36,6 +37,11 @@ const expectedBindings = [
     rustModulePath: ["runners", "storage"],
     rustTypeName: "StorageManifest",
     direction: "response",
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "Request",
+    direction: "request",
   },
   {
     rustModulePath: ["webhooks", "agent", "storages"],
@@ -172,6 +178,7 @@ describe("Rust type bindings", () => {
 
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod webhooks {");
+    expect(firstRender).toContain("pub mod checkpoints {");
     expect(firstRender).toContain("pub mod prepare {");
     expect(firstRender).toContain("pub struct FileEntryWithHash {");
     expect(firstRender).toContain(
@@ -207,6 +214,22 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("PreserveParentVersion,");
     expect(firstRender).toContain(
       "pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,",
+    );
+    expect(firstRender).toContain(
+      "/// Request body for creating a recoverable agent checkpoint.",
+    );
+    expect(firstRender).toContain("pub struct RequestArtifactSnapshot {");
+    expect(firstRender).toContain(
+      "pub artifact_snapshots: Option<Vec<RequestArtifactSnapshot>>,",
+    );
+    expect(firstRender).toMatch(
+      /pub missing_root_policy: Option<\n\s+crate::generated::types::runners::storage::ArtifactEntryMissingRootPolicy,\n\s+>,/,
+    );
+    expect(firstRender).toContain(
+      "pub volume_versions_snapshot: Option<RequestVolumeVersionsSnapshot>,",
+    );
+    expect(firstRender).toContain(
+      "pub versions: std::collections::BTreeMap<String, String>,",
     );
     expect(firstRender.match(/pub archive_size: Option<u64>,/g)).toHaveLength(
       2,
@@ -254,6 +277,18 @@ describe("Rust type bindings", () => {
 
     expect(prepareFileSchema).toEqual(requestFileSchema);
     expect(commitFileSchema).toEqual(requestFileSchema);
+  });
+
+  it("keeps checkpoint policy override aligned with the runner policy schema", () => {
+    const runnerPolicySchema = z.toJSONSchema(
+      artifactEntrySchema.shape.missingRootPolicy,
+    );
+    const checkpointPolicySchema = z.toJSONSchema(
+      webhookCheckpointsContract.create.body.shape.artifactSnapshots.unwrap()
+        .element.shape.missingRootPolicy,
+    );
+
+    expect(checkpointPolicySchema).toEqual(runnerPolicySchema);
   });
 
   it("renders common JSON schema shapes", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -120,6 +120,7 @@ interface ConstModuleNode {
 
 interface RenderTypeContext {
   readonly label: string;
+  readonly moduleIndentWidth: number;
   readonly fieldTypeOverrides: Readonly<Record<string, string>>;
   readonly declarationDocs: ReadonlyMap<string, NormalizedTypeDeclarationDoc>;
   readonly declarations: RustDeclaration[];
@@ -1022,6 +1023,7 @@ function renderTypeBinding(
   const declarations: RustDeclaration[] = [];
   const context: RenderTypeContext = {
     label: rustTypeName(binding),
+    moduleIndentWidth: binding.rustModulePath.length * 4,
     fieldTypeOverrides: binding.fieldTypeOverrides,
     declarationDocs: binding.declarationDocs,
     declarations,
@@ -1309,7 +1311,7 @@ function renderStruct(
     for (const attribute of attributes) {
       lines.push(`    ${attribute}`);
     }
-    lines.push(`    pub ${rustName}: ${rustType},`);
+    lines.push(...renderStructField(rustName, rustType, context));
   }
 
   lines.push("}");
@@ -1319,6 +1321,29 @@ function renderStruct(
   });
 
   return typeName;
+}
+
+function renderStructField(
+  rustName: string,
+  rustType: string,
+  context: RenderTypeContext,
+): string[] {
+  const indent = "    ";
+  const singleLine = `${indent}pub ${rustName}: ${rustType},`;
+  if (context.moduleIndentWidth + singleLine.length <= 100) {
+    return [singleLine];
+  }
+
+  if (rustType.startsWith("Option<") && rustType.endsWith(">")) {
+    const innerType = rustType.slice("Option<".length, -1);
+    return [
+      `${indent}pub ${rustName}: Option<`,
+      `${indent}    ${innerType},`,
+      `${indent}>,`,
+    ];
+  }
+
+  return [`${indent}pub ${rustName}:`, `${indent}    ${rustType},`];
 }
 
 function renderStringEnum(

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -6,6 +6,7 @@ import {
 } from "../contracts/runners";
 import { fileEntryWithHashSchema } from "../contracts/storages";
 import {
+  webhookCheckpointsContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
 } from "../contracts/webhooks";
@@ -55,6 +56,10 @@ export const rustTypeModuleDocs = [
   {
     rustModulePath: ["webhooks", "agent"],
     rustDoc: ["Agent webhook DTOs exchanged between sandboxes and the API."],
+  },
+  {
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustDoc: ["DTOs for creating recoverable agent checkpoints."],
   },
   {
     rustModulePath: ["webhooks", "agent", "storages"],
@@ -160,6 +165,57 @@ export const rustTypeBindings = [
         fields: {
           storages: ["Volume storage entries to mount for the run."],
           artifacts: ["Artifact entries to mount for the run."],
+        },
+      },
+    ],
+  },
+  {
+    schema: webhookCheckpointsContract.create.body,
+    rustModulePath: ["webhooks", "agent", "checkpoints"],
+    rustTypeName: "Request",
+    direction: "request",
+    fieldTypeOverrides: {
+      missingRootPolicy:
+        "crate::generated::types::runners::storage::ArtifactEntryMissingRootPolicy",
+    },
+    declarations: [
+      {
+        rustTypeName: "RequestArtifactSnapshot",
+        rustDoc: ["Artifact version captured by an agent checkpoint."],
+        fields: {
+          name: ["User-facing artifact name referenced by the run."],
+          version: ["Artifact version selected for the checkpoint."],
+          mountPath: ["Guest filesystem path where the artifact is mounted."],
+          missingRootPolicy: [
+            "Optional policy retained when the artifact mount root is missing.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestVolumeVersionsSnapshot",
+        rustDoc: ["Volume versions captured by an agent checkpoint."],
+        fields: {
+          versions: ["Volume names mapped to their captured versions."],
+        },
+      },
+      {
+        rustTypeName: "Request",
+        rustDoc: ["Request body for creating a recoverable agent checkpoint."],
+        fields: {
+          runId: ["Agent run identifier bound to the sandbox token."],
+          cliAgentType: ["CLI agent implementation that produced the session."],
+          cliAgentSessionId: [
+            "CLI agent session identifier being checkpointed.",
+          ],
+          cliAgentSessionHistoryHash: [
+            "SHA-256 hash of the uploaded CLI agent session history.",
+          ],
+          artifactSnapshots: [
+            "Optional artifact versions captured by the checkpoint.",
+          ],
+          volumeVersionsSnapshot: [
+            "Optional volume versions captured by the checkpoint.",
+          ],
         },
       },
     ],


### PR DESCRIPTION
## Summary

- generate the complete Rust checkpoint request and nested snapshot DTOs from
  `webhookCheckpointsContract.create.body`
- reuse the canonical missing-root policy enum and consume the generated
  request in guest-agent instead of constructing untyped JSON objects
- make generated long field types rustfmt-stable and replace duplicate payload
  shape comments with semantic contract references
- cover exact minimal and preserve-parent serialization, optional-field
  omission, round trips, and the existing guest checkpoint behavior

## Compatibility and scope

The serialized checkpoint request remains JSON-equivalent to the previous
payload. `artifactSnapshots`, `volumeVersionsSnapshot`, and
`missingRootPolicy` remain omitted when absent. The Zod schema, API handler,
authentication, database shape, persistence, error behavior, and missing-root
semantics are unchanged.

The separate checkpoint GET response union versus record normalization is
tracked in #22216 and is intentionally not changed here.

## Validation

- `pnpm -F @vm0/api-contracts generate:rust` with a byte-stable second pass
- `pnpm -F @vm0/api-contracts test` (436 tests)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm check-types` (13 workspaces)
- `pnpm knip`
- affected-file Prettier checks
- `cargo fmt --all -- --check`
- `cargo clippy -p api-contracts -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p api-contracts -p guest-agent --all-features --no-deps`
- `cargo test -p api-contracts`
- `cargo test -p guest-agent`
- workspace Cargo Clippy/doc, file-size, and generated-firewall pre-commit checks

Closes #22183
