### PR TITLE
test(guest-agent): make event delivery overload deterministic

### DIFF
--- a/crates/guest-agent/tests/event_delivery_byte_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_byte_overload.rs
@@ -17,7 +17,7 @@ async fn ordinary_cli_event_delivery_byte_overload_terminates_promptly()
     let mock_cli = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let server = MockServer::start();
-    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    let mut prompt_lines = vec!["@ECHO-HANG@".to_string()];
     // One in-flight payload plus seven queued payloads crosses the byte budget;
     // seven queued payloads alone do not. This distinguishes queued-plus-in-flight
     // accounting from a queue-only implementation.

--- a/crates/guest-agent/tests/event_delivery_count_overload.rs
+++ b/crates/guest-agent/tests/event_delivery_count_overload.rs
@@ -14,7 +14,7 @@ async fn ordinary_cli_event_delivery_count_overload_terminates_promptly()
     let mock_cli = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let server = MockServer::start();
-    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    let mut prompt_lines = vec!["@ECHO-HANG@".to_string()];
     prompt_lines
         .extend((0..260).map(|index| json!({ "type": "assistant", "index": index }).to_string()));
     let prompt = prompt_lines.join("\n");
@@ -40,21 +40,23 @@ async fn ordinary_cli_event_delivery_count_overload_terminates_promptly()
     .await
     .expect("delivery overload should not wait for the stalled event request");
 
-    let (error, last_event_sequence) = match execution {
-        Ok(result) => (
-            result
-                .control_error
-                .expect("a live CLI should expose delivery overload as a control error")
-                .to_string(),
-            result.last_event_sequence,
-        ),
-        Err(error) => (error.to_string(), None),
-    };
+    let result = execution.expect("the live CLI should use controlled delivery termination");
+    let error = result
+        .control_error
+        .expect("count overload should be exposed as a control error")
+        .to_string();
     assert!(
         error.contains("event delivery queue exceeded 128 pending events"),
         "unexpected overload error: {error}"
     );
-    assert_eq!(last_event_sequence, None);
+    assert_eq!(result.last_event_sequence, None);
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("delivery overload should record process-group termination")
+            .reason,
+        guest_contracts::diagnostics::CliTerminationReason::EventDelivery
+    );
     assert!(
         stalled_events.calls() <= 1,
         "the serial sender should have at most one stalled request in flight"

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -46,6 +46,7 @@
 //!                               emit result, and exit(0)
 //!   @ECHO@                    - First-line marker. Validate remaining non-empty
 //!                               lines as JSONL and emit them unchanged.
+//!   @ECHO-HANG@               - Same as @ECHO@, then remain alive until reaped.
 //!   @active-input-smoke:<n>   - Stream-json stdin marker. Emit a first result,
 //!                               then read n later user frames from the same
 //!                               stdin stream and emit a deterministic final result.

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -101,7 +101,8 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
             eprintln!("{}", invalid_active_input_count_message(count));
             ExitCode::from(1)
         }
-        MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload),
+        MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload, false),
+        MockScenario::EchoJsonlAndHang(payload) => run_echo_jsonl_mode(payload, true),
         MockScenario::FailNoNewline(msg) => {
             eprint!("{msg}");
             let _ = std::io::stderr().flush();
@@ -318,7 +319,7 @@ fn run_active_input_smoke_scenario(
     ExitCode::SUCCESS
 }
 
-fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
+fn run_echo_jsonl_mode(payload: &str, hang_after_output: bool) -> ExitCode {
     let events = match parse_echo_jsonl(payload) {
         Ok(events) => events,
         Err(msg) => {
@@ -343,6 +344,9 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
         transcript.write_session_history(session_id);
     }
     let _ = std::io::stdout().flush();
+    if hang_after_output {
+        hang_until_reaped();
+    }
     ExitCode::SUCCESS
 }
 

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 const ACTIVE_INPUT_SMOKE_MARKER: &str = "@active-input-smoke:";
+const ECHO_HANG_MARKER: &str = "@ECHO-HANG@";
 const ECHO_MARKER: &str = "@ECHO@";
 const FAIL_NO_NEWLINE_MARKER: &str = "@fail-no-newline:";
 const FAIL_INVALID_UTF8_MARKER: &str = "@fail-invalid-utf8";
@@ -27,6 +28,7 @@ pub(crate) enum MockScenario<'a> {
     ActiveInputSmoke { expected_follow_ups: usize },
     InvalidActiveInputSmokeCount(&'a str),
     EchoJsonl(&'a str),
+    EchoJsonlAndHang(&'a str),
     FailNoNewline(&'a str),
     FailInvalidUtf8,
     FailInvalidUtf8Long,
@@ -57,6 +59,7 @@ enum ScenarioMatchKind {
 enum ScenarioKind {
     ActiveInputSmoke,
     EchoJsonl,
+    EchoJsonlAndHang,
     FailNoNewline,
     FailInvalidUtf8,
     FailInvalidUtf8Long,
@@ -91,6 +94,11 @@ const SCENARIO_RULES: &[ScenarioRule] = &[
         marker: ACTIVE_INPUT_SMOKE_MARKER,
         match_kind: ScenarioMatchKind::PrefixPayload,
         scenario_kind: ScenarioKind::ActiveInputSmoke,
+    },
+    ScenarioRule {
+        marker: ECHO_HANG_MARKER,
+        match_kind: ScenarioMatchKind::FirstLinePayload,
+        scenario_kind: ScenarioKind::EchoJsonlAndHang,
     },
     ScenarioRule {
         marker: ECHO_MARKER,
@@ -235,6 +243,9 @@ impl ScenarioKind {
                 }
             }
             (Self::EchoJsonl, ScenarioMatch::Payload(payload)) => MockScenario::EchoJsonl(payload),
+            (Self::EchoJsonlAndHang, ScenarioMatch::Payload(payload)) => {
+                MockScenario::EchoJsonlAndHang(payload)
+            }
             (Self::FailNoNewline, ScenarioMatch::Payload(msg)) => MockScenario::FailNoNewline(msg),
             (Self::Fail, ScenarioMatch::Payload(msg)) => MockScenario::Fail(msg),
             (Self::WriteEnvJson, ScenarioMatch::Payload(path)) => MockScenario::WriteEnvJson(path),
@@ -344,6 +355,10 @@ mod tests {
                 MockScenario::ActiveInputSmoke {
                     expected_follow_ups: 2,
                 },
+            ),
+            (
+                "@ECHO-HANG@\n{\"type\":\"result\"}",
+                MockScenario::EchoJsonlAndHang("{\"type\":\"result\"}"),
             ),
             (
                 "@ECHO@\n{\"type\":\"result\"}",


### PR DESCRIPTION
## Summary

- add an `@ECHO-HANG@` mock Claude scenario that emits validated JSONL and remains alive until reaped
- use the live mock in ordinary CLI byte- and count-overload integration tests so child exit cannot race stdout draining
- require both overload tests to preserve controlled `EventDelivery` termination diagnostics

## User-visible impact

None. This makes the event-delivery overload tests deterministic without changing guest-agent production behavior.

## Exclusions

- no changes to event-delivery limits, admission, ordering, or HTTP behavior
- no changes to production CLI process lifecycle or error handling

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-features`
- 50 consecutive runs of `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test event_delivery_byte_overload`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-features --no-deps`
- repository pre-commit and commit-message hooks
