### PR TITLE
feat: gate refreshed website template packages

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -3024,6 +3024,32 @@ describe("CHAT-02: generation templates and attachments", () => {
     );
     expect(websitePrompt).toContain("zero host <output-dir> --site <slug>");
     await cancelChatRun(actor, website.runId);
+
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.WebsiteTemplateV2]: true },
+    );
+    const websiteV2 = await sendChatRun(actor, {
+      agentId,
+      prompt: "make a v2 campaign landing page",
+      generationTemplate: {
+        type: "website",
+        selection: { websiteTemplateId: websiteTemplate.id },
+      },
+    });
+    const websiteV2Run = await api.readRun(actor, websiteV2.runId);
+    const websiteV2Prompt = websiteV2Run.appendSystemPrompt ?? "";
+    expect(websiteV2Prompt).toContain(
+      "zero resource pull template:black-slabs-v2 --dir ./generated/resources",
+    );
+    expect(websiteV2Prompt).toContain(
+      `./generated/resources/${websiteTemplate.sourcePath}/render.mjs`,
+    );
+    await cancelChatRun(actor, websiteV2.runId);
   }, 90_000);
 
   it("is one-shot: a follow-up without re-attaching the style gets no template context", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -213,6 +213,36 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).not.toContain("zero generate website --template");
   });
 
+  it("selects every additive v2 package behind the rollout switch", () => {
+    for (const item of WEBSITE_TEMPLATE_ITEMS) {
+      const resourceId = `${item.resourceId}-v2`;
+      const result = buildGenerationTemplatePrompt(
+        {
+          type: "website",
+          selection: {
+            websiteTemplateId: item.id,
+          },
+        },
+        { websiteTemplateV2Enabled: true },
+      );
+
+      expect(result).toStrictEqual({
+        status: "resolved",
+        prompt: expect.stringContaining(
+          `zero resource pull ${resourceId} --dir ./generated/resources`,
+        ),
+      });
+      if (result.status !== "resolved") {
+        continue;
+      }
+      expect(result.prompt).toContain(`Template package id: ${resourceId}`);
+      expect(result.prompt).toContain(`Package resource: ${resourceId}`);
+      expect(result.prompt).toContain(
+        `./generated/resources/${item.sourcePath}/render.mjs`,
+      );
+    }
+  });
+
   it("rejects unknown workflow templates", () => {
     const result = buildGenerationTemplatePrompt({
       type: "workflow",

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -60,6 +60,116 @@ describe("registry resource download", () => {
     });
   });
 
+  it("resolves every additive website v2 archive without changing the legacy default", () => {
+    const legacySha256 =
+      "8f30984e444283bf0322106a1099623346e153bc11d26e3044fbf61ef43514c3";
+
+    expect(
+      resolvePrivateRegistryResourceArchive(
+        "template:black-slabs",
+        undefined,
+        legacySha256,
+      ),
+    ).toMatchObject({
+      versionId:
+        "eaca342df50857477c64a1ca73faffb4a1819879948fc8610ff095fae9fe3f22",
+      sha256: legacySha256,
+    });
+
+    const v2Archives = [
+      {
+        id: "template:black-slabs-v2",
+        versionId:
+          "3aefcd4de6a6e319ec88b19a1747d0940bcf9b0027298154572f99e4e3ff3697",
+        sha256:
+          "0f12d8408536ce4e0178129db5ceecc3b7d77605eaff76bff8fab04fd6193c22",
+      },
+      {
+        id: "template:blueprint-grid-v2",
+        versionId:
+          "77980498c47758043a2f11d1eed6a65d2aad2cc4847ef6c51cb9dfd759fe52f2",
+        sha256:
+          "38737948531b22ab5ae03c537464b948b48e139ca0362ea68e9dd3daaf6760b6",
+      },
+      {
+        id: "template:coastal-hotel-v2",
+        versionId:
+          "7367f07e13219a0b9c246440f9dcd13ed7840322a5912ec684b342185f7bc86c",
+        sha256:
+          "5c8650684d247143e010859d957c58c3c77d2b4e3a5540dbb4c4961cc2d70d54",
+      },
+      {
+        id: "template:dot-matrix-v2",
+        versionId:
+          "108458f32cade6a87f76acd5308e23d2169544bb2591da285c629cfbcf6e9fbf",
+        sha256:
+          "20931f59434fea45e2772dd4a2a7790572f65b3514b84bfbb245968618f0ad44",
+      },
+      {
+        id: "template:frame-stack-v2",
+        versionId:
+          "892cbceb2ae49855637e4684821f2b5c5ac04769800527c3ca4f66e115d7c8d7",
+        sha256:
+          "628139021e196f12e06723d899d299a89dc16696870fede38fc9864b6ffff9c1",
+      },
+      {
+        id: "template:frosted-scatter-v2",
+        versionId:
+          "d6950c76df5ffa3f96336f68915fd0670de7ff0f73d07e97b82f63f934d856f3",
+        sha256:
+          "3b0fab9f9f52434f37686377793dae2e467e818e48b85b6696f862d9e8e23232",
+      },
+      {
+        id: "template:gallery-wall-v2",
+        versionId:
+          "f4d62d5f46040c51fced1266dac6f590761bc102def7a89ce4cbdceb6bdbbcee",
+        sha256:
+          "df998b7ca480d24665b49e6c07f4e29eb8f26f3916ed3b8051f41e47535588ab",
+      },
+      {
+        id: "template:glass-bloom-v2",
+        versionId:
+          "dd233dec6bec872e173858b8788a22ed2fbfee0f6f687d74a42ba84947bbfb5c",
+        sha256:
+          "b66ec9fda392e13a8f0c71c842cc0b2e655695cf60d7dd28e8db3b322ba35596",
+      },
+      {
+        id: "template:serif-stack-v2",
+        versionId:
+          "6b7d18315b6955ef27318546ed050ae2736386f80d29f8452f1d74855ef8531c",
+        sha256:
+          "0641c65b035abab0b53d3b345178688f1b4091083d1b7c574b640537b49ef3e5",
+      },
+      {
+        id: "template:sticker-pop-v2",
+        versionId:
+          "21c5247800c02f53b87d27d0970707f642a51dd56a9ef0a8fce68ca8ea677783",
+        sha256:
+          "4b076e69118268108e550322cdfe9befd91378bee5d28bf73627df54ccbaacbd",
+      },
+      {
+        id: "template:warm-cards-v2",
+        versionId:
+          "040325e9aa9567d79532c61933d04fdb10e268d371dca30ae793585da1325eaf",
+        sha256:
+          "20f0a7fa09bf2653b55fb0323b050accaa565817587d105b98ada03243b75bf3",
+      },
+    ] as const;
+
+    for (const archive of v2Archives) {
+      expect(
+        resolvePrivateRegistryResourceArchive(
+          archive.id,
+          archive.sha256,
+          archive.sha256,
+        ),
+      ).toMatchObject({
+        versionId: archive.versionId,
+        sha256: archive.sha256,
+      });
+    }
+  });
+
   it("rejects registry resources that are not in the private archive allowlist", async () => {
     const response = await accept(
       client().download({

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -68,8 +68,17 @@ type GenerationTemplatePromptResult =
       readonly message: string;
     };
 
+interface BuildGenerationTemplatePromptOptions {
+  /**
+   * When true, website templates use their refreshed self-contained v2
+   * packages. When false, the existing package resources remain unchanged.
+   */
+  readonly websiteTemplateV2Enabled?: boolean;
+}
+
 export function buildGenerationTemplatePrompt(
   generationTemplate: GenerationTemplateInput | null | undefined,
+  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (!generationTemplate) {
     return { status: "resolved", prompt: "" };
@@ -85,7 +94,7 @@ export function buildGenerationTemplatePrompt(
     return buildWorkflowGenerationTemplatePrompt(generationTemplate);
   }
   if (generationTemplate.type === "website") {
-    return buildWebsiteGenerationTemplatePrompt(generationTemplate);
+    return buildWebsiteGenerationTemplatePrompt(generationTemplate, options);
   }
 
   return buildPresentationGenerationTemplatePrompt(generationTemplate);
@@ -168,6 +177,7 @@ function buildPresentationRunbookPrompt(
 
 function buildWebsiteGenerationTemplatePrompt(
   generationTemplate: WebsiteGenerationTemplateInput,
+  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   const item = findWebsiteTemplateItem(
     generationTemplate.selection.websiteTemplateId,
@@ -176,7 +186,10 @@ function buildWebsiteGenerationTemplatePrompt(
     return { status: "invalid", message: "Unknown website template" };
   }
 
-  const pkg = findWebsiteTemplatePackage(item.templateId);
+  const packageId = options?.websiteTemplateV2Enabled
+    ? `${item.templateId}-v2`
+    : item.templateId;
+  const pkg = findWebsiteTemplatePackage(packageId);
   if (!pkg) {
     return { status: "invalid", message: "Unknown website template" };
   }

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -135,26 +135,48 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   // Website template packages (self-contained per-template archives).
   "template:black-slabs":
     "eaca342df50857477c64a1ca73faffb4a1819879948fc8610ff095fae9fe3f22",
+  "template:black-slabs-v2":
+    "3aefcd4de6a6e319ec88b19a1747d0940bcf9b0027298154572f99e4e3ff3697",
   "template:blueprint-grid":
     "78988a658604a25feb259d54e4543bfe6d57f85efe7ad67737e02c794d25e491",
+  "template:blueprint-grid-v2":
+    "77980498c47758043a2f11d1eed6a65d2aad2cc4847ef6c51cb9dfd759fe52f2",
   "template:coastal-hotel":
     "3907cdbed6078702a058ed9c66c1cdeb76f83f1062efcf3b046cce0bd5c8ed06",
+  "template:coastal-hotel-v2":
+    "7367f07e13219a0b9c246440f9dcd13ed7840322a5912ec684b342185f7bc86c",
   "template:dot-matrix":
     "293a2bc33150ca1f39132a8235c5cf355944e8d3e213b5f7703237314a2ac449",
+  "template:dot-matrix-v2":
+    "108458f32cade6a87f76acd5308e23d2169544bb2591da285c629cfbcf6e9fbf",
   "template:frame-stack":
     "efbf1788c8b084aa12b7cd48f7a3bf5fc9964d1e6115edbd9124f8cacfbfb3ca",
+  "template:frame-stack-v2":
+    "892cbceb2ae49855637e4684821f2b5c5ac04769800527c3ca4f66e115d7c8d7",
   "template:frosted-scatter":
     "c4507fd54d252dc905df36d99f23ab65a4d41185b78e62515ff3eb3d87a381a4",
+  "template:frosted-scatter-v2":
+    "d6950c76df5ffa3f96336f68915fd0670de7ff0f73d07e97b82f63f934d856f3",
   "template:gallery-wall":
     "9e81cd8b35f9f6374440cd3a4a8fc214db4a137962797df69bde46248c4e75f3",
+  "template:gallery-wall-v2":
+    "f4d62d5f46040c51fced1266dac6f590761bc102def7a89ce4cbdceb6bdbbcee",
   "template:glass-bloom":
     "52d38ebc1e62b974f7ab2f6dba8823b0a2f7c43d5c11d8079f32e3ff85df1e50",
+  "template:glass-bloom-v2":
+    "dd233dec6bec872e173858b8788a22ed2fbfee0f6f687d74a42ba84947bbfb5c",
   "template:serif-stack":
     "adee3b87f670c52a3cc4971e5dd8795f8ca05690087caff4b0d8b32b9029bead",
+  "template:serif-stack-v2":
+    "6b7d18315b6955ef27318546ed050ae2736386f80d29f8452f1d74855ef8531c",
   "template:sticker-pop":
     "ddae2ff9236b0a4663dc19ad23b374488c0d4d9eddf9b5a4e8cad36011b0b420",
+  "template:sticker-pop-v2":
+    "21c5247800c02f53b87d27d0970707f642a51dd56a9ef0a8fce68ca8ea677783",
   "template:warm-cards":
     "0a87c99afe9cf24424aa1a1740a57cc3698e43f3c571b8ef1fd4560192f38746",
+  "template:warm-cards-v2":
+    "040325e9aa9567d79532c61933d04fdb10e268d371dca30ae793585da1325eaf",
 } as const satisfies Record<string, string>;
 
 // Keep the default archive version for already released CLIs. Newer CLIs opt

--- a/turbo/apps/api/src/signals/routes/thread-generation-template.ts
+++ b/turbo/apps/api/src/signals/routes/thread-generation-template.ts
@@ -10,10 +10,13 @@ import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
  */
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;
+  readonly websiteTemplateV2Enabled?: boolean;
 }): string {
   if (!args.explicit) {
     return "";
   }
-  const built = buildGenerationTemplatePrompt(args.explicit);
+  const built = buildGenerationTemplatePrompt(args.explicit, {
+    websiteTemplateV2Enabled: args.websiteTemplateV2Enabled,
+  });
   return built.status === "resolved" ? built.prompt : "";
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -238,6 +238,7 @@ function shouldTouchThreadSortFromNormalSend(
 
 interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
+  readonly websiteTemplateV2Enabled: boolean;
 }
 
 interface ResolvedComputerUseHostGrant {
@@ -1125,6 +1126,10 @@ async function resolveNormalSendFeatureSwitches(
   return {
     codexFastModeEnabled: isFeatureEnabled(
       FeatureSwitchKey.CodexFastMode,
+      context,
+    ),
+    websiteTemplateV2Enabled: isFeatureEnabled(
+      FeatureSwitchKey.WebsiteTemplateV2,
       context,
     ),
   };
@@ -2338,6 +2343,7 @@ const prepareNormalSend$ = command(
     signal.throwIfAborted();
     const generationTemplatePrompt = resolveThreadGenerationTemplatePrompt({
       explicit: args.body.generationTemplate,
+      websiteTemplateV2Enabled: featureSwitches.websiteTemplateV2Enabled,
     });
     const persistedExplicitSelection =
       await maybePersistTimedExplicitModelFirstSelection(args, db);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -3,6 +3,8 @@ import { randomBytes } from "node:crypto";
 import { command } from "ccstate";
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
@@ -82,6 +84,7 @@ import {
 } from "./zero-chat-title.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { shouldStartNewChatSession } from "./chat-session-continuity.service";
@@ -1722,7 +1725,7 @@ async function buildCreateQueuedChatRunInput(args: {
     },
   );
 
-  const [latestSession, loadedIncompleteContext] =
+  const [latestSession, loadedIncompleteContext, featureSwitchContext] =
     await measureChatCallbackPreCreateTiming(
       args.timing,
       "api_dispatch_pre_create_zero_chat_callback_auto_send_load_session_state",
@@ -1731,6 +1734,7 @@ async function buildCreateQueuedChatRunInput(args: {
         return Promise.all([
           latestSessionForThreadFromDb(args.db, args.threadId),
           loadWebChatIncompleteContext(args.db, args.threadId),
+          loadUserFeatureSwitchContext(args.db, args.agent.orgId, args.userId),
         ]);
       },
     );
@@ -1759,6 +1763,10 @@ async function buildCreateQueuedChatRunInput(args: {
     () => {
       return resolveThreadGenerationTemplatePrompt({
         explicit: resolvedQueuedMessage.generationTemplate,
+        websiteTemplateV2Enabled: isFeatureEnabled(
+          FeatureSwitchKey.WebsiteTemplateV2,
+          featureSwitchContext,
+        ),
       });
     },
   );

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { WEBSITE_TEMPLATE_ITEMS } from "@vm0/core";
 import { describe, expect, it } from "vitest";
 
 import { findRegistryResourceForPull } from "../index";
@@ -44,5 +45,26 @@ describe("zero resource pull registry resolver", () => {
     expect(findRegistryResourceForPull("dot-matrix")?.id).toBe(
       "template:dot-matrix",
     );
+  });
+
+  it("resolves every feature-switched website v2 package", () => {
+    for (const item of WEBSITE_TEMPLATE_ITEMS) {
+      const resourceId = `${item.resourceId}-v2`;
+
+      expect(findRegistryResourceForPull(resourceId)).toEqual(
+        expect.objectContaining({
+          id: resourceId,
+          kind: "template",
+          targets: ["website"],
+          source: expect.objectContaining({
+            path: item.sourcePath,
+            archive: {
+              type: "tar.gz",
+              sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+            },
+          }),
+        }),
+      );
+    }
   });
 });

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -76,6 +76,7 @@ export enum FeatureSwitchKey {
   Artifacts = "artifacts",
   ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
+  WebsiteTemplateV2 = "websiteTemplateV2",
   OrgPlanEntitlementReads = "orgPlanEntitlementReads",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
   ConnectorActionCallback = "connectorActionCallback",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -148,6 +148,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.Artifacts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       true,
@@ -187,6 +188,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactPreviewImage]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(
       false,

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -49,6 +49,31 @@ const EXPECTED_WEBSITE_TEMPLATE_SHA256: Record<string, string> = {
     "2721c013f76e1b2eea09282269b33d7f143b7e83ee3e701e83a0fcf7773852dd",
 };
 
+const EXPECTED_WEBSITE_TEMPLATE_V2_SHA256: Record<string, string> = {
+  "black-slabs":
+    "0f12d8408536ce4e0178129db5ceecc3b7d77605eaff76bff8fab04fd6193c22",
+  "blueprint-grid":
+    "38737948531b22ab5ae03c537464b948b48e139ca0362ea68e9dd3daaf6760b6",
+  "coastal-hotel":
+    "5c8650684d247143e010859d957c58c3c77d2b4e3a5540dbb4c4961cc2d70d54",
+  "dot-matrix":
+    "20931f59434fea45e2772dd4a2a7790572f65b3514b84bfbb245968618f0ad44",
+  "frame-stack":
+    "628139021e196f12e06723d899d299a89dc16696870fede38fc9864b6ffff9c1",
+  "frosted-scatter":
+    "3b0fab9f9f52434f37686377793dae2e467e818e48b85b6696f862d9e8e23232",
+  "gallery-wall":
+    "df998b7ca480d24665b49e6c07f4e29eb8f26f3916ed3b8051f41e47535588ab",
+  "glass-bloom":
+    "b66ec9fda392e13a8f0c71c842cc0b2e655695cf60d7dd28e8db3b322ba35596",
+  "serif-stack":
+    "0641c65b035abab0b53d3b345178688f1b4091083d1b7c574b640537b49ef3e5",
+  "sticker-pop":
+    "4b076e69118268108e550322cdfe9befd91378bee5d28bf73627df54ccbaacbd",
+  "warm-cards":
+    "20f0a7fa09bf2653b55fb0323b050accaa565817587d105b98ada03243b75bf3",
+};
+
 describe("website template items", () => {
   it("exposes the built-in website template catalog in picker order", () => {
     expect(
@@ -149,6 +174,40 @@ describe("website template items", () => {
         }),
       );
     }
+  });
+
+  it("keeps all v2 packages additive to the picker catalog", () => {
+    for (const item of WEBSITE_TEMPLATE_ITEMS) {
+      const resourceId = `${item.resourceId}-v2`;
+      const pkg = findWebsiteTemplatePackage(resourceId);
+
+      expect(pkg).toMatchObject({
+        templateId: `${item.templateId}-v2`,
+        resourceId,
+        slug: item.sourcePath,
+        source: {
+          path: item.sourcePath,
+          archive: {
+            type: "tar.gz",
+            sha256: EXPECTED_WEBSITE_TEMPLATE_V2_SHA256[item.slug],
+          },
+        },
+      });
+      expect(findWebsiteTemplateResource(resourceId)).toEqual(
+        expect.objectContaining({
+          id: resourceId,
+          targets: ["website"],
+        }),
+      );
+    }
+    expect(listWebsiteTemplatePackages()).toHaveLength(
+      WEBSITE_TEMPLATE_ITEMS.length,
+    );
+    expect(
+      listTemplates("website").some((template) => {
+        return template.id.endsWith("-v2");
+      }),
+    ).toBe(false);
   });
 
   it("keeps built-in R2 website packages out of the unscoped generic template list", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -462,6 +462,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Render a static preview image (screenshot) for HTML/website artifacts on deploy so the artifacts grid shows an image instead of a live iframe.",
     enabled: true,
   },
+  [FeatureSwitchKey.WebsiteTemplateV2]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Generate websites from refreshed self-contained template packages. When off, website generation uses the existing package versions.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.OrgPlanEntitlementReads]: {
     maintainer: "yuma@vm0.ai",
     description:

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -3684,6 +3684,57 @@ const WEBSITE_TEMPLATE_PACKAGES: readonly WebsiteTemplatePackage[] =
     };
   });
 
+const WEBSITE_TEMPLATE_V2_ARCHIVE_SHA256: Record<string, string> = {
+  "black-slabs":
+    "0f12d8408536ce4e0178129db5ceecc3b7d77605eaff76bff8fab04fd6193c22",
+  "blueprint-grid":
+    "38737948531b22ab5ae03c537464b948b48e139ca0362ea68e9dd3daaf6760b6",
+  "coastal-hotel":
+    "5c8650684d247143e010859d957c58c3c77d2b4e3a5540dbb4c4961cc2d70d54",
+  "dot-matrix":
+    "20931f59434fea45e2772dd4a2a7790572f65b3514b84bfbb245968618f0ad44",
+  "frame-stack":
+    "628139021e196f12e06723d899d299a89dc16696870fede38fc9864b6ffff9c1",
+  "frosted-scatter":
+    "3b0fab9f9f52434f37686377793dae2e467e818e48b85b6696f862d9e8e23232",
+  "gallery-wall":
+    "df998b7ca480d24665b49e6c07f4e29eb8f26f3916ed3b8051f41e47535588ab",
+  "glass-bloom":
+    "b66ec9fda392e13a8f0c71c842cc0b2e655695cf60d7dd28e8db3b322ba35596",
+  "serif-stack":
+    "0641c65b035abab0b53d3b345178688f1b4091083d1b7c574b640537b49ef3e5",
+  "sticker-pop":
+    "4b076e69118268108e550322cdfe9befd91378bee5d28bf73627df54ccbaacbd",
+  "warm-cards":
+    "20f0a7fa09bf2653b55fb0323b050accaa565817587d105b98ada03243b75bf3",
+};
+
+function websiteTemplateV2ArchiveSha256(slug: string): string {
+  const sha256 = WEBSITE_TEMPLATE_V2_ARCHIVE_SHA256[slug];
+  if (!sha256) {
+    throw new Error(`Missing website template v2 archive sha256 for ${slug}`);
+  }
+  return sha256;
+}
+
+// Keep refreshed packages outside the picker-backed list. The API selects
+// these additive resource ids behind WebsiteTemplateV2 while released clients
+// and users outside the rollout continue pulling the original package ids.
+const WEBSITE_TEMPLATE_V2_PACKAGES: readonly WebsiteTemplatePackage[] =
+  WEBSITE_TEMPLATE_ITEMS.map((item) => {
+    return {
+      templateId: `${item.templateId}-v2`,
+      resourceId: `${item.resourceId}-v2`,
+      slug: item.sourcePath,
+      name: item.title,
+      description: item.description,
+      source: privateR2ArchiveSource(
+        item.sourcePath,
+        websiteTemplateV2ArchiveSha256(item.slug),
+      ),
+    };
+  });
+
 function websiteTemplatePackageToRegistryEntry(
   pkg: WebsiteTemplatePackage,
 ): RegistryEntry {
@@ -3704,6 +3755,15 @@ export function listWebsiteTemplatePackages(): readonly WebsiteTemplatePackage[]
 export function findWebsiteTemplatePackage(
   templateId: string,
 ): WebsiteTemplatePackage | undefined {
+  const directPackage = [
+    ...WEBSITE_TEMPLATE_PACKAGES,
+    ...WEBSITE_TEMPLATE_V2_PACKAGES,
+  ].find((pkg) => {
+    return pkg.templateId === templateId || pkg.resourceId === templateId;
+  });
+  if (directPackage) {
+    return directPackage;
+  }
   const normalizedTemplateId =
     findWebsiteTemplateItem(templateId)?.templateId ?? templateId;
   return WEBSITE_TEMPLATE_PACKAGES.find((pkg) => {
@@ -3714,6 +3774,12 @@ export function findWebsiteTemplatePackage(
 export function findWebsiteTemplateResource(
   resourceId: string,
 ): RegistryEntry | undefined {
+  const directPackage = WEBSITE_TEMPLATE_V2_PACKAGES.find((pkg) => {
+    return pkg.resourceId === resourceId;
+  });
+  if (directPackage) {
+    return websiteTemplatePackageToRegistryEntry(directPackage);
+  }
   const normalizedResourceId =
     findWebsiteTemplateItem(resourceId)?.resourceId ?? resourceId;
   const pkg = WEBSITE_TEMPLATE_PACKAGES.find((entry) => {


### PR DESCRIPTION
## Summary

- upload and register refreshed private R2 archives for all 11 built-in website templates as additive `template:<slug>-v2` resources
- preserve every existing website resource id, archive version, and digest for users outside the rollout
- follow the presentation runbook rollout pattern: `websiteTemplateV2` is globally off and enabled for `STAFF_ORG_ID_HASHES`
- route all website template selections to their matching v2 package when the switch is enabled, including normal sends and queued-message auto-sends
- keep v2 resources pull-only and out of the user-facing template catalog
- cover all 11 v2 resource ids, archive digests, R2 versions, prompt routing, and the legacy fallback

## Uploaded resources

- `template:black-slabs-v2`
- `template:blueprint-grid-v2`
- `template:coastal-hotel-v2`
- `template:dot-matrix-v2`
- `template:frame-stack-v2`
- `template:frosted-scatter-v2`
- `template:gallery-wall-v2`
- `template:glass-bloom-v2`
- `template:serif-stack-v2`
- `template:sticker-pop-v2`
- `template:warm-cards-v2`

Each archive was downloaded back from R2, SHA-256 checked, and matched against the source directory file count. The full content-addressed storage versions and archive digests are registered in the API allowlist and core resource registry.

## Rollout and compatibility

- staff organizations resolve all website template selections to the additive v2 resource ids
- non-staff organizations continue resolving the existing resource ids
- disabling `websiteTemplateV2` immediately restores the existing package path
- released clients keep resolving the unchanged legacy resources

## Verification

- Prettier and `git diff --check`
- lint: `@vm0/core`, `@vm0/connectors`, `api`, `@vm0/cli`
- type checks: `@vm0/core`, `@vm0/connectors`, `api`, `@vm0/cli`
- `pnpm knip`
- core feature-switch and website registry tests: 31 passed
- API prompt and resource-download tests: 13 passed
- CLI resource resolver tests: 5 passed
- chat generation-template integration test: 1 passed
