### PR TITLE
fix: preserve chat selection when feedback pill closes

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -293,32 +293,17 @@ function createFeedbackSelectionState(threadId: string) {
   const selection$ = computed((get) => {
     return get(selectionState$);
   });
-  const hideSelectionToolbar$ = command(({ set }) => {
+  const closeSelectionToolbar$ = command(({ set }) => {
     set(resetSelectionToolbarSignal$);
     set(selectionState$, null);
   });
-  const closeSelectionToolbar$ = command(({ get, set }) => {
-    if (get(selectionState$) === null) {
-      return;
-    }
-    set(hideSelectionToolbar$);
-    window.getSelection()?.removeAllRanges();
-  });
-  const captureSelection$ = command(({ get, set }) => {
+  const captureSelection$ = command(({ set }) => {
     const selection = readFeedbackSelection();
     if (!selection || selection.threadId !== threadId) {
-      if (get(selectionState$) !== null) {
-        set(hideSelectionToolbar$);
-      }
+      set(closeSelectionToolbar$);
       return;
     }
     set(selectionState$, selection);
-  });
-  const captureSelectionIfPresent$ = command(({ set }) => {
-    const selection = readFeedbackSelection();
-    if (selection?.threadId === threadId) {
-      set(selectionState$, selection);
-    }
   });
   const dismissSelectionOnScroll$ = command(({ get, set }) => {
     if (get(selectionState$) !== null) {
@@ -342,10 +327,8 @@ function createFeedbackSelectionState(threadId: string) {
     selectionState$,
     resetSelectionToolbarSignal$,
     selection$,
-    hideSelectionToolbar$,
     closeSelectionToolbar$,
     captureSelection$,
-    captureSelectionIfPresent$,
     dismissSelectionOnScroll$,
     copySelection$,
   };
@@ -355,12 +338,12 @@ function createFeedbackItemSignals({
   threadId,
   editor,
   selectionState$,
-  hideSelectionToolbar$,
+  closeSelectionToolbar$,
 }: {
   threadId: string;
   editor: FeedbackEditorAdapter;
   selectionState$: State<FeedbackSelection | null>;
-  hideSelectionToolbar$: Command<void, []>;
+  closeSelectionToolbar$: Command<void, []>;
 }) {
   const itemsState$ = state<readonly FeedbackItem[]>([]);
   const rangesState$ = state<ReadonlyMap<number, Range>>(new Map());
@@ -405,7 +388,7 @@ function createFeedbackItemSignals({
     set(rangesState$, ranges);
     set(setFeedbackHighlight$, threadId, ranges);
     editor.insertItem(item);
-    set(hideSelectionToolbar$);
+    set(closeSelectionToolbar$);
   });
   const removeFeedback$ = command(({ get, set }, id: number) => {
     const items = get(itemsState$).filter((item) => {
@@ -448,9 +431,8 @@ function createSelectionToolbarRef({
             return;
           }
           if (matchShortcut("mod+c", event)) {
-            // Let the browser copy the native selection before clearing it.
-            // Closing synchronously here would leave the default copy action
-            // with no selected text to put on the clipboard.
+            // Preserve the browser's native copy action, then dismiss only the
+            // feedback state without changing the document selection.
             await delay(0, { signal: toolbarSignal });
             set(closeSelectionToolbar$);
             return;
@@ -482,157 +464,68 @@ function createSelectionToolbarRef({
   );
 }
 
-interface SelectionListenerRuntime {
-  pendingDismissWhenEmpty: boolean;
-  mouseIsDown: boolean;
-  suppressSelectionCapture: boolean;
-}
-
 function createPointerSelectionListeners({
   selectionState$,
-  hideSelectionToolbar$,
+  closeSelectionToolbar$,
 }: {
   selectionState$: State<FeedbackSelection | null>;
-  hideSelectionToolbar$: Command<void, []>;
+  closeSelectionToolbar$: Command<void, []>;
 }) {
-  const clearSuppressedCaptureSignal$ = resetSignal();
-  return command(
-    (
-      { get, set },
-      doc: Document,
-      runtime: SelectionListenerRuntime,
-      signal: AbortSignal,
-    ) => {
-      // Touch/pen selections settle one macrotask after pointerup; keep the
-      // capture suppressed until then. Rescheduling aborts the previous
-      // pending clear.
-      const clearSuppressedSelectionCaptureSoon = onDomEventFn(async () => {
-        await delay(0, { signal: set(clearSuppressedCaptureSignal$, signal) });
-        runtime.suppressSelectionCapture = false;
-      });
-      doc.addEventListener(
-        "pointerdown",
-        (event) => {
-          if (
-            get(selectionState$) !== null &&
-            shouldDismissSelectionForInteractionTarget(event.target)
-          ) {
-            runtime.suppressSelectionCapture = true;
-            set(hideSelectionToolbar$);
-          }
-        },
-        { capture: true, signal },
-      );
-      doc.addEventListener(
-        "pointerup",
-        (event) => {
-          if ((event as PointerEvent).pointerType !== "mouse") {
-            clearSuppressedSelectionCaptureSoon(event);
-          }
-        },
-        { signal },
-      );
-      doc.addEventListener(
-        "pointercancel",
-        clearSuppressedSelectionCaptureSoon,
-        { signal },
-      );
-      doc.addEventListener(
-        "mousedown",
-        () => {
-          runtime.mouseIsDown = true;
-        },
-        { capture: true, signal },
-      );
-    },
-  );
+  return command(({ get, set }, doc: Document, signal: AbortSignal) => {
+    doc.addEventListener(
+      "pointerdown",
+      (event) => {
+        if (
+          get(selectionState$) !== null &&
+          shouldDismissSelectionForInteractionTarget(event.target)
+        ) {
+          set(closeSelectionToolbar$);
+        }
+      },
+      { capture: true, signal },
+    );
+  });
 }
 
 function createDocumentSelectionListeners({
   threadId,
   captureSelection$,
-  captureSelectionIfPresent$,
   dismissSelectionOnScroll$,
 }: {
   threadId: string;
   captureSelection$: Command<void, []>;
-  captureSelectionIfPresent$: Command<void, []>;
   dismissSelectionOnScroll$: Command<void, []>;
 }) {
   const deferredCaptureSignal$ = resetSignal();
-  return command(
-    (
-      { set },
-      doc: Document,
-      runtime: SelectionListenerRuntime,
-      signal: AbortSignal,
-    ) => {
-      const capture = () => {
-        set(captureSelection$);
-      };
-      const captureIfPresent = () => {
-        set(captureSelectionIfPresent$);
-      };
-      // The browser finalizes the selection after the triggering event, so
-      // read it one macrotask later. Rescheduling aborts the previous pending
-      // read, coalescing event bursts into a single capture.
-      const captureDeferred = async (dismissWhenEmpty: boolean) => {
-        runtime.pendingDismissWhenEmpty ||= dismissWhenEmpty;
-        await delay(0, { signal: set(deferredCaptureSignal$, signal) });
-        const shouldDismissWhenEmpty = runtime.pendingDismissWhenEmpty;
-        runtime.pendingDismissWhenEmpty = false;
-        if (shouldDismissWhenEmpty) {
-          capture();
-        } else {
-          captureIfPresent();
-        }
-      };
-      doc.addEventListener(
-        "mouseup",
-        onDomEventFn(async () => {
-          runtime.mouseIsDown = false;
-          if (runtime.suppressSelectionCapture) {
-            runtime.suppressSelectionCapture = false;
-            return;
-          }
-          await captureDeferred(true);
-        }),
-        { signal },
-      );
-      doc.addEventListener(
-        "dblclick",
-        onDomEventFn(async () => {
-          runtime.mouseIsDown = false;
-          await captureDeferred(false);
-        }),
-        { signal },
-      );
-      doc.addEventListener(
-        "selectionchange",
-        onDomEventFn(async () => {
-          if (!runtime.mouseIsDown && !runtime.suppressSelectionCapture) {
-            await captureDeferred(false);
-          }
-        }),
-        { signal },
-      );
-      doc.addEventListener("keyup", capture, { signal });
-      doc.addEventListener(
-        "scroll",
-        () => {
-          set(dismissSelectionOnScroll$);
-        },
-        { capture: true, passive: true, signal },
-      );
-      signal.addEventListener(
-        "abort",
-        () => {
-          set(setFeedbackHighlight$, threadId, new Map());
-        },
-        { once: true },
-      );
-    },
-  );
+  return command(({ set }, doc: Document, signal: AbortSignal) => {
+    // Read the selection one macrotask after selectionchange. Rescheduling
+    // aborts the previous read, coalescing event bursts into one capture.
+    const captureDeferred = async () => {
+      await delay(0, { signal: set(deferredCaptureSignal$, signal) });
+      set(captureSelection$);
+    };
+    doc.addEventListener(
+      "selectionchange",
+      onDomEventFn(async () => {
+        await captureDeferred();
+      }),
+      { signal },
+    );
+    doc.addEventListener(
+      "scroll",
+      () => {
+        set(dismissSelectionOnScroll$);
+      },
+      { capture: true, passive: true, signal },
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(setFeedbackHighlight$, threadId, new Map());
+      },
+      { once: true },
+    );
+  });
 }
 
 function createSelectionListenersRef({
@@ -644,13 +537,8 @@ function createSelectionListenersRef({
 }) {
   return onRef(
     command(({ set }, el: HTMLElement, signal: AbortSignal) => {
-      const runtime: SelectionListenerRuntime = {
-        pendingDismissWhenEmpty: false,
-        mouseIsDown: false,
-        suppressSelectionCapture: false,
-      };
-      set(pointerListeners$, el.ownerDocument, runtime, signal);
-      set(documentListeners$, el.ownerDocument, runtime, signal);
+      set(pointerListeners$, el.ownerDocument, signal);
+      set(documentListeners$, el.ownerDocument, signal);
     }),
   );
 }
@@ -664,7 +552,7 @@ export function createFeedbackSignals(
     threadId,
     editor,
     selectionState$: selection.selectionState$,
-    hideSelectionToolbar$: selection.hideSelectionToolbar$,
+    closeSelectionToolbar$: selection.closeSelectionToolbar$,
   });
   const setSelectionToolbarRef$ = createSelectionToolbarRef({
     resetSelectionToolbarSignal$: selection.resetSelectionToolbarSignal$,
@@ -674,12 +562,11 @@ export function createFeedbackSignals(
   });
   const pointerListeners$ = createPointerSelectionListeners({
     selectionState$: selection.selectionState$,
-    hideSelectionToolbar$: selection.hideSelectionToolbar$,
+    closeSelectionToolbar$: selection.closeSelectionToolbar$,
   });
   const documentListeners$ = createDocumentSelectionListeners({
     threadId,
     captureSelection$: selection.captureSelection$,
-    captureSelectionIfPresent$: selection.captureSelectionIfPresent$,
     dismissSelectionOnScroll$: selection.dismissSelectionOnScroll$,
   });
   const setSelectionListenersRef$ = createSelectionListenersRef({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -59,11 +59,11 @@ function selectTextRangeForInlineFeedback(element: HTMLElement): void {
 
 function selectTextForInlineFeedback(element: HTMLElement): void {
   selectTextRangeForInlineFeedback(element);
-  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  document.dispatchEvent(new Event("selectionchange"));
 }
 
-// The selection toolbar reads the selection in a deferred macrotask
-// (delay(0)) after mouseup, and the composer applies its own deferred
+// The selection toolbar reads selectionchange in a deferred macrotask
+// (delay(0)), and the composer applies its own deferred
 // DOM/selection sync after paste. vi.waitFor drives its retries from
 // macrotask timers, so requiring one failed check lets those earlier-queued
 // product tasks settle without the test owning a timer of its own.
@@ -112,7 +112,7 @@ function selectTextAcrossElementsForInlineFeedback(
   }
   selection.removeAllRanges();
   selection.addRange(range);
-  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  document.dispatchEvent(new Event("selectionchange"));
 }
 
 function buttonByText(text: string): HTMLElement {
@@ -200,8 +200,9 @@ async function replaceFeedbackNote(
 function dispatchDocumentShortcut(
   key: string,
   init?: Omit<KeyboardEventInit, "key">,
+  type: "keydown" | "keyup" = "keydown",
 ): KeyboardEvent {
-  const event = new KeyboardEvent("keydown", {
+  const event = new KeyboardEvent(type, {
     bubbles: true,
     cancelable: true,
     ...init,
@@ -829,6 +830,7 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
+    expect(window.getSelection()?.toString()).toBe(assistantReply);
 
     const event = dispatchDocumentShortcut("c", { ctrlKey: true });
     expect(event.defaultPrevented).toBeFalsy();
@@ -836,6 +838,13 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
     });
+    expect(window.getSelection()?.toString()).toBe(assistantReply);
+
+    dispatchDocumentShortcut("c", { ctrlKey: true }, "keyup");
+    await waitForDeferredSelectionCapture();
+
+    expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    expect(window.getSelection()?.toString()).toBe(assistantReply);
   });
 
   it("focuses the inline feedback composer when started from the keyboard shortcut", async () => {
@@ -964,11 +973,9 @@ describe("chat inline feedback", () => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
 
-    // Click inside the selection: in a real browser mouseup fires first and the
-    // selection collapses right after. Mirror that order so the deferred read
-    // sees the cleared selection and dismisses the toolbar.
-    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    // A real browser emits selectionchange after the selection collapses.
     window.getSelection()?.removeAllRanges();
+    document.dispatchEvent(new Event("selectionchange"));
 
     await waitFor(() => {
       expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- open the inline feedback pill only from validated `selectionchange` events whose range belongs to an assistant message
- close the pill by clearing its ccstate selection state without mutating the browser's DOM selection
- keep native Cmd/Ctrl+C behavior and dismiss the pill one macrotask later without allowing keyup to reopen it

## User impact

Copying selected assistant text now closes the feedback pill while preserving the browser selection, avoiding clipboard timing races and DOM range changes that can destabilize composer IME input.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (16 passed)
- repository pre-commit checks, including workspace type checks

Browser verification was not run, following the repository preference not to start a local dev server for PR creation.
