### PR TITLE
test(app): narrow device auth connector fixture

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1849,6 +1849,22 @@ describe("connectors page", () => {
 
   it("completes a device-auth connector grant", async () => {
     mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "base44",
+        label: "Base44",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            description: "Sign in with Base44 to grant access.",
+            grantKind: "device-auth",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
 
     context.mocks.browser.open(createMockAuthWindow());
     detachedSetupPage({ context, path: "/connectors" });


### PR DESCRIPTION
## Summary

- isolate the device-auth connector page story to the Base44 catalog fixture it exercises
- preserve the full start, verification, polling, and connected-state flow while avoiding unrelated catalog rendering under CI load

## Exclusions

- no production behavior or polling changes
- no timeout increase or test splitting

## Testing

- `pnpm exec prettier --check apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx -t 'completes a device-auth connector grant' --reporter=verbose`
- `pnpm vitest run --project=@vm0/app --shard=1/8 --coverage.enabled --coverage.reporter=json`
- pre-commit `pnpm knip --cache`
- pre-commit `pnpm check-types`
