### PR TITLE
fix(chat): expand composer for attached template chips

### DIFF
--- a/e2e/playwright/tests/webchat.spec.ts
+++ b/e2e/playwright/tests/webchat.spec.ts
@@ -1,9 +1,21 @@
+import type { Locator } from "@playwright/test";
+
 import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
 
-test("send a chat message and receive a response", async ({ page }) => {
+async function elementHeight(locator: Locator): Promise<number> {
+  const bounds = await locator.boundingBox();
+  if (bounds === null) {
+    throw new Error("Composer bounds are unavailable");
+  }
+  return bounds.height;
+}
+
+test("send a chat message and preserve composer height with a template", async ({
+  page,
+}) => {
   // Navigate to chat page (default agent)
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
@@ -33,4 +45,22 @@ test("send a chat message and receive a response", async ({ page }) => {
   await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
     timeout: 120_000,
   });
+
+  // The completed run leaves us on a chat-thread composer, whose responsive
+  // minimum height is compact on mobile and three lines on desktop.
+  await expect.poll(() => elementHeight(composer)).toBe(96);
+
+  await page.getByRole("button", { name: "Template", exact: true }).click();
+  await page
+    .getByRole("button", { name: /^Select template / })
+    .first()
+    .click();
+
+  await expect.poll(() => elementHeight(composer)).toBe(134);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect.poll(() => elementHeight(composer)).toBe(82);
+
+  await page.getByRole("button", { name: /^Remove template / }).click();
+  await expect.poll(() => elementHeight(composer)).toBe(44);
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -1,7 +1,6 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { pathname } from "../../../signals/location.ts";
@@ -22,7 +21,6 @@ import {
   mockThread,
   mockComposerThreadSnapshot,
   findComposerEditor,
-  selectTemplate,
   placeCaretAfterText,
   workflowSummary,
 } from "./chat-composer-test-helpers.ts";
@@ -61,42 +59,6 @@ describe("chat composer models", () => {
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[96px]");
     expect(editor).not.toHaveClass("min-h-[44px]");
-  });
-
-  it("expands the agent chat composer above an attached template chip", async () => {
-    const user = userEvent.setup({ delay: null });
-    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
-    mockOrgModelRoutes("kimi-k2.7-code");
-    mockAgent();
-
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/chat`,
-    });
-
-    const editor = await findComposerEditor();
-    const input = editor.parentElement;
-    expect(input).toBeInstanceOf(HTMLElement);
-    expect(input).toHaveClass("min-h-[96px]");
-    expect(input).not.toHaveClass("min-h-[134px]");
-
-    await selectTemplate(user, template);
-
-    await waitFor(() => {
-      expect(input).toHaveClass(
-        "min-h-[134px]",
-        "[&_.ProseMirror]:min-h-[134px]",
-      );
-    });
-
-    await user.click(
-      screen.getByLabelText(`Remove template ${template.title}`),
-    );
-
-    await waitFor(() => {
-      expect(input).toHaveClass("min-h-[96px]");
-      expect(input).not.toHaveClass("min-h-[134px]");
-    });
   });
 
   it("uses the mobile single-line height in chat thread composers", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -1,6 +1,7 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { pathname } from "../../../signals/location.ts";
@@ -21,6 +22,7 @@ import {
   mockThread,
   mockComposerThreadSnapshot,
   findComposerEditor,
+  selectTemplate,
   placeCaretAfterText,
   workflowSummary,
 } from "./chat-composer-test-helpers.ts";
@@ -59,6 +61,42 @@ describe("chat composer models", () => {
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[96px]");
     expect(editor).not.toHaveClass("min-h-[44px]");
+  });
+
+  it("expands the agent chat composer above an attached template chip", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const editor = await findComposerEditor();
+    const input = editor.parentElement;
+    expect(input).toBeInstanceOf(HTMLElement);
+    expect(input).toHaveClass("min-h-[96px]");
+    expect(input).not.toHaveClass("min-h-[134px]");
+
+    await selectTemplate(user, template);
+
+    await waitFor(() => {
+      expect(input).toHaveClass(
+        "min-h-[134px]",
+        "[&_.ProseMirror]:min-h-[134px]",
+      );
+    });
+
+    await user.click(
+      screen.getByLabelText(`Remove template ${template.title}`),
+    );
+
+    await waitFor(() => {
+      expect(input).toHaveClass("min-h-[96px]");
+      expect(input).not.toHaveClass("min-h-[134px]");
+    });
   });
 
   it("uses the mobile single-line height in chat thread composers", async () => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -397,6 +397,7 @@ export function TiptapWorkflowComposer({
   const setWorkflowNames = useSet(composer.setWorkflowNames$);
   const setEventHandlers = useSet(composer.setEventHandlers$);
   const insertPromptMarkdown = useSet(composer.insertPromptMarkdown$);
+  const hasTemplateAttachment = useGet(composer.hasTemplateAttachment$);
   const containerRefSignal = singleLineOnMobile
     ? composer.setCompactContainerRef$
     : autoFocus
@@ -458,11 +459,22 @@ export function TiptapWorkflowComposer({
           }
         }}
       />
-      <div
-        className={`relative ${singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]"}`}
-      >
+      <div className="relative">
         <WorkflowComposerPlaceholder composer={composer} sending={sending} />
-        <div ref={setContainerRef} />
+        <div
+          // The template chip is 32px tall with 6px bottom spacing. Reserve
+          // those 38px above the input instead of letting the chip consume it.
+          className={
+            hasTemplateAttachment
+              ? singleLineOnMobile
+                ? "min-h-[82px] md:min-h-[134px] [&_.ProseMirror]:min-h-[82px] md:[&_.ProseMirror]:min-h-[134px]"
+                : "min-h-[134px] [&_.ProseMirror]:min-h-[134px]"
+              : singleLineOnMobile
+                ? "min-h-[44px] md:min-h-[96px]"
+                : "min-h-[96px]"
+          }
+          ref={setContainerRef}
+        />
       </div>
       {suggestionMenu.showWorkflows && (
         <SlashWorkflowMenu


### PR DESCRIPTION
## Summary

- preserve the existing message input area when a template attachment chip is added
- grow the composer upward by the chip height on desktop and mobile layouts
- restore the original composer height when the template is removed
- cover the attach and remove flow through the existing agent chat page test

## Verification

- `pnpm exec prettier --write` on the changed files
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --maxWorkers=1` (84 tests passed)
