### PR TITLE
refactor(runner): remove claim resource telemetry

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -33,9 +33,7 @@ use crate::idle_pool::{
 };
 use crate::ids::RunId;
 use crate::paths::short_digest;
-use crate::provider::{
-    ClaimedJob, JobCandidate, LocalAdmissionResourceKind, SessionAffinityLocalResource,
-};
+use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
@@ -70,15 +68,6 @@ struct LocalAdmission {
 enum LocalAdmissionResource {
     Fresh(BudgetLease),
     Reusable(Box<ReservedIdleSandbox>),
-}
-
-impl LocalAdmissionResource {
-    fn kind(&self) -> LocalAdmissionResourceKind {
-        match self {
-            Self::Fresh(_) => LocalAdmissionResourceKind::Fresh,
-            Self::Reusable(_) => LocalAdmissionResourceKind::ReusableSandbox,
-        }
-    }
 }
 
 struct AdmittedClaim {
@@ -373,8 +362,6 @@ async fn claim_with_local_admission(
             .await?
         }
     };
-    candidate.set_local_admission_resource(resource.kind());
-
     // Insert cancel token before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
     // find the active job. Skip duplicate discoveries; overwriting would break
@@ -467,9 +454,6 @@ async fn prepare_affinity_protected_candidate(
         )
         .await
         {
-            let mut candidate = candidate;
-            candidate
-                .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
             return Some(PreparedAffinityCandidate {
                 candidate,
                 resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
@@ -520,10 +504,6 @@ async fn prepare_affinity_protected_candidate(
             )
             .await
             {
-                let mut candidate = candidate;
-                candidate.set_session_affinity_local_resource(
-                    SessionAffinityLocalResource::ReusableSandbox,
-                );
                 return Some(PreparedAffinityCandidate {
                     candidate,
                     resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
@@ -540,10 +520,6 @@ async fn prepare_affinity_protected_candidate(
             )
             .await
             {
-                let mut candidate = candidate;
-                candidate.set_session_affinity_local_resource(
-                    SessionAffinityLocalResource::ReusableSandbox,
-                );
                 return Some(PreparedAffinityCandidate {
                     candidate,
                     resource: Some(LocalAdmissionResource::Reusable(Box::new(reservation))),
@@ -563,10 +539,6 @@ async fn prepare_affinity_protected_candidate(
                 && let Some(lease) =
                     ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
             {
-                let mut candidate = candidate;
-                candidate.set_session_affinity_local_resource(
-                    SessionAffinityLocalResource::WorkspaceCache,
-                );
                 return Some(PreparedAffinityCandidate {
                     candidate,
                     resource: Some(LocalAdmissionResource::Fresh(lease)),

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -350,25 +350,12 @@ async fn reusable_affinity_reservation_is_restored_after_claim_conflict() {
         "lost claim should restore the generic reusable reservation"
     );
     assert_eq!(budget.allocated(), (2, 4096, 1));
-    let candidates = env.handle.claim_candidates();
-    let candidate = candidates
-        .iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("generic reusable candidate should reach claim");
-    assert_eq!(
-        candidate.session_affinity_local_resource(),
-        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
-    );
-    assert_eq!(
-        candidate.local_admission_resource(),
-        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
-    );
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn reusable_claim_without_generation_target_reports_selected_resources() {
+async fn reusable_claim_without_generation_target_reuses_sandbox() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
@@ -409,14 +396,6 @@ async fn reusable_claim_without_generation_target_reports_selected_resources() {
     assert_eq!(
         candidate.session_affinity_resource(),
         Some(SessionAffinityResource::ReusableSandbox)
-    );
-    assert_eq!(
-        candidate.session_affinity_local_resource(),
-        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
-    );
-    assert_eq!(
-        candidate.local_admission_resource(),
-        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
     );
 
     shutdown(&env, run_handle).await;
@@ -777,14 +756,6 @@ async fn expired_generation_protection_preserves_local_session_claim() {
         .iter()
         .find(|candidate| candidate.run_id() == run_id)
         .expect("claim should record the protected candidate");
-    assert_eq!(
-        claimed_candidate.session_affinity_local_resource(),
-        Some(crate::provider::SessionAffinityLocalResource::ReusableSandbox)
-    );
-    assert_eq!(
-        claimed_candidate.local_admission_resource(),
-        Some(crate::provider::LocalAdmissionResourceKind::ReusableSandbox)
-    );
     assert!(
         claimed_candidate
             .main_loop_to_local_admission_elapsed()
@@ -909,14 +880,6 @@ async fn resource_class_workspace_cache_defers_for_reusable_then_claims_workspac
     assert_eq!(
         claimed_candidate.session_affinity_resource(),
         Some(SessionAffinityResource::WorkspaceCache)
-    );
-    assert_eq!(
-        claimed_candidate.session_affinity_local_resource(),
-        Some(crate::provider::SessionAffinityLocalResource::WorkspaceCache)
-    );
-    assert_eq!(
-        claimed_candidate.local_admission_resource(),
-        Some(crate::provider::LocalAdmissionResourceKind::Fresh)
     );
     assert_eq!(
         env.handle.deferred_poll_delays().len(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -25,7 +25,6 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    LocalAdmissionResourceKind, SessionAffinityLocalResource,
 };
 use crate::duration::duration_ms;
 use crate::error::{ApiStatusError, RunnerError, RunnerResult};
@@ -60,12 +59,6 @@ struct ClaimRequestTelemetry {
     provider_discovery_to_main_loop_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     main_loop_to_local_admission_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    session_affinity_resource: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    session_affinity_local_resource: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    local_admission_resource: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_due_to_job_discovered_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -844,15 +837,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             direct_candidate_inbox_wait_ms,
             provider_discovery_to_main_loop_ms,
             main_loop_to_local_admission_ms,
-            session_affinity_resource: candidate
-                .session_affinity_resource()
-                .map(crate::types::SessionAffinityResource::as_str),
-            session_affinity_local_resource: candidate
-                .session_affinity_local_resource()
-                .map(SessionAffinityLocalResource::as_str),
-            local_admission_resource: candidate
-                .local_admission_resource()
-                .map(LocalAdmissionResourceKind::as_str),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
                 .map(claim_telemetry_duration_ms),
@@ -1641,7 +1625,7 @@ mod tests {
         let now = std::time::Instant::now();
         let target_generation_run_id: RunId =
             "00000000-0000-0000-0000-000000000099".parse().unwrap();
-        let mut candidate = JobCandidate::new_with_timing_for_test(
+        let candidate = JobCandidate::new_with_timing_for_test(
             RunId::nil(),
             crate::profile::DEFAULT_PROFILE.to_string(),
             now.checked_sub(Duration::from_millis(25)).unwrap(),
@@ -1654,9 +1638,6 @@ mod tests {
         .with_history_generation_run_id(Some(target_generation_run_id))
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
-        candidate
-            .set_session_affinity_local_resource(SessionAffinityLocalResource::ReusableSandbox);
-        candidate.set_local_admission_resource(LocalAdmissionResourceKind::ReusableSandbox);
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
@@ -1674,18 +1655,13 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
-        assert_eq!(
-            body["telemetry"]["sessionAffinityResource"],
-            "reusableSandbox"
+        assert!(body["telemetry"].get("sessionAffinityResource").is_none());
+        assert!(
+            body["telemetry"]
+                .get("sessionAffinityLocalResource")
+                .is_none()
         );
-        assert_eq!(
-            body["telemetry"]["sessionAffinityLocalResource"],
-            "reusableSandbox"
-        );
-        assert_eq!(
-            body["telemetry"]["localAdmissionResource"],
-            "reusableSandbox"
-        );
+        assert!(body["telemetry"].get("localAdmissionResource").is_none());
         assert!(
             !body
                 .to_string()

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -45,36 +45,6 @@ impl JobDiscoverySource {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum SessionAffinityLocalResource {
-    ReusableSandbox,
-    WorkspaceCache,
-}
-
-impl SessionAffinityLocalResource {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ReusableSandbox => "reusableSandbox",
-            Self::WorkspaceCache => "workspaceCache",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LocalAdmissionResourceKind {
-    ReusableSandbox,
-    Fresh,
-}
-
-impl LocalAdmissionResourceKind {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ReusableSandbox => "reusableSandbox",
-            Self::Fresh => "fresh",
-        }
-    }
-}
-
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -95,8 +65,6 @@ pub struct JobCandidate {
     poll_http_request_elapsed: Option<Duration>,
     cli_agent_session_id: Option<String>,
     session_affinity_resource: Option<SessionAffinityResource>,
-    session_affinity_local_resource: Option<SessionAffinityLocalResource>,
-    local_admission_resource: Option<LocalAdmissionResourceKind>,
     history_generation_run_id: Option<RunId>,
     history_generation_affinity_protected_until: Option<DateTime<Utc>>,
     affinity_protected_until: Option<DateTime<Utc>>,
@@ -130,8 +98,6 @@ impl JobCandidate {
             poll_http_request_elapsed: None,
             cli_agent_session_id: None,
             session_affinity_resource: None,
-            session_affinity_local_resource: None,
-            local_admission_resource: None,
             history_generation_run_id: None,
             history_generation_affinity_protected_until: None,
             affinity_protected_until: None,
@@ -228,14 +194,6 @@ impl JobCandidate {
         self.session_affinity_resource
     }
 
-    pub(crate) fn session_affinity_local_resource(&self) -> Option<SessionAffinityLocalResource> {
-        self.session_affinity_local_resource
-    }
-
-    pub(crate) fn local_admission_resource(&self) -> Option<LocalAdmissionResourceKind> {
-        self.local_admission_resource
-    }
-
     pub(crate) fn history_generation_run_id(&self) -> Option<RunId> {
         self.history_generation_run_id
     }
@@ -298,17 +256,6 @@ impl JobCandidate {
             .as_deref()
             .and_then(parse_affinity_protected_until);
         self
-    }
-
-    pub(crate) fn set_session_affinity_local_resource(
-        &mut self,
-        resource: SessionAffinityLocalResource,
-    ) {
-        self.session_affinity_local_resource = Some(resource);
-    }
-
-    pub(crate) fn set_local_admission_resource(&mut self, resource: LocalAdmissionResourceKind) {
-        self.local_admission_resource = Some(resource);
     }
 
     pub(crate) fn with_discovery_source(mut self, source: JobDiscoverySource) -> Self {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -54,15 +54,6 @@ pub enum SessionAffinityResource {
     WorkspaceCache,
 }
 
-impl SessionAffinityResource {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ReusableSandbox => "reusableSandbox",
-            Self::WorkspaceCache => "workspaceCache",
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Claim (execution context)
 // ---------------------------------------------------------------------------

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -138,8 +138,6 @@ const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "mountPath",
   "runner_id",
   "runnerId",
-  "target_runner_id",
-  "targetRunnerId",
   "cli_agent_session_id",
   "cliAgentSessionId",
   "sandbox_token",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -362,8 +362,6 @@ const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "mountPath",
   "runner_id",
   "runnerId",
-  "target_runner_id",
-  "targetRunnerId",
   "cli_agent_session_id",
   "cliAgentSessionId",
   "sandbox_token",
@@ -7917,7 +7915,7 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 });
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
-  it("accepts a previous runner generation relationship", async () => {
+  it("accepts previous runner telemetry", async () => {
     const api = createRunsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
@@ -7928,6 +7926,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     const claim = await api.requestRawClaimRunnerJob(true, run.runId, [200], {
       telemetry: {
+        sessionAffinityResource: "workspaceCache",
+        sessionAffinityLocalResource: "workspaceCache",
+        localAdmissionResource: "fresh",
         sessionHistoryGenerationRelationship: "different",
       },
     });
@@ -8020,9 +8021,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           discoverySource: "poll",
           jobDiscoveredToClaimRequestMs: 1234,
           localAdmissionToClaimRequestMs: 56,
-          sessionAffinityResource: "workspaceCache",
-          sessionAffinityLocalResource: "reusableSandbox",
-          localAdmissionResource: "reusableSandbox",
           pollDueToJobDiscoveredMs: 789,
           pollHttpRequestMs: 321,
           pollReason: "deferred",
@@ -8118,9 +8116,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         auth_type: "user",
         discovery_source: "poll",
         poll_reason: "deferred",
-        session_affinity_resource: "workspaceCache",
-        session_affinity_local_resource: "reusableSandbox",
-        local_admission_resource: "reusableSandbox",
       }),
     );
     expect(
@@ -8138,9 +8133,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         auth_type: "user",
         discovery_source: "poll",
         poll_reason: "deferred",
-        session_affinity_resource: "workspaceCache",
-        session_affinity_local_resource: "reusableSandbox",
-        local_admission_resource: "reusableSandbox",
       }),
     );
     for (const actionType of RUNNER_POLL_TIMING_ACTION_TYPES) {
@@ -8187,9 +8179,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           auth_type: "user",
           discovery_source: "poll",
           poll_reason: "deferred",
-          session_affinity_resource: "workspaceCache",
-          session_affinity_local_resource: "reusableSandbox",
-          local_admission_resource: "reusableSandbox",
         }),
       );
     }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1617,9 +1617,6 @@ interface ClaimTimingTelemetry {
   readonly directCandidateInboxWaitMs?: number;
   readonly providerDiscoveryToMainLoopMs?: number;
   readonly mainLoopToLocalAdmissionMs?: number;
-  readonly sessionAffinityResource?: string;
-  readonly sessionAffinityLocalResource?: string;
-  readonly localAdmissionResource?: string;
   readonly pollDueToJobDiscoveredMs?: number;
   readonly pollHttpRequestMs?: number;
   readonly pollReason?: string;
@@ -1672,9 +1669,6 @@ function scheduleSuccessfulClaimSideEffects(args: {
     providerDiscoveryToMainLoopMs:
       args.telemetry?.providerDiscoveryToMainLoopMs,
     mainLoopToLocalAdmissionMs: args.telemetry?.mainLoopToLocalAdmissionMs,
-    sessionAffinityResource: args.telemetry?.sessionAffinityResource,
-    sessionAffinityLocalResource: args.telemetry?.sessionAffinityLocalResource,
-    localAdmissionResource: args.telemetry?.localAdmissionResource,
     discoverySource: args.telemetry?.discoverySource,
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
@@ -1700,9 +1694,6 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly directCandidateInboxWaitMs: number | undefined;
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
-  readonly sessionAffinityResource: string | undefined;
-  readonly sessionAffinityLocalResource: string | undefined;
-  readonly localAdmissionResource: string | undefined;
   readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
@@ -1738,9 +1729,6 @@ interface ClaimTimingMetricArgs {
   readonly directCandidateInboxWaitMs: number | undefined;
   readonly providerDiscoveryToMainLoopMs: number | undefined;
   readonly mainLoopToLocalAdmissionMs: number | undefined;
-  readonly sessionAffinityResource: string | undefined;
-  readonly sessionAffinityLocalResource: string | undefined;
-  readonly localAdmissionResource: string | undefined;
   readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
@@ -1838,16 +1826,6 @@ function claimTimingDimensions(
   }
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
-  }
-  if (args.sessionAffinityResource) {
-    dimensions.session_affinity_resource = args.sessionAffinityResource;
-  }
-  if (args.sessionAffinityLocalResource) {
-    dimensions.session_affinity_local_resource =
-      args.sessionAffinityLocalResource;
-  }
-  if (args.localAdmissionResource) {
-    dimensions.local_admission_resource = args.localAdmissionResource;
   }
   return dimensions;
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -716,18 +716,18 @@ describe("runner claim capability contract", () => {
         directCandidateInboxWaitMs: 2,
         providerDiscoveryToMainLoopMs: 3,
         mainLoopToLocalAdmissionMs: 4,
-        sessionAffinityResource: "workspaceCache",
-        sessionAffinityLocalResource: "workspaceCache",
-        localAdmissionResource: "fresh",
       },
     });
 
     expect(result.success).toBe(true);
   });
 
-  it("accepts and strips a previous runner generation relationship", () => {
+  it("accepts and strips previous runner telemetry", () => {
     const body = runnersJobClaimContract.claim.body.parse({
       telemetry: {
+        sessionAffinityResource: "workspaceCache",
+        sessionAffinityLocalResource: "workspaceCache",
+        localAdmissionResource: "fresh",
         sessionHistoryGenerationRelationship: "fresh",
       },
     });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -81,11 +81,6 @@ export const sessionAffinityResourceSchema = z.enum([
   "reusableSandbox",
   "workspaceCache",
 ]);
-const sessionAffinityLocalResourceSchema = z.enum([
-  "reusableSandbox",
-  "workspaceCache",
-]);
-const runnerLocalAdmissionResourceSchema = z.enum(["reusableSandbox", "fresh"]);
 
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
 const runnerClaimTelemetrySchema = z.object({
@@ -100,9 +95,6 @@ const runnerClaimTelemetrySchema = z.object({
   directCandidateInboxWaitMs: z.number().int().nonnegative().optional(),
   providerDiscoveryToMainLoopMs: z.number().int().nonnegative().optional(),
   mainLoopToLocalAdmissionMs: z.number().int().nonnegative().optional(),
-  sessionAffinityResource: sessionAffinityResourceSchema.optional(),
-  sessionAffinityLocalResource: sessionAffinityLocalResourceSchema.optional(),
-  localAdmissionResource: runnerLocalAdmissionResourceSchema.optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
   pollHttpRequestMs: z.number().int().nonnegative().optional(),
   pollReason: runnerClaimPollReasonSchema.optional(),


### PR DESCRIPTION
## Summary

- remove `sessionAffinityResource`, `sessionAffinityLocalResource`, and
  `localAdmissionResource` from runner claim telemetry and API claim timing dimensions
- remove the runner candidate state and classification code that existed only to emit those fields
- preserve the behavior-bearing queued-job `sessionAffinityResource`, runner admission logic, and
  API-derived poll/notification resource dimensions
- preserve old-runner compatibility by accepting and stripping the retired claim fields
- remove expired `targetRunnerId` telemetry-test residue

## Compatibility

The removed claim fields were optional. Old runners may continue sending them to the new API, where
they are stripped, while new runners remain compatible with an old API by omitting them.

This PR changes no database schema, persisted state, queue payload, heartbeat payload, guest
protocol, affinity scheduling, or resource admission behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only -t 'accepts previous runner telemetry|dispatches, scopes, and claims runs through user API keys'`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/api-contracts`
- `pnpm knip --workspace api`
- pre-commit hooks, including repository-wide Turbo type checking and Knip

Closes #22229

Parent context: #22028
