### PR TITLE
ci: validate app e2e on cloudflare pr previews

### DIFF
--- a/.github/scripts/resolve-app-preview-url.sh
+++ b/.github/scripts/resolve-app-preview-url.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 3 )); then
+  echo "usage: $0 <job-ref> <preview-domain> <cloudflare-preview-domain>" >&2
+  exit 1
+fi
+
+job_ref="$1"
+preview_domain="$2"
+cloudflare_preview_domain="$3"
+
+: "${job_ref:?job ref is required}"
+: "${preview_domain:?preview domain is required}"
+
+if [[ "$job_ref" =~ ^pr-[0-9]+$ ]]; then
+  : "${cloudflare_preview_domain:?Cloudflare preview domain is required for PR app previews}"
+  printf 'https://%s-app.%s\n' "$job_ref" "$cloudflare_preview_domain"
+else
+  printf 'https://%s-app.%s\n' "$job_ref" "$preview_domain"
+fi

--- a/.github/scripts/tests/resolve-app-preview-url-test.sh
+++ b/.github/scripts/tests/resolve-app-preview-url-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/resolve-app-preview-url.sh"
+
+test "$(bash "$script" pr-22085 vm6.ai omby.ai)" = "https://pr-22085-app.omby.ai"
+test "$(bash "$script" staging vm6.ai omby.ai)" = "https://staging-app.vm6.ai"
+
+if bash "$script" pr-22085 vm6.ai '' >/dev/null 2>&1; then
+  echo "expected a missing Cloudflare preview domain to be rejected for PR previews" >&2
+  exit 1
+fi
+
+if bash "$script" '' vm6.ai omby.ai >/dev/null 2>&1; then
+  echo "expected a missing job ref to be rejected" >&2
+  exit 1
+fi
+
+echo "resolve-app-preview-url tests passed"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -273,14 +273,19 @@ jobs:
         run: |
           JOB_REF="${{ steps.set-job-ref.outputs.job-ref }}"
           PREVIEW_DOMAIN="${{ vars.PREVIEW_DOMAIN }}"
+          CF_PAGES_PREVIEW_DOMAIN="${{ vars.CF_PAGES_PREVIEW_DOMAIN }}"
 
           if [ -n "$PREVIEW_DOMAIN" ] && [ -n "$JOB_REF" ]; then
+            APP_URL="$(bash .github/scripts/resolve-app-preview-url.sh \
+              "$JOB_REF" \
+              "$PREVIEW_DOMAIN" \
+              "$CF_PAGES_PREVIEW_DOMAIN")"
             {
-              echo "app-url=https://${JOB_REF}-app.${PREVIEW_DOMAIN}"
+              echo "app-url=${APP_URL}"
               echo "api-url=https://${JOB_REF}-api.${PREVIEW_DOMAIN}"
               echo "www-url=https://${JOB_REF}-www.${PREVIEW_DOMAIN}"
             } >> "$GITHUB_OUTPUT"
-            echo "Preview URLs set for app, api, and www on ${PREVIEW_DOMAIN}"
+            echo "App preview URL set to ${APP_URL}; API and WWW previews use ${PREVIEW_DOMAIN}"
           else
             {
               echo "app-url="
@@ -1579,7 +1584,7 @@ jobs:
     concurrency:
       group: cli-e2e-02-browser-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-api, deploy-app]
+    needs: [prepare, deploy-api, deploy-app, build-app-cf]
     if: |
       always() &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1591,7 +1596,10 @@ jobs:
         needs.prepare.outputs.e2e-changed == 'true'
       ) &&
       needs.deploy-api.result == 'success' &&
-      needs.deploy-app.result == 'success'
+      (
+        (startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.build-app-cf.result == 'success') ||
+        (!startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.deploy-app.result == 'success')
+      )
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1607,8 +1615,8 @@ jobs:
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
         env:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
-          VM0_AUTH_URL: ${{ needs.deploy-app.outputs.preview-url }}
-          VM0_AUTH_REDIRECT_URL: ${{ needs.deploy-app.outputs.preview-url }}/_/skeleton
+          VM0_AUTH_URL: ${{ needs.prepare.outputs.app-preview-url }}
+          VM0_AUTH_REDIRECT_URL: ${{ needs.prepare.outputs.app-preview-url }}/_/skeleton
           VM0_AUTH_DOMAIN: ${{ startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.prepare.outputs.api-preview-url != '' && format('{0}-api.{1}', needs.prepare.outputs.job-ref, vars.PREVIEW_DOMAIN || 'vm6.ai') || '' }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -1633,6 +1641,7 @@ jobs:
       - alias-onboarding-www
       - deploy-api
       - deploy-app
+      - build-app-cf
       - deploy-stripe-listener
     if: |
       always() &&
@@ -1646,7 +1655,10 @@ jobs:
       ) &&
       needs.deploy-api.result == 'success' &&
       (github.event_name == 'push' || needs.alias-onboarding-www.result == 'success') &&
-      needs.deploy-app.result == 'success' &&
+      (
+        (startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.build-app-cf.result == 'success') ||
+        (!startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.deploy-app.result == 'success')
+      ) &&
       (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success')
     steps:
       - uses: actions/checkout@v7
@@ -1714,7 +1726,7 @@ jobs:
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts
         env:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
-          VM0_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
+          VM0_APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
           VM0_ONBOARDING_URL: ${{ needs.prepare.outputs.www-preview-url || vars.ONBOARDING_URL_STAGING || 'https://staging-www.vm6.ai' }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -2659,6 +2671,7 @@ jobs:
       - alias-onboarding-www
       - deploy-api
       - deploy-app
+      - build-app-cf
       - deploy-stripe-listener
       - build-cli
       - build-e2b-template
@@ -2693,10 +2706,15 @@ jobs:
           if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ]; then
             RUNNER_E2E_SKIP_ALLOWED=""
           fi
+          CF_APP_SKIP_ALLOWED=""
           if [ "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}" = "true" ]; then
             # External fork PRs cannot access runner infra secrets, so their
             # runner deployment and runner E2E jobs are expected to skip.
             RUNNER_E2E_SKIP_ALLOWED="true"
+            CF_APP_SKIP_ALLOWED="true"
+          fi
+          if [ "${{ github.actor == 'dependabot[bot]' }}" = "true" ]; then
+            CF_APP_SKIP_ALLOWED="true"
           fi
 
           check_result() {
@@ -2743,6 +2761,7 @@ jobs:
           check_result "alias-onboarding-www" "${{ needs.alias-onboarding-www.result }}" "true"
           check_result "deploy-api" "${{ needs.deploy-api.result }}" "true"
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"
+          check_result "build-app-cf" "${{ needs.build-app-cf.result }}" "$CF_APP_SKIP_ALLOWED"
           check_result "deploy-stripe-listener" "${{ needs.deploy-stripe-listener.result }}" "true"
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "test": "tsx --test playwright/lib/clerk-api.test.ts"
+    "test": "tsx --test playwright/lib/clerk-api.test.ts playwright/lib/onboarding-handoff-url.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/e2e/playwright/lib/onboarding-handoff-url.test.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { rewritePreviewAppFallbackUrl } from "./onboarding-handoff-url";
+
+const previewAppOrigin = "https://pr-22231-app.omby.ai";
+const previewOnboardingOrigin = "https://pr-22231-www.vm6.ai";
+
+test("rewrites the standing app handoff to a cross-domain preview app", () => {
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    new URL("https://staging-app.vm6.ai/agents/agent-1/chat?source=e2e#run"),
+    previewAppOrigin,
+    previewOnboardingOrigin,
+  );
+
+  assert.equal(
+    rewrittenUrl,
+    "https://pr-22231-app.omby.ai/agents/agent-1/chat?source=e2e#run",
+  );
+});
+
+test("preserves the same-domain preview handoff", () => {
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    new URL("https://staging-app.vm6.ai/prompt"),
+    "https://pr-22231-app.vm6.ai",
+    previewOnboardingOrigin,
+  );
+
+  assert.equal(rewrittenUrl, "https://pr-22231-app.vm6.ai/prompt");
+});
+
+test("rewrites a nested Clerk redirect to the preview app", () => {
+  const authUrl = new URL("https://staging-app.vm6.ai/sign-in");
+  authUrl.searchParams.set(
+    "redirect_url",
+    "https://staging-app.vm6.ai/prompt?source=clerk",
+  );
+
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    authUrl,
+    previewAppOrigin,
+    previewOnboardingOrigin,
+  );
+
+  assert.ok(rewrittenUrl);
+  const rewrittenAuthUrl = new URL(rewrittenUrl);
+  assert.equal(rewrittenAuthUrl.origin, previewAppOrigin);
+
+  const redirectUrl = rewrittenAuthUrl.searchParams.get("redirect_url");
+  assert.ok(redirectUrl);
+  assert.equal(redirectUrl, "https://pr-22231-app.omby.ai/prompt?source=clerk");
+});
+
+test("keeps an unrelated app origin unchanged", () => {
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    new URL("https://staging-app.example.com/prompt"),
+    previewAppOrigin,
+    previewOnboardingOrigin,
+  );
+
+  assert.equal(rewrittenUrl, null);
+});
+
+test("keeps a non-preview onboarding handoff unchanged", () => {
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    new URL("https://staging-app.vm6.ai/prompt"),
+    "https://staging-app.vm6.ai",
+    "https://staging-www.vm6.ai",
+  );
+
+  assert.equal(rewrittenUrl, null);
+});

--- a/e2e/playwright/lib/onboarding-handoff-url.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.ts
@@ -1,0 +1,70 @@
+export function rewritePreviewAppFallbackUrl(
+  url: URL,
+  appOrigin: string,
+  onboardingOrigin: string,
+): string | null {
+  const rewrittenUrl = withExpectedPreviewAppOrigin(
+    url,
+    appOrigin,
+    onboardingOrigin,
+  );
+  if (!rewrittenUrl) {
+    return null;
+  }
+
+  rewriteNestedRedirectUrl(rewrittenUrl, appOrigin, onboardingOrigin);
+  return rewrittenUrl.toString();
+}
+
+function withExpectedPreviewAppOrigin(
+  url: URL,
+  appOrigin: string,
+  onboardingOrigin: string,
+): URL | null {
+  if (url.origin !== previewAppFallbackOrigin(onboardingOrigin)) {
+    return null;
+  }
+
+  const appUrl = new URL(appOrigin);
+  const rewrittenUrl = new URL(url.toString());
+  rewrittenUrl.protocol = appUrl.protocol;
+  rewrittenUrl.host = appUrl.host;
+  return rewrittenUrl;
+}
+
+function previewAppFallbackOrigin(onboardingOrigin: string): string | null {
+  const onboardingUrl = new URL(onboardingOrigin);
+  const previewDomainMatch = /^pr-\d+-www\.(.+)$/.exec(onboardingUrl.hostname);
+  if (!previewDomainMatch) {
+    return null;
+  }
+
+  onboardingUrl.hostname = `staging-app.${previewDomainMatch[1]}`;
+  return onboardingUrl.origin;
+}
+
+function rewriteNestedRedirectUrl(
+  url: URL,
+  appOrigin: string,
+  onboardingOrigin: string,
+): void {
+  const redirectUrl = url.searchParams.get("redirect_url");
+  if (!redirectUrl) {
+    return;
+  }
+
+  try {
+    const rewrittenRedirectUrl = withExpectedPreviewAppOrigin(
+      new URL(redirectUrl),
+      appOrigin,
+      onboardingOrigin,
+    );
+    if (rewrittenRedirectUrl) {
+      url.searchParams.set("redirect_url", rewrittenRedirectUrl.toString());
+    }
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+  }
+}

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 import { deriveServiceOrigin } from "../playwright.config";
 import { signInFromCurrentHostedAuthPage } from "./auth";
+import { rewritePreviewAppFallbackUrl } from "./onboarding-handoff-url";
 
 type AuthHeaders = Readonly<
   Record<"Authorization", string> &
@@ -68,7 +69,7 @@ export async function startVideoOnboardingCheckout(
 
 export async function waitForPaidOnboardingAppHandoff(
   page: Page,
-  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "onboardingUrl" | "auth">,
 ): Promise<URL> {
   return await waitForPaidOnboardingHandoff(page, options, 180_000);
 }
@@ -110,7 +111,7 @@ async function clickOnboardingButton(page: Page, name: RegExp): Promise<void> {
 
 async function waitForChatPage(
   page: Page,
-  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "onboardingUrl" | "auth">,
   continueAfterAuth: (() => Promise<void>) | undefined,
 ): Promise<void> {
   await waitForOnboardingHandoff(
@@ -124,23 +125,25 @@ async function waitForChatPage(
 
 async function waitForOnboardingHandoff(
   page: Page,
-  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "onboardingUrl" | "auth">,
   isTargetUrl: (url: URL) => boolean,
   timeout: number,
   continueAfterAuth?: () => Promise<void>,
 ): Promise<URL> {
   const configuredAppOrigin = new URL(options.appUrl).origin;
+  const onboardingOrigin = new URL(options.onboardingUrl).origin;
+  const isExpectedTargetUrl = (url: URL) =>
+    url.origin === configuredAppOrigin && isTargetUrl(url);
   await waitForExpectedUrl(
     page,
     configuredAppOrigin,
-    (url) =>
-      (url.origin === configuredAppOrigin && isTargetUrl(url)) ||
-      isHostedSignInUrl(url),
+    onboardingOrigin,
+    (url) => isExpectedTargetUrl(url) || isHostedSignInUrl(url),
     timeout,
   );
 
   const currentUrl = new URL(page.url());
-  if (isTargetUrl(currentUrl)) {
+  if (isExpectedTargetUrl(currentUrl)) {
     return currentUrl;
   }
 
@@ -150,26 +153,18 @@ async function waitForOnboardingHandoff(
     );
   }
 
-  const redirectOrigin = redirectOriginFromAuthUrl(currentUrl);
   await signInFromCurrentHostedAuthPage(page, options.auth.email, {
     activeOrganizationId: options.auth.activeOrganizationId,
   });
-  const isAllowedTargetUrl = (url: URL) => {
-    return (
-      isTargetUrl(url) &&
-      (url.origin === configuredAppOrigin ||
-        url.origin === redirectOrigin ||
-        redirectOrigin === null)
-    );
-  };
   await waitForExpectedUrl(
     page,
     configuredAppOrigin,
-    (url) => isAllowedTargetUrl(url) || isOnboardingUrl(url),
+    onboardingOrigin,
+    (url) => isExpectedTargetUrl(url) || isOnboardingUrl(url),
     timeout,
   );
   const postAuthUrl = new URL(page.url());
-  if (isAllowedTargetUrl(postAuthUrl)) {
+  if (isExpectedTargetUrl(postAuthUrl)) {
     return postAuthUrl;
   }
 
@@ -183,7 +178,8 @@ async function waitForOnboardingHandoff(
   await waitForExpectedUrl(
     page,
     configuredAppOrigin,
-    isAllowedTargetUrl,
+    onboardingOrigin,
+    isExpectedTargetUrl,
     timeout,
   );
   return new URL(page.url());
@@ -201,6 +197,7 @@ type UrlMatcher = (url: URL) => boolean;
 async function waitForExpectedUrl(
   page: Page,
   appOrigin: string,
+  onboardingOrigin: string,
   matchesExpectedUrl: UrlMatcher,
   timeoutMs: number,
 ): Promise<URL> {
@@ -208,7 +205,11 @@ async function waitForExpectedUrl(
 
   while (true) {
     const currentUrl = new URL(page.url());
-    const rewrittenUrl = rewritePreviewAppFallbackUrl(currentUrl, appOrigin);
+    const rewrittenUrl = rewritePreviewAppFallbackUrl(
+      currentUrl,
+      appOrigin,
+      onboardingOrigin,
+    );
     if (rewrittenUrl) {
       console.log("[e2e] rewriting onboarding preview handoff", {
         from: currentUrl.toString(),
@@ -232,68 +233,9 @@ async function waitForExpectedUrl(
     await page.waitForURL(
       (url) =>
         matchesExpectedUrl(url) ||
-        rewritePreviewAppFallbackUrl(url, appOrigin) !== null,
+        rewritePreviewAppFallbackUrl(url, appOrigin, onboardingOrigin) !== null,
       { timeout: remainingMs, waitUntil: "domcontentloaded" },
     );
-  }
-}
-
-function rewritePreviewAppFallbackUrl(
-  url: URL,
-  appOrigin: string,
-): string | null {
-  const rewrittenUrl = withExpectedPreviewAppOrigin(url, appOrigin);
-  if (!rewrittenUrl) {
-    return null;
-  }
-
-  rewriteNestedRedirectUrl(rewrittenUrl, appOrigin);
-  return rewrittenUrl.toString();
-}
-
-function withExpectedPreviewAppOrigin(url: URL, appOrigin: string): URL | null {
-  if (!isPreviewAppStagingFallback(url, appOrigin)) {
-    return null;
-  }
-
-  const appUrl = new URL(appOrigin);
-  const rewrittenUrl = new URL(url.toString());
-  rewrittenUrl.protocol = appUrl.protocol;
-  rewrittenUrl.host = appUrl.host;
-  return rewrittenUrl;
-}
-
-function isPreviewAppStagingFallback(url: URL, appOrigin: string): boolean {
-  const appUrl = new URL(appOrigin);
-  const previewDomainMatch = /^pr-\d+-app\.(.+)$/.exec(appUrl.hostname);
-  if (!previewDomainMatch) {
-    return false;
-  }
-
-  return (
-    url.protocol === appUrl.protocol &&
-    url.hostname === `staging-app.${previewDomainMatch[1]}`
-  );
-}
-
-function rewriteNestedRedirectUrl(url: URL, appOrigin: string): void {
-  const redirectUrl = url.searchParams.get("redirect_url");
-  if (!redirectUrl) {
-    return;
-  }
-
-  try {
-    const rewrittenRedirectUrl = withExpectedPreviewAppOrigin(
-      new URL(redirectUrl),
-      appOrigin,
-    );
-    if (rewrittenRedirectUrl) {
-      url.searchParams.set("redirect_url", rewrittenRedirectUrl.toString());
-    }
-  } catch (error) {
-    if (!(error instanceof TypeError)) {
-      throw error;
-    }
   }
 }
 
@@ -313,17 +255,13 @@ function isOnboardingUrl(url: URL): boolean {
   return url.pathname.startsWith("/onboarding/");
 }
 
-function redirectOriginFromAuthUrl(url: URL): string | null {
-  const redirectUrl = url.searchParams.get("redirect_url");
-  return redirectUrl ? new URL(redirectUrl).origin : null;
-}
-
 async function waitForPaidOnboardingHandoff(
   page: Page,
-  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "onboardingUrl" | "auth">,
   timeout: number,
 ): Promise<URL> {
   const configuredAppOrigin = new URL(options.appUrl).origin;
+  const onboardingOrigin = new URL(options.onboardingUrl).origin;
   const deadline = Date.now() + timeout;
   let nextBillingReturnReloadAt: number | null = null;
 
@@ -332,6 +270,7 @@ async function waitForPaidOnboardingHandoff(
     const rewrittenUrl = rewritePreviewAppFallbackUrl(
       currentUrl,
       configuredAppOrigin,
+      onboardingOrigin,
     );
     if (rewrittenUrl) {
       console.log("[e2e] rewriting paid onboarding preview handoff", {

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -41,6 +41,7 @@ test("paid onboarding completes through the video workflow", async ({
     await fillStripeCheckout(page);
     const handoffUrl = await waitForPaidOnboardingAppHandoff(page, {
       appUrl,
+      onboardingUrl,
       auth: { email, activeOrganizationId: orgId },
     });
 


### PR DESCRIPTION
## Summary

- resolve PR app preview URLs to `pr-<id>-app.omby.ai` while keeping staging, API, and WWW previews on `vm6.ai`
- configure preview API `APP_URL`, Clerk browser E2E, and Playwright E2E to use the Cloudflare Pages custom domain
- require the Cloudflare Pages preview job for internal CI, while preserving expected skips for forks and Dependabot
- derive the standing App onboarding fallback from the PR WWW origin, then continue both onboarding flows on the configured PR App origin
- preserve nested Clerk `redirect_url` rewriting across preview domains and reject unrelated origins
- add focused tests for preview URL resolution and onboarding handoff rewriting

## User impact

Pull requests now exercise the app through the same Cloudflare Pages serving path used by `app.okou.ai`. This makes Pages deployment, custom-domain, SPA, authentication, onboarding, and browser-flow regressions visible before merge instead of validating only the Vercel app preview.

## Verification

- `bash -n .github/scripts/resolve-app-preview-url.sh .github/scripts/tests/resolve-app-preview-url-test.sh`
- `bash .github/scripts/tests/resolve-app-preview-url-test.sh`
- `npx --yes prettier@3.8.1 --check .github/workflows/turbo.yml`
- `actionlint .github/workflows/turbo.yml`
- `pnpm dlx prettier@3.8.1 --check e2e/package.json e2e/playwright/lib/onboarding.ts e2e/playwright/lib/onboarding-handoff-url.ts e2e/playwright/lib/onboarding-handoff-url.test.ts e2e/playwright/tests/paid-onboarding.spec.ts`
- `pnpm --dir e2e check-types`
- `pnpm --dir e2e exec tsx --test playwright/lib/clerk-api.test.ts playwright/lib/onboarding-handoff-url.test.ts` (11 passed)
- full local Vitest suite not run, per repository PR verification guidance
