### PR TITLE
refactor(api): align checkpoint artifact response with record wire

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -901,8 +901,10 @@ describe("RUN-04: session and checkpoint reads", () => {
     expect(checkpoint.body).toMatchObject({
       id: withArtifacts.body.checkpointId,
       runId: r1.runId,
-      artifactSnapshots: { "bdd-out": outArtifact.vasVersionId },
       volumeVersionsSnapshot: { versions: { data: "vol-v1" } },
+    });
+    expect(checkpoint.body.artifactSnapshots).toStrictEqual({
+      "bdd-out": outArtifact.vasVersionId,
     });
     if (checkpoint.status !== 200) {
       throw new Error("Expected the checkpoint read to succeed");

--- a/turbo/packages/api-contracts/src/contracts/sessions.ts
+++ b/turbo/packages/api-contracts/src/contracts/sessions.ts
@@ -35,25 +35,6 @@ const volumeVersionsSnapshotSchema = z.object({
 });
 
 /**
- * Artifact snapshots schema.
- *
- * Tolerant union accepting both the legacy `Record<name, version>` map
- * (pre-#10911 guest-agent payloads) and the canonical `Array<{name, version,
- * mountPath}>` form (post-#10911). The GET-by-id handler echoes whatever shape
- * is stored in the JSONB column; CLI consumers tolerate both via the union.
- */
-const artifactSnapshotsSchema = z.union([
-  z.record(z.string(), z.string()),
-  z.array(
-    z.object({
-      name: z.string(),
-      version: z.string(),
-      mountPath: z.string(),
-    }),
-  ),
-]);
-
-/**
  * Checkpoint response schema
  * Represents an immutable snapshot of agent run state
  */
@@ -62,11 +43,9 @@ const checkpointResponseSchema = z.object({
   runId: z.string(),
   conversationId: z.string(),
   agentComposeSnapshot: agentComposeSnapshotSchema,
-  // Multi-artifact snapshot payload. Accepts both the legacy
-  // `Record<name, version>` map and the canonical
-  // `Array<{name, version, mountPath}>` form. Null when the checkpoint has
-  // no artifacts.
-  artifactSnapshots: artifactSnapshotsSchema.nullable(),
+  // Checkpoints persist context-artifact arrays, while the GET handler
+  // projects them to this stable name-to-version response map.
+  artifactSnapshots: z.record(z.string(), z.string()).nullable(),
   volumeVersionsSnapshot: volumeVersionsSnapshotSchema.nullable(),
   createdAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- narrow checkpoint GET `artifactSnapshots` to the record-or-null shape the
  endpoint has always returned
- document that persisted context-artifact arrays are projected to the stable
  name-to-version response map
- strengthen the existing public API BDD journey with an exact response-field
  assertion

## Compatibility

This does not change the HTTP wire, checkpoint writer, handler projection,
database schema, persisted data, resume behavior, or completion response.
Previous and current CLI/backend combinations continue exchanging a record or
`null`.

## Validation

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (436 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts`
  (19 tests)
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/cli check-types`
- scoped Knip analysis for the affected contract, API, core, and CLI workspaces
- staged pre-commit hooks, including full Knip and full Turbo type checking
- `git diff --check`

Closes #22216
