### PR TITLE
fix(runner): fail local cancel on incomplete claim scan

### DIFF
--- a/crates/runner/src/cmd/local/cancel.rs
+++ b/crates/runner/src/cmd/local/cancel.rs
@@ -24,10 +24,26 @@ pub struct CancelArgs {
 }
 
 pub async fn run_cancel(args: CancelArgs) -> RunnerResult<ExitCode> {
-    run_cancel_with_home(args, HomePaths::new()?).await
+    run_cancel_with_home(
+        args,
+        HomePaths::new()?,
+        read_claim_entries,
+        inspect_claim_entry,
+    )
+    .await
 }
 
-async fn run_cancel_with_home(args: CancelArgs, home: HomePaths) -> RunnerResult<ExitCode> {
+async fn run_cancel_with_home<ReadEntries, Entries, Entry, InspectEntry>(
+    args: CancelArgs,
+    home: HomePaths,
+    read_entries: ReadEntries,
+    inspect_entry: InspectEntry,
+) -> RunnerResult<ExitCode>
+where
+    ReadEntries: FnOnce(&std::path::Path) -> std::io::Result<Entries>,
+    Entries: IntoIterator<Item = std::io::Result<Entry>>,
+    InspectEntry: FnMut(Entry) -> std::io::Result<ClaimEntry>,
+{
     if args.run.is_empty() {
         return Err(RunnerError::Config("run_id must not be empty".into()));
     }
@@ -48,7 +64,7 @@ async fn run_cancel_with_home(args: CancelArgs, home: HomePaths) -> RunnerResult
         ))
     })?;
 
-    let run_id = resolve_run_id(&group_dir, &args.run)?;
+    let run_id = resolve_run_id(&group_dir, &args.run, read_entries, inspect_entry)?;
 
     local_queue::ensure_cancels_dir(&group_dir)
         .map_err(|e| RunnerError::Internal(format!("create cancel dir: {e}")))?;
@@ -60,9 +76,42 @@ async fn run_cancel_with_home(args: CancelArgs, home: HomePaths) -> RunnerResult
     Ok(ExitCode::SUCCESS)
 }
 
+struct ClaimEntry {
+    path: std::path::PathBuf,
+    is_file: bool,
+}
+
+fn read_claim_entries(claims_dir: &std::path::Path) -> std::io::Result<std::fs::ReadDir> {
+    std::fs::read_dir(claims_dir)
+}
+
+fn inspect_claim_entry(entry: std::fs::DirEntry) -> std::io::Result<ClaimEntry> {
+    let path = entry.path();
+    let is_file = entry
+        .file_type()
+        .map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!("inspect claim entry {}: {e}", path.display()),
+            )
+        })?
+        .is_file();
+    Ok(ClaimEntry { path, is_file })
+}
+
 /// Resolve a (possibly prefix) run ID against group-wide `.claim` files.
 /// Returns an error if the prefix is ambiguous or matches nothing.
-fn resolve_run_id(group_dir: &std::path::Path, prefix: &str) -> RunnerResult<RunId> {
+fn resolve_run_id<ReadEntries, Entries, Entry, InspectEntry>(
+    group_dir: &std::path::Path,
+    prefix: &str,
+    read_entries: ReadEntries,
+    mut inspect_entry: InspectEntry,
+) -> RunnerResult<RunId>
+where
+    ReadEntries: FnOnce(&std::path::Path) -> std::io::Result<Entries>,
+    Entries: IntoIterator<Item = std::io::Result<Entry>>,
+    InspectEntry: FnMut(Entry) -> std::io::Result<ClaimEntry>,
+{
     let Some(claims_dir) = validated_claims_dir(group_dir)? else {
         return Err(RunnerError::Config(format!(
             "no claimed job matches prefix '{prefix}'"
@@ -83,25 +132,39 @@ fn resolve_run_id(group_dir: &std::path::Path, prefix: &str) -> RunnerResult<Run
     }
 
     // Prefix match against .claim files.
-    let entries = match std::fs::read_dir(&claims_dir) {
+    let entries = match read_entries(&claims_dir) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Err(RunnerError::Config(format!(
                 "no claimed job matches prefix '{prefix}'"
             )));
         }
-        Err(e) => return Err(RunnerError::Config(format!("read claims dir: {e}"))),
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "read claims directory {}: {e}",
+                claims_dir.display()
+            )));
+        }
     };
 
     let mut matches = Vec::new();
-    for entry in entries.filter_map(Result::ok) {
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if !file_type.is_file() {
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            RunnerError::Config(format!(
+                "read entry in claims directory {}: {e}",
+                claims_dir.display()
+            ))
+        })?;
+        let entry = inspect_entry(entry).map_err(|e| {
+            RunnerError::Config(format!(
+                "inspect entry in claims directory {}: {e}",
+                claims_dir.display()
+            ))
+        })?;
+        if !entry.is_file {
             continue;
         }
-        let path = entry.path();
+        let path = entry.path;
         if path.extension().and_then(|e| e.to_str()) != Some("claim") {
             continue;
         }
@@ -151,6 +214,20 @@ mod tests {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
+    fn resolve_run_id_from_fs(group_dir: &std::path::Path, prefix: &str) -> RunnerResult<RunId> {
+        resolve_run_id(group_dir, prefix, read_claim_entries, inspect_claim_entry)
+    }
+
+    async fn run_cancel_with_fs(args: CancelArgs, home: HomePaths) -> RunnerResult<ExitCode> {
+        run_cancel_with_home(args, home, read_claim_entries, inspect_claim_entry).await
+    }
+
+    fn fail_prefix_read(
+        _claims_dir: &std::path::Path,
+    ) -> std::io::Result<std::iter::Empty<std::io::Result<ClaimEntry>>> {
+        Err(std::io::Error::other("prefix reader must not be called"))
+    }
+
     #[test]
     fn resolve_exact_uuid() {
         let dir = tempfile::tempdir().unwrap();
@@ -158,7 +235,7 @@ mod tests {
         std::fs::create_dir_all(local_queue::claims_dir(dir.path())).unwrap();
         std::fs::write(local_queue::claim_path(dir.path(), id), b"").unwrap();
 
-        let resolved = resolve_run_id(dir.path(), &id.to_string()).unwrap();
+        let resolved = resolve_run_id_from_fs(dir.path(), &id.to_string()).unwrap();
         assert_eq!(resolved, id);
     }
 
@@ -170,14 +247,14 @@ mod tests {
         std::fs::write(local_queue::claim_path(dir.path(), id), b"").unwrap();
 
         let prefix = &id.to_string()[..8];
-        let resolved = resolve_run_id(dir.path(), prefix).unwrap();
+        let resolved = resolve_run_id_from_fs(dir.path(), prefix).unwrap();
         assert_eq!(resolved, id);
     }
 
     #[test]
     fn resolve_no_match() {
         let dir = tempfile::tempdir().unwrap();
-        let err = resolve_run_id(dir.path(), "deadbeef").unwrap_err();
+        let err = resolve_run_id_from_fs(dir.path(), "deadbeef").unwrap_err();
         assert!(err.to_string().contains("no claimed job"), "got: {err}");
     }
 
@@ -191,7 +268,7 @@ mod tests {
         std::fs::write(local_queue::claim_path(dir.path(), id2), b"").unwrap();
 
         // Empty prefix matches every `.claim` file, so two files guarantee ambiguity.
-        let err = resolve_run_id(dir.path(), "").unwrap_err();
+        let err = resolve_run_id_from_fs(dir.path(), "").unwrap_err();
         assert!(err.to_string().contains("ambiguous"), "got: {err}");
     }
 
@@ -200,7 +277,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let id = RunId::new_v4();
         // No .claim file written.
-        let err = resolve_run_id(dir.path(), &id.to_string()).unwrap_err();
+        let err = resolve_run_id_from_fs(dir.path(), &id.to_string()).unwrap_err();
         assert!(err.to_string().contains("no claimed job"), "got: {err}");
     }
 
@@ -214,12 +291,12 @@ mod tests {
         std::fs::write(&target, b"").unwrap();
         symlink(&target, local_queue::claim_path(dir.path(), id)).unwrap();
 
-        let exact_err = resolve_run_id(dir.path(), &id.to_string()).unwrap_err();
+        let exact_err = resolve_run_id_from_fs(dir.path(), &id.to_string()).unwrap_err();
         assert!(
             exact_err.to_string().contains("no claimed job"),
             "got: {exact_err}"
         );
-        let prefix_err = resolve_run_id(dir.path(), &id.to_string()[..8]).unwrap_err();
+        let prefix_err = resolve_run_id_from_fs(dir.path(), &id.to_string()[..8]).unwrap_err();
         assert!(
             prefix_err.to_string().contains("no claimed job"),
             "got: {prefix_err}"
@@ -227,7 +304,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_cancel_writes_group_wide_cancel_file() {
+    async fn run_cancel_exact_uuid_skips_prefix_reader_and_writes_cancel_file() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
         let group_dir = home.groups_dir().join("test/group");
@@ -241,6 +318,8 @@ mod tests {
                 group: "test/group".into(),
             },
             home,
+            fail_prefix_read,
+            Ok,
         )
         .await
         .unwrap();
@@ -250,6 +329,90 @@ mod tests {
         assert!(cancel_path.exists());
         assert_eq!(mode(&local_queue::cancels_dir(&group_dir)), 0o700);
         assert_eq!(mode(&cancel_path), 0o600);
+    }
+
+    #[tokio::test]
+    async fn run_cancel_rejects_incomplete_claim_enumeration_without_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group_dir = home.groups_dir().join("test/group");
+        let claims_dir = local_queue::ensure_claims_dir(&group_dir).unwrap();
+        let run_id = RunId::new_v4();
+        let claim_path = local_queue::claim_path(&group_dir, run_id);
+        local_queue::write_private_marker(&claim_path, "test claim marker").unwrap();
+        let entries = vec![
+            Ok(ClaimEntry {
+                path: claim_path.clone(),
+                is_file: true,
+            }),
+            Err(std::io::Error::other("injected enumeration failure")),
+        ];
+
+        let err = run_cancel_with_home(
+            CancelArgs {
+                run: run_id.to_string()[..8].into(),
+                group: "test/group".into(),
+            },
+            home,
+            move |_claims_dir| Ok(entries.into_iter()),
+            Ok,
+        )
+        .await
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains(&claims_dir.display().to_string()),
+            "got: {err}"
+        );
+        assert!(
+            message.contains("injected enumeration failure"),
+            "got: {err}"
+        );
+        assert!(!local_queue::cancel_path(&group_dir, run_id).exists());
+        assert!(!local_queue::cancels_dir(&group_dir).exists());
+    }
+
+    #[tokio::test]
+    async fn run_cancel_rejects_claim_inspection_error_without_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group_dir = home.groups_dir().join("test/group");
+        let claims_dir = local_queue::ensure_claims_dir(&group_dir).unwrap();
+        let run_id = RunId::new_v4();
+        let claim_path = local_queue::claim_path(&group_dir, run_id);
+        local_queue::write_private_marker(&claim_path, "test claim marker").unwrap();
+        let entries = vec![Ok(claim_path.clone())];
+
+        let err = run_cancel_with_home(
+            CancelArgs {
+                run: run_id.to_string()[..8].into(),
+                group: "test/group".into(),
+            },
+            home,
+            move |_claims_dir| Ok(entries.into_iter()),
+            |path: std::path::PathBuf| -> std::io::Result<ClaimEntry> {
+                Err(std::io::Error::other(format!(
+                    "inspect claim entry {}: injected file type failure",
+                    path.display()
+                )))
+            },
+        )
+        .await
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains(&claims_dir.display().to_string()),
+            "got: {err}"
+        );
+        assert!(
+            message.contains(&claim_path.display().to_string()),
+            "got: {err}"
+        );
+        assert!(message.contains("injected file type failure"), "got: {err}");
+        assert!(!local_queue::cancel_path(&group_dir, run_id).exists());
+        assert!(!local_queue::cancels_dir(&group_dir).exists());
     }
 
     #[tokio::test]
@@ -265,7 +428,7 @@ mod tests {
         let group_dir = org_dir.join("group");
         symlink(&target, &group_dir).unwrap();
 
-        let err = run_cancel_with_home(
+        let err = run_cancel_with_fs(
             CancelArgs {
                 run: RunId::new_v4().to_string(),
                 group: "test/group".into(),
@@ -293,7 +456,7 @@ mod tests {
         std::fs::write(target.join(format!("{run_id}.claim")), b"").unwrap();
         symlink(&target, local_queue::claims_dir(&group_dir)).unwrap();
 
-        let err = run_cancel_with_home(
+        let err = run_cancel_with_fs(
             CancelArgs {
                 run: run_id.to_string()[..8].into(),
                 group: "test/group".into(),


### PR DESCRIPTION
## Summary

- fail non-exact local-cancel prefix resolution when claims-directory iteration is incomplete
- propagate directory-entry and file-type inspection errors with actionable path context
- preserve direct full-UUID lookup, one-pass prefix matching, and existing file filtering
- cover both injected failure paths through the command mutation gate and verify no cancel marker is created

## Scope

- Changes are limited to `crates/runner/src/cmd/local/cancel.rs`.
- This does not add queue locking or change the existing point-in-time scan semantics.
- This does not change queue formats, filenames, protocols, APIs, migrations, deployment compatibility, or unrelated best-effort directory scans.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::local::cancel::tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit workspace Rust formatting, Clippy, and documentation hooks

Closes #22189
