### PR TITLE
perf(vsock-host): copy exec output outside state lock

### DIFF
--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -125,6 +125,18 @@ fn owned_output_event(output: vsock_proto::DecodedExecOutput<'_>) -> ExecOutputE
     }
 }
 
+#[cfg(test)]
+fn run_exec_output_before_copy_hook(shared: &Arc<Shared>) {
+    let hook = shared
+        .exec_output_before_copy_hook
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .take();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 fn owned_result(
     result: vsock_proto::DecodedExecResult<'_>,
     stream_overflowed: bool,
@@ -157,7 +169,8 @@ pub(crate) fn dispatch_incoming_frame(
 
 fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
     let mut first_output_slow = None;
-    {
+    let mut senders_to_drop = None;
+    let prepared_output = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { operations, .. } = &mut *guard
             && let Some(operation) = operations.get_mut(msg.seq)
@@ -171,19 +184,57 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
             }
             validate_output(operation, &decoded)?;
             first_output_slow = operation.diagnostic.mark_first_output();
-            if let Some(tx) = operation.stream_tx.take() {
+            // Keep the registered sender in state so teardown can clear it
+            // while payload ownership happens outside the lock.
+            if let Some(tx) = operation.stream_tx.clone() {
                 match tx.try_reserve_owned() {
-                    Ok(permit) => {
-                        operation.stream_tx = Some(permit.send(owned_output_event(decoded)));
-                    }
-                    Err(mpsc::error::TrySendError::Full(_)) => {
+                    Ok(permit) => Some((permit, decoded)),
+                    Err(mpsc::error::TrySendError::Full(tx)) => {
                         operation.stream_overflowed = true;
+                        senders_to_drop = Some((operation.stream_tx.take(), tx));
+                        None
                     }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {}
+                    Err(mpsc::error::TrySendError::Closed(tx)) => {
+                        senders_to_drop = Some((operation.stream_tx.take(), tx));
+                        None
+                    }
                 }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+    drop(senders_to_drop);
+
+    let returned_sender = if let Some((permit, decoded)) = prepared_output {
+        #[cfg(test)]
+        run_exec_output_before_copy_hook(shared);
+
+        let event = owned_output_event(decoded);
+        {
+            let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+            // Channel identity rejects a replacement operation after sequence
+            // wrap; holding state makes the check and delivery atomic with teardown.
+            let sender_matches = if let ConnectionState::Connected { operations, .. } = &mut *guard
+                && let Some(operation) = operations.get_mut(msg.seq)
+                && let Some(tx) = operation.stream_tx.as_ref()
+            {
+                permit.same_channel_as_sender(tx)
+            } else {
+                false
+            };
+            if sender_matches {
+                Some(permit.send(event))
+            } else {
+                None
             }
         }
-    }
+    } else {
+        None
+    };
+    drop(returned_sender);
 
     if let Some(snapshot) = first_output_slow {
         tracing::warn!(

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -96,6 +96,18 @@ pub(crate) mod test_support {
         drop(ExecOperationFrameWriteGuard::new(shared, state));
     }
 
+    pub(crate) fn set_exec_output_before_copy_hook(
+        shared: &Arc<Shared>,
+        hook: impl FnOnce() + Send + 'static,
+    ) {
+        let previous = shared
+            .exec_output_before_copy_hook
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .replace(Box::new(hook));
+        assert!(previous.is_none(), "exec output copy hook already set");
+    }
+
     pub(crate) async fn start_supervised_exec_after_start_write<F>(
         shared: &Arc<Shared>,
         request: SupervisedExecRequest<'_>,

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -422,6 +422,7 @@ fn shared_with_logged_operation(
         }),
         normal_operations: crate::operation_tracker::NormalOperationTracker::new(),
         close_notify: tokio::sync::Notify::new(),
+        exec_output_before_copy_hook: std::sync::Mutex::new(None),
     });
     let mut diagnostic = ExecOperationDiagnostic::new(7, label);
     diagnostic.registered_at =

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -237,6 +237,9 @@ struct Shared {
     /// Notified when the connection closes. Pure signalling — all state is in
     /// `state`.
     close_notify: Notify,
+    /// One-shot test hook at the unlocked exec-output payload-copy boundary.
+    #[cfg(test)]
+    exec_output_before_copy_hook: std::sync::Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 struct ListenerSocketGuard {
@@ -961,6 +964,8 @@ impl VsockHost {
             }),
             normal_operations: NormalOperationTracker::new(),
             close_notify: Notify::new(),
+            #[cfg(test)]
+            exec_output_before_copy_hook: std::sync::Mutex::new(None),
         });
 
         let reader_shared = Arc::clone(&shared);

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -9,10 +9,12 @@ use vsock_proto::{
 };
 
 use super::super::support::{
-    assert_connection_accepts_exec_operation, operation_count, read_guest_message,
+    assert_connection_accepts_exec_operation, is_connected, operation_count, read_guest_message,
     send_discarded_exec_result, send_exec_output, send_exec_result, setup_host_and_guest,
 };
-use crate::{ExecOperationRequest, ExecStreamRequest, exec_operation as exec_operation_impl};
+use crate::{
+    ConnectionState, ExecOperationRequest, ExecStreamRequest, exec_operation as exec_operation_impl,
+};
 
 fn stream_request(label: &str) -> ExecStreamRequest<'_> {
     ExecStreamRequest {
@@ -478,6 +480,61 @@ async fn exec_operation_stream_handles_output_and_pending_response_from_one_writ
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(!result.stream_overflowed);
     assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn exec_output_teardown_before_copy_discards_reserved_event() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let mut handle = host
+        .exec_operation_stream(stream_request("stream-copy-teardown"))
+        .await
+        .unwrap();
+    let mut rx = handle.take_stream_receiver().unwrap();
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    let seq = msg.seq;
+    let shared = Arc::downgrade(&host.shared);
+    exec_operation_impl::test_support::set_exec_output_before_copy_hook(&host.shared, move || {
+        let removed = std::thread::spawn(move || {
+            let Some(shared) = shared.upgrade() else {
+                return false;
+            };
+            let Ok(mut guard) = shared.state.try_lock() else {
+                return false;
+            };
+            let ConnectionState::Connected { operations, .. } = &mut *guard else {
+                return false;
+            };
+            operations.remove(seq);
+            true
+        })
+        .join()
+        .expect("operation teardown thread should not panic");
+        assert!(
+            removed,
+            "operation teardown should acquire the unlocked state and remove the operation"
+        );
+    });
+
+    send_exec_output(
+        &mut guest,
+        seq,
+        0,
+        ExecOutputStream::Stdout,
+        b"teardown",
+        false,
+    )
+    .await;
+
+    let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("stream should close after operation teardown");
+    assert!(event.is_none(), "reserved output must not survive teardown");
+    let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(operation_count(&host), 0);
+    assert!(is_connected(&host));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reserve exec-output queue capacity through a temporary sender clone, then copy the event payload after releasing the connection state lock
- commit delivery under the state lock only when the active sender still belongs to the reserved Tokio channel, preventing stale delivery after operation teardown or sequence reuse
- preserve output validation, byte accounting, truncation, queue overflow, and receiver-closed behavior
- add deterministic integration coverage for operation teardown at the unlocked copy boundary

## Scope

- no wire-format, public Rust API, guest behavior, persisted-state, or deployment compatibility changes
- no new benchmark harness; the regression test proves the critical-section boundary and teardown ordering without timing assertions

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features` (315 passed)
- focused teardown regression repeated 50 times
- repository pre-commit Rust format, documentation, and Clippy hooks

Closes #22188
