### PR TITLE
ci: run staging app e2e on cloudflare

### DIFF
--- a/.github/scripts/manage-okou-pages-domain.sh
+++ b/.github/scripts/manage-okou-pages-domain.sh
@@ -26,18 +26,20 @@ cloudflare_request() {
     --header "Content-Type: application/json"
 }
 
-dns_record_id() {
+dns_record() {
   cloudflare_request \
     "${dns_records_url}?type=CNAME&name=${domain}" |
-    jq -r '.result[0].id // empty'
+    jq -c '.result[0] // null'
 }
 
 upsert_cname() {
   local target="$1"
+  local record
   local record_id
   local body
 
-  record_id="$(dns_record_id)"
+  record="$(dns_record)"
+  record_id="$(jq -r '.id // empty' <<< "$record")"
   body="$(jq -n \
     --arg name "$domain" \
     --arg target "$target" \
@@ -51,6 +53,14 @@ upsert_cname() {
     }')"
 
   if [[ -n "$record_id" ]]; then
+    if jq -e \
+      --arg target "$target" \
+      '.type == "CNAME" and .content == $target and .proxied == true and .ttl == 1' \
+      <<< "$record" >/dev/null; then
+      echo "Cloudflare DNS record already configured: ${domain} -> ${target}"
+      return
+    fi
+
     cloudflare_request \
       --request PUT \
       "${dns_records_url}/${record_id}" \
@@ -110,7 +120,7 @@ case "$action" in
         "${pages_domains_url}/${domain}" >/dev/null
     fi
 
-    record_id="$(dns_record_id)"
+    record_id="$(dns_record | jq -r '.id // empty')"
     if [[ -n "$record_id" ]]; then
       cloudflare_request \
         --request DELETE \

--- a/.github/scripts/manage-okou-pages-domain.sh
+++ b/.github/scripts/manage-okou-pages-domain.sh
@@ -20,10 +20,29 @@ auth_header="Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
 pages_domains_url="${api_base}/accounts/${account_id}/pages/projects/${project_name}/domains"
 dns_records_url="${api_base}/zones/${zone_id}/dns_records"
 
-cloudflare_request() {
-  curl --fail-with-body --silent --show-error "$@" \
+cloudflare_response() {
+  curl --silent --show-error "$@" \
     --header "$auth_header" \
     --header "Content-Type: application/json"
+}
+
+cloudflare_request() {
+  cloudflare_response --fail-with-body "$@"
+}
+
+pages_domain_state() {
+  cloudflare_response "${pages_domains_url}/${domain}"
+}
+
+pages_domain_missing() {
+  jq -e 'any(.errors[]?; .code == 8000021)' >/dev/null
+}
+
+require_cloudflare_success() {
+  if jq -e '.success == false' >/dev/null; then
+    jq -r '.errors[]? | "Cloudflare API error \(.code): \(.message)"' >&2
+    return 1
+  fi
 }
 
 dns_record() {
@@ -77,16 +96,17 @@ case "$action" in
   ensure)
     : "${branch:?branch is required for ensure}"
 
-    domains="$(cloudflare_request "$pages_domains_url")"
-    if ! jq -e --arg domain "$domain" \
-      '.result[] | select(.name == $domain)' <<< "$domains" >/dev/null; then
+    domain_state="$(pages_domain_state)"
+    if pages_domain_missing <<< "$domain_state"; then
       cloudflare_request \
         --request POST \
         "$pages_domains_url" \
         --data "$(jq -n --arg name "$domain" '{name: $name}')" >/dev/null
+      domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
+    else
+      require_cloudflare_success <<< "$domain_state"
     fi
 
-    domain_state="$(cloudflare_request "${pages_domains_url}/${domain}")"
     domain_status="$(jq -r '.result.status' <<< "$domain_state")"
     verification_status="$(jq -r '.result.verification_data.status' <<< "$domain_state")"
 
@@ -112,9 +132,11 @@ case "$action" in
     echo "Cloudflare Pages custom branch domain configured: https://${domain}"
     ;;
   delete)
-    domains="$(cloudflare_request "$pages_domains_url")"
-    if jq -e --arg domain "$domain" \
-      '.result[] | select(.name == $domain)' <<< "$domains" >/dev/null; then
+    domain_state="$(pages_domain_state)"
+    if pages_domain_missing <<< "$domain_state"; then
+      :
+    else
+      require_cloudflare_success <<< "$domain_state"
       cloudflare_request \
         --request DELETE \
         "${pages_domains_url}/${domain}" >/dev/null

--- a/.github/scripts/resolve-app-preview-url.sh
+++ b/.github/scripts/resolve-app-preview-url.sh
@@ -13,8 +13,8 @@ cloudflare_preview_domain="$3"
 : "${job_ref:?job ref is required}"
 : "${preview_domain:?preview domain is required}"
 
-if [[ "$job_ref" =~ ^pr-[0-9]+$ ]]; then
-  : "${cloudflare_preview_domain:?Cloudflare preview domain is required for PR app previews}"
+if [[ "$job_ref" =~ ^pr-[0-9]+$ || "$job_ref" == "staging" ]]; then
+  : "${cloudflare_preview_domain:?Cloudflare preview domain is required for app previews}"
   printf 'https://%s-app.%s\n' "$job_ref" "$cloudflare_preview_domain"
 else
   printf 'https://%s-app.%s\n' "$job_ref" "$preview_domain"

--- a/.github/scripts/tests/manage-okou-pages-domain-test.sh
+++ b/.github/scripts/tests/manage-okou-pages-domain-test.sh
@@ -36,10 +36,19 @@ done
 
 case "$url" in
   */pages/projects/okou-app/domains)
-    printf '{"result":[{"name":"pr-22239-app.omby.ai"}]}\n'
+    if [[ "$method" != "POST" ]]; then
+      echo "the paginated Pages domain list must not be used for existence checks" >&2
+      exit 1
+    fi
+    printf '{"success":true,"result":{"name":"pr-22239-app.omby.ai"}}\n'
     ;;
   */pages/projects/okou-app/domains/pr-22239-app.omby.ai)
-    printf '{"result":{"status":"active","verification_data":{"status":"active"}}}\n'
+    if [[ "${MOCK_PAGES_DOMAIN_EXISTS:-true}" == "false" ]] && \
+      ! grep -q -- '--request POST' "$MOCK_CURL_LOG"; then
+      printf '{"success":false,"errors":[{"code":8000021,"message":"domain does not exist"}],"result":null}\n'
+    else
+      printf '{"success":true,"result":{"status":"active","verification_data":{"status":"active"}}}\n'
+    fi
     ;;
   *'/dns_records?type=CNAME&name=pr-22239-app.omby.ai')
     jq -n --arg content "$MOCK_DNS_CONTENT" '{result:[{
@@ -82,5 +91,12 @@ export MOCK_DNS_CONTENT="okou-app.pages.dev"
 PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
   ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
 grep -q -- '--request PUT' "$request_log"
+
+: > "$request_log"
+export MOCK_PAGES_DOMAIN_EXISTS="false"
+export MOCK_DNS_CONTENT="pr-22239-app.okou-app.pages.dev"
+PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+grep -q -- '--request POST' "$request_log"
 
 echo "manage-okou-pages-domain tests passed"

--- a/.github/scripts/tests/manage-okou-pages-domain-test.sh
+++ b/.github/scripts/tests/manage-okou-pages-domain-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/manage-okou-pages-domain.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "${tmp_dir}/bin"
+request_log="${tmp_dir}/requests.log"
+
+cat > "${tmp_dir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%q ' "$@" >> "$MOCK_CURL_LOG"
+printf '\n' >> "$MOCK_CURL_LOG"
+
+url=""
+method="GET"
+while (( $# > 0 )); do
+  case "$1" in
+    --request)
+      method="$2"
+      shift 2
+      ;;
+    http*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */pages/projects/okou-app/domains)
+    printf '{"result":[{"name":"pr-22239-app.omby.ai"}]}\n'
+    ;;
+  */pages/projects/okou-app/domains/pr-22239-app.omby.ai)
+    printf '{"result":{"status":"active","verification_data":{"status":"active"}}}\n'
+    ;;
+  *'/dns_records?type=CNAME&name=pr-22239-app.omby.ai')
+    jq -n --arg content "$MOCK_DNS_CONTENT" '{result:[{
+      id: "record-id",
+      type: "CNAME",
+      name: "pr-22239-app.omby.ai",
+      content: $content,
+      proxied: true,
+      ttl: 1
+    }]}'
+    ;;
+  */dns_records/record-id)
+    if [[ "$method" != "PUT" ]]; then
+      echo "expected a PUT for the existing DNS record" >&2
+      exit 1
+    fi
+    printf '{"success":true}\n'
+    ;;
+  *)
+    echo "unexpected Cloudflare request: ${method} ${url}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/bin/curl"
+
+export CLOUDFLARE_API_TOKEN="test-token"
+export MOCK_CURL_LOG="$request_log"
+
+export MOCK_DNS_CONTENT="pr-22239-app.okou-app.pages.dev"
+PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+if grep -q -- '--request PUT' "$request_log"; then
+  echo "expected an already-correct DNS record to skip PUT" >&2
+  exit 1
+fi
+
+: > "$request_log"
+export MOCK_DNS_CONTENT="okou-app.pages.dev"
+PATH="${tmp_dir}/bin:${PATH}" bash "$script" \
+  ensure account-id zone-id okou-app pr-22239-app.omby.ai pr-22239-app
+grep -q -- '--request PUT' "$request_log"
+
+echo "manage-okou-pages-domain tests passed"

--- a/.github/scripts/tests/resolve-app-preview-url-test.sh
+++ b/.github/scripts/tests/resolve-app-preview-url-test.sh
@@ -5,10 +5,15 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 script="${repo_root}/.github/scripts/resolve-app-preview-url.sh"
 
 test "$(bash "$script" pr-22085 vm6.ai omby.ai)" = "https://pr-22085-app.omby.ai"
-test "$(bash "$script" staging vm6.ai omby.ai)" = "https://staging-app.vm6.ai"
+test "$(bash "$script" staging vm6.ai omby.ai)" = "https://staging-app.omby.ai"
 
 if bash "$script" pr-22085 vm6.ai '' >/dev/null 2>&1; then
   echo "expected a missing Cloudflare preview domain to be rejected for PR previews" >&2
+  exit 1
+fi
+
+if bash "$script" staging vm6.ai '' >/dev/null 2>&1; then
+  echo "expected a missing Cloudflare preview domain to be rejected for staging previews" >&2
   exit 1
 fi
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1358,14 +1358,9 @@ jobs:
           {
             echo "dist=$pages_dist"
             echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
-            if [[ "$PAGES_BRANCH" == pr-*-app ]]; then
-              : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
-              echo "custom-domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
-              echo "custom-url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
-            else
-              echo "custom-domain="
-              echo "custom-url="
-            fi
+            : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
+            echo "custom-domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
+            echo "custom-url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
@@ -1584,7 +1579,7 @@ jobs:
     concurrency:
       group: cli-e2e-02-browser-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-api, deploy-app, build-app-cf]
+    needs: [prepare, deploy-api, build-app-cf]
     if: |
       always() &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1596,10 +1591,7 @@ jobs:
         needs.prepare.outputs.e2e-changed == 'true'
       ) &&
       needs.deploy-api.result == 'success' &&
-      (
-        (startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.build-app-cf.result == 'success') ||
-        (!startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.deploy-app.result == 'success')
-      )
+      needs.build-app-cf.result == 'success'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1617,7 +1609,7 @@ jobs:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
           VM0_AUTH_URL: ${{ needs.prepare.outputs.app-preview-url }}
           VM0_AUTH_REDIRECT_URL: ${{ needs.prepare.outputs.app-preview-url }}/_/skeleton
-          VM0_AUTH_DOMAIN: ${{ startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.prepare.outputs.api-preview-url != '' && format('{0}-api.{1}', needs.prepare.outputs.job-ref, vars.PREVIEW_DOMAIN || 'vm6.ai') || '' }}
+          VM0_AUTH_DOMAIN: ${{ needs.prepare.outputs.api-preview-url != '' && format('{0}-api.{1}', needs.prepare.outputs.job-ref, vars.PREVIEW_DOMAIN || 'vm6.ai') || '' }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+browser@vm0-e2e.ai
@@ -1640,7 +1632,6 @@ jobs:
       - prepare
       - alias-onboarding-www
       - deploy-api
-      - deploy-app
       - build-app-cf
       - deploy-stripe-listener
     if: |
@@ -1655,10 +1646,7 @@ jobs:
       ) &&
       needs.deploy-api.result == 'success' &&
       (github.event_name == 'push' || needs.alias-onboarding-www.result == 'success') &&
-      (
-        (startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.build-app-cf.result == 'success') ||
-        (!startsWith(needs.prepare.outputs.job-ref, 'pr-') && needs.deploy-app.result == 'success')
-      ) &&
+      needs.build-app-cf.result == 'success' &&
       (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success')
     steps:
       - uses: actions/checkout@v7

--- a/e2e/playwright/lib/onboarding-handoff-url.test.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.test.ts
@@ -61,12 +61,12 @@ test("keeps an unrelated app origin unchanged", () => {
   assert.equal(rewrittenUrl, null);
 });
 
-test("keeps a non-preview onboarding handoff unchanged", () => {
+test("rewrites the staging app handoff to the Cloudflare staging app", () => {
   const rewrittenUrl = rewritePreviewAppFallbackUrl(
     new URL("https://staging-app.vm6.ai/prompt"),
-    "https://staging-app.vm6.ai",
+    "https://staging-app.omby.ai",
     "https://staging-www.vm6.ai",
   );
 
-  assert.equal(rewrittenUrl, null);
+  assert.equal(rewrittenUrl, "https://staging-app.omby.ai/prompt");
 });

--- a/e2e/playwright/lib/onboarding-handoff-url.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.ts
@@ -34,7 +34,9 @@ function withExpectedPreviewAppOrigin(
 
 function previewAppFallbackOrigin(onboardingOrigin: string): string | null {
   const onboardingUrl = new URL(onboardingOrigin);
-  const previewDomainMatch = /^pr-\d+-www\.(.+)$/.exec(onboardingUrl.hostname);
+  const previewDomainMatch = /^(?:pr-\d+|staging)-www\.(.+)$/.exec(
+    onboardingUrl.hostname,
+  );
   if (!previewDomainMatch) {
     return null;
   }


### PR DESCRIPTION
## Summary

- publish `staging-app.omby.ai` as the custom domain for the Cloudflare Pages `staging-app` branch
- resolve staging App previews to `staging-app.omby.ai` while keeping staging API and WWW on `staging-api.vm6.ai` and `staging-www.vm6.ai`
- make Browser and Playwright E2E wait on the Cloudflare App deployment for both PR and staging runs
- rewrite staging onboarding handoffs from the standing Vercel App fallback to the configured Cloudflare staging App

## Verification

- `bash .github/scripts/tests/resolve-app-preview-url-test.sh`
- `bash .github/scripts/tests/resolve-okou-pages-branch-test.sh`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (11 tests passed)
- `actionlint .github/workflows/turbo.yml`
- Prettier 3.8.1 on the changed workflow and TypeScript files

## Deferred

The existing Vercel `deploy-app` job and aliases remain unchanged in this PR. They can be removed after the Cloudflare staging path has run successfully on `main`.
