### PR TITLE
fix(runner): preserve active tcp logs at run completion

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -39,17 +39,21 @@ _queued_writes = 0
 _drop_warning_logged = False
 
 
-def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
-    """Queue a JSONL line for best-effort append without blocking hook latency."""
+def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> bool:
+    """Queue a JSONL line for best-effort append without blocking hook latency.
+
+    Return whether the writer accepted the line. Append failures after
+    admission remain best effort and are reported asynchronously.
+    """
     global _pending_bytes, _queued_writes
 
     if not log_path:
-        return
+        return False
 
     dropped = False
     with _condition:
         if _shutdown:
-            return
+            return False
         line_size = len(line)
         if (
             _queued_writes >= MAX_PENDING_JSONL_WRITES
@@ -58,7 +62,7 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
             dropped = True
         elif not _ensure_worker_locked():
             _warn(f"Failed to start JSONL writer for {log_name} log")
-            return
+            return False
         else:
             sequence = _accepted_by_path.get(log_path, 0) + 1
             item = _WriteItem(
@@ -74,6 +78,8 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
 
     if dropped:
         _warn_drop_once(log_name)
+        return False
+    return True
 
 
 def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -33,17 +33,17 @@ def _utc_log_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
-def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
-    """Best-effort JSONL write for proxy-hook logging paths."""
+def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> bool:
+    """Best-effort JSONL admission for proxy-hook logging paths."""
     if not log_path:
-        return
+        return False
     try:
         line = (json.dumps(entry) + "\n").encode()
     except Exception as e:
         ctx.log.warn(f"Failed to encode {log_name} log: {type(e).__name__}: {e}")
-        return
+        return False
 
-    jsonl_writer.write_jsonl_line(log_path, line, log_name)
+    return jsonl_writer.write_jsonl_line(log_path, line, log_name)
 
 
 def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
@@ -81,12 +81,12 @@ def reset_log_writer_for_tests() -> None:
     jsonl_writer.reset_for_tests()
 
 
-def log_network_entry(log_path: str, entry: dict) -> None:
-    """Write a network log entry to the per-run JSONL file."""
+def log_network_entry(log_path: str, entry: dict) -> bool:
+    """Admit a network log entry to the per-run JSONL writer."""
     if not log_path:
-        return
+        return False
     log_entry = {**entry, "timestamp": _utc_log_timestamp()}
-    _write_jsonl_entry(log_path, log_entry, "network")
+    return _write_jsonl_entry(log_path, log_entry, "network")
 
 
 def sanitize_proxy_log_extra_value(key: str, value: object) -> object:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -27,8 +27,9 @@ from mitmproxy.addonmanager import Loader
 # --- Sub-module imports ---
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/matching/registry/
-# response_encoding_negotiation/response_streaming/runner_flush_lifecycle/terminal_usage/
-# upstream_admission/usage are imported by module (not selective `from X import ...`) so that:
+# response_encoding_negotiation/response_streaming/runner_flush_lifecycle/tcp_logging/
+# tcp_seal_lifecycle/terminal_usage/upstream_admission/usage are imported by module (not
+# selective `from X import ...`) so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
 #      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
 #      ``connector_intent.X(...)`` /
@@ -59,6 +60,7 @@ import response_encoding_negotiation
 import response_streaming
 import runner_flush_lifecycle
 import tcp_logging
+import tcp_seal_lifecycle
 import terminal_usage
 import upstream_admission
 import upstream_destination_binding
@@ -127,10 +129,7 @@ class _AuthBaseBodyCheck:
 def load(loader: Loader) -> None:
     """Register custom options for the addon."""
     mitmproxy_compat.install_request_end_stream_bridge()
-    signal.signal(
-        runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
-        runner_flush_lifecycle.handle_runner_usage_flush_signal,
-    )
+    signal.signal(runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL, handle_runner_flush_signal)
     loader.add_option(
         name="vm0_api_url",
         typespec=str,
@@ -217,6 +216,17 @@ def get_api_url() -> str:
 def get_registry_path() -> str:
     """Get registry path from options."""
     return ctx.options.vm0_proxy_registry_path
+
+
+def handle_runner_flush_signal(signum: int, frame: object) -> None:
+    """Wake independent runner-requested lifecycle workers."""
+    tcp_seal_lifecycle.handle_runner_tcp_seal_signal(signum, frame)
+    runner_flush_lifecycle.handle_runner_usage_flush_signal(signum, frame)
+
+
+def running() -> None:
+    """Capture the mitmproxy event loop that owns TCP flow state."""
+    tcp_logging.set_event_loop(asyncio.get_running_loop())
 
 
 def _request_headers_probe_metadata_keys() -> tuple[str, ...]:
@@ -1419,27 +1429,33 @@ def _handle_error(flow: http.HTTPFlow) -> None:
 def done():
     """Flush pending usage reports and forwarding workers before mitmproxy exits.
 
-    The runner flush lifecycle waits for any active SIGUSR1 worker, drains
-    accepted requests, and closes admission before this hook shuts down the
-    usage executor. Any retryable outcome retained by those completed workers
-    is then retried synchronously before the remaining workers and JSONL writer
-    stop. Auth.base forwarding does not need to finish running work
-    during shutdown, so its worker shutdown stops new forwards and best-effort
-    closes active upstream sockets without waiting for slow upstream responses.
-    JSONL writer shutdown is also bounded and best-effort; if it times out,
-    process shutdown continues with accepted log entries possibly still pending.
+    TCP seal admission closes without joining a worker that may be waiting on
+    this event loop. Remaining active TCP rows are admitted directly before the
+    runner flush lifecycle waits for its independent SIGUSR1 worker, drains
+    accepted requests, and closes admission. Any retryable usage outcome
+    retained by those completed workers is retried synchronously before the
+    remaining workers and JSONL writer stop. Auth.base forwarding does not need
+    to finish running work during shutdown, so its worker shutdown stops new
+    forwards and best-effort closes active upstream sockets without waiting for
+    slow upstream responses. JSONL writer shutdown is also bounded and
+    best-effort; if it times out, process shutdown continues with accepted log
+    entries possibly still pending.
     """
+    tcp_seal_lifecycle.close_admission()
     try:
-        runner_flush_lifecycle.drain_and_close()
+        tcp_logging.shutdown()
     finally:
         try:
-            try:
-                usage.webhook.usage_executor.shutdown(wait=True)
-                usage.drain_usage_events_after_executor_shutdown()
-            finally:
-                auth_base_forwarder.shutdown_forward_request_workers(wait=False)
+            runner_flush_lifecycle.drain_and_close()
         finally:
-            shutdown_log_writer()
+            try:
+                try:
+                    usage.webhook.usage_executor.shutdown(wait=True)
+                    usage.drain_usage_events_after_executor_shutdown()
+                finally:
+                    auth_base_forwarder.shutdown_forward_request_workers(wait=False)
+            finally:
+                shutdown_log_writer()
 
 
 # ============================================================================
@@ -1473,6 +1489,7 @@ def tcp_error(flow: tcp.TCPFlow) -> None:
 
 # mitmproxy addon registration
 addons = [
+    running,
     server_connect,
     server_disconnected,
     server_connect_error,

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -24,7 +24,7 @@ _TCP_LOG_FINALIZED = "_tcp_log_finalized"
 
 _event_loop: asyncio.AbstractEventLoop | None = None
 _active_flows_by_path: dict[str, dict[str, tcp.TCPFlow]] = {}
-_pending_seal_futures: set[Future[None]] = set()
+_pending_seal_futures: set[Future[bool]] = set()
 _pending_seal_futures_lock = threading.Lock()
 
 
@@ -60,7 +60,7 @@ def seal_path_from_thread(log_path: str, *, timeout: float) -> bool:
     if loop is None:
         raise RuntimeError("TCP logging event loop is not running")
 
-    future: Future[None] = Future()
+    future: Future[bool] = Future()
     with _pending_seal_futures_lock:
         _pending_seal_futures.add(future)
     try:
@@ -70,31 +70,30 @@ def seal_path_from_thread(log_path: str, *, timeout: float) -> bool:
         raise
 
     try:
-        future.result(timeout=timeout)
+        return future.result(timeout=timeout)
     except TimeoutError:
         future.cancel()
-        return False
+        raise
     except CancelledError:
-        return False
-    return True
+        raise RuntimeError("TCP logging path seal was cancelled") from None
 
 
-def _complete_path_seal(log_path: str, future: Future[None]) -> None:
+def _complete_path_seal(log_path: str, future: Future[bool]) -> None:
     if not future.set_running_or_notify_cancel():
         _discard_pending_seal_future(future)
         return
 
     try:
-        _seal_path(log_path)
+        sealed = _seal_path(log_path)
     except Exception as exc:
         future.set_exception(exc)
     else:
-        future.set_result(None)
+        future.set_result(sealed)
     finally:
         _discard_pending_seal_future(future)
 
 
-def _discard_pending_seal_future(future: Future[None]) -> None:
+def _discard_pending_seal_future(future: Future[bool]) -> None:
     with _pending_seal_futures_lock:
         _pending_seal_futures.discard(future)
 
@@ -173,10 +172,13 @@ def _remove_active_flow(flow: tcp.TCPFlow, log_path: str) -> None:
         _active_flows_by_path.pop(log_path, None)
 
 
-def _seal_path(log_path: str) -> None:
+def _seal_path(log_path: str) -> bool:
     active_flows = tuple(_active_flows_by_path.get(log_path, {}).values())
+    sealed = True
     for flow in active_flows:
-        _log_tcp(flow)
+        if not _log_tcp(flow):
+            sealed = False
+    return sealed
 
 
 def _tcp_counter_value(flow: tcp.TCPFlow, key: str) -> int:
@@ -184,13 +186,6 @@ def _tcp_counter_value(flow: tcp.TCPFlow, key: str) -> int:
     if type(value) is not int:
         return 0
     return max(0, min(value, logging_utils.NETWORK_LOG_MAX_SAFE_SIZE))
-
-
-def _has_tcp_size_counters(flow: tcp.TCPFlow) -> bool:
-    return (
-        type(flow.metadata.get(_TCP_REQUEST_SIZE)) is int
-        or type(flow.metadata.get(_TCP_RESPONSE_SIZE)) is int
-    )
 
 
 def _add_tcp_size(flow: tcp.TCPFlow, key: str, delta: int) -> None:
@@ -225,45 +220,23 @@ def _drain_tcp_messages(flow: tcp.TCPFlow) -> None:
     flow.messages.clear()
 
 
-def _sum_tcp_messages(flow: tcp.TCPFlow) -> tuple[int, int]:
-    request_size = 0
-    response_size = 0
-    for message in flow.messages:
-        if message.from_client:
-            request_size = min(
-                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
-                request_size + len(message.content),
-            )
-        else:
-            response_size = min(
-                logging_utils.NETWORK_LOG_MAX_SAFE_SIZE,
-                response_size + len(message.content),
-            )
-    return request_size, response_size
-
-
 def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
-    if flow.metadata.get(_TCP_MESSAGE_DRAIN_SCHEDULED, False) or _has_tcp_size_counters(flow):
-        _drain_tcp_messages(flow)
-        return (
-            _tcp_counter_value(flow, _TCP_REQUEST_SIZE),
-            _tcp_counter_value(flow, _TCP_RESPONSE_SIZE),
-        )
-
-    request_size, response_size = _sum_tcp_messages(flow)
-    flow.messages.clear()
-    return request_size, response_size
+    _drain_tcp_messages(flow)
+    return (
+        _tcp_counter_value(flow, _TCP_REQUEST_SIZE),
+        _tcp_counter_value(flow, _TCP_RESPONSE_SIZE),
+    )
 
 
-def _log_tcp(flow: tcp.TCPFlow) -> None:
+def _log_tcp(flow: tcp.TCPFlow) -> bool:
     if flow.metadata.get(_TCP_LOG_FINALIZED, False):
         _drain_tcp_messages(flow)
-        return
+        return True
 
     run_id = flow_metadata.run_id(flow.metadata)
     network_log_path = flow_metadata.network_log_path(flow.metadata)
     if not run_id or not network_log_path:
-        return
+        return False
 
     start_time = flow.metadata.get(metadata_keys.TCP_START_MONOTONIC)
     latency_ms = logging_utils.elapsed_ms(start_time)
@@ -287,6 +260,8 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
     if flow.error:
         log_entry["error"] = flow.error.msg
 
-    logging_utils.log_network_entry(network_log_path, log_entry)
+    if not logging_utils.log_network_entry(network_log_path, log_entry):
+        return False
     flow.metadata[_TCP_LOG_FINALIZED] = True
     _remove_active_flow(flow, network_log_path)
+    return True

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -1,6 +1,9 @@
 """TCP lifecycle logging for mitm addon flows."""
 
+import asyncio
+import threading
 import time
+from concurrent.futures import CancelledError, Future
 
 from mitmproxy import tcp
 
@@ -17,6 +20,91 @@ import registry
 _TCP_MESSAGE_DRAIN_SCHEDULED = "_tcp_message_drain_scheduled"
 _TCP_REQUEST_SIZE = "_tcp_request_size"
 _TCP_RESPONSE_SIZE = "_tcp_response_size"
+_TCP_LOG_FINALIZED = "_tcp_log_finalized"
+
+_event_loop: asyncio.AbstractEventLoop | None = None
+_active_flows_by_path: dict[str, dict[str, tcp.TCPFlow]] = {}
+_pending_seal_futures: set[Future[None]] = set()
+_pending_seal_futures_lock = threading.Lock()
+
+
+def set_event_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Set the mitmproxy event loop that owns TCP flow state."""
+    global _event_loop
+
+    _event_loop = loop
+
+
+def reset_for_tests() -> None:
+    """Reset module lifecycle state after background workers have stopped."""
+    global _event_loop
+
+    _event_loop = None
+    _active_flows_by_path.clear()
+    _cancel_pending_seal_futures()
+
+
+def shutdown() -> None:
+    """Finalize active flows and close cross-thread event-loop admission."""
+    global _event_loop
+
+    for log_path in tuple(_active_flows_by_path):
+        _seal_path(log_path)
+    _event_loop = None
+    _cancel_pending_seal_futures()
+
+
+def seal_path_from_thread(log_path: str, *, timeout: float) -> bool:
+    """Seal one path on the mitmproxy event loop from a worker thread."""
+    loop = _event_loop
+    if loop is None:
+        raise RuntimeError("TCP logging event loop is not running")
+
+    future: Future[None] = Future()
+    with _pending_seal_futures_lock:
+        _pending_seal_futures.add(future)
+    try:
+        loop.call_soon_threadsafe(_complete_path_seal, log_path, future)
+    except RuntimeError:
+        _discard_pending_seal_future(future)
+        raise
+
+    try:
+        future.result(timeout=timeout)
+    except TimeoutError:
+        future.cancel()
+        return False
+    except CancelledError:
+        return False
+    return True
+
+
+def _complete_path_seal(log_path: str, future: Future[None]) -> None:
+    if not future.set_running_or_notify_cancel():
+        _discard_pending_seal_future(future)
+        return
+
+    try:
+        _seal_path(log_path)
+    except Exception as exc:
+        future.set_exception(exc)
+    else:
+        future.set_result(None)
+    finally:
+        _discard_pending_seal_future(future)
+
+
+def _discard_pending_seal_future(future: Future[None]) -> None:
+    with _pending_seal_futures_lock:
+        _pending_seal_futures.discard(future)
+
+
+def _cancel_pending_seal_futures() -> None:
+    with _pending_seal_futures_lock:
+        pending = tuple(_pending_seal_futures)
+        _pending_seal_futures.clear()
+    for future in pending:
+        future.cancel()
 
 
 def start(flow: tcp.TCPFlow, *, registry_path: str) -> None:
@@ -40,6 +128,7 @@ def start(flow: tcp.TCPFlow, *, registry_path: str) -> None:
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
     flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
+    _register_active_flow(flow)
 
 
 def message(flow: tcp.TCPFlow) -> None:
@@ -65,6 +154,29 @@ def _is_registered_tcp_log_flow(flow: tcp.TCPFlow) -> bool:
     return bool(
         flow_metadata.run_id(flow.metadata) and flow_metadata.network_log_path(flow.metadata)
     )
+
+
+def _register_active_flow(flow: tcp.TCPFlow) -> None:
+    if not _is_registered_tcp_log_flow(flow):
+        return
+    log_path = flow_metadata.network_log_path(flow.metadata)
+    flow.metadata.pop(_TCP_LOG_FINALIZED, None)
+    _active_flows_by_path.setdefault(log_path, {})[flow.id] = flow
+
+
+def _remove_active_flow(flow: tcp.TCPFlow, log_path: str) -> None:
+    active_flows = _active_flows_by_path.get(log_path)
+    if active_flows is None:
+        return
+    active_flows.pop(flow.id, None)
+    if not active_flows:
+        _active_flows_by_path.pop(log_path, None)
+
+
+def _seal_path(log_path: str) -> None:
+    active_flows = tuple(_active_flows_by_path.get(log_path, {}).values())
+    for flow in active_flows:
+        _log_tcp(flow)
 
 
 def _tcp_counter_value(flow: tcp.TCPFlow, key: str) -> int:
@@ -102,6 +214,9 @@ def _drain_tcp_messages(flow: tcp.TCPFlow) -> None:
     if not _is_registered_tcp_log_flow(flow):
         return
     if not flow.messages:
+        return
+    if flow.metadata.get(_TCP_LOG_FINALIZED, False):
+        flow.messages.clear()
         return
 
     for message in flow.messages:
@@ -141,6 +256,10 @@ def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
 
 
 def _log_tcp(flow: tcp.TCPFlow) -> None:
+    if flow.metadata.get(_TCP_LOG_FINALIZED, False):
+        _drain_tcp_messages(flow)
+        return
+
     run_id = flow_metadata.run_id(flow.metadata)
     network_log_path = flow_metadata.network_log_path(flow.metadata)
     if not run_id or not network_log_path:
@@ -169,3 +288,5 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
         log_entry["error"] = flow.error.msg
 
     logging_utils.log_network_entry(network_log_path, log_entry)
+    flow.metadata[_TCP_LOG_FINALIZED] = True
+    _remove_active_flow(flow, network_log_path)

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -3,9 +3,11 @@
 import asyncio
 import threading
 import time
+from collections import OrderedDict
 from concurrent.futures import CancelledError, Future
+from typing import Literal
 
-from mitmproxy import tcp
+from mitmproxy import ctx, tcp
 
 import deferred_callbacks
 import flow_metadata
@@ -22,9 +24,17 @@ _TCP_REQUEST_SIZE = "_tcp_request_size"
 _TCP_RESPONSE_SIZE = "_tcp_response_size"
 _TCP_LOG_FINALIZED = "_tcp_log_finalized"
 
+TcpSealResult = Literal["sealed", "pending", "failed"]
+
+# Keep rejected rows independently from mitmproxy flows so a stalled writer
+# cannot retain live connection objects without bound.
+MAX_PENDING_TCP_LOG_ROWS = 4096
+
 _event_loop: asyncio.AbstractEventLoop | None = None
 _active_flows_by_path: dict[str, dict[str, tcp.TCPFlow]] = {}
-_pending_seal_futures: set[Future[bool]] = set()
+_pending_log_rows: OrderedDict[tuple[str, str], dict[str, object]] = OrderedDict()
+_pending_log_drop_warning_logged = False
+_pending_seal_futures: set[Future[TcpSealResult]] = set()
 _pending_seal_futures_lock = threading.Lock()
 
 
@@ -37,10 +47,12 @@ def set_event_loop(loop: asyncio.AbstractEventLoop) -> None:
 
 def reset_for_tests() -> None:
     """Reset module lifecycle state after background workers have stopped."""
-    global _event_loop
+    global _event_loop, _pending_log_drop_warning_logged
 
     _event_loop = None
     _active_flows_by_path.clear()
+    _pending_log_rows.clear()
+    _pending_log_drop_warning_logged = False
     _cancel_pending_seal_futures()
 
 
@@ -48,23 +60,30 @@ def shutdown() -> None:
     """Finalize active flows and close cross-thread event-loop admission."""
     global _event_loop
 
-    for log_path in tuple(_active_flows_by_path):
-        _seal_path(log_path)
+    log_paths = set(_active_flows_by_path)
+    log_paths.update(log_path for log_path, _flow_id in _pending_log_rows)
+    for log_path in log_paths:
+        _seal_path(log_path, final_attempt=True)
     _event_loop = None
     _cancel_pending_seal_futures()
 
 
-def seal_path_from_thread(log_path: str, *, timeout: float) -> bool:
+def seal_path_from_thread(
+    log_path: str,
+    *,
+    final_attempt: bool,
+    timeout: float,
+) -> TcpSealResult:
     """Seal one path on the mitmproxy event loop from a worker thread."""
     loop = _event_loop
     if loop is None:
         raise RuntimeError("TCP logging event loop is not running")
 
-    future: Future[bool] = Future()
+    future: Future[TcpSealResult] = Future()
     with _pending_seal_futures_lock:
         _pending_seal_futures.add(future)
     try:
-        loop.call_soon_threadsafe(_complete_path_seal, log_path, future)
+        loop.call_soon_threadsafe(_complete_path_seal, log_path, final_attempt, future)
     except RuntimeError:
         _discard_pending_seal_future(future)
         raise
@@ -78,22 +97,26 @@ def seal_path_from_thread(log_path: str, *, timeout: float) -> bool:
         raise RuntimeError("TCP logging path seal was cancelled") from None
 
 
-def _complete_path_seal(log_path: str, future: Future[bool]) -> None:
+def _complete_path_seal(
+    log_path: str,
+    final_attempt: bool,
+    future: Future[TcpSealResult],
+) -> None:
     if not future.set_running_or_notify_cancel():
         _discard_pending_seal_future(future)
         return
 
     try:
-        sealed = _seal_path(log_path)
+        result = _seal_path(log_path, final_attempt=final_attempt)
     except Exception as exc:
         future.set_exception(exc)
     else:
-        future.set_result(sealed)
+        future.set_result(result)
     finally:
         _discard_pending_seal_future(future)
 
 
-def _discard_pending_seal_future(future: Future[bool]) -> None:
+def _discard_pending_seal_future(future: Future[TcpSealResult]) -> None:
     with _pending_seal_futures_lock:
         _pending_seal_futures.discard(future)
 
@@ -172,13 +195,22 @@ def _remove_active_flow(flow: tcp.TCPFlow, log_path: str) -> None:
         _active_flows_by_path.pop(log_path, None)
 
 
-def _seal_path(log_path: str) -> bool:
+def _seal_path(log_path: str, *, final_attempt: bool) -> TcpSealResult:
+    _admit_pending_log_rows(log_path)
     active_flows = tuple(_active_flows_by_path.get(log_path, {}).values())
-    sealed = True
     for flow in active_flows:
-        if not _log_tcp(flow):
-            sealed = False
-    return sealed
+        _freeze_tcp_log(flow)
+
+    _admit_pending_log_rows(log_path)
+    pending = _pending_log_row_count(log_path)
+    if pending == 0:
+        return "sealed"
+    if not final_attempt:
+        return "pending"
+
+    _discard_pending_log_rows(log_path)
+    ctx.log.warn(f"Dropped {pending} TCP network-log rows after final writer rejection")
+    return "failed"
 
 
 def _tcp_counter_value(flow: tcp.TCPFlow, key: str) -> int:
@@ -228,15 +260,22 @@ def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
     )
 
 
-def _log_tcp(flow: tcp.TCPFlow) -> bool:
+def _log_tcp(flow: tcp.TCPFlow) -> None:
+    network_log_path = flow_metadata.network_log_path(flow.metadata)
+    if network_log_path:
+        _admit_pending_log_rows(network_log_path)
+    _freeze_tcp_log(flow)
+
+
+def _freeze_tcp_log(flow: tcp.TCPFlow) -> str | None:
     if flow.metadata.get(_TCP_LOG_FINALIZED, False):
         _drain_tcp_messages(flow)
-        return True
+        return None
 
     run_id = flow_metadata.run_id(flow.metadata)
     network_log_path = flow_metadata.network_log_path(flow.metadata)
     if not run_id or not network_log_path:
-        return False
+        return None
 
     start_time = flow.metadata.get(metadata_keys.TCP_START_MONOTONIC)
     latency_ms = logging_utils.elapsed_ms(start_time)
@@ -260,8 +299,45 @@ def _log_tcp(flow: tcp.TCPFlow) -> bool:
     if flow.error:
         log_entry["error"] = flow.error.msg
 
-    if not logging_utils.log_network_entry(network_log_path, log_entry):
-        return False
     flow.metadata[_TCP_LOG_FINALIZED] = True
     _remove_active_flow(flow, network_log_path)
-    return True
+    if not logging_utils.log_network_entry(network_log_path, log_entry):
+        _retain_pending_log_row(network_log_path, flow.id, log_entry)
+    return network_log_path
+
+
+def _retain_pending_log_row(
+    log_path: str,
+    flow_id: str,
+    log_entry: dict[str, object],
+) -> None:
+    global _pending_log_drop_warning_logged
+
+    key = (log_path, flow_id)
+    if key not in _pending_log_rows and len(_pending_log_rows) >= MAX_PENDING_TCP_LOG_ROWS:
+        _pending_log_rows.popitem(last=False)
+        if not _pending_log_drop_warning_logged:
+            ctx.log.warn("Dropped oldest pending TCP network-log row because retry buffer is full")
+            _pending_log_drop_warning_logged = True
+    _pending_log_rows[key] = log_entry
+
+
+def _admit_pending_log_rows(log_path: str) -> None:
+    for key, log_entry in tuple(_pending_log_rows.items()):
+        pending_log_path, _flow_id = key
+        if pending_log_path != log_path:
+            continue
+        if not logging_utils.log_network_entry(log_path, log_entry):
+            return
+        _pending_log_rows.pop(key)
+
+
+def _pending_log_row_count(log_path: str) -> int:
+    return sum(pending_log_path == log_path for pending_log_path, _flow_id in _pending_log_rows)
+
+
+def _discard_pending_log_rows(log_path: str) -> None:
+    for key in tuple(_pending_log_rows):
+        pending_log_path, _flow_id = key
+        if pending_log_path == log_path:
+            _pending_log_rows.pop(key)

--- a/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
@@ -116,16 +116,21 @@ def _seal_tcp_for_runner_request() -> None:
     if request is None:
         return
 
-    log_path, seal_request_id = request
+    log_path, seal_request_id, final_attempt = request
     pending = 0
+    failed = False
     timed_out = False
     try:
-        if not tcp_logging.seal_path_from_thread(
+        result = tcp_logging.seal_path_from_thread(
             log_path,
+            final_attempt=final_attempt,
             timeout=RUNNER_TCP_SEAL_TIMEOUT_SECONDS,
-        ):
+        )
+        if result == "pending":
             pending = 1
             ctx.log.warn("TCP network-log seal could not admit all rows")
+        elif result == "failed":
+            failed = True
     except TimeoutError:
         pending = 1
         timed_out = True
@@ -134,12 +139,17 @@ def _seal_tcp_for_runner_request() -> None:
         pending = 1
         ctx.log.warn(f"Failed to seal TCP network logs after runner request ({type(exc).__name__})")
     finally:
-        state_written = _write_tcp_seal_state(log_path, seal_request_id, pending=pending)
-        if state_written and (pending == 0 or timed_out):
+        state_written = _write_tcp_seal_state(
+            log_path,
+            seal_request_id,
+            pending=pending,
+            failed=failed,
+        )
+        if state_written and (pending == 0 or timed_out or failed):
             _last_tcp_seal_request_id = seal_request_id
 
 
-def _read_tcp_seal_request() -> tuple[str, str] | None:
+def _read_tcp_seal_request() -> tuple[str, str, bool] | None:
     marker_path = Path(__file__).resolve().parent / _TCP_SEAL_REQUEST_FILE
     try:
         marker = json.loads(marker_path.read_text(encoding="utf-8"))
@@ -164,7 +174,10 @@ def _read_tcp_seal_request() -> tuple[str, str] | None:
     log_path = marker.get("path")
     if not isinstance(log_path, str) or not log_path:
         return None
-    return log_path, seal_request_id
+    final_attempt = marker.get("finalAttempt", False)
+    if type(final_attempt) is not bool:
+        return None
+    return log_path, seal_request_id, final_attempt
 
 
 def _is_safe_tcp_seal_request_id(seal_request_id: str) -> bool:
@@ -179,6 +192,7 @@ def _write_tcp_seal_state(
     seal_request_id: str,
     *,
     pending: int = 0,
+    failed: bool = False,
 ) -> bool:
     state_path = Path(__file__).resolve().parent / _TCP_SEAL_STATE_FILE
     state = {
@@ -189,6 +203,8 @@ def _write_tcp_seal_state(
         "path": log_path,
         "pending": pending,
     }
+    if failed:
+        state["failed"] = True
     tmp_path = state_path.with_name(f"{state_path.name}.{seal_request_id}.tmp")
     with _tcp_seal_state_write_lock:
         try:

--- a/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
@@ -125,8 +125,11 @@ def _seal_tcp_for_runner_request() -> None:
             timeout=RUNNER_TCP_SEAL_TIMEOUT_SECONDS,
         ):
             pending = 1
-            timed_out = True
-            ctx.log.warn("TCP network-log seal did not complete before timeout")
+            ctx.log.warn("TCP network-log seal could not admit all rows")
+    except TimeoutError:
+        pending = 1
+        timed_out = True
+        ctx.log.warn("TCP network-log seal did not complete before timeout")
     except Exception as exc:
         pending = 1
         ctx.log.warn(f"Failed to seal TCP network logs after runner request ({type(exc).__name__})")

--- a/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/src/tcp_seal_lifecycle.py
@@ -1,0 +1,200 @@
+"""Runner-triggered TCP network-log seal lifecycle owner."""
+
+import json
+import os
+import threading
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Literal
+
+from mitmproxy import ctx
+
+import tcp_logging
+import usage
+
+_TcpSealPhase = Literal["running", "closed"]
+
+_tcp_seal_requested = threading.Event()
+_tcp_seal_worker_lock = threading.Lock()
+_tcp_seal_phase: _TcpSealPhase = "running"
+_tcp_seal_state_write_lock = threading.Lock()
+_last_tcp_seal_request_id: str | None = None
+_TCP_SEAL_REQUEST_FILE = "tcp-seal-request"
+_TCP_SEAL_STATE_FILE = "tcp-seal-state"
+RUNNER_TCP_SEAL_TIMEOUT_SECONDS = 4.0
+
+
+def handle_runner_tcp_seal_signal(signum: int, _frame: object) -> None:
+    """Schedule TCP seal work from the runner signal handler."""
+    del signum, _frame
+    if _tcp_seal_phase == "closed":
+        return
+    _tcp_seal_requested.set()
+    _start_tcp_seal_worker()
+
+
+def wait_for_runner_tcp_seal_worker_to_stop_for_tests(timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError("runner TCP seal worker did not stop")
+
+        acquired = _tcp_seal_worker_lock.acquire(timeout=remaining)
+        if not acquired:
+            raise AssertionError("runner TCP seal worker did not stop")
+        try:
+            if not _tcp_seal_requested.is_set():
+                return
+        finally:
+            _tcp_seal_worker_lock.release()
+        _start_tcp_seal_worker()
+
+
+def reset_runner_tcp_seal_state_for_tests(timeout: float = 1.0) -> None:
+    global _last_tcp_seal_request_id, _tcp_seal_phase
+
+    acquired = _tcp_seal_worker_lock.acquire(timeout=timeout)
+    if not acquired:
+        raise AssertionError("runner TCP seal worker did not stop")
+    try:
+        _tcp_seal_phase = "running"
+        _tcp_seal_requested.clear()
+        _last_tcp_seal_request_id = None
+    finally:
+        _tcp_seal_worker_lock.release()
+
+
+def close_admission() -> None:
+    """Close new worker admission without waiting on the mitmproxy event loop."""
+    global _tcp_seal_phase
+
+    _tcp_seal_phase = "closed"
+    _tcp_seal_requested.clear()
+
+
+def _start_tcp_seal_worker() -> None:
+    """Start one seal worker, coalescing repeated signals while active."""
+    if _tcp_seal_phase != "running":
+        return
+    if not _tcp_seal_worker_lock.acquire(blocking=False):
+        return
+    if _tcp_seal_phase != "running":
+        _tcp_seal_worker_lock.release()
+        return
+
+    thread = threading.Thread(
+        target=_run_tcp_seal_worker,
+        name="runner-tcp-seal-request",
+        daemon=True,
+    )
+    started = False
+    try:
+        thread.start()
+        started = True
+    finally:
+        if not started:
+            _tcp_seal_worker_lock.release()
+
+
+def _run_tcp_seal_worker() -> None:
+    try:
+        while _tcp_seal_requested.is_set():
+            _tcp_seal_requested.clear()
+            _seal_tcp_for_runner_request()
+    finally:
+        _tcp_seal_worker_lock.release()
+        if _tcp_seal_requested.is_set():
+            _start_tcp_seal_worker()
+
+
+def _seal_tcp_for_runner_request() -> None:
+    global _last_tcp_seal_request_id
+
+    request = _read_tcp_seal_request()
+    if request is None:
+        return
+
+    log_path, seal_request_id = request
+    pending = 0
+    timed_out = False
+    try:
+        if not tcp_logging.seal_path_from_thread(
+            log_path,
+            timeout=RUNNER_TCP_SEAL_TIMEOUT_SECONDS,
+        ):
+            pending = 1
+            timed_out = True
+            ctx.log.warn("TCP network-log seal did not complete before timeout")
+    except Exception as exc:
+        pending = 1
+        ctx.log.warn(f"Failed to seal TCP network logs after runner request ({type(exc).__name__})")
+    finally:
+        state_written = _write_tcp_seal_state(log_path, seal_request_id, pending=pending)
+        if state_written and (pending == 0 or timed_out):
+            _last_tcp_seal_request_id = seal_request_id
+
+
+def _read_tcp_seal_request() -> tuple[str, str] | None:
+    marker_path = Path(__file__).resolve().parent / _TCP_SEAL_REQUEST_FILE
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(marker, dict):
+        return None
+    if marker.get("usageStateId") != usage.current_usage_state_id():
+        return None
+    seal_request_id = marker.get("sealRequestId")
+    if (
+        not isinstance(seal_request_id, str)
+        or not seal_request_id
+        or not _is_safe_tcp_seal_request_id(seal_request_id)
+        or seal_request_id == _last_tcp_seal_request_id
+    ):
+        return None
+    requested_at_ms = marker.get("requestedAtMs")
+    if type(requested_at_ms) is not int or requested_at_ms < 0:
+        return None
+    log_path = marker.get("path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    return log_path, seal_request_id
+
+
+def _is_safe_tcp_seal_request_id(seal_request_id: str) -> bool:
+    return all(
+        ("a" <= char <= "z") or ("A" <= char <= "Z") or ("0" <= char <= "9") or char in "-_"
+        for char in seal_request_id
+    )
+
+
+def _write_tcp_seal_state(
+    log_path: str,
+    seal_request_id: str,
+    *,
+    pending: int = 0,
+) -> bool:
+    state_path = Path(__file__).resolve().parent / _TCP_SEAL_STATE_FILE
+    state = {
+        "pid": os.getpid(),
+        "usageStateId": usage.current_usage_state_id(),
+        "updatedAtMs": int(time.time() * 1000),
+        "sealRequestId": seal_request_id,
+        "path": log_path,
+        "pending": pending,
+    }
+    tmp_path = state_path.with_name(f"{state_path.name}.{seal_request_id}.tmp")
+    with _tcp_seal_state_write_lock:
+        try:
+            with tmp_path.open("w") as file:
+                json.dump(state, file, separators=(",", ":"))
+            tmp_path.replace(state_path)
+            return True
+        except OSError as exc:
+            with suppress(OSError):
+                tmp_path.unlink()
+            ctx.log.warn(f"Failed to write TCP seal state: {type(exc).__name__}: {exc}")
+            return False

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -33,6 +33,8 @@ import mitm_addon
 import platform_api
 import registry
 import runner_flush_lifecycle
+import tcp_logging
+import tcp_seal_lifecycle
 import upstream_admission
 import upstream_destination_binding
 import usage
@@ -58,6 +60,8 @@ def _reset_module_state() -> Iterator[None]:
     registry.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
     runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
+    tcp_seal_lifecycle.reset_runner_tcp_seal_state_for_tests()
+    tcp_logging.reset_for_tests()
     upstream_admission.reset_tls_admission_state_for_tests()
     platform_api.configure_client_headers(client_session_id="", client_version="")
     clear_auth_state()
@@ -67,6 +71,8 @@ def _reset_module_state() -> Iterator[None]:
     usage.reset_usage_buffer_for_tests()
     logging_utils.reset_log_writer_for_tests()
     yield
+    tcp_seal_lifecycle.reset_runner_tcp_seal_state_for_tests()
+    tcp_logging.reset_for_tests()
     runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
     usage.reset_usage_buffer_for_tests()
     logging_utils.reset_log_writer_for_tests()

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -133,22 +133,6 @@ class TestAddonConfiguration:
         ):
             mitm_addon.load(loader)
 
-    def test_runner_signal_wakes_both_independent_lifecycles(self):
-        with (
-            patch.object(
-                mitm_addon.tcp_seal_lifecycle,
-                "handle_runner_tcp_seal_signal",
-            ) as seal_signal,
-            patch.object(
-                runner_flush_lifecycle,
-                "handle_runner_usage_flush_signal",
-            ) as flush_signal,
-        ):
-            mitm_addon.handle_runner_flush_signal(10, None)
-
-        seal_signal.assert_called_once_with(10, None)
-        flush_signal.assert_called_once_with(10, None)
-
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
 

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -121,7 +121,7 @@ class TestAddonConfiguration:
         assert not pending_path.exists()
         signal_handler.assert_called_once_with(
             runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
-            runner_flush_lifecycle.handle_runner_usage_flush_signal,
+            mitm_addon.handle_runner_flush_signal,
         )
 
     def test_load_rejects_unreviewed_mitmproxy_version(self):
@@ -132,6 +132,22 @@ class TestAddonConfiguration:
             pytest.raises(RuntimeError, match=r"requires mitmproxy 12\.2\.3; found 12\.2\.4"),
         ):
             mitm_addon.load(loader)
+
+    def test_runner_signal_wakes_both_independent_lifecycles(self):
+        with (
+            patch.object(
+                mitm_addon.tcp_seal_lifecycle,
+                "handle_runner_tcp_seal_signal",
+            ) as seal_signal,
+            patch.object(
+                runner_flush_lifecycle,
+                "handle_runner_usage_flush_signal",
+            ) as flush_signal,
+        ):
+            mitm_addon.handle_runner_flush_signal(10, None)
+
+        seal_signal.assert_called_once_with(10, None)
+        flush_signal.assert_called_once_with(10, None)
 
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -22,13 +22,13 @@ def test_worker_start_failure_does_not_publish_or_consume_retry_capacity(tmp_pat
             "start",
             side_effect=RuntimeError("can't start new thread"),
         ):
-            jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
+            assert not jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
 
         assert jsonl_writer.flush_log_path(str(log_path), timeout=0)
         assert jsonl_writer._worker is None
         assert not log_path.exists()
 
-        jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
+        assert jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
         assert jsonl_writer.flush_log_path(str(log_path), timeout=1)
 
         log.warn.assert_called_once_with("Failed to start JSONL writer for proxy log")
@@ -419,7 +419,7 @@ def test_shutdown_writer_timeout_preserves_state_for_retry(tmp_path):
 
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
-            jsonl_writer.write_jsonl_line(log_path, accepted_line, "network")
+            assert jsonl_writer.write_jsonl_line(log_path, accepted_line, "network")
             assert append_started.wait(timeout=1)
 
             worker = jsonl_writer._worker
@@ -431,7 +431,7 @@ def test_shutdown_writer_timeout_preserves_state_for_retry(tmp_path):
             assert worker.is_alive()
             assert jsonl_writer._stop_enqueued
 
-            jsonl_writer.write_jsonl_line(log_path, rejected_line, "network")
+            assert not jsonl_writer.write_jsonl_line(log_path, rejected_line, "network")
         finally:
             release_append.set()
 

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -21,7 +21,7 @@ class TestLogNetworkEntry:
         entry = {"action": "ALLOW", "host": "example.com"}
 
         with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry(log_path, entry)
+            assert logging_utils.log_network_entry(log_path, entry)
 
         entries = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert len(entries) == 1
@@ -57,7 +57,7 @@ class TestLogNetworkEntry:
         log = MagicMock()
 
         with patch.object(logging_utils.ctx, "log", log, create=True):
-            logging_utils.log_network_entry("", {"payload": b"binary"})
+            assert not logging_utils.log_network_entry("", {"payload": b"binary"})
 
         log.warn.assert_not_called()
 
@@ -79,7 +79,7 @@ class TestLogNetworkEntry:
         log = MagicMock()
 
         with patch.object(logging_utils.ctx, "log", log, create=True):
-            logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
+            assert not logging_utils.log_network_entry(str(log_path), {"payload": b"binary"})
 
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
@@ -95,7 +95,7 @@ class TestLogNetworkEntry:
             patch.object(logging_utils.jsonl_writer, "MAX_PENDING_JSONL_BYTES", 1),
             patch.object(logging_utils.ctx, "log", log, create=True),
         ):
-            logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+            assert not logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]

--- a/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
@@ -25,6 +25,7 @@ def _write_seal_request(
     log_path: Path,
     *,
     seal_request_id: str,
+    final_attempt: bool = False,
 ) -> Path:
     request_path = lifecycle_file.parent / "tcp-seal-request"
     request_path.write_text(
@@ -34,6 +35,7 @@ def _write_seal_request(
                 "sealRequestId": seal_request_id,
                 "requestedAtMs": _REQUESTED_AT_MS,
                 "path": str(log_path),
+                "finalAttempt": final_attempt,
             }
         )
     )
@@ -263,6 +265,11 @@ async def test_seal_retries_row_rejected_by_jsonl_backpressure(
         assert first_state["pending"] == 1
         assert not log_path.exists()
 
+        flow.messages.append(tcp.TCPMessage(False, b"late-server-data"))
+        mitm_addon.tcp_message(flow)
+        await asyncio.sleep(0)
+        assert flow.messages == []
+
         monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 4096)
         _write_seal_request(
             lifecycle_file,
@@ -277,6 +284,150 @@ async def test_seal_retries_row_rejected_by_jsonl_backpressure(
     retry_state = json.loads(state_path.read_text())
     assert retry_state["sealRequestId"] == "seal-backpressure-retry"
     assert retry_state["pending"] == 0
+
+
+async def test_final_seal_discards_row_rejected_by_jsonl_backpressure(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-rejected-row",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 0)
+    flow = real_tcp_flow()
+
+    with mitm_ctx(registry_path=str(registry_file)):
+        mitm_addon.running()
+        mitm_addon.tcp_start(flow)
+        await _request_seal_and_wait()
+
+        _write_seal_request(
+            lifecycle_file,
+            log_path,
+            seal_request_id="seal-final-rejection",
+            final_attempt=True,
+        )
+        await _request_seal_and_wait()
+        final_state = json.loads(state_path.read_text())
+        assert final_state["sealRequestId"] == "seal-final-rejection"
+        assert final_state["pending"] == 0
+        assert final_state["failed"] is True
+
+        monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 4096)
+        _write_seal_request(
+            lifecycle_file,
+            log_path,
+            seal_request_id="seal-after-final-rejection",
+        )
+        await _request_seal_and_wait()
+
+    logging_utils.flush_log_path(str(log_path))
+    assert not log_path.exists()
+    retry_state = json.loads(state_path.read_text())
+    assert retry_state["sealRequestId"] == "seal-after-final-rejection"
+    assert retry_state["pending"] == 0
+    assert "failed" not in retry_state
+
+
+async def test_rejected_tcp_log_retry_buffer_is_bounded(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    first_log_path = tmp_path / "network.jsonl"
+    second_log_path = tmp_path / "network-2.jsonl"
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 0)
+    monkeypatch.setattr(tcp_logging, "MAX_PENDING_TCP_LOG_ROWS", 1)
+    first_flow = real_tcp_flow(client_ip="10.200.0.1")
+    second_flow = real_tcp_flow(client_ip="10.200.0.2")
+
+    with mitm_ctx(registry_path=str(registry_file)) as log:
+        mitm_addon.running()
+        mitm_addon.tcp_start(first_flow)
+        mitm_addon.tcp_end(first_flow)
+        mitm_addon.tcp_start(second_flow)
+        mitm_addon.tcp_end(second_flow)
+
+        log.warn.assert_any_call(
+            "Dropped oldest pending TCP network-log row because retry buffer is full"
+        )
+        monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 4096)
+
+        _write_seal_request(
+            lifecycle_file,
+            first_log_path,
+            seal_request_id="seal-evicted-row",
+        )
+        await _request_seal_and_wait()
+        _write_seal_request(
+            lifecycle_file,
+            second_log_path,
+            seal_request_id="seal-retained-row",
+        )
+        await _request_seal_and_wait()
+
+    logging_utils.flush_log_path(str(first_log_path))
+    assert not first_log_path.exists()
+    [entry] = read_jsonl_entries_after_flush(second_log_path)
+    assert entry["type"] == "tcp"
+
+
+async def test_full_retry_buffer_does_not_evict_when_writer_recovers(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    first_log_path = tmp_path / "network.jsonl"
+    second_log_path = tmp_path / "network-2.jsonl"
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 0)
+    monkeypatch.setattr(tcp_logging, "MAX_PENDING_TCP_LOG_ROWS", 1)
+    first_flow = real_tcp_flow(client_ip="10.200.0.1")
+    second_flow = real_tcp_flow(client_ip="10.200.0.2")
+
+    with mitm_ctx(registry_path=str(registry_file)) as log:
+        mitm_addon.running()
+        mitm_addon.tcp_start(first_flow)
+        mitm_addon.tcp_end(first_flow)
+
+        monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 4096)
+        mitm_addon.tcp_start(second_flow)
+        mitm_addon.tcp_end(second_flow)
+        _write_seal_request(
+            lifecycle_file,
+            first_log_path,
+            seal_request_id="seal-row-after-writer-recovery",
+        )
+        await _request_seal_and_wait()
+
+        assert not any(
+            call.args
+            == ("Dropped oldest pending TCP network-log row because retry buffer is full",)
+            for call in log.warn.call_args_list
+        )
+
+    [first_entry] = read_jsonl_entries_after_flush(first_log_path)
+    [second_entry] = read_jsonl_entries_after_flush(second_log_path)
+    assert first_entry["type"] == "tcp"
+    assert second_entry["type"] == "tcp"
 
 
 async def test_seal_timeout_writes_terminal_pending_state(

--- a/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
@@ -233,6 +233,52 @@ async def test_seal_acknowledges_while_usage_flush_is_blocked(
         )
 
 
+async def test_seal_retries_row_rejected_by_jsonl_backpressure(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-backpressure-first",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 0)
+    flow = real_tcp_flow()
+
+    with mitm_ctx(registry_path=str(registry_file)):
+        mitm_addon.running()
+        mitm_addon.tcp_start(flow)
+        mitm_addon.tcp_message(flow)
+        await _request_seal_and_wait()
+
+        first_state = json.loads(state_path.read_text())
+        assert first_state["sealRequestId"] == "seal-backpressure-first"
+        assert first_state["pending"] == 1
+        assert not log_path.exists()
+
+        monkeypatch.setattr(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 4096)
+        _write_seal_request(
+            lifecycle_file,
+            log_path,
+            seal_request_id="seal-backpressure-retry",
+        )
+        await _request_seal_and_wait()
+
+    [entry] = read_jsonl_entries_after_flush(log_path)
+    assert entry["request_size"] == len(b"hello")
+    assert entry["response_size"] == len(b"SSH-2.0-babeld")
+    retry_state = json.loads(state_path.read_text())
+    assert retry_state["sealRequestId"] == "seal-backpressure-retry"
+    assert retry_state["pending"] == 0
+
+
 async def test_seal_timeout_writes_terminal_pending_state(
     tmp_path,
     monkeypatch,

--- a/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_seal_lifecycle.py
@@ -1,0 +1,261 @@
+"""Integration tests for runner-triggered TCP network-log sealing."""
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+
+from mitmproxy import tcp
+
+import jsonl_writer
+import logging_utils
+import mitm_addon
+import runner_flush_lifecycle
+import tcp_logging
+import tcp_seal_lifecycle
+import usage
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+
+_USAGE_STATE_ID = "runner-tcp-seal-state"
+_REQUESTED_AT_MS = 1_770_000_000_000
+
+
+def _write_seal_request(
+    lifecycle_file: Path,
+    log_path: Path,
+    *,
+    seal_request_id: str,
+) -> Path:
+    request_path = lifecycle_file.parent / "tcp-seal-request"
+    request_path.write_text(
+        json.dumps(
+            {
+                "usageStateId": _USAGE_STATE_ID,
+                "sealRequestId": seal_request_id,
+                "requestedAtMs": _REQUESTED_AT_MS,
+                "path": str(log_path),
+            }
+        )
+    )
+    return lifecycle_file.parent / "tcp-seal-state"
+
+
+async def _request_seal_and_wait() -> None:
+    tcp_seal_lifecycle.handle_runner_tcp_seal_signal(0, None)
+    await asyncio.to_thread(tcp_seal_lifecycle.wait_for_runner_tcp_seal_worker_to_stop_for_tests)
+
+
+async def test_seal_persists_active_flow_without_terminal_hook(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-active-flow",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    flow = real_tcp_flow()
+
+    with mitm_ctx(registry_path=str(registry_file)):
+        mitm_addon.running()
+        mitm_addon.tcp_start(flow)
+        mitm_addon.tcp_message(flow)
+        await _request_seal_and_wait()
+
+    [entry] = read_jsonl_entries_after_flush(log_path)
+    assert entry["type"] == "tcp"
+    assert entry["host"] == "140.82.116.3"
+    assert entry["port"] == 22
+    assert entry["request_size"] == len(b"hello")
+    assert entry["response_size"] == len(b"SSH-2.0-babeld")
+    state = json.loads(state_path.read_text())
+    assert state == {
+        "pid": state["pid"],
+        "usageStateId": _USAGE_STATE_ID,
+        "updatedAtMs": state["updatedAtMs"],
+        "sealRequestId": "seal-active-flow",
+        "path": str(log_path),
+        "pending": 0,
+    }
+
+
+async def test_seal_then_late_hooks_do_not_duplicate_or_extend_old_row(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    _write_seal_request(lifecycle_file, log_path, seal_request_id="seal-before-terminal")
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    flow = real_tcp_flow()
+
+    with mitm_ctx(registry_path=str(registry_file)):
+        mitm_addon.running()
+        mitm_addon.tcp_start(flow)
+        await _request_seal_and_wait()
+
+        flow.messages.append(tcp.TCPMessage(False, b"late-server-data"))
+        mitm_addon.tcp_message(flow)
+        await asyncio.sleep(0)
+        assert flow.messages == []
+
+        mitm_addon.tcp_end(flow)
+        mitm_addon.tcp_error(flow)
+
+    [entry] = read_jsonl_entries_after_flush(log_path)
+    assert entry["request_size"] == len(b"hello")
+    assert entry["response_size"] == len(b"SSH-2.0-babeld")
+
+
+async def test_terminal_then_seal_emits_one_row(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    _write_seal_request(lifecycle_file, log_path, seal_request_id="terminal-before-seal")
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    flow = real_tcp_flow()
+
+    with mitm_ctx(registry_path=str(registry_file)):
+        mitm_addon.running()
+        mitm_addon.tcp_start(flow)
+        mitm_addon.tcp_end(flow)
+        await _request_seal_and_wait()
+
+    entries = read_jsonl_entries_after_flush(log_path)
+    assert len(entries) == 1
+
+
+async def test_seal_acknowledges_while_jsonl_writer_is_blocked(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-blocked-writer",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    append_started = threading.Event()
+    release_append = threading.Event()
+    original_append_lines = jsonl_writer._append_lines
+
+    def append_lines(path: str, lines: list[bytes]) -> None:
+        append_started.set()
+        release_append.wait()
+        original_append_lines(path, lines)
+
+    monkeypatch.setattr(jsonl_writer, "_append_lines", append_lines)
+    flow = real_tcp_flow()
+
+    try:
+        with mitm_ctx(registry_path=str(registry_file)):
+            mitm_addon.running()
+            mitm_addon.tcp_start(flow)
+            await _request_seal_and_wait()
+
+        assert await asyncio.to_thread(append_started.wait, 1)
+        state = json.loads(state_path.read_text())
+        assert state["pending"] == 0
+        assert not release_append.is_set()
+    finally:
+        release_append.set()
+        await asyncio.to_thread(logging_utils.flush_log_path, str(log_path))
+
+
+async def test_seal_acknowledges_while_usage_flush_is_blocked(
+    tmp_path,
+    registry_file,
+    monkeypatch,
+    mitm_ctx,
+    real_tcp_flow,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-blocked-usage",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    usage_flush_started = threading.Event()
+    release_usage_flush = threading.Event()
+
+    def flush_usage_events(*, trigger: str) -> int:
+        assert trigger == "runner"
+        usage_flush_started.set()
+        release_usage_flush.wait()
+        return 0
+
+    monkeypatch.setattr(usage, "flush_usage_events", flush_usage_events)
+    flow = real_tcp_flow()
+
+    try:
+        with mitm_ctx(registry_path=str(registry_file)):
+            mitm_addon.running()
+            mitm_addon.tcp_start(flow)
+            mitm_addon.handle_runner_flush_signal(0, None)
+            assert await asyncio.to_thread(usage_flush_started.wait, 1)
+            await asyncio.to_thread(
+                tcp_seal_lifecycle.wait_for_runner_tcp_seal_worker_to_stop_for_tests
+            )
+
+        state = json.loads(state_path.read_text())
+        assert state["pending"] == 0
+        assert not release_usage_flush.is_set()
+    finally:
+        release_usage_flush.set()
+        await asyncio.to_thread(
+            runner_flush_lifecycle.wait_for_runner_usage_flush_worker_to_stop_for_tests
+        )
+
+
+async def test_seal_timeout_writes_terminal_pending_state(
+    tmp_path,
+    monkeypatch,
+    mitm_ctx,
+):
+    lifecycle_file = tmp_path / "tcp_seal_lifecycle.py"
+    log_path = tmp_path / "network.jsonl"
+    state_path = _write_seal_request(
+        lifecycle_file,
+        log_path,
+        seal_request_id="seal-timeout",
+    )
+    usage.set_pending_path(str(tmp_path / "usage-pending"), usage_state_id=_USAGE_STATE_ID)
+    monkeypatch.setattr(tcp_seal_lifecycle, "__file__", str(lifecycle_file))
+    monkeypatch.setattr(tcp_seal_lifecycle, "RUNNER_TCP_SEAL_TIMEOUT_SECONDS", 0.01)
+    dormant_loop = asyncio.new_event_loop()
+    tcp_logging.set_event_loop(dormant_loop)
+    try:
+        with mitm_ctx() as log:
+            await _request_seal_and_wait()
+    finally:
+        dormant_loop.close()
+
+    state = json.loads(state_path.read_text())
+    assert state["pending"] == 1
+    log.warn.assert_called_once_with("TCP network-log seal did not complete before timeout")

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -445,7 +445,7 @@ impl DeferredUploadPhase {
         let network_log_path = exec_config.log_paths.network_log(run_id);
         let network_log_upload = async {
             if let Some(mitm_tcp_seal) = exec_config.mitm_tcp_seal.as_ref() {
-                let sealed = mitm_tcp_seal.seal_path(&network_log_path).await;
+                let sealed = mitm_tcp_seal.seal_path_for_upload(&network_log_path).await;
                 if !sealed {
                     warn!(
                         run_id = %run_id,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -40,6 +40,7 @@ use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
 use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
+use crate::proxy::MitmTcpSealHandle;
 use crate::resource_budget::BudgetLease;
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::StatusTracker;
@@ -248,6 +249,7 @@ struct FinalizationPhase {
     held_session_snapshot: HeldSessionStateSnapshot,
     parking_gate: ParkingGate,
     network_log_drain: NetworkLogDrainCoordinator,
+    mitm_tcp_seal: Option<MitmTcpSealHandle>,
     cancel: RunCancellationHandle,
     cleanup_state: RunCleanupState,
     #[cfg(test)]
@@ -281,6 +283,7 @@ impl FinalizationPhase {
             held_session_snapshot,
             parking_gate,
             network_log_drain,
+            mitm_tcp_seal,
             cancel,
             cleanup_state,
             #[cfg(test)]
@@ -330,6 +333,7 @@ impl FinalizationPhase {
                 restored_session_identity,
                 source_ip,
                 network_log_session,
+                mitm_tcp_seal,
                 workspace_image,
                 workspace_image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
                 storage_fingerprints,
@@ -440,6 +444,16 @@ impl DeferredUploadPhase {
         // defensive no-op for any accepted writes still finishing.
         let network_log_path = exec_config.log_paths.network_log(run_id);
         let network_log_upload = async {
+            if let Some(mitm_tcp_seal) = exec_config.mitm_tcp_seal.as_ref() {
+                let sealed = mitm_tcp_seal.seal_path(&network_log_path).await;
+                if !sealed {
+                    warn!(
+                        run_id = %run_id,
+                        path = %network_log_path.display(),
+                        "proxy TCP network-log fallback seal did not complete before upload"
+                    );
+                }
+            }
             exec_config
                 .network_log_manager
                 .flush_path(&network_log_path)
@@ -614,6 +628,7 @@ pub(super) fn spawn_job(
         held_session_snapshot,
         parking_gate,
         network_log_drain: exec_config.network_log_drain.clone(),
+        mitm_tcp_seal: exec_config.mitm_tcp_seal.clone(),
         cancel: job_cancel.clone(),
         cleanup_state: cleanup_state_for_body.clone(),
         #[cfg(test)]
@@ -1196,6 +1211,7 @@ mod tests {
                 held_session_snapshot: HeldSessionStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
+                mitm_tcp_seal: None,
                 cancel: RunCancellationHandle::new(),
                 cleanup_state,
                 outer_job_panic: None,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -677,6 +677,7 @@ async fn run_start_with_home(
         network_log_manager,
         network_log_drain,
         mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
+        mitm_tcp_seal: Some(mitm.tcp_seal_handle(usage_flush_tx.clone())),
         network_policy_refresh,
         session_history_cpu: SessionHistoryCpuPool::for_host_cpus(host_cpus),
         session_history_probe: SessionHistoryProbe::default(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -31,6 +31,7 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogSession;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
+use crate::proxy::MitmTcpSealHandle;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
@@ -88,6 +89,7 @@ pub(super) struct FinalizeContext {
     pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
     pub(super) source_ip: String,
     pub(super) network_log_session: Option<NetworkLogSession>,
+    pub(super) mitm_tcp_seal: Option<MitmTcpSealHandle>,
     pub(super) workspace_image: Option<WorkspaceImageLease>,
     pub(super) workspace_image_size_bytes: u64,
     pub(super) storage_fingerprints: StorageFingerprints,
@@ -112,9 +114,16 @@ pub(super) async fn finalize_sandbox_for_completion(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
     completion_payload: CompletionPayload,
-    ctx: FinalizeContext,
+    mut ctx: FinalizeContext,
 ) -> CompletionReady {
     let Some(sandbox) = sandbox else {
+        close_network_log_session(
+            ctx.run_id,
+            ctx.network_log_session.take(),
+            &ctx.network_log_drain,
+            ctx.mitm_tcp_seal.as_ref(),
+        )
+        .await;
         return CompletionReady::new(completion_payload, BudgetOwnership::active(active_lease));
     };
 
@@ -127,6 +136,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         restored_session_identity,
         source_ip,
         mut network_log_session,
+        mitm_tcp_seal,
         workspace_image,
         workspace_image_size_bytes,
         storage_fingerprints,
@@ -230,6 +240,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         reason: failure.reason,
                         network_log_session: network_log_session.take(),
                         network_log_drain: network_log_drain.clone(),
+                        mitm_tcp_seal: mitm_tcp_seal.clone(),
                     },
                 )
                 .await;
@@ -255,7 +266,13 @@ pub(super) async fn finalize_sandbox_for_completion(
         let (candidate, non_reusable_reason) = park_outcome.into_parts();
         if cancel.is_cancelled() {
             let (payload, budget_lease) = candidate.into_active_destroy_parts();
-            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            close_network_log_session(
+                run_id,
+                network_log_session.take(),
+                &network_log_drain,
+                mitm_tcp_seal.as_ref(),
+            )
+            .await;
             info!(
                 run_id = %run_id,
                 session_id = %cli_agent_session_id,
@@ -277,7 +294,13 @@ pub(super) async fn finalize_sandbox_for_completion(
             );
             destroy_result.budget
         } else if let Some(reason) = non_reusable_reason {
-            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            close_network_log_session(
+                run_id,
+                network_log_session.take(),
+                &network_log_drain,
+                mitm_tcp_seal.as_ref(),
+            )
+            .await;
             info!(
                 run_id = %run_id,
                 session_id = %cli_agent_session_id,
@@ -302,7 +325,13 @@ pub(super) async fn finalize_sandbox_for_completion(
             );
             destroy_result.budget
         } else {
-            close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            close_network_log_session(
+                run_id,
+                network_log_session.take(),
+                &network_log_drain,
+                mitm_tcp_seal.as_ref(),
+            )
+            .await;
             #[cfg(test)]
             test_observer.notify_before_idle_pool_ownership_transfer(run_id);
             loop {
@@ -481,6 +510,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 reason: cleanup_reason,
                 network_log_session: network_log_session.take(),
                 network_log_drain: network_log_drain.clone(),
+                mitm_tcp_seal,
             },
         )
         .await;
@@ -550,9 +580,20 @@ async fn close_network_log_session(
     run_id: RunId,
     session: Option<NetworkLogSession>,
     drain: &NetworkLogDrainCoordinator,
+    mitm_tcp_seal: Option<&MitmTcpSealHandle>,
 ) {
     if let Some(session) = session {
+        let path = session.path().to_path_buf();
         session.close_for_upload(run_id, drain).await;
+        if let Some(mitm_tcp_seal) = mitm_tcp_seal
+            && !mitm_tcp_seal.seal_path(&path).await
+        {
+            warn!(
+                run_id = %run_id,
+                path = %path.display(),
+                "proxy TCP network-log seal did not complete before sandbox release"
+            );
+        }
     }
 }
 
@@ -593,6 +634,7 @@ struct ActiveCleanupContext<'a> {
     reason: &'static str,
     network_log_session: Option<NetworkLogSession>,
     network_log_drain: NetworkLogDrainCoordinator,
+    mitm_tcp_seal: Option<MitmTcpSealHandle>,
 }
 
 /// Stop a sandbox and destroy it via its factory.
@@ -649,6 +691,7 @@ async fn stop_and_destroy_sandbox(
         context.run_id,
         context.network_log_session.take(),
         &context.network_log_drain,
+        context.mitm_tcp_seal.as_ref(),
     )
     .await;
     if AssertUnwindSafe(factory.destroy(sandbox))
@@ -799,6 +842,7 @@ mod tests {
                 restored_session_identity: None,
                 source_ip: "10.0.0.1".into(),
                 network_log_session: Some(network_log_session),
+                mitm_tcp_seal: None,
                 workspace_image: None,
                 workspace_image_size_bytes: 0,
                 storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
@@ -941,6 +985,77 @@ mod tests {
                 .await,
             "parked sandbox must not retain the previous run's network-log attribution",
         );
+    }
+
+    #[tokio::test]
+    async fn finalizer_waits_for_tcp_seal_after_park_before_idle_pool_transfer() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        add_healthy_reuse_preparation_matcher(&overrides);
+        let (factory, sandbox) = sandbox_with_overrides(sandbox_id, Arc::clone(&overrides)).await;
+        let addon_dir = fixture.dir.path().join("mitm-addon");
+        std::fs::create_dir_all(&addon_dir).unwrap();
+        let (mut proxy, _crash_rx) = crate::proxy::MitmProxy::noop();
+        proxy.set_addon_dir_for_test(addon_dir.clone());
+        let (signal_tx, mut signal_rx) = tokio::sync::mpsc::channel(1);
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-network-log-seal",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.factory = factory;
+        context.mitm_tcp_seal = Some(proxy.tcp_seal_handle(signal_tx));
+
+        let idle_pool = Arc::clone(&fixture.idle_pool);
+        let finalizer = tokio::spawn(finalize_sandbox_for_completion(
+            Some(sandbox),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), signal_rx.recv())
+            .await
+            .expect("TCP seal request signal timed out")
+            .expect("TCP seal request signal channel closed");
+        assert_eq!(overrides.park_call_count(), 1);
+        assert!(!finalizer.is_finished());
+        assert_eq!(idle_pool.lock().await.len(), 0);
+
+        let marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(addon_dir.join("tcp-seal-request")).unwrap(),
+        )
+        .unwrap();
+        let updated_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64;
+        let state = serde_json::json!({
+            "pid": std::process::id(),
+            "usageStateId": marker["usageStateId"],
+            "updatedAtMs": updated_at_ms,
+            "sealRequestId": marker["sealRequestId"],
+            "path": marker["path"],
+            "pending": 0,
+        });
+        std::fs::write(addon_dir.join("tcp-seal-state"), state.to_string()).unwrap();
+
+        let _completion_ready = finalizer.await.unwrap();
+        assert_eq!(idle_pool.lock().await.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -56,6 +56,10 @@ request="$base_dir/mitm-addon/usage-flush-request"
 pending="$base_dir/mitm-addon/usage-pending"
 jsonl_request="$base_dir/mitm-addon/jsonl-flush-request"
 jsonl_state="$base_dir/mitm-addon/jsonl-flush-state"
+tcp_seal_request="$base_dir/mitm-addon/tcp-seal-request"
+tcp_seal_state="$base_dir/mitm-addon/tcp-seal-state"
+tcp_seal_observed="$base_dir/mitm-addon/tcp-seal-observed"
+last_tcp_seal_id=""
 write_pending_snapshot() {
   [[ -f "$request" ]] || return 0
   flush_id="$(sed -n 's/.*"flushRequestId":"\([^"]*\)".*/\1/p' "$request")"
@@ -73,8 +77,21 @@ write_jsonl_flush_state() {
   now_ms="$(date +%s%3N)"
   printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"flushRequestId":"%s","path":"%s","pending":0}' "$$" "$state_id" "$now_ms" "$flush_id" "$path" > "$jsonl_state"
 }
+write_tcp_seal_state() {
+  [[ -f "$tcp_seal_request" ]] || return 0
+  seal_id="$(sed -n 's/.*"sealRequestId":"\([^"]*\)".*/\1/p' "$tcp_seal_request")"
+  state_id="$(sed -n 's/.*"usageStateId":"\([^"]*\)".*/\1/p' "$tcp_seal_request")"
+  path="$(sed -n 's/.*"path":"\([^"]*\)".*/\1/p' "$tcp_seal_request")"
+  [[ -n "$seal_id" && -n "$state_id" && -n "$path" ]] || return 0
+  [[ "$seal_id" != "$last_tcp_seal_id" ]] || return 0
+  now_ms="$(date +%s%3N)"
+  printf '{"pid":%s,"usageStateId":"%s","updatedAtMs":%s,"sealRequestId":"%s","path":"%s","pending":0}' "$$" "$state_id" "$now_ms" "$seal_id" "$path" > "$tcp_seal_state"
+  printf '%s\n' "$seal_id" >> "$tcp_seal_observed"
+  last_tcp_seal_id="$seal_id"
+}
 handle_flush_request() {
   write_pending_snapshot
+  write_tcp_seal_state
   write_jsonl_flush_state
 }
 mkfifo "$fifo"
@@ -178,6 +195,10 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
         .proxy
         .mitm
         .jsonl_flush_handle(config.usage_flush_tx.clone());
+    let mitm_tcp_seal = config
+        .proxy
+        .mitm
+        .tcp_seal_handle(config.usage_flush_tx.clone());
     let write_started = Arc::new(tokio::sync::Notify::new());
     let release_write = Arc::new(tokio::sync::Semaphore::new(0));
     let network_log_manager =
@@ -186,6 +207,7 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
         .expect("test config should not share exec_config before run starts");
     exec_config.network_log_manager = network_log_manager.clone();
     exec_config.mitm_jsonl_flush = Some(mitm_jsonl_flush);
+    exec_config.mitm_tcp_seal = Some(mitm_tcp_seal);
 
     // Seed a network log file so `upload_network_logs` has a payload to POST
     // (otherwise it early-returns on NotFound and the assertion below would
@@ -256,6 +278,28 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     );
     assert_eq!(jsonl_state["path"], network_log_path_string);
     assert_eq!(jsonl_state["pending"], 0);
+    let tcp_seal_request: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(addon_dir.join("tcp-seal-request")).unwrap())
+            .unwrap();
+    let tcp_seal_state: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(addon_dir.join("tcp-seal-state")).unwrap())
+            .unwrap();
+    assert_eq!(tcp_seal_request["path"], network_log_path_string);
+    assert_eq!(
+        tcp_seal_state["sealRequestId"],
+        tcp_seal_request["sealRequestId"]
+    );
+    let observed_seal_ids: Vec<_> = std::fs::read_to_string(addon_dir.join("tcp-seal-observed"))
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        observed_seal_ids.len(),
+        2,
+        "finalization and deferred upload must use distinct seal requests"
+    );
+    assert_ne!(observed_seal_ids[0], observed_seal_ids[1]);
 
     // Stronger invariant: drain must actually WAIT for the deferred work.
     // With a 400 ms mock delay, a well-behaved drain takes ≥ the delay;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -260,6 +260,7 @@ fn build_mock_run_config_with_runtime(
             network_log_manager: NetworkLogManager::new(),
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             mitm_jsonl_flush: None,
+            mitm_tcp_seal: None,
             network_policy_refresh: None,
             session_history_cpu: executor::SessionHistoryCpuPool::with_capacity(1),
             session_history_probe: executor::SessionHistoryProbe::default(),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -163,6 +163,7 @@ pub struct ExecutorConfig {
     pub network_log_manager: NetworkLogManager,
     pub network_log_drain: NetworkLogDrainCoordinator,
     pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
+    pub mitm_tcp_seal: Option<crate::proxy::MitmTcpSealHandle>,
     pub(crate) network_policy_refresh: Option<crate::provider::NetworkPolicyRefreshHandle>,
     pub(crate) session_history_cpu: SessionHistoryCpuPool,
     pub(crate) session_history_probe: SessionHistoryProbe,

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -36,6 +36,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         network_log_manager: NetworkLogManager::new(),
         network_log_drain: NetworkLogDrainCoordinator::noop(),
         mitm_jsonl_flush: None,
+        mitm_tcp_seal: None,
         network_policy_refresh: None,
         session_history_cpu: super::super::super::SessionHistoryCpuPool::with_capacity(1),
         session_history_probe: super::super::super::SessionHistoryProbe::default(),

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -71,6 +71,10 @@ pub struct NetworkLogSession {
 }
 
 impl NetworkLogSession {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
     /// Close local Rust-side network logs for this run before upload reads the file.
     ///
     /// The barrier only covers rows observable to the runner reader tasks. It

--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -23,7 +23,7 @@ pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Maximum time to wait for mitmproxy JSONL writes to become visible before upload.
 pub const JSONL_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Maximum time to wait for active TCP rows to enter the JSONL writer queue.
+/// Total request-slot and acknowledgement budget for active TCP rows to enter the JSONL queue.
 pub const TCP_SEAL_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Poll interval when waiting for usage flush.
@@ -175,6 +175,7 @@ struct TcpSealRequestMarker<'a> {
     seal_request_id: &'a str,
     requested_at_ms: u64,
     path: &'a str,
+    final_attempt: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -186,6 +187,8 @@ struct TcpSealState {
     seal_request_id: String,
     path: String,
     pending: u32,
+    #[serde(default)]
+    failed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -196,6 +199,7 @@ struct TcpSealSnapshot {
     seal_request_id: String,
     path: String,
     pending: u32,
+    failed: bool,
 }
 
 impl From<&TcpSealState> for TcpSealSnapshot {
@@ -207,12 +211,16 @@ impl From<&TcpSealState> for TcpSealSnapshot {
             seal_request_id: state.seal_request_id.clone(),
             path: state.path.clone(),
             pending: state.pending,
+            failed: state.failed,
         }
     }
 }
 
 enum FlushReadiness<S> {
     Ready,
+    Failed {
+        not_ready: String,
+    },
     NotReady {
         not_ready: String,
         snapshot: Option<S>,
@@ -336,20 +344,64 @@ impl MitmJsonlFlushHandle {
 
 impl MitmTcpSealHandle {
     pub async fn seal_path(&self, path: &Path) -> bool {
-        let _request_guard = self.request_lock.lock().await;
-        let target = usage_flush_state_guard(&self.usage_state).clone();
-        let request = match write_tcp_seal_request(&self.addon_dir, &target, path).await {
-            Ok(request) => request,
-            Err(e) => {
-                warn!(error = %e, path = %path.display(), "failed to create TCP seal request");
+        self.seal_path_with_final_attempt(path, false).await
+    }
+
+    pub async fn seal_path_for_upload(&self, path: &Path) -> bool {
+        self.seal_path_with_final_attempt(path, true).await
+    }
+
+    async fn seal_path_with_final_attempt(&self, path: &Path, final_attempt: bool) -> bool {
+        let deadline = tokio::time::Instant::now() + TCP_SEAL_TIMEOUT;
+        let _request_guard = match tokio::time::timeout_at(deadline, self.request_lock.lock()).await
+        {
+            Ok(guard) => guard,
+            Err(_) => {
+                warn!(
+                    timeout_secs = TCP_SEAL_TIMEOUT.as_secs(),
+                    path = %path.display(),
+                    "TCP seal deadline expired while waiting to create request"
+                );
                 return false;
             }
         };
+        if tokio::time::Instant::now() >= deadline {
+            warn!(
+                timeout_secs = TCP_SEAL_TIMEOUT.as_secs(),
+                path = %path.display(),
+                "TCP seal deadline expired before creating request"
+            );
+            return false;
+        }
+
+        let target = usage_flush_state_guard(&self.usage_state).clone();
+        let request =
+            match write_tcp_seal_request(&self.addon_dir, &target, path, final_attempt).await {
+                Ok(request) => request,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        path = %path.display(),
+                        "failed to create TCP seal request"
+                    );
+                    return false;
+                }
+            };
         if !self.request_flush() {
             warn!(path = %path.display(), "failed to request TCP network-log seal");
             return false;
         }
-        wait_tcp_seal_requesting(&self.addon_dir, TCP_SEAL_TIMEOUT, &request, || {
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            warn!(
+                timeout_secs = TCP_SEAL_TIMEOUT.as_secs(),
+                path = %path.display(),
+                "TCP seal deadline expired after creating request"
+            );
+            return false;
+        }
+        wait_tcp_seal_requesting(&self.addon_dir, remaining, &request, || {
             self.request_flush()
         })
         .await
@@ -409,6 +461,7 @@ async fn write_tcp_seal_request(
     addon_dir: &Path,
     target: &UsageFlushTarget,
     log_path: &Path,
+    final_attempt: bool,
 ) -> RunnerResult<TcpSealRequest> {
     let request = TcpSealRequest::new(target, log_path);
     let marker = TcpSealRequestMarker {
@@ -416,6 +469,7 @@ async fn write_tcp_seal_request(
         seal_request_id: &request.core.flush_request_id,
         requested_at_ms: request.core.requested_at_ms,
         path: &request.path,
+        final_attempt,
     };
     write_flush_request_marker(addon_dir, "tcp-seal-request", &marker, "TCP seal request").await?;
     Ok(request)
@@ -687,6 +741,9 @@ async fn wait_flush_requesting<S>(
         let (not_ready, snapshot) = match read_addon_state_file(&path).await {
             Ok(Some(content)) => match evaluate_state(&content) {
                 FlushReadiness::Ready => return Ok(()),
+                FlushReadiness::Failed { not_ready } => {
+                    return Err(FlushWaitFailure::RequestFailed { not_ready });
+                }
                 FlushReadiness::NotReady {
                     not_ready,
                     snapshot,
@@ -817,6 +874,10 @@ async fn wait_tcp_seal_requesting(
             Ok(state) => {
                 let snapshot = Some(TcpSealSnapshot::from(&state));
                 match validate_tcp_seal_state(&state, request, now_millis()) {
+                    Ok(()) if state.failed => FlushReadiness::Failed {
+                        not_ready: "addon discarded TCP rows after final writer rejection"
+                            .to_string(),
+                    },
                     Ok(()) if state.pending == 0 => FlushReadiness::Ready,
                     Ok(()) => FlushReadiness::NotReady {
                         not_ready: format!("pending TCP seals={}", state.pending),
@@ -860,6 +921,7 @@ async fn wait_tcp_seal_requesting(
                         seal_request_id = %snapshot.seal_request_id,
                         path = %snapshot.path,
                         pending = snapshot.pending,
+                        failed = snapshot.failed,
                         "TCP seal timed out, proceeding with sandbox finalization"
                     );
                 }
@@ -992,6 +1054,19 @@ mod tests {
         .to_string()
     }
 
+    fn failed_tcp_seal_state(path: &Path) -> String {
+        serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "sealRequestId": "tcp-seal-request-test",
+            "path": path.to_string_lossy().to_string(),
+            "pending": 0,
+            "failed": true,
+        })
+        .to_string()
+    }
+
     fn usage_state(flows: u32, buffered: u32, reports: u32) -> String {
         usage_state_with_request(flows, buffered, reports, Some("request-test"))
     }
@@ -1095,7 +1170,7 @@ mod tests {
         let target = usage_target();
         let log_path = dir.path().join("network.jsonl");
 
-        let request = write_tcp_seal_request(dir.path(), &target, &log_path)
+        let request = write_tcp_seal_request(dir.path(), &target, &log_path, false)
             .await
             .unwrap();
 
@@ -1107,6 +1182,7 @@ mod tests {
         assert_eq!(marker["sealRequestId"], request.core.flush_request_id);
         assert_eq!(marker["requestedAtMs"], request.core.requested_at_ms);
         assert_eq!(marker["path"], log_path.to_string_lossy().to_string());
+        assert_eq!(marker["finalAttempt"], false);
         assert!(marker.get("flushRequestId").is_none());
     }
 
@@ -1163,6 +1239,20 @@ mod tests {
         .unwrap();
 
         assert!(!wait_tcp_seal(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_tcp_seal_rejects_terminal_writer_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = tcp_seal_request(&log_path);
+        std::fs::write(
+            dir.path().join("tcp-seal-state"),
+            failed_tcp_seal_state(&log_path),
+        )
+        .unwrap();
+
+        assert!(!wait_tcp_seal(dir.path(), Duration::from_secs(5), &request).await);
     }
 
     #[tokio::test(start_paused = true)]
@@ -1637,6 +1727,33 @@ mod tests {
         )
         .unwrap();
         assert!(jsonl_task.await.unwrap());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_tcp_seals_share_one_total_deadline() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_log_path = dir.path().join("network-a.jsonl");
+        let second_log_path = dir.path().join("network-b.jsonl");
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        proxy.set_addon_dir_for_test(dir.path().to_path_buf());
+        let (tx, mut rx) = mpsc::channel(1);
+        let handle = proxy.tcp_seal_handle(tx);
+
+        let started_at = tokio::time::Instant::now();
+        let first_handle = handle.clone();
+        let first = tokio::spawn(async move { first_handle.seal_path(&first_log_path).await });
+        rx.recv().await.unwrap();
+
+        let second = tokio::spawn(async move { handle.seal_path(&second_log_path).await });
+        tokio::task::yield_now().await;
+
+        let (first_result, second_result) = tokio::join!(first, second);
+        assert!(!first_result.unwrap());
+        assert!(!second_result.unwrap());
+        assert_eq!(
+            tokio::time::Instant::now().duration_since(started_at),
+            TCP_SEAL_TIMEOUT
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -23,6 +23,9 @@ pub const USAGE_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 /// Maximum time to wait for mitmproxy JSONL writes to become visible before upload.
 pub const JSONL_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Maximum time to wait for active TCP rows to enter the JSONL writer queue.
+pub const TCP_SEAL_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
 
@@ -35,6 +38,12 @@ const JSONL_FLUSH_POLL: Duration = Duration::from_millis(50);
 
 /// Minimum interval between repeated JSONL flush signals while the addon is not ready.
 const JSONL_FLUSH_REQUEST_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Poll interval when waiting for one active TCP path seal.
+const TCP_SEAL_POLL: Duration = Duration::from_millis(10);
+
+/// Minimum interval between repeated TCP seal signals while the addon is not ready.
+const TCP_SEAL_REQUEST_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
@@ -153,6 +162,55 @@ impl From<&JsonlFlushState> for JsonlFlushSnapshot {
     }
 }
 
+#[derive(Debug, Clone)]
+struct TcpSealRequest {
+    core: FlushRequestCore,
+    path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TcpSealRequestMarker<'a> {
+    usage_state_id: &'a str,
+    seal_request_id: &'a str,
+    requested_at_ms: u64,
+    path: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TcpSealState {
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    seal_request_id: String,
+    path: String,
+    pending: u32,
+}
+
+#[derive(Debug, Clone)]
+struct TcpSealSnapshot {
+    pid: u32,
+    usage_state_id: String,
+    updated_at_ms: u64,
+    seal_request_id: String,
+    path: String,
+    pending: u32,
+}
+
+impl From<&TcpSealState> for TcpSealSnapshot {
+    fn from(state: &TcpSealState) -> Self {
+        Self {
+            pid: state.pid,
+            usage_state_id: state.usage_state_id.clone(),
+            updated_at_ms: state.updated_at_ms,
+            seal_request_id: state.seal_request_id.clone(),
+            path: state.path.clone(),
+            pending: state.pending,
+        }
+    }
+}
+
 enum FlushReadiness<S> {
     Ready,
     NotReady {
@@ -173,6 +231,14 @@ enum FlushWaitFailure<S> {
 
 #[derive(Clone)]
 pub struct MitmJsonlFlushHandle {
+    pub(super) addon_dir: PathBuf,
+    pub(super) usage_state: Arc<Mutex<UsageFlushTarget>>,
+    pub(super) request_lock: Arc<AsyncMutex<()>>,
+    pub(super) request_flush_tx: mpsc::Sender<()>,
+}
+
+#[derive(Clone)]
+pub struct MitmTcpSealHandle {
     pub(super) addon_dir: PathBuf,
     pub(super) usage_state: Arc<Mutex<UsageFlushTarget>>,
     pub(super) request_lock: Arc<AsyncMutex<()>>,
@@ -230,6 +296,15 @@ impl JsonlFlushRequest {
     }
 }
 
+impl TcpSealRequest {
+    fn new(target: &UsageFlushTarget, path: &Path) -> Self {
+        Self {
+            core: FlushRequestCore::new(target),
+            path: path.to_string_lossy().into_owned(),
+        }
+    }
+}
+
 impl MitmJsonlFlushHandle {
     pub async fn flush_path(&self, path: &Path) -> bool {
         let _request_guard = self.request_lock.lock().await;
@@ -246,6 +321,35 @@ impl MitmJsonlFlushHandle {
             return false;
         }
         wait_jsonl_flush_requesting(&self.addon_dir, JSONL_FLUSH_TIMEOUT, &request, || {
+            self.request_flush()
+        })
+        .await
+    }
+
+    fn request_flush(&self) -> bool {
+        match self.request_flush_tx.try_send(()) {
+            Ok(()) | Err(mpsc::error::TrySendError::Full(())) => true,
+            Err(mpsc::error::TrySendError::Closed(())) => false,
+        }
+    }
+}
+
+impl MitmTcpSealHandle {
+    pub async fn seal_path(&self, path: &Path) -> bool {
+        let _request_guard = self.request_lock.lock().await;
+        let target = usage_flush_state_guard(&self.usage_state).clone();
+        let request = match write_tcp_seal_request(&self.addon_dir, &target, path).await {
+            Ok(request) => request,
+            Err(e) => {
+                warn!(error = %e, path = %path.display(), "failed to create TCP seal request");
+                return false;
+            }
+        };
+        if !self.request_flush() {
+            warn!(path = %path.display(), "failed to request TCP network-log seal");
+            return false;
+        }
+        wait_tcp_seal_requesting(&self.addon_dir, TCP_SEAL_TIMEOUT, &request, || {
             self.request_flush()
         })
         .await
@@ -298,6 +402,22 @@ async fn write_jsonl_flush_request(
         "JSONL flush request",
     )
     .await?;
+    Ok(request)
+}
+
+async fn write_tcp_seal_request(
+    addon_dir: &Path,
+    target: &UsageFlushTarget,
+    log_path: &Path,
+) -> RunnerResult<TcpSealRequest> {
+    let request = TcpSealRequest::new(target, log_path);
+    let marker = TcpSealRequestMarker {
+        usage_state_id: &request.core.expected_usage_state_id,
+        seal_request_id: &request.core.flush_request_id,
+        requested_at_ms: request.core.requested_at_ms,
+        path: &request.path,
+    };
+    write_flush_request_marker(addon_dir, "tcp-seal-request", &marker, "TCP seal request").await?;
     Ok(request)
 }
 
@@ -363,6 +483,36 @@ fn validate_jsonl_flush_state(
     )?;
     if state.path != request.path {
         return Err("JSONL flush path does not match current request".to_string());
+    }
+
+    Ok(())
+}
+
+fn parse_tcp_seal_state(content: &str) -> Result<TcpSealState, String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err("state file is empty".to_string());
+    }
+    serde_json::from_str::<TcpSealState>(trimmed)
+        .map_err(|e| format!("state file is not valid TCP seal JSON: {e}"))
+}
+
+fn validate_tcp_seal_state(
+    state: &TcpSealState,
+    request: &TcpSealRequest,
+    now_ms: u64,
+) -> Result<(), String> {
+    validate_flush_state_core(
+        &state.usage_state_id,
+        state.updated_at_ms,
+        Some(&state.seal_request_id),
+        &request.core,
+        "TCP seal request id does not match current request",
+        "TCP seal request id is missing",
+        now_ms,
+    )?;
+    if state.path != request.path {
+        return Err("TCP seal path does not match current request".to_string());
     }
 
     Ok(())
@@ -646,6 +796,86 @@ async fn wait_jsonl_flush_requesting(
     }
 }
 
+#[cfg(test)]
+async fn wait_tcp_seal(addon_dir: &Path, timeout: Duration, request: &TcpSealRequest) -> bool {
+    wait_tcp_seal_requesting(addon_dir, timeout, request, || true).await
+}
+
+async fn wait_tcp_seal_requesting(
+    addon_dir: &Path,
+    timeout: Duration,
+    request: &TcpSealRequest,
+    request_flush: impl FnMut() -> bool,
+) -> bool {
+    match wait_flush_requesting(
+        addon_dir,
+        "tcp-seal-state",
+        timeout,
+        TCP_SEAL_POLL,
+        TCP_SEAL_REQUEST_INTERVAL,
+        |content| match parse_tcp_seal_state(content) {
+            Ok(state) => {
+                let snapshot = Some(TcpSealSnapshot::from(&state));
+                match validate_tcp_seal_state(&state, request, now_millis()) {
+                    Ok(()) if state.pending == 0 => FlushReadiness::Ready,
+                    Ok(()) => FlushReadiness::NotReady {
+                        not_ready: format!("pending TCP seals={}", state.pending),
+                        snapshot,
+                    },
+                    Err(not_ready) => FlushReadiness::NotReady {
+                        not_ready,
+                        snapshot,
+                    },
+                }
+            }
+            Err(not_ready) => FlushReadiness::NotReady {
+                not_ready,
+                snapshot: None,
+            },
+        },
+        request_flush,
+    )
+    .await
+    {
+        Ok(()) => true,
+        Err(FlushWaitFailure::RequestFailed { not_ready }) => {
+            warn!(
+                reason = %not_ready,
+                "TCP seal request failed, proceeding with sandbox finalization"
+            );
+            false
+        }
+        Err(FlushWaitFailure::TimedOut {
+            not_ready,
+            snapshot,
+        }) => {
+            match snapshot {
+                Some(snapshot) => {
+                    warn!(
+                        timeout_secs = timeout.as_secs(),
+                        reason = %not_ready,
+                        pid = snapshot.pid,
+                        usage_state_id = %snapshot.usage_state_id,
+                        updated_at_ms = snapshot.updated_at_ms,
+                        seal_request_id = %snapshot.seal_request_id,
+                        path = %snapshot.path,
+                        pending = snapshot.pending,
+                        "TCP seal timed out, proceeding with sandbox finalization"
+                    );
+                }
+                None => {
+                    warn!(
+                        timeout_secs = timeout.as_secs(),
+                        reason = %not_ready,
+                        "TCP seal timed out, proceeding with sandbox finalization"
+                    );
+                }
+            }
+            false
+        }
+    }
+}
+
 async fn read_addon_state_file(path: &Path) -> RunnerResult<Option<String>> {
     crate::state_file::read_to_string(
         path,
@@ -726,12 +956,36 @@ mod tests {
         }
     }
 
+    fn tcp_seal_request(path: &Path) -> TcpSealRequest {
+        TcpSealRequest {
+            core: FlushRequestCore {
+                expected_usage_state_id: "state-test".to_string(),
+                usage_state_started_at_ms: 1_770_000_000_000,
+                flush_request_id: "tcp-seal-request-test".to_string(),
+                requested_at_ms: 1_770_000_000_000,
+            },
+            path: path.to_string_lossy().into_owned(),
+        }
+    }
+
     fn jsonl_state(path: &Path, pending: u32) -> String {
         serde_json::json!({
             "pid": 1234,
             "usageStateId": "state-test",
             "updatedAtMs": 1_770_000_000_001u64,
             "flushRequestId": "jsonl-request-test",
+            "path": path.to_string_lossy().to_string(),
+            "pending": pending,
+        })
+        .to_string()
+    }
+
+    fn tcp_seal_state(path: &Path, pending: u32) -> String {
+        serde_json::json!({
+            "pid": 1234,
+            "usageStateId": "state-test",
+            "updatedAtMs": 1_770_000_000_001u64,
+            "sealRequestId": "tcp-seal-request-test",
             "path": path.to_string_lossy().to_string(),
             "pending": pending,
         })
@@ -835,6 +1089,27 @@ mod tests {
         assert!(!leaked_tmp, "JSONL flush request tmp file leaked");
     }
 
+    #[tokio::test]
+    async fn write_tcp_seal_request_writes_independent_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = usage_target();
+        let log_path = dir.path().join("network.jsonl");
+
+        let request = write_tcp_seal_request(dir.path(), &target, &log_path)
+            .await
+            .unwrap();
+
+        let marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("tcp-seal-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(marker["usageStateId"], "state-test");
+        assert_eq!(marker["sealRequestId"], request.core.flush_request_id);
+        assert_eq!(marker["requestedAtMs"], request.core.requested_at_ms);
+        assert_eq!(marker["path"], log_path.to_string_lossy().to_string());
+        assert!(marker.get("flushRequestId").is_none());
+    }
+
     fn usage_state_without_request(flows: u32, buffered: u32, reports: u32) -> String {
         serde_json::json!({
             "pid": 1234,
@@ -860,6 +1135,34 @@ mod tests {
         )
         .unwrap();
         assert!(wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_tcp_seal_returns_true_when_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = tcp_seal_request(&log_path);
+        std::fs::write(
+            dir.path().join("tcp-seal-state"),
+            tcp_seal_state(&log_path, 0),
+        )
+        .unwrap();
+
+        assert!(wait_tcp_seal(dir.path(), Duration::from_millis(50), &request).await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_tcp_seal_rejects_wrong_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let request = tcp_seal_request(&log_path);
+        std::fs::write(
+            dir.path().join("tcp-seal-state"),
+            tcp_seal_state(&dir.path().join("other.jsonl"), 0),
+        )
+        .unwrap();
+
+        assert!(!wait_tcp_seal(dir.path(), Duration::from_millis(50), &request).await);
     }
 
     #[tokio::test(start_paused = true)]
@@ -1277,6 +1580,63 @@ mod tests {
         )
         .unwrap();
         assert!(second.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn tcp_seal_from_same_proxy_is_not_blocked_by_jsonl_request_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl_path = dir.path().join("network-jsonl.jsonl");
+        let seal_path = dir.path().join("network-seal.jsonl");
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        proxy.set_addon_dir_for_test(dir.path().to_path_buf());
+        let (tx, mut rx) = mpsc::channel(1);
+        let jsonl_handle = proxy.jsonl_flush_handle(tx.clone());
+        let seal_handle = proxy.tcp_seal_handle(tx);
+
+        let jsonl_task_path = jsonl_path.clone();
+        let jsonl_task =
+            tokio::spawn(async move { jsonl_handle.flush_path(&jsonl_task_path).await });
+        rx.recv().await.unwrap();
+        let jsonl_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
+        )
+        .unwrap();
+
+        let seal_task_path = seal_path.clone();
+        let seal_task = tokio::spawn(async move { seal_handle.seal_path(&seal_task_path).await });
+        rx.recv()
+            .await
+            .expect("TCP seal must signal while JSONL request is still pending");
+        let seal_marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("tcp-seal-request")).unwrap(),
+        )
+        .unwrap();
+        let seal_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": seal_marker["usageStateId"],
+            "updatedAtMs": now_millis(),
+            "sealRequestId": seal_marker["sealRequestId"],
+            "path": seal_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(dir.path().join("tcp-seal-state"), seal_state.to_string()).unwrap();
+        assert!(seal_task.await.unwrap());
+        assert!(!jsonl_task.is_finished());
+
+        let jsonl_state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": jsonl_marker["usageStateId"],
+            "updatedAtMs": now_millis(),
+            "flushRequestId": jsonl_marker["flushRequestId"],
+            "path": jsonl_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(
+            dir.path().join("jsonl-flush-state"),
+            jsonl_state.to_string(),
+        )
+        .unwrap();
+        assert!(jsonl_task.await.unwrap());
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -1729,6 +1729,37 @@ mod tests {
         assert!(jsonl_task.await.unwrap());
     }
 
+    #[tokio::test]
+    async fn tcp_seal_for_upload_marks_request_as_final_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("network.jsonl");
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        proxy.set_addon_dir_for_test(dir.path().to_path_buf());
+        let (tx, mut rx) = mpsc::channel(1);
+        let handle = proxy.tcp_seal_handle(tx);
+
+        let task_path = log_path.clone();
+        let task = tokio::spawn(async move { handle.seal_path_for_upload(&task_path).await });
+        rx.recv().await.unwrap();
+
+        let marker: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("tcp-seal-request")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(marker["finalAttempt"], true);
+        let state = serde_json::json!({
+            "pid": 1234,
+            "usageStateId": marker["usageStateId"],
+            "updatedAtMs": now_millis(),
+            "sealRequestId": marker["sealRequestId"],
+            "path": log_path.to_string_lossy().to_string(),
+            "pending": 0,
+        });
+        std::fs::write(dir.path().join("tcp-seal-state"), state.to_string()).unwrap();
+
+        assert!(task.await.unwrap());
+    }
+
     #[tokio::test(start_paused = true)]
     async fn concurrent_tcp_seals_share_one_total_deadline() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -23,13 +23,16 @@
 //! - `jsonl-flush-request` is written by Rust for one network log path before
 //!   upload. The addon acknowledges in `jsonl-flush-state` after accepted
 //!   writes for that path are visible.
+//! - `tcp-seal-request` is written after sandbox quiescence and again before
+//!   JSONL flush. The addon acknowledges in `tcp-seal-state` after active TCP
+//!   rows for that path enter the writer queue.
 //!
 //! On supported Unix runner hosts, registry writes are target-path atomic so
 //! the addon never consumes partial JSON. Flush acknowledgements must match the
 //! active usage state and request id; missing, stale, invalid, or mismatched
 //! addon state is treated as "not ready" until the bounded wait times out.
-//! Usage drain is a shutdown path for billing and usage reports, while JSONL
-//! flush is a per-upload network-log path.
+//! Usage drain is a shutdown path for billing and usage reports, TCP seal
+//! closes per-run producer attribution, and JSONL flush drains one upload path.
 //!
 //! `MitmProxy::new` prepares addon files, an empty registry, crash channel, and
 //! initial usage state. `start` spawns `mitmdump` and monitor tasks. Unexpected
@@ -43,6 +46,8 @@
 //! (mitmproxy hook orchestration),
 //! `crates/runner/mitm-addon/src/runner_flush_lifecycle.py` (SIGUSR1 worker and
 //! request handling),
+//! `crates/runner/mitm-addon/src/tcp_seal_lifecycle.py` (independent TCP seal
+//! worker and request handling),
 //! `crates/runner/mitm-addon/src/usage/counters.py` (`usage-pending`),
 //! `crates/runner/mitm-addon/src/registry.py` (registry loading), and
 //! `crates/runner/mitm-addon/src/jsonl_writer.py` (accepted-write flush
@@ -54,7 +59,7 @@ mod registry;
 mod stderr;
 
 pub use flush::{
-    MitmJsonlFlushHandle, USAGE_FLUSH_TIMEOUT, wait_usage_flush_requesting,
+    MitmJsonlFlushHandle, MitmTcpSealHandle, USAGE_FLUSH_TIMEOUT, wait_usage_flush_requesting,
     write_usage_flush_request,
 };
 pub use process::{MitmProxy, ProxyConfig};

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -10,7 +10,8 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tracing::{error, info, warn};
 
 use super::flush::{
-    MitmJsonlFlushHandle, UsageFlushTarget, new_usage_state_id, usage_flush_state_guard,
+    MitmJsonlFlushHandle, MitmTcpSealHandle, UsageFlushTarget, new_usage_state_id,
+    usage_flush_state_guard,
 };
 use super::registry::{ProxyRegistryHandle, VmRegistration, write_empty_registry};
 use super::stderr::log_mitmdump_stderr_line;
@@ -72,6 +73,7 @@ pub struct MitmProxy {
     usage_state_started_at_ms: u64,
     usage_flush_state: Arc<Mutex<UsageFlushTarget>>,
     jsonl_flush_request_lock: Arc<AsyncMutex<()>>,
+    tcp_seal_request_lock: Arc<AsyncMutex<()>>,
 }
 
 impl MitmProxy {
@@ -126,6 +128,7 @@ impl MitmProxy {
             usage_state_started_at_ms,
         }));
         let jsonl_flush_request_lock = Arc::new(AsyncMutex::new(()));
+        let tcp_seal_request_lock = Arc::new(AsyncMutex::new(()));
 
         Ok((
             Self {
@@ -138,6 +141,7 @@ impl MitmProxy {
                 usage_state_started_at_ms,
                 usage_flush_state,
                 jsonl_flush_request_lock,
+                tcp_seal_request_lock,
             },
             crash_rx,
         ))
@@ -180,6 +184,16 @@ impl MitmProxy {
             addon_dir: self.config.addon_dir.clone(),
             usage_state: Arc::clone(&self.usage_flush_state),
             request_lock: Arc::clone(&self.jsonl_flush_request_lock),
+            request_flush_tx,
+        }
+    }
+
+    /// Create a cloneable handle for sealing active TCP logs for one path.
+    pub fn tcp_seal_handle(&self, request_flush_tx: mpsc::Sender<()>) -> MitmTcpSealHandle {
+        MitmTcpSealHandle {
+            addon_dir: self.config.addon_dir.clone(),
+            usage_state: Arc::clone(&self.usage_flush_state),
+            request_lock: Arc::clone(&self.tcp_seal_request_lock),
             request_flush_tx,
         }
     }
@@ -450,6 +464,7 @@ impl MitmProxy {
                     usage_state_started_at_ms: super::flush::now_millis(),
                 })),
                 jsonl_flush_request_lock: Arc::new(AsyncMutex::new(())),
+                tcp_seal_request_lock: Arc::new(AsyncMutex::new(())),
             },
             crash_rx,
         )


### PR DESCRIPTION
## Summary

- seal active TCP flows after the sandbox is parked or stopped and before ownership can transfer to the idle pool
- use an independent TCP seal request/state lane so usage and JSONL flush work cannot block run-boundary accounting
- freeze each flow's row and release the live flow immediately at the run boundary; retry rejected rows from a bounded 4,096-row snapshot buffer without accepting late bytes
- make the deferred-upload seal final: report and discard rows that still cannot enter the writer, and bound concurrent seal lock/ack waits to one shared five-second deadline per caller
- cover exactly-once finalization, race ordering, late messages, backpressure recovery and exhaustion, timeouts, and idle-pool ordering

## Compatibility

- no database, API, network-log schema, migration, or persisted product-data changes
- existing TCP log rows and the JSONL flush protocol remain unchanged
- the private TCP seal marker/state protocol gains `finalAttempt` and an optional `failed` acknowledgement; missing fields retain the previous non-final/success defaults
- the addon still adds only two ephemeral marker files in its regenerated runtime directory

## Validation

- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && basedpyright`
- `cd crates/runner/mitm-addon && pytest -q` (4,132 passed)
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (2,771 passed, 13 ignored)
- after rebasing onto the latest `main`: 52 focused Rust flush tests and 10 TCP seal lifecycle tests passed

Closes #21047
