### PR TITLE
fix(api): serialize workflow queue dispatch

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,20 +135,30 @@ The orchestration layer coordinates job execution between web API and runners.
 A chat thread runs at most one run at a time. Queued work lives in
 `chat_message_queue` with two item types: `user_message` (a chat message
 waiting for its run) and `workflow_event` (a fired workflow automation event
-carrying its encrypted payload). Admission and consumption serialize on a
-per-thread Postgres advisory lock and pop in `ORDER BY created_at, id` order,
-with user messages always draining before workflow events.
+carrying its encrypted payload). Automated workflow intake always commits its
+queue row before run preparation. Drains peek at the workflow FIFO head rather
+than removing it, with user messages always taking priority over workflow
+events ordered by `created_at, id`.
+
+Prepared workflow runs are candidates until a pre-dispatch transaction locks
+the chat thread and rechecks pause state, queued-user priority, active
+ownership, and the exact FIFO head. Only the winner removes that event, binds
+its user message, and proceeds to runner dispatch; competing candidates cancel
+without consuming queue work. Short advisory-lock transactions still
+serialize queue intake, inspection, and mutation, but no database lock or
+connection spans full run preparation.
 
 All scheduling flows converge on a single drain entry
 (`drainChatThreadQueueForThread$` in
 `turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts`):
 terminal run callbacks, run cancellation, queue resume, and a cron sweep for
-threads missed by callbacks. A run-creation failure for a dequeued workflow
-event restores the event at its original queue position and pauses the
-thread's queue (`chat_threads.queue_paused_at` / `pause_reason`); pause
-freezes consumption while intake continues. Schedule ticks coalesce to at
-most one pending event per automation. The drain entry is the designated
-mounting point for a future unified per-thread rate limiter.
+threads missed by callbacks. A failure before the workflow event is bound to a
+run leaves that event pending and pauses the thread's queue
+(`chat_threads.queue_paused_at` / `pause_reason`); after the claim commits, a
+later dispatch failure belongs to the bound run. Pause freezes consumption
+while intake continues. Schedule ticks coalesce to at most one pending event
+per automation. The drain entry is the designated mounting point for a future
+unified per-thread rate limiter.
 
 ---
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -61,6 +61,7 @@ import {
   hasVm0ApiKeyLabel,
   holdChatMessageWritesFixture,
   holdOrgAdmissionLockFixture,
+  queuedUserMessageIsWriteLockedFixture,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
 
@@ -4132,7 +4133,15 @@ describe("CHAT-02: shared user message queue", () => {
     });
     admissionLock.release();
     await admissionLock.done;
-    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(1);
+    await expect
+      .poll(() => {
+        return queuedUserMessageIsWriteLockedFixture({
+          threadId: anchor.threadId,
+          messageId,
+        });
+      })
+      .toBe(true);
+    const blockedBeforeRecall = await messageWritesLock.blockedWaiterCount();
 
     const recall = chat.requestSendMessage(
       actor,
@@ -4144,7 +4153,12 @@ describe("CHAT-02: shared user message queue", () => {
       },
       [400],
     );
-    await expect.poll(messageWritesLock.blockedWaiterCount).toBe(2);
+    // The claim holds this exact queue row before recall starts. Recall then
+    // adds one transitive waiter behind the write-blocked claim; unrelated
+    // chat-message writers may already be waiting on the table boundary.
+    await expect
+      .poll(messageWritesLock.blockedWaiterCount)
+      .toBeGreaterThan(blockedBeforeRecall);
     messageWritesLock.release();
 
     const recalled = await recall;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -451,5 +451,14 @@ describe("workflow queue API", () => {
     expect(afterSecond).toHaveLength(3);
     await completeRunThroughSandbox(scenario, afterSecond[2]!);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(3);
+    const drained = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(drained.body.running).toBeNull();
+    expect(drained.body.pending).toHaveLength(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -1,7 +1,8 @@
-import { createHash } from "node:crypto";
-
 import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { onTestFinished } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
@@ -9,7 +10,9 @@ import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { holdOrgAdmissionLockFixture } from "../../../test-fixtures/chat-messages";
 import type { ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
@@ -20,6 +23,7 @@ const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
+const connectorsApi = createConnectorBddApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-api-workflow";
 
@@ -33,6 +37,10 @@ function automationsClient() {
 
 function queueClient() {
   return setupApp({ context })(zeroWorkflowQueueContract);
+}
+
+function modelProvidersClient() {
+  return setupApp({ context })(zeroModelProvidersByTypeContract);
 }
 
 interface Scenario {
@@ -51,6 +59,11 @@ async function setup(): Promise<Scenario> {
   if (!actor.orgId) {
     throw new Error("Expected an org-scoped workflow actor");
   }
+  // Completed sandbox runs persist memory versions. Keep this queue suite's
+  // actors out of the repository-wide memory summarization sweep.
+  await connectorsApi.updateFeatureSwitches(actor, {
+    [FeatureSwitchKey.MemoryViewer]: false,
+  });
   const agent = await wf.createAgent(actor, {
     displayName: "Workflow Queue API Agent",
   });
@@ -158,18 +171,6 @@ async function completeRunThroughSandbox(
   await runsApi.heartbeatRunner(scenario.runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
   const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
-  await webhooksApi.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `workflow-queue-api-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`workflow queue api history ${runId}`)
-        .digest("hex"),
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooksApi.requestAgentComplete(
     { runId, exitCode: 0 },
     sandboxHeaders,
@@ -310,5 +311,145 @@ describe("workflow queue API", () => {
     expect(resumed.body.pausedAt).toBeNull();
     expect(resumed.body.running).not.toBeNull();
     expect(resumed.body.pending).toHaveLength(1);
+  });
+
+  it("lets a pause arriving during run preparation keep the event pending", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const deliveryPromise = postWorkflowWebhook(
+      automation,
+      "pause-during-preparation",
+    );
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    const paused = await accept(
+      queueClient().pause({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(paused.body.pausedAt).not.toBeNull();
+
+    admissionLock.release();
+    await admissionLock.done;
+    await expect(deliveryPromise).resolves.toBeNull();
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running).toBeNull();
+    expect(queue.body.pending).toHaveLength(1);
+    expect(queue.body.pending[0]?.automationId).toBe(automation.automationId);
+  });
+
+  it("pauses a durable event when run creation fails before its claim", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    await accept(
+      modelProvidersClient().delete({
+        headers: authHeaders(),
+        params: { type: "anthropic-api-key" },
+      }),
+      [204],
+    );
+
+    await expect(
+      postWorkflowWebhook(automation, "pre-claim-create-failure"),
+    ).resolves.toBeNull();
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running).toBeNull();
+    expect(queue.body.pending).toHaveLength(1);
+    expect(queue.body.pending[0]?.automationId).toBe(automation.automationId);
+    expect(queue.body.pausedAt).not.toBeNull();
+    expect(queue.body.pauseReason).toContain("No model provider configured");
+  });
+
+  it("serializes concurrent resumes before advancing the next event", async () => {
+    const { scenario, automation, runningRunId } = await busyQueueFixture(1);
+    await accept(
+      queueClient().pause({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    await expect(
+      postWorkflowWebhook(automation, "while-paused"),
+    ).resolves.toBeNull();
+    await completeRunThroughSandbox(scenario, runningRunId);
+
+    const idle = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(idle.body.running).toBeNull();
+    expect(idle.body.pending).toHaveLength(2);
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+    const firstResumePromise = accept(
+      queueClient().resume({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    const secondResumePromise = accept(
+      queueClient().resume({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+    admissionLock.release();
+    await admissionLock.done;
+    const secondResume = await secondResumePromise;
+    const firstResume = await firstResumePromise;
+
+    expect(firstResume.body.running).not.toBeNull();
+    expect(firstResume.body.pending).toHaveLength(1);
+    expect(secondResume.body.running?.runId).toBe(
+      firstResume.body.running?.runId,
+    );
+    expect(secondResume.body.pending).toHaveLength(1);
+
+    const afterResume = await workflowRunIds(automation.threadId);
+    expect(afterResume).toHaveLength(2);
+    await completeRunThroughSandbox(scenario, afterResume[1]!);
+    const afterSecond = await workflowRunIds(automation.threadId);
+    expect(afterSecond).toHaveLength(3);
+    await completeRunThroughSandbox(scenario, afterSecond[2]!);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(3);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -264,6 +264,15 @@ describe("workflow queue", () => {
     expect(afterFirst).toHaveLength(2);
     await completeRunThroughSandbox(scenario, afterFirst[1]!);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
+    const drained = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(drained.body.running).toBeNull();
+    expect(drained.body.pending).toHaveLength(0);
   });
 
   it("lets a user message arriving during workflow preparation take priority", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1,7 +1,8 @@
-import { createHash } from "node:crypto";
-
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { onTestFinished } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
@@ -9,8 +10,10 @@ import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { holdOrgAdmissionLockFixture } from "../../../test-fixtures/chat-messages";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
@@ -21,6 +24,7 @@ const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
+const connectorsApi = createConnectorBddApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
@@ -37,6 +41,10 @@ function automationsClient() {
 
 function chatMessagesClient() {
   return setupApp({ context })(chatMessagesContract);
+}
+
+function queueClient() {
+  return setupApp({ context })(zeroWorkflowQueueContract);
 }
 
 interface Scenario {
@@ -56,6 +64,11 @@ async function setup(): Promise<Scenario> {
   if (!actor.orgId) {
     throw new Error("Expected an org-scoped workflow actor");
   }
+  // Completed sandbox runs persist memory versions. Keep this queue suite's
+  // actors out of the repository-wide memory summarization sweep.
+  await connectorsApi.updateFeatureSwitches(actor, {
+    [FeatureSwitchKey.MemoryViewer]: false,
+  });
   const agent = await wf.createAgent(actor, {
     displayName: "Workflow Queue Agent",
   });
@@ -183,18 +196,6 @@ async function completeRunThroughSandbox(
   await runsApi.heartbeatRunner(scenario.runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
   const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
-  await webhooksApi.requestAgentCheckpoint(
-    {
-      runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId: `workflow-queue-cli-${runId}`,
-      cliAgentSessionHistoryHash: createHash("sha256")
-        .update(`workflow queue history ${runId}`)
-        .digest("hex"),
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooksApi.requestAgentComplete(
     { runId, exitCode: 0 },
     sandboxHeaders,
@@ -212,6 +213,109 @@ async function executeDueWorkflowAutomations(): Promise<void> {
 }
 
 describe("workflow queue", () => {
+  it("serializes concurrent workflow events admitted to an idle thread", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const firstPromise = postWorkflowWebhook(automation, "first");
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    let secondSettled = false;
+    const secondPromise = postWorkflowWebhook(automation, "second").then(
+      (result) => {
+        secondSettled = true;
+        return result;
+      },
+    );
+    await expect
+      .poll(async () => {
+        return {
+          secondSettled,
+          waiterCount: await admissionLock.waiterCount(),
+        };
+      })
+      .toStrictEqual({ secondSettled: true, waiterCount: 1 });
+    const second = await secondPromise;
+    admissionLock.release();
+    await admissionLock.done;
+    const first = await firstPromise;
+
+    const firstRunId = expectAcceptedRunId(first);
+    expectAcceptedWithoutRun(second);
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running?.runId).toBe(firstRunId);
+    expect(queue.body.pending).toHaveLength(1);
+
+    await completeRunThroughSandbox(scenario, firstRunId);
+    const afterFirst = await workflowRunIds(automation.threadId);
+    expect(afterFirst).toHaveLength(2);
+    await completeRunThroughSandbox(scenario, afterFirst[1]!);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
+  });
+
+  it("lets a user message arriving during workflow preparation take priority", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: scenario.orgId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      admissionLock.release();
+      await admissionLock.done;
+    });
+
+    const workflowPromise = postWorkflowWebhook(
+      automation,
+      "workflow-preparing",
+    );
+    await expect.poll(admissionLock.waiterCount).toBe(1);
+    const userPromise = accept(
+      chatMessagesClient().send({
+        headers: authHeaders(),
+        body: {
+          agentId: scenario.agentId,
+          threadId: automation.threadId,
+          prompt: "user takes priority",
+        },
+      }),
+      [201],
+    );
+    await expect.poll(admissionLock.waiterCount).toBe(2);
+    admissionLock.release();
+    await admissionLock.done;
+
+    expectAcceptedWithoutRun(await workflowPromise);
+    const user = await userPromise;
+    if (!user.body.runId) {
+      throw new Error("Expected the queued user message to claim a run");
+    }
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: automation.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running?.runId).toBe(user.body.runId);
+    expect(queue.body.pending).toHaveLength(1);
+    expect(queue.body.pending[0]?.automationId).toBe(automation.automationId);
+  });
+
   it("queues webhook events behind the in-flight run and drains them serially", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -12,7 +12,6 @@ import {
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -56,7 +55,6 @@ import {
 } from "../../lib/error";
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
 import {
@@ -68,6 +66,7 @@ import {
   type BeforeRunDispatch,
 } from "../services/agent-run-create.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
+import { activeChatThreadOwnerExists } from "../services/chat-message-queue.service";
 import { drainChatThreadQueueForThread$ } from "../services/chat-thread-queue-drain.service";
 import {
   ApiDispatchTimingCollector,
@@ -326,8 +325,6 @@ const sendBody$ = bodyResultOf(chatMessagesContract.send);
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
-const idRowSchema = z.object({ id: z.string() });
-
 function forbidden(message: string) {
   return {
     status: 403 as const,
@@ -827,34 +824,7 @@ async function activeRunExistsForThread(
   db: Db,
   threadId: string,
 ): Promise<boolean> {
-  const runs = await executeRawRows(
-    db,
-    sql`
-      SELECT ${zeroRuns.id} AS "id"
-      FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-      WHERE ${zeroRuns.chatThreadId} = ${threadId}
-        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-        AND (
-          NOT EXISTS (
-            SELECT 1
-            FROM ${agentRunCallbacks}
-            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-              AND ${agentRunCallbacks.internalKind} = 'chat'
-              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-          )
-          OR EXISTS (
-            SELECT 1
-            FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${zeroRuns.id}
-              AND ${chatMessages.role} = 'user'
-          )
-        )
-      LIMIT 1
-    `,
-    idRowSchema,
-  );
-  return runs[0] !== undefined;
+  return await activeChatThreadOwnerExists(db, { threadId });
 }
 
 async function resolveClientMessageSend(params: {

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -1,5 +1,7 @@
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -7,7 +9,7 @@ import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
 } from "@vm0/db/schema/zero-workflow";
-import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import type { Db, ReadonlyDb } from "../external/db";
@@ -20,6 +22,8 @@ import {
   type InternalRunCallbackKind,
 } from "./internal-run-callback";
 import { hasUnclaimedQueuedUserMessage } from "./zero-chat-queued-message.service";
+import { insertChatMessage } from "./zero-chat-message.service";
+import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 
 const WORKFLOW_QUEUE_EVENT_PARAMS_KEY = "__workflow_queue_event_params__";
 
@@ -103,6 +107,57 @@ async function queuePausedForThread(
 }
 
 /**
+ * Pre-dispatch chat candidates do not own the thread until their user message
+ * is durable. Candidate markers let concurrent contenders coexist briefly
+ * while the thread-row claim chooses exactly one dispatchable run.
+ */
+function chatRunOwnsThreadCondition(): SQL {
+  return sql`
+    (
+      NOT EXISTS (
+        SELECT 1
+        FROM ${agentRunCallbacks}
+        WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+          AND ${agentRunCallbacks.internalKind} = 'chat'
+          AND (
+            ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
+            OR ${agentRunCallbacks.payload}->>'workflowQueueEventId' IS NOT NULL
+          )
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM ${chatMessages}
+        WHERE ${chatMessages.runId} = ${zeroRuns.id}
+          AND ${chatMessages.role} = 'user'
+      )
+    )
+  `;
+}
+
+export async function activeChatThreadOwnerExists(
+  db: ReadonlyDb,
+  args: {
+    readonly threadId: string;
+    readonly excludeRunId?: string;
+  },
+): Promise<boolean> {
+  const [run] = await db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, args.threadId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+        args.excludeRunId ? ne(zeroRuns.id, args.excludeRunId) : undefined,
+        chatRunOwnsThreadCondition(),
+      ),
+    )
+    .limit(1);
+  return run !== undefined;
+}
+
+/**
  * Thread-level busy check: any in-flight run bound to the workflow's chat
  * thread blocks the queue. `queued` counts — the workflow's single in-flight
  * run may itself be waiting on an org concurrency slot, and admitting more
@@ -112,18 +167,7 @@ async function activeRunExistsForWorkflowThread(
   db: Db,
   threadId: string,
 ): Promise<boolean> {
-  const [run] = await db
-    .select({ id: zeroRuns.id })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(
-      and(
-        eq(zeroRuns.chatThreadId, threadId),
-        inArray(agentRuns.status, ["queued", "pending", "running"]),
-      ),
-    )
-    .limit(1);
-  return run !== undefined;
+  return await activeChatThreadOwnerExists(db, { threadId });
 }
 
 async function pendingWorkflowEventExists(
@@ -155,12 +199,52 @@ async function pendingTickExistsForAutomation(
   return tick !== undefined;
 }
 
-type WorkflowQueueAdmission = "proceed" | "enqueued";
+export interface WorkflowQueueEvent {
+  readonly id: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly automationId: string;
+  readonly chatThreadId: string;
+  readonly triggerSource: string;
+  readonly triggerBrief: string | null;
+  readonly encryptedParams: string;
+  readonly createdAt: Date;
+}
+
+function workflowQueueEventFromRow(
+  item: typeof chatMessageQueue.$inferSelect,
+): WorkflowQueueEvent {
+  if (
+    item.itemType !== "workflow_event" ||
+    !item.automationId ||
+    !item.triggerSource ||
+    !item.encryptedParams
+  ) {
+    throw new Error(
+      `Workflow event queue item ${item.id} is missing its automation payload`,
+    );
+  }
+  return {
+    id: item.id,
+    orgId: item.orgId,
+    userId: item.userId,
+    automationId: item.automationId,
+    chatThreadId: item.chatThreadId,
+    triggerSource: item.triggerSource,
+    triggerBrief: item.triggerBrief,
+    encryptedParams: item.encryptedParams,
+    createdAt: item.createdAt,
+  };
+}
+
+type WorkflowQueueAdmission =
+  | { readonly kind: "proceed"; readonly event: WorkflowQueueEvent }
+  | { readonly kind: "enqueued" };
 
 /**
- * Decide whether a fired automation event may create its run now or must wait in
- * the chat message queue. Serialized per chat thread via an advisory lock.
- * Schedule ticks coalesce per automation: at most one pending tick.
+ * Persist a fired automation event before deciding whether its queue head may
+ * create a run inline. Schedule ticks coalesce per automation, while every
+ * non-coalesced event has a durable row before run preparation begins.
  */
 export async function admitWorkflowAutomationEvent(
   db: Db,
@@ -181,62 +265,51 @@ export async function admitWorkflowAutomationEvent(
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(args.chatThreadId));
 
-    const paused = await queuePausedForThread(tx, args.chatThreadId);
-
-    if (!paused) {
-      const busy = await activeRunExistsForWorkflowThread(
-        tx,
-        args.chatThreadId,
-      );
-      if (!busy && !(await pendingWorkflowEventExists(tx, args.chatThreadId))) {
-        return "proceed";
-      }
-    }
-
     if (
       automation.kind === "schedule" &&
       (await pendingTickExistsForAutomation(tx, automation.id))
     ) {
-      return "enqueued";
+      return { kind: "enqueued" };
     }
 
-    await tx.insert(chatMessageQueue).values({
-      orgId: automation.orgId,
-      userId: automation.ownerUserId,
-      chatThreadId: args.chatThreadId,
-      itemType: "workflow_event",
-      automationId: automation.id,
-      triggerSource: args.triggerSource,
-      triggerBrief: args.triggerBrief ?? null,
-      encryptedParams,
-    });
-    return "enqueued";
+    const paused = await queuePausedForThread(tx, args.chatThreadId);
+    const mayProceed =
+      !paused &&
+      !(await hasUnclaimedQueuedUserMessage(tx, args.chatThreadId)) &&
+      !(await activeRunExistsForWorkflowThread(tx, args.chatThreadId)) &&
+      !(await pendingWorkflowEventExists(tx, args.chatThreadId));
+
+    const [item] = await tx
+      .insert(chatMessageQueue)
+      .values({
+        orgId: automation.orgId,
+        userId: automation.ownerUserId,
+        chatThreadId: args.chatThreadId,
+        itemType: "workflow_event",
+        automationId: automation.id,
+        triggerSource: args.triggerSource,
+        triggerBrief: args.triggerBrief ?? null,
+        encryptedParams,
+      })
+      .returning();
+    if (!item) {
+      throw new Error("Workflow event queue insert returned no row");
+    }
+    return mayProceed
+      ? { kind: "proceed", event: workflowQueueEventFromRow(item) }
+      : { kind: "enqueued" };
   });
 }
 
-export interface ClaimedWorkflowQueueEvent {
-  readonly id: string;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly automationId: string;
-  readonly chatThreadId: string;
-  readonly triggerSource: string;
-  readonly triggerBrief: string | null;
-  readonly encryptedParams: string;
-  readonly createdAt: Date;
-}
-
 /**
- * Pop the oldest pending workflow event for the thread's queue, or return
- * null when the queue must not advance: paused, a queued user chat message
- * waiting (user messages always drain first), or an in-flight run.
- * The claimed row is deleted; a failed dequeue re-inserts it via
- * `restoreWorkflowQueueEventAndPause`.
+ * Read the oldest dispatchable workflow event without consuming it. Expensive
+ * run preparation happens after this read; the pre-dispatch claim rechecks and
+ * deletes the exact head only when its candidate run wins ownership.
  */
-export async function claimNextWorkflowQueueEvent(
+export async function peekNextWorkflowQueueEvent(
   db: Db,
   chatThreadId: string,
-): Promise<ClaimedWorkflowQueueEvent | null> {
+): Promise<WorkflowQueueEvent | null> {
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(chatThreadId));
     if (await queuePausedForThread(tx, chatThreadId)) {
@@ -264,24 +337,7 @@ export async function claimNextWorkflowQueueEvent(
     if (!item) {
       return null;
     }
-    if (!item.automationId || !item.triggerSource || !item.encryptedParams) {
-      throw new Error(
-        `Workflow event queue item ${item.id} is missing its automation payload`,
-      );
-    }
-
-    await tx.delete(chatMessageQueue).where(eq(chatMessageQueue.id, item.id));
-    return {
-      id: item.id,
-      orgId: item.orgId,
-      userId: item.userId,
-      automationId: item.automationId,
-      chatThreadId: item.chatThreadId,
-      triggerSource: item.triggerSource,
-      triggerBrief: item.triggerBrief,
-      encryptedParams: item.encryptedParams,
-      createdAt: item.createdAt,
-    };
+    return workflowQueueEventFromRow(item);
   });
 }
 
@@ -304,45 +360,196 @@ async function setPauseState(
     .where(eq(chatThreads.id, chatThreadId));
 }
 
-/**
- * Put a claimed event back at its original queue position (id and createdAt
- * are preserved) and pause the queue so the failure does not burn through
- * the backlog. Used when run creation for a dequeued event fails.
- */
-export async function restoreWorkflowQueueEventAndPause(
+export async function claimWorkflowQueueEventForRun(
   db: Db,
   args: {
-    readonly event: ClaimedWorkflowQueueEvent;
+    readonly event: WorkflowQueueEvent;
+    readonly runId: string;
+    readonly prompt: string;
+  },
+): Promise<boolean> {
+  const { event } = args;
+  return await db.transaction(async (tx) => {
+    const [thread] = await tx
+      .select({ queuePausedAt: chatThreads.queuePausedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, event.chatThreadId))
+      .for("update");
+    if (!thread || thread.queuePausedAt !== null) {
+      return false;
+    }
+
+    const [run] = await tx
+      .select({
+        status: agentRuns.status,
+        chatThreadId: zeroRuns.chatThreadId,
+      })
+      .from(agentRuns)
+      .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+      .where(eq(agentRuns.id, args.runId))
+      .for("update", { of: agentRuns });
+    if (
+      !run ||
+      run.chatThreadId !== event.chatThreadId ||
+      (run.status !== "queued" && run.status !== "pending")
+    ) {
+      return false;
+    }
+
+    const [marker] = await tx
+      .select({ id: agentRunCallbacks.id })
+      .from(agentRunCallbacks)
+      .where(
+        and(
+          eq(agentRunCallbacks.runId, args.runId),
+          eq(agentRunCallbacks.internalKind, "chat"),
+          sql`${agentRunCallbacks.payload}->>'workflowQueueEventId' = ${event.id}`,
+        ),
+      )
+      .limit(1);
+    if (!marker) {
+      throw new Error(
+        `Workflow queue candidate ${args.runId} is missing event marker ${event.id}`,
+      );
+    }
+
+    if (await hasUnclaimedQueuedUserMessage(tx, event.chatThreadId)) {
+      return false;
+    }
+    if (
+      await activeChatThreadOwnerExists(tx, {
+        threadId: event.chatThreadId,
+        excludeRunId: args.runId,
+      })
+    ) {
+      return false;
+    }
+
+    const [head] = await tx
+      .select({ id: chatMessageQueue.id })
+      .from(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.chatThreadId, event.chatThreadId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))
+      .for("update")
+      .limit(1);
+    if (head?.id !== event.id) {
+      return false;
+    }
+
+    const [deleted] = await tx
+      .delete(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.id, event.id),
+          eq(chatMessageQueue.chatThreadId, event.chatThreadId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .returning({ id: chatMessageQueue.id });
+    if (!deleted) {
+      return false;
+    }
+
+    const message = await insertChatMessage(tx, {
+      chatThreadId: event.chatThreadId,
+      role: "user",
+      content: args.prompt,
+      runId: args.runId,
+      runGroupId: event.automationId,
+    });
+    if (!message) {
+      throw new Error(
+        `Workflow queue event ${event.id} user message was not inserted`,
+      );
+    }
+    if (run.status === "queued") {
+      await appendQueuedRunAssistantMarker(tx, {
+        chatThreadId: event.chatThreadId,
+        runId: args.runId,
+        runGroupId: event.automationId,
+        createdAfter: message.createdAt,
+      });
+    }
+    return true;
+  });
+}
+
+/** Consume a stale/invalid event only if it is still the workflow FIFO head. */
+export async function discardWorkflowQueueEvent(
+  db: Db,
+  event: WorkflowQueueEvent,
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(chatMessageQueueLock(event.chatThreadId));
+    const [head] = await tx
+      .select({ id: chatMessageQueue.id })
+      .from(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.chatThreadId, event.chatThreadId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .orderBy(asc(chatMessageQueue.createdAt), asc(chatMessageQueue.id))
+      .for("update")
+      .limit(1);
+    if (head?.id !== event.id) {
+      return false;
+    }
+    const deleted = await tx
+      .delete(chatMessageQueue)
+      .where(eq(chatMessageQueue.id, event.id))
+      .returning({ id: chatMessageQueue.id });
+    return deleted.length > 0;
+  });
+}
+
+/** Pause only while the failed pre-dispatch event is still pending. */
+export async function pauseWorkflowQueueEvent(
+  db: Db,
+  args: {
+    readonly event: WorkflowQueueEvent;
     readonly pauseReason: string;
     readonly pausedAt: Date;
   },
-): Promise<void> {
-  const { event } = args;
-  await db.transaction(async (tx) => {
-    await tx.execute(chatMessageQueueLock(event.chatThreadId));
-
-    await tx
-      .insert(chatMessageQueue)
-      .values({
-        id: event.id,
-        orgId: event.orgId,
-        userId: event.userId,
-        chatThreadId: event.chatThreadId,
-        itemType: "workflow_event",
-        automationId: event.automationId,
-        triggerSource: event.triggerSource,
-        triggerBrief: event.triggerBrief,
-        encryptedParams: event.encryptedParams,
-        createdAt: event.createdAt,
-      })
-      .onConflictDoNothing();
-
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(chatMessageQueueLock(args.event.chatThreadId));
+    const [thread] = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.event.chatThreadId))
+      .for("update");
+    if (!thread) {
+      return false;
+    }
+    const [pending] = await tx
+      .select({ id: chatMessageQueue.id })
+      .from(chatMessageQueue)
+      .where(
+        and(
+          eq(chatMessageQueue.id, args.event.id),
+          eq(chatMessageQueue.chatThreadId, args.event.chatThreadId),
+          eq(chatMessageQueue.itemType, "workflow_event"),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!pending) {
+      return false;
+    }
     await setPauseState(
       tx,
-      event.chatThreadId,
+      args.event.chatThreadId,
       { pausedAt: args.pausedAt, pauseReason: args.pauseReason },
       args.pausedAt,
     );
+    return true;
   });
 }
 
@@ -457,6 +664,7 @@ export async function loadRunningWorkflowThreadRun(
       and(
         eq(zeroRuns.chatThreadId, threadId),
         inArray(agentRuns.status, ["queued", "pending", "running"]),
+        chatRunOwnsThreadCondition(),
       ),
     )
     .orderBy(asc(agentRuns.createdAt))

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -23,9 +23,10 @@ interface DrainChatThreadQueueInput {
  * The single per-thread scheduler entry: terminal run callbacks, cancel,
  * resume, and the stale sweep all converge here. User messages are attempted
  * first; the workflow drain then observes the newly-created active run and
- * stops, or consumes the oldest workflow event when no user message
- * dispatched. Both halves serialize on the same per-thread advisory lock and
- * pop in `ORDER BY created_at, id` order.
+ * stops, or prepares the oldest workflow event when no user message
+ * dispatched. Their pre-dispatch claims serialize on the chat-thread row,
+ * recheck user priority and ownership, and consume only the exact candidate
+ * that may proceed.
  *
  * This entry is the designated mounting point for a future unified per-thread
  * rate limiter: admission delays belong here, before either drain half runs.

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -5,7 +5,6 @@ import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/e
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
 import {
@@ -33,7 +32,6 @@ import { z } from "zod";
 
 import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
-import { executeRawRows } from "../../lib/db-raw-rows";
 import { nullableDriverValueDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
@@ -53,6 +51,7 @@ import {
   BEFORE_DISPATCH_CANCELLED_ERROR,
   type DispatchFailedRunCallbacks,
 } from "./agent-run-create.service";
+import { activeChatThreadOwnerExists } from "./chat-message-queue.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
@@ -94,8 +93,6 @@ const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
-const idRowSchema = z.object({ id: z.string() });
-
 type ChatCallbackPreCreateTimingSpanKind = "top_level" | "nested";
 
 type ChatCallbackPreCreateTimingActionType =
@@ -1582,34 +1579,7 @@ async function activeChatRunExistsForThread(
   db: Db,
   threadId: string,
 ): Promise<boolean> {
-  const runs = await executeRawRows(
-    db,
-    sql`
-      SELECT ${zeroRuns.id} AS "id"
-      FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-      WHERE ${zeroRuns.chatThreadId} = ${threadId}
-        AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-        AND (
-          NOT EXISTS (
-            SELECT 1
-            FROM ${agentRunCallbacks}
-            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-              AND ${agentRunCallbacks.internalKind} = 'chat'
-              AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-          )
-          OR EXISTS (
-            SELECT 1
-            FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${zeroRuns.id}
-              AND ${chatMessages.role} = 'user'
-          )
-        )
-      LIMIT 1
-    `,
-    idRowSchema,
-  );
-  return runs[0] !== undefined;
+  return await activeChatThreadOwnerExists(db, { threadId });
 }
 
 async function chatThreadExists(db: Db, threadId: string): Promise<boolean> {
@@ -1855,35 +1825,12 @@ async function claimQueuedUserMessageForDispatch(args: {
     // message. Concurrent drains may insert more than one candidate before
     // reaching this serialized gate; ignoring those unclaimed candidates lets
     // one claim win while the others cancel before dispatch.
-    const competingRuns = await executeRawRows(
-      tx,
-      sql`
-        SELECT ${zeroRuns.id} AS "id"
-        FROM ${zeroRuns}
-        INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-        WHERE ${zeroRuns.chatThreadId} = ${args.threadId}
-          AND ${zeroRuns.id} <> ${args.runId}
-          AND ${agentRuns.status} IN ('queued', 'pending', 'running')
-          AND (
-            NOT EXISTS (
-              SELECT 1
-              FROM ${agentRunCallbacks}
-              WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
-                AND ${agentRunCallbacks.internalKind} = 'chat'
-                AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM ${chatMessages}
-              WHERE ${chatMessages.runId} = ${zeroRuns.id}
-                AND ${chatMessages.role} = 'user'
-            )
-          )
-        LIMIT 1
-      `,
-      idRowSchema,
-    );
-    if (competingRuns[0]) {
+    if (
+      await activeChatThreadOwnerExists(tx, {
+        threadId: args.threadId,
+        excludeRunId: args.runId,
+      })
+    ) {
       return null;
     }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -185,13 +185,15 @@ export async function postRunUserMessage(params: {
       });
     }
   });
-  await publishUserSignal(
-    [params.userId],
-    `chatThreadMessageCreated:${params.threadId}`,
-  );
-  await publishUserSignal(
-    [params.userId],
-    `chatThreadRunCreated:${params.threadId}`,
-  );
-  await publishThreadListChanged(params.userId);
+  await publishRunUserMessageSignals(params.userId, params.threadId);
+}
+
+/** Publish the post-commit signals for a newly materialized run user message. */
+export async function publishRunUserMessageSignals(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
+  await publishUserSignal([userId], `chatThreadRunCreated:${threadId}`);
+  await publishThreadListChanged(userId);
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -10,10 +10,14 @@ import { eq } from "drizzle-orm";
 import { writeDb$, type Db } from "../external/db";
 import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
 import { now, nowDate } from "../external/time";
-import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
+import type {
+  BeforeRunDispatch,
+  DispatchFailedRunCallbacks,
+} from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   postRunUserMessage,
+  publishRunUserMessageSignals,
   resolveRunChatThreadModelPin,
 } from "./zero-chat-run-message.service";
 import {
@@ -21,11 +25,17 @@ import {
   type ModelFirstPin,
 } from "./zero-model-selection.service";
 import {
+  admitWorkflowAutomationEvent,
+  claimWorkflowQueueEventForRun,
+  discardWorkflowQueueEvent,
+  pauseWorkflowQueueEvent,
+  type WorkflowQueueEvent,
+} from "./chat-message-queue.service";
+import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
-import { admitWorkflowAutomationEvent } from "./chat-message-queue.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 
 export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
@@ -60,6 +70,7 @@ export type RunFailure = Exclude<
   RunWorkflowAutomationResult,
   { kind: "ok" } | { kind: "enqueued" }
 >;
+type RunConflict = Extract<RunFailure, { readonly kind: "conflict" }>;
 type ActivePreviousRunPolicy = "block" | "allow";
 
 interface InternalRunCallbackInput {
@@ -91,6 +102,9 @@ export interface RunWorkflowAutomationNowArgs {
   // Set by the queue drain (and manual "Run now"): skip workflow-queue
   // admission and always create the run.
   readonly bypassWorkflowQueue?: boolean;
+  // Set by the queue drain. The run must claim this exact event before runner
+  // queue persistence; manual queue bypasses leave it undefined.
+  readonly workflowQueueEvent?: WorkflowQueueEvent;
   readonly recordLastRunId?: boolean;
   readonly recordLastRunAt?: boolean;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
@@ -103,6 +117,8 @@ interface WorkflowAutomationRunInput {
   readonly callbacks: readonly InternalRunCallbackInput[];
   readonly zeroRunMetadata: ReturnType<typeof workflowAutomationRunMetadata>;
 }
+
+type WorkflowQueueClaimState = "pending" | "claimed" | "lost";
 
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
@@ -293,12 +309,12 @@ async function checkWorkflowAutomationTargetReadable(args: {
   readonly allowClaimedOnceScheduleAutomation: boolean;
   readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
-}): Promise<RunFailure | undefined> {
+}): Promise<RunConflict | undefined> {
   return await measureApiDispatchTiming(
     args.timing,
     "api_dispatch_pre_create_zero_workflow_automation_check_target_access",
     "nested",
-    async (): Promise<RunFailure | undefined> => {
+    async (): Promise<RunConflict | undefined> => {
       const canFire = await workflowAutomationCanFire(args.db, {
         automation: args.automation,
         agentId: args.agentId,
@@ -375,20 +391,77 @@ async function buildTimedWorkflowAutomationRunInput(args: {
   );
 }
 
-/**
- * Workflow-queue admission: an event fired while the workflow is busy (or its
- * queue is paused/non-empty) is persisted as a queue event instead of creating
- * a run. Returns true when the event was enqueued.
- */
-async function enqueueWorkflowAutomationEventIfBusy(input: {
+function callbackPayloadRecord(
+  payload: unknown,
+): payload is Readonly<Record<string, unknown>> {
+  return (
+    typeof payload === "object" && payload !== null && !Array.isArray(payload)
+  );
+}
+
+function markWorkflowQueueCandidateCallbacks(
+  callbacks: readonly InternalRunCallbackInput[],
+  eventId: string,
+): readonly InternalRunCallbackInput[] {
+  let marked = false;
+  const result = callbacks.map((callback) => {
+    if (callback.internalKind !== "chat") {
+      return callback;
+    }
+    if (!callbackPayloadRecord(callback.payload)) {
+      throw new Error("Workflow chat callback payload must be an object");
+    }
+    marked = true;
+    return {
+      ...callback,
+      payload: {
+        ...callback.payload,
+        workflowQueueEventId: eventId,
+      },
+    };
+  });
+  if (!marked) {
+    throw new Error("Workflow queue candidate requires a chat callback");
+  }
+  return result;
+}
+
+type WorkflowQueuePreparation =
+  | {
+      readonly kind: "run";
+      readonly event: WorkflowQueueEvent | undefined;
+    }
+  | { readonly kind: "enqueued" };
+
+interface PreparedWorkflowAutomationRun {
+  readonly runInput: WorkflowAutomationRunInput;
+  readonly modelPin: ModelFirstPin;
+  readonly effectiveModelProvider: string | null | undefined;
+}
+
+type WorkflowAutomationPreparation =
+  | {
+      readonly kind: "ready";
+      readonly prepared: PreparedWorkflowAutomationRun;
+    }
+  | {
+      readonly kind: "complete";
+      readonly result: RunWorkflowAutomationResult;
+    };
+
+/** Persist automated intake before allowing its new FIFO head to prepare. */
+async function prepareWorkflowQueueEvent(input: {
   readonly db: Db;
   readonly args: RunWorkflowAutomationNowArgs;
   readonly signal: AbortSignal;
-}): Promise<boolean> {
+}): Promise<WorkflowQueuePreparation> {
   const { db, args, signal } = input;
   const { automation, chatThreadId } = args.due;
   if (args.bypassWorkflowQueue === true) {
-    return false;
+    return { kind: "run", event: args.workflowQueueEvent };
+  }
+  if (args.workflowQueueEvent) {
+    throw new Error("Workflow queue event requires queue-admission bypass");
   }
   const admission = await admitWorkflowAutomationEvent(db, {
     automation,
@@ -405,15 +478,98 @@ async function enqueueWorkflowAutomationEventIfBusy(input: {
     },
   });
   signal.throwIfAborted();
-  if (admission === "enqueued") {
-    await publishChatThreadWorkflowQueueChangedSafely(
-      automation.ownerUserId,
-      chatThreadId,
-    );
-    signal.throwIfAborted();
-    return true;
+  await publishChatThreadWorkflowQueueChangedSafely(
+    automation.ownerUserId,
+    chatThreadId,
+  );
+  signal.throwIfAborted();
+  if (admission.kind === "enqueued") {
+    return { kind: "enqueued" };
   }
-  return false;
+  return { kind: "run", event: admission.event };
+}
+
+async function prepareWorkflowAutomationRun(input: {
+  readonly db: Db;
+  readonly args: RunWorkflowAutomationNowArgs;
+  readonly queueEvent: WorkflowQueueEvent | undefined;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<WorkflowAutomationPreparation> {
+  const { db, args, queueEvent, timing, signal } = input;
+  const { automation, agentId, workflowName, chatThreadId } = args.due;
+  const activePreviousRunFailure = await checkActivePreviousWorkflowRun({
+    db,
+    automation,
+    activePreviousRunPolicy: args.activePreviousRunPolicy,
+    timing,
+    signal,
+  });
+  if (activePreviousRunFailure) {
+    return {
+      kind: "complete",
+      result: queueEvent ? { kind: "enqueued" } : activePreviousRunFailure,
+    };
+  }
+
+  const targetAccessFailure = await checkWorkflowAutomationTargetReadable({
+    db,
+    automation,
+    agentId,
+    allowClaimedOnceScheduleAutomation:
+      args.due.allowClaimedOnceScheduleAutomation === true,
+    timing,
+    signal,
+  });
+  if (targetAccessFailure) {
+    const result = queueEvent
+      ? await discardUnfireableWorkflowQueueEvent({
+          db,
+          event: queueEvent,
+          failure: targetAccessFailure,
+          signal,
+        })
+      : targetAccessFailure;
+    return { kind: "complete", result };
+  }
+
+  const modelContext = await resolveTimedWorkflowModelContext({
+    db,
+    automation,
+    chatThreadId,
+    timing,
+    signal,
+  });
+  if (!modelContext.ok) {
+    const result =
+      queueEvent && modelContext.failure.kind === "run_error"
+        ? await preserveWorkflowQueueEventAfterFailure({
+            db,
+            event: queueEvent,
+            response: modelContext.failure.response,
+            signal,
+          })
+        : modelContext.failure;
+    return { kind: "complete", result };
+  }
+
+  const runInput = await buildTimedWorkflowAutomationRunInput({
+    command: args,
+    automation,
+    agentId,
+    workflowName,
+    chatThreadId,
+    timing,
+  });
+  signal.throwIfAborted();
+  return {
+    kind: "ready",
+    prepared: {
+      runInput,
+      modelPin: modelContext.modelPin,
+      effectiveModelProvider: modelContext.effectiveModelProvider,
+    },
+  };
 }
 
 async function recordWorkflowAutomationRunStart(input: {
@@ -424,19 +580,28 @@ async function recordWorkflowAutomationRunStart(input: {
   readonly prompt: string;
   readonly modelPin: ModelFirstPin;
   readonly effectiveModelProvider: string | null | undefined;
+  readonly queueEvent: WorkflowQueueEvent | undefined;
   readonly signal: AbortSignal;
 }): Promise<void> {
   const { db, args, runId, signal } = input;
   const { automation, chatThreadId } = args.due;
-  await postRunUserMessage({
-    db,
-    threadId: chatThreadId,
-    userId: automation.ownerUserId,
-    runId,
-    prompt: input.prompt,
-    appendQueueMarker: input.runStatus === "queued",
-    runGroupId: automation.id,
-  });
+  if (input.queueEvent) {
+    await publishRunUserMessageSignals(automation.ownerUserId, chatThreadId);
+    await publishChatThreadWorkflowQueueChangedSafely(
+      automation.ownerUserId,
+      chatThreadId,
+    );
+  } else {
+    await postRunUserMessage({
+      db,
+      threadId: chatThreadId,
+      userId: automation.ownerUserId,
+      runId,
+      prompt: input.prompt,
+      appendQueueMarker: input.runStatus === "queued",
+      runGroupId: automation.id,
+    });
+  }
   signal.throwIfAborted();
 
   await db
@@ -461,6 +626,62 @@ async function recordWorkflowAutomationRunStart(input: {
   signal.throwIfAborted();
 }
 
+async function preserveWorkflowQueueEventAfterFailure(input: {
+  readonly db: Db;
+  readonly event: WorkflowQueueEvent;
+  readonly response: RunErrorResponse;
+  readonly signal: AbortSignal;
+}): Promise<RunWorkflowAutomationResult> {
+  const pausedAt = nowDate();
+  const paused = await pauseWorkflowQueueEvent(input.db, {
+    event: input.event,
+    pauseReason: input.response.body.error.message,
+    pausedAt,
+  });
+  input.signal.throwIfAborted();
+  if (paused) {
+    await publishChatThreadWorkflowQueueChangedSafely(
+      input.event.userId,
+      input.event.chatThreadId,
+    );
+    input.signal.throwIfAborted();
+  }
+  return { kind: "enqueued" };
+}
+
+async function discardUnfireableWorkflowQueueEvent(input: {
+  readonly db: Db;
+  readonly event: WorkflowQueueEvent;
+  readonly failure: RunConflict;
+  readonly signal: AbortSignal;
+}): Promise<RunWorkflowAutomationResult> {
+  const discarded = await discardWorkflowQueueEvent(input.db, input.event);
+  input.signal.throwIfAborted();
+  if (!discarded) {
+    return { kind: "enqueued" };
+  }
+  await publishChatThreadWorkflowQueueChangedSafely(
+    input.event.userId,
+    input.event.chatThreadId,
+  );
+  input.signal.throwIfAborted();
+  return input.failure;
+}
+
+function workflowQueueClaimFailureResponse(
+  error: string | undefined,
+): RunErrorResponse {
+  return {
+    status: 500,
+    body: {
+      error: {
+        message: error ?? "Workflow queue ownership claim failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+  };
+}
+
 export const runWorkflowAutomationNow$ = command(
   async (
     { set },
@@ -468,63 +689,47 @@ export const runWorkflowAutomationNow$ = command(
     signal: AbortSignal,
   ): Promise<RunWorkflowAutomationResult> => {
     const db = set(writeDb$);
-    const { automation, agentId, workflowName, chatThreadId } = args.due;
+    const { automation, agentId, chatThreadId } = args.due;
     const timing = workflowAutomationTiming(args);
 
-    const enqueued = await enqueueWorkflowAutomationEventIfBusy({
+    const queuePreparation = await prepareWorkflowQueueEvent({
       db,
       args,
       signal,
     });
-    if (enqueued) {
+    if (queuePreparation.kind === "enqueued") {
       return { kind: "enqueued" };
     }
+    const queueEvent = queuePreparation.event;
 
-    const activePreviousRunFailure = await checkActivePreviousWorkflowRun({
+    const preparation = await prepareWorkflowAutomationRun({
       db,
-      automation,
-      activePreviousRunPolicy: args.activePreviousRunPolicy,
+      args,
+      queueEvent,
       timing,
       signal,
     });
-    if (activePreviousRunFailure) {
-      return activePreviousRunFailure;
+    if (preparation.kind === "complete") {
+      return preparation.result;
     }
-
-    const targetAccessFailure = await checkWorkflowAutomationTargetReadable({
-      db,
-      automation,
-      agentId,
-      allowClaimedOnceScheduleAutomation:
-        args.due.allowClaimedOnceScheduleAutomation === true,
-      timing,
-      signal,
-    });
-    if (targetAccessFailure) {
-      return targetAccessFailure;
-    }
-
-    const modelContext = await resolveTimedWorkflowModelContext({
-      db,
-      automation,
-      chatThreadId,
-      timing,
-      signal,
-    });
-    if (!modelContext.ok) {
-      return modelContext.failure;
-    }
-    const { modelPin, effectiveModelProvider } = modelContext;
-
-    const runInput = await buildTimedWorkflowAutomationRunInput({
-      command: args,
-      automation,
-      agentId,
-      workflowName,
-      chatThreadId,
-      timing,
-    });
-    signal.throwIfAborted();
+    const { runInput, modelPin, effectiveModelProvider } = preparation.prepared;
+    const callbacks = queueEvent
+      ? markWorkflowQueueCandidateCallbacks(runInput.callbacks, queueEvent.id)
+      : runInput.callbacks;
+    const queueClaimState: { current: WorkflowQueueClaimState } = {
+      current: "pending",
+    };
+    const beforeDispatch: BeforeRunDispatch | undefined = queueEvent
+      ? async ({ runId }) => {
+          const claimed = await claimWorkflowQueueEventForRun(db, {
+            event: queueEvent,
+            runId,
+            prompt: runInput.prompt,
+          });
+          queueClaimState.current = claimed ? "claimed" : "lost";
+          return claimed;
+        }
+      : undefined;
     timing.recordElapsed(
       "api_dispatch_pre_create_zero_workflow_automation_create_run",
       "nested",
@@ -555,9 +760,10 @@ export const runWorkflowAutomationNow$ = command(
           modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
         appendSystemPrompt: runInput.appendSystemPrompt,
-        callbacks: runInput.callbacks,
+        callbacks,
         zeroRunMetadata: runInput.zeroRunMetadata,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+        beforeDispatch,
         timing,
       },
       signal,
@@ -565,7 +771,26 @@ export const runWorkflowAutomationNow$ = command(
     signal.throwIfAborted();
 
     if (result.status !== 201) {
+      if (queueEvent) {
+        return await preserveWorkflowQueueEventAfterFailure({
+          db,
+          event: queueEvent,
+          response: result,
+          signal,
+        });
+      }
       return { kind: "run_error", response: result };
+    }
+    if (queueEvent && queueClaimState.current === "lost") {
+      return { kind: "enqueued" };
+    }
+    if (queueEvent && queueClaimState.current === "pending") {
+      return await preserveWorkflowQueueEventAfterFailure({
+        db,
+        event: queueEvent,
+        response: workflowQueueClaimFailureResponse(result.body.error),
+        signal,
+      });
     }
 
     await recordWorkflowAutomationRunStart({
@@ -576,6 +801,7 @@ export const runWorkflowAutomationNow$ = command(
       prompt: runInput.prompt,
       modelPin,
       effectiveModelProvider,
+      queueEvent,
       signal,
     });
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -12,10 +12,11 @@ import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtim
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import {
-  claimNextWorkflowQueueEvent,
+  discardWorkflowQueueEvent,
   decryptWorkflowQueueEventParams,
-  restoreWorkflowQueueEventAndPause,
-  type ClaimedWorkflowQueueEvent,
+  pauseWorkflowQueueEvent,
+  peekNextWorkflowQueueEvent,
+  type WorkflowQueueEvent,
 } from "./chat-message-queue.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 
@@ -33,7 +34,7 @@ interface DequeueTarget {
 
 async function loadDequeueTarget(
   db: Db,
-  event: ClaimedWorkflowQueueEvent,
+  event: WorkflowQueueEvent,
 ): Promise<DequeueTarget | null> {
   const [row] = await db
     .select({
@@ -57,11 +58,10 @@ async function loadDequeueTarget(
 }
 
 /**
- * Advance the thread's workflow queue: as long as user queued messages always
- * win (enforced inside `claimNextWorkflowQueueEvent`), pop the oldest event
- * and turn it into a run. Events whose automation disappeared or can no longer
- * fire are consumed and skipped; a run-creation failure restores the event to
- * the queue head and pauses the queue so the backlog is preserved.
+ * Advance the thread's workflow queue: peek the oldest event, prepare its run,
+ * and let the pre-dispatch thread claim consume exactly that head. Events whose
+ * automation disappeared or can no longer fire are consumed and skipped; a
+ * pre-claim failure leaves the event in place and pauses the queue.
  */
 export const drainWorkflowQueueForThread$ = command(
   async (
@@ -75,7 +75,7 @@ export const drainWorkflowQueueForThread$ = command(
     const db = set(writeDb$);
 
     for (let attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
-      const event = await claimNextWorkflowQueueEvent(db, args.chatThreadId);
+      const event = await peekNextWorkflowQueueEvent(db, args.chatThreadId);
       signal.throwIfAborted();
       if (!event) {
         return;
@@ -88,6 +88,11 @@ export const drainWorkflowQueueForThread$ = command(
           eventId: event.id,
           automationId: event.automationId,
         });
+        const discarded = await discardWorkflowQueueEvent(db, event);
+        signal.throwIfAborted();
+        if (!discarded) {
+          return;
+        }
         await publishChatThreadWorkflowQueueChangedSafely(
           event.userId,
           event.chatThreadId,
@@ -106,6 +111,16 @@ export const drainWorkflowQueueForThread$ = command(
           eventId: event.id,
           automationId: event.automationId,
         });
+        const discarded = await discardWorkflowQueueEvent(db, event);
+        signal.throwIfAborted();
+        if (!discarded) {
+          return;
+        }
+        await publishChatThreadWorkflowQueueChangedSafely(
+          event.userId,
+          event.chatThreadId,
+        );
+        signal.throwIfAborted();
         continue;
       }
 
@@ -129,6 +144,7 @@ export const drainWorkflowQueueForThread$ = command(
           recordLastRunId: params.recordLastRunId,
           recordLastRunAt: params.recordLastRunAt,
           bypassWorkflowQueue: true,
+          workflowQueueEvent: event,
           dispatchFailedCallbacks: args.dispatchFailedCallbacks,
         },
         signal,
@@ -136,11 +152,6 @@ export const drainWorkflowQueueForThread$ = command(
       signal.throwIfAborted();
 
       if (result.kind === "ok" || result.kind === "enqueued") {
-        await publishChatThreadWorkflowQueueChangedSafely(
-          event.userId,
-          event.chatThreadId,
-        );
-        signal.throwIfAborted();
         return;
       }
       if (result.kind === "conflict") {
@@ -152,12 +163,15 @@ export const drainWorkflowQueueForThread$ = command(
         continue;
       }
 
-      await restoreWorkflowQueueEventAndPause(db, {
+      const paused = await pauseWorkflowQueueEvent(db, {
         event,
         pauseReason: result.response.body.error.message,
         pausedAt: nowDate(),
       });
       signal.throwIfAborted();
+      if (!paused) {
+        return;
+      }
       log.warn("Workflow queue paused after run creation failure", {
         eventId: event.id,
         chatThreadId: event.chatThreadId,

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -1,4 +1,5 @@
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { and, eq, like, or, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -116,7 +117,7 @@ export async function hasVm0ApiKeyLabel(args: {
 /**
  * Holds the production org admission advisory lock and reports its waiter
  * count. No product API exposes database lock timing, so this fixture is the
- * narrow boundary exception for the queue-drain concurrency test.
+ * narrow boundary exception for queue-admission and drain concurrency tests.
  */
 export async function holdOrgAdmissionLockFixture(args: {
   readonly orgId: string;
@@ -240,4 +241,35 @@ export async function holdChatMessageWritesFixture(args: {
       return rows[0]?.waiterCount ?? 0;
     },
   };
+}
+
+/**
+ * Reports whether the production queue row is write-locked by another
+ * transaction. This observes lock timing only; it neither creates nor changes
+ * product rows.
+ */
+export async function queuedUserMessageIsWriteLockedFixture(args: {
+  readonly threadId: string;
+  readonly messageId: string;
+}): Promise<boolean> {
+  const condition = and(
+    eq(chatMessageQueue.chatThreadId, args.threadId),
+    eq(chatMessageQueue.chatMessageId, args.messageId),
+    eq(chatMessageQueue.itemType, "user_message"),
+  );
+  const existing = await db()
+    .select({ id: chatMessageQueue.id })
+    .from(chatMessageQueue)
+    .where(condition)
+    .limit(1);
+  if (existing.length === 0) {
+    return false;
+  }
+  const unlocked = await db()
+    .select({ id: chatMessageQueue.id })
+    .from(chatMessageQueue)
+    .where(condition)
+    .for("update", { skipLocked: true })
+    .limit(1);
+  return unlocked.length === 0;
 }


### PR DESCRIPTION
## Summary

- persist every automated workflow event before run preparation and peek queue heads without consuming them
- bind exactly one marked candidate run to the FIFO event in a short pre-dispatch thread transaction
- centralize active chat-run ownership so workflow and queued-user candidates preserve pause, user priority, and serial dispatch
- add deterministic PostgreSQL concurrency coverage for idle delivery, concurrent resume, pause, user-message priority, and pre-claim failure

## Compatibility

- no database schema, public API, frontend, or runner protocol changes
- `workflowQueueEventId` is an optional additive field in the existing internal callback JSON
- manual **Run now**, schedule coalescing, webhook response shapes, and stale-event behavior remain unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts src/signals/routes/__tests__/zero-workflow-queue-api.test.ts --maxWorkers=1 --silent=passed-only` (12/12)
- focused chat ownership, workflow-source, and full-suite failure reruns passed

The local full-suite diagnostic completed 7,895 tests successfully and exposed
four cross-file shared-fixture races (one global memory sweep and three shared
managed-key requests); all four passed in an immediate focused rerun. CI remains
the independent full-suite gate.

Closes #21046
