### PR TITLE
ci: check connector credential readiness

### DIFF
--- a/.github/workflows/connector-credential-readiness.yml
+++ b/.github/workflows/connector-credential-readiness.yml
@@ -1,0 +1,105 @@
+name: Check connector credential readiness
+
+run-name: Check production connector credential readiness
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/connector-credential-readiness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  readiness:
+    name: Check production connector credential readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    steps:
+      - name: Query connector catalog status
+        shell: bash
+        env:
+          VM0_API_BACKEND_URL: ${{ vars.VM0_API_BACKEND_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${VM0_API_BACKEND_URL}" ]]; then
+            echo "::error::VM0_API_BACKEND_URL is not configured"
+            exit 1
+          fi
+          if [[ -z "${CRON_SECRET}" ]]; then
+            echo "::error::CRON_SECRET is not configured"
+            exit 1
+          fi
+
+          response_path="${RUNNER_TEMP}/connector-catalog-status.json"
+          trap 'rm -f "${response_path}"' EXIT
+
+          http_status="$(
+            curl --silent --show-error \
+              --output "${response_path}" \
+              --write-out "%{http_code}" \
+              --header "Authorization: Bearer ${CRON_SECRET}" \
+              "${VM0_API_BACKEND_URL%/}/api/cron/connector-catalog-status"
+          )"
+
+          if [[ "${http_status}" != "200" ]]; then
+            echo "::error::Connector catalog status endpoint returned HTTP ${http_status}"
+            exit 1
+          fi
+
+          if ! jq -e '
+            [
+              .credentialStorage.missingConnectorVersions,
+              .credentialStorage.unownedConnectorSecrets,
+              .credentialStorage.unownedConnectorVariables,
+              .credentialStorage.unresolvedBridgeCredentials
+            ]
+            | map(select(type == "number")) as $counts
+            | ($counts | length) == 4
+              and ($counts | all(. >= 0 and . == floor))
+          ' "${response_path}" > /dev/null; then
+            echo "::error::Production has not exposed a valid connector credential readiness status"
+            exit 1
+          fi
+
+          {
+            echo "## Connector credential storage readiness"
+            echo
+            echo "| Check | Count |"
+            echo "| --- | ---: |"
+            jq -r '
+              .credentialStorage
+              | [
+                  ["missingConnectorVersions", .missingConnectorVersions],
+                  ["unownedConnectorSecrets", .unownedConnectorSecrets],
+                  ["unownedConnectorVariables", .unownedConnectorVariables],
+                  [
+                    "unresolvedBridgeCredentials",
+                    .unresolvedBridgeCredentials
+                  ]
+                ][]
+              | "| \(.[0]) | \(.[1]) |"
+            ' "${response_path}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          ready="$(
+            jq -r '
+              [
+                .credentialStorage.missingConnectorVersions,
+                .credentialStorage.unownedConnectorSecrets,
+                .credentialStorage.unownedConnectorVariables,
+                .credentialStorage.unresolvedBridgeCredentials
+              ]
+              | all(.[]; . == 0)
+            ' "${response_path}"
+          )"
+          if [[ "${ready}" != "true" ]]; then
+            echo "::error::Connector credential storage is not ready for contraction"
+            exit 1
+          fi
+
+          echo "::notice::Connector credential storage is ready for contraction"


### PR DESCRIPTION
## Summary

- add a pull-request-triggered production connector credential readiness check
- read the API URL and cron secret from the protected `production` environment
- expose only the four aggregate readiness counts and fail until every count is zero
- retain manual dispatch for later checks after the workflow reaches the default branch

The workflow is read-only. Its own pull request triggers the production check, so merging this PR is not required to collect readiness evidence.

## Out of scope

- modifying or remediating production connector credential data
- applying the final schema contraction from #22126
- changing connector catalog source selection or synchronization

## Validation

- `actionlint .github/workflows/connector-credential-readiness.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/connector-credential-readiness.yml`
- `pnpm --dir turbo exec prettier --check ../.github/workflows/connector-credential-readiness.yml`
- ready, residual, and pre-deployment payload checks with `jq`
- `git diff --check`

Relates to #22126.

Parent context: #22023.
