### PR TITLE
test(api): narrow workflow queue lifecycle coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -21,6 +21,7 @@ const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
+const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
@@ -65,6 +66,7 @@ async function setup(): Promise<Scenario> {
   });
   mocks.clerk.session(actor.userId, actor.orgId);
   context.mocks.s3.send.mockResolvedValue({});
+  chatCallbacks.mockChatOutputEvents([]);
   return {
     actor,
     orgId: actor.orgId,
@@ -212,7 +214,7 @@ async function executeDueWorkflowAutomations(): Promise<void> {
 }
 
 describe("workflow queue", () => {
-  it("queues webhook events behind the in-flight run and drains them serially", async () => {
+  it("queues webhook events behind the active run and drains one per completion", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
 
@@ -231,14 +233,6 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, firstRunId);
     const afterFirst = await workflowRunIds(automation.threadId);
     expect(afterFirst).toHaveLength(2);
-
-    await completeRunThroughSandbox(scenario, afterFirst[1]!);
-    const afterSecond = await workflowRunIds(automation.threadId);
-    expect(afterSecond).toHaveLength(3);
-
-    // The queue is empty: completing the last run creates nothing new.
-    await completeRunThroughSandbox(scenario, afterSecond[2]!);
-    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(3);
   });
 
   it("coalesces schedule ticks: at most one pending tick per automation", async () => {
@@ -308,7 +302,6 @@ describe("workflow queue", () => {
     // The queued-message auto-send runs inside the terminal chat callback,
     // which needs the run's assistant output (Axiom) and session-history
     // blobs (S3) to resolve.
-    const chatCallbacks = createChatCallbacksApi(context);
     chatCallbacks.mockChatOutputEvents([
       {
         eventType: "assistant",


### PR DESCRIPTION
## Summary

- narrow the webhook queue integration test from three complete runner
  lifecycles to one while preserving the assertion that two pending events
  start exactly one new run
- configure an explicit empty Axiom event response for workflow queue scenarios
  that do not consume assistant output
- reuse the shared callback helper while preserving the queued user message
  scenario's non-empty output override

## Scope

This is a test-only change. It does not change workflow queue behavior,
timeouts, CI worker counts, schemas, persisted data, APIs, or runner protocols.
The neighboring schedule and queued-user-message tests continue to cover
empty-queue completion and later scheduler re-entry.

## Validation

- `pnpm prettier --write apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts --reporter=verbose` (3 tests passed; no `events is not iterable` errors)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm vitest run --project=api --shard=5/8 --coverage.enabled --coverage.reporter=json --maxWorkers=4` against a fresh test database (20 files, 275 tests passed)
- pre-commit hook: Prettier, repository Knip, repository TypeScript checks, and commitlint

Closes #22244
