### PR TITLE
chore(api): stop archive-size backfill cron

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -21,7 +21,6 @@ import {
   cronSummarizeMemoryContract,
   cronSyncSkillsContract,
   cronTelegramCleanupContract,
-  cronStorageArchiveSizeBackfillContract,
 } from "@vm0/api-contracts/contracts/cron";
 import { describe, expect, it } from "vitest";
 
@@ -46,10 +45,6 @@ function readVercelConfig(): VercelConfig {
 const expectedVercelCrons = [
   {
     path: cronCleanupSandboxesContract.cleanup.path,
-    schedule: "* * * * *",
-  },
-  {
-    path: cronStorageArchiveSizeBackfillContract.backfill.path,
     schedule: "* * * * *",
   },
   {

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -9,10 +9,6 @@
       "schedule": "* * * * *"
     },
     {
-      "path": "/api/cron/backfill-storage-archive-sizes",
-      "schedule": "* * * * *"
-    },
-    {
       "path": "/api/cron/execute-workflow-automations",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
## Summary

- remove the minute Vercel schedule for the storage archive-size backfill
- update the exact API cron configuration expectation
- keep the backfill/status endpoints, service, contracts, work table, schema,
  and persisted state unchanged

## Deployment sequencing

This is the configuration-only first phase of #22133. Once this PR is merged
and confirmed in production, blocked sibling #22248 can finalize the data and
schema and remove all remaining temporary runtime.

No fixed `retired` response or status drain is added because each backfill run
is request-scoped serverless execution.

## Validation

- `pnpm -F api exec vitest run src/__tests__/vercel-crons.test.ts --silent=passed-only`
- `pnpm exec prettier --check apps/api/vercel.json apps/api/src/__tests__/vercel-crons.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit Knip and repository Turbo type checks

Closes #22247

Parent: #22133
