### PR TITLE
fix(connectors): roll back failed remote grants

### DIFF
--- a/turbo/apps/api/src/signals/e2e-routes.ts
+++ b/turbo/apps/api/src/signals/e2e-routes.ts
@@ -3,6 +3,7 @@ import { cliAuthTestRoutes } from "./routes/cli-auth-test";
 import { testOAuthProviderAuthorizeRoutes } from "./routes/test-oauth-provider-authorize";
 import { testOAuthProviderDeviceAuthRoutes } from "./routes/test-oauth-provider-device-auth";
 import { testOAuthProviderEchoRoutes } from "./routes/test-oauth-provider-echo";
+import { testOAuthProviderRevokeRoutes } from "./routes/test-oauth-provider-revoke";
 import { testOAuthProviderTokenRoutes } from "./routes/test-oauth-provider-token";
 import { testOAuthProviderUserinfoRoutes } from "./routes/test-oauth-provider-userinfo";
 import { testSlackDispatchProbeRoutes } from "./routes/test-slack-dispatch-probe";
@@ -46,6 +47,7 @@ export const E2E_ROUTES: readonly RouteEntry[] = [
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderDeviceAuthRoutes,
   ...testOAuthProviderEchoRoutes,
+  ...testOAuthProviderRevokeRoutes,
   ...testOAuthProviderTokenRoutes,
   ...testOAuthProviderUserinfoRoutes,
   ...testSlackDispatchProbeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -21,8 +21,10 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
   createBddApi,
   expectApiError,
@@ -155,7 +157,12 @@ function mockNintendoStoreExternalCodeProvider(): {
   return { sessionTokenBodies, tokenBodies };
 }
 
-function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
+function mockNintendoSwitchParentalControlsExternalCodeProvider(
+  options: {
+    readonly federationResponse?: "valid" | "malformed";
+    readonly onFederation?: () => void;
+  } = {},
+): {
   readonly federatedSmartDeviceIds: string[];
   readonly federationBodies: unknown[];
   readonly failLogout: () => void;
@@ -259,6 +266,10 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
         }
         federationBodies.push(body);
         federatedSmartDeviceIds.push(body["smartDeviceInfo"]["id"]);
+        options.onFederation?.();
+        if (options.federationResponse === "malformed") {
+          return HttpResponse.json({ loginInfo: {} });
+        }
         return HttpResponse.json({
           loginInfo: {
             ownedDevices: [
@@ -304,6 +315,19 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
     sessionTokenBodies,
     tokenBodies,
   };
+}
+
+function nintendoSwitchParentalControlsCompletionCode(
+  authorizationUrl: string,
+  sessionTokenCode: string,
+): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error(
+      "Expected Nintendo Switch Parental Controls authorization state",
+    );
+  }
+  return `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=${sessionTokenCode}&state=${state}`;
 }
 
 describe("CONN-02: external-code session lifecycle", () => {
@@ -690,6 +714,126 @@ describe("CONN-02: external-code session lifecycle", () => {
     await connectorsApi.deleteConnectorByType(actor, "nintendo-store");
   });
 
+  it("logs out a Nintendo smart device when federation returns malformed data", async () => {
+    const provider = mockNintendoSwitchParentalControlsExternalCodeProvider({
+      federationResponse: "malformed",
+    });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    const session = await connectorsApi.startExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      "api",
+    );
+
+    const response = await connectorsApi.requestExternalCodeComplete(
+      actor,
+      "nintendo-switch-parental-controls",
+      {
+        sessionId: session.sessionId,
+        sessionToken: session.sessionToken,
+        code: nintendoSwitchParentalControlsCompletionCode(
+          session.authorizationUrl,
+          NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE,
+        ),
+      },
+      [500],
+    );
+    expect(response.status).toBe(500);
+    expect(provider.federatedSmartDeviceIds).toHaveLength(1);
+    expect(provider.logoutBodies).toStrictEqual([
+      { smartDeviceId: provider.federatedSmartDeviceIds[0] },
+    ]);
+    expect(provider.logoutAuthorizations).toStrictEqual([
+      `Bearer ${provider.initialIdToken}`,
+    ]);
+    const missing = await connectorsApi.requestReadConnectorByType(
+      actor,
+      "nintendo-switch-parental-controls",
+      [404],
+    );
+    expectApiError(missing.body);
+  });
+
+  it("preserves a malformed Nintendo federation failure when logout also fails", async () => {
+    const provider = mockNintendoSwitchParentalControlsExternalCodeProvider({
+      federationResponse: "malformed",
+    });
+    provider.failLogout();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    const session = await connectorsApi.startExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      "api",
+    );
+
+    const response = await connectorsApi.requestExternalCodeComplete(
+      actor,
+      "nintendo-switch-parental-controls",
+      {
+        sessionId: session.sessionId,
+        sessionToken: session.sessionToken,
+        code: nintendoSwitchParentalControlsCompletionCode(
+          session.authorizationUrl,
+          NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE,
+        ),
+      },
+      [500],
+    );
+    expect(response.status).toBe(500);
+    expect(provider.logoutBodies).toHaveLength(1);
+    const warnings = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(warnings).toContain("Connector provider grant cleanup failed");
+    expect(warnings).not.toContain(provider.initialIdToken);
+  });
+
+  it("logs out the exact Nintendo smart device after a known local write failure", async () => {
+    const provider = mockNintendoSwitchParentalControlsExternalCodeProvider({
+      onFederation: () => {
+        mockEnv("SECRETS_KMS_KEY_ID", undefined);
+      },
+    });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    const session = await connectorsApi.startExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      "api",
+    );
+
+    const response = await connectorsApi.requestExternalCodeComplete(
+      actor,
+      "nintendo-switch-parental-controls",
+      {
+        sessionId: session.sessionId,
+        sessionToken: session.sessionToken,
+        code: nintendoSwitchParentalControlsCompletionCode(
+          session.authorizationUrl,
+          NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE,
+        ),
+      },
+      [500],
+    );
+    expect(response.status).toBe(500);
+
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+    expect(provider.federatedSmartDeviceIds).toHaveLength(1);
+    expect(provider.logoutBodies).toStrictEqual([
+      { smartDeviceId: provider.federatedSmartDeviceIds[0] },
+    ]);
+    expect(provider.logoutAuthorizations).toStrictEqual([
+      `Bearer ${provider.initialIdToken}`,
+    ]);
+    const missing = await connectorsApi.requestReadConnectorByType(
+      actor,
+      "nintendo-switch-parental-controls",
+      [404],
+    );
+    expectApiError(missing.body);
+  });
+
   it("replaces the remote Nintendo registration and keeps local deletion resilient", async () => {
     const provider = mockNintendoSwitchParentalControlsExternalCodeProvider();
     const bdd = createBddApi(context);
@@ -773,6 +917,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     );
     expectNoVisibleSecret(complete, "bdd-serial-must-not-leak");
     expectNoVisibleSecret(complete, "1234");
+    expect(provider.logoutBodies).toStrictEqual([]);
 
     const listed = await connectorsApi.listConnectors(actor);
     for (const name of [

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -16,8 +16,10 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
-import { mockEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import {
   createBddApi,
   expectApiError,
@@ -2752,7 +2754,9 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     expectApiError(afterTokenFail.body);
     expect(afterTokenFail.body.error.code).toBe("NOT_FOUND");
 
-    mockTestOAuthAuthCodeProvider({ userinfoError: true });
+    const userinfoFailureProvider = mockTestOAuthAuthCodeProvider({
+      userinfoError: true,
+    });
     const userinfoFailStart = await connectorsApi.startOauth(
       actor,
       "test-oauth",
@@ -2776,8 +2780,216 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     );
     expectApiError(afterUserinfoFail.body);
     expect(afterUserinfoFail.body.error.code).toBe("NOT_FOUND");
+    expect(
+      userinfoFailureProvider.revokeBodies.map((body) => {
+        return body.get("token");
+      }),
+    ).toStrictEqual(["bdd-test-oauth-access-token"]);
 
     await connectorsApi.deleteConnectorByType(actor, "slack");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+});
+
+describe("CONN-02: auth-code grant compensation", () => {
+  it("rolls back the issued token after a known pre-commit persistence failure", async () => {
+    const provider = mockTestOAuthAuthCodeProvider({
+      accessToken: "bdd-precommit-access-token",
+    });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+
+    const start = await connectorsApi.startOauth(actor, "test-oauth", "oauth");
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const callback = await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "bdd-precommit-failure",
+      state: stateFromAuthorizationUrl(start.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(callback, {
+      type: "test-oauth",
+      message: "OAuth authorization failed. Please try again.",
+    });
+
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+    expect(
+      provider.revokeBodies.map((body) => {
+        return body.get("token");
+      }),
+    ).toStrictEqual(["bdd-precommit-access-token"]);
+    const missing = await connectorsApi.requestReadConnectorByType(
+      actor,
+      "test-oauth",
+      [404],
+    );
+    expectApiError(missing.body);
+
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("keeps the persistence failure primary when rollback also fails", async () => {
+    const accessToken = "bdd-rollback-failure-access-token";
+    const provider = mockTestOAuthAuthCodeProvider({
+      accessToken,
+      revokeError: true,
+    });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+
+    const start = await connectorsApi.startOauth(actor, "test-oauth", "oauth");
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const callback = await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "bdd-rollback-failure",
+      state: stateFromAuthorizationUrl(start.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(callback, {
+      type: "test-oauth",
+      message: "OAuth authorization failed. Please try again.",
+    });
+
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+    expect(provider.revokeBodies).toHaveLength(1);
+    const warnings = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(warnings).toContain("Connector grant rollback failed");
+    expect(warnings).not.toContain(accessToken);
+
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("finishes persistence after the request is cancelled following provider success", async () => {
+    const requestAbort = new AbortController();
+    const provider = mockTestOAuthAuthCodeProvider({
+      accessToken: "bdd-cancelled-request-access-token",
+      onUserinfo: () => {
+        requestAbort.abort();
+      },
+    });
+    mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+
+    const start = await connectorsApi.startOauth(actor, "test-oauth", "oauth");
+    await Promise.allSettled([
+      requestOauthCallbackRaw(context, {
+        origin: "https://www.vm0.ai",
+        type: "test-oauth",
+        query: {
+          code: "bdd-cancelled-request",
+          state: stateFromAuthorizationUrl(start.authorizationUrl),
+        },
+        signal: requestAbort.signal,
+      }),
+    ]);
+
+    const connector = await connectorsApi.readConnectorByType(
+      actor,
+      "test-oauth",
+    );
+    expect(connector.connectionStatus).toBe("connected");
+    expect(provider.revokeBodies).toStrictEqual([]);
+
+    await connectorsApi.deleteConnectorByType(actor, "test-oauth");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("does not roll back an acknowledged commit when realtime publication fails", async () => {
+    const accessToken = "bdd-postcommit-publication-access-token";
+    const provider = mockTestOAuthAuthCodeProvider({ accessToken });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+    context.mocks.ably.publish.mockRejectedValueOnce(
+      new Error("Synthetic realtime publication failure"),
+    );
+
+    const start = await connectorsApi.startOauth(actor, "test-oauth", "oauth");
+    const callback = await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "bdd-postcommit-publication",
+      state: stateFromAuthorizationUrl(start.authorizationUrl),
+    });
+    expect(redirectLocation(callback).pathname).toBe("/connector/success");
+    const connector = await connectorsApi.readConnectorByType(
+      actor,
+      "test-oauth",
+    );
+    expect(connector.connectionStatus).toBe("connected");
+    expect(provider.revokeBodies).toStrictEqual([]);
+    const warnings = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(warnings).toContain("Connector post-commit publication failed");
+    expect(warnings).not.toContain(accessToken);
+
+    await connectorsApi.deleteConnectorByType(actor, "test-oauth");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("rolls back only the failed attempt while a newer attempt commits", async () => {
+    const rollbackGate = createDeferredPromise<void>(context.signal);
+    const provider = mockTestOAuthAuthCodeProvider({
+      accessTokenForCode: (code) => {
+        return `bdd-concurrent-access-${code}`;
+      },
+      revokeWaitUntil: rollbackGate.promise,
+    });
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+
+    const firstStart = await connectorsApi.startOauth(
+      actor,
+      "test-oauth",
+      "oauth",
+    );
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "attempt-a",
+      state: stateFromAuthorizationUrl(firstStart.authorizationUrl),
+    });
+
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    const secondStart = await connectorsApi.startOauth(
+      actor,
+      "test-oauth",
+      "oauth",
+    );
+    const secondCallback = await connectorsApi.completeOauthCallback(
+      "test-oauth",
+      {
+        code: "attempt-b",
+        state: stateFromAuthorizationUrl(secondStart.authorizationUrl),
+      },
+    );
+    expect(redirectLocation(secondCallback).pathname).toBe(
+      "/connector/success",
+    );
+
+    rollbackGate.resolve(undefined);
+    await flushWaitUntilForTest();
+    expect(
+      provider.revokeBodies.map((body) => {
+        return body.get("token");
+      }),
+    ).toStrictEqual(["bdd-concurrent-access-attempt-a"]);
+    const connector = await connectorsApi.readConnectorByType(
+      actor,
+      "test-oauth",
+    );
+    expect(connector.connectionStatus).toBe("connected");
+
+    await connectorsApi.deleteConnectorByType(actor, "test-oauth");
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 });
@@ -2871,6 +3083,96 @@ describe("CONN-02: device-auth method switching", () => {
 });
 
 describe("CONN-02: GitHub installation link after connector OAuth", () => {
+  it("separates failed-attempt token rollback from ordinary grant revocation", async () => {
+    const provider = mockGitHubConnectorOAuth();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+
+    const failedStart = await connectorsApi.startOauth(
+      actor,
+      "github",
+      "oauth",
+    );
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const failed = await connectorsApi.completeOauthCallback("github", {
+      code: "failed-attempt",
+      state: stateFromAuthorizationUrl(failedStart.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(failed, {
+      type: "github",
+      message: "OAuth authorization failed. Please try again.",
+    });
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+
+    expect(provider.tokenRollbackClientIds).toStrictEqual(["github-client-id"]);
+    expect(provider.tokenRollbackBodies).toStrictEqual([
+      { access_token: "github-access-failed-attempt" },
+    ]);
+    expect(provider.grantRevokeBodies).toStrictEqual([]);
+
+    const connectedStart = await connectorsApi.startOauth(
+      actor,
+      "github",
+      "oauth",
+    );
+    await connectorsApi.completeOauthCallback("github", {
+      code: "connected-attempt",
+      state: stateFromAuthorizationUrl(connectedStart.authorizationUrl),
+    });
+    await connectorsApi.deleteConnectorByType(actor, "github");
+
+    expect(provider.grantRevokeClientIds).toStrictEqual(["github-client-id"]);
+    expect(provider.grantRevokeBodies).toStrictEqual([
+      { access_token: "github-access-connected-attempt" },
+    ]);
+    expect(provider.tokenRollbackBodies).toHaveLength(1);
+  });
+
+  it("uses the GitHub App OAuth client and omits redirect_uri during setup rollback", async () => {
+    const provider = mockGitHubConnectorOAuth({
+      onUserinfo: () => {
+        mockEnv("SECRETS_KMS_KEY_ID", undefined);
+      },
+    });
+    mockOptionalEnv("GITHUB_APP_CLIENT_ID", "github-app-client-id");
+    mockOptionalEnv("GITHUB_APP_CLIENT_SECRET", "github-app-client-secret");
+    const installationId = String(randomInt(100_000_000, 999_999_999));
+    const targetId = String(randomInt(100_000_000, 999_999_999));
+    mockGithubAppInstallProvider({ installationId, targetId });
+
+    const bdd = createBddApi(context);
+    bdd.acceptAgentStorageWrites();
+    const admin = bdd.user();
+    const agent = await bdd.createAgent(admin, {
+      displayName: "BDD GitHub App OAuth Rollback Agent",
+    });
+
+    await expect(
+      connectorsApi.installGithubAppViaApi(
+        admin,
+        agent.agentId,
+        installationId,
+        "github-app-setup-code",
+      ),
+    ).rejects.toThrow();
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+
+    const appExchange = provider.tokenBodies.find((body) => {
+      return body.get("code") === "github-app-setup-code";
+    });
+    expect(appExchange?.get("client_id")).toBe("github-app-client-id");
+    expect(appExchange?.get("client_secret")).toBe("github-app-client-secret");
+    expect(appExchange?.has("redirect_uri")).toBeFalsy();
+    expect(provider.tokenRollbackClientIds).toStrictEqual([
+      "github-app-client-id",
+    ]);
+    expect(provider.tokenRollbackBodies).toStrictEqual([
+      { access_token: "github-access-github-app-setup-code" },
+    ]);
+  });
+
   it("links the org GitHub installation when the GitHub connector completes OAuth", async () => {
     mockGitHubConnectorOAuth();
     const installationId = String(randomInt(100_000_000, 999_999_999));

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -9,6 +9,7 @@
  *   /api/zero/feature-switches.
  */
 
+import { Buffer } from "node:buffer";
 import { randomInt, randomUUID } from "node:crypto";
 
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
@@ -33,6 +34,7 @@ import {
   mockDeferredTestOAuthTokenEndpoint,
   mockGitHubConnectorOAuth,
   mockGithubAppInstallProvider,
+  mockLinearConnectorOAuth,
   mockSlackConnectorOAuth,
   mockSlockOAuthProvider,
   mockStripeCliDashboardAuth,
@@ -2863,6 +2865,93 @@ describe("CONN-02: auth-code grant compensation", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
+  it("does not reuse Slack's authorization-wide revoke for failed-attempt rollback", async () => {
+    const provider = mockSlackConnectorOAuth();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+
+    const start = await connectorsApi.startOauth(actor, "slack", "oauth");
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const callback = await connectorsApi.completeOauthCallback("slack", {
+      code: "bdd-slack-precommit-failure",
+      state: stateFromAuthorizationUrl(start.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(callback, {
+      type: "slack",
+      message: "OAuth authorization failed. Please try again.",
+    });
+
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+    expect(provider.revokeAuthorizations).toStrictEqual([]);
+    const missing = await connectorsApi.requestReadConnectorByType(
+      actor,
+      "slack",
+      [404],
+    );
+    expectApiError(missing.body);
+  });
+
+  it("revokes both Linear credentials for rollback and ordinary disconnect", async () => {
+    const provider = mockLinearConnectorOAuth();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+
+    const failedStart = await connectorsApi.startOauth(
+      actor,
+      "linear",
+      "oauth",
+    );
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const failed = await connectorsApi.completeOauthCallback("linear", {
+      code: "failed-attempt",
+      state: stateFromAuthorizationUrl(failedStart.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(failed, {
+      type: "linear",
+      message: "OAuth authorization failed. Please try again.",
+    });
+    mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
+    await flushWaitUntilForTest();
+
+    const connectedStart = await connectorsApi.startOauth(
+      actor,
+      "linear",
+      "oauth",
+    );
+    await connectorsApi.completeOauthCallback("linear", {
+      code: "connected-attempt",
+      state: stateFromAuthorizationUrl(connectedStart.authorizationUrl),
+    });
+    await connectorsApi.deleteConnectorByType(actor, "linear");
+
+    expect(
+      provider.revokeBodies.map((body) => {
+        return {
+          token: body.get("token"),
+          tokenTypeHint: body.get("token_type_hint"),
+        };
+      }),
+    ).toStrictEqual([
+      {
+        token: "linear-access-failed-attempt",
+        tokenTypeHint: "access_token",
+      },
+      {
+        token: "linear-refresh-failed-attempt",
+        tokenTypeHint: "refresh_token",
+      },
+      {
+        token: "linear-access-connected-attempt",
+        tokenTypeHint: "access_token",
+      },
+      {
+        token: "linear-refresh-connected-attempt",
+        tokenTypeHint: "refresh_token",
+      },
+    ]);
+  });
+
   it("finishes persistence after the request is cancelled following provider success", async () => {
     const requestAbort = new AbortController();
     const provider = mockTestOAuthAuthCodeProvider({
@@ -3167,6 +3256,11 @@ describe("CONN-02: GitHub installation link after connector OAuth", () => {
     expect(appExchange?.has("redirect_uri")).toBeFalsy();
     expect(provider.tokenRollbackClientIds).toStrictEqual([
       "github-app-client-id",
+    ]);
+    expect(provider.tokenRollbackAuthorizations).toStrictEqual([
+      `Basic ${Buffer.from(
+        "github-app-client-id:github-app-client-secret",
+      ).toString("base64")}`,
     ]);
     expect(provider.tokenRollbackBodies).toStrictEqual([
       { access_token: "github-access-github-app-setup-code" },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -100,6 +100,9 @@ const TEST_OAUTH_USERINFO_URL =
   "http://localhost:3000/api/test/oauth-provider/userinfo";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
 const SLACK_OAUTH_USER_INFO_URL = "https://slack.com/api/users.info";
+const LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token";
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+const LINEAR_OAUTH_REVOKE_URL = "https://api.linear.app/oauth/revoke";
 const GITHUB_APP_INSTALLATIONS_URL = "https://api.github.com/app/installations";
 const GITHUB_APP_SLUG = "bdd-github-app";
 
@@ -121,6 +124,7 @@ function expectStatus<
 
 interface GitHubConnectorOAuthRecorder {
   readonly tokenBodies: URLSearchParams[];
+  readonly tokenRollbackAuthorizations: (string | null)[];
   readonly tokenRollbackBodies: Readonly<Record<string, unknown>>[];
   readonly tokenRollbackClientIds: string[];
   readonly grantRevokeBodies: Readonly<Record<string, unknown>>[];
@@ -136,6 +140,7 @@ export function mockGitHubConnectorOAuth(
 
   const recorder: GitHubConnectorOAuthRecorder = {
     tokenBodies: [],
+    tokenRollbackAuthorizations: [],
     tokenRollbackBodies: [],
     tokenRollbackClientIds: [],
     grantRevokeBodies: [],
@@ -162,6 +167,9 @@ export function mockGitHubConnectorOAuth(
     http.delete(
       "https://api.github.com/applications/:clientId/token",
       async ({ params, request }) => {
+        recorder.tokenRollbackAuthorizations.push(
+          request.headers.get("authorization"),
+        );
         recorder.tokenRollbackClientIds.push(String(params.clientId));
         recorder.tokenRollbackBodies.push(
           z.record(z.string(), z.unknown()).parse(await request.json()),
@@ -300,9 +308,16 @@ export function mockTestOAuthAuthCodeProvider(
  * the slack oauth method has static (non-refreshable) access, so a stored
  * token has no expiry.
  */
-export function mockSlackConnectorOAuth(): void {
+interface SlackConnectorOAuthRecorder {
+  readonly revokeAuthorizations: (string | null)[];
+}
+
+export function mockSlackConnectorOAuth(): SlackConnectorOAuthRecorder {
   mockOptionalEnv("SLACK_OAUTH_CLIENT_ID", "slack-client-id");
   mockOptionalEnv("SLACK_OAUTH_CLIENT_SECRET", "slack-client-secret");
+  const recorder: SlackConnectorOAuthRecorder = {
+    revokeAuthorizations: [],
+  };
 
   server.use(
     http.post(SLACK_OAUTH_TOKEN_URL, () => {
@@ -326,7 +341,53 @@ export function mockSlackConnectorOAuth(): void {
         },
       });
     }),
+    http.post("https://slack.com/api/auth.revoke", ({ request }) => {
+      recorder.revokeAuthorizations.push(request.headers.get("authorization"));
+      return HttpResponse.json({ ok: true, revoked: true });
+    }),
   );
+  return recorder;
+}
+
+interface LinearConnectorOAuthRecorder {
+  readonly revokeBodies: URLSearchParams[];
+}
+
+export function mockLinearConnectorOAuth(): LinearConnectorOAuthRecorder {
+  mockOptionalEnv("LINEAR_OAUTH_CLIENT_ID", "linear-client-id");
+  mockOptionalEnv("LINEAR_OAUTH_CLIENT_SECRET", "linear-client-secret");
+  const recorder: LinearConnectorOAuthRecorder = {
+    revokeBodies: [],
+  };
+
+  server.use(
+    http.post(LINEAR_OAUTH_TOKEN_URL, async ({ request }) => {
+      const body = new URLSearchParams(await request.text());
+      const code = body.get("code") ?? "missing-code";
+      return HttpResponse.json({
+        access_token: `linear-access-${code}`,
+        refresh_token: `linear-refresh-${code}`,
+        expires_in: 86_400,
+        scope: "read,write",
+      });
+    }),
+    http.post(LINEAR_GRAPHQL_URL, () => {
+      return HttpResponse.json({
+        data: {
+          viewer: {
+            id: "linear-user-id",
+            name: "BDD Linear User",
+            email: "bdd-linear@example.test",
+          },
+        },
+      });
+    }),
+    http.post(LINEAR_OAUTH_REVOKE_URL, async ({ request }) => {
+      recorder.revokeBodies.push(new URLSearchParams(await request.text()));
+      return new HttpResponse(null, { status: 200 });
+    }),
+  );
+  return recorder;
 }
 
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -81,6 +81,8 @@ const TEST_OAUTH_DEVICE_CODE_URL =
   "http://localhost:3000/api/test/oauth-provider/device/code";
 const TEST_OAUTH_TOKEN_URL =
   "http://localhost:3000/api/test/oauth-provider/token";
+const TEST_OAUTH_REVOKE_URL =
+  "http://localhost:3000/api/test/oauth-provider/revoke";
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const BASE44_DEVICE_CODE_URL = "https://app.base44.com/oauth/device/code";
 const BASE44_TOKEN_URL = "https://app.base44.com/oauth/token";
@@ -117,14 +119,32 @@ function expectStatus<
   }
 }
 
-export function mockGitHubConnectorOAuth(): void {
+interface GitHubConnectorOAuthRecorder {
+  readonly tokenBodies: URLSearchParams[];
+  readonly tokenRollbackBodies: Readonly<Record<string, unknown>>[];
+  readonly tokenRollbackClientIds: string[];
+  readonly grantRevokeBodies: Readonly<Record<string, unknown>>[];
+  readonly grantRevokeClientIds: string[];
+}
+
+export function mockGitHubConnectorOAuth(
+  options: { readonly onUserinfo?: () => void } = {},
+): GitHubConnectorOAuthRecorder {
   mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
   mockOptionalEnv("GH_OAUTH_CLIENT_ID", "github-client-id");
   mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "github-client-secret");
 
+  const recorder: GitHubConnectorOAuthRecorder = {
+    tokenBodies: [],
+    tokenRollbackBodies: [],
+    tokenRollbackClientIds: [],
+    grantRevokeBodies: [],
+    grantRevokeClientIds: [],
+  };
   server.use(
     http.post(GITHUB_TOKEN_URL, async ({ request }) => {
       const body = new URLSearchParams(await request.text());
+      recorder.tokenBodies.push(body);
       const code = body.get("code") ?? "missing-code";
       return HttpResponse.json({
         access_token: `github-access-${code}`,
@@ -132,13 +152,35 @@ export function mockGitHubConnectorOAuth(): void {
       });
     }),
     http.get(GITHUB_USER_URL, () => {
+      options.onUserinfo?.();
       return HttpResponse.json({
         id: 42,
         login: "bdd-github-user",
         email: "bdd-github@example.test",
       });
     }),
+    http.delete(
+      "https://api.github.com/applications/:clientId/token",
+      async ({ params, request }) => {
+        recorder.tokenRollbackClientIds.push(String(params.clientId));
+        recorder.tokenRollbackBodies.push(
+          z.record(z.string(), z.unknown()).parse(await request.json()),
+        );
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
+    http.delete(
+      "https://api.github.com/applications/:clientId/grant",
+      async ({ params, request }) => {
+        recorder.grantRevokeClientIds.push(String(params.clientId));
+        recorder.grantRevokeBodies.push(
+          z.record(z.string(), z.unknown()).parse(await request.json()),
+        );
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
   );
+  return recorder;
 }
 
 interface DatadogOAuthProviderRecorder {
@@ -174,10 +216,15 @@ interface TestOAuthAuthCodeProviderOptions {
   readonly scope?: string;
   readonly tokenError?: boolean;
   readonly userinfoError?: boolean;
+  readonly accessTokenForCode?: (code: string) => string;
+  readonly onUserinfo?: () => void;
+  readonly revokeError?: boolean;
+  readonly revokeWaitUntil?: Promise<void>;
 }
 
 interface TestOAuthAuthCodeProviderRecorder {
   readonly tokenBodies: URLSearchParams[];
+  readonly revokeBodies: URLSearchParams[];
 }
 
 /**
@@ -189,7 +236,10 @@ interface TestOAuthAuthCodeProviderRecorder {
 export function mockTestOAuthAuthCodeProvider(
   options: TestOAuthAuthCodeProviderOptions = {},
 ): TestOAuthAuthCodeProviderRecorder {
-  const recorded: TestOAuthAuthCodeProviderRecorder = { tokenBodies: [] };
+  const recorded: TestOAuthAuthCodeProviderRecorder = {
+    tokenBodies: [],
+    revokeBodies: [],
+  };
 
   server.use(
     http.post(TEST_OAUTH_TOKEN_URL, async ({ request }) => {
@@ -204,8 +254,12 @@ export function mockTestOAuthAuthCodeProvider(
         );
       }
       const refreshToken = options.refreshToken ?? null;
+      const code = recorded.tokenBodies.at(-1)?.get("code") ?? "";
       return HttpResponse.json({
-        access_token: options.accessToken ?? "bdd-test-oauth-access-token",
+        access_token:
+          options.accessTokenForCode?.(code) ??
+          options.accessToken ??
+          "bdd-test-oauth-access-token",
         ...(refreshToken === null ? {} : { refresh_token: refreshToken }),
         ...(options.omitExpiresIn
           ? {}
@@ -215,6 +269,7 @@ export function mockTestOAuthAuthCodeProvider(
       });
     }),
     http.get(TEST_OAUTH_USERINFO_URL, () => {
+      options.onUserinfo?.();
       if (options.userinfoError) {
         return HttpResponse.json(
           { error: "userinfo_lookup_failed" },
@@ -226,6 +281,14 @@ export function mockTestOAuthAuthCodeProvider(
         username: "bdd-test-oauth",
         email: "bdd-test-oauth@example.test",
       });
+    }),
+    http.post(TEST_OAUTH_REVOKE_URL, async ({ request }) => {
+      recorded.revokeBodies.push(new URLSearchParams(await request.text()));
+      await options.revokeWaitUntil;
+      if (options.revokeError) {
+        return HttpResponse.json({ error: "revoke_failed" }, { status: 500 });
+      }
+      return HttpResponse.json({ revoked: true });
     }),
   );
 
@@ -551,13 +614,14 @@ export async function requestOauthCallbackRaw(
     readonly type: string;
     readonly query: Readonly<Record<string, string>>;
     readonly headers?: Readonly<Record<string, string>>;
+    readonly signal?: AbortSignal;
   },
 ): Promise<Response> {
   const url = new URL(`/api/connectors/${args.type}/callback`, args.origin);
   for (const [name, value] of Object.entries(args.query)) {
     url.searchParams.set(name, value);
   }
-  const app = createApp({ signal: context.signal });
+  const app = createApp({ signal: args.signal ?? context.signal });
   return await app.request(url.toString(), { headers: args.headers });
 }
 
@@ -1320,6 +1384,7 @@ export function createConnectorBddApi(context: TestContext) {
       actor: ApiTestUser,
       composeId: string,
       installationId: string,
+      code?: string,
     ): Promise<void> {
       if (!actor.orgId) {
         throw new Error("GitHub App install requires an actor with an org");
@@ -1368,6 +1433,7 @@ export function createConnectorBddApi(context: TestContext) {
             installation_id: installationId,
             setup_action: "install",
             state,
+            ...(code ? { code } : {}),
           },
         }),
         [307],

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -7,9 +7,11 @@ import {
 import {
   connectorGrantScopes,
   resolveConnectorAuthClient,
+  type ConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
 import {
   exchangeConnectorAuthCodeWithMethod,
+  rollbackConnectorAuthGrantWithMethod,
   verifyConnectorOpenIdAuthCallbackWithMethod,
   type ConnectorAuthProviderGrantResult,
 } from "@vm0/connectors/auth-providers";
@@ -38,10 +40,14 @@ import {
 } from "../services/connector-catalog-runtime.service";
 import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
 import {
+  observeConnectorGrantError,
+  persistConnectorGrant,
+} from "../services/connector-grant-lifecycle.service";
+import {
   linkGithubVm0User,
   loadActiveGithubInstallationForOrg,
 } from "../services/github-oauth.service";
-import { safeJsonParse, tapError } from "../utils";
+import { onRejection, safeJsonParse, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import {
   getConnectorOAuthCanonicalRedirectUrlForMethods,
@@ -187,7 +193,10 @@ async function exchangeTokenForConnector(args: {
   readonly state: string | undefined;
   readonly codeVerifier: string | undefined;
   readonly oauthContext: string | undefined;
-}): Promise<ConnectorAuthProviderGrantResult> {
+}): Promise<{
+  readonly token: ConnectorAuthProviderGrantResult;
+  readonly authClient: ConnectorAuthClient;
+}> {
   if (
     args.resolvedMethod.method.grant.kind !== "auth-code" ||
     args.resolvedMethod.method.client === undefined
@@ -204,17 +213,29 @@ async function exchangeTokenForConnector(args: {
     );
   }
 
-  return await exchangeConnectorAuthCodeWithMethod({
-    connectorRef: args.resolvedMethod.connectorRef,
-    authMethodId: args.resolvedMethod.authMethodId,
-    method: args.resolvedMethod.method,
-    authClient,
-    code: args.code,
-    redirectUri: args.redirectUri,
-    state: args.state,
-    codeVerifier: args.codeVerifier,
-    oauthContext: args.oauthContext,
-  });
+  const token = await onRejection(
+    exchangeConnectorAuthCodeWithMethod({
+      connectorRef: args.resolvedMethod.connectorRef,
+      authMethodId: args.resolvedMethod.authMethodId,
+      method: args.resolvedMethod.method,
+      authClient,
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: args.codeVerifier,
+      oauthContext: args.oauthContext,
+    }),
+    (error) => {
+      throw observeConnectorGrantError(
+        {
+          connectorRef: args.resolvedMethod.connectorRef,
+          authMethodId: args.resolvedMethod.authMethodId,
+        },
+        error,
+      );
+    },
+  );
+  return { token, authClient };
 }
 
 async function verifyOpenIdForConnector(args: {
@@ -233,6 +254,76 @@ async function verifyOpenIdForConnector(args: {
     expectedRealm: args.expectedRealm,
     signal: args.signal,
   });
+}
+
+async function exchangeAndPersistOAuthConnector<T>(args: {
+  readonly input: CompleteOAuthCallbackInput;
+  readonly persist: (
+    token: ConnectorAuthProviderGrantResult,
+    signal: AbortSignal,
+  ) => Promise<T>;
+}): Promise<{
+  readonly token: ConnectorAuthProviderGrantResult;
+  readonly result: T;
+}> {
+  const exchange = await exchangeTokenForConnector({
+    resolvedMethod: args.input.resolvedMethod,
+    code: args.input.code,
+    redirectUri: args.input.redirectUri,
+    state: args.input.state,
+    codeVerifier: args.input.codeVerifier,
+    oauthContext: args.input.oauthContext,
+  });
+  const result = await persistConnectorGrant({
+    context: {
+      connectorRef: args.input.resolvedMethod.connectorRef,
+      authMethodId: args.input.resolvedMethod.authMethodId,
+    },
+    persist: (persistSignal) => {
+      return args.persist(exchange.token, persistSignal);
+    },
+    rollback: (rollbackSignal) => {
+      return rollbackConnectorAuthGrantWithMethod({
+        connectorRef: args.input.resolvedMethod.connectorRef,
+        authMethodId: args.input.resolvedMethod.authMethodId,
+        method: args.input.resolvedMethod.method,
+        authClient: exchange.authClient,
+        result: exchange.token,
+        signal: rollbackSignal,
+      });
+    },
+  });
+  return { token: exchange.token, result };
+}
+
+async function verifyAndPersistOpenIdConnector<T>(args: {
+  readonly input: CompleteOpenIdCallbackInput;
+  readonly signal: AbortSignal;
+  readonly persist: (
+    token: ConnectorAuthProviderGrantResult,
+    signal: AbortSignal,
+  ) => Promise<T>;
+}): Promise<{
+  readonly token: ConnectorAuthProviderGrantResult;
+  readonly result: T;
+}> {
+  const token = await verifyOpenIdForConnector({
+    resolvedMethod: args.input.resolvedMethod,
+    callbackParams: args.input.callbackParams,
+    expectedReturnTo: args.input.expectedReturnTo,
+    expectedRealm: args.input.expectedRealm,
+    signal: args.signal,
+  });
+  const result = await persistConnectorGrant({
+    context: {
+      connectorRef: args.input.resolvedMethod.connectorRef,
+      authMethodId: args.input.resolvedMethod.authMethodId,
+    },
+    persist: (persistSignal) => {
+      return args.persist(token, persistSignal);
+    },
+  });
+  return { token, result };
 }
 
 function resolveConnectorWithGrant(args: {
@@ -451,31 +542,26 @@ const completeOAuthCallback$ = command(
     args: CompleteOAuthCallbackInput,
     signal: AbortSignal,
   ): Promise<Response> => {
-    const token = await exchangeTokenForConnector({
-      resolvedMethod: args.resolvedMethod,
-      code: args.code,
-      redirectUri: args.redirectUri,
-      state: args.state,
-      codeVerifier: args.codeVerifier,
-      oauthContext: args.oauthContext,
-    });
-    signal.throwIfAborted();
-
-    const result = await set(
-      upsertConnectorTokenConnection$,
-      {
-        orgId: args.identity.orgId,
-        userId: args.identity.userId,
-        runtimeMethod: args.resolvedMethod.runtimeMethod,
-        snapshot: args.resolvedMethod.snapshot,
-        outputs: token.outputs,
-        userInfo: token.userInfo,
-        oauthScopes: connectorGrantScopes(args.resolvedMethod.method.grant),
-        expiresIn: token.expiresIn,
-        extraConnectorSecrets: token.extraConnectorSecrets,
+    const { result, token } = await exchangeAndPersistOAuthConnector({
+      input: args,
+      persist: (grant, persistSignal) => {
+        return set(
+          upsertConnectorTokenConnection$,
+          {
+            orgId: args.identity.orgId,
+            userId: args.identity.userId,
+            runtimeMethod: args.resolvedMethod.runtimeMethod,
+            snapshot: args.resolvedMethod.snapshot,
+            outputs: grant.outputs,
+            userInfo: grant.userInfo,
+            oauthScopes: connectorGrantScopes(args.resolvedMethod.method.grant),
+            expiresIn: grant.expiresIn,
+            extraConnectorSecrets: grant.extraConnectorSecrets,
+          },
+          persistSignal,
+        );
       },
-      signal,
-    );
+    });
     signal.throwIfAborted();
 
     if (args.authorizeAgent) {
@@ -522,30 +608,27 @@ const completeOpenIdCallback$ = command(
     args: CompleteOpenIdCallbackInput,
     signal: AbortSignal,
   ): Promise<Response> => {
-    const token = await verifyOpenIdForConnector({
-      resolvedMethod: args.resolvedMethod,
-      callbackParams: args.callbackParams,
-      expectedReturnTo: args.expectedReturnTo,
-      expectedRealm: args.expectedRealm,
+    const { result } = await verifyAndPersistOpenIdConnector({
+      input: args,
       signal,
-    });
-    signal.throwIfAborted();
-
-    const result = await set(
-      upsertConnectorTokenConnection$,
-      {
-        orgId: args.identity.orgId,
-        userId: args.identity.userId,
-        runtimeMethod: args.resolvedMethod.runtimeMethod,
-        snapshot: args.resolvedMethod.snapshot,
-        outputs: token.outputs,
-        userInfo: token.userInfo,
-        oauthScopes: token.scopes,
-        expiresIn: token.expiresIn,
-        extraConnectorSecrets: token.extraConnectorSecrets,
+      persist: (token, persistSignal) => {
+        return set(
+          upsertConnectorTokenConnection$,
+          {
+            orgId: args.identity.orgId,
+            userId: args.identity.userId,
+            runtimeMethod: args.resolvedMethod.runtimeMethod,
+            snapshot: args.resolvedMethod.snapshot,
+            outputs: token.outputs,
+            userInfo: token.userInfo,
+            oauthScopes: token.scopes,
+            expiresIn: token.expiresIn,
+            extraConnectorSecrets: token.extraConnectorSecrets,
+          },
+          persistSignal,
+        );
       },
-      signal,
-    );
+    });
     signal.throwIfAborted();
 
     if (args.authorizeAgent) {

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -499,7 +499,6 @@ async function connectGithubUserWithSetupGrant(args: {
     readonly clientSecret: string;
   };
   readonly installRecordId: string;
-  readonly orgId: string;
   readonly resolvedMethod: ResolvedConnectorActionMethod;
   readonly signal: AbortSignal;
   readonly userId: string;
@@ -603,7 +602,6 @@ const connectGithubUserAfterSetup$ = command(
         codeExchangeLogContext,
         credentials,
         installRecordId: args.installRecordId,
-        orgId: args.orgId,
         resolvedMethod,
         signal,
         userId: vm0UserId,

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -9,10 +9,14 @@ import {
   isStaticConfidentialConnectorAuthClient,
   type StaticConfidentialConnectorAuthClient,
 } from "@vm0/connectors/connector-utils";
-import { exchangeConnectorAuthCodeWithMethod } from "@vm0/connectors/auth-providers";
 import {
-  exchangeGitHubCode,
-  fetchGitHubUserInfo,
+  exchangeConnectorAuthCodeWithMethod,
+  rollbackConnectorAuthGrantWithMethod,
+  type ConnectorAuthProviderGrantResult,
+} from "@vm0/connectors/auth-providers";
+import {
+  exchangeGitHubGrant,
+  type GitHubGrantResult,
 } from "@vm0/connectors/auth-providers/connectors/github/oauth";
 
 import { requiredAuthContext$ } from "../auth/auth-context";
@@ -48,8 +52,12 @@ import {
   verifyGithubConnectSignature,
 } from "../services/github-oauth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
+import {
+  observeConnectorGrantError,
+  persistConnectorGrant,
+} from "../services/connector-grant-lifecycle.service";
 import { upsertConnectorTokenConnection$ } from "../services/zero-connector-data.service";
-import { settle } from "../utils";
+import { settleIncludingAbort } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import {
   getOAuthCanonicalRedirectUrl,
@@ -129,6 +137,62 @@ async function resolveGithubOauthMethodForNewAction(
     expectedGrantKind: "auth-code",
   });
   return resolved.ok ? resolved : null;
+}
+
+async function exchangeAndPersistGithubUserGrant(args: {
+  readonly authClient: StaticConfidentialConnectorAuthClient;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly state: string | undefined;
+  readonly persistConnector: (
+    token: ConnectorAuthProviderGrantResult,
+    signal: AbortSignal,
+  ) => Promise<unknown>;
+}): Promise<ConnectorAuthProviderGrantResult> {
+  const tokenResult = await settleIncludingAbort(
+    exchangeConnectorAuthCodeWithMethod({
+      connectorRef: args.resolvedMethod.connectorRef,
+      authMethodId: args.resolvedMethod.authMethodId,
+      method: args.resolvedMethod.method,
+      authClient: args.authClient,
+      code: args.code,
+      redirectUri: args.redirectUri,
+      state: args.state,
+      codeVerifier: undefined,
+      oauthContext: undefined,
+    }),
+  );
+  if (!tokenResult.ok) {
+    throw observeConnectorGrantError(
+      {
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+      },
+      tokenResult.error,
+    );
+  }
+  const token = tokenResult.value;
+  await persistConnectorGrant({
+    context: {
+      connectorRef: args.resolvedMethod.connectorRef,
+      authMethodId: args.resolvedMethod.authMethodId,
+    },
+    persist: (persistSignal) => {
+      return args.persistConnector(token, persistSignal);
+    },
+    rollback: (rollbackSignal) => {
+      return rollbackConnectorAuthGrantWithMethod({
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+        method: args.resolvedMethod.method,
+        authClient: args.authClient,
+        result: token,
+        signal: rollbackSignal,
+      });
+    },
+  });
+  return token;
 }
 
 function githubAppUserOauthCredentials():
@@ -356,6 +420,143 @@ async function linkGithubUserWithoutSetupCode(
   return { ok: true, connected: githubUserId !== null };
 }
 
+async function exchangeGithubSetupGrant(args: {
+  readonly code: string;
+  readonly codeExchangeLogContext: ReturnType<
+    typeof githubSetupCodeExchangeLogContext
+  >;
+  readonly credentials: {
+    readonly clientId: string;
+    readonly clientSecret: string;
+  };
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly authClient: StaticConfidentialConnectorAuthClient;
+      readonly token: GitHubGrantResult;
+    }
+  | { readonly ok: false; readonly response: Response }
+> {
+  if (args.resolvedMethod.method.grant.kind !== "auth-code") {
+    return {
+      ok: false,
+      response: worksErrorRedirect("GitHub OAuth is not available"),
+    };
+  }
+  L.warn("Starting GitHub setup code exchange", {
+    ...args.codeExchangeLogContext,
+    client: "github_app",
+    sendsRedirectUri: false,
+  });
+  const authClient: StaticConfidentialConnectorAuthClient = {
+    clientRegistration: "static",
+    clientType: "confidential",
+    clientId: args.credentials.clientId,
+    clientSecret: args.credentials.clientSecret,
+  };
+  const tokenResult = await settleIncludingAbort(
+    exchangeGitHubGrant({
+      authCodeGrant: args.resolvedMethod.method.grant,
+      clientId: authClient.clientId,
+      clientSecret: authClient.clientSecret,
+      code: args.code,
+    }),
+  );
+  if (!tokenResult.ok) {
+    const providerError = observeConnectorGrantError(
+      {
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+      },
+      tokenResult.error,
+    );
+    L.warn("GitHub setup code exchange failed", {
+      ...args.codeExchangeLogContext,
+      error: errorMessageFromUnknown(providerError),
+    });
+    return {
+      ok: false,
+      response: worksErrorRedirect(errorMessageFromUnknown(providerError)),
+    };
+  }
+  L.warn("GitHub setup code exchange succeeded", {
+    ...args.codeExchangeLogContext,
+    githubUserId: tokenResult.value.userInfo.id,
+    githubUsername: tokenResult.value.userInfo.username,
+    scopes: tokenResult.value.scopes,
+  });
+  return { ok: true, authClient, token: tokenResult.value };
+}
+
+async function connectGithubUserWithSetupGrant(args: {
+  readonly code: string;
+  readonly codeExchangeLogContext: ReturnType<
+    typeof githubSetupCodeExchangeLogContext
+  >;
+  readonly credentials: {
+    readonly clientId: string;
+    readonly clientSecret: string;
+  };
+  readonly installRecordId: string;
+  readonly orgId: string;
+  readonly resolvedMethod: ResolvedConnectorActionMethod;
+  readonly signal: AbortSignal;
+  readonly userId: string;
+  readonly db: Db;
+  readonly persistConnector: (
+    token: GitHubGrantResult,
+    signal: AbortSignal,
+  ) => Promise<unknown>;
+}): Promise<GithubSetupUserConnectionResolution> {
+  const grant = await exchangeGithubSetupGrant(args);
+  if (!grant.ok) {
+    return grant;
+  }
+  const { authClient, token } = grant;
+  await persistConnectorGrant({
+    context: {
+      connectorRef: args.resolvedMethod.connectorRef,
+      authMethodId: args.resolvedMethod.authMethodId,
+    },
+    persist: (persistSignal) => {
+      return args.persistConnector(token, persistSignal);
+    },
+    rollback: (rollbackSignal) => {
+      return rollbackConnectorAuthGrantWithMethod({
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+        method: args.resolvedMethod.method,
+        authClient,
+        result: token,
+        signal: rollbackSignal,
+      });
+    },
+  });
+  args.signal.throwIfAborted();
+
+  const githubUserId = await linkGithubVm0User({
+    db: args.db,
+    installRecordId: args.installRecordId,
+    vm0UserId: args.userId,
+    knownGithubUserId: token.userInfo.id,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+  if (!githubUserId) {
+    return {
+      ok: false,
+      response: worksErrorRedirect(
+        "This GitHub account is already linked to the installation",
+      ),
+    };
+  }
+
+  await publishUserSignal([args.userId], "github:changed");
+  args.signal.throwIfAborted();
+  return { ok: true, connected: true };
+}
+
 const connectGithubUserAfterSetup$ = command(
   async (
     { get, set },
@@ -387,99 +588,47 @@ const connectGithubUserAfterSetup$ = command(
         };
       }
 
-      L.warn("Starting GitHub setup code exchange", {
-        ...codeExchangeLogContext,
-        client: "github_app",
-        sendsRedirectUri: false,
-      });
-
       const resolver = await get(connectorActionResolver());
       signal.throwIfAborted();
       const resolvedMethod = await resolveGithubOauthMethod(resolver);
       signal.throwIfAborted();
-      if (!resolvedMethod || resolvedMethod.method.grant.kind !== "auth-code") {
+      if (!resolvedMethod) {
         return {
           ok: false,
           response: worksErrorRedirect("GitHub OAuth is not available"),
         };
       }
-      const authCodeGrant = resolvedMethod.method.grant;
-      const tokenResult = await settle(
-        (async () => {
-          const { accessToken, scopes } = await exchangeGitHubCode(
-            authCodeGrant,
-            credentials.clientId,
-            credentials.clientSecret,
-            code,
-          );
-          signal.throwIfAborted();
-          const userInfo = await fetchGitHubUserInfo(accessToken);
-          signal.throwIfAborted();
-          return { accessToken, scopes, userInfo };
-        })(),
-        signal,
-      );
-      signal.throwIfAborted();
-      if (!tokenResult.ok) {
-        L.warn("GitHub setup code exchange failed", {
-          ...codeExchangeLogContext,
-          error: errorMessageFromUnknown(tokenResult.error),
-        });
-        return {
-          ok: false,
-          response: worksErrorRedirect(
-            errorMessageFromUnknown(tokenResult.error),
-          ),
-        };
-      }
-      const { accessToken, scopes, userInfo } = tokenResult.value;
-      L.warn("GitHub setup code exchange succeeded", {
-        ...codeExchangeLogContext,
-        githubUserId: userInfo.id,
-        githubUsername: userInfo.username,
-        scopes,
-      });
-
-      await set(
-        upsertConnectorTokenConnection$,
-        {
-          orgId: args.orgId,
-          userId: vm0UserId,
-          runtimeMethod: resolvedMethod.runtimeMethod,
-          snapshot: resolvedMethod.snapshot,
-          outputs: { accessToken },
-          userInfo,
-          oauthScopes:
-            scopes.length > 0
-              ? scopes
-              : connectorGrantScopes(resolvedMethod.method.grant),
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-
-      const githubUserId = await linkGithubVm0User({
-        db: args.db,
+      const connection = await connectGithubUserWithSetupGrant({
+        code,
+        codeExchangeLogContext,
+        credentials,
         installRecordId: args.installRecordId,
-        vm0UserId,
-        knownGithubUserId: userInfo.id,
+        orgId: args.orgId,
+        resolvedMethod,
         signal,
+        userId: vm0UserId,
+        db: args.db,
+        persistConnector: (token, persistSignal) => {
+          return set(
+            upsertConnectorTokenConnection$,
+            {
+              orgId: args.orgId,
+              userId: vm0UserId,
+              runtimeMethod: resolvedMethod.runtimeMethod,
+              snapshot: resolvedMethod.snapshot,
+              outputs: token.outputs,
+              userInfo: token.userInfo,
+              oauthScopes:
+                token.scopes.length > 0
+                  ? token.scopes
+                  : connectorGrantScopes(resolvedMethod.method.grant),
+            },
+            persistSignal,
+          );
+        },
       });
       signal.throwIfAborted();
-
-      if (!githubUserId) {
-        return {
-          ok: false,
-          response: worksErrorRedirect(
-            "This GitHub account is already linked to the installation",
-          ),
-        };
-      }
-
-      await publishUserSignal([vm0UserId], "github:changed");
-      signal.throwIfAborted();
-
-      return { ok: true, connected: true };
+      return connection;
     }
 
     return await linkGithubUserWithoutSetupCode(args, vm0UserId, signal);
@@ -775,6 +924,8 @@ const callbackGithubUserOauth$ = command(
         "Invalid OAuth state. Please try connecting again from the Platform.",
       );
     }
+    const orgId = state.orgId;
+    const vm0UserId = state.vm0UserId;
 
     if (
       !(await isGithubOauthStateSignatureValid({
@@ -799,51 +950,47 @@ const callbackGithubUserOauth$ = command(
       return worksErrorRedirect("GitHub OAuth is not configured");
     }
 
-    const origin = getOAuthWebOrigin(request);
-    const redirectUri = githubUserConnectCallbackRedirectUri(origin);
-    const token = await exchangeConnectorAuthCodeWithMethod({
-      connectorRef: resolvedMethod.connectorRef,
-      authMethodId: resolvedMethod.authMethodId,
-      method: resolvedMethod.method,
-      authClient,
-      code: query.code,
-      redirectUri,
-      state: query.state,
-      codeVerifier: undefined,
-      oauthContext: undefined,
-    });
-    signal.throwIfAborted();
-
     const db = set(writeDb$);
     const installation = await loadActiveGithubInstallationForOrg({
       db,
-      orgId: state.orgId,
+      orgId,
       signal,
     });
     if (!installation) {
       return worksErrorRedirect("No GitHub installation found");
     }
 
-    await set(
-      upsertConnectorTokenConnection$,
-      {
-        orgId: state.orgId,
-        userId: state.vm0UserId,
-        runtimeMethod: resolvedMethod.runtimeMethod,
-        snapshot: resolvedMethod.snapshot,
-        outputs: token.outputs,
-        userInfo: token.userInfo,
-        oauthScopes: connectorGrantScopes(resolvedMethod.method.grant),
-        extraConnectorSecrets: token.extraConnectorSecrets,
+    const origin = getOAuthWebOrigin(request);
+    const redirectUri = githubUserConnectCallbackRedirectUri(origin);
+    const token = await exchangeAndPersistGithubUserGrant({
+      authClient,
+      code: query.code,
+      redirectUri,
+      resolvedMethod,
+      state: query.state,
+      persistConnector: (grant, persistSignal) => {
+        return set(
+          upsertConnectorTokenConnection$,
+          {
+            orgId,
+            userId: vm0UserId,
+            runtimeMethod: resolvedMethod.runtimeMethod,
+            snapshot: resolvedMethod.snapshot,
+            outputs: grant.outputs,
+            userInfo: grant.userInfo,
+            oauthScopes: connectorGrantScopes(resolvedMethod.method.grant),
+            extraConnectorSecrets: grant.extraConnectorSecrets,
+          },
+          persistSignal,
+        );
       },
-      signal,
-    );
+    });
     signal.throwIfAborted();
 
     const githubUserId = await linkGithubVm0User({
       db,
       installRecordId: installation.id,
-      vm0UserId: state.vm0UserId,
+      vm0UserId,
       knownGithubUserId: token.userInfo.id,
       signal,
     });
@@ -855,7 +1002,7 @@ const callbackGithubUserOauth$ = command(
       );
     }
 
-    await publishUserSignal([state.vm0UserId], "github:changed");
+    await publishUserSignal([vm0UserId], "github:changed");
     signal.throwIfAborted();
 
     return redirectResponse(appUrl("/workflows"));

--- a/turbo/apps/api/src/signals/routes/test-oauth-provider-revoke.ts
+++ b/turbo/apps/api/src/signals/routes/test-oauth-provider-revoke.ts
@@ -1,0 +1,50 @@
+import { testOAuthProviderRevokeContract } from "@vm0/api-contracts/contracts/test-oauth-provider-revoke";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  isTestOAuthAccessToken,
+  TEST_OAUTH_CLIENT_ID,
+  TEST_OAUTH_CLIENT_SECRET,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+function errorResponse(status: 400 | 401, error: string) {
+  return { status, body: { error } };
+}
+
+const revoke$ = command(async ({ get }, signal: AbortSignal) => {
+  const request = get(request$);
+  if (!isTestEndpointAllowed(request)) {
+    return testEndpointNotFoundResponse();
+  }
+
+  const contentType = request.header("content-type") ?? "";
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    return errorResponse(400, "invalid_request");
+  }
+
+  const body = new URLSearchParams(await request.text());
+  signal.throwIfAborted();
+  if (
+    body.get("client_id") !== TEST_OAUTH_CLIENT_ID ||
+    body.get("client_secret") !== TEST_OAUTH_CLIENT_SECRET
+  ) {
+    return errorResponse(401, "invalid_client");
+  }
+
+  const token = body.get("token");
+  if (!token || !isTestOAuthAccessToken(token)) {
+    return errorResponse(400, "invalid_token");
+  }
+  return { status: 200 as const, body: { revoked: true as const } };
+});
+
+export const testOAuthProviderRevokeRoutes: readonly RouteEntry[] = [
+  {
+    route: testOAuthProviderRevokeContract.revoke,
+    handler: revoke$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -17,6 +17,7 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   completeConnectorExternalCodeAuthorizationWithMethod,
+  rollbackConnectorAuthGrantWithMethod,
   startConnectorExternalCodeAuthorizationWithMethod,
   type ConnectorAuthProviderGrantResult,
 } from "@vm0/connectors/auth-providers";
@@ -30,7 +31,7 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
-import { onRejection, settle, throwIfAbort } from "../utils";
+import { onRejection, settleIncludingAbort, throwIfAbort } from "../utils";
 import {
   decryptPersistentSecretValue,
   encryptPersistentSecretValue,
@@ -41,6 +42,10 @@ import {
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
 } from "./connector-action-resolver.service";
+import {
+  observeConnectorGrantError,
+  persistConnectorGrant,
+} from "./connector-grant-lifecycle.service";
 import {
   upsertConnectorTokenConnection$,
   zeroConnectorByType,
@@ -620,7 +625,7 @@ async function completeClaimedExternalCodeSession(
     }) => Promise<ConnectorResponse>;
   },
 ) {
-  const providerResult = await settle(
+  const providerResult = await settleIncludingAbort(
     (async () => {
       const providerState = await parseEncryptedProviderState({
         session: args.session,
@@ -636,18 +641,25 @@ async function completeClaimedExternalCodeSession(
         signal: args.signal,
       });
     })(),
-    args.signal,
   );
   if (!providerResult.ok) {
-    if (shouldRestorePendingAfterProviderError(providerResult.error)) {
+    const providerError = observeConnectorGrantError(
+      {
+        connectorRef: args.resolvedMethod.connectorRef,
+        authMethodId: args.resolvedMethod.authMethodId,
+      },
+      providerResult.error,
+    );
+    args.signal.throwIfAborted();
+    if (shouldRestorePendingAfterProviderError(providerError)) {
       await markClaimPending({
         writeDb: args.writeDb,
         session: args.session,
         claimStartedAt: args.claimStartedAt,
-        errorMessage: errorMessage(providerResult.error),
+        errorMessage: errorMessage(providerError),
         signal: args.signal,
       });
-      const badRequest = providerBadRequest(providerResult.error);
+      const badRequest = providerBadRequest(providerError);
       if (badRequest) {
         return badRequest;
       }
@@ -656,11 +668,11 @@ async function completeClaimedExternalCodeSession(
         writeDb: args.writeDb,
         session: args.session,
         claimStartedAt: args.claimStartedAt,
-        errorMessage: errorMessage(providerResult.error),
+        errorMessage: errorMessage(providerError),
         signal: args.signal,
       });
     }
-    throw providerResult.error;
+    throw providerError;
   }
 
   // The provider code may already be consumed; finish DB commit even if the
@@ -675,7 +687,30 @@ async function completeClaimedExternalCodeSession(
       userId: args.userId,
       session: args.session,
       claimStartedAt: args.claimStartedAt,
-      persistConnector: args.persistConnector,
+      persistConnector: ({ token }) => {
+        return persistConnectorGrant({
+          context: {
+            connectorRef: args.resolvedMethod.connectorRef,
+            authMethodId: args.resolvedMethod.authMethodId,
+          },
+          persist: (persistSignal) => {
+            return args.persistConnector({
+              token,
+              signal: persistSignal,
+            });
+          },
+          rollback: (rollbackSignal) => {
+            return rollbackConnectorAuthGrantWithMethod({
+              connectorRef: args.resolvedMethod.connectorRef,
+              authMethodId: args.resolvedMethod.authMethodId,
+              method: args.resolvedMethod.method,
+              authClient: args.authClient,
+              result: token,
+              signal: rollbackSignal,
+            });
+          },
+        });
+      },
       token: providerResult.value,
       signal: commitSignal,
     }),

--- a/turbo/apps/api/src/signals/services/connector-grant-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-grant-lifecycle.service.ts
@@ -1,0 +1,93 @@
+import {
+  connectorGrantCleanupError,
+  connectorGrantPrimaryError,
+  type ConnectorAuthProviderGrantRollbackResult,
+} from "@vm0/connectors/auth-providers";
+
+import { logger } from "../../lib/log";
+import { waitUntil } from "../context/wait-until";
+import { settleIncludingAbort } from "../utils";
+import { ConnectorTokenPersistenceError } from "./zero-connector-data.service";
+
+const GRANT_ROLLBACK_TIMEOUT_MS = 5000;
+const L = logger("ConnectorGrantLifecycleService");
+
+interface ConnectorGrantLifecycleContext {
+  readonly connectorRef: string;
+  readonly authMethodId: string;
+}
+
+function safeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+export function observeConnectorGrantError(
+  context: ConnectorGrantLifecycleContext,
+  error: unknown,
+): unknown {
+  const cleanupError = connectorGrantCleanupError(error);
+  if (cleanupError !== undefined) {
+    L.warn("Connector provider grant cleanup failed", {
+      ...context,
+      operation: "cleanup_incomplete_grant",
+      error: safeErrorMessage(cleanupError),
+    });
+  }
+  return connectorGrantPrimaryError(error);
+}
+
+async function runGrantRollback(args: {
+  readonly context: ConnectorGrantLifecycleContext;
+  readonly rollback: (
+    signal: AbortSignal,
+  ) => Promise<ConnectorAuthProviderGrantRollbackResult>;
+}): Promise<void> {
+  const rollback = await settleIncludingAbort(
+    args.rollback(AbortSignal.timeout(GRANT_ROLLBACK_TIMEOUT_MS)),
+  );
+  if (!rollback.ok) {
+    L.warn("Connector grant rollback failed", {
+      ...args.context,
+      operation: "rollback_uncommitted_grant",
+      error: safeErrorMessage(rollback.error),
+    });
+    return;
+  }
+  if (rollback.value.status === "unsupported") {
+    L.debug("Connector grant rollback is unsupported", {
+      ...args.context,
+      operation: "rollback_uncommitted_grant",
+    });
+  }
+}
+
+export async function persistConnectorGrant<T>(args: {
+  readonly context: ConnectorGrantLifecycleContext;
+  readonly persist: (signal: AbortSignal) => Promise<T>;
+  readonly rollback?: (
+    signal: AbortSignal,
+  ) => Promise<ConnectorAuthProviderGrantRollbackResult>;
+}): Promise<T> {
+  const persistence = await settleIncludingAbort(
+    args.persist(new AbortController().signal),
+  );
+  if (!persistence.ok) {
+    const error = persistence.error;
+    if (
+      error instanceof ConnectorTokenPersistenceError &&
+      error.commitStatus === "not_committed" &&
+      args.rollback
+    ) {
+      waitUntil(
+        runGrantRollback({
+          context: args.context,
+          rollback: args.rollback,
+        }),
+      );
+    }
+    throw error instanceof ConnectorTokenPersistenceError
+      ? error.originalError
+      : error;
+  }
+  return persistence.value;
+}

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -43,6 +43,7 @@ import {
   type ConnectorActionResolver,
   type ResolvedConnectorActionMethod,
 } from "./connector-action-resolver.service";
+import { persistConnectorGrant } from "./connector-grant-lifecycle.service";
 import {
   upsertConnectorTokenConnection$,
   zeroConnectorByType,
@@ -800,9 +801,9 @@ async function runClaimedSession(
       ? {}
       : { pollState: providerState.pollState }),
   });
-  args.signal.throwIfAborted();
 
   if (pollResult.status === "pending" || pollResult.status === "slow_down") {
+    args.signal.throwIfAborted();
     const intervalSeconds =
       pollResult.status === "pending"
         ? (pollResult.interval ?? args.session.intervalSeconds)
@@ -828,6 +829,7 @@ async function runClaimedSession(
   }
 
   if (pollResult.status !== "complete") {
+    args.signal.throwIfAborted();
     return await markClaimTerminal({
       writeDb: args.writeDb,
       session: args.session,
@@ -845,7 +847,7 @@ async function runClaimedSession(
     userId: args.userId,
     session: args.session,
     claimStartedAt: args.claimStartedAt,
-    signal: args.signal,
+    signal: new AbortController().signal,
     persistConnector: args.persistConnector,
     result: pollResult,
   });
@@ -1102,23 +1104,31 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
       session: claimedSession,
       claimStartedAt,
       signal,
-      persistConnector: async ({ result }) => {
-        const connectorResult = await set(
-          upsertConnectorTokenConnection$,
-          {
-            orgId: args.orgId,
-            userId: args.userId,
-            runtimeMethod: resolvedMethod.runtimeMethod,
-            snapshot: resolvedMethod.snapshot,
-            outputs: result.token.outputs,
-            userInfo: result.token.userInfo,
-            oauthScopes: result.token.scopes,
-            expiresIn: result.token.expiresIn,
-            extraConnectorSecrets: result.token.extraConnectorSecrets,
+      persistConnector: ({ result }) => {
+        return persistConnectorGrant({
+          context: {
+            connectorRef: resolvedMethod.connectorRef,
+            authMethodId: resolvedMethod.authMethodId,
           },
-          signal,
-        );
-        return connectorResult.connector;
+          persist: async (persistSignal) => {
+            const connectorResult = await set(
+              upsertConnectorTokenConnection$,
+              {
+                orgId: args.orgId,
+                userId: args.userId,
+                runtimeMethod: resolvedMethod.runtimeMethod,
+                snapshot: resolvedMethod.snapshot,
+                outputs: result.token.outputs,
+                userInfo: result.token.userInfo,
+                oauthScopes: result.token.scopes,
+                expiresIn: result.token.expiresIn,
+                extraConnectorSecrets: result.token.extraConnectorSecrets,
+              },
+              persistSignal,
+            );
+            return connectorResult.connector;
+          },
+        });
       },
     });
     if (response.body.status !== "complete") {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -2220,6 +2220,8 @@ export const upsertConnectorTokenConnection$ = command(
           }),
         );
         if (!transaction.ok) {
+          // Drizzle issues COMMIT only after the callback resolves. A
+          // rejection after that point cannot prove that the write rolled back.
           if (transactionCallbackCompleted) {
             commitStatus = "unknown";
           }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -35,10 +35,11 @@ import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
-import { bestEffort } from "../utils";
+import { bestEffort, settleIncludingAbort } from "../utils";
 import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
@@ -90,7 +91,46 @@ type StoredConnectorRow = {
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
+const CONNECTOR_POST_COMMIT_TIMEOUT_MS = 5000;
+const L = logger("ZeroConnectorDataService");
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
+
+type ConnectorTokenPersistenceCommitStatus =
+  | "not_committed"
+  | "unknown"
+  | "committed";
+
+export class ConnectorTokenPersistenceError extends Error {
+  readonly commitStatus: ConnectorTokenPersistenceCommitStatus;
+  readonly originalError: unknown;
+
+  constructor(
+    commitStatus: ConnectorTokenPersistenceCommitStatus,
+    originalError: unknown,
+  ) {
+    super(`Connector token persistence failed (${commitStatus})`, {
+      cause: originalError,
+    });
+    this.name = "ConnectorTokenPersistenceError";
+    this.commitStatus = commitStatus;
+    this.originalError = originalError;
+  }
+}
+
+async function classifyConnectorTokenPersistence<T>(
+  operation: Promise<T>,
+  commitStatus: () => ConnectorTokenPersistenceCommitStatus,
+): Promise<T> {
+  const persistence = await settleIncludingAbort(operation);
+  if (persistence.ok) {
+    return persistence.value;
+  }
+  const error = persistence.error;
+  if (error instanceof ConnectorTokenPersistenceError) {
+    throw error;
+  }
+  throw new ConnectorTokenPersistenceError(commitStatus(), error);
+}
 
 interface ExternalUserInfo {
   readonly id: string;
@@ -299,6 +339,45 @@ async function finalizeConnectorStateChangeAfterCommit(args: {
     postCommitAbort ??= args.signal.reason;
   }
   throwCapturedAbort(postCommitAbort);
+}
+
+function loggedConnectorPostCommitError(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+async function finalizeConnectorTokenStateAfterCommit(args: {
+  readonly userId: string;
+  readonly runtimeMethod: ConnectorRuntimeMethod;
+  readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
+}): Promise<void> {
+  if (args.pendingTokenRevoke) {
+    const cleanup = await settleIncludingAbort(
+      revokePendingConnectorTokenOnce({
+        pending: args.pendingTokenRevoke,
+        signal: AbortSignal.timeout(CONNECTOR_POST_COMMIT_TIMEOUT_MS),
+      }),
+    );
+    if (!cleanup.ok) {
+      L.warn("Connector post-commit token cleanup failed", {
+        connectorRef: args.runtimeMethod.connectorRef,
+        authMethodId: args.runtimeMethod.authMethodId,
+        operation: "revoke_replaced_token",
+        error: loggedConnectorPostCommitError(cleanup.error),
+      });
+    }
+  }
+
+  const publication = await settleIncludingAbort(
+    publishUserSignal([args.userId], "connector:changed"),
+  );
+  if (!publication.ok) {
+    L.warn("Connector post-commit publication failed", {
+      connectorRef: args.runtimeMethod.connectorRef,
+      authMethodId: args.runtimeMethod.authMethodId,
+      operation: "publish_connector_changed",
+      error: loggedConnectorPostCommitError(publication.error),
+    });
+  }
 }
 
 function prepareManualGrantConnect(
@@ -703,21 +782,26 @@ async function revokePendingConnectorToken(args: {
   readonly signal: AbortSignal;
 }): Promise<void> {
   // Provider revocation is best-effort; local cleanup still owns visible state.
-  await bestEffort(
-    revokeConnectorAuthMethodAccessTokenWithMethod({
-      connectorRef: args.pending.runtimeMethod.connectorRef,
-      authMethodId: args.pending.runtimeMethod.authMethodId,
-      method: args.pending.runtimeMethod.method,
-      readEnv: optionalEnv,
-      signal: args.signal,
-      loadInputs: () => {
-        return decryptConnectorRevokeInputs({
-          encryptedInputs: args.pending.encryptedInputs,
-          featureSwitchContext: args.pending.featureSwitchContext,
-        });
-      },
-    }),
-  );
+  await bestEffort(revokePendingConnectorTokenOnce(args));
+}
+
+async function revokePendingConnectorTokenOnce(args: {
+  readonly pending: PendingConnectorTokenRevoke;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await revokeConnectorAuthMethodAccessTokenWithMethod({
+    connectorRef: args.pending.runtimeMethod.connectorRef,
+    authMethodId: args.pending.runtimeMethod.authMethodId,
+    method: args.pending.runtimeMethod.method,
+    readEnv: optionalEnv,
+    signal: args.signal,
+    loadInputs: () => {
+      return decryptConnectorRevokeInputs({
+        encryptedInputs: args.pending.encryptedInputs,
+        featureSwitchContext: args.pending.featureSwitchContext,
+      });
+    },
+  });
 }
 
 async function deleteManualGrantConnectorLocalState(args: {
@@ -2058,7 +2142,7 @@ async function commitConnectorTokenConnection(args: {
 }
 
 export const upsertConnectorTokenConnection$ = command(
-  async (
+  (
     { get, set },
     args: {
       readonly orgId: string;
@@ -2076,80 +2160,95 @@ export const upsertConnectorTokenConnection$ = command(
     readonly connector: ConnectorResponse;
     readonly created: boolean;
   }> => {
-    const writeDb = set(writeDb$);
-    const outputMetadata = connectorTokenOutputMetadataForAuthMethod({
-      runtimeMethod: args.runtimeMethod,
-    });
-    if (!outputMetadata) {
-      throw new Error(
-        `${args.runtimeMethod.connectorRef} connector auth method ${args.runtimeMethod.authMethodId} does not expose token outputs`,
-      );
-    }
-    const tokenExpiresAt = connectorTokenExpiresAt({
-      isRefreshable: outputMetadata.isRefreshable,
-      expiresIn: args.expiresIn,
-    });
-    const extraSecrets = validateExtraConnectorTokenSecrets({
-      connectorRef: args.runtimeMethod.connectorRef,
-      method: args.runtimeMethod.method,
-      extraConnectorSecrets: args.extraConnectorSecrets,
-      outputTargets: outputMetadata.outputTargets,
-    });
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(args.orgId, args.userId),
+    let commitStatus: ConnectorTokenPersistenceCommitStatus = "not_committed";
+    return classifyConnectorTokenPersistence(
+      (async () => {
+        const writeDb = set(writeDb$);
+        const outputMetadata = connectorTokenOutputMetadataForAuthMethod({
+          runtimeMethod: args.runtimeMethod,
+        });
+        if (!outputMetadata) {
+          throw new Error(
+            `${args.runtimeMethod.connectorRef} connector auth method ${args.runtimeMethod.authMethodId} does not expose token outputs`,
+          );
+        }
+        const tokenExpiresAt = connectorTokenExpiresAt({
+          isRefreshable: outputMetadata.isRefreshable,
+          expiresIn: args.expiresIn,
+        });
+        const extraSecrets = validateExtraConnectorTokenSecrets({
+          connectorRef: args.runtimeMethod.connectorRef,
+          method: args.runtimeMethod.method,
+          extraConnectorSecrets: args.extraConnectorSecrets,
+          outputTargets: outputMetadata.outputTargets,
+        });
+        const featureSwitchContext = await get(
+          userFeatureSwitchContext(args.orgId, args.userId),
+        );
+        signal.throwIfAborted();
+
+        const connectorTokenState = await prepareConnectorTokenState({
+          type: args.runtimeMethod.connectorRef,
+          outputTargets: outputMetadata.outputTargets,
+          requiredOutputNames: outputMetadata.requiredOutputNames,
+          requiredExtraSecretNames: outputMetadata.requiredExtraSecretNames,
+          outputs: args.outputs,
+          extraSecrets,
+          featureSwitchContext,
+          signal,
+        });
+        signal.throwIfAborted();
+
+        let transactionCallbackCompleted = false;
+        const transaction = await settleIncludingAbort(
+          writeDb.transaction(async (tx) => {
+            const result = await commitConnectorTokenConnection({
+              db: tx,
+              orgId: args.orgId,
+              userId: args.userId,
+              runtimeMethod: args.runtimeMethod,
+              snapshot: args.snapshot,
+              connectorTokenState,
+              featureSwitchContext,
+              userInfo: args.userInfo,
+              oauthScopes: args.oauthScopes,
+              tokenExpiresAt,
+              signal,
+            });
+            transactionCallbackCompleted = true;
+            return result;
+          }),
+        );
+        if (!transaction.ok) {
+          if (transactionCallbackCompleted) {
+            commitStatus = "unknown";
+          }
+          throw transaction.error;
+        }
+        const connectionResult = transaction.value;
+        commitStatus = "committed";
+
+        await finalizeConnectorTokenStateAfterCommit({
+          userId: args.userId,
+          runtimeMethod: args.runtimeMethod,
+          pendingTokenRevoke: connectionResult.pendingTokenRevoke,
+        });
+
+        return {
+          connector: storedConnectorRowToResponse(
+            connectionResult.connectorRow,
+            args.runtimeMethod,
+            nowDate(),
+          ),
+          created:
+            connectionResult.connectorRow.createdAt.getTime() ===
+            connectionResult.connectorRow.updatedAt.getTime(),
+        };
+      })(),
+      () => {
+        return commitStatus;
+      },
     );
-    signal.throwIfAborted();
-
-    const connectorTokenState = await prepareConnectorTokenState({
-      type: args.runtimeMethod.connectorRef,
-      outputTargets: outputMetadata.outputTargets,
-      requiredOutputNames: outputMetadata.requiredOutputNames,
-      requiredExtraSecretNames: outputMetadata.requiredExtraSecretNames,
-      outputs: args.outputs,
-      extraSecrets,
-      featureSwitchContext,
-      signal,
-    });
-    signal.throwIfAborted();
-
-    let postCommitAbort: unknown = null;
-    const connectionResult = await writeDb.transaction(async (tx) => {
-      return await commitConnectorTokenConnection({
-        db: tx,
-        orgId: args.orgId,
-        userId: args.userId,
-        runtimeMethod: args.runtimeMethod,
-        snapshot: args.snapshot,
-        connectorTokenState,
-        featureSwitchContext,
-        userInfo: args.userInfo,
-        oauthScopes: args.oauthScopes,
-        tokenExpiresAt,
-        signal,
-      });
-    });
-    if (signal.aborted) {
-      postCommitAbort ??= signal.reason;
-    }
-
-    await finalizeConnectorStateChangeAfterCommit({
-      userId: args.userId,
-      pendingTokenRevoke: connectionResult.pendingTokenRevoke,
-      signal,
-      postCommitAbort,
-    });
-    signal.throwIfAborted();
-
-    return {
-      connector: storedConnectorRowToResponse(
-        connectionResult.connectorRow,
-        args.runtimeMethod,
-        nowDate(),
-      ),
-      created:
-        connectionResult.connectorRow.createdAt.getTime() ===
-        connectionResult.connectorRow.updatedAt.getTime(),
-    };
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -315,6 +315,12 @@ export {
   type TestOAuthProviderTokenResponse,
 } from "./test-oauth-provider-token";
 export {
+  testOAuthProviderRevokeContract,
+  testOAuthProviderRevokeErrorSchema,
+  testOAuthProviderRevokeResponseSchema,
+  type TestOAuthProviderRevokeContract,
+} from "./test-oauth-provider-revoke";
+export {
   testOAuthProviderDeviceAuthContract,
   testOAuthProviderDeviceAuthErrorSchema,
   testOAuthProviderDeviceAuthResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-oauth-provider-revoke.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-oauth-provider-revoke.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testOAuthProviderRevokeErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testOAuthProviderRevokeResponseSchema = z.object({
+  revoked: z.literal(true),
+});
+
+export const testOAuthProviderRevokeContract = c.router({
+  revoke: {
+    method: "POST",
+    path: "/api/test/oauth-provider/revoke",
+    body: c.type<string>(),
+    responses: {
+      200: testOAuthProviderRevokeResponseSchema,
+      400: testOAuthProviderRevokeErrorSchema,
+      401: testOAuthProviderRevokeErrorSchema,
+      404: z.string(),
+    },
+    summary: "Synthetic OAuth token revocation endpoint for test flows",
+  },
+});
+
+export type TestOAuthProviderRevokeContract =
+  typeof testOAuthProviderRevokeContract;

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -51,6 +51,7 @@ import type {
   ConnectorAuthProviderGrantResult,
   ConnectorAuthProviderGrantResultForMethod,
 } from "./grant-result";
+import { withConnectorGrantCompensation } from "./grant-compensation";
 import {
   type AuthUrlResult,
   type ExternalCodeAuthorizationStartResult,
@@ -1302,6 +1303,29 @@ function assertGrantOutputs(args: {
   });
 }
 
+async function assertGrantOutputsWithRollback(args: {
+  readonly selection: ConnectorAuthProviderMethodSelection;
+  readonly authClient: ConnectorAuthClient;
+  readonly result: ConnectorAuthProviderGrantResult;
+}): Promise<void> {
+  await withConnectorGrantCompensation(
+    async () => {
+      assertGrantOutputs({
+        selection: args.selection,
+        result: args.result,
+      });
+    },
+    async (signal) => {
+      await rollbackConnectorAuthGrantWithMethod({
+        ...args.selection,
+        authClient: args.authClient,
+        result: args.result,
+        signal,
+      });
+    },
+  );
+}
+
 function assertOptionalConnectorAuthClientMatchesMethod(args: {
   readonly selection: ConnectorAuthProviderMethodSelection;
   readonly authClient: ConnectorAuthClient | undefined;
@@ -1409,7 +1433,11 @@ export async function exchangeConnectorAuthCodeWithMethod(
     codeVerifier: args.codeVerifier,
     oauthContext: args.oauthContext,
   });
-  assertGrantOutputs({ selection: args, result });
+  await assertGrantOutputsWithRollback({
+    selection: args,
+    authClient: args.authClient,
+    result,
+  });
   return result;
 }
 
@@ -1493,7 +1521,11 @@ export async function completeConnectorExternalCodeAuthorizationWithMethod(
     providerState: args.providerState,
     signal: args.signal,
   });
-  assertGrantOutputs({ selection: args, result });
+  await assertGrantOutputsWithRollback({
+    selection: args,
+    authClient: args.authClient,
+    result,
+  });
   return result;
 }
 
@@ -1516,7 +1548,6 @@ export async function rollbackConnectorAuthGrantWithMethod(
     selection: args,
     authClient: args.authClient,
   });
-  assertGrantOutputs({ selection: args, result: args.result });
   await invokeRuntimeProvider<RuntimeGrantRollbackArgs, Promise<void>>(
     grant.rollbackGrant,
     {

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -149,11 +149,19 @@ export type {
   ConnectorAuthProviderRefreshResultBase,
   ConnectorAuthProviderRefreshResult,
 };
+export {
+  connectorGrantCleanupError,
+  connectorGrantPrimaryError,
+} from "./grant-compensation";
 export type { ProviderEnv };
 export { providerEnvFromObject };
 
 export type ConnectorAuthProviderAccessTokenRevokeResult =
   | { readonly status: "revoked" }
+  | { readonly status: "unsupported" };
+
+export type ConnectorAuthProviderGrantRollbackResult =
+  | { readonly status: "compensated" }
   | { readonly status: "unsupported" };
 
 type ConnectorAuthMethodIdsWithoutProviderGrant<Type extends ConnectorType> =
@@ -202,6 +210,7 @@ type RuntimeAuthCodeGrantProvider = {
     args: never,
   ): string | AuthUrlResult | Promise<string | AuthUrlResult>;
   exchangeCode(args: never): Promise<ConnectorAuthProviderGrantResult>;
+  rollbackGrant?(args: never): Promise<void>;
 };
 
 type RuntimeDeviceAuthGrantProvider = {
@@ -226,6 +235,7 @@ type RuntimeExternalCodeGrantProvider = {
   completeExternalCodeAuthorization(
     args: never,
   ): Promise<ConnectorAuthProviderGrantResult>;
+  rollbackGrant?(args: never): Promise<void>;
 };
 
 type RuntimeGrantProvider =
@@ -1250,6 +1260,12 @@ interface RuntimeTokenRevokeArgs {
   readonly signal: AbortSignal;
 }
 
+interface RuntimeGrantRollbackArgs {
+  readonly authClient: ConnectorAuthClient;
+  readonly result: ConnectorAuthProviderGrantResult;
+  readonly signal: AbortSignal;
+}
+
 function getStaticConnectorAuthProviderMethod(
   type: ConnectorType,
   authMethod: string,
@@ -1479,6 +1495,37 @@ export async function completeConnectorExternalCodeAuthorizationWithMethod(
   });
   assertGrantOutputs({ selection: args, result });
   return result;
+}
+
+export async function rollbackConnectorAuthGrantWithMethod(
+  args: ConnectorAuthProviderMethodSelection & {
+    readonly authClient: ConnectorAuthClient;
+    readonly result: ConnectorAuthProviderGrantResult;
+    readonly signal: AbortSignal;
+  },
+): Promise<ConnectorAuthProviderGrantRollbackResult> {
+  const registration = connectorAuthProviderRegistrationFor(args);
+  const { grant } = registration.entry;
+  if (
+    (grant?.kind !== "auth-code" && grant?.kind !== "external-code") ||
+    grant.rollbackGrant === undefined
+  ) {
+    return { status: "unsupported" };
+  }
+  assertConnectorAuthClientMatchesMethod({
+    selection: args,
+    authClient: args.authClient,
+  });
+  assertGrantOutputs({ selection: args, result: args.result });
+  await invokeRuntimeProvider<RuntimeGrantRollbackArgs, Promise<void>>(
+    grant.rollbackGrant,
+    {
+      authClient: args.authClient,
+      result: args.result,
+      signal: args.signal,
+    },
+  );
+  return { status: "compensated" };
 }
 
 export async function startConnectorDeviceAuthorizationWithMethod(

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
@@ -286,6 +286,75 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
     });
   });
 
+  it("logs out the generated smart device when federation is cancelled", async () => {
+    const { result: started, providerState } =
+      await startNintendoSwitchParentalControlsSession();
+    const requestAbort = new AbortController();
+    const idToken = jwtPayload({
+      sub: "nintendo-cancelled-account",
+      email: "cancelled@example.com",
+    });
+    let federatedSmartDeviceId: string | null = null;
+    let logoutBody: unknown;
+    let logoutHeaders: Headers | undefined;
+
+    server.use(
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN_URL, () => {
+        return HttpResponse.json({ session_token: "cancelled-session-token" });
+      }),
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "cancelled-access-token",
+          expires_in: 3600,
+          id_token: idToken,
+          token_type: "Bearer",
+        });
+      }),
+      http.get(NINTENDO_SWITCH_PARENTAL_CONTROLS_PROFILE_URL, () => {
+        return HttpResponse.json({ country: "US", language: "en" });
+      }),
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
+        ({ request }) => {
+          federatedSmartDeviceId = request.headers.get(
+            "x-moon-smart-device-id",
+          );
+          requestAbort.abort();
+          return HttpResponse.json({
+            loginInfo: { ownedDevices: [] },
+          });
+        },
+      ),
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
+        async ({ request }) => {
+          logoutBody = await request.json();
+          logoutHeaders = request.headers;
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "nintendo-switch-parental-controls",
+        authMethod: "api",
+        authClient: nintendoSwitchParentalControlsAuthClient(),
+        providerState: started.providerState,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri}#session_token_code=cancelled-code&state=${providerState.state}`,
+        signal: requestAbort.signal,
+      }),
+    ).rejects.toThrow();
+    expect(federatedSmartDeviceId).toStrictEqual(expect.any(String));
+    expect(logoutBody).toStrictEqual({
+      smartDeviceId: federatedSmartDeviceId,
+    });
+    expect(logoutHeaders?.get("authorization")).toBe(`Bearer ${idToken}`);
+    expect(logoutHeaders?.get("x-moon-smart-device-id")).toBe(
+      federatedSmartDeviceId,
+    );
+  });
+
   it("refreshes both tokens and omits only a transiently unavailable catalog", async () => {
     let catalogRequests = 0;
     let tokenRequests = 0;

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
@@ -286,6 +286,55 @@ describe("Nintendo Switch Parental Controls external-code provider", () => {
     });
   });
 
+  it("validates Nintendo identity before registering a smart device", async () => {
+    const { result: started, providerState } =
+      await startNintendoSwitchParentalControlsSession();
+    let federationRequests = 0;
+    let logoutRequests = 0;
+
+    server.use(
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN_URL, () => {
+        return HttpResponse.json({ session_token: "invalid-id-session-token" });
+      }),
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "invalid-id-access-token",
+          expires_in: 3600,
+          id_token: "invalid-id-token",
+          token_type: "Bearer",
+        });
+      }),
+      http.get(NINTENDO_SWITCH_PARENTAL_CONTROLS_PROFILE_URL, () => {
+        return HttpResponse.json({ country: "US", language: "en" });
+      }),
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL, () => {
+        federationRequests += 1;
+        return HttpResponse.json({
+          loginInfo: { ownedDevices: [] },
+        });
+      }),
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL, () => {
+        logoutRequests += 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await expect(
+      completeConnectorExternalCodeAuthorization({
+        type: "nintendo-switch-parental-controls",
+        authMethod: "api",
+        authClient: nintendoSwitchParentalControlsAuthClient(),
+        providerState: started.providerState,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri}#session_token_code=invalid-id-code&state=${providerState.state}`,
+        signal: testSignal(),
+      }),
+    ).rejects.toThrow(
+      "Nintendo Switch Parental Controls ID token is missing a payload",
+    );
+    expect(federationRequests).toBe(0);
+    expect(logoutRequests).toBe(0);
+  });
+
   it("logs out the generated smart device when federation is cancelled", async () => {
     const { result: started, providerState } =
       await startNintendoSwitchParentalControlsSession();

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/slack.test.ts
@@ -166,7 +166,12 @@ describe("connector/providers/slack", () => {
       server.use(handler);
 
       await expect(
-        revokeSlackToken("client-id", "client-secret", "xoxp-token"),
+        revokeSlackToken(
+          "client-id",
+          "client-secret",
+          "xoxp-token",
+          new AbortController().signal,
+        ),
       ).resolves.toBeUndefined();
     });
 
@@ -177,7 +182,12 @@ describe("connector/providers/slack", () => {
       server.use(handler);
 
       await expect(
-        revokeSlackToken("client-id", "client-secret", "xoxp-token"),
+        revokeSlackToken(
+          "client-id",
+          "client-secret",
+          "xoxp-token",
+          new AbortController().signal,
+        ),
       ).rejects.toThrow("token_revoked");
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/connectors/github/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/github/oauth.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
+import { withConnectorGrantCompensation } from "../../grant-compensation";
+import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
 import { throwOAuthError } from "../../oauth/error";
 
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -13,6 +15,14 @@ interface GitHubUserInfo {
   id: string;
   username: string;
   email: string | null;
+}
+
+export interface GitHubGrantResult {
+  readonly outputs: {
+    readonly accessToken: string;
+  };
+  readonly scopes: readonly string[];
+  readonly userInfo: ConnectorAuthProviderGrantUserInfo;
 }
 
 /**
@@ -122,6 +132,36 @@ export async function fetchGitHubUserInfo(
   };
 }
 
+export async function exchangeGitHubGrant(args: {
+  readonly authCodeGrant: ConnectorAuthCodeGrantConfig;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly code: string;
+  readonly redirectUri?: string;
+}): Promise<GitHubGrantResult> {
+  const { accessToken, scopes } = await exchangeGitHubCode(
+    args.authCodeGrant,
+    args.clientId,
+    args.clientSecret,
+    args.code,
+    args.redirectUri,
+  );
+  const userInfo = await withConnectorGrantCompensation(
+    () => {
+      return fetchGitHubUserInfo(accessToken);
+    },
+    (signal) => {
+      return revokeGitHubToken(
+        args.clientId,
+        args.clientSecret,
+        accessToken,
+        signal,
+      );
+    },
+  );
+  return { outputs: { accessToken }, scopes, userInfo };
+}
+
 /**
  * Revoke GitHub OAuth app authorization grant.
  * Uses the grant revocation endpoint (not token) to force re-consent on next connect.
@@ -131,11 +171,13 @@ export async function revokeGitHubGrant(
   clientId: string,
   clientSecret: string,
   accessToken: string,
+  signal: AbortSignal,
 ): Promise<void> {
   const response = await fetch(
     `${GITHUB_API_BASE}/applications/${clientId}/grant`,
     {
       method: "DELETE",
+      signal,
       headers: {
         Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
         Accept: "application/vnd.github+json",
@@ -148,6 +190,36 @@ export async function revokeGitHubGrant(
 
   if (!response.ok) {
     throw new Error(`GitHub grant revocation failed: ${response.status}`);
+  }
+}
+
+/**
+ * Delete one exact GitHub OAuth token without revoking the app grant.
+ * Ref: https://docs.github.com/en/rest/apps/oauth-applications#delete-an-app-token
+ */
+export async function revokeGitHubToken(
+  clientId: string,
+  clientSecret: string,
+  accessToken: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/applications/${clientId}/token`,
+    {
+      method: "DELETE",
+      signal,
+      headers: {
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ access_token: accessToken }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub token revocation failed: ${response.status}`);
   }
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/github/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/github/provider.ts
@@ -1,9 +1,10 @@
 import type { AuthCodeConnectorAuthProvider } from "../../types";
+import { requiredConnectorGrantOutput } from "../../grant-compensation";
 import {
   buildGitHubAuthorizationUrl,
-  exchangeGitHubCode,
-  fetchGitHubUserInfo,
+  exchangeGitHubGrant,
   revokeGitHubGrant,
+  revokeGitHubToken,
 } from "./oauth";
 export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
   grant: {
@@ -19,17 +20,22 @@ export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
     },
     exchangeCode: async (args) => {
       const { clientId, clientSecret } = args.authClient;
-      const code = args.code;
-      const redirectUri = args.redirectUri;
-      const { accessToken, scopes } = await exchangeGitHubCode(
-        args.authCodeGrant,
+      return await exchangeGitHubGrant({
+        authCodeGrant: args.authCodeGrant,
         clientId,
         clientSecret,
-        code,
-        redirectUri,
+        code: args.code,
+        redirectUri: args.redirectUri,
+      });
+    },
+    rollbackGrant: (args) => {
+      const { clientId, clientSecret } = args.authClient;
+      return revokeGitHubToken(
+        clientId,
+        clientSecret,
+        requiredConnectorGrantOutput(args.result.outputs, "accessToken"),
+        args.signal,
       );
-      const userInfo = await fetchGitHubUserInfo(accessToken);
-      return { outputs: { accessToken }, scopes, userInfo };
     },
   },
   access: {
@@ -39,7 +45,12 @@ export const githubProvider: AuthCodeConnectorAuthProvider<"github"> = {
     kind: "token-revoke",
     revokeToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
-      return revokeGitHubGrant(clientId, clientSecret, args.inputs.accessToken);
+      return revokeGitHubGrant(
+        clientId,
+        clientSecret,
+        args.inputs.accessToken,
+        args.signal,
+      );
     },
   },
 };

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
@@ -108,7 +108,13 @@ export async function exchangeLinearCode(
       return fetchLinearUserInfo(accessToken);
     },
     (signal) => {
-      return revokeLinearToken(clientId, clientSecret, accessToken, signal);
+      return revokeLinearGrant({
+        clientId,
+        clientSecret,
+        accessToken,
+        refreshToken: data.refresh_token ?? null,
+        signal,
+      });
     },
   );
 
@@ -234,10 +240,11 @@ async function fetchLinearUserInfo(
  * Uses RFC 7009 token revocation endpoint with Basic Auth.
  * Ref: https://linear.app/developers/oauth-2-0-authentication
  */
-export async function revokeLinearToken(
+async function revokeLinearOAuthToken(
   clientId: string,
   clientSecret: string,
-  accessToken: string,
+  token: string,
+  tokenTypeHint: "access_token" | "refresh_token",
   signal: AbortSignal,
 ): Promise<void> {
   const response = await fetch("https://api.linear.app/oauth/revoke", {
@@ -248,13 +255,38 @@ export async function revokeLinearToken(
       Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
     },
     body: new URLSearchParams({
-      token: accessToken,
-      token_type_hint: "access_token",
+      token,
+      token_type_hint: tokenTypeHint,
     }),
   });
 
   if (!response.ok) {
     throw new Error(`Linear token revocation failed: ${response.status}`);
+  }
+}
+
+export async function revokeLinearGrant(args: {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly accessToken: string;
+  readonly refreshToken: string | null | undefined;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  await revokeLinearOAuthToken(
+    args.clientId,
+    args.clientSecret,
+    args.accessToken,
+    "access_token",
+    args.signal,
+  );
+  if (args.refreshToken) {
+    await revokeLinearOAuthToken(
+      args.clientId,
+      args.clientSecret,
+      args.refreshToken,
+      "refresh_token",
+      args.signal,
+    );
   }
 }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ConnectorAuthCodeGrantConfig } from "@vm0/connectors/connectors";
+import { withConnectorGrantCompensation } from "../../grant-compensation";
 import { throwOAuthError } from "../../oauth/error";
 
 const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
@@ -100,11 +101,19 @@ export async function exchangeLinearCode(
   if (!data.access_token) {
     throw new Error("No access token in Linear response");
   }
+  const accessToken = data.access_token;
 
-  const userInfo = await fetchLinearUserInfo(data.access_token);
+  const userInfo = await withConnectorGrantCompensation(
+    () => {
+      return fetchLinearUserInfo(accessToken);
+    },
+    (signal) => {
+      return revokeLinearToken(clientId, clientSecret, accessToken, signal);
+    },
+  );
 
   return {
-    accessToken: data.access_token,
+    accessToken,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(",") : [],
@@ -229,9 +238,11 @@ export async function revokeLinearToken(
   clientId: string,
   clientSecret: string,
   accessToken: string,
+  signal: AbortSignal,
 ): Promise<void> {
   const response = await fetch("https://api.linear.app/oauth/revoke", {
     method: "POST",
+    signal,
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/provider.ts
@@ -4,7 +4,7 @@ import {
   buildLinearAuthorizationUrl,
   exchangeLinearCode,
   refreshLinearToken,
-  revokeLinearToken,
+  revokeLinearGrant,
 } from "./oauth";
 import { oauthRefreshResultToProviderResult } from "../../oauth/types";
 export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
@@ -46,12 +46,16 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
     },
     rollbackGrant: (args) => {
       const { clientId, clientSecret } = args.authClient;
-      return revokeLinearToken(
+      return revokeLinearGrant({
         clientId,
         clientSecret,
-        requiredConnectorGrantOutput(args.result.outputs, "accessToken"),
-        args.signal,
-      );
+        accessToken: requiredConnectorGrantOutput(
+          args.result.outputs,
+          "accessToken",
+        ),
+        refreshToken: args.result.outputs["refreshToken"],
+        signal: args.signal,
+      });
     },
   },
   access: {
@@ -72,12 +76,13 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
     kind: "token-revoke",
     revokeToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
-      return revokeLinearToken(
+      return revokeLinearGrant({
         clientId,
         clientSecret,
-        args.inputs.accessToken,
-        args.signal,
-      );
+        accessToken: args.inputs.accessToken,
+        refreshToken: args.inputs.refreshToken,
+        signal: args.signal,
+      });
     },
   },
 };

--- a/turbo/packages/connectors/src/auth-providers/connectors/linear/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/linear/provider.ts
@@ -1,4 +1,5 @@
 import type { AuthCodeConnectorAuthProvider } from "../../types";
+import { requiredConnectorGrantOutput } from "../../grant-compensation";
 import {
   buildLinearAuthorizationUrl,
   exchangeLinearCode,
@@ -43,6 +44,15 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
         },
       };
     },
+    rollbackGrant: (args) => {
+      const { clientId, clientSecret } = args.authClient;
+      return revokeLinearToken(
+        clientId,
+        clientSecret,
+        requiredConnectorGrantOutput(args.result.outputs, "accessToken"),
+        args.signal,
+      );
+    },
   },
   access: {
     kind: "refresh-token",
@@ -62,7 +72,12 @@ export const linearProvider: AuthCodeConnectorAuthProvider<"linear"> = {
     kind: "token-revoke",
     revokeToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
-      return revokeLinearToken(clientId, clientSecret, args.inputs.accessToken);
+      return revokeLinearToken(
+        clientId,
+        clientSecret,
+        args.inputs.accessToken,
+        args.signal,
+      );
     },
   },
 };

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
@@ -72,6 +72,8 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
         accessToken: token.accessToken,
         signal: args.signal,
       });
+      const accountId = nintendoSwitchParentalControlsAccountId(token.idToken);
+      const userInfo = nintendoSwitchParentalControlsUserInfo(token.idToken);
       const smartDeviceId = randomUUID();
       const deviceCatalog = await withConnectorGrantCompensation(
         () => {
@@ -97,7 +99,7 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
           accessToken: token.accessToken,
           idToken: token.idToken,
           smartDeviceId,
-          accountId: nintendoSwitchParentalControlsAccountId(token.idToken),
+          accountId,
           language: profile.language,
           deviceCatalog,
         },
@@ -106,7 +108,7 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
           token.scopes.length > 0
             ? token.scopes
             : args.externalCodeGrant.scopes,
-        userInfo: nintendoSwitchParentalControlsUserInfo(token.idToken),
+        userInfo,
       };
     },
     rollbackGrant: (args) => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
@@ -7,6 +7,10 @@ import type {
   RefreshTokenAccessProvider,
   TokenRevokeProvider,
 } from "../../types";
+import {
+  requiredConnectorGrantOutput,
+  withConnectorGrantCompensation,
+} from "../../grant-compensation";
 import { isOAuthProviderHttpError } from "../../oauth/error";
 import {
   buildNintendoSwitchParentalControlsAuthorizationUrl,
@@ -69,13 +73,24 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
         signal: args.signal,
       });
       const smartDeviceId = randomUUID();
-      const deviceCatalog =
-        await federateNintendoSwitchParentalControlsSmartDevice({
-          idToken: token.idToken,
-          smartDeviceId,
-          language: profile.language,
-          signal: args.signal,
-        });
+      const deviceCatalog = await withConnectorGrantCompensation(
+        () => {
+          return federateNintendoSwitchParentalControlsSmartDevice({
+            idToken: token.idToken,
+            smartDeviceId,
+            language: profile.language,
+            signal: args.signal,
+          });
+        },
+        (signal) => {
+          return logoutNintendoSwitchParentalControlsSmartDevice({
+            idToken: token.idToken,
+            smartDeviceId,
+            language: profile.language,
+            signal,
+          });
+        },
+      );
       return {
         outputs: {
           sessionToken: session.sessionToken,
@@ -93,6 +108,17 @@ function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
             : args.externalCodeGrant.scopes,
         userInfo: nintendoSwitchParentalControlsUserInfo(token.idToken),
       };
+    },
+    rollbackGrant: (args) => {
+      return logoutNintendoSwitchParentalControlsSmartDevice({
+        idToken: requiredConnectorGrantOutput(args.result.outputs, "idToken"),
+        smartDeviceId: requiredConnectorGrantOutput(
+          args.result.outputs,
+          "smartDeviceId",
+        ),
+        language: requiredConnectorGrantOutput(args.result.outputs, "language"),
+        signal: args.signal,
+      });
     },
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/oauth.ts
@@ -153,9 +153,11 @@ export async function revokeSlackToken(
   _clientId: string,
   _clientSecret: string,
   accessToken: string,
+  signal: AbortSignal,
 ): Promise<void> {
   const response = await fetch("https://slack.com/api/auth.revoke", {
     method: "POST",
+    signal,
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/provider.ts
@@ -1,5 +1,9 @@
 import type { AuthCodeConnectorAuthProvider } from "../../types";
 import {
+  requiredConnectorGrantOutput,
+  withConnectorGrantCompensation,
+} from "../../grant-compensation";
+import {
   buildSlackAuthorizationUrl,
   exchangeSlackCode,
   fetchSlackUserInfo,
@@ -28,9 +32,21 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
         code,
         redirectUri,
       );
-      const slackUser = await fetchSlackUserInfo(
-        slackResult.userId,
-        slackResult.accessToken,
+      const slackUser = await withConnectorGrantCompensation(
+        () => {
+          return fetchSlackUserInfo(
+            slackResult.userId,
+            slackResult.accessToken,
+          );
+        },
+        (signal) => {
+          return revokeSlackToken(
+            clientId,
+            clientSecret,
+            slackResult.accessToken,
+            signal,
+          );
+        },
       );
       return {
         outputs: {
@@ -44,6 +60,15 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
         },
       };
     },
+    rollbackGrant: (args) => {
+      const { clientId, clientSecret } = args.authClient;
+      return revokeSlackToken(
+        clientId,
+        clientSecret,
+        requiredConnectorGrantOutput(args.result.outputs, "accessToken"),
+        args.signal,
+      );
+    },
   },
   access: {
     kind: "none",
@@ -52,7 +77,12 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
     kind: "token-revoke",
     revokeToken: (args) => {
       const { clientId, clientSecret } = args.authClient;
-      return revokeSlackToken(clientId, clientSecret, args.inputs.accessToken);
+      return revokeSlackToken(
+        clientId,
+        clientSecret,
+        args.inputs.accessToken,
+        args.signal,
+      );
     },
   },
 };

--- a/turbo/packages/connectors/src/auth-providers/connectors/slack/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/slack/provider.ts
@@ -1,9 +1,5 @@
 import type { AuthCodeConnectorAuthProvider } from "../../types";
 import {
-  requiredConnectorGrantOutput,
-  withConnectorGrantCompensation,
-} from "../../grant-compensation";
-import {
   buildSlackAuthorizationUrl,
   exchangeSlackCode,
   fetchSlackUserInfo,
@@ -32,21 +28,9 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
         code,
         redirectUri,
       );
-      const slackUser = await withConnectorGrantCompensation(
-        () => {
-          return fetchSlackUserInfo(
-            slackResult.userId,
-            slackResult.accessToken,
-          );
-        },
-        (signal) => {
-          return revokeSlackToken(
-            clientId,
-            clientSecret,
-            slackResult.accessToken,
-            signal,
-          );
-        },
+      const slackUser = await fetchSlackUserInfo(
+        slackResult.userId,
+        slackResult.accessToken,
       );
       return {
         outputs: {
@@ -59,15 +43,6 @@ export const slackProvider: AuthCodeConnectorAuthProvider<"slack"> = {
           email: slackUser.email,
         },
       };
-    },
-    rollbackGrant: (args) => {
-      const { clientId, clientSecret } = args.authClient;
-      return revokeSlackToken(
-        clientId,
-        clientSecret,
-        requiredConnectorGrantOutput(args.result.outputs, "accessToken"),
-        args.signal,
-      );
     },
   },
   access: {

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/oauth.ts
@@ -24,6 +24,7 @@ export {
 
 const TEST_OAUTH_AUTHORIZATION_URL = "/api/test/oauth-provider/authorize";
 const TEST_OAUTH_TOKEN_URL = "/api/test/oauth-provider/token";
+const TEST_OAUTH_REVOKE_URL = "/api/test/oauth-provider/revoke";
 
 interface TokenResponse {
   accessToken: string;
@@ -142,6 +143,10 @@ function getAuthorizationUrl(): string {
 
 function getTestOAuthTokenUrl(): string {
   return resolveTestOAuthProviderUrl("tokenUrl", TEST_OAUTH_TOKEN_URL);
+}
+
+function getTestOAuthRevokeUrl(): string {
+  return resolveTestOAuthProviderUrl("revokeUrl", TEST_OAUTH_REVOKE_URL);
 }
 
 export function buildTestOAuthAuthorizationUrl(
@@ -266,4 +271,28 @@ export async function fetchTestOAuthUserInfo(
     username: data.username ?? null,
     email: data.email ?? null,
   };
+}
+
+export async function revokeTestOAuthToken(
+  clientId: string,
+  clientSecret: string,
+  accessToken: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await fetch(getTestOAuthRevokeUrl(), {
+    method: "POST",
+    signal,
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...testOAuthPreviewBypassHeaders(),
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      token: accessToken,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Test OAuth token revocation failed: ${response.status}`);
+  }
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/test-oauth/provider.ts
@@ -8,7 +8,12 @@ import {
   exchangeTestOAuthCode,
   fetchTestOAuthUserInfo,
   refreshTestOAuthToken,
+  revokeTestOAuthToken,
 } from "./oauth";
+import {
+  requiredConnectorGrantOutput,
+  withConnectorGrantCompensation,
+} from "../../grant-compensation";
 import { oauthRefreshResultToProviderResult } from "../../oauth/types";
 import type {
   ConnectorAuthProviderGrantResult,
@@ -63,7 +68,19 @@ async function exchangeTestOauthToken(args: {
     args.code,
     args.redirectUri,
   );
-  const user = await fetchTestOAuthUserInfo(token.accessToken);
+  const user = await withConnectorGrantCompensation(
+    () => {
+      return fetchTestOAuthUserInfo(token.accessToken);
+    },
+    (signal) => {
+      return revokeTestOAuthToken(
+        args.clientId,
+        args.clientSecret,
+        token.accessToken,
+        signal,
+      );
+    },
+  );
   return {
     accessToken: token.accessToken,
     refreshToken: token.refreshToken,
@@ -132,6 +149,18 @@ function createTestOauthGrant(): AuthCodeGrantProvider<"test-oauth", "oauth"> {
         redirectUri: exchangeArgs.redirectUri,
       });
     },
+    rollbackGrant: (rollbackArgs) => {
+      const { clientId, clientSecret } = rollbackArgs.authClient;
+      return revokeTestOAuthToken(
+        clientId,
+        clientSecret,
+        requiredConnectorGrantOutput(
+          rollbackArgs.result.outputs,
+          "accessToken",
+        ),
+        rollbackArgs.signal,
+      );
+    },
   };
 }
 
@@ -155,6 +184,18 @@ function createTestOauthApiGrant(): AuthCodeGrantProvider<"test-oauth", "api"> {
         code: exchangeArgs.code,
         redirectUri: exchangeArgs.redirectUri,
       });
+    },
+    rollbackGrant: (rollbackArgs) => {
+      const { clientId, clientSecret } = rollbackArgs.authClient;
+      return revokeTestOAuthToken(
+        clientId,
+        clientSecret,
+        requiredConnectorGrantOutput(
+          rollbackArgs.result.outputs,
+          "initialAccessToken",
+        ),
+        rollbackArgs.signal,
+      );
     },
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/grant-compensation.ts
+++ b/turbo/packages/connectors/src/auth-providers/grant-compensation.ts
@@ -1,0 +1,59 @@
+const GRANT_COMPENSATION_TIMEOUT_MS = 5_000;
+
+class ConnectorGrantCompensationError extends Error {
+  readonly primaryError: unknown;
+  readonly compensationError: unknown;
+
+  constructor(primaryError: unknown, compensationError: unknown) {
+    super("Connector grant cleanup failed after grant finalization failed", {
+      cause: primaryError,
+    });
+    this.name = "ConnectorGrantCompensationError";
+    this.primaryError = primaryError;
+    this.compensationError = compensationError;
+  }
+}
+
+export async function withConnectorGrantCompensation<T>(
+  operation: () => Promise<T>,
+  compensate: (signal: AbortSignal) => Promise<void>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (primaryError) {
+    try {
+      await compensate(AbortSignal.timeout(GRANT_COMPENSATION_TIMEOUT_MS));
+    } catch (compensationError) {
+      throw new ConnectorGrantCompensationError(
+        primaryError,
+        compensationError,
+      );
+    }
+    throw primaryError;
+  }
+}
+
+export function connectorGrantPrimaryError(error: unknown): unknown {
+  return error instanceof ConnectorGrantCompensationError
+    ? error.primaryError
+    : error;
+}
+
+export function connectorGrantCleanupError(
+  error: unknown,
+): unknown | undefined {
+  return error instanceof ConnectorGrantCompensationError
+    ? error.compensationError
+    : undefined;
+}
+
+export function requiredConnectorGrantOutput(
+  outputs: Readonly<Record<string, string | null | undefined>>,
+  name: string,
+): string {
+  const value = outputs[name];
+  if (!value) {
+    throw new Error(`Connector grant cleanup requires ${name}`);
+  }
+  return value;
+}

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -213,6 +213,24 @@ export type ConnectorExternalCodeAuthorizationCompleteArgs<
     readonly externalCodeGrant: ConnectorExternalCodeGrantConfig;
   };
 
+export type ConnectorAuthCodeGrantRollbackArgs<
+  T extends AuthCodeGrantConnectorType,
+  Method extends ConnectorAuthCodeGrantAuthMethodId<T> =
+    ConnectorAuthCodeGrantAuthMethodId<T>,
+> = ConnectorAuthMethodClientArgs<T, Method> & {
+  readonly result: ConnectorAuthProviderGrantResultForMethod<T, Method>;
+  readonly signal: AbortSignal;
+};
+
+export type ConnectorExternalCodeGrantRollbackArgs<
+  T extends ExternalCodeGrantConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<T> =
+    ConnectorExternalCodeGrantAuthMethodId<T>,
+> = ConnectorAuthMethodClientArgs<T, Method> & {
+  readonly result: ConnectorAuthProviderGrantResultForMethod<T, Method>;
+  readonly signal: AbortSignal;
+};
+
 export type ConnectorAuthProviderRevokeArgs<
   T extends TokenRevokeConnectorType,
   Method extends ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke"> =

--- a/turbo/packages/connectors/src/auth-providers/types.ts
+++ b/turbo/packages/connectors/src/auth-providers/types.ts
@@ -30,6 +30,8 @@ import type {
   ConnectorExternalCodeAuthorizationCompleteArgs,
   ConnectorExternalCodeAuthorizationStartArgs,
   ConnectorAuthCodeExchangeArgs,
+  ConnectorAuthCodeGrantRollbackArgs,
+  ConnectorExternalCodeGrantRollbackArgs,
   ConnectorOpenIdAuthorizeArgs,
   ConnectorOpenIdVerifyArgs,
   ConnectorAuthProviderRevokeArgs,
@@ -56,6 +58,9 @@ export interface AuthCodeGrantProvider<
   exchangeCode(
     args: ConnectorAuthCodeExchangeArgs<T, Method>,
   ): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
+  rollbackGrant?(
+    args: ConnectorAuthCodeGrantRollbackArgs<T, Method>,
+  ): Promise<void>;
 }
 
 export interface OpenIdAuthGrantProvider<
@@ -98,6 +103,9 @@ export interface ExternalCodeGrantProvider<
   completeExternalCodeAuthorization(
     args: ConnectorExternalCodeAuthorizationCompleteArgs<T, Method>,
   ): Promise<ConnectorAuthProviderGrantResultForMethod<T, Method>>;
+  rollbackGrant?(
+    args: ConnectorExternalCodeGrantRollbackArgs<T, Method>,
+  ): Promise<void>;
 }
 
 export interface NoneAccessProvider {

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -53,6 +53,7 @@ export const linear = {
           kind: "token-revoke",
           inputs: {
             accessToken: "$secrets.LINEAR_ACCESS_TOKEN",
+            refreshToken: "$secrets.LINEAR_REFRESH_TOKEN",
           },
         },
       },


### PR DESCRIPTION
## Summary

- classify connector persistence outcomes and compensate remote grants only when the local write is known not to have committed
- add attempt-scoped rollback for GitHub OAuth tokens, both Linear access and refresh tokens, Nintendo parental-control smart devices, and the synthetic OAuth provider
- compensate provider-finalization failures before a grant result escapes, keep persistence independent from request cancellation, and make acknowledged post-commit work non-failing

## Validation

- `pnpm format`
- `pnpm turbo run check-types lint --filter=@vm0/connectors --filter=api`
- `pnpm check-types`
- `pnpm -F @vm0/connectors test` (1,288 tests passed)
- focused connector API integration tests (56 tests passed)
- `pnpm knip`
- pre-commit formatting, Knip, and repository-wide type checks

The full API suite was also exercised against fresh temporary databases. The affected connector suites passed; the serial run completed 2,307 of 2,310 tests, with three existing shared-state/order-sensitive failures outside this change (`cron-backfill`, `cron-summarize-memory`, and `zero-agents`). The `zero-agents` test passed in isolation.

## Scope

- rollback is intentionally unsupported for Slack, Google, Cloudflare, OpenID-only providers, and generic device authorization providers without a proven attempt-local revocation contract
- Slack `auth.revoke` remains available for explicit disconnect, but is not reused for failed-attempt rollback because a non-rotating token revocation can invalidate the underlying authorization
- ambiguous persistence outcomes are not compensated, because deleting a grant after an unknown commit result could leave a stored connector without usable credentials
- this change does not add a durable compensation outbox or alter public connector contracts

Closes #21043
