### PR TITLE
feat: enable connector action callbacks for all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7941,7 +7941,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("keeps goal tools allowed when no feature flags are enabled", async () => {
+  it("keeps goal tools allowed with globally enabled callbacks", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -7965,10 +7965,8 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(claim.appendSystemPrompt ?? "").not.toContain(
       "zero web-search --help",
     );
-    expect(claim.appendSystemPrompt ?? "").not.toContain("--callback-prompt");
-    expect(
-      claim.environment?.ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED,
-    ).toBeUndefined();
+    expect(claim.appendSystemPrompt ?? "").toContain("--callback-prompt");
+    expect(claim.environment?.ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED).toBe("1");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,6 +15,9 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ArtifactPreviewImage, {})).toBe(
       true,
     );
+    expect(isFeatureEnabled(FeatureSwitchKey.ConnectorActionCallback, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -194,6 +197,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Artifacts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ArtifactPreviewImage]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ConnectorActionCallback]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerInlinePromptItems]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -496,8 +496,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Resume a web chat with a callback prompt after a connector or permission action succeeds.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ZeroMail]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- Enable `connectorActionCallback` globally so supported connector and permission actions can resume web chats for every organization.
- Remove the staff-only organization allowlist and add core regression coverage for the global rollout.

## User impact

- Web chat users can continue automatically after completing a supported connector or permission action, regardless of organization.

## Verification

- `pnpm format` — passed
- `pnpm turbo run lint --log-order grouped` — passed (12 workspaces)
- `pnpm check-types` — 12 of 13 workspaces passed; API `tsc` exhausted the runtime's default ~2 GB Node heap without reporting a type error
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` — passed (23 tests)

The PR pipeline will run the complete type check in CI.
