### PR TITLE
refactor: prepare workflow queue identifier contract

### DIFF
--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -251,7 +251,17 @@ export async function claimNextWorkflowQueueEvent(
     }
 
     const [item] = await tx
-      .select()
+      .select({
+        id: chatMessageQueue.id,
+        orgId: chatMessageQueue.orgId,
+        userId: chatMessageQueue.userId,
+        automationId: chatMessageQueue.automationId,
+        chatThreadId: chatMessageQueue.chatThreadId,
+        triggerSource: chatMessageQueue.triggerSource,
+        triggerBrief: chatMessageQueue.triggerBrief,
+        encryptedParams: chatMessageQueue.encryptedParams,
+        createdAt: chatMessageQueue.createdAt,
+      })
       .from(chatMessageQueue)
       .where(
         and(


### PR DESCRIPTION
## Summary

- explicitly select the canonical workflow queue columns when claiming an event
- stop deployed API queries from depending on the legacy `trigger_id` column
- keep runtime behavior unchanged while preparing the follow-up destructive schema migration

## Deployment compatibility

This PR intentionally contains no schema migration. It must be deployed before the contract PR removes `chat_message_queue.trigger_id`, because production migrations run before the new API is promoted.

## Verification

- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (13/13 packages)
- pre-commit hooks: Prettier, knip, and repository type checks passed
- targeted `zero-workflow-queue.test.ts` was attempted after local DB migration; both this branch and the untouched baseline fail at the earlier Runner fixture claim with the same `Job not found in queue` 404
