### PR TITLE
fix: disable meta ads connector

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -790,6 +790,7 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
     });
 
     await waitFor(() => {
@@ -1447,6 +1448,7 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
     });
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "meta");

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2656,10 +2656,15 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes Meta Ads OAuth", () => {
-    expect(getAvailableConnectorAuthMethodIds("meta-ads", {})).toStrictEqual([
-      "oauth",
-    ]);
+  it("exposes Meta Ads OAuth only when its switch is enabled", () => {
+    expect(getAvailableConnectorAuthMethodIds("meta-ads", {})).toStrictEqual(
+      [],
+    );
+    expect(
+      getAvailableConnectorAuthMethodIds("meta-ads", {
+        [FeatureSwitchKey.MetaAdsConnector]: true,
+      }),
+    ).toStrictEqual(["oauth"]);
   });
 
   it("exposes Microsoft OAuth connectors", () => {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -1,4 +1,5 @@
 import type { ConnectorConfig } from "../connector-config";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const metaAds = {
   "meta-ads": {
@@ -8,6 +9,7 @@ export const metaAds = {
       "Connect your Meta Ads Manager account to manage ad campaigns, audiences, and insights",
     authMethods: {
       oauth: {
+        featureFlag: FeatureSwitchKey.MetaAdsConnector,
         showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Facebook to grant access to Ads Manager.",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -29,6 +29,7 @@ export enum FeatureSwitchKey {
   SupabaseConnector = "supabaseConnector",
   WebflowConnector = "webflowConnector",
   CloseConnector = "closeConnector",
+  MetaAdsConnector = "metaAdsConnector",
   TikTokAdsConnector = "tiktokAdsConnector",
   AwsConnector = "awsConnector",
   PosthogConnector = "posthogConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -25,6 +25,7 @@ describe("isFeatureEnabled", () => {
 
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.GoogleContactsConnector, {})).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -166,6 +166,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Webflow site management connector",
     enabled: false,
   },
+  [FeatureSwitchKey.MetaAdsConnector]: {
+    maintainer: "ethan@vm0.ai",
+    description: "Enable the Meta Ads Manager connector",
+    enabled: false,
+  },
   [FeatureSwitchKey.TikTokAdsConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the TikTok Ads Manager connector",


### PR DESCRIPTION
## Summary

- restore the Meta Ads connector feature switch with a disabled default
- gate Meta Ads OAuth discovery behind the switch
- explicitly enable the switch in platform tests that exercise Meta Ads connection flows

## Testing

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=1 --silent=passed-only`
- affected workspace formatting, lint, and type checks
- `pnpm knip --cache`
- full repository type checks via pre-commit hook