### PR TITLE
fix: scope composer connector state to each chat thread

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -16,6 +16,7 @@ import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 import type { HeaderAutomationSignals } from "./header-automation-menu.ts";
 import type { WorkflowQueueSignals } from "./workflow-queue.ts";
 import type { MailDraftSignals } from "./mail-draft.ts";
+import type { ComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 
 type RecommendedFollowup = NonNullable<
   Extract<PagedChatMessage, { role: "assistant" }>["recommendedFollowups"]
@@ -104,6 +105,7 @@ export interface ChatThreadSignals {
   awayFromBottom$: Computed<boolean>;
   draft: DraftSignals;
   workflowComposer: WorkflowComposerSignals;
+  composerConnectors: ComposerConnectorSignals;
   composerFileInput$: Computed<HTMLElement | null>;
   setComposerFileInput$: Command<
     (() => void) | undefined,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -135,6 +135,7 @@ import type {
 } from "./chat-thread-signals.ts";
 import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
 import { createMailDraftCardSignalsRegistry } from "./mail-draft.ts";
+import { createComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
 
 type ChatThreadRemote = ReturnType<typeof createRemoteChatThreadDataSource>;
 
@@ -4117,6 +4118,7 @@ function createThreadComposer(
   draft: DraftSignals,
   threadId: string,
   featureModes: ChatThreadComposerFeatureModes,
+  agentId$: Computed<Promise<string | null>>,
 ) {
   const { inlinePromptItems = false, inlineAttachmentReferences = false } =
     featureModes;
@@ -4126,7 +4128,11 @@ function createThreadComposer(
     inlinePromptItems,
     inlineAttachmentReferences,
   );
-  return { workflowComposer, focusInput$: workflowComposer.focus$ };
+  return {
+    workflowComposer,
+    composerConnectors: createComposerConnectorSignals(agentId$),
+    focusInput$: workflowComposer.focus$,
+  };
 }
 
 export function createChatThreadSignals(
@@ -4207,7 +4213,12 @@ export function createChatThreadSignals(
     appendOptimisticMessage$: messages.appendOptimisticMessage$,
     dataSource,
   });
-  const composer = createThreadComposer(draft, threadId, composerFeatureModes);
+  const composer = createThreadComposer(
+    draft,
+    threadId,
+    composerFeatureModes,
+    threadOwned.agentId$,
+  );
   return {
     threadId,
     remoteThreadDetail$,

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -1,47 +1,11 @@
 import { command, computed, state } from "ccstate";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { jsonParseOr } from "../utils.ts";
-import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 
 // ---------------------------------------------------------------------------
 // Composer UI state — search, dialogs, loading indicators
 // ---------------------------------------------------------------------------
-
-// -- Add-connectors dialog --------------------------------------------------
-
-const internalShowAddDialog$ = state(false);
-export const showAddDialog$ = computed((get) => {
-  return get(internalShowAddDialog$);
-});
-export const setShowAddDialog$ = command(({ set }, open: boolean) => {
-  set(internalShowAddDialog$, open);
-});
-
-// -- Pending OAuth connection type ------------------------------------------
-
-const internalPendingConnectType$ = state<ConnectorType | null>(null);
-export const pendingConnectType$ = computed((get) => {
-  return get(internalPendingConnectType$);
-});
-export const setPendingConnectType$ = command(
-  ({ set }, type: ConnectorType | null) => {
-    set(internalPendingConnectType$, type);
-  },
-);
-
-// -- Connector toggle saving indicator --------------------------------------
-
-const internalComposerSavingType$ = state<string | null>(null);
-export const composerSavingType$ = computed((get) => {
-  return get(internalComposerSavingType$);
-});
-export const setComposerSavingType$ = command(
-  ({ set }, type: string | null) => {
-    set(internalComposerSavingType$, type);
-  },
-);
 
 // -- Slash workflow picker --------------------------------------------------
 
@@ -75,38 +39,6 @@ export const setSelectedSlashWorkflowIndex$ = command(
   },
 );
 
-// -- Add-connectors dialog search filter ------------------------------------
-
-const internalAddDialogSearch$ = state("");
-export const addDialogSearch$ = computed((get) => {
-  return get(internalAddDialogSearch$);
-});
-export const setAddDialogSearch$ = command(({ set }, value: string) => {
-  set(internalAddDialogSearch$, value);
-});
-
-// -- Connector popover search filter ----------------------------------------
-
-const internalPopoverSearch$ = state("");
-export const popoverSearch$ = computed((get) => {
-  return get(internalPopoverSearch$);
-});
-export const setPopoverSearch$ = command(({ set }, value: string) => {
-  set(internalPopoverSearch$, value);
-});
-
-// -- Connector popover sort order snapshot ----------------------------------
-
-const internalPopoverSortOrder$ = state<ConnectorType[] | null>(null);
-export const popoverSortOrder$ = computed((get) => {
-  return get(internalPopoverSortOrder$);
-});
-export const setPopoverSortOrder$ = command(
-  ({ set }, order: ConnectorType[] | null) => {
-    set(internalPopoverSortOrder$, order);
-  },
-);
-
 // -- New-thread Computer Use host selection ---------------------------------
 
 const internalNewThreadComputerUseHostId$ = state<string | null>(null);
@@ -118,37 +50,6 @@ export const setNewThreadComputerUseHostId$ = command(
     set(internalNewThreadComputerUseHostId$, hostId);
   },
 );
-
-const internalComputerUseDownloadDialogOpen$ = state(false);
-export const computerUseDownloadDialogOpen$ = computed((get) => {
-  return get(internalComputerUseDownloadDialogOpen$);
-});
-export const setComputerUseDownloadDialogOpen$ = command(
-  ({ set }, open: boolean) => {
-    set(internalComputerUseDownloadDialogOpen$, open);
-  },
-);
-
-// -- Connector permission dialog (composer popover) -------------------------
-
-const internalComposerPermissionConnector$ = state<ConnectorType | null>(null);
-export const composerPermissionConnector$ = computed((get) => {
-  return get(internalComposerPermissionConnector$);
-});
-export const setComposerPermissionConnector$ = command(
-  ({ set }, connectorType: ConnectorType | null) => {
-    set(internalComposerPermissionConnector$, connectorType);
-  },
-);
-export const composerPermissionMetadata$ = computed(async (get) => {
-  const connectorType = get(composerPermissionConnector$);
-  if (!connectorType) {
-    return null;
-  }
-  return await get(
-    firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
-  );
-});
 
 // -- Model picker open state ------------------------------------------------
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -24,6 +24,8 @@ import {
 import { personalModelProvider$ } from "./model-first-personal-oauth.ts";
 import { openClaudeCodeDeviceAuthDialogPersonal$ } from "./settings/claude-code-device-auth.ts";
 import { openCodexDeviceAuthDialogPersonal$ } from "./settings/codex-device-auth.ts";
+import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { createComposerConnectorSignals } from "./zero-connectors.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -45,6 +47,10 @@ export const chatPageWorkflowComposer$ = computed((get) => {
     features[FeatureSwitchKey.ComposerInlineAttachmentReferences] ?? false,
   );
 });
+
+export const chatPageComposerConnectors = createComposerConnectorSignals(
+  currentChatAgentRecordId$,
+);
 
 const internalTaglineIndex$ = state(Math.floor(Math.random() * 18));
 export const reloadTagline$ = command(({ set }) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -1,81 +1,237 @@
-import { command, computed } from "ccstate";
-import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
-import { zeroClient$ } from "../api-client.ts";
-import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
+import { userPermissionGrantsByAgent } from "../permission-allow/permission-allow-signals.ts";
 import { withCleanup } from "../utils.ts";
 import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
 } from "./agent-connector-authorizations.ts";
-import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 
-// ---------------------------------------------------------------------------
-// Authorized connectors: User↔Agent↔Connector (per-agent grant)
-//  - GET/PUT /api/zero/agents/:id/user-connectors
-//  - Data: { enabledTypes: string[] } — connector types this user authorized
-//    for the current agent
-// ---------------------------------------------------------------------------
+export interface ComposerConnectorSignals {
+  readonly agentId$: Computed<Promise<string | null>>;
+  readonly authorizedConnectors$: Computed<Promise<readonly ConnectorType[]>>;
+  readonly authorizeConnector$: Command<
+    Promise<void>,
+    [ConnectorType, AbortSignal]
+  >;
+  readonly deauthorizeConnector$: Command<
+    Promise<void>,
+    [ConnectorType, AbortSignal]
+  >;
+  readonly showAddDialog$: Computed<boolean>;
+  readonly setShowAddDialog$: Command<void, [boolean]>;
+  readonly pendingConnectType$: Computed<ConnectorType | null>;
+  readonly setPendingConnectType$: Command<void, [ConnectorType | null]>;
+  readonly selectedConnectType$: Computed<ConnectorType | null>;
+  readonly setSelectedConnectType$: Command<void, [ConnectorType | null]>;
+  readonly savingType$: Computed<ConnectorType | null>;
+  readonly setSavingType$: Command<void, [ConnectorType | null]>;
+  readonly addDialogSearch$: Computed<string>;
+  readonly setAddDialogSearch$: Command<void, [string]>;
+  readonly popoverSearch$: Computed<string>;
+  readonly setPopoverSearch$: Command<void, [string]>;
+  readonly popoverSortOrder$: Computed<readonly ConnectorType[] | null>;
+  readonly setPopoverSortOrder$: Command<
+    void,
+    [readonly ConnectorType[] | null]
+  >;
+  readonly computerUseDownloadDialogOpen$: Computed<boolean>;
+  readonly setComputerUseDownloadDialogOpen$: Command<void, [boolean]>;
+  readonly permissionConnector$: Computed<ConnectorType | null>;
+  readonly setPermissionConnector$: Command<void, [ConnectorType | null]>;
+  readonly permissionMetadata$: Computed<
+    Promise<PublicConnectorCatalogPermissionDetail | null>
+  >;
+  readonly permissionGrants$: Computed<
+    Promise<readonly UserPermissionGrantResponse[]>
+  >;
+}
 
-/** Connectors the current user has authorized for the current agent. */
-const authorizedConnectors$ = computed(async (get) => {
-  const agentId = await get(currentChatAgentRecordId$);
-  if (!agentId) {
-    return [];
-  }
-  const authorizations = await get(agentConnectorAuthorizations({ agentId }));
-  return [...authorizations.enabledTypes];
-});
+function createStateBinding<T>(initialValue: T) {
+  const internal$ = state(initialValue);
+  return {
+    value$: computed((get) => {
+      return get(internal$);
+    }),
+    set$: command(({ set }, value: T) => {
+      set(internal$, value);
+    }),
+  };
+}
 
-export const zeroAuthorizedConnectors$ = computed(async (get) => {
-  return await get(authorizedConnectors$);
-});
+interface ComposerConnectorUiState {
+  readonly showAddDialog: boolean;
+  readonly pendingConnectType: ConnectorType | null;
+  readonly selectedConnectType: ConnectorType | null;
+  readonly savingType: ConnectorType | null;
+  readonly addDialogSearch: string;
+  readonly popoverSearch: string;
+  readonly popoverSortOrder: readonly ConnectorType[] | null;
+  readonly computerUseDownloadDialogOpen: boolean;
+  readonly permissionConnector: ConnectorType | null;
+}
 
-/** Grant the current agent access to a connector. */
-export const authorizeConnector$ = command(
-  async ({ set }, name: string, signal: AbortSignal) => {
-    await set(updateAuthorizedConnectors$, "add", name, signal);
-  },
-);
+function initialComposerConnectorUiState(): ComposerConnectorUiState {
+  return {
+    showAddDialog: false,
+    pendingConnectType: null,
+    selectedConnectType: null,
+    savingType: null,
+    addDialogSearch: "",
+    popoverSearch: "",
+    popoverSortOrder: null,
+    computerUseDownloadDialogOpen: false,
+    permissionConnector: null,
+  };
+}
 
-/** Revoke the current agent's access to a connector. */
-export const deauthorizeConnector$ = command(
-  async ({ set }, name: string, signal: AbortSignal) => {
-    await set(updateAuthorizedConnectors$, "remove", name, signal);
-  },
-);
+type ConnectorAuthorizationSignals = Pick<
+  ComposerConnectorSignals,
+  "authorizedConnectors$" | "authorizeConnector$" | "deauthorizeConnector$"
+>;
 
-/** Atomically add/remove an authorized connector on the server. */
-const updateAuthorizedConnectors$ = command(
-  async (
-    { get, set },
-    operation: "add" | "remove",
-    connectorValue: string,
-    signal: AbortSignal,
-  ) => {
-    const agentId = await get(currentChatAgentRecordId$);
-    signal.throwIfAborted();
-    if (!agentId) {
-      throw new Error("No agent available");
+function createConnectorAuthorizationSignals(
+  agentId$: Computed<Promise<string | null>>,
+): ConnectorAuthorizationSignals {
+  const authorizedConnectors$ = computed(
+    async (get): Promise<readonly ConnectorType[]> => {
+      const agentId = await get(agentId$);
+      if (!agentId) {
+        return [];
+      }
+      const authorizations = await get(
+        agentConnectorAuthorizations({ agentId }),
+      );
+      return authorizations.enabledTypes;
+    },
+  );
+
+  const updateAuthorizedConnectors$ = command(
+    async (
+      { get, set },
+      operation: "add" | "remove",
+      connectorType: ConnectorType,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const agentId = await get(agentId$);
+      signal.throwIfAborted();
+      if (!agentId) {
+        throw new Error("No agent available");
+      }
+
+      const client = get(zeroClient$)(zeroUserConnectorsContract);
+      await withCleanup(
+        accept(
+          client.update({
+            params: { id: agentId },
+            body: { enabledTypes: [connectorType], operation },
+            fetchOptions: { signal },
+          }),
+          [200],
+        ),
+        () => {
+          set(reloadAgentConnectorAuthorizations$);
+        },
+      );
+      signal.throwIfAborted();
+
+      await set(reloadOnboardingStatus$);
+      signal.throwIfAborted();
+    },
+  );
+
+  const authorizeConnector$ = command(
+    async (
+      { set },
+      connectorType: ConnectorType,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await set(updateAuthorizedConnectors$, "add", connectorType, signal);
+    },
+  );
+
+  const deauthorizeConnector$ = command(
+    async (
+      { set },
+      connectorType: ConnectorType,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await set(updateAuthorizedConnectors$, "remove", connectorType, signal);
+    },
+  );
+
+  return {
+    authorizedConnectors$,
+    authorizeConnector$,
+    deauthorizeConnector$,
+  };
+}
+
+export function createComposerConnectorSignals(
+  agentId$: Computed<Promise<string | null>>,
+): ComposerConnectorSignals {
+  const authorization = createConnectorAuthorizationSignals(agentId$);
+  const initial = initialComposerConnectorUiState();
+  const showAddDialog = createStateBinding(initial.showAddDialog);
+  const pendingConnectType = createStateBinding(initial.pendingConnectType);
+  const selectedConnectType = createStateBinding(initial.selectedConnectType);
+  const savingType = createStateBinding(initial.savingType);
+  const addDialogSearch = createStateBinding(initial.addDialogSearch);
+  const popoverSearch = createStateBinding(initial.popoverSearch);
+  const popoverSortOrder = createStateBinding(initial.popoverSortOrder);
+  const computerUseDownloadDialogOpen = createStateBinding(
+    initial.computerUseDownloadDialogOpen,
+  );
+  const permissionConnector = createStateBinding(initial.permissionConnector);
+
+  const permissionMetadata$ = computed(async (get) => {
+    const connectorType = get(permissionConnector.value$);
+    if (!connectorType) {
+      return null;
     }
-
-    const client = get(zeroClient$)(zeroUserConnectorsContract);
-    await withCleanup(
-      accept(
-        client.update({
-          params: { id: agentId },
-          body: { enabledTypes: [connectorValue], operation },
-          fetchOptions: { signal },
-        }),
-        [200],
-      ),
-      () => {
-        set(reloadAgentConnectorAuthorizations$);
-      },
+    return await get(
+      firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
     );
-    signal.throwIfAborted();
+  });
+  const permissionGrants$ = computed(
+    async (get): Promise<readonly UserPermissionGrantResponse[]> => {
+      const agentId = await get(agentId$);
+      if (!agentId) {
+        return [];
+      }
+      return await get(userPermissionGrantsByAgent({ agentId }));
+    },
+  );
 
-    await set(reloadOnboardingStatus$);
-    signal.throwIfAborted();
-  },
-);
+  return {
+    agentId$,
+    ...authorization,
+    showAddDialog$: showAddDialog.value$,
+    setShowAddDialog$: showAddDialog.set$,
+    pendingConnectType$: pendingConnectType.value$,
+    setPendingConnectType$: pendingConnectType.set$,
+    selectedConnectType$: selectedConnectType.value$,
+    setSelectedConnectType$: selectedConnectType.set$,
+    savingType$: savingType.value$,
+    setSavingType$: savingType.set$,
+    addDialogSearch$: addDialogSearch.value$,
+    setAddDialogSearch$: addDialogSearch.set$,
+    popoverSearch$: popoverSearch.value$,
+    setPopoverSearch$: popoverSearch.set$,
+    popoverSortOrder$: popoverSortOrder.value$,
+    setPopoverSortOrder$: popoverSortOrder.set$,
+    computerUseDownloadDialogOpen$: computerUseDownloadDialogOpen.value$,
+    setComputerUseDownloadDialogOpen$: computerUseDownloadDialogOpen.set$,
+    permissionConnector$: permissionConnector.value$,
+    setPermissionConnector$: permissionConnector.set$,
+    permissionMetadata$,
+    permissionGrants$,
+  };
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -39,6 +39,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
 import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
@@ -367,8 +368,9 @@ function mockBillingCapabilities(
 function mockAgent(options?: {
   selectedModel?: string | null;
   modelProviderId?: string | null;
+  includeOtherAgent?: boolean;
 }): void {
-  context.mocks.data.team([
+  const agents = [
     {
       id: AGENT_ID,
       displayName: "Scout",
@@ -378,17 +380,32 @@ function mockAgent(options?: {
       headVersionId: "version_1",
       updatedAt: "2024-01-01T00:00:00Z",
     },
-  ]);
-  context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+    ...(options?.includeOtherAgent
+      ? [
+          {
+            id: OTHER_AGENT_ID,
+            displayName: "Other Agent",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_2",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]
+      : []),
+  ];
+  context.mocks.data.team(agents);
+  context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
+    const isOtherAgent = params.id === OTHER_AGENT_ID;
     return respond(200, {
-      agentId: AGENT_ID,
+      agentId: params.id,
       ownerId: "test-user-123",
-      displayName: "Scout",
+      displayName: isOtherAgent ? "Other Agent" : "Scout",
       description: null,
       sound: null,
       avatarUrl: null,
-      modelProviderId: options?.modelProviderId ?? null,
-      selectedModel: options?.selectedModel ?? null,
+      modelProviderId: isOtherAgent ? null : (options?.modelProviderId ?? null),
+      selectedModel: isOtherAgent ? null : (options?.selectedModel ?? null),
       preferPersonalProvider: false,
     });
   });
@@ -3498,6 +3515,117 @@ describe("chat composer models", () => {
       expect(screen.getByLabelText("Add GitHub")).toBeInTheDocument();
       expect(screen.getByLabelText("Remove Slack")).toBeInTheDocument();
       expectTextBefore("GitHub", "Slack");
+    });
+  });
+
+  it("scopes connector permissions and access to each split chat composer", async () => {
+    const user = userEvent.setup({ delay: null });
+    const enabledByAgent = new Map<string, string[]>([
+      [AGENT_ID, []],
+      [OTHER_AGENT_ID, ["slack"]],
+    ]);
+    const authorizationAgentIds: string[] = [];
+    const permissionGrantAgentIds: string[] = [];
+    let updatedAuthorizationAgentId: string | undefined;
+    let appliedPermissionAgentId: string | undefined;
+
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent({ includeOtherAgent: true });
+    mockConnectors([{ type: "slack", externalUsername: "launch-team" }]);
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "Scout thread" },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: OTHER_AGENT_ID,
+        title: "Other agent thread",
+      },
+    ]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+      authorizationAgentIds.push(params.id);
+      return respond(200, {
+        enabledTypes: enabledByAgent.get(params.id) ?? [],
+      });
+    });
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ params, body, respond }) => {
+        updatedAuthorizationAgentId = params.id;
+        const enabledTypes = applyUserConnectorUpdate(
+          enabledByAgent.get(params.id) ?? [],
+          body,
+        );
+        enabledByAgent.set(params.id, enabledTypes);
+        return respond(200, { enabledTypes });
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      ({ query, respond }) => {
+        permissionGrantAgentIds.push(query.agentId);
+        return respond(200, []);
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        appliedPermissionAgentId = body.agentId;
+        return respond(200, []);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}?sidebar=${OTHER_AGENT_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerConnectorPermissions]: true,
+      },
+    });
+
+    const threadRegions = await screen.findAllByLabelText("Chat thread");
+    expect(threadRegions).toHaveLength(2);
+    const sideThread = threadRegions[1];
+    if (!sideThread) {
+      throw new Error("Side chat thread not found");
+    }
+    const sideComposer = sideThread.querySelector("[data-chat-composer]");
+    if (!(sideComposer instanceof HTMLElement)) {
+      throw new Error("Side chat composer not found");
+    }
+
+    await waitFor(() => {
+      expect(new Set(authorizationAgentIds)).toStrictEqual(
+        new Set([AGENT_ID, OTHER_AGENT_ID]),
+      );
+    });
+    await user.click(within(sideComposer).getByLabelText("Connectors"));
+    await user.click(
+      await screen.findByLabelText("Configure Slack permissions"),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Slack permissions for Other Agent",
+    });
+    await waitFor(() => {
+      expect(permissionGrantAgentIds).not.toHaveLength(0);
+      expect(
+        permissionGrantAgentIds.every((id) => {
+          return id === OTHER_AGENT_ID;
+        }),
+      ).toBeTruthy();
+    });
+    await user.click(buttonContainingText("Deny", dialog));
+    await user.click(buttonContainingText("Apply", dialog));
+
+    await waitFor(() => {
+      expect(appliedPermissionAgentId).toBe(OTHER_AGENT_ID);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await user.click(within(sideComposer).getByLabelText("Connectors"));
+    await user.click(await screen.findByLabelText("Remove Slack"));
+    await waitFor(() => {
+      expect(updatedAuthorizationAgentId).toBe(OTHER_AGENT_ID);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -50,6 +50,7 @@ import {
 } from "../../signals/chat-page/workflow-prompt-action.ts";
 import { AttachmentLightbox } from "./zero-attachment-chips.tsx";
 import {
+  chatPageComposerConnectors,
   chatPageWorkflowComposer$,
   chatPageModelSelection$,
   chatPageSelectedModelOauthAvailable$,
@@ -736,6 +737,7 @@ export function AgentChatPage() {
           <ZeroChatComposer
             className="w-full"
             composer={composer}
+            composerConnectors={chatPageComposerConnectors}
             draft={draft}
             onSend={handleSendMessage}
             onDraftChange={handleDraftChange}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -148,8 +148,6 @@ import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   allConnectorTypes$,
   matchesConnectorSearch,
-  selectedConnectorType$,
-  setSelectedConnectorType$,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
   type ConnectorTypeWithStatus,
@@ -169,34 +167,13 @@ import {
   ZERO_DESKTOP_MACOS_REQUIREMENT_LABEL,
   ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
-import {
-  zeroAuthorizedConnectors$,
-  authorizeConnector$,
-  deauthorizeConnector$,
-} from "../../signals/zero-page/zero-connectors.ts";
-import { currentChatAgentRecordId$ } from "../../signals/agent-chat.ts";
-import {
-  userPermissionGrantsByAgent,
-  applyUserPermissionGrants$,
-} from "../../signals/permission-allow/permission-allow-signals.ts";
+import type { ComposerConnectorSignals } from "../../signals/zero-page/zero-connectors.ts";
+import { applyUserPermissionGrants$ } from "../../signals/permission-allow/permission-allow-signals.ts";
 import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission-grants.ts";
 import { savePermissionDraftPolicies } from "../../signals/zero-page/settings/permission-grant-save.ts";
 import { PermissionsDialog } from "./components/settings/permissions-dialog.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
-  showAddDialog$,
-  setShowAddDialog$,
-  pendingConnectType$,
-  setPendingConnectType$,
-  composerSavingType$,
-  setComposerSavingType$,
-  computerUseDownloadDialogOpen$,
-  addDialogSearch$,
-  setAddDialogSearch$,
-  popoverSearch$,
-  setPopoverSearch$,
-  popoverSortOrder$,
-  setPopoverSortOrder$,
   modelPickerOpen$,
   setModelPickerOpen$,
   uploadPopoverOpen$,
@@ -214,10 +191,6 @@ import {
   setTemplatePickerPreviewSlug$,
   restoreTemplatePickerPresentationScroll$,
   setTemplatePickerPresentationScrollTop$,
-  setComputerUseDownloadDialogOpen$,
-  composerPermissionConnector$,
-  setComposerPermissionConnector$,
-  composerPermissionMetadata$,
   illustrationVariantIndex$,
   setIllustrationVariantIndex$,
   templateCardHover$,
@@ -274,6 +247,7 @@ function shouldLoadTemplateDetailHtmlPreviewInHappyDom(): boolean {
 
 export interface ZeroChatComposerProps {
   composer: WorkflowComposerSignals;
+  composerConnectors: ComposerConnectorSignals;
   onSend: (
     message: string,
     generationTemplate: GenerationTemplateRequest | undefined,
@@ -5418,18 +5392,20 @@ function ConnectorTriggerIcons({
 }
 
 function AddConnectorsDialog({
+  signals,
   unconnected,
   pollingType,
   onClose,
   onSelect,
 }: {
+  signals: ComposerConnectorSignals;
   unconnected: ConnectorTypeWithStatus[];
   pollingType: string | null;
   onClose: () => void;
   onSelect: (type: ConnectorType) => void;
 }) {
-  const search = useGet(addDialogSearch$);
-  const setSearch = useSet(setAddDialogSearch$);
+  const search = useGet(signals.addDialogSearch$);
+  const setSearch = useSet(signals.setAddDialogSearch$);
   const filtered = unconnected.filter((item) => {
     return matchesConnectorSearch(search, item);
   });
@@ -5617,19 +5593,19 @@ function ComputerUseConnectorMenuSection({
 }
 
 function ComposerConnectorPermissionDialog({
+  signals,
   agentId,
   agentDisplayName,
   connector,
   onClose,
 }: {
+  signals: ComposerConnectorSignals;
   agentId: string;
   agentDisplayName: string;
   connector: ComposerConnectorItem;
   onClose: () => void;
 }) {
-  const grantsLoadable = useLastLoadable(
-    userPermissionGrantsByAgent({ agentId }),
-  );
+  const grantsLoadable = useLastLoadable(signals.permissionGrants$);
   const pageSignal = useGet(pageSignal$);
   const [, applyGrantPolicies] = useLoadableSet(applyUserPermissionGrants$);
 
@@ -5648,7 +5624,7 @@ function ComposerConnectorPermissionDialog({
       agentId={agentId}
       connectorType={connector.type}
       connectorLabel={connector.label}
-      metadata$={composerPermissionMetadata$}
+      metadata$={signals.permissionMetadata$}
       displayName={agentDisplayName}
       initialPolicies={initialPolicies}
       initialGrants={activeSnapshot.grants}
@@ -5673,6 +5649,7 @@ function ComposerConnectorPermissionDialog({
 }
 
 function ConnectorsPopoverButton({
+  signals,
   agentId,
   agentDisplayName,
   agentConnectors,
@@ -5682,6 +5659,7 @@ function ConnectorsPopoverButton({
   onOpenAddDialog,
   onToggle,
 }: {
+  signals: ComposerConnectorSignals;
   agentId: string | null;
   agentDisplayName: string;
   agentConnectors: ComposerConnectorItem[];
@@ -5691,15 +5669,17 @@ function ConnectorsPopoverButton({
   onOpenAddDialog: () => void;
   onToggle: (type: ConnectorType, checked: boolean) => void | Promise<void>;
 }) {
-  const search = useGet(popoverSearch$);
-  const setSearch = useSet(setPopoverSearch$);
-  const sortOrder = useGet(popoverSortOrder$);
-  const setSortOrder = useSet(setPopoverSortOrder$);
-  const downloadDialogOpen = useGet(computerUseDownloadDialogOpen$);
-  const setDownloadDialogOpen = useSet(setComputerUseDownloadDialogOpen$);
+  const search = useGet(signals.popoverSearch$);
+  const setSearch = useSet(signals.setPopoverSearch$);
+  const sortOrder = useGet(signals.popoverSortOrder$);
+  const setSortOrder = useSet(signals.setPopoverSortOrder$);
+  const downloadDialogOpen = useGet(signals.computerUseDownloadDialogOpen$);
+  const setDownloadDialogOpen = useSet(
+    signals.setComputerUseDownloadDialogOpen$,
+  );
   const permissionEntryEnabled = useGet(composerConnectorPermissionsEnabled$);
-  const permissionConnectorType = useGet(composerPermissionConnector$);
-  const setPermissionConnectorType = useSet(setComposerPermissionConnector$);
+  const permissionConnectorType = useGet(signals.permissionConnector$);
+  const setPermissionConnectorType = useSet(signals.setPermissionConnector$);
   const showSearch = agentConnectors.length > 20;
   const permissionConnector =
     permissionEntryEnabled && permissionConnectorType
@@ -5886,6 +5866,7 @@ function ConnectorsPopoverButton({
       )}
       {agentId && permissionConnector && (
         <ComposerConnectorPermissionDialog
+          signals={signals}
           agentId={agentId}
           agentDisplayName={agentDisplayName}
           connector={permissionConnector}
@@ -6624,11 +6605,16 @@ function loadableDataOrNull<T>(loadable: Loadable<T>): T | null {
   return loadable.state === "hasData" ? loadable.data : null;
 }
 
+function nullToUndefined<T>(value: T | null): T | undefined {
+  return value === null ? undefined : value;
+}
+
 // The thread route invokes this hook from its ccstate-connected composer so
 // dynamic bindings do not cross another React component boundary. The agent
 // landing page uses the component wrapper below for its separate signal scope.
 export function useZeroChatComposer({
   composer,
+  composerConnectors,
   onSend,
   onQueue,
   sending,
@@ -6656,8 +6642,8 @@ export function useZeroChatComposer({
   activeGoal,
   onCancelActiveGoal,
 }: ZeroChatComposerProps) {
-  const showAddDialog = useGet(showAddDialog$);
-  const setShowAddDialog = useSet(setShowAddDialog$);
+  const showAddDialog = useGet(composerConnectors.showAddDialog$);
+  const setShowAddDialog = useSet(composerConnectors.setShowAddDialog$);
   const openGoalDialog = useSet(openChatThreadGoalDialog$);
 
   const resolved = useResolvedComposerSignals(
@@ -6911,23 +6897,27 @@ export function useZeroChatComposer({
   // Connectors: connected (org-level) + authorized (agent-level) → available
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const authorizedConnectorsLoadable = useLastLoadable(
-    zeroAuthorizedConnectors$,
+    composerConnectors.authorizedConnectors$,
     { equalityFn: equalArrays },
   );
   const pageSignal = useGet(pageSignal$);
-  const selectedConnType = useGet(selectedConnectorType$);
-  const pendingConnectType = useGet(pendingConnectType$);
-  const setPendingConnectType = useSet(setPendingConnectType$);
-  const setSelectedConnType = useSet(setSelectedConnectorType$);
+  const selectedConnType = useGet(composerConnectors.selectedConnectType$);
+  const pendingConnectType = useGet(composerConnectors.pendingConnectType$);
+  const setPendingConnectType = useSet(
+    composerConnectors.setPendingConnectType$,
+  );
+  const setSelectedConnType = useSet(
+    composerConnectors.setSelectedConnectType$,
+  );
   const pollingConnType = useGet(pollingOAuthAuthCodeConnectorType$);
-  const authorizeFn = useSet(authorizeConnector$);
-  const deauthorizeFn = useSet(deauthorizeConnector$);
+  const authorizeFn = useSet(composerConnectors.authorizeConnector$);
+  const deauthorizeFn = useSet(composerConnectors.deauthorizeConnector$);
   const optimisticConnected = useGet(justConnectedTypes$);
 
-  const savingType = useGet(composerSavingType$);
-  const setSavingType = useSet(setComposerSavingType$);
+  const savingType = useGet(composerConnectors.savingType$);
+  const setSavingType = useSet(composerConnectors.setSavingType$);
   const agentRecordId = loadableDataOrNull(
-    useLastLoadable(currentChatAgentRecordId$),
+    useLastLoadable(composerConnectors.agentId$),
   );
 
   const connectorsLoading =
@@ -7223,6 +7213,7 @@ export function useZeroChatComposer({
                     onCreateWorkflowPrompt={onCreateWorkflowPrompt}
                   />
                   <ConnectorsPopoverButton
+                    signals={composerConnectors}
                     agentId={agentRecordId}
                     agentDisplayName={displayName}
                     agentConnectors={agentConnectors}
@@ -7276,6 +7267,8 @@ export function useZeroChatComposer({
       </div>
       {selectedConnType && (
         <ConnectModal
+          selectedType={selectedConnType}
+          agentId={nullToUndefined(agentRecordId)}
           onClose={() => {
             return setSelectedConnType(null);
           }}
@@ -7295,6 +7288,7 @@ export function useZeroChatComposer({
       )}
       {showAddDialog && (
         <AddConnectorsDialog
+          signals={composerConnectors}
           unconnected={unconnectedConnectors}
           pollingType={pollingConnType}
           onClose={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4288,6 +4288,7 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
   });
   const composerOptions: ZeroChatComposerProps = {
     composer: thread.workflowComposer,
+    composerConnectors: thread.composerConnectors,
     onSend: handleSend,
     onQueue: handleQueue,
     sending: composerSending,


### PR DESCRIPTION
## Summary

- Scope connector authorization, permission grants, and transient connector UI state to the composer owner's agent.
- Attach the connector signal factory to each `ChatThreadSignals` instance, while keeping a separate landing-composer instance for agent chat.
- Pass stable permission signals and explicit agent/connector context into React, eliminating render-time signal creation and route-level agent drift in split chats.
- Add split-pane regression coverage that verifies permission reads, permission saves, and connector authorization updates all target the side chat's agent.

## User impact

When two chats for different agents are open side by side, configuring permissions or toggling a connector from either composer now updates the correct agent. Composer rerenders also reuse the same permission-grant signal graph instead of allocating a new signal.

## Verification

- `pnpm -F @vm0/app check-types`
- Targeted Oxlint and ESLint checks for all touched platform files
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "shows agent connector access from the composer|keeps composer connector order independent of authorization state|scopes connector permissions and access to each split chat composer" --maxWorkers=1`
- Prettier 3.8.1 check for all touched files
