### PR TITLE
refactor(api): eliminate unsafe sql.raw usage

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -132,14 +132,16 @@ use a dedicated decoder that preserves or validates the required representation.
 
 Prefer schema-aware Drizzle builders and operators when they preserve the
 intended SQL semantics. Use the `sql` tag or `SQL` type without a compile-time
-result generic for constructs they cannot express cleanly. Raw SQL used only as
-a predicate, join condition, ordering or grouping expression, write value,
-discarded command, or `rowCount` command result does not produce a structured
-field and needs no result decoder. If a write query adds `.returning({...})`,
-map raw SQL in the returned fields independently of `.set({...})`. Likewise,
-raw SQL passed to `insert(...).select(...)` is the write source rather than a
-returned field; only a subsequent `returning(...)` introduces a result-mapping
-boundary.
+result generic for constructs they cannot express cleanly. Compose dynamic SQL
+from tagged `sql` fragments so interpolated values remain driver parameters;
+`sql.raw(...)` bypasses parameter binding and is prohibited in API source except
+for the local development seed script. Raw SQL used only as a predicate, join
+condition, ordering or grouping expression, write value, discarded command, or
+`rowCount` command result does not produce a structured field and needs no
+result decoder. If a write query adds `.returning({...})`, map raw SQL in the
+returned fields independently of `.set({...})`. Likewise, raw SQL passed to
+`insert(...).select(...)` is the write source rather than a returned field; only
+a subsequent `returning(...)` introduces a result-mapping boundary.
 
 ### Raw Execute Rows
 

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -178,10 +178,19 @@ export default [
       "api/no-getter-setter-params": "error",
       "api/no-logger-info": "error",
       "api/no-new-promise": "error",
+      "api/no-sql-raw": "error",
       "api/no-store-in-params": "error",
       "api/require-execute-row-schema": "error",
       "api/require-sql-result-mapping": "error",
       "api/signal-check-await": "error",
+    },
+  },
+  {
+    files: ["src/scripts/dev-seed.ts"],
+    rules: {
+      // PostgreSQL's DO statement requires a code literal, so this local-only
+      // seed script uses pg.escapeLiteral before passing the block to sql.raw.
+      "api/no-sql-raw": "off",
     },
   },
   {

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -139,7 +139,7 @@ function parseModelRankingPeriod(
 }
 
 function modelUsageObservationModelExpression() {
-  const modelColumn = sql.raw('"model_usage_observation"."model"');
+  const modelColumn = modelUsageObservation.model;
   return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
       return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
@@ -149,7 +149,7 @@ function modelUsageObservationModelExpression() {
 }
 
 function modelStatModelExpression() {
-  const modelColumn = sql.raw('"model_stat"."model"');
+  const modelColumn = modelStat.model;
   return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
       return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -301,7 +301,7 @@ async function touchRecentlyUsedCacheRows(
     orderedCacheKeys.map((cacheKey) => {
       return sql`${cacheKey}`;
     }),
-    sql.raw(", "),
+    sql`, `,
   );
   const issuedAtTimestamp = timestampWithoutTimeZone(issuedAt);
   const touchCutoffTimestamp = timestampWithoutTimeZone(touchCutoff(issuedAt));

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -712,7 +712,7 @@ function activeRunStatusSqlList() {
     ACTIVE_RUN_STATUSES.map((status) => {
       return sql`${status}`;
     }),
-    sql.raw(", "),
+    sql`, `,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -148,7 +148,7 @@ export const triggerAutoRecharge$ = command(
             AND ${orgMetadata.autoRechargeAmount} IS NOT NULL
             AND ${orgMetadata.credits} <= ${orgMetadata.autoRechargeThreshold}
             AND (${orgMetadata.autoRechargePendingAt} IS NULL
-                 OR ${orgMetadata.autoRechargePendingAt} < now() - interval '${sql.raw(String(STALE_THRESHOLD_MINUTES))} minutes')`,
+                 OR ${orgMetadata.autoRechargePendingAt} < now() - make_interval(mins => ${STALE_THRESHOLD_MINUTES}))`,
       )
       .returning({
         credits: orgMetadata.credits,

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -23,8 +23,6 @@ const MODEL_TOKEN_CATEGORIES = [
   "tokens.cache_creation",
 ] as const;
 
-const USAGE_ROW_ALIAS = "ur";
-
 interface UsageInsightOptions {
   range: "today" | "yesterday" | "day" | "7d" | "28d" | "30d";
   date?: string;
@@ -42,12 +40,12 @@ interface TimeParts {
 }
 
 interface UsageInsightSqlParams {
-  userIdLit: string;
-  orgIdLit: string;
-  startTsLit: string;
-  endTsLit: string;
-  truncLit: string;
-  tzLit: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly startTs: string;
+  readonly endTs: string;
+  readonly trunc: "hour" | "day";
+  readonly tz: string;
 }
 
 const usageInsightBucketRowSchema = z.object({
@@ -274,7 +272,7 @@ function rangeToWindow(
   range: UsageInsightOptions["range"],
   tz: string,
   date: string | undefined,
-): { trunc: string; startTs: Date; endTs: Date } {
+): { trunc: "hour" | "day"; startTs: Date; endTs: Date } {
   const now = nowDate();
   const todayStart = startOfDayInTz(now, tz);
 
@@ -309,56 +307,54 @@ function rangeToWindow(
   }
 }
 
-function pgLit(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
+function usageBucketExpr(p: UsageInsightSqlParams) {
+  return sql`date_trunc(${p.trunc}, ur.activity_time AT TIME ZONE 'UTC' AT TIME ZONE ${p.tz})`;
 }
 
-function usageBucketExpr(p: UsageInsightSqlParams): string {
-  return `date_trunc(${p.truncLit}, ${USAGE_ROW_ALIAS}.activity_time AT TIME ZONE 'UTC' AT TIME ZONE ${p.tzLit})`;
+function activityTimeWindowPredicate(p: UsageInsightSqlParams) {
+  return sql`ue.created_at AT TIME ZONE 'UTC' >= ${p.startTs}::timestamptz
+        AND ue.created_at AT TIME ZONE 'UTC' < ${p.endTs}::timestamptz`;
 }
 
-function activityTimeWindowPredicate(
-  alias: string,
-  p: UsageInsightSqlParams,
-): string {
-  return `${alias}.created_at AT TIME ZONE 'UTC' >= ${p.startTsLit}::timestamptz
-        AND ${alias}.created_at AT TIME ZONE 'UTC' < ${p.endTsLit}::timestamptz`;
+function usageRowTokenExpr() {
+  const tokenCategoryList = sql.join(
+    MODEL_TOKEN_CATEGORIES.map((category) => {
+      return sql`${category}`;
+    }),
+    sql`, `,
+  );
+  return sql`CASE WHEN ue.kind = ${MODEL_USAGE_KIND} AND ue.category IN (${tokenCategoryList}) THEN ue.quantity ELSE 0 END`;
 }
 
-function usageRowTokenExpr(): string {
-  const tokenCategoryList = MODEL_TOKEN_CATEGORIES.map(pgLit).join(", ");
-  return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${tokenCategoryList}) THEN ue.quantity ELSE 0 END`;
+function usageCreditsExpr() {
+  return sql`COALESCE(ue.credits_charged, 0) + COALESCE(uaa.units_applied, 0)`;
 }
 
-function usageCreditsExpr(usageAlias: string, allowanceAlias: string): string {
-  return `COALESCE(${usageAlias}.credits_charged, 0) + COALESCE(${allowanceAlias}.units_applied, 0)`;
-}
-
-function usageRowsCte(p: UsageInsightSqlParams): string {
-  return `
+function usageRowsCte(p: UsageInsightSqlParams) {
+  return sql`
     usage_rows AS (
       SELECT
         ue.created_at AS activity_time,
         ue.run_id,
         ue.user_id,
         ue.org_id,
-        ${usageCreditsExpr("ue", "uaa")}::bigint AS credits_charged,
+        ${usageCreditsExpr()}::bigint AS credits_charged,
         ${usageRowTokenExpr()}::bigint AS tokens
       FROM usage_event ue
       LEFT JOIN usage_allowance_allocations uaa ON uaa.usage_event_id = ue.id
-      WHERE ue.user_id = ${p.userIdLit}
-        AND ue.org_id = ${p.orgIdLit}
+      WHERE ue.user_id = ${p.userId}
+        AND ue.org_id = ${p.orgId}
         AND ue.status = 'processed'
-        AND ${activityTimeWindowPredicate("ue", p)}
+        AND ${activityTimeWindowPredicate(p)}
     )`;
 }
 
-function usageRowsWith(p: UsageInsightSqlParams): string {
-  return `WITH ${usageRowsCte(p)}`;
+function usageRowsWith(p: UsageInsightSqlParams) {
+  return sql`WITH ${usageRowsCte(p)}`;
 }
 
-function agentNameExpr(): string {
-  return `CASE
+function agentNameExpr() {
+  return sql`CASE
     WHEN ar.id IS NULL THEN 'others'
     ELSE COALESCE(za.display_name, za.name, acv_compose.name, 'unknown')
   END`;
@@ -395,7 +391,7 @@ function pivotBucketRows(
 function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
   return executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${usageRowsWith(p)}
       SELECT
         ${usageBucketExpr(p)} AS ts,
@@ -406,13 +402,13 @@ function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
           WHEN zr.trigger_source IN ('workflow-schedule', 'workflow-event') THEN 'automation'
           ELSE 'others'
         END AS bucket,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
-      FROM usage_rows ${USAGE_ROW_ALIAS}
-      LEFT JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
+      FROM usage_rows ur
+      LEFT JOIN zero_runs zr ON zr.id = ur.run_id
       GROUP BY 1, 2
       ORDER BY 1
-    `),
+    `,
     usageInsightBucketRowSchema,
   );
 }
@@ -422,14 +418,14 @@ function queryUsageInsightAgentBuckets(db: Db, p: UsageInsightSqlParams) {
 
   return executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${usageRowsWith(p)},
       agent_totals AS (
         SELECT
           ${agentName} AS agent_name,
-          COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS total_credits
-        FROM usage_rows ${USAGE_ROW_ALIAS}
-        LEFT JOIN agent_runs ar ON ar.id = ${USAGE_ROW_ALIAS}.run_id
+          COALESCE(SUM(ur.credits_charged), 0)::bigint AS total_credits
+        FROM usage_rows ur
+        LEFT JOIN agent_runs ar ON ar.id = ur.run_id
         LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
         LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
         LEFT JOIN zero_agents za ON za.id = acv_compose.id
@@ -444,16 +440,16 @@ function queryUsageInsightAgentBuckets(db: Db, p: UsageInsightSqlParams) {
           THEN ${agentName}
           ELSE 'others'
         END AS bucket,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
-      FROM usage_rows ${USAGE_ROW_ALIAS}
-      LEFT JOIN agent_runs ar ON ar.id = ${USAGE_ROW_ALIAS}.run_id
+        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
+      FROM usage_rows ur
+      LEFT JOIN agent_runs ar ON ar.id = ur.run_id
       LEFT JOIN agent_compose_versions acv ON acv.id = ar.agent_compose_version_id
       LEFT JOIN agent_composes acv_compose ON acv_compose.id = acv.compose_id
       LEFT JOIN zero_agents za ON za.id = acv_compose.id
       GROUP BY 1, 2
       ORDER BY 1
-    `),
+    `,
     usageInsightBucketRowSchema,
   );
 }
@@ -464,13 +460,13 @@ async function queryUsageInsightGrandTotal(
 ): Promise<{ grandTotalCredits: number; grandTotalTokens: number }> {
   const rows = await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${usageRowsWith(p)}
       SELECT
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS grand_credits,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS grand_tokens
-      FROM usage_rows ${USAGE_ROW_ALIAS}
-    `),
+        COALESCE(SUM(ur.credits_charged), 0)::bigint AS grand_credits,
+        COALESCE(SUM(ur.tokens), 0)::bigint AS grand_tokens
+      FROM usage_rows ur
+    `,
     usageInsightGrandTotalRowSchema,
   );
   return {
@@ -490,17 +486,17 @@ async function queryUsageInsightChannelTotals(
 }> {
   const rows = await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${usageRowsWith(p)}
       SELECT
         zr.trigger_source AS source,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
-        COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens
-      FROM usage_rows ${USAGE_ROW_ALIAS}
-      LEFT JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+        COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
+        COALESCE(SUM(ur.tokens), 0)::bigint AS tokens
+      FROM usage_rows ur
+      LEFT JOIN zero_runs zr ON zr.id = ur.run_id
       WHERE zr.trigger_source IN ('email', 'slack')
       GROUP BY 1
-    `),
+    `,
     usageInsightChannelTotalRowSchema,
   );
   let emailCredits = 0;
@@ -529,17 +525,17 @@ async function queryUsageInsightTopChats(
 }> {
   const rows = await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${usageRowsWith(p)},
       agg AS (
         SELECT
           zr.chat_thread_id,
           ct.title AS thread_title,
-          COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
-          COALESCE(SUM(${USAGE_ROW_ALIAS}.tokens), 0)::bigint AS tokens,
-          ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
-        FROM usage_rows ${USAGE_ROW_ALIAS}
-        INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+          COALESCE(SUM(ur.credits_charged), 0)::bigint AS credits,
+          COALESCE(SUM(ur.tokens), 0)::bigint AS tokens,
+          ROW_NUMBER() OVER (ORDER BY SUM(ur.credits_charged) DESC NULLS LAST) AS rn
+        FROM usage_rows ur
+        INNER JOIN zero_runs zr ON zr.id = ur.run_id
         LEFT JOIN chat_threads ct ON ct.id = zr.chat_thread_id
         WHERE zr.chat_thread_id IS NOT NULL
         GROUP BY zr.chat_thread_id, ct.title
@@ -555,7 +551,7 @@ async function queryUsageInsightTopChats(
         101 AS rn
       FROM agg WHERE rn > 100
       ORDER BY rn
-    `),
+    `,
     usageInsightTopChatRowSchema,
   );
 
@@ -580,18 +576,18 @@ async function queryUsageInsightTopChats(
   if (hasChatOverflow) {
     const countRows = await executeRawRows(
       db,
-      sql.raw(`
+      sql`
         ${usageRowsWith(p)},
         agg AS (
           SELECT zr.chat_thread_id,
-            ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
-          FROM usage_rows ${USAGE_ROW_ALIAS}
-          INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
+            ROW_NUMBER() OVER (ORDER BY SUM(ur.credits_charged) DESC NULLS LAST) AS rn
+          FROM usage_rows ur
+          INNER JOIN zero_runs zr ON zr.id = ur.run_id
           WHERE zr.chat_thread_id IS NOT NULL
           GROUP BY zr.chat_thread_id
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100
-      `),
+      `,
       usageInsightCountRowSchema,
     );
     chatOtherCount = countRows[0]?.cnt ?? 0;
@@ -613,12 +609,12 @@ export const zeroUsageInsight$ = command(
       args.options.date,
     );
     const params: UsageInsightSqlParams = {
-      userIdLit: pgLit(args.userId),
-      orgIdLit: pgLit(args.orgId),
-      startTsLit: pgLit(startTs.toISOString()),
-      endTsLit: pgLit(endTs.toISOString()),
-      truncLit: pgLit(trunc),
-      tzLit: pgLit(args.options.tz),
+      userId: args.userId,
+      orgId: args.orgId,
+      startTs: startTs.toISOString(),
+      endTs: endTs.toISOString(),
+      trunc,
+      tz: args.options.tz,
     };
 
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 import {
   type UsageRecordKind,
   type UsageRecordRow,
@@ -105,37 +105,48 @@ type UsageRecordBreakdownSqlRow = z.output<
   typeof usageRecordBreakdownSqlRowSchema
 >;
 
-function pgLit(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
+function tokenExpr() {
+  const list = sql.join(
+    MODEL_TOKEN_CATEGORIES.map((category) => {
+      return sql`${category}`;
+    }),
+    sql`, `,
+  );
+  return sql`CASE WHEN ue.kind = ${MODEL_USAGE_KIND} AND ue.category IN (${list}) THEN ue.quantity ELSE 0 END`;
 }
 
-function tokenExpr(): string {
-  const list = MODEL_TOKEN_CATEGORIES.map(pgLit).join(", ");
-  return `CASE WHEN ue.kind = ${pgLit(MODEL_USAGE_KIND)} AND ue.category IN (${list}) THEN ue.quantity ELSE 0 END`;
-}
-
-function sourceExpr(triggerSource: string): string {
-  const passthroughList = PASSTHROUGH_TRIGGER_SOURCES.map(pgLit).join(", ");
-  return `
+function sourceExpr() {
+  const passthroughList = sql.join(
+    PASSTHROUGH_TRIGGER_SOURCES.map((source) => {
+      return sql`${source}`;
+    }),
+    sql`, `,
+  );
+  return sql`
     CASE
-      WHEN ${triggerSource} = 'web' THEN 'chat'
-      WHEN ${triggerSource} IN ('workflow-schedule', 'workflow-event') THEN 'automation'
-      WHEN ${triggerSource} IN (${passthroughList}) THEN ${triggerSource}
+      WHEN zr.trigger_source = 'web' THEN 'chat'
+      WHEN zr.trigger_source IN ('workflow-schedule', 'workflow-event') THEN 'automation'
+      WHEN zr.trigger_source IN (${passthroughList}) THEN zr.trigger_source
       ELSE 'other'
     END`;
 }
 
-function usageKindExpr(kind: string): string {
-  const usageKindList = USAGE_RECORD_KINDS.map(pgLit).join(", ");
-  return `
+function usageKindExpr() {
+  const usageKindList = sql.join(
+    USAGE_RECORD_KINDS.map((kind) => {
+      return sql`${kind}`;
+    }),
+    sql`, `,
+  );
+  return sql`
     CASE
-      WHEN ${kind} IN (${usageKindList}) THEN ${kind}
+      WHEN ue.kind IN (${usageKindList}) THEN ue.kind
       ELSE 'other'
     END`;
 }
 
-function usageCreditsExpr(usageAlias: string, allowanceAlias: string): string {
-  return `COALESCE(${usageAlias}.credits_charged, 0) + COALESCE(${allowanceAlias}.units_applied, 0)`;
+function usageCreditsExpr() {
+  return sql`COALESCE(ue.credits_charged, 0) + COALESCE(uaa.units_applied, 0)`;
 }
 
 // Per-source usage for one user in one org. `record` is the shared CTE so the
@@ -144,27 +155,33 @@ function usageCreditsExpr(usageAlias: string, allowanceAlias: string): string {
 // NULL, collapse to one synthetic row per source/user. Everything else is one
 // row per run.
 function recordWith(
-  userIdLit: string,
-  orgIdLit: string,
+  userId: string | null,
+  orgId: string,
   period: UsagePeriod | null,
-): string {
-  const threadedSourceList = THREADED_SOURCES.map(pgLit).join(", ");
-  const userPredicate = userIdLit ? `AND ue.user_id = ${userIdLit}` : "";
+): SQL {
+  const threadedSourceList = sql.join(
+    THREADED_SOURCES.map((source) => {
+      return sql`${source}`;
+    }),
+    sql`, `,
+  );
+  const userPredicate =
+    userId === null ? sql.empty() : sql`AND ue.user_id = ${userId}`;
   const periodPredicate = period
-    ? `
-        AND ue.created_at AT TIME ZONE 'UTC' >= ${pgLit(period.start.toISOString())}::timestamptz
-        AND ue.created_at AT TIME ZONE 'UTC' < ${pgLit(period.end.toISOString())}::timestamptz`
-    : "";
-  return `
+    ? sql`
+        AND ue.created_at AT TIME ZONE 'UTC' >= ${period.start.toISOString()}::timestamptz
+        AND ue.created_at AT TIME ZONE 'UTC' < ${period.end.toISOString()}::timestamptz`
+    : sql.empty();
+  return sql`
     WITH usage_rows AS (
       SELECT
         ue.run_id,
         ue.user_id,
-        ${usageCreditsExpr("ue", "uaa")}::bigint AS credits,
+        ${usageCreditsExpr()}::bigint AS credits,
         ${tokenExpr()}::bigint AS tokens
       FROM usage_event ue
       LEFT JOIN usage_allowance_allocations uaa ON uaa.usage_event_id = ue.id
-      WHERE ue.org_id = ${orgIdLit}
+      WHERE ue.org_id = ${orgId}
         ${userPredicate}
         AND ue.status = 'processed'
         ${periodPredicate}
@@ -175,7 +192,7 @@ function recordWith(
         ur.user_id,
         ur.credits,
         ur.tokens,
-        ${sourceExpr("zr.trigger_source")} AS source,
+        ${sourceExpr()} AS source,
         zr.chat_thread_id,
         zr.summary,
         ar.prompt,
@@ -243,39 +260,45 @@ function recordWith(
 
 async function queryUsageRecordRows(
   db: Db,
-  recordCte: string,
-  sourceFilterLit: string | null,
+  recordCte: SQL,
+  sourceFilter: UsageRecordSource | undefined,
   pageSize: number,
   offset: number,
 ): Promise<UsageRecordIntermediateRow[]> {
-  const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
+  const where =
+    sourceFilter === undefined
+      ? sql.empty()
+      : sql`WHERE source = ${sourceFilter}`;
   return await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${recordCte}
       SELECT row_key, source, user_id, thread_id, run_id, title, credits, tokens, last_activity
       FROM record
       ${where}
       ORDER BY last_activity DESC
       LIMIT ${pageSize} OFFSET ${offset}
-    `),
+    `,
     usageRecordSqlRowSchema,
   );
 }
 
 async function queryUsageRecordTotals(
   db: Db,
-  recordCte: string,
-  sourceFilterLit: string | null,
+  recordCte: SQL,
+  sourceFilter: UsageRecordSource | undefined,
 ): Promise<{ total: number; totalCredits: number }> {
-  const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
+  const where =
+    sourceFilter === undefined
+      ? sql.empty()
+      : sql`WHERE source = ${sourceFilter}`;
   const rows = await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       ${recordCte}
       SELECT COUNT(*)::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
       FROM record ${where}
-    `),
+    `,
     usageRecordTotalsSqlRowSchema,
   );
   return {
@@ -284,27 +307,27 @@ async function queryUsageRecordTotals(
   };
 }
 
-function rowKeyExpr(
-  source: string,
-  chatThreadId: string,
-  runId: string,
-  userId: string,
-): string {
-  const threadedSourceList = THREADED_SOURCES.map(pgLit).join(", ");
-  return `
+function rowKeyExpr() {
+  const threadedSourceList = sql.join(
+    THREADED_SOURCES.map((source) => {
+      return sql`${source}`;
+    }),
+    sql`, `,
+  );
+  return sql`
     CASE
-      WHEN ${chatThreadId} IS NOT NULL AND ${source} IN (${threadedSourceList})
-        THEN CONCAT(${source}, ':thread:', ${chatThreadId}::text, ':user:', ${userId})
-      WHEN ${chatThreadId} IS NULL AND ${source} IN (${threadedSourceList})
-        THEN CONCAT(${source}, ':deleted-thread:user:', ${userId})
-      ELSE CONCAT(${source}, ':run:', ${runId}::text, ':user:', ${userId})
+      WHEN chat_thread_id IS NOT NULL AND source IN (${threadedSourceList})
+        THEN CONCAT(source, ':thread:', chat_thread_id::text, ':user:', user_id)
+      WHEN chat_thread_id IS NULL AND source IN (${threadedSourceList})
+        THEN CONCAT(source, ':deleted-thread:user:', user_id)
+      ELSE CONCAT(source, ':run:', run_id::text, ':user:', user_id)
     END`;
 }
 
 async function queryUsageRecordBreakdown(
   db: Db,
-  userIdLit: string,
-  orgIdLit: string,
+  userId: string | null,
+  orgId: string,
   period: UsagePeriod | null,
   rowKeys: readonly string[],
 ): Promise<Map<string, UsageRecordRow["breakdown"]>> {
@@ -312,19 +335,25 @@ async function queryUsageRecordBreakdown(
     return new Map();
   }
 
-  const userPredicate = userIdLit ? `AND ue.user_id = ${userIdLit}` : "";
+  const userPredicate =
+    userId === null ? sql.empty() : sql`AND ue.user_id = ${userId}`;
   const periodPredicate = period
-    ? `
-          AND ue.created_at AT TIME ZONE 'UTC' >= ${pgLit(period.start.toISOString())}::timestamptz
-          AND ue.created_at AT TIME ZONE 'UTC' < ${pgLit(period.end.toISOString())}::timestamptz`
-    : "";
-  const rowKeyList = rowKeys.map(pgLit).join(", ");
-  const sourceSql = sourceExpr("zr.trigger_source");
-  const kindSql = usageKindExpr("ue.kind");
+    ? sql`
+          AND ue.created_at AT TIME ZONE 'UTC' >= ${period.start.toISOString()}::timestamptz
+          AND ue.created_at AT TIME ZONE 'UTC' < ${period.end.toISOString()}::timestamptz`
+    : sql.empty();
+  const rowKeyList = sql.join(
+    rowKeys.map((rowKey) => {
+      return sql`${rowKey}`;
+    }),
+    sql`, `,
+  );
+  const sourceSql = sourceExpr();
+  const kindSql = usageKindExpr();
 
   const rows = await executeRawRows(
     db,
-    sql.raw(`
+    sql`
       WITH usage_rows AS (
         SELECT
           ${sourceSql} AS source,
@@ -333,18 +362,18 @@ async function queryUsageRecordBreakdown(
           ue.user_id,
           ${kindSql} AS kind,
           COALESCE(NULLIF(ue.provider, ''), 'unknown') AS provider,
-          ${usageCreditsExpr("ue", "uaa")}::bigint AS credits
+          ${usageCreditsExpr()}::bigint AS credits
         FROM usage_event ue
         LEFT JOIN usage_allowance_allocations uaa ON uaa.usage_event_id = ue.id
         INNER JOIN zero_runs zr ON zr.id = ue.run_id
-        WHERE ue.org_id = ${orgIdLit}
+        WHERE ue.org_id = ${orgId}
           ${userPredicate}
           AND ue.status = 'processed'
           ${periodPredicate}
       ),
       keyed AS (
         SELECT
-          ${rowKeyExpr("source", "chat_thread_id", "run_id", "user_id")} AS row_key,
+          ${rowKeyExpr()} AS row_key,
           kind,
           provider,
           credits
@@ -356,7 +385,7 @@ async function queryUsageRecordBreakdown(
       GROUP BY row_key, kind, provider
       HAVING SUM(credits) > 0
       ORDER BY row_key, kind, provider
-    `),
+    `,
     usageRecordBreakdownSqlRowSchema,
   );
 
@@ -443,25 +472,23 @@ export const zeroUsageRecord$ = command(
     }
 
     const db = set(writeDb$);
-    const userIdLit = args.scope === "mine" ? pgLit(args.userId) : "";
-    const orgIdLit = pgLit(args.orgId);
-    const sourceFilterLit = args.source ? pgLit(args.source) : null;
+    const userId = args.scope === "mine" ? args.userId : null;
     const offset = (args.page - 1) * args.pageSize;
-    const recordCte = recordWith(userIdLit, orgIdLit, period);
+    const recordCte = recordWith(userId, args.orgId, period);
 
     signal.throwIfAborted();
     const rows = await queryUsageRecordRows(
       db,
       recordCte,
-      sourceFilterLit,
+      args.source,
       args.pageSize,
       offset,
     );
     signal.throwIfAborted();
     const breakdownByRow = await queryUsageRecordBreakdown(
       db,
-      userIdLit,
-      orgIdLit,
+      userId,
+      args.orgId,
       period,
       rows.map((row) => {
         return row.rowKey;
@@ -471,7 +498,7 @@ export const zeroUsageRecord$ = command(
     const { total, totalCredits } = await queryUsageRecordTotals(
       db,
       recordCte,
-      sourceFilterLit,
+      args.source,
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -190,7 +190,7 @@ function usageEventTokenSum(categories: readonly string[], alias: string) {
     categories.map((category) => {
       return sql`${category}`;
     }),
-    sql.raw(", "),
+    sql`, `,
   );
   return sql`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-sql-raw.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-sql-raw.test.ts
@@ -1,0 +1,108 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, it } from "vitest";
+
+import { noSqlRaw } from "../rules/no-sql-raw.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+ruleTester.run("no-sql-raw", noSqlRaw, {
+  valid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const id = "user-1";
+        sql\`SELECT * FROM users WHERE id = \${id}\`;
+      `,
+    },
+    {
+      code: `
+        const sql = { raw(value: string) { return value; } };
+        sql.raw("SELECT 1");
+      `,
+    },
+    {
+      code: `
+        import { sql as drizzleSql } from "drizzle-orm";
+        function query() {
+          const drizzleSql = { raw(value: string) { return value; } };
+          return drizzleSql.raw("SELECT 1");
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        sql.raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import { sql as drizzleSql } from "drizzle-orm";
+        drizzleSql.raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import * as drizzle from "drizzle-orm";
+        drizzle.sql.raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const sqlAlias = sql;
+        sqlAlias.raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const raw = sql.raw;
+        raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        sql["raw"]("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+    {
+      code: `
+        import { sql } from "drizzle-orm";
+        const { raw } = sql;
+        raw("SELECT 1");
+      `,
+      errors: [{ messageId: "sqlRaw" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -5,6 +5,7 @@ import { noLoggerInfo } from "./rules/no-logger-info.ts";
 import { noNewPromise } from "./rules/no-new-promise.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
+import { noSqlRaw } from "./rules/no-sql-raw.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
 import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
 import { requireSqlResultMapping } from "./rules/require-sql-result-mapping.ts";
@@ -23,6 +24,7 @@ export const apiLintPlugin = {
     "no-new-promise": noNewPromise,
     "no-package-variable": noPackageVariable,
     "no-store-in-params": noStoreInParams,
+    "no-sql-raw": noSqlRaw,
     "no-test-vi-mocks": noTestViMocks,
     "require-execute-row-schema": requireExecuteRowSchema,
     "require-sql-result-mapping": requireSqlResultMapping,

--- a/turbo/packages/eslint-rules/src/api/rules/no-sql-raw.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-sql-raw.ts
@@ -1,0 +1,120 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  SymbolFlags,
+  type Declaration,
+  type Symbol as TypeScriptSymbol,
+  type TypeChecker,
+} from "typescript";
+
+import { createRule } from "../utils.ts";
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (node.computed && node.property.type === AST_NODE_TYPES.Literal) {
+    return typeof node.property.value === "string" ? node.property.value : null;
+  }
+  return null;
+}
+
+function propertyName(node: TSESTree.Property): string | null {
+  if (!node.computed && node.key.type === AST_NODE_TYPES.Identifier) {
+    return node.key.name;
+  }
+  if (node.key.type === AST_NODE_TYPES.Literal) {
+    return typeof node.key.value === "string" ? node.key.value : null;
+  }
+  return null;
+}
+
+function isDrizzleDeclaration(node: Declaration): boolean {
+  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
+  return sourcePath.includes("/node_modules/drizzle-orm/");
+}
+
+function isDrizzleSymbol(
+  checker: TypeChecker,
+  symbol: TypeScriptSymbol | undefined,
+): boolean {
+  if (symbol?.declarations?.some(isDrizzleDeclaration) === true) {
+    return true;
+  }
+  const aliased =
+    symbol === undefined || (symbol.flags & SymbolFlags.Alias) === 0
+      ? symbol
+      : checker.getAliasedSymbol(symbol);
+  return aliased?.declarations?.some(isDrizzleDeclaration) === true;
+}
+
+export const noSqlRaw = createRule({
+  name: "no-sql-raw",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Drizzle sql.raw because it bypasses parameter binding",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      sqlRaw:
+        "Drizzle sql.raw bypasses parameter binding. Compose SQL with the sql tagged template so interpolated values are sent as driver parameters.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function isDrizzleRawMember(node: TSESTree.MemberExpression): boolean {
+      if (memberName(node) !== "raw") {
+        return false;
+      }
+      const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
+      const directSymbol = checker.getSymbolAtLocation(tsProperty);
+      if (isDrizzleSymbol(checker, directSymbol)) {
+        return true;
+      }
+      const tsObject = services.esTreeNodeToTSNodeMap.get(node.object);
+      const objectType = checker.getTypeAtLocation(tsObject);
+      return isDrizzleSymbol(
+        checker,
+        checker.getPropertyOfType(objectType, "raw"),
+      );
+    }
+
+    function destructuresDrizzleRaw(node: TSESTree.Property): boolean {
+      if (
+        node.parent.type !== AST_NODE_TYPES.ObjectPattern ||
+        propertyName(node) !== "raw"
+      ) {
+        return false;
+      }
+      const tsPattern = services.esTreeNodeToTSNodeMap.get(node.parent);
+      const patternType = checker.getTypeAtLocation(tsPattern);
+      return isDrizzleSymbol(
+        checker,
+        checker.getPropertyOfType(patternType, "raw"),
+      );
+    }
+
+    return {
+      MemberExpression(node: TSESTree.MemberExpression): void {
+        if (isDrizzleRawMember(node)) {
+          context.report({ node, messageId: "sqlRaw" });
+        }
+      },
+      Property(node: TSESTree.Property): void {
+        if (destructuresDrizzleRaw(node)) {
+          context.report({ node, messageId: "sqlRaw" });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- replace API `sql.raw(...)` composition with parameterized Drizzle `sql` fragments and schema columns
- remove manual SQL literal escaping from usage insight and usage record queries
- add a type-aware `api/no-sql-raw` rule that covers aliases, namespace imports, computed access, and destructuring
- keep `src/scripts/dev-seed.ts` as the only API exception because PostgreSQL `DO` requires a code literal

## Scope

- no database schema, migration, persisted-data, API, queue, or runner protocol changes
- raw execute result validation and structured result mapping remain unchanged

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-insight.test.ts src/signals/routes/__tests__/zero-usage-record.test.ts src/signals/routes/__tests__/billing-usage-media.bdd.test.ts src/signals/routes/__tests__/zero-billing-auto-recharge.test.ts src/signals/routes/__tests__/storage-presigned-url-cache.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test -- --silent=passed-only`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/eslint-rules`
- `git diff --check`
