### PR TITLE
refactor: retire open design website templates

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -140,8 +140,8 @@ describe("zero generate source-backed artifact commands", () => {
     expect(selection.candidates.templates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "template:saas-landing",
-          description: expect.stringContaining("Single-page SaaS landing"),
+          id: "template:finance-report",
+          description: expect.stringContaining("financial report"),
         }),
       ]),
     );
@@ -162,10 +162,6 @@ describe("zero generate source-backed artifact commands", () => {
     expect(websiteSelection.candidates.templates).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "template:saas-landing",
-          description: expect.stringContaining("Single-page SaaS landing"),
-        }),
-        expect.objectContaining({
           id: "template:warm-cards",
           source: expect.objectContaining({
             path: "warm-cards",
@@ -176,6 +172,7 @@ describe("zero generate source-backed artifact commands", () => {
     );
     expect(websiteSelection.candidates.templates).not.toEqual(
       expect.arrayContaining([
+        expect.objectContaining({ id: "template:saas-landing" }),
         expect.objectContaining({ id: "template:html-ppt-pitch-deck" }),
       ]),
     );
@@ -251,7 +248,7 @@ describe("zero generate source-backed artifact commands", () => {
   });
 
   it("rejects a template that does not target the requested kind", async () => {
-    // saas-landing is a website-only template — should fail for dashboard-design
+    // finance-report only targets report and should fail for dashboard-design
     await expect(async () => {
       await generateCommand.parseAsync([
         "node",
@@ -260,7 +257,7 @@ describe("zero generate source-backed artifact commands", () => {
         "--prompt",
         "a dashboard",
         "--template",
-        "saas-landing",
+        "finance-report",
       ]);
     }).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -53,7 +53,8 @@ describe("zero generate website command", () => {
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain("## Candidate Registry Slice");
     expect(stdout).toContain("observability launch site");
-    expect(stdout).toContain("template:web-prototype-taste-editorial");
+    expect(stdout).toContain("template:black-slabs");
+    expect(stdout).not.toContain("template:web-prototype-taste-editorial");
     expect(stdout).not.toContain("template:html-ppt-pitch-deck");
     expect(stdout).toContain(
       "Write the artifact under `./generated/mockups/clearpath-demo/`.",
@@ -80,28 +81,21 @@ describe("zero generate website command", () => {
     );
   });
 
-  it("should accept --template and --design-system from the registry", async () => {
-    await generateCommand.parseAsync([
-      "node",
-      "cli",
-      "website",
-      "--prompt",
-      "Pricing page for a SaaS",
-      "--template",
-      "saas-landing",
-      "--design-system",
-      "stripe",
-      "--site-slug",
-      "saas-pricing-demo",
-    ]);
+  it("should reject an Open Design website template", async () => {
+    await expect(async () => {
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "website",
+        "--prompt",
+        "Pricing page for a SaaS",
+        "--template",
+        "saas-landing",
+      ]);
+    }).rejects.toThrow("process.exit called");
 
-    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(stdout).toContain(
-      "Selected template: template:saas-landing (Saas Landing)",
-    );
-    expect(stdout).toContain(
-      "Selected design system: design-system:stripe (Stripe)",
-    );
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("Unknown template for website");
   });
 
   it("should accept the built-in R2 website template package", async () => {
@@ -113,6 +107,8 @@ describe("zero generate website command", () => {
       "Kinetic onchain brand studio",
       "--template",
       "dot-matrix",
+      "--design-system",
+      "stripe",
       "--site-slug",
       "dot-matrix-demo",
     ]);
@@ -120,6 +116,9 @@ describe("zero generate website command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(
       "Selected template: template:dot-matrix (Dot Matrix)",
+    );
+    expect(stdout).toContain(
+      "Selected design system: design-system:stripe (Stripe)",
     );
     expect(stdout).toContain(
       "Selected template package: zero resource pull template:dot-matrix --dir ./generated/resources",

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -84,7 +84,7 @@ export const websiteCommand = new Command()
   )
   .option(
     "--template <id>",
-    "Template id from the registry, scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
+    "Template id scoped to website (see Templates below). Accepts either short id or full 'template:<id>'.",
   )
   .addHelpText("after", () => {
     const designSystems = listDesignSystems();
@@ -92,7 +92,7 @@ export const websiteCommand = new Command()
     return `
 Examples:
   Generate site:         zero generate website --prompt "A launch site for a developer observability tool"
-  Pick template:         zero generate website --template saas-landing --prompt "Launch site for a billing API"
+  Pick template:         zero generate website --template black-slabs --prompt "Launch site for a billing API"
   Pick design system:    zero generate website --design-system stripe --prompt "Pricing page for a SaaS"
   Custom site slug:      zero generate website --site-slug api-migration-demo --prompt "An internal migration microsite"
   Pipe prompt:           cat brief.txt | zero generate website

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -125,20 +125,15 @@ describe("website template items", () => {
     expect(findWebsiteTemplateItem("template:web-prototype")).toBeUndefined();
   });
 
-  it("does not expose existing Open Design website templates through the picker catalog", () => {
-    const websiteTemplateIds = WEBSITE_TEMPLATE_ITEMS.flatMap((item) => {
-      return [item.id, item.templateId, item.resourceId];
-    });
-
-    expect(websiteTemplateIds).not.toContain("template:web-prototype");
-    expect(websiteTemplateIds).not.toContain(
-      "template:web-prototype-taste-editorial",
-    );
-    expect(websiteTemplateIds).not.toContain(
-      "template:web-prototype-taste-brutalist",
-    );
-    expect(websiteTemplateIds).not.toContain(
-      "template:web-prototype-taste-soft",
+  it("does not expose Open Design website registry entries", () => {
+    expect(
+      listTemplates("website").map((template) => {
+        return template.id;
+      }),
+    ).toEqual(
+      WEBSITE_TEMPLATE_ITEMS.map((item) => {
+        return item.templateId;
+      }),
     );
   });
 

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -956,15 +956,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     targets: ["report"],
   },
   {
-    id: "template:web-prototype-taste-editorial",
-    kind: "template",
-    name: "Taste Editorial Web Prototype",
-    description:
-      "Editorial-minimalist web prototype with warm monochrome canvas, serif display type, hairline borders, pastel chips, and ambient micro-motion.",
-    source: { path: "design-templates/web-prototype-taste-editorial" },
-    targets: ["website"],
-  },
-  {
     id: "template:audio-jingle",
     kind: "template",
     name: "Audio Jingle",
@@ -972,15 +963,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       "Audio generation skill — jingles, beds, voiceover, and sound effects. Routes music requests to Suno V5 / Udio / Lyria, speech to MiniMax TTS / FishAudio / ElevenLabs V3, and SFX to ElevenLabs SFX or AudioCraft. Output is one MP3/WAV file…",
     source: { path: "design-templates/audio-jingle" },
     targets: ["intro-video"],
-  },
-  {
-    id: "template:blog-post",
-    kind: "template",
-    name: "Blog Post",
-    description:
-      "A long-form article / blog post — masthead, hero image placeholder, article body with figures and pull quotes, author byline, related posts.",
-    source: { path: "design-templates/blog-post" },
-    targets: ["website"],
   },
   {
     id: "template:clinical-case-report",
@@ -999,22 +981,12 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       "Run a 5-dimension expert design review on any HTML artifact in the project — Philosophy / Visual hierarchy / Detail / Functionality / Innovation, each scored 0–10. Outputs a single self-contained HTML report with a radar chart, evidence…",
     source: { path: "design-templates/critique" },
     targets: [
-      "website",
       "dashboard-design",
       "report",
       "docs-design",
       "poster",
       "mobile-app-design",
     ],
-  },
-  {
-    id: "template:dating-web",
-    kind: "template",
-    name: "Dating Web",
-    description:
-      "A consumer-feeling dating / matchmaking dashboard — left rail navigation, ticker bar of community signals, headline KPIs, a 30-day mutual-matches bar chart, and a match-rate trend block. Editorial typography, restrained accent.",
-    source: { path: "design-templates/dating-web" },
-    targets: ["website"],
   },
   {
     id: "template:dcf-valuation",
@@ -1032,16 +1004,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       'A two-spread digital e-guide preview — page 1 is a cover (display title, author, "What\'s inside" stats, table of contents teaser); page 2 is a spread (lesson body with pull-quote and a step list). Lifestyle / creator brand tone.',
     source: { path: "design-templates/digital-eguide" },
-    targets: ["website", "docs-design"],
-  },
-  {
-    id: "template:email-marketing",
-    kind: "template",
-    name: "Email Marketing",
-    description:
-      "A brand product-launch email — masthead with wordmark, hero image block, headline lockup with skewed-italic accent, body copy, primary CTA, and a specifications grid. Pure HTML email layout (centered single column, table fallback).",
-    source: { path: "design-templates/email-marketing" },
-    targets: ["website"],
+    targets: ["docs-design"],
   },
   {
     id: "template:eng-runbook",
@@ -1068,7 +1031,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "A multi-frame gamified mobile-app prototype — three phone frames on a dark showcase stage. Frame 1: cover / poster, Frame 2: today's quests with XP ribbons and a level bar, Frame 3: quest detail. Vivid quest tiles, level ribbon, bottom t…",
     source: { path: "design-templates/gamified-app" },
-    targets: ["website", "mobile-app-design"],
+    targets: ["mobile-app-design"],
   },
   {
     id: "template:github-dashboard",
@@ -1185,15 +1148,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
   },
 
   {
-    id: "template:kami-landing",
-    kind: "template",
-    name: "Kami Landing",
-    description:
-      "Produce a print-grade single-page kami (紙 / 纸) document — warm parchment canvas, ink-blue accent, serif at one weight, no italic, no cool grays. The output reads like a professional white paper or studio one-pager, not an app UI. Multili…",
-    source: { path: "design-templates/kami-landing" },
-    targets: ["website"],
-  },
-  {
     id: "template:kanban-board",
     kind: "template",
     name: "Kanban Board",
@@ -1218,7 +1172,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Create refreshable, auditable artifacts backed by connector or local data. Trigger when the user asks for live dashboards, refreshable reports, synced views, or reusable data-backed artifacts.",
     source: { path: "design-templates/live-artifact" },
-    targets: ["dashboard-design", "report", "website"],
+    targets: ["dashboard-design", "report"],
   },
   {
     id: "template:live-dashboard",
@@ -1265,16 +1219,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     source: { path: "design-templates/motion-frames" },
     targets: ["intro-video"],
   },
-  {
-    id: "template:open-design-landing",
-    kind: "template",
-    name: "Editorial Landing",
-    description:
-      "Single-page editorial landing site in the Atelier Zero visual language (Monocle / Apartamento / Études collage). Composes from a typed inputs.json with optional gpt-image-2 assets.",
-    source: { path: "design-templates/open-design-landing" },
-    targets: ["website"],
-  },
-
   {
     id: "template:orbit-general",
     kind: "template",
@@ -1329,26 +1273,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     source: { path: "design-templates/pm-spec" },
     targets: ["docs-design"],
   },
-  {
-    id: "template:pricing-page",
-    kind: "template",
-    name: "Pricing Page",
-    description:
-      "A standalone pricing page — header, plan tiers, feature comparison table, and an FAQ.",
-    source: { path: "design-templates/pricing-page" },
-    targets: ["website"],
-  },
-
-  {
-    id: "template:saas-landing",
-    kind: "template",
-    name: "Saas Landing",
-    description:
-      "Single-page SaaS landing with hero, features, social proof, pricing, and CTA. Respects the active DESIGN.md color/typography/layout tokens.",
-    source: { path: "design-templates/saas-landing" },
-    targets: ["website"],
-  },
-
   {
     id: "template:social-carousel",
     kind: "template",
@@ -1410,7 +1334,6 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       "Wrap any HTML artifact with a side panel of live, parameterized controls — accent color, type scale, density, motion, theme — that rewrite CSS custom properties in real time and persist to localStorage. Lets the user explore variants of…",
     source: { path: "design-templates/tweaks" },
     targets: [
-      "website",
       "dashboard-design",
       "report",
       "docs-design",
@@ -1428,49 +1351,13 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     targets: ["intro-video"],
   },
   {
-    id: "template:waitlist-page",
-    kind: "template",
-    name: "Waitlist Page",
-    description:
-      "Minimal pre-launch landing with email capture, brand logo, and optional decorative layer. Reads DESIGN.md for colors, typography, and layout rules.",
-    source: { path: "design-templates/waitlist-page" },
-    targets: ["website"],
-  },
-  {
-    id: "template:web-prototype",
-    kind: "template",
-    name: "Web Prototype",
-    description:
-      "General-purpose desktop web prototype. Single self-contained HTML file built by copying the seed `assets/template.html` and pasting section layouts from `references/layouts.md`. Default for any landing / marketing / docs / SaaS page when…",
-    source: { path: "design-templates/web-prototype" },
-    targets: ["website"],
-  },
-  {
-    id: "template:web-prototype-taste-brutalist",
-    kind: "template",
-    name: "Web Prototype Taste Brutalist",
-    description:
-      "Swiss industrial-print web prototype. Newsprint canvas, monolithic black grotesque, viewport-bleeding numerals, hairline grid dividers, hazard-red accent, ASCII syntax decoration. Distilled from Leonxlnx/taste-skill `brutalist-skill` (Sw…",
-    source: { path: "design-templates/web-prototype-taste-brutalist" },
-    targets: ["website"],
-  },
-  {
-    id: "template:web-prototype-taste-soft",
-    kind: "template",
-    name: "Web Prototype Taste Soft",
-    description:
-      "Apple-tier soft web prototype. Silver/cream canvas, double-bezel cards, button-in-button CTAs, generous squircle radii, spring motion, ambient mesh. Distilled from Leonxlnx/taste-skill `soft-skill` + sections 4–8 of `taste-skill`.",
-    source: { path: "design-templates/web-prototype-taste-soft" },
-    targets: ["website"],
-  },
-  {
     id: "template:wireframe-sketch",
     kind: "template",
     name: "Wireframe Sketch",
     description:
       "A hand-drawn wireframe exploration — graph-paper background, marker / pencil tone, multiple tab labels for variants, sticky-note annotations, scribbled chart placeholders, hatched fills. Reads like a designer's whiteboard before any pixe…",
     source: { path: "design-templates/wireframe-sketch" },
-    targets: ["website", "mobile-app-design", "dashboard-design"],
+    targets: ["mobile-app-design", "dashboard-design"],
   },
   {
     id: "template:x-research",

--- a/turbo/packages/core/src/website-template-items.ts
+++ b/turbo/packages/core/src/website-template-items.ts
@@ -12,9 +12,8 @@ export interface WebsiteTemplateItem {
   readonly target: "website";
 }
 
-// Curated user-facing website picker catalog. Keep this separate from the
-// generic Open Design website registry so feature-switched users only see vm0
-// built-in R2-backed website templates.
+// Curated user-facing website picker catalog backed by vm0 private R2
+// packages.
 const WEBSITE_TEMPLATE_PREVIEW_BASE_URL =
   "https://static.vm0.io/vm0/artifact-templates/website/website-studio-v2-20260708-5f944f83";
 


### PR DESCRIPTION
## Summary

- remove the 12 Open Design registry templates whose only generation target was `website`
- remove the `website` target from six mixed-use Open Design templates while preserving their remaining targets
- keep the 11 vm0 private R2-backed website packages as the only website template candidates
- update CLI help, source-selection output, and integration coverage for the retired templates

## User-visible impact

`zero generate website` no longer advertises or resolves Open Design website templates such as `template:saas-landing` and `template:web-prototype`. The vm0 built-in website picker templates continue to resolve through their private R2 packages.

## Verification

- `pnpm exec prettier --check` on all six touched files
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/website-template-items.spec.ts` (8 tests)
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/generate/__tests__/website.test.ts src/commands/zero/generate/__tests__/artifacts.test.ts` (22 tests)
- `pnpm exec knip --workspace @vm0/core --workspace @vm0/cli`
- `git diff --check`

Full local Vitest was not run; PR CI will run the full pipeline.
