### PR TITLE
docs(mitm-addon): clarify usage buffer close contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -197,7 +197,12 @@ def reset_usage_buffer_for_tests(
     flush_owner_lock: _FlushOwnerLock | None = None,
     max_retained_batch_retries: int = MAX_RETAINED_USAGE_BATCH_RETRIES,
 ) -> None:
-    """Cancel pending timer work and replace singleton state for test isolation."""
+    """Destructively replace the singleton buffer for test isolation.
+
+    The existing timer is canceled, while live events, retained retries,
+    delivery bookkeeping, and source idempotency keys are discarded without
+    flushing or waiting for delivery.
+    """
     global _usage_event_buffer
     _usage_event_buffer.close()
     _usage_event_buffer = UsageEventBuffer(

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -179,7 +179,17 @@ class UsageEventBuffer:
             self._flush_usage_events(trigger="shutdown")
 
     def close(self) -> None:
-        """Cancel any pending timer for test cleanup or process shutdown."""
+        """Cancel the pending timer and discard buffered usage state.
+
+        This clears live events, retained retries, active delivery bookkeeping,
+        and source idempotency keys without flushing or waiting for delivery.
+        Callers that need pending usage must first stop producers and complete
+        the appropriate flush and drain lifecycle, including any required
+        delivery wait.
+
+        The instance remains usable with its existing configuration, but its
+        work and source idempotency state starts empty after this call.
+        """
         with self._lock:
             timer = self._pop_timer_locked()
             self._state.clear()


### PR DESCRIPTION
## Summary

- document that `UsageEventBuffer.close()` cancels its timer and discards live, retained, delivery-tracking, and source-idempotency state
- clarify that callers must stop producers and complete required flush/drain delivery work before closing
- document reusable-instance semantics and align the singleton test-reset contract

## Scope

- documentation only; runtime behavior is unchanged
- no tests added because there is no executable behavior change

## Validation

- `.venv/bin/ruff check src/usage/buffer/orchestrator.py src/usage/buffer/__init__.py`
- `.venv/bin/ruff format --check src/usage/buffer/orchestrator.py src/usage/buffer/__init__.py`
- `.venv/bin/basedpyright -p .`
- pre-commit Ruff lint and format hooks

Closes #22277
