### PR TITLE
ci: prevent release pull request app preview domains

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,8 +10,6 @@ concurrency:
 
 jobs:
   cleanup-okou-pages-domain:
-    # Skip for release-please PRs (only version bumps and changelogs)
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1135,8 +1135,10 @@ jobs:
           retention-days: 1
 
   # Build the canonical Cloudflare app artifact independently of Vercel, then
-  # deploy the verified R2 artifact to a Pages preview branch.
+  # deploy the verified R2 artifact to a Pages preview branch. Release PRs keep
+  # the provider preview but do not receive a custom preview domain.
   build-app-cf:
+    needs: [detect-release]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
@@ -1358,10 +1360,17 @@ jobs:
           {
             echo "dist=$pages_dist"
             echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PROJECT_NAME}.pages.dev"
-            : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
-            echo "custom-domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
-            echo "custom-url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Cloudflare Pages custom preview domain
+        id: pages-custom-domain
+        if: needs.detect-release.outputs.skip != 'true' || github.event_name == 'push'
+        env:
+          PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
+        run: |
+          : "${CF_PAGES_PREVIEW_DOMAIN:?CF_PAGES_PREVIEW_DOMAIN variable is required}"
+          echo "domain=${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
+          echo "url=https://${PAGES_BRANCH}.${CF_PAGES_PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cloudflare Pages preview
         env:
@@ -1380,11 +1389,11 @@ jobs:
             --commit-dirty=false
 
       - name: Configure Cloudflare Pages custom preview domain
-        if: steps.pages-preview.outputs.custom-domain != ''
+        if: steps.pages-custom-domain.outputs.domain != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
-          PAGES_CUSTOM_DOMAIN: ${{ steps.pages-preview.outputs.custom-domain }}
+          PAGES_CUSTOM_DOMAIN: ${{ steps.pages-custom-domain.outputs.domain }}
         run: |
           : "${CF_PAGES_PREVIEW_ZONE_ID:?CF_PAGES_PREVIEW_ZONE_ID variable is required}"
           bash .github/scripts/manage-okou-pages-domain.sh \
@@ -1397,7 +1406,7 @@ jobs:
 
       - name: Record Cloudflare Pages preview
         env:
-          PAGES_CUSTOM_URL: ${{ steps.pages-preview.outputs.custom-url }}
+          PAGES_CUSTOM_URL: ${{ steps.pages-custom-domain.outputs.url }}
           PAGES_PREVIEW_URL: ${{ steps.pages-preview.outputs.url }}
         run: |
           echo "Cloudflare Pages preview: ${PAGES_PREVIEW_URL}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- keep Cloudflare Pages provider previews for release-please pull requests without binding `pr-<id>-app.omby.ai`
- preserve the staging custom domain on `main` pushes, including release commits
- run idempotent Pages custom-domain cleanup for every closed pull request so accidental and historical release domains can be removed
- leave runner, database, Clerk, and deployment cleanup release skips unchanged

## User impact

Release-please pull requests no longer consume or leak Omby custom preview domains. Ordinary pull requests continue to receive their App preview domains, and staging publication remains unchanged.

## Verification

- `npx -y prettier@3.8.1 --check .github/workflows/turbo.yml .github/workflows/cleanup.yml`
- `actionlint` v1.7.12
- lefthook pre-commit and commitlint

The PR pipeline will run the repository workflow checks.