### PR TITLE
docs(runner): update storage cache gc documentation

### DIFF
--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -58,8 +58,8 @@ struct StorageEvictionResult {
 /// `<version>.tmp/` staging directories are removed under the final
 /// version's flock so crashed writers do not leak disk indefinitely.
 ///
-/// Missing `storages_dir` is a no-op (cold host before the cache writer
-/// in #10808 lands).
+/// A missing `storages_dir` is a no-op: a host without a populated storage
+/// cache has nothing to collect.
 pub(super) async fn gc_storage_cache(home: &HomePaths, dry_run: bool) -> RunnerResult<GcReport> {
     gc_storage_cache_with_limits_report(
         home,


### PR DESCRIPTION
## Summary

- replace the stale pre-launch reference in the storage cache GC rustdoc
- preserve the missing-directory no-op contract using current cache lifecycle language

## Scope

Documentation only. Runtime behavior and tests are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo doc -p runner --all-features --no-deps`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo test -p runner --all-features`
- `git diff --check`

Closes #22276
