### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.215"
+CLAUDE_CODE_VERSION="2.1.216"
 CODEX_CLI_VERSION="0.144.6"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.3"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.215` to `2.1.216`.

## Verification

- Confirmed `2.1.216` is the latest published Claude Code release.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
- Ran `git diff --check`.