### PR TITLE
perf(api): batch chat search context queries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2095,6 +2095,7 @@ describe("CHAT-01 chat search", () => {
       before: 1,
       after: 0,
     });
+    expect(beforeOnly.results).toHaveLength(3);
     for (const match of beforeOnly.results) {
       expect(match.contextBefore).toHaveLength(1);
       expect(match.contextAfter).toStrictEqual([]);
@@ -2105,6 +2106,7 @@ describe("CHAT-01 chat search", () => {
       before: 0,
       after: 1,
     });
+    expect(afterOnly.results).toHaveLength(3);
     for (const match of afterOnly.results) {
       expect(match.contextBefore).toStrictEqual([]);
       expect(match.contextAfter).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1950,6 +1950,166 @@ describe("CHAT-01 chat search", () => {
       "discount is 50% today",
     );
   }, 60_000);
+
+  it("associates batched context windows across matches and threads", async () => {
+    const owner = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const agentA = await bdd.createAgent(owner, {
+      displayName: "Batched search agent A",
+    });
+    const agentB = await bdd.createAgent(owner, {
+      displayName: "Batched search agent B",
+    });
+    const marker = `batched-${randomUUID()}`;
+    const alphaPrompt = `${marker} needle alpha`;
+    const betaPrompt = `${marker} needle beta`;
+    const gammaPrompt = `${marker} needle gamma`;
+    const sharedPrompt = `${marker} shared bridge`;
+
+    const threadA = await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      prompt: `${marker} first anchor`,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      threadId: threadA,
+      prompt: alphaPrompt,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      threadId: threadA,
+      prompt: sharedPrompt,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      threadId: threadA,
+      prompt: betaPrompt,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      threadId: threadA,
+      prompt: `${marker} final anchor`,
+    });
+
+    const threadB = await sendNoCreditMessage(owner, {
+      agentId: agentB.agentId,
+      prompt: `${marker} second anchor`,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentB.agentId,
+      threadId: threadB,
+      prompt: gammaPrompt,
+    });
+    await sendNoCreditMessage(owner, {
+      agentId: agentB.agentId,
+      threadId: threadB,
+      prompt: `${marker} second tail`,
+    });
+
+    const contextual = await chat.searchChat(owner, `${marker} needle`, {
+      limit: 3,
+      before: 2,
+      after: 2,
+    });
+    expect(contextual.hasMore).toBeFalsy();
+    expect(
+      contextual.results
+        .map((result) => {
+          return result.matchedMessage.content;
+        })
+        .sort(),
+    ).toStrictEqual([alphaPrompt, betaPrompt, gammaPrompt].sort());
+
+    const matchesByContent = new Map(
+      contextual.results.map((result) => {
+        return [result.matchedMessage.content, result] as const;
+      }),
+    );
+    const alpha = matchesByContent.get(alphaPrompt);
+    const beta = matchesByContent.get(betaPrompt);
+    const gamma = matchesByContent.get(gammaPrompt);
+    if (!alpha || !beta || !gamma) {
+      throw new Error("Expected all batched chat-search matches");
+    }
+    expect(alpha.chatThreadId).toBe(threadA);
+    expect(beta.chatThreadId).toBe(threadA);
+    expect(gamma.chatThreadId).toBe(threadB);
+
+    for (const match of contextual.results) {
+      expect(match.contextBefore).toHaveLength(2);
+      expect(match.contextAfter).toHaveLength(2);
+      expect(
+        [...match.contextBefore, ...match.contextAfter].every((message) => {
+          return message.chatThreadId === match.chatThreadId;
+        }),
+      ).toBeTruthy();
+      expect(
+        [...match.contextBefore, ...match.contextAfter].some((message) => {
+          return message.messageId === match.matchedMessage.messageId;
+        }),
+      ).toBeFalsy();
+
+      const matchedAt = Date.parse(match.matchedMessage.createdAt);
+      const beforeTimes = match.contextBefore.map((message) => {
+        return Date.parse(message.createdAt);
+      });
+      const afterTimes = match.contextAfter.map((message) => {
+        return Date.parse(message.createdAt);
+      });
+      expect(
+        beforeTimes.every((createdAt) => {
+          return createdAt < matchedAt;
+        }),
+      ).toBeTruthy();
+      expect(
+        afterTimes.every((createdAt) => {
+          return createdAt > matchedAt;
+        }),
+      ).toBeTruthy();
+      expect(
+        [...beforeTimes].sort((left, right) => {
+          return left - right;
+        }),
+      ).toStrictEqual(beforeTimes);
+      expect(
+        [...afterTimes].sort((left, right) => {
+          return left - right;
+        }),
+      ).toStrictEqual(afterTimes);
+    }
+
+    const sharedAfterAlpha = alpha.contextAfter.filter((message) => {
+      return message.content === sharedPrompt;
+    });
+    const sharedBeforeBeta = beta.contextBefore.filter((message) => {
+      return message.content === sharedPrompt;
+    });
+    // The revoked queue-first duplicate stays hidden, while the visible row
+    // remains associated with both overlapping windows.
+    expect(sharedAfterAlpha).toHaveLength(1);
+    expect(sharedBeforeBeta).toHaveLength(1);
+    expect(sharedAfterAlpha[0]?.messageId).toBe(sharedBeforeBeta[0]?.messageId);
+
+    const beforeOnly = await chat.searchChat(owner, `${marker} needle`, {
+      limit: 3,
+      before: 1,
+      after: 0,
+    });
+    for (const match of beforeOnly.results) {
+      expect(match.contextBefore).toHaveLength(1);
+      expect(match.contextAfter).toStrictEqual([]);
+    }
+
+    const afterOnly = await chat.searchChat(owner, `${marker} needle`, {
+      limit: 3,
+      before: 0,
+      after: 1,
+    });
+    for (const match of afterOnly.results) {
+      expect(match.contextBefore).toStrictEqual([]);
+      expect(match.contextAfter).toHaveLength(1);
+    }
+  }, 60_000);
 });
 
 describe("CHAT-03 thread artifacts and google drive status", () => {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -75,7 +75,7 @@ import {
   pgTextDecoder,
   zodEnumDriverValueDecoder,
 } from "../../lib/db-structured-result";
-import { type Db, db$, writeDb$ } from "../external/db";
+import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import {
   inferMimetype,
   insertAssistantEventMessages$,
@@ -109,14 +109,6 @@ function chatMessageOrderSequenceSql() {
     WHEN ${chatMessages.runLifecycleEvent} IS NOT NULL THEN ${TERMINAL_MESSAGE_ORDER_SEQUENCE}
     ELSE COALESCE(${chatMessages.sequenceNumber}, -1)
   END`;
-}
-
-function matchedMessageCreatedAtSql(messageId: string) {
-  return sql`(
-    SELECT ${matchedChatMessage.createdAt}
-    FROM ${chatMessages} AS matched_chat_message
-    WHERE ${matchedChatMessage.id} = ${messageId}
-  )`;
 }
 
 type ChatMessageRow = {
@@ -192,6 +184,11 @@ type ChatSearchMessageRow = {
   readonly sequenceNumber: number | null;
   readonly runId: string | null;
 };
+
+interface ChatSearchContext {
+  readonly before: ChatSearchMessage[];
+  readonly after: ChatSearchMessage[];
+}
 
 type ChatThreadRow = {
   readonly id: string;
@@ -1605,6 +1602,132 @@ function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
   };
 }
 
+function chatSearchMatchesTable(messageIds: readonly string[]): SQL {
+  return sql`unnest(${sql.param([...messageIds])}::uuid[])
+    WITH ORDINALITY AS chat_search_matches(message_id, result_ordinality)`;
+}
+
+function chatSearchContextSideQuery(
+  db: ReadonlyDb,
+  args: {
+    readonly isBefore: boolean;
+    readonly limit: number;
+  },
+) {
+  return db
+    .select({
+      isBefore: sql`${args.isBefore}::boolean`
+        .mapWith(pgBooleanDecoder)
+        .as("is_before"),
+      ...searchMessageColumns,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, matchedChatMessage.chatThreadId),
+        args.isBefore
+          ? lt(chatMessages.createdAt, matchedChatMessage.createdAt)
+          : gt(chatMessages.createdAt, matchedChatMessage.createdAt),
+        isNotNull(chatMessages.content),
+        visibleChatMessageCondition(),
+        excludeGoalMarkerCondition(),
+      ),
+    )
+    .orderBy(
+      args.isBefore
+        ? desc(chatMessages.createdAt)
+        : asc(chatMessages.createdAt),
+    )
+    .limit(args.limit);
+}
+
+async function loadChatSearchContexts(
+  db: ReadonlyDb,
+  args: {
+    readonly matches: readonly ChatSearchMessageRow[];
+    readonly before: number;
+    readonly after: number;
+  },
+): Promise<ReadonlyMap<string, ChatSearchContext>> {
+  const contextsByMessageId = new Map<string, ChatSearchContext>(
+    args.matches.map((match): readonly [string, ChatSearchContext] => {
+      return [match.messageId, { before: [], after: [] }];
+    }),
+  );
+  if (args.matches.length === 0 || (args.before === 0 && args.after === 0)) {
+    return contextsByMessageId;
+  }
+
+  const contextQuery =
+    args.before > 0
+      ? args.after > 0
+        ? chatSearchContextSideQuery(db, {
+            isBefore: true,
+            limit: args.before,
+          }).unionAll(
+            chatSearchContextSideQuery(db, {
+              isBefore: false,
+              limit: args.after,
+            }),
+          )
+        : chatSearchContextSideQuery(db, {
+            isBefore: true,
+            limit: args.before,
+          })
+      : chatSearchContextSideQuery(db, {
+          isBefore: false,
+          limit: args.after,
+        });
+
+  const context = contextQuery.as("chat_search_context");
+  const resultOrdinality = sql`chat_search_matches.result_ordinality::integer`
+    .mapWith(pgIntegerDecoder)
+    .as("result_ordinality");
+  const rows = await db
+    .select({
+      resultOrdinality,
+      matchedMessageId: matchedChatMessage.id,
+      isBefore: context.isBefore,
+      messageId: context.messageId,
+      chatThreadId: context.chatThreadId,
+      role: context.role,
+      content: context.content,
+      createdAt: context.createdAt,
+      sequenceNumber: context.sequenceNumber,
+      runId: context.runId,
+    })
+    .from(
+      chatSearchMatchesTable(
+        args.matches.map((match) => {
+          return match.messageId;
+        }),
+      ),
+    )
+    .innerJoin(
+      matchedChatMessage,
+      sql`${matchedChatMessage.id} = chat_search_matches.message_id`,
+    )
+    .innerJoinLateral(context, sql`true`)
+    .orderBy(resultOrdinality, asc(context.createdAt));
+
+  for (const row of rows) {
+    const matchedContext = contextsByMessageId.get(row.matchedMessageId);
+    if (!matchedContext) {
+      throw new Error(
+        "chat search context returned an unknown matched message",
+      );
+    }
+    const message = toChatSearchMessage(row);
+    if (row.isBefore) {
+      matchedContext.before.push(message);
+    } else {
+      matchedContext.after.push(message);
+    }
+  }
+
+  return contextsByMessageId;
+}
+
 export function zeroChatSearch(args: {
   readonly userId: string;
   readonly orgId: string;
@@ -1659,58 +1782,24 @@ export function zeroChatSearch(args: {
     const hasMore = matches.length > args.limit;
     const truncated = hasMore ? matches.slice(0, args.limit) : matches;
 
-    const results = await Promise.all(
-      truncated.map(async (match): Promise<ChatSearchResult> => {
-        // Keep the comparison inside Postgres so timestamp microseconds are
-        // not lost when the match is round-tripped through JavaScript Date.
-        const matchedCreatedAt = matchedMessageCreatedAtSql(match.messageId);
-        const [contextBeforeRows, contextAfterRows] = await Promise.all([
-          args.before > 0
-            ? db
-                .select(searchMessageColumns)
-                .from(chatMessages)
-                .where(
-                  and(
-                    eq(chatMessages.chatThreadId, match.chatThreadId),
-                    lt(chatMessages.createdAt, matchedCreatedAt),
-                    isNotNull(chatMessages.content),
-                    visibleChatMessageCondition(),
-                    excludeGoalMarkerCondition(),
-                  ),
-                )
-                .orderBy(desc(chatMessages.createdAt))
-                .limit(args.before)
-            : Promise.resolve([] as ChatSearchMessageRow[]),
-          args.after > 0
-            ? db
-                .select(searchMessageColumns)
-                .from(chatMessages)
-                .where(
-                  and(
-                    eq(chatMessages.chatThreadId, match.chatThreadId),
-                    gt(chatMessages.createdAt, matchedCreatedAt),
-                    isNotNull(chatMessages.content),
-                    visibleChatMessageCondition(),
-                    excludeGoalMarkerCondition(),
-                  ),
-                )
-                .orderBy(asc(chatMessages.createdAt))
-                .limit(args.after)
-            : Promise.resolve([] as ChatSearchMessageRow[]),
-        ]);
-
-        return {
-          chatThreadId: match.chatThreadId,
-          agentName: match.agentName,
-          matchedMessage: toChatSearchMessage(match),
-          contextBefore: contextBeforeRows
-            .slice()
-            .reverse()
-            .map(toChatSearchMessage),
-          contextAfter: contextAfterRows.map(toChatSearchMessage),
-        };
-      }),
-    );
+    const contextsByMessageId = await loadChatSearchContexts(db, {
+      matches: truncated,
+      before: args.before,
+      after: args.after,
+    });
+    const results = truncated.map((match): ChatSearchResult => {
+      const context = contextsByMessageId.get(match.messageId);
+      if (!context) {
+        throw new Error("chat search context is missing a matched message");
+      }
+      return {
+        chatThreadId: match.chatThreadId,
+        agentName: match.agentName,
+        matchedMessage: toChatSearchMessage(match),
+        contextBefore: context.before,
+        contextAfter: context.after,
+      };
+    });
 
     return { results, hasMore };
   });


### PR DESCRIPTION
## Summary

- batch every matched chat message into one ordered PostgreSQL context query
- preserve per-match before/after limits, chronological output, visibility filtering, and overlapping windows
- add route-level integration coverage for multiple matches, multiple threads, overlap, and one-sided windows

At the maximum request size, chat search now performs one match query plus one context query instead of one match query plus up to 100 context queries.

## Scope

- No API contract changes
- No schema, migration, or persisted-data changes
- No cache or cross-deployment compatibility changes

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=4 --silent=passed-only` (25 passed)
- `pnpm -F api build`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- Prettier check and `git diff --check`
- pre-commit full Turbo type check (13 workspaces passed)

Closes #22269

Parent: #21674
