### PR TITLE
feat(api): alert on orphaned queued chat messages

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -12,6 +12,7 @@ import {
   cronComputerUseScreenshotCleanupContract,
   cronDrainEmailOutboxContract,
   cronExecuteWorkflowAutomationsContract,
+  cronMonitorChatMessageQueueContract,
   cronProcessUsageEventsContract,
   cronRenewGoogleCalendarWatchesContract,
   cronRenewGmailWatchesContract,
@@ -45,6 +46,10 @@ function readVercelConfig(): VercelConfig {
 const expectedVercelCrons = [
   {
     path: cronCleanupSandboxesContract.cleanup.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronMonitorChatMessageQueueContract.monitor.path,
     schedule: "* * * * *",
   },
   {

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -25,6 +25,7 @@ import { cronCleanupSandboxesRoutes } from "./routes/cron-cleanup-sandboxes";
 import { cronConnectorCatalogRoutes } from "./routes/cron-connector-catalog";
 import { cronDrainEmailOutboxRoutes } from "./routes/cron-drain-email-outbox";
 import { cronExecuteWorkflowAutomationsRoutes } from "./routes/cron-execute-workflow-automations";
+import { cronMonitorChatMessageQueueRoutes } from "./routes/cron-monitor-chat-message-queue";
 import { cronRenewGmailWatchesRoutes } from "./routes/cron-renew-gmail-watches";
 import { cronRenewGoogleCalendarWatchesRoutes } from "./routes/cron-renew-google-calendar-watches";
 import { cronRenewGoogleWorkspaceEventSubscriptionsRoutes } from "./routes/cron-renew-google-workspace-event-subscriptions";
@@ -249,6 +250,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronConnectorCatalogRoutes,
   ...cronDrainEmailOutboxRoutes,
   ...cronExecuteWorkflowAutomationsRoutes,
+  ...cronMonitorChatMessageQueueRoutes,
   ...cronRenewGmailWatchesRoutes,
   ...cronRenewGoogleCalendarWatchesRoutes,
   ...cronRenewGoogleWorkspaceEventSubscriptionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-message-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-message-queue.test.ts
@@ -1,0 +1,153 @@
+import { cronMonitorChatMessageQueueContract } from "@vm0/api-contracts/contracts/cron";
+import type {
+  TestCronMonitorChatMessageQueueStateActionBody,
+  TestCronMonitorChatMessageQueueStateActionResponse,
+} from "@vm0/api-contracts/contracts/test-cron-monitor-chat-message-queue-state";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createApp } from "../../../app-factory";
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { testCronMonitorChatMessageQueueStateRoutes } from "../test-cron-monitor-chat-message-queue-state";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const CRON_SECRET = "test-cron-secret";
+const STATE_ROUTE = "/api/test/cron-monitor-chat-message-queue-state/action";
+
+interface MonitorFixture {
+  readonly composeId: string;
+}
+
+function apiClient() {
+  return setupApp({ context })(cronMonitorChatMessageQueueContract);
+}
+
+function cronHeaders(secret = CRON_SECRET) {
+  return { authorization: `Bearer ${secret}` };
+}
+
+async function rawCronRequest(
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const app = createApp({ signal: context.signal });
+  return await app.request("/api/cron/monitor-chat-message-queue", {
+    method: "GET",
+    headers,
+  });
+}
+
+async function postState(
+  body: TestCronMonitorChatMessageQueueStateActionBody,
+): Promise<TestCronMonitorChatMessageQueueStateActionResponse> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: testCronMonitorChatMessageQueueStateRoutes,
+  });
+  const response = await app.request(STATE_ROUTE, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `orphan monitor state action failed with ${response.status}`,
+    );
+  }
+  return (await response.json()) as TestCronMonitorChatMessageQueueStateActionResponse;
+}
+
+function stringField(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string") {
+    throw new Error(`orphan monitor state response missing ${key}`);
+  }
+  return value;
+}
+
+async function seedFixture(
+  fixtureKind: Extract<
+    TestCronMonitorChatMessageQueueStateActionBody,
+    { readonly action: "seed-fixture" }
+  >["fixture_kind"],
+): Promise<MonitorFixture> {
+  const response = await postState({
+    action: "seed-fixture",
+    fixture_kind: fixtureKind,
+  });
+  return { composeId: stringField(response, "compose_id") };
+}
+
+async function cleanupFixture(fixture: MonitorFixture): Promise<void> {
+  await postState({
+    action: "delete-fixture",
+    compose_id: fixture.composeId,
+  });
+}
+
+const trackFixture = createFixtureTracker(cleanupFixture);
+
+describe("cron monitor chat message queue", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+  });
+
+  it("requires the cron secret", async () => {
+    const response = await accept(apiClient().monitor({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: { code: "UNAUTHORIZED", message: "Invalid cron secret" },
+    });
+  });
+
+  it("reports zero for legitimate unassociated user messages", async () => {
+    await Promise.all([
+      trackFixture(seedFixture("active-run")),
+      trackFixture(seedFixture("failed-message")),
+      trackFixture(seedFixture("queued-message")),
+      trackFixture(seedFixture("revoked-message")),
+    ]);
+
+    const response = await accept(
+      apiClient().monitor({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
+    });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("raises the existing error alert when an orphan is present", async () => {
+    await trackFixture(seedFixture("orphan"));
+
+    const response = await rawCronRequest(cronHeaders());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: "Internal server error",
+    });
+    expect(
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
+    ).toMatchObject({
+      name: "OrphanedQueuedChatMessagesError",
+      code: "ORPHANED_QUEUED_CHAT_MESSAGES",
+      orphanedMessages: 1,
+    });
+    const [, fields] = context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(fields).toMatchObject({
+      type: "unhandled_request_error",
+      route: "/api/cron/monitor-chat-message-queue",
+      method: "GET",
+      errorCode: "ORPHANED_QUEUED_CHAT_MESSAGES",
+      error: {
+        name: "OrphanedQueuedChatMessagesError",
+        code: "ORPHANED_QUEUED_CHAT_MESSAGES",
+        orphanedMessages: 1,
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/cron-monitor-chat-message-queue.ts
+++ b/turbo/apps/api/src/signals/routes/cron-monitor-chat-message-queue.ts
@@ -1,0 +1,25 @@
+import { cronMonitorChatMessageQueueContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route-entry";
+import { monitorChatMessageQueue$ } from "../services/cron-monitor-chat-message-queue.service";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const monitorChatMessageQueueRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(monitorChatMessageQueue$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronMonitorChatMessageQueueRoutes: readonly RouteEntry[] = [
+  {
+    route: cronMonitorChatMessageQueueContract.monitor,
+    handler: monitorChatMessageQueueRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-message-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-message-queue-state.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  testCronMonitorChatMessageQueueStateContract,
+  type TestCronMonitorChatMessageQueueStateActionBody,
+} from "@vm0/api-contracts/contracts/test-cron-monitor-chat-message-queue-state";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { command } from "ccstate";
+import { eq } from "drizzle-orm";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const actionBody$ = bodyResultOf(
+  testCronMonitorChatMessageQueueStateContract.action,
+);
+
+type FixtureKind = Extract<
+  TestCronMonitorChatMessageQueueStateActionBody,
+  { readonly action: "seed-fixture" }
+>["fixture_kind"];
+
+function actionOk(extra: Record<string, unknown> = {}) {
+  return {
+    status: 200 as const,
+    body: { ok: true as const, ...extra },
+  };
+}
+
+async function seedActiveRun(
+  db: Db,
+  fixture: {
+    readonly composeId: string;
+    readonly orgId: string;
+    readonly threadId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const [session] = await db
+    .insert(agentSessions)
+    .values({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      agentComposeId: fixture.composeId,
+      artifacts: [],
+    })
+    .returning({ id: agentSessions.id });
+  signal.throwIfAborted();
+  if (!session) {
+    throw new Error("Failed to seed orphan monitor session");
+  }
+
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      sessionId: session.id,
+      status: "pending",
+      prompt: "orphan monitor active run fixture",
+    })
+    .returning({ id: agentRuns.id });
+  signal.throwIfAborted();
+  if (!run) {
+    throw new Error("Failed to seed orphan monitor run");
+  }
+
+  await db.insert(zeroRuns).values({
+    id: run.id,
+    triggerSource: "web",
+    chatThreadId: fixture.threadId,
+  });
+  signal.throwIfAborted();
+}
+
+async function seedFixture(
+  db: Db,
+  fixtureKind: FixtureKind,
+  signal: AbortSignal,
+) {
+  const userId = `orphan-monitor-user-${randomUUID()}`;
+  const orgId = `orphan-monitor-org-${randomUUID()}`;
+  const [compose] = await db
+    .insert(agentComposes)
+    .values({
+      userId,
+      orgId,
+      name: `orphan-monitor-${randomUUID()}`,
+    })
+    .returning({ id: agentComposes.id });
+  signal.throwIfAborted();
+  if (!compose) {
+    throw new Error("Failed to seed orphan monitor compose");
+  }
+
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({ userId, agentComposeId: compose.id })
+    .returning({ id: chatThreads.id });
+  signal.throwIfAborted();
+  if (!thread) {
+    throw new Error("Failed to seed orphan monitor thread");
+  }
+
+  const [message] = await db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: thread.id,
+      role: "user",
+      content: "orphan monitor fixture",
+      runId: null,
+      error: fixtureKind === "failed-message" ? "INSUFFICIENT_CREDITS" : null,
+    })
+    .returning({ id: chatMessages.id });
+  signal.throwIfAborted();
+  if (!message) {
+    throw new Error("Failed to seed orphan monitor message");
+  }
+
+  if (fixtureKind === "queued-message") {
+    await db.insert(chatMessageQueue).values({
+      orgId,
+      userId,
+      chatThreadId: thread.id,
+      itemType: "user_message",
+      chatMessageId: message.id,
+    });
+  } else if (fixtureKind === "revoked-message") {
+    await db.insert(chatMessages).values({
+      chatThreadId: thread.id,
+      role: "user",
+      content: "claimed orphan monitor fixture",
+      runId: randomUUID(),
+      revokesMessageId: message.id,
+    });
+  } else if (fixtureKind === "active-run") {
+    await seedActiveRun(
+      db,
+      { composeId: compose.id, orgId, threadId: thread.id, userId },
+      signal,
+    );
+  }
+  signal.throwIfAborted();
+
+  return actionOk({ compose_id: compose.id });
+}
+
+const mutateTestCronMonitorChatMessageQueueState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(actionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const db = set(writeDb$);
+    if (bodyResult.data.action === "seed-fixture") {
+      return await seedFixture(db, bodyResult.data.fixture_kind, signal);
+    }
+
+    await db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, bodyResult.data.compose_id));
+    signal.throwIfAborted();
+    return actionOk();
+  },
+);
+
+export const testCronMonitorChatMessageQueueStateRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: testCronMonitorChatMessageQueueStateContract.action,
+      handler: mutateTestCronMonitorChatMessageQueueState$,
+    },
+  ];

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
@@ -16,9 +16,9 @@ import {
 import { writeDb$ } from "../external/db";
 import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
 
-export const ORPHANED_CHAT_MESSAGE_ERROR_CODE = "ORPHANED_QUEUED_CHAT_MESSAGES";
+const ORPHANED_CHAT_MESSAGE_ERROR_CODE = "ORPHANED_QUEUED_CHAT_MESSAGES";
 
-export class OrphanedQueuedChatMessagesError extends Error {
+class OrphanedQueuedChatMessagesError extends Error {
   readonly code = ORPHANED_CHAT_MESSAGE_ERROR_CODE;
 
   constructor(readonly orphanedMessages: number) {

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-message-queue.service.ts
@@ -1,0 +1,75 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatMessageQueue } from "@vm0/db/schema/chat-message-queue";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { command } from "ccstate";
+import {
+  and,
+  count,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  notExists,
+} from "drizzle-orm";
+
+import { writeDb$ } from "../external/db";
+import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
+
+export const ORPHANED_CHAT_MESSAGE_ERROR_CODE = "ORPHANED_QUEUED_CHAT_MESSAGES";
+
+export class OrphanedQueuedChatMessagesError extends Error {
+  readonly code = ORPHANED_CHAT_MESSAGE_ERROR_CODE;
+
+  constructor(readonly orphanedMessages: number) {
+    super("Orphaned queued chat messages detected");
+    this.name = "OrphanedQueuedChatMessagesError";
+  }
+}
+
+export const monitorChatMessageQueue$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const db = set(writeDb$);
+    const [result] = await db
+      .select({ orphanedMessages: count() })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.role, "user"),
+          isNull(chatMessages.runId),
+          isNotNull(chatMessages.content),
+          isNull(chatMessages.error),
+          visibleChatMessageCondition(),
+          notExists(
+            db
+              .select({ id: chatMessageQueue.id })
+              .from(chatMessageQueue)
+              .where(eq(chatMessageQueue.chatMessageId, chatMessages.id)),
+          ),
+          notExists(
+            db
+              .select({ id: zeroRuns.id })
+              .from(zeroRuns)
+              .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+              .where(
+                and(
+                  eq(zeroRuns.chatThreadId, chatMessages.chatThreadId),
+                  inArray(agentRuns.status, ["queued", "pending", "running"]),
+                ),
+              ),
+          ),
+        ),
+      );
+    signal.throwIfAborted();
+
+    const orphanedMessages = result?.orphanedMessages ?? 0;
+    if (orphanedMessages > 0) {
+      throw new OrphanedQueuedChatMessagesError(orphanedMessages);
+    }
+
+    return {
+      success: true as const,
+      orphanedMessages,
+    };
+  },
+);

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -9,6 +9,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/monitor-chat-message-queue",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/execute-workflow-automations",
       "schedule": "* * * * *"
     },

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -67,6 +67,11 @@ const cronCompactChatThreadSnapshotsResponseSchema = z.object({
   eventsPruned: z.number(),
 });
 
+const cronMonitorChatMessageQueueResponseSchema = z.object({
+  success: z.literal(true),
+  orphanedMessages: z.number().int().nonnegative(),
+});
+
 const cronReconcileBillingEntitlementsResponseSchema = z.object({
   success: z.literal(true),
   downgraded: z.number(),
@@ -304,6 +309,20 @@ export const cronCompactChatThreadSnapshotsContract = c.router({
   },
 });
 
+export const cronMonitorChatMessageQueueContract = c.router({
+  monitor: {
+    method: "GET",
+    path: "/api/cron/monitor-chat-message-queue",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronMonitorChatMessageQueueResponseSchema,
+      401: apiErrorSchema,
+      500: z.object({ error: z.string() }),
+    },
+    summary: "Monitor for orphaned queued chat messages",
+  },
+});
+
 export const cronReconcileBillingEntitlementsContract = c.router({
   reconcile: {
     method: "GET",
@@ -522,6 +541,8 @@ export type CronProcessUsageEventsContract =
   typeof cronProcessUsageEventsContract;
 export type CronCompactChatThreadSnapshotsContract =
   typeof cronCompactChatThreadSnapshotsContract;
+export type CronMonitorChatMessageQueueContract =
+  typeof cronMonitorChatMessageQueueContract;
 export type CronReconcileBillingEntitlementsContract =
   typeof cronReconcileBillingEntitlementsContract;
 export type CronAggregateInsightsContract =

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-message-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-message-queue-state.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+const fixtureKindSchema = z.enum([
+  "active-run",
+  "failed-message",
+  "orphan",
+  "queued-message",
+  "revoked-message",
+]);
+
+export const testCronMonitorChatMessageQueueStateActionBodySchema =
+  z.discriminatedUnion("action", [
+    z.object({
+      action: z.literal("seed-fixture"),
+      fixture_kind: fixtureKindSchema,
+    }),
+    z.object({
+      action: z.literal("delete-fixture"),
+      compose_id: z.string().uuid(),
+    }),
+  ]);
+
+export const testCronMonitorChatMessageQueueStateActionResponseSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .passthrough();
+
+export const testCronMonitorChatMessageQueueStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/cron-monitor-chat-message-queue-state/action",
+    body: testCronMonitorChatMessageQueueStateActionBodySchema,
+    responses: {
+      200: testCronMonitorChatMessageQueueStateActionResponseSchema,
+      404: z.string(),
+    },
+    summary: "Mutate orphaned queued chat message monitor test state",
+  },
+});
+
+export type TestCronMonitorChatMessageQueueStateActionBody = z.infer<
+  typeof testCronMonitorChatMessageQueueStateActionBodySchema
+>;
+export type TestCronMonitorChatMessageQueueStateActionResponse = z.infer<
+  typeof testCronMonitorChatMessageQueueStateActionResponseSchema
+>;
+export type TestCronMonitorChatMessageQueueStateContract =
+  typeof testCronMonitorChatMessageQueueStateContract;


### PR DESCRIPTION
## Summary

- add an authenticated per-minute cron monitor for visible user messages that have no `run_id`, no `chat_message_queue` row, and no active run on their thread
- exclude legitimate queued, revoked, failed, control, and active-run message states to keep the signal specific to true orphans
- send detections through the existing Sentry and Axiom unhandled-error pipeline with stable code `ORPHANED_QUEUED_CHAT_MESSAGES` and an `orphanedMessages` count; return the same count as the healthy rollout metric
- cover cron authentication, false-positive exclusions, and an artificial orphan alert with real-database integration tests

## Verification

- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/cron-monitor-chat-message-queue.test.ts` (3 passed)
- Prettier 3.8.1 check on all changed files

Closes #22295
