### PR TITLE
test(e2e): validate gpt-5.6 luna through zero web

### DIFF
--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -222,17 +222,17 @@ wait_for_chat_assistant_done() {
 # Exports on success:
 #   LAST_RUN_ID    — runId returned by the route
 #   LAST_THREAD_ID — threadId returned by the route (newly created)
-# Usage: send_chat_run_message <agent_id> <prompt>
+# Usage: send_chat_run_message <agent_id> <prompt> <model>
 send_chat_run_message() {
     local agent_id="$1"
     local prompt="$2"
+    local selected_model="$3"
     local payload body
     # realAgentInPreview=true bypasses USE_MOCK_CODEX in the runner so the real
     # codex CLI executes against $OPENAI_API_KEY. Without it, CI's
     # USE_MOCK_CODEX=true env var causes guest-mock-codex to echo the prompt
     # verbatim — see crates/runner/src/executor.rs (insert_codex_env) and
     # guest_mock_codex::build_events.
-    local selected_model="${CODEX_ZERO_SELECTED_MODEL:-gpt-5.5}"
     payload=$(jq -nc \
         --arg agentId "$agent_id" \
         --arg prompt "$prompt" \

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -36,9 +36,12 @@ setup_file() {
     $ZERO_CLI org model-provider setup --type "openai-api-key" --secret "$OPENAI_API_KEY" >/dev/null
     export OPENAI_PROVIDER_ID
     OPENAI_PROVIDER_ID=$(zero_model_provider_id_by_type "openai-api-key")
-    export CODEX_ZERO_SELECTED_MODEL="gpt-5.4-mini"
     configure_codex_zero_model_policy \
-        "$CODEX_ZERO_SELECTED_MODEL" \
+        "gpt-5.4-mini" \
+        "openai-api-key" \
+        "$OPENAI_PROVIDER_ID"
+    configure_codex_zero_model_policy \
+        "gpt-5.6-luna" \
         "openai-api-key" \
         "$OPENAI_PROVIDER_ID"
 
@@ -69,11 +72,14 @@ EOF
         -X POST -d "{\"action\":\"seed-agent\",\"agent_id\":\"$AGENT_ID\",\"display_name\":\"BYOK codex e2e\",\"visibility\":\"private\"}" >/dev/null
 }
 
-teardown_file() {
+teardown() {
     # Best-effort cleanup; never mask the actual test failure.
     if [[ -n "${THREAD_ID:-}" ]]; then
         _codex_zero_curl "/api/zero/chat-threads/$THREAD_ID" -X DELETE >/dev/null 2>&1 || true
     fi
+}
+
+teardown_file() {
     if [[ -n "${AGENT_ID:-}" ]]; then
         $ZERO_CLI agent delete "$AGENT_ID" -y >/dev/null 2>&1 || true
     fi
@@ -83,7 +89,7 @@ teardown_file() {
     fi
 }
 
-@test "t-codex-zero-byok-smoke: full BYOK codex via zero web layer" {
+@test "t-codex-zero-byok-smoke-1: gpt-5.4-mini via zero web layer" {
     # Trigger a real run by hitting the same unified chat endpoint the web
     # composer uses. This both creates the thread (with eager-pin) and
     # dispatches the codex run in one call. Sets LAST_RUN_ID + LAST_THREAD_ID.
@@ -93,7 +99,8 @@ teardown_file() {
     # LAST_THREAD_ID / LAST_RUN_ID would arrive empty. The helper returns
     # non-zero on failure, which fails the test naturally.
     send_chat_run_message "$AGENT_ID" \
-        "Compute 123+456 and reply with exactly: RESULT=<answer>"
+        "Compute 123+456 and reply with exactly: RESULT=<answer>" \
+        "gpt-5.4-mini"
 
     THREAD_ID="$LAST_THREAD_ID"
     [[ -n "$THREAD_ID" ]] || fail "Could not extract thread id from chat/messages response"
@@ -111,4 +118,19 @@ teardown_file() {
     # key the run cannot produce the sentinel.
     [[ "$LAST_MSG_CONTENT" == *"RESULT=579"* ]] \
         || fail "Expected 'RESULT=579' in assistant content, got: $LAST_MSG_CONTENT"
+}
+
+@test "t-codex-zero-byok-smoke-2: gpt-5.6-luna via zero web layer" {
+    send_chat_run_message "$AGENT_ID" \
+        "Compute 234+567 and reply with exactly: LUNA_RESULT=<answer>" \
+        "gpt-5.6-luna"
+
+    THREAD_ID="$LAST_THREAD_ID"
+    [[ -n "$THREAD_ID" ]] || fail "Could not extract thread id from chat/messages response"
+    export THREAD_ID
+
+    wait_for_chat_assistant_done "$THREAD_ID"
+
+    [[ "$LAST_MSG_CONTENT" == *"LUNA_RESULT=801"* ]] \
+        || fail "Expected 'LUNA_RESULT=801' in assistant content, got: $LAST_MSG_CONTENT"
 }


### PR DESCRIPTION
## Summary

- keep the existing `gpt-5.4-mini` real Codex BYOK baseline
- add a serialized `gpt-5.6-luna` run through the Zero Web Chat `/api/zero/chat/messages` endpoint
- configure both model policies against the CI OpenAI BYOK provider and pass the selected model explicitly to the chat helper
- clean up each generated chat thread after its scenario

## Impact

The runner E2E suite now verifies the complete Luna path from Zero model policy resolution and Web Chat dispatch through a real Codex execution and assistant response.

## Verification

- `bash -n e2e/helpers/codex-zero.bash`
- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t-codex-zero-byok-smoke.bats` (2 tests discovered)
- `git diff --check`
- real model execution is delegated to the PR `cli-e2e-03-runner` pipeline
