### PR TITLE
fix(vsock-host): isolate chunked private writes

### DIFF
--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -5,7 +5,7 @@ mod write;
 use std::collections::{BTreeSet, HashMap};
 use std::io;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 
 use shell_quote::quote_shell_arg;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
@@ -23,8 +23,9 @@ pub(crate) struct FileWritePathLocks {
 }
 
 struct FileWritePathLockEntry {
-    lock: Weak<RwLock<()>>,
-    users: usize,
+    lock: Arc<RwLock<()>>,
+    // Includes operations waiting to acquire the lock as well as guard holders.
+    reservations: usize,
 }
 
 struct FileWritePathLockReservation<'a> {
@@ -80,21 +81,17 @@ impl FileWritePathLocks {
 
     fn reserve(&self, path: PathBuf) -> FileWritePathLockReservation<'_> {
         let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
-        let lock = entries.get_mut(&path).and_then(|entry| {
-            entry.lock.upgrade().inspect(|_| {
-                assert_ne!(entry.users, usize::MAX);
-                entry.users += 1;
-            })
-        });
-        let lock = if let Some(lock) = lock {
-            lock
+        let lock = if let Some(entry) = entries.get_mut(&path) {
+            assert_ne!(entry.reservations, usize::MAX);
+            entry.reservations += 1;
+            Arc::clone(&entry.lock)
         } else {
             let lock = Arc::new(RwLock::new(()));
             entries.insert(
                 path.clone(),
                 FileWritePathLockEntry {
-                    lock: Arc::downgrade(&lock),
-                    users: 1,
+                    lock: Arc::clone(&lock),
+                    reservations: 1,
                 },
             );
             lock
@@ -121,6 +118,8 @@ impl<'a> FileWritePathGuard<'a> {
 
 impl Drop for FileWritePathGuard<'_> {
     fn drop(&mut self) {
+        // Release destination ownership before the reservation can remove its
+        // registry entry and allow a new lock for the same path to be created.
         match self.guard.take() {
             Some(FileWritePathGuardKind::Shared(guard)) => drop(guard),
             Some(FileWritePathGuardKind::Exclusive(guard)) => drop(guard),
@@ -137,13 +136,12 @@ impl Drop for FileWritePathLockReservation<'_> {
             .entries
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        let reservation_lock = Arc::downgrade(&self.lock);
         let remove = if let Some(entry) = entries.get_mut(&self.path)
-            && Weak::ptr_eq(&entry.lock, &reservation_lock)
+            && Arc::ptr_eq(&entry.lock, &self.lock)
         {
-            assert!(entry.users > 0);
-            entry.users -= 1;
-            entry.users == 0
+            assert!(entry.reservations > 0);
+            entry.reservations -= 1;
+            entry.reservations == 0
         } else {
             false
         };

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -2,9 +2,13 @@ mod copy;
 mod read;
 mod write;
 
+use std::collections::{BTreeSet, HashMap};
 use std::io;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, Weak};
 
 use shell_quote::quote_shell_arg;
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 use crate::exec_operation;
 
@@ -12,6 +16,142 @@ pub use copy::{CopyFileOptions, CopyFileResult};
 pub use write::WriteFileEntry;
 
 const MISSING_FILE_EXIT_CODE: i32 = 66;
+
+#[derive(Default)]
+pub(crate) struct FileWritePathLocks {
+    entries: Mutex<HashMap<PathBuf, FileWritePathLockEntry>>,
+}
+
+struct FileWritePathLockEntry {
+    lock: Weak<RwLock<()>>,
+    users: usize,
+}
+
+struct FileWritePathLockReservation<'a> {
+    owner: &'a FileWritePathLocks,
+    path: PathBuf,
+    lock: Arc<RwLock<()>>,
+}
+
+enum FileWritePathGuardKind {
+    Shared(OwnedRwLockReadGuard<()>),
+    Exclusive(OwnedRwLockWriteGuard<()>),
+}
+
+struct FileWritePathGuard<'a> {
+    guard: Option<FileWritePathGuardKind>,
+    reservation: Option<FileWritePathLockReservation<'a>>,
+}
+
+impl FileWritePathLocks {
+    async fn acquire_shared(&self, path: &str) -> FileWritePathGuard<'_> {
+        let reservation = self.reserve(PathBuf::from(path));
+        let guard = Arc::clone(&reservation.lock).read_owned().await;
+        FileWritePathGuard::new(FileWritePathGuardKind::Shared(guard), reservation)
+    }
+
+    async fn acquire_shared_many<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a str>,
+    ) -> Vec<FileWritePathGuard<'_>> {
+        let reservations = paths
+            .into_iter()
+            .map(PathBuf::from)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|path| self.reserve(path))
+            .collect::<Vec<_>>();
+        let mut guards = Vec::with_capacity(reservations.len());
+        for reservation in reservations {
+            let guard = Arc::clone(&reservation.lock).read_owned().await;
+            guards.push(FileWritePathGuard::new(
+                FileWritePathGuardKind::Shared(guard),
+                reservation,
+            ));
+        }
+        guards
+    }
+
+    async fn acquire_exclusive(&self, path: &str) -> FileWritePathGuard<'_> {
+        let reservation = self.reserve(PathBuf::from(path));
+        let guard = Arc::clone(&reservation.lock).write_owned().await;
+        FileWritePathGuard::new(FileWritePathGuardKind::Exclusive(guard), reservation)
+    }
+
+    fn reserve(&self, path: PathBuf) -> FileWritePathLockReservation<'_> {
+        let mut entries = self.entries.lock().unwrap_or_else(|err| err.into_inner());
+        let lock = entries.get_mut(&path).and_then(|entry| {
+            entry.lock.upgrade().inspect(|_| {
+                assert_ne!(entry.users, usize::MAX);
+                entry.users += 1;
+            })
+        });
+        let lock = if let Some(lock) = lock {
+            lock
+        } else {
+            let lock = Arc::new(RwLock::new(()));
+            entries.insert(
+                path.clone(),
+                FileWritePathLockEntry {
+                    lock: Arc::downgrade(&lock),
+                    users: 1,
+                },
+            );
+            lock
+        };
+        FileWritePathLockReservation {
+            owner: self,
+            path,
+            lock,
+        }
+    }
+}
+
+impl<'a> FileWritePathGuard<'a> {
+    fn new(
+        guard: FileWritePathGuardKind,
+        reservation: FileWritePathLockReservation<'a>,
+    ) -> FileWritePathGuard<'a> {
+        FileWritePathGuard {
+            guard: Some(guard),
+            reservation: Some(reservation),
+        }
+    }
+}
+
+impl Drop for FileWritePathGuard<'_> {
+    fn drop(&mut self) {
+        match self.guard.take() {
+            Some(FileWritePathGuardKind::Shared(guard)) => drop(guard),
+            Some(FileWritePathGuardKind::Exclusive(guard)) => drop(guard),
+            None => {}
+        }
+        drop(self.reservation.take());
+    }
+}
+
+impl Drop for FileWritePathLockReservation<'_> {
+    fn drop(&mut self) {
+        let mut entries = self
+            .owner
+            .entries
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let reservation_lock = Arc::downgrade(&self.lock);
+        let remove = if let Some(entry) = entries.get_mut(&self.path)
+            && Weak::ptr_eq(&entry.lock, &reservation_lock)
+        {
+            assert!(entry.users > 0);
+            entry.users -= 1;
+            entry.users == 0
+        } else {
+            false
+        };
+        if remove {
+            entries.remove(&self.path);
+        }
+    }
+}
 
 fn validate_guest_file_path(path: &str) -> io::Result<()> {
     if path.is_empty() {

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -437,6 +437,9 @@ impl VsockHost {
 
     /// Write a private runtime file on the guest and report before each
     /// helper frame is written to the guest.
+    ///
+    /// This uses the destination-isolation semantics documented on
+    /// [`write_private_file`](Self::write_private_file).
     pub async fn write_private_file_with_write_observer(
         &self,
         path: &str,

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -424,6 +424,12 @@ impl VsockHost {
     /// chunk creates or truncates the final file through private runtime-file
     /// semantics; later chunks append to the same file. A failed chunk leaves
     /// the run failed and may leave a partial private runtime file behind.
+    ///
+    /// Within one [`VsockHost`], a chunked private write excludes other writes
+    /// whose destinations compare equal as [`std::path::Path`] values until
+    /// the call finishes. This does not coordinate guest processes, other
+    /// connections, hard links, or aliases that depend on guest filesystem
+    /// state.
     pub async fn write_private_file(&self, path: &str, content: &[u8]) -> io::Result<()> {
         self.write_private_file_with_write_observer(path, content, FrameWriteObserver::default())
             .await
@@ -439,15 +445,18 @@ impl VsockHost {
     ) -> io::Result<()> {
         validate_guest_file_path(path)?;
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
+            let request = WriteFileChunkRequest::private(path, content, false);
+            validate_write_file_chunk_request(request)?;
+            let _path_guard = self.file_write_path_locks.acquire_shared(path).await;
             return self
-                .write_file_chunk(
-                    WriteFileChunkRequest::private(path, content, false),
-                    WriteFileChunkTracking::Tracked,
-                    write_observer,
-                )
+                .write_file_chunk(request, WriteFileChunkTracking::Tracked, write_observer)
                 .await;
         }
 
+        for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
+            validate_write_file_chunk_request(WriteFileChunkRequest::private(path, chunk, i > 0))?;
+        }
+        let _path_guard = self.file_write_path_locks.acquire_exclusive(path).await;
         let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
         let result = async {
             for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
@@ -483,15 +492,15 @@ impl VsockHost {
     ) -> io::Result<()> {
         validate_guest_file_path(path)?;
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
+            let request = WriteFileChunkRequest::standard(path, content, sudo, false);
+            validate_write_file_chunk_request(request)?;
+            let _path_guard = self.file_write_path_locks.acquire_shared(path).await;
             return self
-                .write_file_chunk(
-                    WriteFileChunkRequest::standard(path, content, sudo, false),
-                    WriteFileChunkTracking::Tracked,
-                    write_observer,
-                )
+                .write_file_chunk(request, WriteFileChunkTracking::Tracked, write_observer)
                 .await;
         }
 
+        let _path_guard = self.file_write_path_locks.acquire_shared(path).await;
         let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
 
         // Write chunks to a per-call temp file, then atomic rename. The
@@ -622,6 +631,10 @@ impl VsockHost {
         }
         vsock_proto::validate_write_files(&proto_entries).map_err(protocol_invalid_input)?;
 
+        let _path_guards = self
+            .file_write_path_locks
+            .acquire_shared_many(files.iter().map(|file| file.path))
+            .await;
         let _file_write_guard = self.shared.file_write_gate.lock().await;
         let timeout = Duration::from_secs(300);
         let resp = normal_request_on_shared_with_write_observer_frame_builder(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -461,6 +461,7 @@ enum ConnectionCloseKind {
 /// appropriate caller.
 pub struct VsockHost {
     shared: Arc<Shared>,
+    file_write_path_locks: file::FileWritePathLocks,
     _reader: JoinHandle<()>,
     /// Raw fd of the underlying socket, used for shutdown on Drop.
     ///
@@ -973,6 +974,7 @@ impl VsockHost {
 
         Ok(Self {
             shared,
+            file_write_path_locks: file::FileWritePathLocks::default(),
             _reader: reader,
             fd,
         })

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::Poll;
 use std::time::Duration;
 
 use shell_quote::quote_shell_arg;
@@ -11,7 +14,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use vsock_proto::{
     ExecOutputPolicy, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
 };
 
 use super::super::support::{
@@ -21,9 +24,12 @@ use super::super::support::{
 };
 use super::support::{
     ExecStartFrame, WriteFileFrame, expect_exec_start, expect_write_file, send_guest_error,
-    send_write_file_failure, send_write_file_success, spawn_write_file, spawn_write_private_file,
+    send_write_file_failure, send_write_file_success, send_write_files_success, spawn_write_file,
+    spawn_write_private_file,
 };
-use crate::{FrameWriteObserver, VsockHost, operation_tracker::NormalOperationReadiness};
+use crate::{
+    FrameWriteObserver, VsockHost, WriteFileEntry, operation_tracker::NormalOperationReadiness,
+};
 use crate::{exec_operation, file as file_impl};
 
 struct ChunkedWriteFixture {
@@ -126,6 +132,17 @@ fn assert_helper_exec_capture_policy(frame: &ExecStartFrame) {
     assert_eq!(frame.stdout, capture_policy);
     assert_eq!(frame.stderr, capture_policy);
     assert!(frame.expected_exit_codes.is_empty());
+}
+
+async fn poll_once_pending<F: Future>(mut future: Pin<&mut F>) {
+    std::future::poll_fn(|cx| {
+        assert!(
+            future.as_mut().poll(cx).is_pending(),
+            "write future unexpectedly completed"
+        );
+        Poll::Ready(())
+    })
+    .await;
 }
 
 fn helper_exec_capture_policy() -> ExecOutputPolicy {
@@ -470,6 +487,185 @@ async fn write_private_file_chunked_writes_final_path_without_rename() {
 }
 
 #[tokio::test]
+async fn write_private_file_chunked_serializes_equivalent_destinations() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let content_a = vec![0xAA; chunk_limit + 1];
+    let content_b = vec![0xBB; chunk_limit + 1];
+    let mut write_a = Box::pin(host.write_private_file("/tmp/private-serialized.bin", &content_a));
+    let mut write_b =
+        Box::pin(host.write_private_file("/tmp/./private-serialized.bin", &content_b));
+
+    let first_a = tokio::select! {
+        _ = write_a.as_mut() => panic!("first private write completed before its first response"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    poll_once_pending(write_b.as_mut()).await;
+    assert_eq!(first_a.path, "/tmp/private-serialized.bin");
+    assert_eq!(first_a.content.len(), chunk_limit);
+    assert_eq!(first_a.content.first(), Some(&0xAA));
+    assert!(!first_a.append);
+    assert!(first_a.private);
+    send_write_file_success(&mut guest, first_a.seq()).await;
+
+    let second_a = tokio::select! {
+        _ = write_a.as_mut() => panic!("first private write completed before its append"),
+        _ = write_b.as_mut() => panic!("second private write completed while the first held the destination"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(second_a.path, "/tmp/private-serialized.bin");
+    assert_eq!(second_a.content, [0xAA]);
+    assert!(second_a.append);
+    assert!(second_a.private);
+    send_write_file_success(&mut guest, second_a.seq()).await;
+    write_a.await.unwrap();
+
+    let first_b = tokio::select! {
+        _ = write_b.as_mut() => panic!("second private write completed before its first frame"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(first_b.path, "/tmp/./private-serialized.bin");
+    assert_eq!(first_b.content.len(), chunk_limit);
+    assert_eq!(first_b.content.first(), Some(&0xBB));
+    assert!(!first_b.append);
+    assert!(first_b.private);
+    send_write_file_success(&mut guest, first_b.seq()).await;
+
+    let second_b = tokio::select! {
+        _ = write_b.as_mut() => panic!("second private write completed before its append"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(second_b.path, "/tmp/./private-serialized.bin");
+    assert_eq!(second_b.content, [0xBB]);
+    assert!(second_b.append);
+    assert!(second_b.private);
+    send_write_file_success(&mut guest, second_b.seq()).await;
+    write_b.await.unwrap();
+}
+
+#[tokio::test]
+async fn write_private_file_chunked_excludes_ordinary_and_batch_writes() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let target = "/tmp/private-exclusive.bin";
+    let private_content = ChunkedWriteFixture::two_chunk_content();
+    let mut private_write = Box::pin(host.write_private_file(target, &private_content));
+
+    let first_private = tokio::select! {
+        _ = private_write.as_mut() => panic!("private write completed before its first response"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(first_private.path, target);
+    assert!(!first_private.append);
+    assert!(first_private.private);
+
+    let mut ordinary_write = Box::pin(host.write_file(target, b"ordinary", false));
+    let batch_entries = [WriteFileEntry {
+        path: target,
+        content: b"batch",
+    }];
+    let mut batch_write = Box::pin(host.write_files(&batch_entries));
+    poll_once_pending(ordinary_write.as_mut()).await;
+    poll_once_pending(batch_write.as_mut()).await;
+
+    send_write_file_success(&mut guest, first_private.seq()).await;
+    let second_private = tokio::select! {
+        _ = private_write.as_mut() => panic!("private write completed before its append"),
+        _ = ordinary_write.as_mut() => panic!("ordinary write completed while private write held the destination"),
+        _ = batch_write.as_mut() => panic!("batch write completed while private write held the destination"),
+        msg = read_guest_message(&mut guest) => msg,
+    };
+    assert_eq!(second_private.msg_type, MSG_WRITE_FILE);
+    let (path, content, sudo, append, private) =
+        vsock_proto::decode_write_file(&second_private.payload).unwrap();
+    assert_eq!(path, target);
+    assert_eq!(content.len(), 100);
+    assert!(!sudo);
+    assert!(append);
+    assert!(private);
+    send_write_file_success(&mut guest, second_private.seq).await;
+    private_write.await.unwrap();
+
+    let guest_drive = async {
+        let mut saw_ordinary = false;
+        let mut saw_batch = false;
+        while !(saw_ordinary && saw_batch) {
+            let msg = read_guest_message(&mut guest).await;
+            match msg.msg_type {
+                MSG_WRITE_FILE => {
+                    assert!(!saw_ordinary);
+                    let (path, content, sudo, append, private) =
+                        vsock_proto::decode_write_file(&msg.payload).unwrap();
+                    assert_eq!(path, target);
+                    assert_eq!(content, b"ordinary");
+                    assert!(!sudo);
+                    assert!(!append);
+                    assert!(!private);
+                    saw_ordinary = true;
+                    send_write_file_success(&mut guest, msg.seq).await;
+                }
+                MSG_WRITE_FILES => {
+                    assert!(!saw_batch);
+                    let files = vsock_proto::decode_write_files(&msg.payload).unwrap();
+                    assert_eq!(files.len(), 1);
+                    assert_eq!(files[0].path, target);
+                    assert_eq!(files[0].content, b"batch");
+                    saw_batch = true;
+                    send_write_files_success(&mut guest, msg.seq).await;
+                }
+                _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
+            }
+        }
+    };
+    let ((), ordinary_result, batch_result) =
+        tokio::join!(guest_drive, ordinary_write.as_mut(), batch_write.as_mut());
+    ordinary_result.unwrap();
+    batch_result.unwrap();
+}
+
+#[tokio::test]
+async fn write_private_file_chunked_allows_independent_path_progress() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let private_content = ChunkedWriteFixture::two_chunk_content();
+    let mut private_write =
+        Box::pin(host.write_private_file("/tmp/private-progress.bin", &private_content));
+
+    let first_private = tokio::select! {
+        _ = private_write.as_mut() => panic!("private write completed before its first response"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(first_private.path, "/tmp/private-progress.bin");
+    assert!(!first_private.append);
+    assert!(first_private.private);
+
+    let mut independent_write =
+        Box::pin(host.write_file("/tmp/independent.bin", b"independent", false));
+    poll_once_pending(independent_write.as_mut()).await;
+    send_write_file_success(&mut guest, first_private.seq()).await;
+
+    let independent = tokio::select! {
+        _ = private_write.as_mut() => panic!("private write completed before its append"),
+        _ = independent_write.as_mut() => panic!("independent write completed before its response"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(independent.path, "/tmp/independent.bin");
+    assert_eq!(independent.content, b"independent");
+    assert!(!independent.append);
+    assert!(!independent.private);
+    send_write_file_success(&mut guest, independent.seq()).await;
+    independent_write.await.unwrap();
+
+    let second_private = tokio::select! {
+        _ = private_write.as_mut() => panic!("private write completed before its append"),
+        frame = expect_write_file(&mut guest) => frame,
+    };
+    assert_eq!(second_private.path, "/tmp/private-progress.bin");
+    assert!(second_private.append);
+    assert!(second_private.private);
+    send_write_file_success(&mut guest, second_private.seq()).await;
+    private_write.await.unwrap();
+}
+
+#[tokio::test]
 async fn write_private_file_chunked_guest_failure_releases_tracker() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -547,7 +743,19 @@ async fn write_private_file_chunked_cancelled_before_first_frame_write_releases_
         NormalOperationReadiness::Idle
     );
 
+    let successor = spawn_write_file(
+        Arc::clone(&host),
+        "/tmp/private-blocked.env",
+        b"replacement".to_vec(),
+        false,
+    );
     drop(writer_guard);
+    let successor_frame = expect_write_file(&mut guest).await;
+    assert_eq!(successor_frame.path, "/tmp/private-blocked.env");
+    assert_eq!(successor_frame.content, b"replacement");
+    assert!(!successor_frame.private);
+    send_write_file_success(&mut guest, successor_frame.seq()).await;
+    successor.await.unwrap().unwrap();
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -544,7 +544,7 @@ async fn write_private_file_chunked_serializes_equivalent_destinations() {
 }
 
 #[tokio::test]
-async fn write_private_file_chunked_excludes_ordinary_and_batch_writes() {
+async fn write_private_file_chunked_excludes_single_private_ordinary_and_batch_writes() {
     let (host, mut guest) = setup_host_and_guest().await;
     let target = "/tmp/private-exclusive.bin";
     let private_content = ChunkedWriteFixture::two_chunk_content();
@@ -559,18 +559,21 @@ async fn write_private_file_chunked_excludes_ordinary_and_batch_writes() {
     assert!(first_private.private);
 
     let mut ordinary_write = Box::pin(host.write_file(target, b"ordinary", false));
+    let mut single_private_write = Box::pin(host.write_private_file(target, b"single-private"));
     let batch_entries = [WriteFileEntry {
         path: target,
         content: b"batch",
     }];
     let mut batch_write = Box::pin(host.write_files(&batch_entries));
     poll_once_pending(ordinary_write.as_mut()).await;
+    poll_once_pending(single_private_write.as_mut()).await;
     poll_once_pending(batch_write.as_mut()).await;
 
     send_write_file_success(&mut guest, first_private.seq()).await;
     let second_private = tokio::select! {
         _ = private_write.as_mut() => panic!("private write completed before its append"),
         _ = ordinary_write.as_mut() => panic!("ordinary write completed while private write held the destination"),
+        _ = single_private_write.as_mut() => panic!("single-frame private write completed while chunked private write held the destination"),
         _ = batch_write.as_mut() => panic!("batch write completed while private write held the destination"),
         msg = read_guest_message(&mut guest) => msg,
     };
@@ -587,20 +590,26 @@ async fn write_private_file_chunked_excludes_ordinary_and_batch_writes() {
 
     let guest_drive = async {
         let mut saw_ordinary = false;
+        let mut saw_single_private = false;
         let mut saw_batch = false;
-        while !(saw_ordinary && saw_batch) {
+        while !(saw_ordinary && saw_single_private && saw_batch) {
             let msg = read_guest_message(&mut guest).await;
             match msg.msg_type {
                 MSG_WRITE_FILE => {
-                    assert!(!saw_ordinary);
                     let (path, content, sudo, append, private) =
                         vsock_proto::decode_write_file(&msg.payload).unwrap();
                     assert_eq!(path, target);
-                    assert_eq!(content, b"ordinary");
                     assert!(!sudo);
                     assert!(!append);
-                    assert!(!private);
-                    saw_ordinary = true;
+                    if private {
+                        assert!(!saw_single_private);
+                        assert_eq!(content, b"single-private");
+                        saw_single_private = true;
+                    } else {
+                        assert!(!saw_ordinary);
+                        assert_eq!(content, b"ordinary");
+                        saw_ordinary = true;
+                    }
                     send_write_file_success(&mut guest, msg.seq).await;
                 }
                 MSG_WRITE_FILES => {
@@ -616,9 +625,14 @@ async fn write_private_file_chunked_excludes_ordinary_and_batch_writes() {
             }
         }
     };
-    let ((), ordinary_result, batch_result) =
-        tokio::join!(guest_drive, ordinary_write.as_mut(), batch_write.as_mut());
+    let ((), ordinary_result, single_private_result, batch_result) = tokio::join!(
+        guest_drive,
+        ordinary_write.as_mut(),
+        single_private_write.as_mut(),
+        batch_write.as_mut()
+    );
     ordinary_result.unwrap();
+    single_private_result.unwrap();
     batch_result.unwrap();
 }
 


### PR DESCRIPTION
## Summary

- add connection-local, per-destination reader/writer coordination for guest file writes
- hold exclusive destination access across each chunked private truncate-and-append transaction while ordinary, batch, and single-frame private writes use shared access
- remove reservation-counted registry entries exactly when the last waiting or active operation leaves, including cancellation, without scanning unrelated paths
- preserve ordinary same-target staging concurrency and allow unrelated destinations to progress between private chunks

## Compatibility and performance

- keeps the existing request-level file-write gate, wire frames, guest helper behavior, tracking, and private-path protections unchanged
- adds one short connection-local map reservation/release pair and an uncontended shared lock on the common write path; only the same lexical destination blocks behind a chunked private write
- introduces no guest, protocol, database, persisted-state, or rollout changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host` (318 passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- `git diff --check`

Closes #22280
