### PR TITLE
fix(guest-agent): warn on skipped artifact entries

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -33,8 +33,15 @@ pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, Ar
 #[cfg(target_os = "linux")]
 fn walk_dir(current: &Dir, relative: &str, out: &mut Vec<FileEntry>) -> Result<(), ArchiveError> {
     let entries = match current.read_dir() {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
+        Ok(entries) => entries,
+        Err(error) => {
+            log_warn!(
+                LOG_TAG,
+                "Could not read artifact directory {:?}: {error}; skipping subtree",
+                artifact_directory_path(relative)
+            );
+            return Ok(());
+        }
     };
     walk_entries(current, relative, entries, out)
 }
@@ -46,46 +53,130 @@ fn walk_entries(
     entries: fs::ReadDir,
     out: &mut Vec<FileEntry>,
 ) -> Result<(), ArchiveError> {
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        if is_excluded_artifact_entry(&name) {
-            continue;
-        }
-
-        let (try_directory, try_file) = match entry.file_type() {
-            Ok(file_type) => (file_type.is_dir(), file_type.is_file()),
-            Err(_) => (true, true),
-        };
-        if try_directory && let Ok(dir) = current.open_child_dir(&name) {
-            let name_str = artifact_path_component(&name, relative)?;
-            let rel = relative_artifact_path(relative, name_str);
-            walk_dir(&dir, &rel, out)?;
-            continue;
-        }
-        if !try_file {
-            continue;
-        }
-
-        let Ok(file) = current.open_child_file(&name) else {
-            continue;
-        };
-        let Ok(metadata) = file.metadata() else {
-            continue;
-        };
-        if !metadata.is_file() {
-            continue;
-        }
-        let name_str = artifact_path_component(&name, relative)?;
-        let rel = relative_artifact_path(relative, name_str);
-        match compute_file_hash_from_reader(file) {
-            Ok((hash, size)) => out.push(FileEntry {
-                path: rel,
-                hash,
-                size,
-            }),
-            Err(e) => {
-                log_warn!(LOG_TAG, "Could not process file {rel}: {e}");
+    for entry_result in entries {
+        match entry_result {
+            Ok(entry) => walk_entry(current, relative, entry, out)?,
+            Err(error) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Could not read artifact directory entry under {:?}: {error}; skipping entry",
+                    artifact_directory_path(relative)
+                );
             }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn walk_entry(
+    current: &Dir,
+    relative: &str,
+    entry: fs::DirEntry,
+    out: &mut Vec<FileEntry>,
+) -> Result<(), ArchiveError> {
+    let name = entry.file_name();
+    if is_excluded_artifact_entry(&name) {
+        return Ok(());
+    }
+
+    let file_type = entry.file_type();
+    let (try_directory, try_file) = match &file_type {
+        Ok(file_type) => (file_type.is_dir(), file_type.is_file()),
+        Err(_) => (true, true),
+    };
+    let mut directory_open_error = None;
+    if try_directory {
+        match current.open_child_dir(&name) {
+            Ok(dir) => {
+                let name_str = artifact_path_component(&name, relative)?;
+                let rel = relative_artifact_path(relative, name_str);
+                walk_dir(&dir, &rel, out)?;
+                return Ok(());
+            }
+            Err(error) if !try_file => {
+                log_warn!(
+                    LOG_TAG,
+                    "Could not open artifact directory {}: {error}; skipping subtree",
+                    artifact_entry_log_path(relative, &name)
+                );
+                return Ok(());
+            }
+            Err(error) => directory_open_error = Some(error),
+        }
+    }
+    if !try_file {
+        return Ok(());
+    }
+
+    let file = match current.open_child_file(&name) {
+        Ok(file) => file,
+        Err(error) => {
+            let path = artifact_entry_log_path(relative, &name);
+            match (&file_type, directory_open_error.as_ref()) {
+                (Err(type_error), Some(directory_error)) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Could not process artifact entry {path}: type lookup failed: {type_error}; directory open failed: {directory_error}; file open failed: {error}; skipping entry"
+                    );
+                }
+                (Err(type_error), None) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Could not process artifact entry {path}: type lookup failed: {type_error}; file open failed: {error}; skipping entry"
+                    );
+                }
+                (Ok(_), _) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Could not open artifact file {path}: {error}; skipping file"
+                    );
+                }
+            }
+            return Ok(());
+        }
+    };
+    let metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            let path = artifact_entry_log_path(relative, &name);
+            if let Err(type_error) = &file_type {
+                log_warn!(
+                    LOG_TAG,
+                    "Could not read metadata for artifact entry {path} after type lookup failed: {type_error}; metadata read failed: {error}; skipping entry"
+                );
+            } else {
+                log_warn!(
+                    LOG_TAG,
+                    "Could not read metadata for artifact file {path}: {error}; skipping file"
+                );
+            }
+            return Ok(());
+        }
+    };
+    if !metadata.is_file() {
+        if file_type.is_ok() {
+            log_warn!(
+                LOG_TAG,
+                "Artifact file {} is no longer a regular file; skipping file",
+                artifact_entry_log_path(relative, &name)
+            );
+        }
+        return Ok(());
+    }
+    let name_str = artifact_path_component(&name, relative)?;
+    let rel = relative_artifact_path(relative, name_str);
+    match compute_file_hash_from_reader(file) {
+        Ok((hash, size)) => out.push(FileEntry {
+            path: rel,
+            hash,
+            size,
+        }),
+        Err(error) => {
+            log_warn!(
+                LOG_TAG,
+                "Could not hash artifact file {rel:?}: {error}; skipping file"
+            );
         }
     }
     Ok(())
@@ -102,6 +193,22 @@ fn relative_artifact_path(parent: &str, component: &str) -> String {
         component.to_string()
     } else {
         format!("{parent}/{component}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn artifact_directory_path(relative: &str) -> &str {
+    if relative.is_empty() { "." } else { relative }
+}
+
+#[cfg(target_os = "linux")]
+fn artifact_entry_log_path(parent: &str, name: &std::ffi::OsStr) -> String {
+    match name.to_str() {
+        Some(component) => format!("{:?}", relative_artifact_path(parent, component)),
+        None => format!(
+            "under {:?} for component {name:?}",
+            artifact_directory_path(parent)
+        ),
     }
 }
 
@@ -564,6 +671,29 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
+    struct SystemLogOverrideGuard;
+
+    impl SystemLogOverrideGuard {
+        fn set(path: &Path) -> Self {
+            guest_common::log::set_system_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SystemLogOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::log::clear_system_log_file();
+        }
+    }
+
+    fn read_system_log(path: &Path) -> io::Result<String> {
+        match std::fs::read_to_string(path) {
+            Ok(content) => Ok(content),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+            Err(error) => Err(error),
+        }
+    }
+
     struct FailingWriter;
 
     impl io::Write for FailingWriter {
@@ -624,6 +754,79 @@ mod tests {
         for fragment in expected_fragments {
             assert!(msg.contains(fragment), "got: {msg}");
         }
+    }
+
+    #[test]
+    fn walk_entry_warns_when_listed_directory_disappears() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        let private = root.join("private");
+        std::fs::create_dir_all(&private).unwrap();
+        std::fs::write(private.join("secret.txt"), "secret").unwrap();
+        let root_dir = Dir::open(&root).unwrap();
+        let entry = std::fs::read_dir(&root).unwrap().next().unwrap().unwrap();
+        std::fs::remove_dir_all(&private).unwrap();
+        let system_log_path = temp.path().join("system.log");
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let mut files = Vec::new();
+
+        walk_entry(&root_dir, "", entry, &mut files).unwrap();
+
+        assert!(files.is_empty());
+        let log = read_system_log(&system_log_path).unwrap();
+        assert!(log.contains("[WARN] [sandbox:guest-agent]"), "got: {log}");
+        assert!(
+            log.contains("Could not open artifact directory \"private\""),
+            "got: {log}"
+        );
+        assert!(log.contains("os error 2"), "got: {log}");
+    }
+
+    #[test]
+    fn walk_entry_warns_when_listed_regular_file_disappears() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        let private_file = root.join("secret.txt");
+        std::fs::write(&private_file, "secret").unwrap();
+        let root_dir = Dir::open(&root).unwrap();
+        let entry = std::fs::read_dir(&root).unwrap().next().unwrap().unwrap();
+        std::fs::remove_file(&private_file).unwrap();
+        let system_log_path = temp.path().join("system.log");
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let mut files = Vec::new();
+
+        walk_entry(&root_dir, "", entry, &mut files).unwrap();
+
+        assert!(files.is_empty());
+        let log = read_system_log(&system_log_path).unwrap();
+        assert!(log.contains("[WARN] [sandbox:guest-agent]"), "got: {log}");
+        assert!(
+            log.contains("Could not open artifact file \"secret.txt\""),
+            "got: {log}"
+        );
+        assert!(log.contains("os error 2"), "got: {log}");
+    }
+
+    #[test]
+    fn collect_file_metadata_silently_skips_intentional_non_regular_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("real.txt"), "hello").unwrap();
+        unix_fs::symlink(root.join("real.txt"), root.join("link.txt")).unwrap();
+        make_fifo(&root.join("pipe")).unwrap();
+        let system_log_path = temp.path().join("system.log");
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "real.txt");
+        assert!(read_system_log(&system_log_path).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -95,11 +95,7 @@ fn walk_entry(
                 return Ok(());
             }
             Err(error) if !try_file => {
-                log_warn!(
-                    LOG_TAG,
-                    "Could not open artifact directory {}: {error}; skipping subtree",
-                    artifact_entry_log_path(relative, &name)
-                );
+                log_directory_open_failure(relative, &name, &error);
                 return Ok(());
             }
             Err(error) => directory_open_error = Some(error),
@@ -210,6 +206,23 @@ fn artifact_entry_log_path(parent: &str, name: &std::ffi::OsStr) -> String {
             artifact_directory_path(parent)
         ),
     }
+}
+
+#[cfg(target_os = "linux")]
+fn log_directory_open_failure(relative: &str, name: &std::ffi::OsStr, error: &io::Error) {
+    // ext filesystems reserve a root-owned `lost+found` at the volume root.
+    // Keep readable or nested directories with that name on the normal path.
+    if relative.is_empty()
+        && name == std::ffi::OsStr::new("lost+found")
+        && error.kind() == io::ErrorKind::PermissionDenied
+    {
+        return;
+    }
+    log_warn!(
+        LOG_TAG,
+        "Could not open artifact directory {}: {error}; skipping subtree",
+        artifact_entry_log_path(relative, name)
+    );
 }
 
 #[cfg(target_os = "linux")]
@@ -827,6 +840,43 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, "real.txt");
         assert!(read_system_log(&system_log_path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn directory_open_warnings_only_suppress_root_lost_found_permission_denied() {
+        let temp = tempfile::tempdir().unwrap();
+        let system_log_path = temp.path().join("system.log");
+        let _system_log_state_guard = crate::lock_system_log_test_state();
+        let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let permission_denied = io::Error::from(io::ErrorKind::PermissionDenied);
+
+        log_directory_open_failure("", OsStr::new("lost+found"), &permission_denied);
+        assert!(read_system_log(&system_log_path).unwrap().is_empty());
+
+        log_directory_open_failure("nested", OsStr::new("lost+found"), &permission_denied);
+        let not_found = io::Error::from(io::ErrorKind::NotFound);
+        log_directory_open_failure("", OsStr::new("lost+found"), &not_found);
+
+        let log = read_system_log(&system_log_path).unwrap();
+        assert_eq!(log.matches("[WARN] [sandbox:guest-agent]").count(), 2);
+        assert!(log.contains("\"nested/lost+found\""), "got: {log}");
+        assert!(
+            log.contains("Could not open artifact directory \"lost+found\""),
+            "got: {log}"
+        );
+    }
+
+    #[test]
+    fn collect_file_metadata_includes_readable_root_lost_found() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(root.join("lost+found")).unwrap();
+        std::fs::write(root.join("lost+found/recovered.txt"), "recovered").unwrap();
+
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "lost+found/recovered.txt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- warn when best-effort artifact traversal skips an unreadable child entry or subtree
- preserve the existing safe directory-then-file fallback when entry type lookup fails
- keep artifact-root failures strict and intentional `.git`, `.vm0`, symlink, FIFO, socket, device, and other non-regular exclusions silent
- silently omit only a root-level, known-directory `lost+found` that cannot be opened because of `PermissionDenied`
- continue traversing readable root-level `lost+found` directories and warning for nested or otherwise failing entries with that name
- add deterministic real-filesystem coverage for disappearing directories/files, the narrow `lost+found` policy, and silent intentional exclusions

## Compatibility

- no API, schema, migration, persisted artifact format, content hash, or checkpoint control-flow changes
- child traversal failures still omit the affected content and allow checkpointing to continue
- the `lost+found` exception changes only warning emission for the expected unreadable filesystem metadata directory

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent artifact::archive` (38 passed)
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- repository pre-commit hooks (`cargo fmt`, workspace rustdoc, workspace Clippy)

Closes #22279
