### PR TITLE
fix(guest-agent): batch queued event delivery

### DIFF
--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -33,6 +33,7 @@ zstd.workspace = true
 httpmock.workspace = true
 nix = { workspace = true, features = ["inotify"] }
 shell-quote.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 vsock-host.workspace = true
 vsock-guest = { workspace = true, features = ["test-support"] }
 vsock-proto.workspace = true

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -73,8 +73,11 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
     let should_send_events = http.has_api();
-    let event_delivery =
-        EventDeliveryRuntime::start(http.clone(), runtime.event_error_flag.to_string());
+    let event_delivery = EventDeliveryRuntime::start(
+        http.clone(),
+        runtime.event_error_flag.to_string(),
+        &runtime.run_id,
+    );
 
     let run_result = run_codex_app_server(
         masker,

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -1,14 +1,16 @@
 //! Shared CLI event delivery worker and acknowledgement state.
 //!
 //! Event schema transformation and HTTP retry details stay in `events` and
-//! `http`; this module owns ordered background delivery shared by CLI backends.
+//! `http`; this module owns bounded non-blocking admission and serial FIFO
+//! backlog batching shared by CLI backends. A batch is one retry/failure unit,
+//! and acknowledgement remains the highest contiguous successful sequence.
 
 use crate::error::AgentError;
 use crate::events;
 use crate::http::HttpClient;
-use guest_common::log_warn;
-use std::io::Write;
+use guest_common::{log_info, log_warn};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio::task::JoinHandle;
@@ -17,54 +19,75 @@ use super::LOG_TAG;
 
 const EVENT_DELIVERY_QUEUE_CAPACITY: usize = 512;
 const EVENT_DELIVERY_MAX_BYTES: usize = 16 * 1024 * 1024;
+const EVENT_DELIVERY_MAX_REQUEST_EVENTS: usize = 32;
+const EVENT_DELIVERY_MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
 const EVENT_DELIVERY_DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
 
 struct PreparedEvent {
     sequence: u32,
-    payload: serde_json::Value,
-    _byte_budget: OwnedSemaphorePermit,
+    event: serde_json::Value,
+    conservative_bytes: usize,
+    byte_budget: OwnedSemaphorePermit,
 }
 
 pub(super) struct EventDeliverySender {
     tx: mpsc::Sender<PreparedEvent>,
     byte_budget: Arc<Semaphore>,
+    pressure: Arc<DeliveryPressure>,
+    run_id: Arc<str>,
 }
 
 impl EventDeliverySender {
     pub(super) fn try_send(
         &self,
         sequence: u32,
-        payload: serde_json::Value,
+        event: serde_json::Value,
     ) -> Result<(), AgentError> {
-        let payload_bytes = serialized_size(&payload)?;
-        if payload_bytes > EVENT_DELIVERY_MAX_BYTES {
+        let conservative_bytes = events::serialized_event_payload_size_for_run_id(
+            std::slice::from_ref(&event),
+            &self.run_id,
+        )?;
+        if conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES {
             return Err(AgentError::Execution(format!(
-                "CLI event delivery payload at sequence {sequence} is {payload_bytes} bytes, exceeding the {EVENT_DELIVERY_MAX_BYTES}-byte buffer limit"
+                "CLI event delivery payload at sequence {sequence} is {conservative_bytes} bytes, exceeding the {EVENT_DELIVERY_MAX_REQUEST_BYTES}-byte request limit"
             )));
         }
 
         let available_bytes = self.byte_budget.available_permits();
         let byte_budget = Arc::clone(&self.byte_budget)
-            .try_acquire_many_owned(payload_bytes as u32)
+            .try_acquire_many_owned(conservative_bytes as u32)
             .map_err(|_| {
                 AgentError::Execution(format!(
-                    "CLI event delivery byte buffer exhausted at sequence {sequence}: payload is {payload_bytes} bytes, {available_bytes} of {EVENT_DELIVERY_MAX_BYTES} bytes available"
+                    "CLI event delivery byte buffer exhausted at sequence {sequence}: payload is {conservative_bytes} bytes, {available_bytes} of {EVENT_DELIVERY_MAX_BYTES} bytes available, {} events pending",
+                    self.pressure.pending_events()
                 ))
             })?;
+        let admission = self.pressure.begin_admission(conservative_bytes);
         let prepared = PreparedEvent {
             sequence,
-            payload,
-            _byte_budget: byte_budget,
+            event,
+            conservative_bytes,
+            byte_budget,
         };
 
         match self.tx.try_send(prepared) {
-            Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(_)) => Err(AgentError::Execution(format!(
-                "CLI event delivery queue exceeded {EVENT_DELIVERY_QUEUE_CAPACITY} pending events at sequence {sequence}"
-            ))),
-            Err(mpsc::error::TrySendError::Closed(_)) => Err(AgentError::Execution(format!(
-                "CLI event delivery worker stopped before sequence {sequence} could be queued"
-            ))),
+            Ok(()) => {
+                self.pressure.confirm_admission(admission);
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.pressure.reject_admission(conservative_bytes);
+                Err(AgentError::Execution(format!(
+                    "CLI event delivery queue exceeded {EVENT_DELIVERY_QUEUE_CAPACITY} pending events at sequence {sequence}; {} bytes buffered",
+                    self.pressure.buffered_bytes()
+                )))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.pressure.reject_admission(conservative_bytes);
+                Err(AgentError::Execution(format!(
+                    "CLI event delivery worker stopped before sequence {sequence} could be queued"
+                )))
+            }
         }
     }
 }
@@ -72,17 +95,32 @@ impl EventDeliverySender {
 pub(super) struct EventDeliveryRuntime {
     sender: EventDeliverySender,
     worker: JoinHandle<Option<u32>>,
+    pressure: Arc<DeliveryPressure>,
 }
 
 impl EventDeliveryRuntime {
-    pub(super) fn start(http: HttpClient, event_error_flag: String) -> Self {
+    pub(super) fn start(http: HttpClient, event_error_flag: String, run_id: &str) -> Self {
         let (tx, event_rx) = mpsc::channel(EVENT_DELIVERY_QUEUE_CAPACITY);
+        let pressure = Arc::new(DeliveryPressure::default());
+        let run_id: Arc<str> = Arc::from(run_id);
         let sender = EventDeliverySender {
             tx,
             byte_budget: Arc::new(Semaphore::new(EVENT_DELIVERY_MAX_BYTES)),
+            pressure: Arc::clone(&pressure),
+            run_id: Arc::clone(&run_id),
         };
-        let worker = tokio::spawn(run_event_sender(event_rx, http, event_error_flag));
-        Self { sender, worker }
+        let worker = tokio::spawn(run_event_sender(
+            event_rx,
+            http,
+            event_error_flag,
+            run_id,
+            Arc::clone(&pressure),
+        ));
+        Self {
+            sender,
+            worker,
+            pressure,
+        }
     }
 
     pub(super) fn sender(&self) -> &EventDeliverySender {
@@ -90,8 +128,19 @@ impl EventDeliveryRuntime {
     }
 
     pub(super) async fn finish(self) -> Result<Option<u32>, AgentError> {
-        let Self { sender, mut worker } = self;
+        let Self {
+            sender,
+            mut worker,
+            pressure,
+        } = self;
         drop(sender);
+        let drain_start = pressure.snapshot();
+        log_info!(
+            LOG_TAG,
+            "Event delivery drain started: pending_events={} buffered_bytes={}",
+            drain_start.pending_events,
+            drain_start.buffered_bytes
+        );
 
         match tokio::time::timeout(EVENT_DELIVERY_DRAIN_TIMEOUT, &mut worker).await {
             Ok(Ok(sequence)) => Ok(sequence),
@@ -101,42 +150,95 @@ impl EventDeliveryRuntime {
             Err(_) => {
                 worker.abort();
                 let _ = worker.await;
+                let snapshot = pressure.snapshot();
                 Err(AgentError::Execution(format!(
-                    "CLI event delivery did not drain within {} seconds",
-                    EVENT_DELIVERY_DRAIN_TIMEOUT.as_secs()
+                    "CLI event delivery did not drain within {} seconds: {} events pending, {} bytes buffered",
+                    EVENT_DELIVERY_DRAIN_TIMEOUT.as_secs(),
+                    snapshot.pending_events,
+                    snapshot.buffered_bytes
                 )))
             }
         }
     }
 
     pub(super) async fn abort(self) {
-        let Self { sender, worker } = self;
+        let Self {
+            sender,
+            worker,
+            pressure: _,
+        } = self;
         drop(sender);
         worker.abort();
         let _ = worker.await;
     }
 }
 
+#[derive(Clone, Copy)]
+struct AdmissionPressure {
+    pending_events: usize,
+    buffered_bytes: usize,
+}
+
+#[derive(Clone, Copy)]
+struct DeliveryPressureSnapshot {
+    pending_events: usize,
+    buffered_bytes: usize,
+    max_pending_events: usize,
+    max_buffered_bytes: usize,
+}
+
 #[derive(Default)]
-struct SerializedSize {
-    bytes: usize,
+struct DeliveryPressure {
+    pending_events: AtomicUsize,
+    buffered_bytes: AtomicUsize,
+    max_pending_events: AtomicUsize,
+    max_buffered_bytes: AtomicUsize,
 }
 
-impl Write for SerializedSize {
-    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-        self.bytes = self.bytes.saturating_add(buffer.len());
-        Ok(buffer.len())
+impl DeliveryPressure {
+    fn begin_admission(&self, bytes: usize) -> AdmissionPressure {
+        AdmissionPressure {
+            pending_events: self.pending_events.fetch_add(1, Ordering::Relaxed) + 1,
+            buffered_bytes: self.buffered_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes,
+        }
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+    fn confirm_admission(&self, admission: AdmissionPressure) {
+        self.max_pending_events
+            .fetch_max(admission.pending_events, Ordering::Relaxed);
+        self.max_buffered_bytes
+            .fetch_max(admission.buffered_bytes, Ordering::Relaxed);
     }
-}
 
-fn serialized_size(payload: &serde_json::Value) -> Result<usize, AgentError> {
-    let mut size = SerializedSize::default();
-    serde_json::to_writer(&mut size, payload)?;
-    Ok(size.bytes)
+    fn reject_admission(&self, bytes: usize) {
+        self.pending_events.fetch_sub(1, Ordering::Relaxed);
+        self.buffered_bytes.fetch_sub(bytes, Ordering::Relaxed);
+    }
+
+    fn mark_dequeued(&self) {
+        self.pending_events.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    fn release_bytes(&self, bytes: usize) {
+        self.buffered_bytes.fetch_sub(bytes, Ordering::Relaxed);
+    }
+
+    fn pending_events(&self) -> usize {
+        self.pending_events.load(Ordering::Relaxed)
+    }
+
+    fn buffered_bytes(&self) -> usize {
+        self.buffered_bytes.load(Ordering::Relaxed)
+    }
+
+    fn snapshot(&self) -> DeliveryPressureSnapshot {
+        DeliveryPressureSnapshot {
+            pending_events: self.pending_events(),
+            buffered_bytes: self.buffered_bytes(),
+            max_pending_events: self.max_pending_events.load(Ordering::Relaxed),
+            max_buffered_bytes: self.max_buffered_bytes.load(Ordering::Relaxed),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -175,23 +277,160 @@ async fn run_event_sender(
     mut event_rx: mpsc::Receiver<PreparedEvent>,
     http: HttpClient,
     event_error_flag: String,
+    run_id: Arc<str>,
+    pressure: Arc<DeliveryPressure>,
 ) -> Option<u32> {
     let mut acked_prefix = AckedEventPrefix::default();
-    while let Some(PreparedEvent {
-        sequence, payload, ..
-    }) = event_rx.recv().await
-    {
-        match events::post_event_with_error_flag(&http, &payload, &event_error_flag).await {
+    let mut carried_event = None;
+    let mut stats = DeliveryStats::default();
+
+    loop {
+        let first_event = match carried_event.take() {
+            Some(event) => event,
+            None => {
+                let Some(event) = event_rx.recv().await else {
+                    break;
+                };
+                pressure.mark_dequeued();
+                event
+            }
+        };
+        let first_sequence = first_event.sequence;
+        let (batch, next_carried_event) = collect_batch(first_event, &mut event_rx, &pressure);
+        let last_sequence = batch.last().map_or(first_sequence, |event| event.sequence);
+        carried_event = next_carried_event;
+        let batch = EventBatch::new(batch, &run_id);
+        let event_count = batch.sequences.len();
+        let send_result =
+            events::post_event_with_error_flag(&http, &batch.payload, &event_error_flag).await;
+
+        let EventBatch {
+            sequences,
+            payload: _,
+            conservative_bytes,
+            byte_budgets,
+            ..
+        } = batch;
+        drop(byte_budgets);
+        pressure.release_bytes(conservative_bytes);
+
+        let succeeded = send_result.is_ok();
+        stats.record_request(event_count, conservative_bytes, succeeded);
+        log_info!(
+            LOG_TAG,
+            "Event delivery request: first_sequence={first_sequence} last_sequence={last_sequence} events={event_count} conservative_bytes={conservative_bytes} result={} queued_events_remaining={}",
+            if succeeded { "success" } else { "failure" },
+            pressure.pending_events() + usize::from(carried_event.is_some())
+        );
+
+        match send_result {
             Ok(()) => {
-                acked_prefix.record_success(sequence);
+                for sequence in sequences {
+                    acked_prefix.record_success(sequence);
+                }
             }
             Err(e) => {
-                acked_prefix.record_failure(sequence);
-                log_warn!(LOG_TAG, "Event send failed: {e}");
+                acked_prefix.record_failure(first_sequence);
+                log_warn!(
+                    LOG_TAG,
+                    "Event send failed for sequences {first_sequence}-{last_sequence}: {e}"
+                );
             }
         }
     }
-    acked_prefix.last_contiguous()
+
+    let last_contiguous = acked_prefix.last_contiguous();
+    let pressure = pressure.snapshot();
+    log_info!(
+        LOG_TAG,
+        "Event delivery complete: events={} requests={} failed_requests={} max_batch_events={} max_batch_bytes={} max_pending_events={} max_buffered_bytes={} last_contiguous_sequence={last_contiguous:?}",
+        stats.total_events,
+        stats.total_requests,
+        stats.failed_requests,
+        stats.max_batch_events,
+        stats.max_batch_bytes,
+        pressure.max_pending_events,
+        pressure.max_buffered_bytes
+    );
+    last_contiguous
+}
+
+fn collect_batch(
+    first_event: PreparedEvent,
+    event_rx: &mut mpsc::Receiver<PreparedEvent>,
+    pressure: &DeliveryPressure,
+) -> (Vec<PreparedEvent>, Option<PreparedEvent>) {
+    let mut conservative_bytes = first_event.conservative_bytes;
+    let mut batch = Vec::with_capacity(EVENT_DELIVERY_MAX_REQUEST_EVENTS);
+    batch.push(first_event);
+
+    while batch.len() < EVENT_DELIVERY_MAX_REQUEST_EVENTS {
+        let next_event = match event_rx.try_recv() {
+            Ok(event) => {
+                pressure.mark_dequeued();
+                event
+            }
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
+                break;
+            }
+        };
+        if next_event.conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES - conservative_bytes {
+            return (batch, Some(next_event));
+        }
+        conservative_bytes += next_event.conservative_bytes;
+        batch.push(next_event);
+    }
+
+    (batch, None)
+}
+
+struct EventBatch {
+    sequences: Vec<u32>,
+    payload: serde_json::Value,
+    conservative_bytes: usize,
+    byte_budgets: Vec<OwnedSemaphorePermit>,
+}
+
+impl EventBatch {
+    fn new(events: Vec<PreparedEvent>, run_id: &str) -> Self {
+        let mut sequences = Vec::with_capacity(events.len());
+        let mut values = Vec::with_capacity(events.len());
+        let mut conservative_bytes = 0usize;
+        let mut byte_budgets = Vec::with_capacity(events.len());
+
+        for event in events {
+            sequences.push(event.sequence);
+            values.push(event.event);
+            conservative_bytes += event.conservative_bytes;
+            byte_budgets.push(event.byte_budget);
+        }
+
+        Self {
+            sequences,
+            payload: events::event_payload_for_run_id(values, run_id),
+            conservative_bytes,
+            byte_budgets,
+        }
+    }
+}
+
+#[derive(Default)]
+struct DeliveryStats {
+    total_events: usize,
+    total_requests: usize,
+    failed_requests: usize,
+    max_batch_events: usize,
+    max_batch_bytes: usize,
+}
+
+impl DeliveryStats {
+    fn record_request(&mut self, events: usize, bytes: usize, succeeded: bool) {
+        self.total_events += events;
+        self.total_requests += 1;
+        self.failed_requests += usize::from(!succeeded);
+        self.max_batch_events = self.max_batch_events.max(events);
+        self.max_batch_bytes = self.max_batch_bytes.max(bytes);
+    }
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -429,7 +429,6 @@ enum ParsedEventAction {
 
 struct CliEventIngestor {
     seq: u32,
-    run_id: String,
     api_start_time: String,
     last_read_event_at: Option<Instant>,
     session_metadata_capture: events::SessionMetadataCapture,
@@ -440,7 +439,6 @@ impl CliEventIngestor {
     fn new(runtime: &CliRuntimeConfig<'_>) -> Self {
         Self {
             seq: 0,
-            run_id: runtime.run_id.to_string(),
             api_start_time: runtime.api_start_time.to_string(),
             last_read_event_at: None,
             session_metadata_capture: events::SessionMetadataCapture::from_values(
@@ -520,9 +518,8 @@ impl CliEventIngestor {
         let sequence = self.seq;
         self.seq += 1;
         if should_send_events {
-            let payload =
-                events::prepare_event_payload_for_run_id(event, sequence, masker, &self.run_id);
-            event_tx.try_send(sequence, payload)?;
+            let event = events::prepare_event_for_delivery(event, sequence, masker);
+            event_tx.try_send(sequence, event)?;
         }
         Ok(())
     }
@@ -753,10 +750,15 @@ async fn execute_cli_inner(
 
     // Background event sender: HTTP POSTs happen here, never in the stdout
     // reading loop. Admission is non-blocking and bounded by count and bytes;
-    // overload enters controlled CLI termination rather than blocking stdout.
+    // the serial worker greedily batches only existing FIFO backlog. There is
+    // no collection delay or concurrent POST path. Overload enters controlled
+    // CLI termination rather than blocking stdout.
     let mut should_send_events = http.has_api();
-    let event_delivery =
-        EventDeliveryRuntime::start(http.clone(), runtime.event_error_flag.to_string());
+    let event_delivery = EventDeliveryRuntime::start(
+        http.clone(),
+        runtime.event_error_flag.to_string(),
+        &runtime.run_id,
+    );
 
     let mut heartbeat_done = false;
     let mut cli_exit_at: Option<Instant> = None;

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -16,7 +16,9 @@ use crate::paths;
 use crate::session_metadata;
 use guest_common::{log_error, log_info};
 use guest_contracts::diagnostics::FailureReason;
+use serde::Serialize;
 use serde_json::{Map, Value, json};
+use std::io::Write;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
@@ -64,10 +66,19 @@ pub async fn send_event_for_config(
 }
 
 pub fn prepare_event_payload_for_run_id(
-    mut event: Value,
+    event: Value,
     seq: u32,
     masker: &SecretMasker,
     run_id: &str,
+) -> Value {
+    let event = prepare_event_for_delivery(event, seq, masker);
+    event_payload_for_run_id(vec![event], run_id)
+}
+
+pub(crate) fn prepare_event_for_delivery(
+    mut event: Value,
+    seq: u32,
+    masker: &SecretMasker,
 ) -> Value {
     // Mask event-controlled content before adding system-owned fields.
     masker.mask_value(&mut event);
@@ -77,10 +88,46 @@ pub fn prepare_event_payload_for_run_id(
         obj.insert("sequenceNumber".to_string(), json!(seq));
     }
 
+    event
+}
+
+pub(crate) fn event_payload_for_run_id(events: Vec<Value>, run_id: &str) -> Value {
     let mut payload = Map::new();
     payload.insert("runId".to_string(), Value::String(run_id.to_string()));
-    payload.insert("events".to_string(), Value::Array(vec![event]));
+    payload.insert("events".to_string(), Value::Array(events));
     Value::Object(payload)
+}
+
+pub(crate) fn serialized_event_payload_size_for_run_id(
+    events: &[Value],
+    run_id: &str,
+) -> Result<usize, AgentError> {
+    let mut size = SerializedSize::default();
+    serde_json::to_writer(&mut size, &BorrowedEventPayload { run_id, events })?;
+    Ok(size.bytes)
+}
+
+#[derive(Serialize)]
+struct BorrowedEventPayload<'a> {
+    #[serde(rename = "runId")]
+    run_id: &'a str,
+    events: &'a [Value],
+}
+
+#[derive(Default)]
+struct SerializedSize {
+    bytes: usize,
+}
+
+impl Write for SerializedSize {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(buffer.len());
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Extract a secret-masked Codex failure diagnostic from stdout JSONL.

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -42,23 +42,18 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
     )?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let sequence_0 = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_includes(r#""sequenceNumber":0"#);
-        then.status(200);
-    });
-    let sequence_1 = server.mock(|when, then| {
+    // Keep response matchers mutually exclusive: sequence 1 may share a batch
+    // with later notifications, and the whole request is one failure unit.
+    let failed_batch = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
             .body_includes(r#""sequenceNumber":1"#);
         then.status(500);
     });
-    let later_batch = server.mock(|when, then| {
+    let successful_batches = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""sequenceNumber":2"#)
-            .body_includes(r#""sequenceNumber":3"#);
+            .body_excludes(r#""sequenceNumber":1"#);
         then.status(200);
     });
 
@@ -76,9 +71,11 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
         std::fs::read_to_string(runtime.paths.event_error_flag())?,
         "1"
     );
-    sequence_0.assert_calls_async(1).await;
-    sequence_1.assert_calls_async(3).await;
-    later_batch.assert_calls_async(1).await;
+    failed_batch.assert_calls_async(3).await;
+    assert!(
+        successful_batches.calls_async().await >= 1,
+        "the sequence-zero prefix should be acknowledged before the failed batch"
+    );
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -6,17 +6,17 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
-use httpmock::prelude::*;
 use std::time::Duration;
 
 const RUN_ID: &str = "codex-app-server-event-delivery-test";
+const TOTAL_EVENTS: usize = 4;
 
 #[tokio::test]
 async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
-    let server = MockServer::start();
+    let mut server = common::ControlledHttpServer::start().await?;
 
     unsafe {
         common::setup_codex_app_server_env(
@@ -29,53 +29,71 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
                 resume_session_id: None,
             },
         )?;
-        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     runtime.http = guest_agent::http::HttpClient::with_api_config(
-        server.base_url(),
+        &server.base_url,
         "test-token",
         "",
         RUN_ID,
         Duration::ZERO,
     )?;
+    let event_error_flag = runtime.paths.event_error_flag().to_string();
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    // Keep response matchers mutually exclusive: sequence 1 may share a batch
-    // with later notifications, and the whole request is one failure unit.
-    let failed_batch = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_includes(r#""sequenceNumber":1"#);
-        then.status(500);
-    });
-    let successful_batches = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
-            .body_excludes(r#""sequenceNumber":1"#);
-        then.status(200);
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
     });
 
-    let masker = SecretMasker::from_raw("");
-    let cli_result = tokio::time::timeout(
-        Duration::from_secs(5),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
-    )
-    .await
-    .expect("execute_cli should return promptly")?;
+    let mut logical_sequences = Vec::new();
+    let mut failed_sequences = None;
+    let mut failed_attempts = 0usize;
+    while logical_sequences.len() < TOTAL_EVENTS || failed_attempts < 3 {
+        let request = server.next_request(Duration::from_secs(5)).await?;
+        let sequences = common::event_request_sequences(&request.request)?;
+        if sequences.contains(&1) {
+            if let Some(expected) = &failed_sequences {
+                assert_eq!(
+                    &sequences, expected,
+                    "every retry should preserve the batch"
+                );
+            } else {
+                logical_sequences.extend(sequences.iter().copied());
+                failed_sequences = Some(sequences.clone());
+            }
+            failed_attempts += 1;
+            request.respond(500)?;
+        } else {
+            logical_sequences.extend(sequences);
+            request.respond(200)?;
+        }
+    }
+
+    let failed_sequences = failed_sequences.expect("sequence 1 should belong to a failed batch");
+    let expected_watermark = failed_sequences
+        .first()
+        .copied()
+        .and_then(|sequence| sequence.checked_sub(1));
+    let cli_result = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .expect("execute_cli should return promptly")??;
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
-    assert_eq!(cli_result.last_event_sequence, Some(0));
+    assert_eq!(cli_result.last_event_sequence, expected_watermark);
+    assert_eq!(failed_attempts, 3);
     assert_eq!(
-        std::fs::read_to_string(runtime.paths.event_error_flag())?,
-        "1"
+        logical_sequences,
+        (0..TOTAL_EVENTS as u32).collect::<Vec<_>>(),
+        "logical batches should cover the translated Codex events in FIFO order"
     );
-    failed_batch.assert_calls_async(3).await;
-    assert!(
-        successful_batches.calls_async().await >= 1,
-        "the sequence-zero prefix should be acknowledged before the failed batch"
-    );
+    assert_eq!(std::fs::read_to_string(event_error_flag)?, "1");
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_event_delivery.rs
@@ -54,15 +54,10 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
             .body_includes(r#""sequenceNumber":1"#);
         then.status(500);
     });
-    let sequence_2 = server.mock(|when, then| {
+    let later_batch = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""sequenceNumber":2"#);
-        then.status(200);
-    });
-    let sequence_3 = server.mock(|when, then| {
-        when.method(POST)
-            .path("/api/webhooks/agent/events")
+            .body_includes(r#""sequenceNumber":2"#)
             .body_includes(r#""sequenceNumber":3"#);
         then.status(200);
     });
@@ -83,8 +78,7 @@ async fn codex_app_server_event_delivery_stops_watermark_at_failed_sequence()
     );
     sequence_0.assert_calls_async(1).await;
     sequence_1.assert_calls_async(3).await;
-    sequence_2.assert_calls_async(1).await;
-    sequence_3.assert_calls_async(1).await;
+    later_batch.assert_calls_async(1).await;
 
     Ok(())
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -27,12 +27,13 @@ use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot};
 
 pub type SystemLogOverrideGuard = system_log::SystemLogOverrideGuard;
 
@@ -191,6 +192,88 @@ impl RecordingServer {
 }
 
 impl Drop for RecordingServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub struct ControlledRequest {
+    pub request: RecordedRequest,
+    response: oneshot::Sender<u16>,
+}
+
+impl ControlledRequest {
+    pub fn respond(self, status: u16) -> Result<(), String> {
+        self.response
+            .send(status)
+            .map_err(|_| "controlled HTTP request closed before response".to_string())
+    }
+}
+
+pub struct ControlledHttpServer {
+    pub base_url: String,
+    requests: Arc<AtomicUsize>,
+    request_rx: mpsc::UnboundedReceiver<ControlledRequest>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl ControlledHttpServer {
+    pub async fn start() -> Result<Self, String> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|error| format!("bind controlled HTTP server: {error}"))?;
+        let addr = listener
+            .local_addr()
+            .map_err(|error| format!("controlled HTTP server local_addr: {error}"))?;
+        let requests = Arc::new(AtomicUsize::new(0));
+        let task_requests = Arc::clone(&requests);
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            while let Ok((mut socket, _peer)) = listener.accept().await {
+                let connection_tx = request_tx.clone();
+                let connection_requests = Arc::clone(&task_requests);
+                tokio::spawn(async move {
+                    let Ok(request) = read_http_request(&mut socket).await else {
+                        let _ = write_http_response(&mut socket, 400).await;
+                        return;
+                    };
+                    connection_requests.fetch_add(1, Ordering::SeqCst);
+                    let (response, response_rx) = oneshot::channel();
+                    if connection_tx
+                        .send(ControlledRequest { request, response })
+                        .is_err()
+                    {
+                        return;
+                    }
+                    let Ok(status) = response_rx.await else {
+                        return;
+                    };
+                    let _ = write_http_response(&mut socket, status).await;
+                });
+            }
+        });
+
+        Ok(Self {
+            base_url: format!("http://{addr}"),
+            requests,
+            request_rx,
+            handle,
+        })
+    }
+
+    pub async fn next_request(&mut self, timeout: Duration) -> Result<ControlledRequest, String> {
+        tokio::time::timeout(timeout, self.request_rx.recv())
+            .await
+            .map_err(|_| format!("controlled HTTP server received no request within {timeout:?}"))?
+            .ok_or_else(|| "controlled HTTP server stopped accepting requests".to_string())
+    }
+
+    pub fn request_count(&self) -> usize {
+        self.requests.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for ControlledHttpServer {
     fn drop(&mut self) {
         self.handle.abort();
     }
@@ -792,6 +875,61 @@ pub async fn wait_for_path(path: &Path, timeout: Duration) -> io::Result<()> {
                 format!("timed out waiting for {}", path.display()),
             )
         })?
+}
+
+pub async fn wait_for_file_contains(
+    path: &Path,
+    needle: &str,
+    timeout: Duration,
+) -> io::Result<()> {
+    tokio::time::timeout(
+        timeout,
+        wait_for_file_contains_event(path, needle.as_bytes()),
+    )
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "timed out waiting for {} to contain {needle:?}",
+                path.display()
+            ),
+        )
+    })?
+}
+
+async fn wait_for_file_contains_event(path: &Path, needle: &[u8]) -> io::Result<()> {
+    let dir = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no parent directory: {}", path.display()),
+        )
+    })?;
+    let inotify = Inotify::init(InitFlags::IN_NONBLOCK)
+        .map_err(|error| io::Error::other(format!("inotify init: {error}")))?;
+    inotify
+        .add_watch(
+            dir,
+            AddWatchFlags::IN_CREATE
+                | AddWatchFlags::IN_MODIFY
+                | AddWatchFlags::IN_MOVED_TO
+                | AddWatchFlags::IN_CLOSE_WRITE,
+        )
+        .map_err(|error| io::Error::other(format!("inotify watch: {error}")))?;
+    let async_fd = async_inotify_fd(inotify)?;
+
+    loop {
+        match tokio::fs::read(path).await {
+            Ok(contents) if find_subsequence(&contents, needle).is_some() => return Ok(()),
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+
+        let mut guard = async_fd.readable().await?;
+        drain_inotify_fd(async_fd.get_ref().as_fd());
+        guard.clear_ready();
+    }
 }
 
 async fn wait_for_path_event(path: &Path) -> io::Result<()> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -83,6 +83,23 @@ pub struct RecordedRequest {
     pub body: String,
 }
 
+pub fn event_request_sequences(request: &RecordedRequest) -> Result<Vec<u32>, String> {
+    let body: Value = serde_json::from_str(&request.body)
+        .map_err(|error| format!("parse event request body: {error}"))?;
+    body.get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "event request omitted events array".to_string())?
+        .iter()
+        .map(|event| {
+            event
+                .get("sequenceNumber")
+                .and_then(Value::as_u64)
+                .and_then(|sequence| u32::try_from(sequence).ok())
+                .ok_or_else(|| "event omitted a u32 sequenceNumber".to_string())
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecordedHttpEvent {
     Request(RecordedRequest),

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -1,0 +1,117 @@
+//! A failed multi-event request freezes the contiguous watermark at its first
+//! sequence while later batches continue.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use serde_json::{Value, json};
+use std::io;
+use std::time::Duration;
+
+const TOTAL_EVENTS: usize = 81;
+
+fn request_sequences(
+    request: &common::RecordedRequest,
+) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
+    let body: Value = serde_json::from_str(&request.body)?;
+    body.get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("event request omitted events array"))?
+        .iter()
+        .map(|event| {
+            event
+                .get("sequenceNumber")
+                .and_then(Value::as_u64)
+                .and_then(|sequence| u32::try_from(sequence).ok())
+                .ok_or_else(|| io::Error::other("event omitted a u32 sequenceNumber").into())
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn failed_batch_retries_three_times_and_later_batches_continue()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines.extend(
+        (0..TOTAL_EVENTS - 1)
+            .map(|index| json!({ "type": "assistant", "index": index }).to_string()),
+    );
+    prompt_lines.push(json!({ "type": "result", "marker": "failed-batch-sentinel" }).to_string());
+    let prompt = prompt_lines.join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        run_id,
+        Duration::ZERO,
+    )?;
+    let agent_log_file = runtime.paths.agent_log_file().to_string();
+    let event_error_flag = runtime.paths.event_error_flag().to_string();
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+
+    let first_request = server.next_request(Duration::from_secs(5)).await?;
+    common::wait_for_file_contains(
+        std::path::Path::new(&agent_log_file),
+        "failed-batch-sentinel",
+        Duration::from_secs(5),
+    )
+    .await?;
+    let first_sequences = request_sequences(&first_request.request)?;
+    let expected_watermark = first_sequences
+        .last()
+        .copied()
+        .ok_or_else(|| io::Error::other("first request contained no events"))?;
+    first_request.respond(200)?;
+
+    let failed_request = server.next_request(Duration::from_secs(5)).await?;
+    let failed_sequences = request_sequences(&failed_request.request)?;
+    assert_eq!(failed_sequences.len(), 32);
+    failed_request.respond(500)?;
+    for _ in 1..3 {
+        let retry = server.next_request(Duration::from_secs(5)).await?;
+        assert_eq!(request_sequences(&retry.request)?, failed_sequences);
+        retry.respond(500)?;
+    }
+
+    let mut logical_sequences = first_sequences;
+    logical_sequences.extend(failed_sequences);
+    while logical_sequences.len() < TOTAL_EVENTS {
+        let request = server.next_request(Duration::from_secs(5)).await?;
+        logical_sequences.extend(request_sequences(&request.request)?);
+        request.respond(200)?;
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .expect("CLI should finish after later batches are acknowledged")??;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(result.last_event_sequence, Some(expected_watermark));
+    assert_eq!(
+        logical_sequences,
+        (0..TOTAL_EVENTS as u32).collect::<Vec<_>>(),
+        "logical batches should remain FIFO even though one batch was retried"
+    );
+    assert_eq!(std::fs::read_to_string(event_error_flag)?, "1");
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_batch_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_batch_failure.rs
@@ -4,29 +4,11 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
-use serde_json::{Value, json};
+use serde_json::json;
 use std::io;
 use std::time::Duration;
 
 const TOTAL_EVENTS: usize = 81;
-
-fn request_sequences(
-    request: &common::RecordedRequest,
-) -> Result<Vec<u32>, Box<dyn std::error::Error>> {
-    let body: Value = serde_json::from_str(&request.body)?;
-    body.get("events")
-        .and_then(Value::as_array)
-        .ok_or_else(|| io::Error::other("event request omitted events array"))?
-        .iter()
-        .map(|event| {
-            event
-                .get("sequenceNumber")
-                .and_then(Value::as_u64)
-                .and_then(|sequence| u32::try_from(sequence).ok())
-                .ok_or_else(|| io::Error::other("event omitted a u32 sequenceNumber").into())
-        })
-        .collect()
-}
 
 #[tokio::test]
 async fn failed_batch_retries_three_times_and_later_batches_continue()
@@ -76,7 +58,7 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
         Duration::from_secs(5),
     )
     .await?;
-    let first_sequences = request_sequences(&first_request.request)?;
+    let first_sequences = common::event_request_sequences(&first_request.request)?;
     let expected_watermark = first_sequences
         .last()
         .copied()
@@ -84,12 +66,15 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
     first_request.respond(200)?;
 
     let failed_request = server.next_request(Duration::from_secs(5)).await?;
-    let failed_sequences = request_sequences(&failed_request.request)?;
+    let failed_sequences = common::event_request_sequences(&failed_request.request)?;
     assert_eq!(failed_sequences.len(), 32);
     failed_request.respond(500)?;
     for _ in 1..3 {
         let retry = server.next_request(Duration::from_secs(5)).await?;
-        assert_eq!(request_sequences(&retry.request)?, failed_sequences);
+        assert_eq!(
+            common::event_request_sequences(&retry.request)?,
+            failed_sequences
+        );
         retry.respond(500)?;
     }
 
@@ -97,7 +82,7 @@ async fn failed_batch_retries_three_times_and_later_batches_continue()
     logical_sequences.extend(failed_sequences);
     while logical_sequences.len() < TOTAL_EVENTS {
         let request = server.next_request(Duration::from_secs(5)).await?;
-        logical_sequences.extend(request_sequences(&request.request)?);
+        logical_sequences.extend(common::event_request_sequences(&request.request)?);
         request.respond(200)?;
     }
 

--- a/crates/guest-agent/tests/event_delivery_batching.rs
+++ b/crates/guest-agent/tests/event_delivery_batching.rs
@@ -1,0 +1,191 @@
+//! Healthy CLI backlog should drain in ordered count- and byte-bounded batches.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+use std::io;
+use std::time::Duration;
+
+const SMALL_EVENT_COUNT: usize = 70;
+const LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
+const MAX_BATCH_EVENTS: usize = 32;
+const MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+struct CapturedBatch {
+    sequences: Vec<u32>,
+    conservative_bytes: usize,
+    body_bytes: usize,
+}
+
+fn capture_batch(
+    request: &common::RecordedRequest,
+    run_id: &str,
+) -> Result<CapturedBatch, Box<dyn std::error::Error>> {
+    if request.path != "/api/webhooks/agent/events" {
+        return Err(io::Error::other(format!("unexpected request path: {}", request.path)).into());
+    }
+    if request.authorization.as_deref() != Some("Bearer test-token") {
+        return Err(io::Error::other("event request omitted bearer authorization").into());
+    }
+    let body: Value = serde_json::from_str(&request.body)?;
+    if body.get("runId").and_then(Value::as_str) != Some(run_id) {
+        return Err(io::Error::other("event request used the wrong run ID").into());
+    }
+    let events = body
+        .get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("event request omitted events array"))?;
+    let sequences = events
+        .iter()
+        .map(|event| {
+            event
+                .get("sequenceNumber")
+                .and_then(Value::as_u64)
+                .and_then(|sequence| u32::try_from(sequence).ok())
+                .ok_or_else(|| io::Error::other("event omitted a u32 sequenceNumber"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let conservative_bytes = events.iter().try_fold(0usize, |total, event| {
+        let singleton = json!({ "runId": run_id, "events": [event] });
+        let bytes = serde_json::to_vec(&singleton)?.len();
+        Ok::<usize, serde_json::Error>(total + bytes)
+    })?;
+
+    Ok(CapturedBatch {
+        sequences,
+        conservative_bytes,
+        body_bytes: request.body.len(),
+    })
+}
+
+#[tokio::test]
+async fn ordinary_cli_drains_healthy_backlog_in_bounded_fifo_batches()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines.extend((0..SMALL_EVENT_COUNT).map(|index| {
+        json!({ "type": "assistant", "index": index, "content": "small" }).to_string()
+    }));
+    prompt_lines.push(
+        json!({
+            "type": "assistant",
+            "marker": "large-a",
+            "content": "a".repeat(LARGE_EVENT_BYTES),
+        })
+        .to_string(),
+    );
+    prompt_lines.push(
+        json!({
+            "type": "assistant",
+            "marker": "large-b",
+            "content": "b".repeat(LARGE_EVENT_BYTES),
+        })
+        .to_string(),
+    );
+    prompt_lines.push(json!({ "type": "result", "marker": "batching-sentinel" }).to_string());
+    let prompt = prompt_lines.join("\n");
+    let total_events = SMALL_EVENT_COUNT + 3;
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        &run_id,
+        Duration::ZERO,
+    )?;
+    let agent_log_file = runtime.paths.agent_log_file().to_string();
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let system_log_file = tmp.path().join("system.log");
+    let _system_log = common::SystemLogOverrideGuard::set(&system_log_file);
+
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+
+    let first_request = server.next_request(Duration::from_secs(5)).await?;
+    common::wait_for_file_contains(
+        std::path::Path::new(&agent_log_file),
+        "batching-sentinel",
+        Duration::from_secs(5),
+    )
+    .await?;
+    let mut batches = vec![capture_batch(&first_request.request, &run_id)?];
+    let mut delivered_events = batches[0].sequences.len();
+    first_request.respond(200)?;
+
+    while delivered_events < total_events {
+        let request = server.next_request(Duration::from_secs(5)).await?;
+        let batch = capture_batch(&request.request, &run_id)?;
+        delivered_events += batch.sequences.len();
+        batches.push(batch);
+        request.respond(200)?;
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .expect("CLI should finish after all batches are acknowledged")??;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(result.last_event_sequence, Some((total_events - 1) as u32));
+
+    let sequences = batches
+        .iter()
+        .flat_map(|batch| batch.sequences.iter().copied())
+        .collect::<Vec<_>>();
+    assert_eq!(sequences, (0..total_events as u32).collect::<Vec<_>>());
+    assert_eq!(
+        sequences.iter().copied().collect::<BTreeSet<_>>().len(),
+        total_events,
+        "every event should be delivered exactly once"
+    );
+    assert!(
+        batches
+            .iter()
+            .any(|batch| batch.sequences.len() == MAX_BATCH_EVENTS),
+        "the queued small-event burst should exercise the count boundary"
+    );
+    for batch in &batches {
+        assert!(batch.sequences.len() <= MAX_BATCH_EVENTS);
+        assert!(batch.conservative_bytes <= MAX_BATCH_BYTES);
+        assert!(batch.body_bytes <= MAX_BATCH_BYTES);
+    }
+    let large_a_batch = batches
+        .iter()
+        .position(|batch| batch.sequences.contains(&(SMALL_EVENT_COUNT as u32)))
+        .expect("large-a event should be delivered");
+    let large_b_batch = batches
+        .iter()
+        .position(|batch| batch.sequences.contains(&((SMALL_EVENT_COUNT + 1) as u32)))
+        .expect("large-b event should be delivered");
+    assert_ne!(
+        large_a_batch, large_b_batch,
+        "two individually valid large events should split at the 4 MiB conservative boundary"
+    );
+    assert!(batches.len() < total_events);
+
+    let system_log = std::fs::read_to_string(system_log_file)?;
+    assert!(system_log.contains("Event delivery request:"));
+    assert!(system_log.contains("Event delivery complete:"));
+    assert!(system_log.contains(&format!("events={total_events}")));
+    assert!(system_log.contains("failed_requests=0"));
+    assert!(system_log.contains("max_batch_events=32"));
+    assert!(system_log.contains("max_pending_events="));
+    assert!(system_log.contains("max_buffered_bytes="));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -1,0 +1,104 @@
+//! The production 120-second event-delivery drain deadline is exercised with
+//! paused Tokio time through the real CLI entry point.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use serde_json::json;
+use std::time::Duration;
+
+const EVENT_COUNT: usize = 40;
+
+#[tokio::test]
+async fn event_delivery_aborts_after_the_global_drain_deadline()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let mut prompt_lines = vec!["@ECHO@".to_string()];
+    prompt_lines.extend(
+        (0..EVENT_COUNT - 1)
+            .map(|index| json!({ "type": "assistant", "index": index }).to_string()),
+    );
+    prompt_lines.push(json!({ "type": "result", "marker": "drain-timeout-sentinel" }).to_string());
+    let prompt = prompt_lines.join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        run_id,
+        Duration::from_secs(1),
+    )?;
+    let agent_log_file = runtime.paths.agent_log_file().to_string();
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let system_log_file = tmp.path().join("system.log");
+    let _system_log = common::SystemLogOverrideGuard::set(&system_log_file);
+
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+    let _stalled_request = server.next_request(Duration::from_secs(5)).await?;
+    common::wait_for_file_contains(
+        std::path::Path::new(&agent_log_file),
+        "drain-timeout-sentinel",
+        Duration::from_secs(5),
+    )
+    .await?;
+    common::wait_for_file_contains(
+        &system_log_file,
+        "Event delivery drain started:",
+        Duration::from_secs(5),
+    )
+    .await?;
+
+    tokio::time::pause();
+    for _ in 0..125 {
+        if execution.is_finished() {
+            break;
+        }
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        execution.is_finished(),
+        "event delivery should stop at the unchanged 120-second global deadline"
+    );
+    let error = execution
+        .await?
+        .expect_err("the drain deadline should fail the CLI run");
+    assert!(
+        error
+            .to_string()
+            .contains("CLI event delivery did not drain within 120 seconds"),
+        "unexpected drain error: {error}"
+    );
+
+    tokio::task::yield_now().await;
+    let requests_after_abort = server.request_count();
+    assert!(
+        requests_after_abort >= 4,
+        "virtual time should exercise one exhausted batch and a later batch before the global abort"
+    );
+    tokio::time::advance(Duration::from_secs(60)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        server.request_count(),
+        requests_after_abort,
+        "aborting the delivery worker should prevent later requests"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_oversized.rs
+++ b/crates/guest-agent/tests/event_delivery_oversized.rs
@@ -1,0 +1,69 @@
+//! An event that cannot fit below the webhook request boundary must fail before
+//! any network delivery attempt.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use httpmock::prelude::*;
+use serde_json::json;
+use std::time::Duration;
+
+const MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
+
+#[tokio::test]
+async fn oversized_single_event_fails_before_network_delivery()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+    let prompt = [
+        "@ECHO-HANG@".to_string(),
+        json!({
+            "type": "assistant",
+            "content": "x".repeat(MAX_REQUEST_BYTES),
+        })
+        .to_string(),
+    ]
+    .join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 1, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200);
+    });
+
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        ),
+    )
+    .await
+    .expect("oversized event should fail promptly")?;
+    let error = execution
+        .control_error
+        .expect("oversized event should enter controlled delivery termination")
+        .to_string();
+    assert!(
+        error.contains("exceeding the 4194304-byte request limit"),
+        "unexpected oversized event error: {error}"
+    );
+    assert_eq!(
+        execution
+            .cli_termination
+            .expect("oversized event should record process-group termination")
+            .reason,
+        guest_contracts::diagnostics::CliTerminationReason::EventDelivery
+    );
+    events.assert_calls_async(0).await;
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/event_delivery_singleton.rs
+++ b/crates/guest-agent/tests/event_delivery_singleton.rs
@@ -1,0 +1,72 @@
+//! A CLI event with no backlog must be sent immediately as a singleton batch.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::test]
+async fn ordinary_cli_sends_a_no_backlog_event_without_collection_delay()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let mut server = common::ControlledHttpServer::start().await?;
+    let prompt = [
+        "@ECHO@".to_string(),
+        json!({ "type": "assistant", "message": "singleton" }).to_string(),
+    ]
+    .join("\n");
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        &run_id,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+    let request = server.next_request(Duration::from_secs(5)).await?;
+    let body: serde_json::Value = serde_json::from_str(&request.request.body)?;
+    assert_eq!(
+        body.get("runId").and_then(serde_json::Value::as_str),
+        Some(run_id.as_str())
+    );
+    let events = body
+        .get("events")
+        .and_then(serde_json::Value::as_array)
+        .expect("event request should contain an events array");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]
+            .get("sequenceNumber")
+            .and_then(serde_json::Value::as_u64),
+        Some(0)
+    );
+    request.respond(200)?;
+
+    let result = tokio::time::timeout(Duration::from_secs(5), execution)
+        .await
+        .expect("CLI should finish after the singleton response")??;
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(result.last_event_sequence, Some(0));
+    assert_eq!(server.request_count(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- greedily batch the existing FIFO CLI event backlog into requests bounded to 32 events and a conservative 4 MiB serialized charge
- preserve serial delivery, the existing 512-event / 16 MiB admission limits, retries, and watermark semantics while adding backlog-pressure observability
- add deterministic integration coverage for singleton delivery, healthy bursts, count and byte boundaries, failed-batch continuation, oversized events, and the 120-second drain deadline

## Compatibility

- no API, schema, persisted-data, or frontend changes
- keeps the existing `runId` plus `events[]` wire shape, so old singleton senders and the new multi-event sender remain compatible
- tracks the independent Axiom SDK error-propagation problem separately in #22319

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude -p guest-mock-codex --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`

Closes #22263
