### PR TITLE
refactor(mail): open draft sidebars without reloading

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -256,8 +256,9 @@ permission cards refresh without replacing their signals identities.
 A vm0 mail link matches `/mail/drafts/:vm0DraftId`. The vm0 UUID is the stable
 resource key; Gmail draft, thread, and message IDs remain provider metadata and
 are not inferred from Gmail Web URLs. The thread-scoped signals read the Gmail
-draft through the Zero Mail API and share edits and send state across repeated
-card occurrences.
+draft through one reloadable Zero Mail API computed. Repeated card occurrences
+and the detail sidebar share that computed, while Send and Delete invalidate it
+after their mutations complete.
 
 The fixed-height card displays the Gmail identity, subject, sender, and
 `Draft`, `Sent`, or `Deleted` status. Draft and Sent cards open the shared right

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -24,9 +24,8 @@ export interface MailDraftDescriptor {
 
 export interface MailDraftSignals extends MailDraftDescriptor {
   readonly draft$: Computed<Promise<ZeroMailDraft | null>>;
-  readonly reload$: Command<void, []>;
   readonly delete$: Command<Promise<void>, [AbortSignal]>;
-  readonly send$: Command<Promise<ZeroMailDraft>, [AbortSignal]>;
+  readonly send$: Command<Promise<void>, [AbortSignal]>;
 }
 
 export interface MailDraftCardSignalsRegistry {
@@ -117,21 +116,11 @@ export function parseMailDraftUrl(value: string): MailDraftDescriptor | null {
   };
 }
 
-function newestDraft(
-  first: ZeroMailDraft,
-  second: ZeroMailDraft,
-): ZeroMailDraft {
-  return Date.parse(second.updatedAt) >= Date.parse(first.updatedAt)
-    ? second
-    : first;
-}
-
 function createMailDraftSignals(
   descriptor: MailDraftDescriptor,
 ): MailDraftSignals {
   const reloadVersion$ = state(0);
-  const mutationDraft$ = state<ZeroMailDraft | null | undefined>(undefined);
-  const serverDraft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
+  const draft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
     get(reloadVersion$);
     const response = await accept(
       get(zeroClient$)(zeroMailContract).getDraft({
@@ -141,14 +130,6 @@ function createMailDraftSignals(
       [200, 404],
     );
     return response.status === 200 ? response.body.mailDraft : null;
-  });
-  const draft$ = computed(async (get): Promise<ZeroMailDraft | null> => {
-    const mutation = get(mutationDraft$);
-    const server = await get(serverDraft$);
-    if (mutation === null || server === null) {
-      return mutation === undefined ? server : mutation;
-    }
-    return mutation === undefined ? server : newestDraft(server, mutation);
   });
   const reload$ = command(({ set }) => {
     set(reloadVersion$, (version) => {
@@ -165,11 +146,11 @@ function createMailDraftSignals(
         [204],
       );
       signal.throwIfAborted();
-      set(mutationDraft$, null);
+      set(reload$);
     },
   );
   const send$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const response = await accept(
+    await accept(
       get(zeroClient$)(zeroMailContract).sendDraft({
         params: { mailDraftId: descriptor.mailDraftId },
         fetchOptions: { signal },
@@ -177,10 +158,9 @@ function createMailDraftSignals(
       [200],
     );
     signal.throwIfAborted();
-    set(mutationDraft$, response.body.mailDraft);
-    return response.body.mailDraft;
+    set(reload$);
   });
-  return { ...descriptor, draft$, reload$, delete$, send$ };
+  return { ...descriptor, draft$, delete$, send$ };
 }
 
 export function createMailDraftCardSignalsRegistry(): MailDraftCardSignalsRegistry {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -199,7 +199,7 @@ async function confirmPermissionAction(
 }
 
 describe("chat message action cards", () => {
-  it("shares a link-backed mail draft between cards and the detail sidebar", async () => {
+  it("opens a shared mail draft without reloading and refreshes after sending", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000010";
     const messageId = "c0000000-0000-4000-a000-000000000011";
@@ -226,11 +226,17 @@ describe("chat message action cards", () => {
           bcc: [],
           subject: "Hello",
           body: "Mail body",
-          status: "draft",
+          status: sent ? "sent" : "draft",
           detailAvailable: true,
           gmailDraftId: "r-test-draft",
           gmailThreadId: "gmail-thread-id",
           gmailMessageId: "gmail-message-id",
+          ...(sent
+            ? {
+                sentGmailMessageId: "gmail-sent-message-id",
+                sentAt: "2026-07-14T10:01:00.000Z",
+              }
+            : {}),
           references: [],
           attachments: [
             {
@@ -240,7 +246,7 @@ describe("chat message action cards", () => {
             },
           ],
           createdAt,
-          updatedAt: createdAt,
+          updatedAt: sent ? "2026-07-14T10:01:00.000Z" : createdAt,
         },
       });
     });
@@ -341,6 +347,7 @@ describe("chat message action cards", () => {
     expect(within(sidebar).getByText("Mail body")).toBeInTheDocument();
     expect(within(sidebar).getByText("report.pdf")).toBeInTheDocument();
     expect(within(sidebar).queryByRole("textbox")).not.toBeInTheDocument();
+    expect(draftRequests).toBe(1);
     await user.click(await waitForButtonByText("Send", sidebar));
 
     await waitFor(() => {
@@ -350,6 +357,84 @@ describe("chat message action cards", () => {
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Send", sidebar)).toBeNull();
     expect(draftRequests).toBe(2);
+  });
+
+  it("reloads the shared mail draft after deleting it", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "c0000000-0000-4000-a000-000000000018";
+    const mailDraftId = "c0000000-0000-4000-a000-000000000019";
+    const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const createdAt = "2026-07-14T10:00:00.000Z";
+    let deleted = false;
+    let draftRequests = 0;
+
+    context.mocks.api(zeroMailContract.getDraft, ({ respond }) => {
+      draftRequests += 1;
+      if (deleted) {
+        return respond(404, {
+          error: { message: "Mail draft not found", code: "NOT_FOUND" },
+        });
+      }
+      return respond(200, {
+        mailDraftId,
+        mailDraftUrl,
+        mailDraft: {
+          version: 3,
+          provider: "gmail",
+          from: "sender@example.com",
+          to: ["recipient@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Delete me",
+          body: "Mail body",
+          status: "draft",
+          detailAvailable: true,
+          gmailDraftId: "r-delete-draft",
+          gmailThreadId: "gmail-thread-id",
+          gmailMessageId: "gmail-message-id",
+          references: [],
+          attachments: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+    });
+    context.mocks.api(zeroMailContract.deleteDraft, ({ respond }) => {
+      deleted = true;
+      return respond(204);
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Delete mail card",
+      chatMessages: [
+        {
+          id: "c0000000-0000-4000-a000-00000000001a",
+          role: "assistant",
+          content: mailDraftUrl,
+          createdAt,
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroMail]: true },
+    });
+
+    const card = await screen.findByLabelText("Open draft email: Delete me");
+    expect(draftRequests).toBe(1);
+    await user.click(card);
+    const sidebar = await screen.findByTestId("mail-draft-sidebar");
+    expect(draftRequests).toBe(1);
+    await user.click(await waitForButtonByText("Delete", sidebar));
+
+    await waitFor(() => {
+      expect(deleted).toBeTruthy();
+      expect(draftRequests).toBe(2);
+      expect(screen.queryByLabelText("Open draft email: Delete me")).toBeNull();
+      expect(screen.queryByTestId("mail-draft-sidebar")).toBeNull();
+    });
   });
 
   it("renders a deleted email card without an interactive sidebar trigger", async () => {

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -51,7 +51,6 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
   const draftLoadable = useLoadable(signals.draft$);
   const selectedMailDraftId = useGet(currentMailDraftId$);
   const openSidebar = useSet(openMailDraftSidebar$);
-  const reload = useSet(signals.reload$);
 
   if (draftLoadable.state === "loading") {
     return <MailDraftCardSkeleton />;
@@ -118,7 +117,6 @@ function EnabledMailDraftCard({ signals }: MailDraftCardProps) {
       data-mail-draft-card
       data-mail-draft-status={draft.status}
       onClick={() => {
-        reload();
         openSidebar(signals.mailDraftId);
       }}
       className={cn(


### PR DESCRIPTION
## Summary

- open an email detail sidebar from the already-loaded thread-scoped draft computed, avoiding the click-time Gmail refresh and loading state
- remove `mutationDraft$` and timestamp-based server/mutation merging so the Zero Mail API computed is the only draft source of truth
- invalidate that shared computed after Send and Delete, keeping repeated cards and the sidebar synchronized from the API result
- document the lifecycle and extend page-level integration coverage for click, send, and delete behavior

## User-visible impact

- clicking a loaded Draft or Sent email card opens its sidebar immediately without issuing a second draft GET
- sending reloads the shared draft and updates every occurrence to Sent
- deleting reloads the shared draft, observes the resulting 404, removes the card, and closes the sidebar

## Verification

- `npx -p prettier@3.8.1 prettier --write ...` — passed for all changed files
- `pnpm -F @vm0/app lint` — passed with 0 warnings and 0 errors
- `pnpm -F @vm0/app check-types` — passed for production and test TypeScript configs
- local Vitest was not run per the vm0 PR verification preference; the updated page-level integration tests are left to the PR pipeline
