### PR TITLE
fix(connectors): use permissionless api as routing fallback

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -130,6 +130,7 @@ class _CompiledApiCore(NamedTuple):
     base_malformed: bool
     auth_malformed: bool
     injects_ordinary_upstream_credentials: bool
+    permissionless: bool
     routing_identity: str | None
     # True when API compilation encountered malformed permissions/rules config.
     has_malformed_rules: bool
@@ -162,6 +163,10 @@ class _CompiledApi(NamedTuple):
     @property
     def injects_ordinary_upstream_credentials(self) -> bool:
         return self.core.injects_ordinary_upstream_credentials
+
+    @property
+    def permissionless(self) -> bool:
+        return self.core.permissionless
 
     @property
     def routing_identity(self) -> str | None:
@@ -845,6 +850,9 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
         seen_permission_names: set[str] = set()
         permissions = api_entry.get("permissions")
         permissions_present = "permissions" in api_entry
+        permissionless = not permissions_present or (
+            isinstance(permissions, list) and len(permissions) == 0
+        )
         if isinstance(permissions, list):
             for perm in permissions:
                 if not isinstance(perm, dict):
@@ -893,6 +901,7 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
                 base_malformed,
                 auth_malformed,
                 injects_ordinary_upstream_credentials,
+                permissionless,
                 routing_identity,
                 has_malformed_rules,
             )
@@ -1412,9 +1421,43 @@ def _selected_source_api_matches(
     collection: _FirewallMatchCollection,
     selected_name: str,
 ) -> list[_MatchedApi]:
-    return [
+    matches = [
         match for match in _winning_api_matches(collection) if match.firewall.name == selected_name
     ]
+    if collection.best_rule_specificity is not None:
+        return matches
+
+    # APIs without permissions are catch-alls only within the selected owner.
+    # Owner selection must still resolve shared bases before this fallback.
+    permissionless_matches = [match for match in matches if match.api.permissionless]
+    return permissionless_matches or matches
+
+
+def _relevant_owner_api_matches(
+    collection: _FirewallMatchCollection,
+    selected_name: str | None,
+) -> list[_MatchedApi]:
+    if selected_name is None:
+        return collection.api_matches
+    return [
+        match
+        for match in collection.api_matches
+        if match.firewall.name == selected_name or match.firewall.name_malformed
+    ]
+
+
+def _selected_base_api_matches(
+    collection: _FirewallMatchCollection,
+    selected_name: str | None,
+) -> list[_MatchedApi]:
+    relevant_matches = _relevant_owner_api_matches(collection, selected_name)
+    if selected_name is None or collection.best_rule_specificity is not None:
+        return relevant_matches
+
+    selected_orders = {
+        match.order for match in _selected_source_api_matches(collection, selected_name)
+    }
+    return [match for match in relevant_matches if match.order in selected_orders]
 
 
 def _conflicting_selected_api_block(
@@ -1511,23 +1554,21 @@ def _reduce_selected_owner(
 
     decision = _FirewallDecisionState()
     evaluable_api_orders: set[int] = set()
-    for api_match in collection.api_matches:
-        fw_entry = api_match.firewall
-        if (
-            selected_name is not None
-            and fw_entry.name != selected_name
-            and not fw_entry.name_malformed
-        ):
-            continue
+    relevant_api_matches = _relevant_owner_api_matches(collection, selected_name)
 
-        api_entry = api_match.api
-        policy = compiled_network_policies.policies.get(fw_entry.name)
+    for api_match in _selected_base_api_matches(collection, selected_name):
+        fw_entry = api_match.firewall
         decision.accept_base_match(
-            api_entry,
+            api_match.api,
             name=fw_entry.name,
             rel_path=api_match.rel_path,
             base_params=api_match.base_params,
         )
+
+    for api_match in relevant_api_matches:
+        fw_entry = api_match.firewall
+        api_entry = api_match.api
+        policy = compiled_network_policies.policies.get(fw_entry.name)
         routing_identity_malformed = api_entry.routing_identity is None
         if (
             api_entry.base_malformed
@@ -1566,8 +1607,6 @@ def _reduce_selected_owner(
         if api_match.order not in evaluable_api_orders:
             continue
         fw_entry = api_match.firewall
-        if selected_name is not None and fw_entry.name != selected_name:
-            continue
         policy = compiled_network_policies.policies.get(fw_entry.name)
         rel_path_segs = _split_path_segments(api_match.rel_path)
         rule_entries = (

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
@@ -417,6 +417,46 @@ def test_compiled_unknown_allow_fails_closed_for_conflicting_same_owner_auth():
     assert result.reason == "malformed_firewall_config"
 
 
+@pytest.mark.parametrize("default_first", [False, True])
+def test_compiled_unknown_allow_uses_permissionless_same_owner_api(
+    default_first: bool,
+):
+    default_api_entry = {
+        "base": "https://api.example.com",
+        "auth": {"headers": {"Authorization": "Bearer default"}},
+        "permissions": [],
+    }
+    route_api_entry = {
+        "base": "https://api.example.com",
+        "auth": {"headers": {"Authorization": "Bearer route"}},
+        "permissions": [{"name": "items-read", "rules": ["GET /items/{id}"]}],
+    }
+    api_entries = (
+        [default_api_entry, route_api_entry]
+        if default_first
+        else [route_api_entry, default_api_entry]
+    )
+    fws = wrap_firewalls(api_entries, name="example")
+    policies = {
+        "example": {
+            "allow": ["items-read"],
+            "deny": [],
+            "unknownPolicy": "allow",
+        }
+    }
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com/profile",
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.api_entry is default_api_entry
+    assert result.permission is None
+
+
 def test_compiled_unknown_allow_combines_same_owner_routing_identity():
     auth = {"headers": {"Authorization": "Bearer shared"}}
     first_api_entry = {

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -470,6 +470,56 @@ describe("builtin firewall base overlap guard", () => {
       firewallName: "nintendo-switch-parental-controls",
     });
   });
+
+  it("uses the generated Meta Ads permissionless API for unknown endpoints", async () => {
+    const metaAds = await loadRequiredConnectorFirewall("meta-ads");
+    const unknownDenyPolicy = {
+      "meta-ads": {
+        allow: ["page-token-ads-posts"],
+        deny: [],
+        ask: [],
+        unknownPolicy: "deny" as const,
+      },
+    };
+
+    expect(
+      matchFirewallRequestDecision(
+        [metaAds],
+        "GET",
+        "https://graph.facebook.com/v22.0/me",
+      ),
+    ).toMatchObject({ kind: "allow", firewallName: "meta-ads" });
+    expect(
+      matchFirewallRequestDecision(
+        [metaAds],
+        "POST",
+        "https://graph.facebook.com/v22.0/",
+      ),
+    ).toMatchObject({ kind: "allow", firewallName: "meta-ads" });
+    expect(
+      matchFirewallRequestDecision(
+        [metaAds],
+        "GET",
+        "https://graph.facebook.com/v22.0/123/ads_posts",
+      ),
+    ).toMatchObject({
+      kind: "allow",
+      firewallName: "meta-ads",
+      permission: "page-token-ads-posts",
+    });
+    expect(
+      matchFirewallRequestDecision(
+        [metaAds],
+        "GET",
+        "https://graph.facebook.com/v22.0/me",
+        unknownDenyPolicy,
+      ),
+    ).toMatchObject({
+      kind: "block",
+      firewallName: "meta-ads",
+      reason: "unknown_endpoint",
+    });
+  });
 });
 
 describe("known endpoint-scoped firewall bases", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1976,6 +1976,100 @@
       }
     },
     {
+      "name": "same-owner permissionless api handles unknown endpoint",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer route" } },
+              "permissions": [
+                { "name": "items-read", "rules": ["GET /items/{id}"] }
+              ]
+            },
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer default" } },
+              "permissions": []
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items-read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/profile"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/profile",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "permissionless fallback does not preempt connector intent",
+      "firewalls": [
+        {
+          "name": "alpha",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer alpha" } },
+              "permissions": []
+            }
+          ]
+        },
+        {
+          "name": "beta",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer beta" } },
+              "permissions": [
+                { "name": "items-read", "rules": ["GET /items/{id}"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "alpha": {
+          "allow": [],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        },
+        "beta": {
+          "allow": ["items-read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/profile",
+        "connectorIntent": { "status": "present", "value": "beta" }
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "beta",
+        "base": "https://api.example.com",
+        "relativePath": "/profile"
+      }
+    },
+    {
       "name": "irrelevant intent cannot hide a unique route owner",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -2069,6 +2069,48 @@
       }
     },
     {
+      "name": "permissionless fallback cannot bypass denied concrete route",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer default" } },
+              "permissions": []
+            },
+            {
+              "base": "https://api.example.com",
+              "auth": { "headers": { "Authorization": "Bearer route" } },
+              "permissions": [
+                { "name": "items-read", "rules": ["GET /items/{id}"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["items-read"],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "permission_denied",
+        "permissions": ["items-read"]
+      }
+    },
+    {
       "name": "irrelevant intent cannot hide a unique route owner",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1990,8 +1990,7 @@
             },
             {
               "base": "https://api.example.com",
-              "auth": { "headers": { "Authorization": "Bearer default" } },
-              "permissions": []
+              "auth": { "headers": { "Authorization": "Bearer default" } }
             }
           ]
         }

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -136,6 +136,7 @@ interface DecisionApi {
   readonly baseMalformed: boolean;
   readonly authMalformed: boolean;
   readonly hasMalformedRules: boolean;
+  readonly permissionless: boolean;
   readonly routingIdentity: string | null;
   readonly rules: readonly DecisionRule[];
 }
@@ -597,6 +598,9 @@ function compileDecisionApi(
   const seenPermissionNames = new Set<string>();
   let hasMalformedRules = nameMalformed;
   const rawPermissions = api.permissions;
+  const permissionless =
+    !rawObjectHasOwn(api, "permissions") ||
+    (Array.isArray(rawPermissions) && rawPermissions.length === 0);
 
   if (Array.isArray(rawPermissions)) {
     for (const rawPermission of rawPermissions) {
@@ -649,6 +653,7 @@ function compileDecisionApi(
     baseMalformed,
     authMalformed,
     hasMalformedRules,
+    permissionless,
     routingIdentity,
     rules,
   };
@@ -1603,6 +1608,52 @@ function winningOwnerNames(
   return [...names].sort();
 }
 
+function selectedOwnerApiMatches(
+  collection: FirewallMatchCollection,
+  selectedName: string,
+): CollectedApiMatch[] {
+  const matches = winningApiMatches(collection).filter((match) => {
+    return match.firewall.name === selectedName;
+  });
+  if (collection.ruleMatches.length > 0) return matches;
+
+  // APIs without permissions are catch-alls only within the selected owner.
+  // Owner selection must still resolve shared bases before this fallback.
+  const permissionlessMatches = matches.filter((match) => {
+    return match.api.permissionless;
+  });
+  return permissionlessMatches.length > 0 ? permissionlessMatches : matches;
+}
+
+function relevantOwnerApiMatches(
+  collection: FirewallMatchCollection,
+  selectedName: string | null,
+): readonly CollectedApiMatch[] {
+  if (selectedName === null) return collection.apiMatches;
+  return collection.apiMatches.filter((match) => {
+    return match.firewall.name === selectedName || match.firewall.nameMalformed;
+  });
+}
+
+function selectedBaseApiMatches(
+  collection: FirewallMatchCollection,
+  selectedName: string | null,
+): readonly CollectedApiMatch[] {
+  const relevantMatches = relevantOwnerApiMatches(collection, selectedName);
+  if (selectedName === null || collection.ruleMatches.length > 0) {
+    return relevantMatches;
+  }
+
+  const selectedOrders = new Set(
+    selectedOwnerApiMatches(collection, selectedName).map((match) => {
+      return match.order;
+    }),
+  );
+  return relevantMatches.filter((match) => {
+    return selectedOrders.has(match.order);
+  });
+}
+
 function connectorAmbiguityReason(
   intent: FirewallConnectorIntent,
 ): ConnectorRouteAmbiguityReason {
@@ -1655,17 +1706,17 @@ function conflictingSelectedApiDecision(
   collection: FirewallMatchCollection,
   selectedName: string,
 ): FirewallRequestDecision | null {
-  const [first, ...otherMatches] = winningApiMatches(collection).filter(
-    (match) => {
-      return (
-        match.firewall.name === selectedName &&
-        !match.firewall.nameMalformed &&
-        !match.api.baseMalformed &&
-        !match.api.authMalformed &&
-        match.api.routingIdentity !== null
-      );
-    },
-  );
+  const [first, ...otherMatches] = selectedOwnerApiMatches(
+    collection,
+    selectedName,
+  ).filter((match) => {
+    return (
+      !match.firewall.nameMalformed &&
+      !match.api.baseMalformed &&
+      !match.api.authMalformed &&
+      match.api.routingIdentity !== null
+    );
+  });
   if (first === undefined || otherMatches.length === 0) return null;
   if (
     otherMatches.every((match) => {
@@ -1696,17 +1747,15 @@ function reduceSelectedOwner(
 
   const state = createDecisionState();
   const evaluableApiOrders = new Set<number>();
-  for (const apiMatch of collection.apiMatches) {
-    const { firewall, api, baseMatch, blockMatch } = apiMatch;
-    if (
-      selectedName !== null &&
-      firewall.name !== selectedName &&
-      !firewall.nameMalformed
-    ) {
-      continue;
-    }
+  const relevantApiMatches = relevantOwnerApiMatches(collection, selectedName);
+
+  for (const apiMatch of selectedBaseApiMatches(collection, selectedName)) {
+    acceptDecisionBaseMatch(state, apiMatch.baseMatch, apiMatch.score);
+  }
+
+  for (const apiMatch of relevantApiMatches) {
+    const { firewall, api, blockMatch } = apiMatch;
     const policy = networkPolicies.policies.get(firewall.name);
-    acceptDecisionBaseMatch(state, baseMatch, apiMatch.score);
     recordMalformedDecisionState(state, api, blockMatch);
     if (apiCannotEvaluateRules(firewall, api)) continue;
     if (policyCannotEvaluateRules(networkPolicies, policy)) {
@@ -1719,9 +1768,6 @@ function reduceSelectedOwner(
   for (const ruleMatch of collection.ruleMatches) {
     const { apiMatch, rule } = ruleMatch;
     if (!evaluableApiOrders.has(apiMatch.order)) continue;
-    if (selectedName !== null && apiMatch.firewall.name !== selectedName) {
-      continue;
-    }
     const policy = networkPolicies.policies.get(apiMatch.firewall.name);
     if (!acceptRuleSpecificity(state, rule.specificity)) continue;
     if (

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -164,6 +164,8 @@ export const firewallBaseHostPolicySchema = z.union([
 
 /**
  * Firewall API entry — a base URL with optional auth headers/query/base and permissions.
+ * An entry without permissions is the owner's fallback when no concrete
+ * permission route matches.
  */
 export const firewallApiSchema = z.object({
   base: z.string(),


### PR DESCRIPTION
## Summary

- Treat API entries without permissions as same-owner routing fallbacks when no concrete permission route matches.
- Keep concrete permission routes ahead of the fallback, so Meta Ads Page Ads Posts requests continue preserving caller-provided Page tokens.
- Apply the same routing semantics in the TypeScript diagnostic matcher and the Python runner matcher.
- Document the empty or omitted permissions fallback contract.

## Behavior and safety

- Select the connector owner before applying the permissionless fallback, preserving connector-intent handling for shared API bases.
- Continue applying `unknownPolicy` after fallback selection.
- Continue failing closed when multiple eligible fallback entries have conflicting credential-routing identities.
- Prevent a denied concrete permission route from falling back to a permissive default entry.
- Preserve malformed-configuration and malformed-policy handling.

## Not included

- No firewall schema shape, persisted format, or runner protocol changes.
- No changes to Meta Ads connector metadata or permission policy defaults.

## Validation

- `pnpm -F @vm0/connectors test` — 1,290 tests passed.
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm knip --workspace @vm0/connectors`
- `.venv/bin/pytest -q` — 4,127 tests passed.
- `.venv/bin/ruff format --check src/matching.py tests/test_compiled_firewall_unknown_policy.py`
- `.venv/bin/ruff check src tests`
- `.venv/bin/basedpyright`
- Repository pre-commit and commit-message hooks.

Closes #22303
