### PR TITLE
chore(api): enforce typed drizzle query construction

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -88,8 +88,9 @@ applicable runtime boundary:
 
 ```typescript
 // Correct: LOWER(text) has the same driver representation as the text column.
-const normalizedEmail =
-  sql`LOWER(${users.email})`.mapWith(users.email).as("normalized_email");
+const normalizedEmail = sql`LOWER(${users.email})`
+  .mapWith(users.email)
+  .as("normalized_email");
 
 // Correct: the explicit decoder owns the runtime number contract.
 const total = sql`COUNT(*)::int`.mapWith(pgIntegerDecoder).as("total");
@@ -149,6 +150,15 @@ its bound value. Likewise, use `max(column)` or `min(column)` for the exact
 aggregate form when the helper preserves the required decoder and nullability
 contract. Keep an existing outer `.mapWith(...)` when it owns a stricter or more
 specific contract than the helper's inferred result.
+
+This preference also applies to a replaceable leaf inside otherwise irreducible
+SQL. Interpolate the typed operator in place of that leaf while retaining the
+outer tag for surrounding CTE, CASE, join, filter, cast, grouping, or statement
+syntax. Do not replace outer composition with `and(...)` or `or(...)` when their
+`SQL | undefined` result would weaken a required concrete `SQL` contract.
+Keep SQL syntax that belongs to an operand inside that operand. For example,
+write ``gte(events.createdAt, sql`${timestamp}::timestamp`)`` rather than
+placing the cast after the interpolated `gte(...)` fragment.
 
 Every remaining SQL-tag interpolation must have one unambiguous static role.
 Do not interpolate `any`, `unknown`, a value that can be `undefined`, an array or

--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -143,6 +143,21 @@ returned fields independently of `.set({...})`. Likewise, raw SQL passed to
 `insert(...).select(...)` is the write source rather than a returned field; only
 a subsequent `returning(...)` introduces a result-mapping boundary.
 
+Use typed operators such as `eq`, `gt`, `isNull`, and `isNotNull` instead of an
+equivalent SQL tag. They preserve the schema relationship between a column and
+its bound value. Likewise, use `max(column)` or `min(column)` for the exact
+aggregate form when the helper preserves the required decoder and nullability
+contract. Keep an existing outer `.mapWith(...)` when it owns a stricter or more
+specific contract than the helper's inferred result.
+
+Every remaining SQL-tag interpolation must have one unambiguous static role.
+Do not interpolate `any`, `unknown`, a value that can be `undefined`, an array or
+tuple directly, or a union that mixes an ordinary bound value with an SQL
+wrapper. Narrow optional values before constructing SQL. Use `sql.empty()` for
+an intentionally empty fragment, `sql.param(...)` when an array or other value
+must be one driver parameter, and `sql.join(...)` when composing SQL fragments.
+Keep bound values and SQL wrappers as distinct types across helper boundaries.
+
 ### Raw Execute Rows
 
 Prefer structured Drizzle selections whenever they can express the query.

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -180,6 +180,8 @@ export default [
       "api/no-new-promise": "error",
       "api/no-sql-raw": "error",
       "api/no-store-in-params": "error",
+      "api/no-unsafe-sql-interpolation": "error",
+      "api/prefer-drizzle-apis": "error",
       "api/require-execute-row-schema": "error",
       "api/require-sql-result-mapping": "error",
       "api/signal-check-await": "error",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -32,6 +32,7 @@ import {
   eq,
   gt,
   inArray,
+  isNull,
   lt,
   notInArray,
   sql,
@@ -446,11 +447,11 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         ? {}
         : {
             setWhere: sql`
-              ${runnerState.heartbeatGeneration} IS NULL
-              OR ${runnerState.heartbeatGeneration} < ${snapshotOrder.generation}
+              ${isNull(runnerState.heartbeatGeneration)}
+              OR ${lt(runnerState.heartbeatGeneration, snapshotOrder.generation)}
               OR (
-                ${runnerState.heartbeatGeneration} = ${snapshotOrder.generation}
-                AND ${runnerState.heartbeatSequence} < ${snapshotOrder.sequence}
+                ${eq(runnerState.heartbeatGeneration, snapshotOrder.generation)}
+                AND ${lt(runnerState.heartbeatSequence, snapshotOrder.sequence)}
               )
             `,
           }),
@@ -883,7 +884,7 @@ async function lockRunnerJob(
         ${runnerJobQueue.runId} AS "runId",
         ${runnerJobQueue.expiresAt} <= now() AS "isExpired"
       FROM ${runnerJobQueue}
-      WHERE ${runnerJobQueue.runId} = ${runId}
+      WHERE ${eq(runnerJobQueue.runId, runId)}
       FOR UPDATE
     `,
     lockedRunnerJobRowSchema,
@@ -911,7 +912,7 @@ async function transitionClaimedJobToRunning(
               ${agentRuns.id} AS "id",
               ${agentRuns.status} AS "status"
             FROM ${agentRuns}
-            WHERE ${agentRuns.id} = ${runId}
+            WHERE ${eq(agentRuns.id, runId)}
             FOR UPDATE
           ),
           locked_job AS MATERIALIZED (

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -210,7 +210,7 @@ async function deleteRunForAction(
       sql`${inArray(chatThreads.id, runThreadIds)} AND NOT EXISTS (
         SELECT 1
         FROM ${chatMessages}
-        WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
+        WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
       )`,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -57,9 +57,9 @@ function uploadedArtifactAccessCondition(args: UserArtifactUrlAccessArgs): SQL {
   return sql`EXISTS (
     SELECT 1
     FROM ${runUploadedFiles}
-    WHERE ${runUploadedFiles.userId} = ${args.userId}
-      AND ${runUploadedFiles.orgId} = ${args.orgId}
-      AND ${runUploadedFiles.url} = ${args.artifactUrl}
+    WHERE ${eq(runUploadedFiles.userId, args.userId)}
+      AND ${eq(runUploadedFiles.orgId, args.orgId)}
+      AND ${eq(runUploadedFiles.url, args.artifactUrl)}
     LIMIT 1
   )`;
 }
@@ -74,11 +74,11 @@ function attachedArtifactAccessCondition(args: UserArtifactUrlAccessArgs): SQL {
     SELECT 1
     FROM ${chatMessages}
     INNER JOIN ${chatThreads}
-      ON ${chatThreads.id} = ${chatMessages.chatThreadId}
+      ON ${eq(chatThreads.id, chatMessages.chatThreadId)}
     INNER JOIN ${agentComposes}
-      ON ${agentComposes.id} = ${chatThreads.agentComposeId}
-    WHERE ${chatThreads.userId} = ${args.userId}
-      AND ${agentComposes.orgId} = ${args.orgId}
+      ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
+    WHERE ${eq(chatThreads.userId, args.userId)}
+      AND ${eq(agentComposes.orgId, args.orgId)}
       AND EXISTS (
         SELECT 1
         FROM jsonb_array_elements(COALESCE(${chatMessages.attachFileMetadata}, '[]'::jsonb)) AS attached_file

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -882,21 +882,21 @@ async function activeRunExistsForThread(
     sql`
       SELECT ${zeroRuns.id} AS "id"
       FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-      WHERE ${zeroRuns.chatThreadId} = ${threadId}
+      INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
+      WHERE ${eq(zeroRuns.chatThreadId, threadId)}
         AND ${agentRuns.status} IN ('queued', 'pending', 'running')
         AND (
           NOT EXISTS (
             SELECT 1
             FROM ${agentRunCallbacks}
-            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+            WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
               AND ${agentRunCallbacks.internalKind} = 'chat'
               AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
           )
           OR EXISTS (
             SELECT 1
             FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${zeroRuns.id}
+            WHERE ${eq(chatMessages.runId, zeroRuns.id)}
               AND ${chatMessages.role} = 'user'
           )
         )

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, desc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { chatThreadMarkAgentReadContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -98,7 +98,7 @@ const markAgentReadInner$ = command(
             isNotNull(lastRunFinish.id),
             or(
               isNull(chatThreads.lastReadAt),
-              sql`${lastRunFinish.createdAt} > ${chatThreads.lastReadAt}`,
+              gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
             )!,
           ),
         );

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -48,8 +48,8 @@ function latestRunFinishCreatedAtSql() {
   return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
-    WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
-      AND ${chatMessages.runLifecycleEvent} IS NOT NULL
+    WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
+      AND ${isNotNull(chatMessages.runLifecycleEvent)}
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
   )`;

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { chatThreadMarkReadContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -66,10 +66,10 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       and(
         eq(chatThreads.id, params.id),
         eq(chatThreads.userId, auth.userId),
-        sql`${latestRunFinishAt} IS NOT NULL`,
+        isNotNull(latestRunFinishAt),
         or(
           isNull(chatThreads.lastReadAt),
-          sql`${latestRunFinishAt} > ${chatThreads.lastReadAt}`,
+          gt(latestRunFinishAt, chatThreads.lastReadAt),
         )!,
       ),
     )

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -17,8 +17,8 @@ function latestRunFinishCreatedAtSql() {
   return sql`(
     SELECT ${chatMessages.createdAt}
     FROM ${chatMessages}
-    WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
-      AND ${chatMessages.runLifecycleEvent} IS NOT NULL
+    WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
+      AND ${isNotNull(chatMessages.runLifecycleEvent)}
     ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
     LIMIT 1
   )`;

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, desc, eq, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lt, or, sql } from "drizzle-orm";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { z } from "zod";
 
@@ -106,7 +106,7 @@ async function extractVideoPoster(
 
 function previewCandidateWhere(cursor?: PreviewCandidateCursor) {
   const conditions = [
-    sql`${runUploadedFiles.url} IS NOT NULL`,
+    isNotNull(runUploadedFiles.url),
     sql`jsonb_typeof(${runUploadedFiles.metadata}->'generatedBy') = 'string'`,
     sql`${runUploadedFiles.contentType} LIKE 'video/%'`,
     sql`${runUploadedFiles.previewImageUrl} IS NULL`,

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, desc, eq, isNotNull, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { z } from "zod";
 
@@ -109,7 +109,7 @@ function previewCandidateWhere(cursor?: PreviewCandidateCursor) {
     isNotNull(runUploadedFiles.url),
     sql`jsonb_typeof(${runUploadedFiles.metadata}->'generatedBy') = 'string'`,
     sql`${runUploadedFiles.contentType} LIKE 'video/%'`,
-    sql`${runUploadedFiles.previewImageUrl} IS NULL`,
+    isNull(runUploadedFiles.previewImageUrl),
     // Preserve the existing grace window so recently written generated videos
     // settle before the cron selects them.
     sql`${runUploadedFiles.updatedAt} < now() - interval '2 minutes'`,

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -144,7 +144,7 @@ export function chatThreadMessagesV1(
     ) > (
       SELECT ${chatMessages.createdAt}, COALESCE(${chatMessages.sequenceNumber}, -1)
       FROM ${chatMessages}
-      WHERE ${chatMessages.id} = ${cursorId}
+      WHERE ${eq(chatMessages.id, cursorId)}
     )`;
     const cursorBefore = sql`(
       ${chatMessages.createdAt},
@@ -152,7 +152,7 @@ export function chatThreadMessagesV1(
     ) < (
       SELECT ${chatMessages.createdAt}, COALESCE(${chatMessages.sequenceNumber}, -1)
       FROM ${chatMessages}
-      WHERE ${chatMessages.id} = ${cursorId}
+      WHERE ${eq(chatMessages.id, cursorId)}
     )`;
 
     if (args.sinceId !== undefined) {

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -123,7 +123,8 @@ export function chatThreadMessagesV1(
       excludeGoalMarkerCondition(),
     );
 
-    if (args.sinceId === undefined && args.beforeId === undefined) {
+    const cursorId = args.sinceId ?? args.beforeId;
+    if (cursorId === undefined) {
       const rows = await db
         .select(messageColumns)
         .from(chatMessages)
@@ -137,7 +138,6 @@ export function chatThreadMessagesV1(
       return rows.reverse().map(toV1Message);
     }
 
-    const cursorId = args.sinceId ?? args.beforeId;
     const cursorAfter = sql`(
       ${chatMessages.createdAt},
       COALESCE(${chatMessages.sequenceNumber}, -1)

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -9,7 +9,17 @@ import { usageEvent } from "@vm0/db/schema/usage-event";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command, computed, type Computed } from "ccstate";
-import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  max,
+  sql,
+} from "drizzle-orm";
 
 import {
   nullableDriverValueDecoder,
@@ -778,7 +788,7 @@ async function queryActiveUsers(
       .select({
         orgId: agentRuns.orgId,
         userId: agentRuns.userId,
-        lastActivity: sql`MAX(${agentRuns.completedAt})`
+        lastActivity: max(agentRuns.completedAt)
           .mapWith(agentRuns.completedAt)
           .as("last_activity"),
       })
@@ -794,7 +804,7 @@ async function queryActiveUsers(
       .select({
         orgId: usageEvent.orgId,
         userId: usageEvent.userId,
-        lastActivity: sql`MAX(${usageEvent.processedAt})`
+        lastActivity: max(usageEvent.processedAt)
           .mapWith(usageEvent.processedAt)
           .as("last_activity"),
       })
@@ -918,7 +928,7 @@ async function queryUsageEventCreditRows(
   dayEnd: Date,
   signal: AbortSignal,
 ): Promise<LedgerCreditRow[]> {
-  const isRunless = sql`${usageEvent.runId} IS NULL`;
+  const isRunless = isNull(usageEvent.runId);
   const rows = await db
     .select({
       orgId: usageEvent.orgId,
@@ -1299,7 +1309,7 @@ export const aggregateInsights$ = command(
       .select({
         orgId: insightsDaily.orgId,
         userId: insightsDaily.userId,
-        lastUpdated: sql`MAX(${insightsDaily.updatedAt})`
+        lastUpdated: max(insightsDaily.updatedAt)
           .mapWith(insightsDaily.updatedAt)
           .as("last_updated"),
       })

--- a/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-usage.service.ts
@@ -1,7 +1,7 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { usageDaily } from "@vm0/db/schema/usage-daily";
 import { command } from "ccstate";
-import { sql } from "drizzle-orm";
+import { gte, isNotNull, lt, sql } from "drizzle-orm";
 
 import { nowDate } from "../external/time";
 import { writeDb$ } from "../external/db";
@@ -32,9 +32,9 @@ export const aggregateUsageDaily$ = command(
         COUNT(*)::int,
         COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint
       FROM ${agentRuns}
-      WHERE ${agentRuns.createdAt} >= ${yesterday}
-        AND ${agentRuns.createdAt} < ${today}
-        AND ${agentRuns.completedAt} IS NOT NULL
+      WHERE ${gte(agentRuns.createdAt, yesterday)}
+        AND ${lt(agentRuns.createdAt, today)}
+        AND ${isNotNull(agentRuns.completedAt)}
       GROUP BY ${agentRuns.userId}, ${agentRuns.orgId}
       ON CONFLICT (user_id, org_id, date) DO UPDATE SET
         run_count = EXCLUDED.run_count,

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { sql, type SQL } from "drizzle-orm";
+import { eq, lt, sql, type SQL } from "drizzle-orm";
 import { chatThreadEvents } from "@vm0/db/schema/chat-thread-event";
 import { chatThreadSnapshots } from "@vm0/db/schema/chat-thread-snapshot";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
@@ -51,7 +51,7 @@ function allScopesCte(staleCutoff: Date): SQL {
       SELECT ${chatThreads.userId} AS user_id, ${agentComposes.orgId} AS org_id
       FROM ${chatThreads}
       INNER JOIN ${agentComposes}
-        ON ${agentComposes.id} = ${chatThreads.agentComposeId}
+        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
 
       UNION
 
@@ -62,7 +62,7 @@ function allScopesCte(staleCutoff: Date): SQL {
 
       SELECT ${chatThreadSnapshots.userId} AS user_id, ${chatThreadSnapshots.orgId} AS org_id
       FROM ${chatThreadSnapshots}
-      WHERE ${chatThreadSnapshots.updatedAt} < ${staleCutoff}
+      WHERE ${lt(chatThreadSnapshots.updatedAt, staleCutoff)}
     )
   `;
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -27,6 +27,7 @@ import {
   isNotNull,
   isNull,
   lte,
+  max,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -777,7 +778,7 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 
   const [message] = await db
     .select({
-      lastEventAt: sql`MAX(${chatMessages.createdAt})`.mapWith(
+      lastEventAt: max(chatMessages.createdAt).mapWith(
         nullableDriverValueDecoder(chatMessages.createdAt),
       ),
     })

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -28,6 +28,7 @@ import {
   isNull,
   lte,
   max,
+  ne,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -1588,21 +1589,21 @@ async function activeChatRunExistsForThread(
     sql`
       SELECT ${zeroRuns.id} AS "id"
       FROM ${zeroRuns}
-      INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-      WHERE ${zeroRuns.chatThreadId} = ${threadId}
+      INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
+      WHERE ${eq(zeroRuns.chatThreadId, threadId)}
         AND ${agentRuns.status} IN ('queued', 'pending', 'running')
         AND (
           NOT EXISTS (
             SELECT 1
             FROM ${agentRunCallbacks}
-            WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+            WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
               AND ${agentRunCallbacks.internalKind} = 'chat'
               AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
           )
           OR EXISTS (
             SELECT 1
             FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${zeroRuns.id}
+            WHERE ${eq(chatMessages.runId, zeroRuns.id)}
               AND ${chatMessages.role} = 'user'
           )
         )
@@ -1861,22 +1862,22 @@ async function claimQueuedUserMessageForDispatch(args: {
       sql`
         SELECT ${zeroRuns.id} AS "id"
         FROM ${zeroRuns}
-        INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-        WHERE ${zeroRuns.chatThreadId} = ${args.threadId}
-          AND ${zeroRuns.id} <> ${args.runId}
+        INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
+        WHERE ${eq(zeroRuns.chatThreadId, args.threadId)}
+          AND ${ne(zeroRuns.id, args.runId)}
           AND ${agentRuns.status} IN ('queued', 'pending', 'running')
           AND (
             NOT EXISTS (
               SELECT 1
               FROM ${agentRunCallbacks}
-              WHERE ${agentRunCallbacks.runId} = ${zeroRuns.id}
+              WHERE ${eq(agentRunCallbacks.runId, zeroRuns.id)}
                 AND ${agentRunCallbacks.internalKind} = 'chat'
                 AND ${agentRunCallbacks.payload}->>'queuedMessageId' IS NOT NULL
             )
             OR EXISTS (
               SELECT 1
               FROM ${chatMessages}
-              WHERE ${chatMessages.runId} = ${zeroRuns.id}
+              WHERE ${eq(chatMessages.runId, zeroRuns.id)}
                 AND ${chatMessages.role} = 'user'
             )
           )

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { lt, sql } from "drizzle-orm";
+import { eq, gte, lt, sql } from "drizzle-orm";
 import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -142,7 +142,7 @@ function modelUsageObservationModelExpression() {
   const modelColumn = modelUsageObservation.model;
   return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
-      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+      return sql`WHEN ${eq(modelColumn, alias)} THEN ${model}`;
     }),
     sql` `,
   )} ELSE ${modelColumn} END`;
@@ -152,7 +152,7 @@ function modelStatModelExpression() {
   const modelColumn = modelStat.model;
   return sql`CASE ${sql.join(
     getModelAliasEntries().map(([alias, model]) => {
-      return sql`WHEN ${modelColumn} = ${alias} THEN ${model}`;
+      return sql`WHEN ${eq(modelColumn, alias)} THEN ${model}`;
     }),
     sql` `,
   )} ELSE ${modelColumn} END`;
@@ -171,8 +171,8 @@ async function replaceModelStats(
   const insertedCount = await db.transaction(async (tx) => {
     await tx.execute(sql`
       DELETE FROM ${modelStat}
-      WHERE ${modelStat.hourStart} >= ${windowStartParam}::timestamp
-        AND ${modelStat.hourStart} < ${windowEndParam}::timestamp
+      WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
+        AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
         AND ${modelStat.model} IN (${modelStatsModelIdSql})
     `);
 
@@ -184,18 +184,18 @@ async function replaceModelStats(
           ${modelUsageObservation.orgId} AS org_id,
           ${modelUsageObservation.userId} AS user_id,
           COALESCE(${modelUsageObservation.runId}::text, ${modelUsageObservation.idempotencyKey}::text) AS request_key,
-          CASE WHEN ${modelUsageObservation.category} = ${TOKEN_CATEGORY_INPUT}
+          CASE WHEN ${eq(modelUsageObservation.category, TOKEN_CATEGORY_INPUT)}
             THEN ${modelUsageObservation.quantity} ELSE 0 END::bigint AS input_tokens,
-          CASE WHEN ${modelUsageObservation.category} = ${TOKEN_CATEGORY_OUTPUT}
+          CASE WHEN ${eq(modelUsageObservation.category, TOKEN_CATEGORY_OUTPUT)}
             THEN ${modelUsageObservation.quantity} ELSE 0 END::bigint AS output_tokens,
-          CASE WHEN ${modelUsageObservation.category} = ${TOKEN_CATEGORY_CACHE_READ}
+          CASE WHEN ${eq(modelUsageObservation.category, TOKEN_CATEGORY_CACHE_READ)}
             THEN ${modelUsageObservation.quantity} ELSE 0 END::bigint AS cache_read_input_tokens,
-          CASE WHEN ${modelUsageObservation.category} = ${TOKEN_CATEGORY_CACHE_CREATION}
+          CASE WHEN ${eq(modelUsageObservation.category, TOKEN_CATEGORY_CACHE_CREATION)}
             THEN ${modelUsageObservation.quantity} ELSE 0 END::bigint AS cache_creation_input_tokens,
           0::bigint AS credits_charged
         FROM ${modelUsageObservation}
-        WHERE ${modelUsageObservation.observedAt} >= ${windowStartParam}::timestamp
-          AND ${modelUsageObservation.observedAt} < ${windowEndParam}::timestamp
+        WHERE ${gte(modelUsageObservation.observedAt, sql`${windowStartParam}::timestamp`)}
+          AND ${lt(modelUsageObservation.observedAt, sql`${windowEndParam}::timestamp`)}
           AND ${modelUsageObservation.model} IN (${modelStatsModelIdSql})
           AND ${modelUsageObservation.category} IN (
             ${TOKEN_CATEGORY_INPUT},
@@ -309,8 +309,8 @@ async function selectModelRankings(
         COALESCE(SUM(${modelStat.outputTokens}), 0)::bigint AS output_tokens,
         COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens
       FROM ${modelStat}
-      WHERE ${modelStat.hourStart} >= ${windowStartParam}::timestamp
-        AND ${modelStat.hourStart} < ${windowEndParam}::timestamp
+      WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
+        AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
         AND ${modelStat.model} IN (${currentModelStatsModelIdSql})
       GROUP BY 1
     ),
@@ -319,8 +319,8 @@ async function selectModelRankings(
         ${modelExpr} AS model,
         COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS previous_total_tokens
       FROM ${modelStat}
-      WHERE ${modelStat.hourStart} >= ${previousStartParam}::timestamp
-        AND ${modelStat.hourStart} < ${previousEndParam}::timestamp
+      WHERE ${gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`)}
+        AND ${lt(modelStat.hourStart, sql`${previousEndParam}::timestamp`)}
         AND ${modelStat.model} IN (${previousModelStatsModelIdSql})
       GROUP BY 1
     )

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,7 +1,15 @@
 import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, gt, sql, type SQL, type SQLWrapper } from "drizzle-orm";
+import {
+  and,
+  eq,
+  gt,
+  isNotNull,
+  sql,
+  type SQL,
+  type SQLWrapper,
+} from "drizzle-orm";
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
@@ -68,15 +76,15 @@ function runnerStateHas(args: {
   readonly resourceCondition: SQL;
 }): SQL {
   const runnerCondition = args.runnerId
-    ? sql`AND ${runnerState.runnerId} = ${args.runnerId}`
+    ? sql`AND ${eq(runnerState.runnerId, args.runnerId)}`
     : sql``;
   return sql`EXISTS (
     SELECT 1
     FROM ${runnerState}
-    WHERE ${runnerState.runnerGroup} = ${args.runnerGroup}
+    WHERE ${eq(runnerState.runnerGroup, args.runnerGroup)}
       ${runnerCondition}
       AND ${runnerState.mode} = 'running'
-      AND ${runnerState.lastSeenAt} > ${args.freshAfter}
+      AND ${gt(runnerState.lastSeenAt, args.freshAfter)}
       AND ${args.resourceCondition}
   )`;
 }
@@ -126,17 +134,17 @@ export function runnerSessionAffinityPollPriority(args: {
   const hasGlobalWorkspace = global(workspaceCondition);
   const hasLocalWorkspace = local(workspaceCondition);
   return sql`CASE
-    WHEN ${runnerJobQueue.createdAt} > ${generationProtectedAfter}
-    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
-    AND ${targetGenerationRunId} IS NOT NULL
+    WHEN ${gt(runnerJobQueue.createdAt, generationProtectedAfter)}
+    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
+    AND ${isNotNull(targetGenerationRunId)}
     AND ${hasGlobalExact}
     THEN CASE WHEN ${hasLocalExact} THEN 5 ELSE 0 END
-    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
-    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    WHEN ${gt(runnerJobQueue.createdAt, protectedAfter)}
+    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
     AND ${hasGlobalReusable}
     THEN CASE WHEN ${hasLocalReusable} THEN 4 ELSE 0 END
-    WHEN ${runnerJobQueue.createdAt} > ${protectedAfter}
-    AND ${runnerJobQueue.cliAgentSessionId} IS NOT NULL
+    WHEN ${gt(runnerJobQueue.createdAt, protectedAfter)}
+    AND ${isNotNull(runnerJobQueue.cliAgentSessionId)}
     AND ${hasGlobalWorkspace}
     THEN CASE
       WHEN ${hasLocalReusable} THEN 4

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,7 +1,7 @@
 import type { SessionAffinityResource } from "@vm0/api-contracts/contracts/runners";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, gt, sql, type SQL } from "drizzle-orm";
+import { and, eq, gt, sql, type SQL, type SQLWrapper } from "drizzle-orm";
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db } from "../external/db";
@@ -19,21 +19,18 @@ function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
   );
 }
 
-type SessionIdSqlValue = string | SQL;
-type ProfileSqlValue = string | SQL;
-type GenerationSqlValue = string | SQL;
-
 function reusableSandboxCondition(args: {
-  readonly sessionId: SessionIdSqlValue;
-  readonly profile: ProfileSqlValue;
-  readonly historyGenerationRunId?: GenerationSqlValue;
+  readonly sessionId: SQLWrapper;
+  readonly profile: SQLWrapper;
+  readonly historyGenerationRunId?: SQLWrapper;
 }): SQL {
-  const reusableSandbox = args.historyGenerationRunId
-    ? sql`jsonb_build_object(
+  const reusableSandbox =
+    args.historyGenerationRunId !== undefined
+      ? sql`jsonb_build_object(
         'profile', cast(${args.profile} as text),
         'historyGenerationRunId', cast(${args.historyGenerationRunId} as text)
       )`
-    : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
+      : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
   return sql`${runnerState.heldSessionStates} @> jsonb_build_array(
     jsonb_build_object(
       'sessionId', cast(${args.sessionId} as text),
@@ -43,8 +40,8 @@ function reusableSandboxCondition(args: {
 }
 
 function capableWorkspaceCondition(args: {
-  readonly sessionId: SessionIdSqlValue;
-  readonly profile: ProfileSqlValue;
+  readonly sessionId: SQLWrapper;
+  readonly profile: SQLWrapper;
 }): SQL {
   return sql`(
     ${runnerState.heldSessionStates} @> jsonb_build_array(
@@ -222,20 +219,22 @@ async function runnerSessionAffinityHolders(args: {
   readonly shouldLookUpExactGeneration: boolean;
 }): Promise<RunnerSessionAffinityHolders> {
   const reusableCondition = reusableSandboxCondition({
-    sessionId: args.cliAgentSessionId,
-    profile: args.profile,
+    sessionId: sql.param(args.cliAgentSessionId),
+    profile: sql.param(args.profile),
   });
   const workspaceCondition = capableWorkspaceCondition({
-    sessionId: args.cliAgentSessionId,
-    profile: args.profile,
+    sessionId: sql.param(args.cliAgentSessionId),
+    profile: sql.param(args.profile),
   });
-  const exactGenerationCondition = args.shouldLookUpExactGeneration
-    ? reusableSandboxCondition({
-        sessionId: args.cliAgentSessionId,
-        profile: args.profile,
-        historyGenerationRunId: args.historyGenerationRunId,
-      })
-    : sql`false`;
+  const exactGenerationCondition =
+    args.shouldLookUpExactGeneration &&
+    args.historyGenerationRunId !== undefined
+      ? reusableSandboxCondition({
+          sessionId: sql.param(args.cliAgentSessionId),
+          profile: sql.param(args.profile),
+          historyGenerationRunId: sql.param(args.historyGenerationRunId),
+        })
+      : sql`false`;
   const [holders] = await args.db
     .select({
       hasReusableHolder:

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -311,7 +311,7 @@ async function touchRecentlyUsedCacheRows(
       FROM ${systemStoragePresignedUrlCache}
       WHERE
         ${systemStoragePresignedUrlCache.cacheKey} IN (${cacheKeySql})
-        AND ${systemStoragePresignedUrlCache.lastRequestedAt} <= ${touchCutoffTimestamp}::timestamp
+        AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${touchCutoffTimestamp}::timestamp`)}
       ORDER BY ${systemStoragePresignedUrlCache.cacheKey}
       FOR UPDATE OF ${systemStoragePresignedUrlCache}
     )
@@ -339,9 +339,9 @@ async function pruneInactiveExpiredCacheRows(
       SELECT ${systemStoragePresignedUrlCache.cacheKey} AS "cacheKey"
       FROM ${systemStoragePresignedUrlCache}
       WHERE
-        ${systemStoragePresignedUrlCache.scope} = ${scope}
-        AND ${systemStoragePresignedUrlCache.expiresAt} <= ${issuedAtTimestamp}::timestamp
-        AND ${systemStoragePresignedUrlCache.lastRequestedAt} <= ${inactiveCutoffTimestamp}::timestamp
+        ${eq(systemStoragePresignedUrlCache.scope, scope)}
+        AND ${lte(systemStoragePresignedUrlCache.expiresAt, sql`${issuedAtTimestamp}::timestamp`)}
+        AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${inactiveCutoffTimestamp}::timestamp`)}
       ORDER BY
         ${systemStoragePresignedUrlCache.lastRequestedAt},
         ${systemStoragePresignedUrlCache.expiresAt},
@@ -354,9 +354,9 @@ async function pruneInactiveExpiredCacheRows(
       INNER JOIN candidates
         ON ${systemStoragePresignedUrlCache.cacheKey} = candidates."cacheKey"
       WHERE
-        ${systemStoragePresignedUrlCache.scope} = ${scope}
-        AND ${systemStoragePresignedUrlCache.expiresAt} <= ${issuedAtTimestamp}::timestamp
-        AND ${systemStoragePresignedUrlCache.lastRequestedAt} <= ${inactiveCutoffTimestamp}::timestamp
+        ${eq(systemStoragePresignedUrlCache.scope, scope)}
+        AND ${lte(systemStoragePresignedUrlCache.expiresAt, sql`${issuedAtTimestamp}::timestamp`)}
+        AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${inactiveCutoffTimestamp}::timestamp`)}
       ORDER BY ${systemStoragePresignedUrlCache.cacheKey}
       FOR UPDATE OF ${systemStoragePresignedUrlCache}
     )

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,6 +1,6 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -79,9 +79,9 @@ async function selectIncompleteRoundFrontier(
           (${isSuccessfulRun}) AS is_success
         FROM ${chatMessages}
         INNER JOIN ${agentRuns}
-          ON ${agentRuns.id} = ${chatMessages.runId}
-        WHERE ${chatMessages.chatThreadId} = ${threadId}
-          AND ${chatMessages.runId} IS NOT NULL
+          ON ${eq(agentRuns.id, chatMessages.runId)}
+        WHERE ${eq(chatMessages.chatThreadId, threadId)}
+          AND ${isNotNull(chatMessages.runId)}
           AND NOT (
             ${chatMessages.runId} = ANY(incomplete_frontier.seen_run_ids)
           )

--- a/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-message-shared.service.ts
@@ -6,7 +6,7 @@ import {
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { eq, sql } from "drizzle-orm";
+import { eq, isNotNull, isNull, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import {
@@ -111,15 +111,15 @@ export function visibleChatMessageCondition() {
     )
     AND NOT (
       ${chatMessages.role} = 'user'
-      AND ${chatMessages.runId} IS NULL
-      AND ${chatMessages.revokesMessageId} IS NOT NULL
-      AND ${chatMessages.content} IS NULL
-      AND ${chatMessages.error} IS NULL
+      AND ${isNull(chatMessages.runId)}
+      AND ${isNotNull(chatMessages.revokesMessageId)}
+      AND ${isNull(chatMessages.content)}
+      AND ${isNull(chatMessages.error)}
     )
     AND NOT (
       ${chatMessages.role} = 'user'
-      AND ${chatMessages.runId} IS NULL
-      AND ${chatMessages.interruptsRunId} IS NOT NULL
+      AND ${isNull(chatMessages.runId)}
+      AND ${isNotNull(chatMessages.interruptsRunId)}
     )`;
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -108,7 +108,7 @@ const matchedChatMessage = alias(chatMessages, "matched_chat_message");
 
 function chatMessageOrderSequenceSql() {
   return sql`CASE
-    WHEN ${chatMessages.runLifecycleEvent} IS NOT NULL THEN ${TERMINAL_MESSAGE_ORDER_SEQUENCE}
+    WHEN ${isNotNull(chatMessages.runLifecycleEvent)} THEN ${TERMINAL_MESSAGE_ORDER_SEQUENCE}
     ELSE COALESCE(${chatMessages.sequenceNumber}, -1)
   END`;
 }
@@ -241,8 +241,8 @@ const messageColumns = {
   isGoalRun: sql`EXISTS (
     SELECT 1
     FROM ${zeroRuns}
-    WHERE ${zeroRuns.id} = ${chatMessages.runId}
-      AND ${zeroRuns.goalId} IS NOT NULL
+    WHERE ${eq(zeroRuns.id, chatMessages.runId)}
+      AND ${isNotNull(zeroRuns.goalId)}
   )`.mapWith(pgBooleanDecoder),
   usagePayload: chatMessages.usagePayload,
   runEventId: chatMessages.runEventId,
@@ -726,8 +726,8 @@ function noActiveRunsForCurrentThreadCondition() {
   return sql`NOT EXISTS (
     SELECT 1
     FROM ${zeroRuns}
-    INNER JOIN ${agentRuns} ON ${agentRuns.id} = ${zeroRuns.id}
-    WHERE ${zeroRuns.chatThreadId} = ${chatThreads.id}
+    INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
+    WHERE ${eq(zeroRuns.chatThreadId, chatThreads.id)}
       AND ${agentRuns.status} IN (${activeRunStatusSqlList()})
   )`;
 }
@@ -736,7 +736,7 @@ function noActiveGoalsForCurrentThreadCondition() {
   return sql`NOT EXISTS (
     SELECT 1
     FROM ${threadGoals}
-    WHERE ${threadGoals.chatThreadId} = ${chatThreads.id}
+    WHERE ${eq(threadGoals.chatThreadId, chatThreads.id)}
       AND ${threadGoals.status} = 'active'
   )`;
 }
@@ -932,7 +932,7 @@ export function zeroChatThreadDraftIds(
             COALESCE(${chatThreads.draftContent}, '') <> ''
             OR ${chatThreads.draftStructuredPrompt} IS NOT NULL
             OR (
-              ${chatThreads.draftAttachments} IS NOT NULL
+              ${isNotNull(chatThreads.draftAttachments)}
               AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
             )
           )`,
@@ -977,8 +977,8 @@ export function zeroChatThreadArtifacts(args: {
               sql`EXISTS (
                 SELECT 1
                 FROM ${chatMessages}
-                WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
-                  AND ${chatMessages.chatThreadId} = ${args.threadId}
+                WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
+                  AND ${eq(chatMessages.chatThreadId, args.threadId)}
               )`,
             ),
           ),
@@ -1232,22 +1232,22 @@ async function listChangedArtifacts(args: {
           ) AS metadata_updated_at
         FROM ${agentRuns}
         INNER JOIN ${zeroRuns}
-          ON ${zeroRuns.id} = ${agentRuns.id}
+          ON ${eq(zeroRuns.id, agentRuns.id)}
         INNER JOIN ${chatThreads}
           ON ${chatThreads.id} = COALESCE(
             ${zeroRuns.chatThreadId},
             (
               SELECT ${chatMessages.chatThreadId}
               FROM ${chatMessages}
-              WHERE ${chatMessages.runId} = ${zeroRuns.id}
+              WHERE ${eq(chatMessages.runId, zeroRuns.id)}
               ORDER BY ${chatMessages.createdAt} ASC
               LIMIT 1
             )
           )
         INNER JOIN ${agentComposes}
-          ON ${agentComposes.id} = ${chatThreads.agentComposeId}
+          ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
         INNER JOIN ${zeroAgents}
-          ON ${zeroAgents.id} = ${agentComposes.id}
+          ON ${eq(zeroAgents.id, agentComposes.id)}
         WHERE ${sql.join(callerConditions, sql` AND `)}
       ),
       changed_artifact_ids AS MATERIALIZED (
@@ -1259,7 +1259,7 @@ async function listChangedArtifacts(args: {
           ON ${runUploadedFiles.runId} = visible_runs.run_id
         WHERE ${sql.join(fileConditions, sql` AND `)}
           AND ${lowerBoundClause}
-          AND ${effectiveUpdatedAt} < ${args.syncUntil}::timestamptz AT TIME ZONE 'UTC'
+          AND ${lt(effectiveUpdatedAt, sql`${args.syncUntil}::timestamptz AT TIME ZONE 'UTC'`)}
         ORDER BY ${effectiveUpdatedAt} ASC, ${runUploadedFiles.id} ASC
         LIMIT ${args.limit + 1}
       )
@@ -1287,33 +1287,33 @@ async function listChangedArtifacts(args: {
         ${zeroAgents.id} AS agent_id,
         COALESCE(${zeroAgents.displayName}, ${agentComposes.name}) AS agent_name,
         ${zeroAgents.avatarUrl} AS agent_avatar_url,
-        (${userArtifactFavorites.artifactUrl} IS NOT NULL) AS is_favorited
+        (${isNotNull(userArtifactFavorites.artifactUrl)}) AS is_favorited
       FROM changed_artifact_ids
       INNER JOIN ${runUploadedFiles}
         ON ${runUploadedFiles.id} = changed_artifact_ids.row_id
       INNER JOIN ${agentRuns}
-        ON ${agentRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(agentRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${zeroRuns}
-        ON ${zeroRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${chatThreads}
         ON ${chatThreads.id} = COALESCE(
           ${zeroRuns.chatThreadId},
           (
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
             ORDER BY ${chatMessages.createdAt} ASC
             LIMIT 1
           )
         )
       INNER JOIN ${agentComposes}
-        ON ${agentComposes.id} = ${chatThreads.agentComposeId}
+        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
       INNER JOIN ${zeroAgents}
-        ON ${zeroAgents.id} = ${agentComposes.id}
+        ON ${eq(zeroAgents.id, agentComposes.id)}
       LEFT JOIN ${userArtifactFavorites}
-        ON ${userArtifactFavorites.orgId} = ${args.query.orgId}
-        AND ${userArtifactFavorites.userId} = ${args.query.userId}
-        AND ${userArtifactFavorites.artifactUrl} = ${runUploadedFiles.url}
+        ON ${eq(userArtifactFavorites.orgId, args.query.orgId)}
+        AND ${eq(userArtifactFavorites.userId, args.query.userId)}
+        AND ${eq(userArtifactFavorites.artifactUrl, runUploadedFiles.url)}
       ORDER BY changed_artifact_ids.effective_updated_at ASC,
         changed_artifact_ids.row_id ASC
     `,
@@ -1360,31 +1360,31 @@ async function listArtifactHistory(args: {
           ${runUploadedFiles.createdAt},
           'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
         ) AS cursor_created_at,
-        (${userArtifactFavorites.artifactUrl} IS NOT NULL) AS is_favorited
+        (${isNotNull(userArtifactFavorites.artifactUrl)}) AS is_favorited
       FROM ${runUploadedFiles}
       INNER JOIN ${agentRuns}
-        ON ${agentRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(agentRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${zeroRuns}
-        ON ${zeroRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${chatThreads}
         ON ${chatThreads.id} = COALESCE(
           ${zeroRuns.chatThreadId},
           (
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
             ORDER BY ${chatMessages.createdAt} ASC
             LIMIT 1
           )
         )
       INNER JOIN ${agentComposes}
-        ON ${agentComposes.id} = ${chatThreads.agentComposeId}
+        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
       INNER JOIN ${zeroAgents}
-        ON ${zeroAgents.id} = ${agentComposes.id}
+        ON ${eq(zeroAgents.id, agentComposes.id)}
       LEFT JOIN ${userArtifactFavorites}
-        ON ${userArtifactFavorites.orgId} = ${args.query.orgId}
-        AND ${userArtifactFavorites.userId} = ${args.query.userId}
-        AND ${userArtifactFavorites.artifactUrl} = ${runUploadedFiles.url}
+        ON ${eq(userArtifactFavorites.orgId, args.query.orgId)}
+        AND ${eq(userArtifactFavorites.userId, args.query.userId)}
+        AND ${eq(userArtifactFavorites.artifactUrl, runUploadedFiles.url)}
       WHERE ${sql.join(conditions, sql` AND `)}
       ${keysetClause}
     ORDER BY ${runUploadedFiles.createdAt} DESC, ${runUploadedFiles.id} DESC
@@ -1500,22 +1500,22 @@ async function artifactUrlIsVisible(
       SELECT 1
       FROM ${runUploadedFiles}
       INNER JOIN ${agentRuns}
-        ON ${agentRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(agentRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${zeroRuns}
-        ON ${zeroRuns.id} = ${runUploadedFiles.runId}
+        ON ${eq(zeroRuns.id, runUploadedFiles.runId)}
       INNER JOIN ${chatThreads}
         ON ${chatThreads.id} = COALESCE(
           ${zeroRuns.chatThreadId},
           (
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
-            WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+            WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
             ORDER BY ${chatMessages.createdAt} ASC
             LIMIT 1
           )
         )
       INNER JOIN ${agentComposes}
-        ON ${agentComposes.id} = ${chatThreads.agentComposeId}
+        ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
       WHERE ${sql.join(conditions, sql` AND `)}
       LIMIT 1
       ) AS visible
@@ -1532,29 +1532,29 @@ async function touchArtifactFavoriteChange(
   await db.execute(sql`
     UPDATE ${runUploadedFiles}
     SET updated_at = clock_timestamp()
-    WHERE ${runUploadedFiles.url} = ${args.artifactUrl}
+    WHERE ${eq(runUploadedFiles.url, args.artifactUrl)}
       AND EXISTS (
         SELECT 1
         FROM ${agentRuns}
         INNER JOIN ${zeroRuns}
-          ON ${zeroRuns.id} = ${agentRuns.id}
+          ON ${eq(zeroRuns.id, agentRuns.id)}
         INNER JOIN ${chatThreads}
           ON ${chatThreads.id} = COALESCE(
             ${zeroRuns.chatThreadId},
             (
               SELECT ${chatMessages.chatThreadId}
               FROM ${chatMessages}
-              WHERE ${chatMessages.runId} = ${runUploadedFiles.runId}
+              WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
               ORDER BY ${chatMessages.createdAt} ASC
               LIMIT 1
             )
           )
         INNER JOIN ${agentComposes}
-          ON ${agentComposes.id} = ${chatThreads.agentComposeId}
-        WHERE ${agentRuns.id} = ${runUploadedFiles.runId}
-          AND ${agentRuns.orgId} = ${args.orgId}
-          AND ${chatThreads.userId} = ${args.userId}
-          AND ${agentComposes.orgId} = ${args.orgId}
+          ON ${eq(agentComposes.id, chatThreads.agentComposeId)}
+        WHERE ${eq(agentRuns.id, runUploadedFiles.runId)}
+          AND ${eq(agentRuns.orgId, args.orgId)}
+          AND ${eq(chatThreads.userId, args.userId)}
+          AND ${eq(agentComposes.orgId, args.orgId)}
       )
   `);
 }
@@ -1898,8 +1898,8 @@ export function zeroChatThreadMessagesPage(args: {
           ${chatMessageOrderSequenceSql()},
           ${chatMessages.id}
         FROM ${chatMessages}
-        WHERE ${chatMessages.id} = ${cursorId}
-          AND ${chatMessages.chatThreadId} = ${args.threadId}
+        WHERE ${eq(chatMessages.id, cursorId)}
+          AND ${eq(chatMessages.chatThreadId, args.threadId)}
       )`;
       const cursorBeforeCondition = sql`(
         ${chatMessages.createdAt},
@@ -1910,8 +1910,8 @@ export function zeroChatThreadMessagesPage(args: {
           ${chatMessageOrderSequenceSql()},
           ${chatMessages.id}
         FROM ${chatMessages}
-        WHERE ${chatMessages.id} = ${cursorId}
-          AND ${chatMessages.chatThreadId} = ${args.threadId}
+        WHERE ${eq(chatMessages.id, cursorId)}
+          AND ${eq(chatMessages.chatThreadId, args.threadId)}
       )`;
 
       if (args.sinceId !== undefined) {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -930,7 +930,7 @@ export function zeroChatThreadDraftIds(
           eq(chatThreads.userId, userId),
           sql`(
             COALESCE(${chatThreads.draftContent}, '') <> ''
-            OR ${chatThreads.draftStructuredPrompt} IS NOT NULL
+            OR ${isNotNull(chatThreads.draftStructuredPrompt)}
             OR (
               ${isNotNull(chatThreads.draftAttachments)}
               AND jsonb_array_length(${chatThreads.draftAttachments}) > 0

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -830,7 +830,7 @@ export function zeroChatThreadUnreads(args: {
           isNotNull(lastRunFinish.id),
           or(
             isNull(chatThreads.lastReadAt),
-            sql`${lastRunFinish.createdAt} > ${chatThreads.lastReadAt}`,
+            gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
           ),
           noActiveRunsForCurrentThreadCondition(),
           noActiveGoalsForCurrentThreadCondition(),
@@ -870,7 +870,7 @@ export function zeroChatThreadUnreadAgentIds(args: {
           isNotNull(lastRunFinish.id),
           or(
             isNull(chatThreads.lastReadAt),
-            sql`${lastRunFinish.createdAt} > ${chatThreads.lastReadAt}`,
+            gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
           ),
           noActiveRunsForCurrentThreadCondition(),
           noActiveGoalsForCurrentThreadCondition(),
@@ -1047,15 +1047,15 @@ function artifactCallerVisibilityConditions(args: {
   readonly orgId: string;
 }): SQL[] {
   return [
-    sql`${agentRuns.orgId} = ${args.orgId}`,
-    sql`${chatThreads.userId} = ${args.userId}`,
-    sql`${agentComposes.orgId} = ${args.orgId}`,
+    eq(agentRuns.orgId, args.orgId),
+    eq(chatThreads.userId, args.userId),
+    eq(agentComposes.orgId, args.orgId),
   ];
 }
 
 function artifactFileVisibilityConditions(): SQL[] {
   return [
-    sql`${runUploadedFiles.url} IS NOT NULL`,
+    isNotNull(runUploadedFiles.url),
     sql`(
       NOT EXISTS (
         SELECT 1
@@ -1491,7 +1491,7 @@ async function artifactUrlIsVisible(
 ): Promise<boolean> {
   const conditions = [
     ...artifactVisibilityConditions(args),
-    sql`${runUploadedFiles.url} = ${args.artifactUrl}`,
+    eq(runUploadedFiles.url, args.artifactUrl),
   ];
   const rows = await executeRawRows(
     db,

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -160,7 +160,7 @@ export const maybeEmitRunUsageMessage$ = command(
         .where(
           and(
             eq(chatMessages.runId, runId),
-            sql`${chatMessages.usagePayload} IS NOT NULL`,
+            isNotNull(chatMessages.usagePayload),
           ),
         )
         .limit(1);

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -2,7 +2,7 @@ import type StripeSDK from "stripe";
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
-import { eq, sql } from "drizzle-orm";
+import { eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -124,7 +124,7 @@ export const triggerAutoRecharge$ = command(
       ? sql`EXISTS (
           SELECT 1
           FROM ${orgPlanEntitlements}
-          WHERE ${orgPlanEntitlements.orgId} = ${orgId}
+          WHERE ${eq(orgPlanEntitlements.orgId, orgId)}
             AND ${orgPlanEntitlements.autoRechargeAllowed} = true
         )`
       : sql`${orgMetadata.tier} IN ('pro', 'team', 'custom')`;
@@ -140,14 +140,14 @@ export const triggerAutoRecharge$ = command(
       .update(orgMetadata)
       .set({ autoRechargePendingAt: nowDate(), updatedAt: nowDate() })
       .where(
-        sql`${orgMetadata.orgId} = ${orgId}
+        sql`${eq(orgMetadata.orgId, orgId)}
             AND ${orgMetadata.autoRechargeEnabled} = true
             AND ${planEligibility}
-            AND ${orgMetadata.stripeCustomerId} IS NOT NULL
-            AND ${orgMetadata.autoRechargeThreshold} IS NOT NULL
-            AND ${orgMetadata.autoRechargeAmount} IS NOT NULL
-            AND ${orgMetadata.credits} <= ${orgMetadata.autoRechargeThreshold}
-            AND (${orgMetadata.autoRechargePendingAt} IS NULL
+            AND ${isNotNull(orgMetadata.stripeCustomerId)}
+            AND ${isNotNull(orgMetadata.autoRechargeThreshold)}
+            AND ${isNotNull(orgMetadata.autoRechargeAmount)}
+            AND ${lte(orgMetadata.credits, orgMetadata.autoRechargeThreshold)}
+            AND (${isNull(orgMetadata.autoRechargePendingAt)}
                  OR ${orgMetadata.autoRechargePendingAt} < now() - make_interval(mins => ${STALE_THRESHOLD_MINUTES}))`,
       )
       .returning({

--- a/turbo/apps/api/src/signals/services/zero-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-insights.service.ts
@@ -6,7 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-insights";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
-import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, max, min, sql } from "drizzle-orm";
 
 import {
   nullableDriverValueDecoder,
@@ -204,10 +204,10 @@ export function zeroInsightsRange(args: {
   return computed(async (get): Promise<InsightsRangeResponse> => {
     const [row] = await get(db$)
       .select({
-        minDate: sql`MIN(${insightsDaily.date})`
+        minDate: min(insightsDaily.date)
           .mapWith(nullableTextDecoder)
           .as("min_date"),
-        maxDate: sql`MAX(${insightsDaily.date})`
+        maxDate: max(insightsDaily.date)
           .mapWith(nullableTextDecoder)
           .as("max_date"),
         totalDays: sql`COUNT(*)::int`

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -620,7 +620,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
             sql`NOT EXISTS (
               SELECT 1
               FROM ${agentRunQueue}
-              WHERE ${agentRunQueue.runId} = ${agentRuns.id}
+              WHERE ${eq(agentRunQueue.runId, agentRuns.id)}
             )`,
           ),
         )
@@ -653,7 +653,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
             sql`NOT EXISTS (
               SELECT 1
               FROM ${agentRunQueue}
-              WHERE ${agentRunQueue.runId} = ${agentRuns.id}
+              WHERE ${eq(agentRunQueue.runId, agentRuns.id)}
             )`,
           ),
         )

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -1,4 +1,13 @@
-import { and, eq, gte, isNotNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  gte,
+  isNotNull,
+  lt,
+  max,
+  sql,
+  type SQLWrapper,
+} from "drizzle-orm";
 import { usageAllowanceAllocations } from "@vm0/db/schema/org-usage-allowance";
 import { usageEvent } from "@vm0/db/schema/usage-event";
 
@@ -132,7 +141,7 @@ export function buildUsageEventRunUsageTotalsSubquery(db: Db, orgId: string) {
       sql`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`
         .mapWith(nullableTextDecoder)
         .as("model"),
-    userId: sql`MAX(${usageEvent.userId})`.mapWith(pgTextDecoder).as("user_id"),
+    userId: max(usageEvent.userId).mapWith(pgTextDecoder).as("user_id"),
   } satisfies Record<keyof UsageRunTotalsRow, unknown>;
 
   return db
@@ -197,7 +206,7 @@ function usageEventTokenSum(categories: readonly string[], alias: string) {
     .as(alias);
 }
 
-function coalesceRunTotal(column: unknown, alias: string) {
+function coalesceRunTotal(column: SQLWrapper, alias: string) {
   return sql`COALESCE(${column}, 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -138,7 +138,7 @@ export function buildUsageEventRunUsageTotalsSubquery(db: Db, orgId: string) {
     ),
     creditsCharged: usageCreditsSum("credits_sum"),
     model:
-      sql`MAX(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} THEN ${usageEvent.provider} ELSE NULL END)`
+      sql`MAX(CASE WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)} THEN ${usageEvent.provider} ELSE NULL END)`
         .mapWith(nullableTextDecoder)
         .as("model"),
     userId: max(usageEvent.userId).mapWith(pgTextDecoder).as("user_id"),
@@ -201,7 +201,7 @@ function usageEventTokenSum(categories: readonly string[], alias: string) {
     }),
     sql`, `,
   );
-  return sql`COALESCE(SUM(CASE WHEN ${usageEvent.kind} = ${MODEL_USAGE_KIND} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
+  return sql`COALESCE(SUM(CASE WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
@@ -1,0 +1,152 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, it } from "vitest";
+
+import { noUnsafeSqlInterpolation } from "../rules/no-unsafe-sql-interpolation.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+const drizzlePreamble = `
+  import { relations } from "drizzle-orm";
+  import { integer, pgTable, text } from "drizzle-orm/pg-core";
+
+  const users = pgTable("users", {
+    id: integer("id").notNull(),
+    name: text("name").notNull(),
+    tags: text("tags").array().notNull(),
+  });
+  const usersRelations = relations(users, () => ({}));
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      users: typeof users;
+      usersRelations: typeof usersRelations;
+    }>;
+  declare const db: DrizzleDatabase;
+`;
+
+ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
+  valid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const values: readonly string[] = ["one", "two"];
+        declare const wrapper: SQL | typeof users.id;
+        declare const unknownValue: unknown;
+        sql\`
+          \${"value"}
+          \${null}
+          \${users}
+          \${users.tags}
+          \${sql.param(values)}
+          \${sql.param(unknownValue)}
+          \${sql.join([sql\`one\`, sql\`two\`], sql\`, \`)}
+          \${sql.empty()}
+          \${wrapper}
+        \`;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        const query = drizzle.sql;
+        query\`\${users.id} = \${1}\`;
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.name} = \${"name"}\`,
+        });
+      `,
+    },
+    {
+      code: `
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        declare const value: any;
+        sql\`\${value}\`;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        declare const value: any;
+        sql\`\${value}\`;
+      `,
+      errors: [{ messageId: "anyInterpolation" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as query } from "drizzle-orm";
+        declare const value: unknown;
+        query\`\${value}\`;
+      `,
+      errors: [{ messageId: "unknownInterpolation" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        declare const value: string | undefined;
+        drizzle.sql\`\${value}\`;
+        drizzle.sql\`\${undefined}\`;
+      `,
+      errors: [
+        { messageId: "undefinedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const query = sql;
+        declare const values: readonly string[];
+        declare const tuple: readonly [string, number];
+        declare const mixedValues: string | string[];
+        query\`\${values} \${tuple} \${mixedValues}\`;
+      `,
+      errors: [
+        { messageId: "arrayInterpolation" },
+        { messageId: "arrayInterpolation" },
+        { messageId: "arrayInterpolation" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { type SQL } from "drizzle-orm";
+        declare const mixed: string | SQL;
+        db.query.users.findMany({
+          where: (_fields, operators) => operators.sql\`\${mixed}\`,
+        });
+      `,
+      errors: [{ messageId: "mixedInterpolation" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare const mixed: SQL | null;
+        sql\`\${mixed}\`;
+      `,
+      errors: [{ messageId: "mixedInterpolation" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unsafe-sql-interpolation.test.ts
@@ -77,6 +77,19 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
       `,
     },
     {
+      code: `${drizzlePreamble}
+        import { sql, type SQLWrapper } from "drizzle-orm";
+        function interpolateBound<T extends string | number>(value: T) {
+          return sql\`\${value}\`;
+        }
+        function interpolateWrapper<T extends SQLWrapper>(value: T) {
+          return sql\`\${value}\`;
+        }
+        void interpolateBound;
+        void interpolateWrapper;
+      `,
+    },
+    {
       code: `
         function sql(strings: TemplateStringsArray, ...values: unknown[]) {
           return { strings, values };
@@ -147,6 +160,31 @@ ruleTester.run("no-unsafe-sql-interpolation", noUnsafeSqlInterpolation, {
         sql\`\${mixed}\`;
       `,
       errors: [{ messageId: "mixedInterpolation" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        declare function returnsVoid(): void;
+        function interpolateUnconstrained<T>(value: T) {
+          return sql\`\${value}\`;
+        }
+        function interpolateArray<T extends readonly string[]>(value: T) {
+          return sql\`\${value}\`;
+        }
+        function interpolateMixed<T extends string | SQL>(value: T) {
+          return sql\`\${value}\`;
+        }
+        sql\`\${returnsVoid()}\`;
+        void interpolateUnconstrained;
+        void interpolateArray;
+        void interpolateMixed;
+      `,
+      errors: [
+        { messageId: "unknownInterpolation" },
+        { messageId: "arrayInterpolation" },
+        { messageId: "mixedInterpolation" },
+        { messageId: "undefinedInterpolation" },
+      ],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -48,12 +48,18 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
   valid: [
     {
       code: `${drizzlePreamble}
-        import { sql } from "drizzle-orm";
+        import { gte, sql } from "drizzle-orm";
         const value = 1;
         const fragment = sql\`\${users.id} + \${value}\`;
         sql\`SELECT \${users.id} FROM \${users} WHERE \${fragment}\`;
-        sql\`(\${users.id} = \${value})\`;
         sql\`\${users.id}::text = \${"1"}\`;
+        sql\`LOWER(\${users.name}) = \${"name"}\`;
+        sql\`LOWER(\${users.name}) IS NULL\`;
+        sql\`\${users.id} IS DISTINCT FROM \${value}\`;
+        sql\`UPDATE users SET \${users.id} = \${value}\`;
+        sql\`1 + \${users.id} = \${value}\`;
+        sql\`\${users.id} = \${value} + 1\`;
+        sql\`\${gte(users.deletedAt, sql\`\${"2026-01-01"}::timestamp\`)}\`;
         sql\`MAX(\${users.id}) FILTER (WHERE \${users.id} > 0)\`;
         sql\`MAX(\${fragment})\`;
         sql\`\${users.id}\`;
@@ -139,12 +145,44 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
     },
     {
       code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = 1;
+        sql\`(\${users.id} = \${value})\`;
+        sql\`\${users.deletedAt} >= \${"2026-01-01"}::timestamp\`;
+        sql\`\${users.deletedAt} < \${"2026-01-02"}::timestamptz AT TIME ZONE 'UTC' ORDER BY 1\`;
+        sql\`
+          SELECT \${users.id}
+          FROM \${users}
+          WHERE \${users.id} >= \${value}
+            AND \${users.deletedAt} IS NOT NULL
+        \`;
+        sql\`CASE
+          WHEN \${users.id} > \${value} AND \${users.id} <> \${value}
+          THEN \${users.name}
+          ELSE NULL
+        END\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "gte" } },
+        { messageId: "typedApi", data: { helper: "lt" } },
+        { messageId: "typedApi", data: { helper: "gte" } },
+        { messageId: "typedApi", data: { helper: "isNotNull" } },
+        { messageId: "typedApi", data: { helper: "gt" } },
+        { messageId: "typedApi", data: { helper: "ne" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
         db.query.users.findMany({
           where: (fields, operators) =>
-            operators.sql\`\${fields.id} > \${0}\`,
+            operators.sql\`(\${fields.id} > \${0}) OR \${fields.deletedAt} IS NULL\`,
         });
       `,
-      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+      errors: [
+        { messageId: "typedApi", data: { helper: "gt" } },
+        { messageId: "typedApi", data: { helper: "isNull" } },
+      ],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -1,0 +1,150 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, it } from "vitest";
+
+import { preferDrizzleApis } from "../rules/prefer-drizzle-apis.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const dbPackageRoot = fileURLToPath(
+  new URL("../../../../db/", import.meta.url),
+);
+const ruleTester = new RuleTester({
+  defaultFilenames: {
+    ts: `${dbPackageRoot}rule-test.ts`,
+    tsx: `${dbPackageRoot}rule-test.tsx`,
+  },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["rule-test.ts", "rule-test.tsx"],
+      },
+      tsconfigRootDir: dbPackageRoot,
+    },
+  },
+});
+
+const drizzlePreamble = `
+  import { relations } from "drizzle-orm";
+  import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+  const users = pgTable("users", {
+    id: integer("id").notNull(),
+    name: text("name").notNull(),
+    deletedAt: timestamp("deleted_at"),
+  });
+  const usersRelations = relations(users, () => ({}));
+  type DrizzleDatabase =
+    import("drizzle-orm/node-postgres").NodePgDatabase<{
+      users: typeof users;
+      usersRelations: typeof usersRelations;
+    }>;
+  declare const db: DrizzleDatabase;
+`;
+
+ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
+  valid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = 1;
+        const fragment = sql\`\${users.id} + \${value}\`;
+        sql\`SELECT \${users.id} FROM \${users} WHERE \${fragment}\`;
+        sql\`(\${users.id} = \${value})\`;
+        sql\`\${users.id}::text = \${"1"}\`;
+        sql\`MAX(\${users.id}) FILTER (WHERE \${users.id} > 0)\`;
+        sql\`MAX(\${fragment})\`;
+        sql\`\${users.id}\`;
+      `,
+    },
+    {
+      code: `
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const left = 1;
+        const right = 2;
+        sql\`\${left} = \${right}\`;
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const left = 1;
+        const right = 2;
+        sql\`\${left} = \${right}\`;
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`length(\${fields.name}) > 0\`,
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const value = 1;
+        sql\`\${users.id} = \${value}\`;
+        sql\`\${users.id} <> \${value}\`;
+        sql\`\${users.id} > \${value}\`;
+        sql\`\${users.id} >= \${value}\`;
+        sql\`\${users.id} < \${value}\`;
+        sql\`\${users.id} <= \${value}\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "ne" } },
+        { messageId: "typedApi", data: { helper: "gt" } },
+        { messageId: "typedApi", data: { helper: "gte" } },
+        { messageId: "typedApi", data: { helper: "lt" } },
+        { messageId: "typedApi", data: { helper: "lte" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as query } from "drizzle-orm";
+        query\` \${users.deletedAt}  is   null \`;
+        query\`\${users.deletedAt}\nIS NOT NULL\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "isNull" } },
+        { messageId: "typedApi", data: { helper: "isNotNull" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import * as drizzle from "drizzle-orm";
+        drizzle.sql\`MAX ( \${users.id} )\`;
+        const query = drizzle.sql;
+        query\`min(\${users.id})\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "max" } },
+        { messageId: "typedApi", data: { helper: "min" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        sql\`\${selected.id} > \${users.id}\`;
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+    {
+      code: `${drizzlePreamble}
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.id} > \${0}\`,
+        });
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "gt" } }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -184,5 +184,24 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "isNull" } },
       ],
     },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQLWrapper } from "drizzle-orm";
+        function predicates<T extends SQLWrapper>(left: T, right: string) {
+          sql\`\${left} = \${right}\`;
+          sql\`\${left} IS NOT NULL\`;
+        }
+        function aggregate<T extends typeof users.id>(column: T) {
+          return sql\`MAX(\${column})\`;
+        }
+        void predicates;
+        void aggregate;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "eq" } },
+        { messageId: "typedApi", data: { helper: "isNotNull" } },
+        { messageId: "typedApi", data: { helper: "max" } },
+      ],
+    },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -1,0 +1,129 @@
+import {
+  AST_NODE_TYPES,
+  type ParserServicesWithTypeInformation,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  SymbolFlags,
+  type Declaration,
+  type Node,
+  type Signature,
+  type Symbol as TypeScriptSymbol,
+  type Type,
+  type TypeChecker,
+} from "typescript";
+
+export function isDrizzleDeclaration(node: Declaration): boolean {
+  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
+  return sourcePath.includes("/node_modules/drizzle-orm/");
+}
+
+export function resolvedSymbol(
+  checker: TypeChecker,
+  symbol: TypeScriptSymbol | undefined,
+): TypeScriptSymbol | undefined {
+  if (symbol === undefined) {
+    return undefined;
+  }
+  return (symbol.flags & SymbolFlags.Alias) === 0
+    ? symbol
+    : checker.getAliasedSymbol(symbol);
+}
+
+export function isDrizzleSymbol(
+  checker: TypeChecker,
+  symbol: TypeScriptSymbol | undefined,
+): boolean {
+  return (
+    resolvedSymbol(checker, symbol)?.declarations?.some(
+      isDrizzleDeclaration,
+    ) === true
+  );
+}
+
+export function isNamedDrizzleSignature(
+  signature: Signature,
+  name: string,
+): boolean {
+  const declaration = signature.declaration;
+  return (
+    declaration !== undefined &&
+    "name" in declaration &&
+    declaration.name?.getText() === name &&
+    isDrizzleDeclaration(declaration)
+  );
+}
+
+export function isDrizzleSqlTag(
+  checker: TypeChecker,
+  services: ParserServicesWithTypeInformation,
+  node: TSESTree.Expression,
+): boolean {
+  let symbol: TypeScriptSymbol | undefined;
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    symbol = resolvedSymbol(checker, checker.getSymbolAtLocation(tsNode));
+  } else if (node.type === AST_NODE_TYPES.MemberExpression) {
+    const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
+    symbol = resolvedSymbol(checker, checker.getSymbolAtLocation(tsProperty));
+  }
+  if (symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol)) {
+    return true;
+  }
+
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  return checker
+    .getTypeAtLocation(tsNode)
+    .getCallSignatures()
+    .some((signature) => {
+      return isNamedDrizzleSignature(signature, "sql");
+    });
+}
+
+export function isDrizzleWrapperType(
+  checker: TypeChecker,
+  type: Type,
+): boolean {
+  if (isDrizzleSymbol(checker, checker.getPropertyOfType(type, "getSQL"))) {
+    return true;
+  }
+  return (
+    type.isUnion() &&
+    type.types.every((member) => {
+      return isDrizzleWrapperType(checker, member);
+    })
+  );
+}
+
+function propertyType(
+  checker: TypeChecker,
+  type: Type,
+  name: string,
+  location: Node,
+): Type | undefined {
+  const symbol = checker.getPropertyOfType(type, name);
+  return symbol === undefined
+    ? undefined
+    : checker.getTypeOfSymbolAtLocation(symbol, location);
+}
+
+export function isDrizzleColumnType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  if (type.isUnion()) {
+    return type.types.every((member) => {
+      return isDrizzleColumnType(checker, member, location);
+    });
+  }
+  if (!isDrizzleWrapperType(checker, type)) {
+    return false;
+  }
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return false;
+  }
+  const brandType = propertyType(checker, metadataType, "brand", location);
+  return brandType?.isStringLiteral() === true && brandType.value === "Column";
+}

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -7,6 +7,8 @@ import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noSqlRaw } from "./rules/no-sql-raw.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
+import { noUnsafeSqlInterpolation } from "./rules/no-unsafe-sql-interpolation.ts";
+import { preferDrizzleApis } from "./rules/prefer-drizzle-apis.ts";
 import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
 import { requireSqlResultMapping } from "./rules/require-sql-result-mapping.ts";
 import { signalCheckAwait } from "./rules/signal-check-await.ts";
@@ -26,6 +28,8 @@ export const apiLintPlugin = {
     "no-store-in-params": noStoreInParams,
     "no-sql-raw": noSqlRaw,
     "no-test-vi-mocks": noTestViMocks,
+    "no-unsafe-sql-interpolation": noUnsafeSqlInterpolation,
+    "prefer-drizzle-apis": preferDrizzleApis,
     "require-execute-row-schema": requireExecuteRowSchema,
     "require-sql-result-mapping": requireSqlResultMapping,
     "signal-check-await": signalCheckAwait,

--- a/turbo/packages/eslint-rules/src/api/rules/no-sql-raw.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-sql-raw.ts
@@ -3,13 +3,7 @@ import {
   ESLintUtils,
   type TSESTree,
 } from "@typescript-eslint/utils";
-import {
-  SymbolFlags,
-  type Declaration,
-  type Symbol as TypeScriptSymbol,
-  type TypeChecker,
-} from "typescript";
-
+import { isDrizzleSymbol } from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
 function memberName(node: TSESTree.MemberExpression): string | null {
@@ -30,25 +24,6 @@ function propertyName(node: TSESTree.Property): string | null {
     return typeof node.key.value === "string" ? node.key.value : null;
   }
   return null;
-}
-
-function isDrizzleDeclaration(node: Declaration): boolean {
-  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
-  return sourcePath.includes("/node_modules/drizzle-orm/");
-}
-
-function isDrizzleSymbol(
-  checker: TypeChecker,
-  symbol: TypeScriptSymbol | undefined,
-): boolean {
-  if (symbol?.declarations?.some(isDrizzleDeclaration) === true) {
-    return true;
-  }
-  const aliased =
-    symbol === undefined || (symbol.flags & SymbolFlags.Alias) === 0
-      ? symbol
-      : checker.getAliasedSymbol(symbol);
-  return aliased?.declarations?.some(isDrizzleDeclaration) === true;
 }
 
 export const noSqlRaw = createRule({

--- a/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
@@ -1,0 +1,100 @@
+import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import { TypeFlags, type Type, type TypeChecker } from "typescript";
+
+import { isDrizzleSqlTag, isDrizzleWrapperType } from "../drizzle.ts";
+import { createRule } from "../utils.ts";
+
+type MessageId =
+  | "anyInterpolation"
+  | "arrayInterpolation"
+  | "mixedInterpolation"
+  | "undefinedInterpolation"
+  | "unknownInterpolation";
+
+function interpolationProblem(
+  checker: TypeChecker,
+  type: Type,
+): MessageId | null {
+  if ((type.flags & TypeFlags.Any) !== 0) {
+    return "anyInterpolation";
+  }
+  if ((type.flags & TypeFlags.Unknown) !== 0) {
+    return "unknownInterpolation";
+  }
+
+  const members = type.isUnion() ? type.types : [type];
+  if (
+    members.some((member) => {
+      return (member.flags & TypeFlags.Undefined) !== 0;
+    })
+  ) {
+    return "undefinedInterpolation";
+  }
+  if (
+    members.some((member) => {
+      return checker.isArrayType(member) || checker.isTupleType(member);
+    })
+  ) {
+    return "arrayInterpolation";
+  }
+  if (
+    type.isUnion() &&
+    members.some((member) => {
+      return isDrizzleWrapperType(checker, member);
+    }) &&
+    members.some((member) => {
+      return !isDrizzleWrapperType(checker, member);
+    })
+  ) {
+    return "mixedInterpolation";
+  }
+  return null;
+}
+
+export const noUnsafeSqlInterpolation = createRule({
+  name: "no-unsafe-sql-interpolation",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require unambiguous types in Drizzle SQL interpolations",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      anyInterpolation:
+        "Do not interpolate any into Drizzle SQL. Give the value an explicit safe type before constructing SQL.",
+      unknownInterpolation:
+        "Do not interpolate unknown into Drizzle SQL. Narrow it to a bound value or an explicit SQL wrapper first.",
+      undefinedInterpolation:
+        "Drizzle omits undefined interpolations. Narrow the value first, or use sql.empty() for an intentionally empty fragment.",
+      arrayInterpolation:
+        "Drizzle expands a directly interpolated array or tuple as SQL chunks. Use sql.param(...) for one bound value or sql.join(...) for fragments.",
+      mixedInterpolation:
+        "Do not mix SQL wrappers and bound values in one interpolation type. Convert the value to an explicit parameter or fragment before this boundary.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
+        if (!isDrizzleSqlTag(checker, services, node.tag)) {
+          return;
+        }
+        for (const expression of node.quasi.expressions) {
+          const tsExpression = services.esTreeNodeToTSNodeMap.get(expression);
+          const messageId = interpolationProblem(
+            checker,
+            checker.getTypeAtLocation(tsExpression),
+          );
+          if (messageId !== null) {
+            context.report({ node: expression, messageId });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unsafe-sql-interpolation.ts
@@ -11,21 +11,66 @@ type MessageId =
   | "undefinedInterpolation"
   | "unknownInterpolation";
 
+function constrainedTypeMembers(
+  checker: TypeChecker,
+  type: Type,
+  visited: Set<Type>,
+): Type[] | null {
+  if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+    if (visited.has(type)) {
+      return null;
+    }
+    visited.add(type);
+    const constraint = checker.getBaseConstraintOfType(type);
+    const members =
+      constraint === undefined
+        ? null
+        : constrainedTypeMembers(checker, constraint, visited);
+    visited.delete(type);
+    return members;
+  }
+
+  if (!type.isUnion()) {
+    return [type];
+  }
+
+  const members: Type[] = [];
+  for (const member of type.types) {
+    const constrainedMembers = constrainedTypeMembers(checker, member, visited);
+    if (constrainedMembers === null) {
+      return null;
+    }
+    members.push(...constrainedMembers);
+  }
+  return members;
+}
+
 function interpolationProblem(
   checker: TypeChecker,
   type: Type,
 ): MessageId | null {
-  if ((type.flags & TypeFlags.Any) !== 0) {
+  const members = constrainedTypeMembers(checker, type, new Set<Type>());
+  if (members === null) {
+    return "unknownInterpolation";
+  }
+  if (
+    members.some((member) => {
+      return (member.flags & TypeFlags.Any) !== 0;
+    })
+  ) {
     return "anyInterpolation";
   }
-  if ((type.flags & TypeFlags.Unknown) !== 0) {
+  if (
+    members.some((member) => {
+      return (member.flags & TypeFlags.Unknown) !== 0;
+    })
+  ) {
     return "unknownInterpolation";
   }
 
-  const members = type.isUnion() ? type.types : [type];
   if (
     members.some((member) => {
-      return (member.flags & TypeFlags.Undefined) !== 0;
+      return (member.flags & (TypeFlags.Undefined | TypeFlags.Void)) !== 0;
     })
   ) {
     return "undefinedInterpolation";
@@ -38,7 +83,6 @@ function interpolationProblem(
     return "arrayInterpolation";
   }
   if (
-    type.isUnion() &&
     members.some((member) => {
       return isDrizzleWrapperType(checker, member);
     }) &&

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1,0 +1,118 @@
+import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import { type Node, type Type } from "typescript";
+
+import {
+  isDrizzleColumnType,
+  isDrizzleSqlTag,
+  isDrizzleWrapperType,
+} from "../drizzle.ts";
+import { createRule } from "../utils.ts";
+
+const COMPARISON_HELPERS = new Map<string, string>([
+  ["=", "eq"],
+  ["<>", "ne"],
+  [">", "gt"],
+  [">=", "gte"],
+  ["<", "lt"],
+  ["<=", "lte"],
+]);
+
+function quasiText(node: TSESTree.TemplateElement): string {
+  return node.value.cooked ?? node.value.raw;
+}
+
+export const preferDrizzleApis = createRule({
+  name: "prefer-drizzle-apis",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Prefer schema-aware Drizzle APIs for exactly equivalent SQL tags",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      typedApi:
+        "Use Drizzle {{helper}}(...) instead of an equivalent sql tagged template.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function expressionType(node: TSESTree.Expression): {
+      readonly location: Node;
+      readonly type: Type;
+    } {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return {
+        location: tsNode,
+        type: checker.getTypeAtLocation(tsNode),
+      };
+    }
+
+    function report(
+      node: TSESTree.TaggedTemplateExpression,
+      helper: string,
+    ): void {
+      context.report({
+        node,
+        messageId: "typedApi",
+        data: { helper },
+      });
+    }
+
+    return {
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
+        if (!isDrizzleSqlTag(checker, services, node.tag)) {
+          return;
+        }
+
+        const quasis = node.quasi.quasis.map(quasiText);
+        const expressions = node.quasi.expressions;
+        if (
+          expressions.length === 2 &&
+          quasis.length === 3 &&
+          quasis[0]?.trim() === "" &&
+          quasis[2]?.trim() === ""
+        ) {
+          const helper = COMPARISON_HELPERS.get(quasis[1]?.trim() ?? "");
+          if (helper !== undefined) {
+            const left = expressionType(expressions[0]);
+            if (isDrizzleWrapperType(checker, left.type)) {
+              report(node, helper);
+            }
+          }
+          return;
+        }
+
+        if (expressions.length !== 1 || quasis.length !== 2) {
+          return;
+        }
+        const expression = expressionType(expressions[0]);
+        const suffix = quasis[1]?.trim().replaceAll(/\s+/g, " ").toUpperCase();
+        if (
+          quasis[0]?.trim() === "" &&
+          (suffix === "IS NULL" || suffix === "IS NOT NULL") &&
+          isDrizzleWrapperType(checker, expression.type)
+        ) {
+          report(node, suffix === "IS NULL" ? "isNull" : "isNotNull");
+          return;
+        }
+
+        const prefix = quasis[0] ?? "";
+        const aggregateSuffix = quasis[1] ?? "";
+        const aggregate = /^\s*(MAX|MIN)\s*\(\s*$/i.exec(prefix);
+        if (
+          aggregate !== null &&
+          /^\s*\)\s*$/.test(aggregateSuffix) &&
+          isDrizzleColumnType(checker, expression.type, expression.location)
+        ) {
+          report(node, aggregate[1]?.toLowerCase() ?? "");
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -21,6 +21,66 @@ function quasiText(node: TSESTree.TemplateElement): string {
   return node.value.cooked ?? node.value.raw;
 }
 
+interface NullPredicateMatch {
+  helper: "isNull" | "isNotNull";
+  length: number;
+}
+
+function nullPredicateMatch(quasi: string): NullPredicateMatch | undefined {
+  const match = /^\s*IS\s+(NOT\s+)?NULL\b/i.exec(quasi);
+  if (match === null) {
+    return undefined;
+  }
+  return {
+    helper: match[1] === undefined ? "isNull" : "isNotNull",
+    length: match[0].length,
+  };
+}
+
+function hasPredicateLeftBoundary(quasi: string): boolean {
+  const prefix = quasi.trimEnd();
+  return (
+    prefix === "" ||
+    prefix.endsWith("(") ||
+    /\b(?:AND|HAVING|NOT|ON|OR|WHEN|WHERE)$/i.test(prefix)
+  );
+}
+
+function removeRightOperandPostfix(quasi: string): string | undefined {
+  let suffix = quasi;
+  while (/^\s*::/.test(suffix)) {
+    const cast =
+      /^\s*::\s*[a-z_][\w$]*(?:\s*\.\s*[a-z_][\w$]*)?(?:\s*\([^()]*\))?(?:\s*\[\s*\])*/i.exec(
+        suffix,
+      );
+    if (cast === null) {
+      return undefined;
+    }
+    suffix = suffix.slice(cast[0].length);
+  }
+
+  const timeZone = /^\s+AT\s+TIME\s+ZONE\s+'(?:''|[^'])*'/i.exec(suffix);
+  if (timeZone !== null) {
+    suffix = suffix.slice(timeZone[0].length);
+  }
+  return suffix;
+}
+
+function hasPredicateRightBoundary(quasi: string): boolean {
+  const withoutPostfix = removeRightOperandPostfix(quasi);
+  if (withoutPostfix === undefined) {
+    return false;
+  }
+  const suffix = withoutPostfix.trimStart();
+  return (
+    suffix === "" ||
+    /^[),;]/.test(suffix) ||
+    /^(?:AND|ELSE|END|EXCEPT|FETCH|FOR|FULL|GROUP|HAVING|INNER|INTERSECT|LEFT|LIMIT|OFFSET|ON|OR|ORDER|RETURNING|RIGHT|THEN|UNION|WHEN|WHERE)\b/i.test(
+      suffix,
+    )
+  );
+}
+
 export const preferDrizzleApis = createRule({
   name: "prefer-drizzle-apis",
   defaultOptions: [],
@@ -28,14 +88,13 @@ export const preferDrizzleApis = createRule({
     type: "problem",
     docs: {
       description:
-        "Prefer schema-aware Drizzle APIs for exactly equivalent SQL tags",
+        "Prefer schema-aware Drizzle APIs for exactly equivalent SQL leaves",
       recommended: true,
       requiresTypeChecking: true,
     },
     schema: [],
     messages: {
-      typedApi:
-        "Use Drizzle {{helper}}(...) instead of an equivalent sql tagged template.",
+      typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
     },
   },
   create(context) {
@@ -53,10 +112,7 @@ export const preferDrizzleApis = createRule({
       };
     }
 
-    function report(
-      node: TSESTree.TaggedTemplateExpression,
-      helper: string,
-    ): void {
+    function report(node: TSESTree.Node, helper: string): void {
       context.report({
         node,
         messageId: "typedApi",
@@ -72,36 +128,48 @@ export const preferDrizzleApis = createRule({
 
         const quasis = node.quasi.quasis.map(quasiText);
         const expressions = node.quasi.expressions;
-        if (
-          expressions.length === 2 &&
-          quasis.length === 3 &&
-          quasis[0]?.trim() === "" &&
-          quasis[2]?.trim() === ""
-        ) {
-          const helper = COMPARISON_HELPERS.get(quasis[1]?.trim() ?? "");
+        for (let index = 0; index < expressions.length - 1; index += 1) {
+          if (
+            !hasPredicateLeftBoundary(quasis[index] ?? "") ||
+            !hasPredicateRightBoundary(quasis[index + 2] ?? "")
+          ) {
+            continue;
+          }
+          const helper = COMPARISON_HELPERS.get(
+            quasis[index + 1]?.trim() ?? "",
+          );
           if (helper !== undefined) {
-            const left = expressionType(expressions[0]);
+            const leftExpression = expressions[index];
+            const left = expressionType(leftExpression);
             if (isDrizzleWrapperType(checker, left.type)) {
-              report(node, helper);
+              report(leftExpression, helper);
             }
           }
-          return;
+        }
+
+        for (let index = 0; index < expressions.length; index += 1) {
+          const match = nullPredicateMatch(quasis[index + 1] ?? "");
+          if (
+            match === undefined ||
+            !hasPredicateLeftBoundary(quasis[index] ?? "") ||
+            !hasPredicateRightBoundary(
+              (quasis[index + 1] ?? "").slice(match.length),
+            )
+          ) {
+            continue;
+          }
+          const expressionNode = expressions[index];
+          const expression = expressionType(expressionNode);
+          if (isDrizzleWrapperType(checker, expression.type)) {
+            report(expressionNode, match.helper);
+          }
         }
 
         if (expressions.length !== 1 || quasis.length !== 2) {
           return;
         }
-        const expression = expressionType(expressions[0]);
-        const suffix = quasis[1]?.trim().replaceAll(/\s+/g, " ").toUpperCase();
-        if (
-          quasis[0]?.trim() === "" &&
-          (suffix === "IS NULL" || suffix === "IS NOT NULL") &&
-          isDrizzleWrapperType(checker, expression.type)
-        ) {
-          report(node, suffix === "IS NULL" ? "isNull" : "isNotNull");
-          return;
-        }
 
+        const expression = expressionType(expressions[0]);
         const prefix = quasis[0] ?? "";
         const aggregateSuffix = quasis[1] ?? "";
         const aggregate = /^\s*(MAX|MIN)\s*\(\s*$/i.exec(prefix);

--- a/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-execute-row-schema.ts
@@ -3,8 +3,8 @@ import {
   ESLintUtils,
   type TSESTree,
 } from "@typescript-eslint/utils";
-import type { Declaration } from "typescript";
 
+import { isDrizzleDeclaration } from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
 function memberName(node: TSESTree.MemberExpression): string | null {
@@ -137,11 +137,6 @@ function executeUsage(node: TSESTree.CallExpression): ExecuteUsage {
   }
 
   return { kind: "raw-result", assertion };
-}
-
-function isDrizzleDeclaration(node: Declaration): boolean {
-  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
-  return sourcePath.includes("/node_modules/drizzle-orm/");
 }
 
 export const requireExecuteRowSchema = createRule({

--- a/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/require-sql-result-mapping.ts
@@ -9,17 +9,22 @@ import {
   isVariableDeclaration,
   isVariableDeclarationList,
   NodeFlags,
-  SymbolFlags,
   TypeFlags,
-  type Declaration,
   type Node,
-  type Signature,
   type Symbol as TypeScriptSymbol,
   type Type,
   type TypeChecker,
   type VariableDeclaration,
 } from "typescript";
 
+import {
+  isDrizzleDeclaration,
+  isDrizzleSqlTag as isDrizzleSqlTagExpression,
+  isDrizzleSymbol,
+  isDrizzleWrapperType,
+  isNamedDrizzleSignature,
+  resolvedSymbol,
+} from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
 const RESULT_FIELD_ARGUMENT = new Map<string, number>([
@@ -74,44 +79,6 @@ function propertyName(node: TSESTree.Property): string | null {
   return null;
 }
 
-function isDrizzleDeclaration(node: Declaration): boolean {
-  const sourcePath = node.getSourceFile().fileName.replaceAll("\\", "/");
-  return sourcePath.includes("/node_modules/drizzle-orm/");
-}
-
-function isNamedDrizzleSignature(signature: Signature, name: string): boolean {
-  const declaration = signature.declaration;
-  return (
-    declaration !== undefined &&
-    "name" in declaration &&
-    declaration.name?.getText() === name &&
-    isDrizzleDeclaration(declaration)
-  );
-}
-
-function resolvedSymbol(
-  checker: TypeChecker,
-  symbol: TypeScriptSymbol | undefined,
-): TypeScriptSymbol | undefined {
-  if (symbol === undefined) {
-    return undefined;
-  }
-  return (symbol.flags & SymbolFlags.Alias) === 0
-    ? symbol
-    : checker.getAliasedSymbol(symbol);
-}
-
-function isDrizzleSymbol(
-  checker: TypeChecker,
-  symbol: TypeScriptSymbol | undefined,
-): boolean {
-  return (
-    resolvedSymbol(checker, symbol)?.declarations?.some(
-      isDrizzleDeclaration,
-    ) === true
-  );
-}
-
 function propertyType(
   checker: TypeChecker,
   type: Type,
@@ -161,7 +128,7 @@ function isUntrustedOutput(type: Type): boolean {
 }
 
 function isDrizzleWrapper(checker: TypeChecker, type: Type): boolean {
-  return isDrizzleSymbol(checker, checker.getPropertyOfType(type, "getSQL"));
+  return isDrizzleWrapperType(checker, type);
 }
 
 function hasUntrustedSqlMetadata(
@@ -497,26 +464,7 @@ export const requireSqlResultMapping = createRule({
     }
 
     function isDrizzleSqlTag(node: TSESTree.Expression): boolean {
-      let symbol: TypeScriptSymbol | undefined;
-      if (node.type === AST_NODE_TYPES.Identifier) {
-        symbol = resolvedSymbol(checker, symbolAt(node));
-      } else if (
-        node.type === AST_NODE_TYPES.MemberExpression &&
-        resolvedMemberName(node) === "sql"
-      ) {
-        symbol = resolvedSymbol(checker, symbolAt(node.property));
-      }
-      if (symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol)) {
-        return true;
-      }
-
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      return checker
-        .getTypeAtLocation(tsNode)
-        .getCallSignatures()
-        .some((signature) => {
-          return isNamedDrizzleSignature(signature, "sql");
-        });
+      return isDrizzleSqlTagExpression(checker, services, node);
     }
 
     function nodeContainsUntrustedSql(node: TSESTree.Node): boolean {


### PR DESCRIPTION
## Summary

- add shared, symbol-aware Drizzle recognition plus focused rules for exact typed-API alternatives and unsafe SQL-tag interpolation types
- extend `prefer-drizzle-apis` from whole-tag matches to comparison and null-predicate leaves inside larger SQL while requiring clear predicate boundaries, so assignments and partial arithmetic operands remain valid
- replace all 143 current embedded findings across 21 API files, preserving outer CTE, CASE, join, filter, statement, decoder, cast, and time-zone structure
- keep explicit casts inside the helper operand, and document the embedded-leaf and concrete-`SQL` guidance in the existing database-development skill

## Scope and compatibility

- no schema, migration, persisted-data, API, queue, runner protocol, or wire-format change
- no feature switch is needed; generated SQL and parameter order remain unchanged, while schema columns now own ordinary bound-value encoding
- deliberately does not require `and(...)` or `or(...)` where their `SQL | undefined` return type would weaken a concrete `SQL` contract
- deliberately leaves assignments, partial arithmetic operands, and SQL forms without an exactly equivalent typed helper alone

## Validation

- `pnpm -F @vm0/eslint-rules test` (46 files, 658 tests)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- affected API entry-point suites: 17 files and 354 tests passed; the two data-sensitive files were also run against a freshly migrated temporary database to exclude unrelated local fixture data
- `pnpm knip --workspace @vm0/eslint-rules --workspace api`
- compiler-backed SQL inventory: zero remaining replaceable whole-tag candidates and zero unsafe interpolations; type-aware API lint reports zero embedded findings
- representative timestamp-cast and timestamp-with-time-zone queries serialize to identical SQL, params, and typings before and after the rewrite
- `TIMING=all pnpm -F api exec eslint . --max-warnings 0`: `api/prefer-drizzle-apis` 7.520 ms (0.1%)
- pre-commit hook: Prettier, repository Knip, and repository-wide Turbo type checking

Closes #22326

Parent context: #22310
