### PR TITLE
refactor(mitm-addon): centralize http network log assembly

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -184,7 +184,6 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     # Optional fields — only include when present with the network-log schema type.
     for log_key, value in (
         ("firewall_params", _metadata_str_record(meta, metadata_keys.FIREWALL_PARAMS)),
-        ("firewall_error", flow_metadata.firewall_error(meta)),
         (
             "connector_diagnostic_type",
             _metadata_optional_str(meta, metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE),
@@ -200,14 +199,6 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
         (
             "connector_diagnostic_base",
             _metadata_optional_str(meta, metadata_keys.CONNECTOR_DIAGNOSTIC_BASE),
-        ),
-        (
-            "connector_route_reason",
-            _metadata_optional_str(meta, metadata_keys.CONNECTOR_ROUTE_REASON),
-        ),
-        (
-            "connector_route_candidates",
-            _metadata_str_list(meta, metadata_keys.CONNECTOR_ROUTE_CANDIDATES),
         ),
         (
             "auth_resolved_secrets",

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -509,6 +509,8 @@ def _http_network_log_entry(
     entry.update(upstream_admission.upstream_binding_log_fields(flow))
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         entry["browser_user_agent"] = True
+    if flow_metadata.firewall_base(flow.metadata):
+        add_firewall_metadata(flow, entry)
     return entry
 
 
@@ -1262,11 +1264,6 @@ def _handle_response(flow: http.HTTPFlow) -> None:
             response_size=response_size,
         )
 
-        # Add firewall match info if this was a firewall request
-        firewall_base = flow_metadata.firewall_base(flow.metadata)
-        if firewall_base:
-            add_firewall_metadata(flow, log_entry)
-
         # Add captured header names, selected safe header values, and bodies when enabled
         if flow_metadata.should_capture_body(flow.metadata):
             body_capture.add_capture_fields(flow, log_entry)
@@ -1381,11 +1378,6 @@ def _handle_error(flow: http.HTTPFlow) -> None:
         response_size=0,
     )
     log_entry["error"] = error_msg
-
-    # Add firewall context if available
-    firewall_base = flow_metadata.firewall_base(flow.metadata)
-    if firewall_base:
-        add_firewall_metadata(flow, log_entry)
 
     log_network_entry(network_log_path, log_entry)
 

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -402,22 +402,6 @@ class TestJsonlWriterBehavior:
 
 
 class TestAddFirewallMetadata:
-    def test_copies_valid_firewall_error_metadata(self, real_flow):
-        flow = real_flow(with_response=False)
-        flow.metadata.update({metadata_keys.FIREWALL_ERROR: "TOKEN_REFRESH_FAILED"})
-        log_entry = {}
-
-        logging_utils.add_firewall_metadata(flow, log_entry)
-
-        assert log_entry == {
-            "firewall_base": "",
-            "firewall_name": "",
-            "firewall_permission": "",
-            "firewall_rule_match": "",
-            "firewall_billable": False,
-            "firewall_error": "TOKEN_REFRESH_FAILED",
-        }
-
     def test_copies_valid_connector_diagnostic_metadata(self, real_flow):
         flow = real_flow(with_response=False)
         flow.metadata.update(
@@ -426,8 +410,6 @@ class TestAddFirewallMetadata:
                 metadata_keys.CONNECTOR_DIAGNOSTIC_REASON: "not_configured_for_run",
                 metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES: ["FAL_TOKEN"],
                 metadata_keys.CONNECTOR_DIAGNOSTIC_BASE: "https://fal.run",
-                metadata_keys.CONNECTOR_ROUTE_REASON: "connector_intent_required",
-                metadata_keys.CONNECTOR_ROUTE_CANDIDATES: ["auditor", "primary"],
             }
         )
         log_entry = {}
@@ -444,8 +426,6 @@ class TestAddFirewallMetadata:
             "connector_diagnostic_reason": "not_configured_for_run",
             "connector_diagnostic_env_names": ["FAL_TOKEN"],
             "connector_diagnostic_base": "https://fal.run",
-            "connector_route_reason": "connector_intent_required",
-            "connector_route_candidates": ["auditor", "primary"],
         }
 
     def test_defaults_missing_required_firewall_metadata(self, real_flow):
@@ -491,7 +471,6 @@ class TestAddFirewallMetadata:
         flow.metadata.update(
             {
                 metadata_keys.FIREWALL_PARAMS: None,
-                metadata_keys.FIREWALL_ERROR: None,
                 metadata_keys.AUTH_RESOLVED_SECRETS: None,
                 metadata_keys.AUTH_REFRESHED_CONNECTORS: None,
                 metadata_keys.AUTH_REFRESHED_SECRETS: None,
@@ -516,7 +495,6 @@ class TestAddFirewallMetadata:
         flow.metadata.update(
             {
                 metadata_keys.FIREWALL_PARAMS: {"owner": "vm0-ai", "branch": None},
-                metadata_keys.FIREWALL_ERROR: 123,
                 metadata_keys.AUTH_RESOLVED_SECRETS: ["GITHUB_TOKEN", None],
                 metadata_keys.AUTH_REFRESHED_CONNECTORS: "github",
                 metadata_keys.AUTH_REFRESHED_SECRETS: [1],

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -136,6 +136,72 @@ def test_response_log_includes_firewall_auth_metadata(tmp_path, real_flow, mitm_
 
 
 @pytest.mark.parametrize(
+    "with_firewall_context",
+    [False, True],
+    ids=["without-firewall", "with-firewall"],
+)
+@pytest.mark.parametrize(
+    ("route_candidates", "expected_candidates"),
+    [
+        pytest.param(None, None, id="absent"),
+        pytest.param([], None, id="empty"),
+        pytest.param(["primary", None], None, id="malformed"),
+        pytest.param(["auditor", "primary"], ["auditor", "primary"], id="populated"),
+    ],
+)
+def test_response_log_serializes_common_metadata_independent_of_firewall_context(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    with_firewall_context,
+    route_candidates,
+    expected_candidates,
+):
+    flow = real_flow(with_response=False, host="api.example.com", path="/items")
+    log_path = str(tmp_path / "network.jsonl")
+    flow.metadata.update(
+        {
+            metadata_keys.VM_RUN_ID: "run-abc-123",
+            metadata_keys.VM_NETWORK_LOG_PATH: log_path,
+            metadata_keys.ORIGINAL_URL: "https://api.example.com/items",
+            metadata_keys.FIREWALL_ACTION: "DENY",
+            metadata_keys.FIREWALL_ERROR: "ambiguous_connector_route",
+            metadata_keys.CONNECTOR_ROUTE_REASON: "connector_intent_required",
+        }
+    )
+    if route_candidates is not None:
+        flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] = route_candidates
+    if with_firewall_context:
+        flow.metadata.update(
+            {
+                metadata_keys.FIREWALL_BASE: "https://api.example.com",
+                metadata_keys.FIREWALL_NAME: "example",
+                metadata_keys.FIREWALL_PERMISSION: "read",
+                metadata_keys.FIREWALL_RULE_MATCH: "GET /items",
+                metadata_keys.FIREWALL_BILLABLE: False,
+            }
+        )
+    flow.response = tutils.tresp(status_code=409, headers=header_map({"content-length": "0"}))
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(Path(log_path))
+    assert entry["firewall_error"] == "ambiguous_connector_route"
+    assert entry["connector_route_reason"] == "connector_intent_required"
+    if expected_candidates is None:
+        assert "connector_route_candidates" not in entry
+    else:
+        assert entry["connector_route_candidates"] == expected_candidates
+    if with_firewall_context:
+        assert entry["firewall_base"] == "https://api.example.com"
+        assert entry["firewall_name"] == "example"
+    else:
+        assert "firewall_base" not in entry
+        assert "firewall_name" not in entry
+
+
+@pytest.mark.parametrize(
     ("raw_url", "expected_url"),
     [
         (


### PR DESCRIPTION
## Summary

- make the shared HTTP network-log builder add applicable firewall/auth context before returning
- give `firewall_error` and connector-route fields one serialization owner with consistent candidate omission
- replace obsolete helper assertions with response-hook integration coverage across firewall and candidate states

## Behavior

Reachable production output is unchanged. Connector-route candidates are emitted only for a non-empty `list[str]`, regardless of whether `firewall_base` is present. A synthetic or future flow containing both firewall context and an empty candidate list now omits the optional field instead of emitting `[]`.

## Explicit exclusions

- no API contract or schema changes
- no database migration or persisted-data rewrite
- no new serializer abstraction or deployment compatibility bridge

## Validation

- `pytest tests/test_response_handler_logging.py tests/test_error_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_logging_utils.py` — 200 passed
- `ruff format src tests` — 236 files left unchanged
- `ruff check src tests` — passed
- `basedpyright` — 0 errors, 0 warnings, 0 notes
- `pytest tests/` — 4,129 passed
- `ruff format --check src tests` — 236 files already formatted

Closes #22282
