### PR TITLE
fix(mitm-addon): preserve auth base response header octets

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -459,23 +459,20 @@ def trusted_request_header_pairs(headers) -> list[tuple[str, str]]:
     return resolved_auth_header_pairs(headers)
 
 
-def _headers_from_pairs(pairs: list[tuple[str, str]]) -> http.Headers:
-    return http.Headers(
-        (
-            name.encode("utf-8", "surrogateescape"),
-            value.encode("utf-8", "surrogateescape"),
-        )
-        for name, value in pairs
-    )
-
-
-def _filter_response_headers(raw) -> http.Headers:
+def _filter_response_headers(headers: list[tuple[str, str]]) -> http.Headers:
     """Strip hop-by-hop headers from an upstream response.
 
     The response body is fully read, so headers like transfer-encoding must
     not be forwarded. Headers named by Connection are hop-by-hop too.
+
+    ``HTTPResponse.getheaders()`` exposes raw field octets through a one-to-one
+    ISO-8859-1 decode. Encode with the same codec to restore those octets for
+    mitmproxy's byte-backed header container.
     """
-    return _headers_from_pairs(_filter_header_pairs(raw))
+    return http.Headers(
+        (name.encode("latin-1"), value.encode("latin-1"))
+        for name, value in _filter_header_pairs(headers)
+    )
 
 
 def _normalized_forward_request_host(parsed: urllib.parse.SplitResult) -> str:

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -639,29 +639,38 @@ class TestAuthBaseForwarderRequestBehavior:
         assert upstream.socket.request_header_values("Content-Length") == ["0"]
         assert upstream.socket.request_text().endswith("\r\n\r\n")
 
-    async def test_preserves_duplicate_response_headers_and_filters_connection_names(self):
-        with fake_forwarder_upstream(
-            headers=[
-                ("Set-Cookie", "a=1"),
-                ("Set-Cookie", "b=2"),
-                ("Connection", "X-Remove"),
-                ("X-Remove", "drop"),
-                ("X-Keep", "ok"),
-            ]
-        ):
-            _status, _body, headers = await forwarder.forward_request(
+    async def test_preserves_response_header_octets_duplicates_and_filters_connection_names(self):
+        raw_response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"X-Bytes: caf\xe9\r\n"
+            b"Set-Cookie: a=1\r\n"
+            b"Set-Cookie: b=2\r\n"
+            b"Connection: X-Remove\r\n"
+            b"X-Remove: drop\r\n"
+            b"X-Keep: ok\r\n"
+            b"\r\n"
+            b"ok"
+        )
+
+        def create_connection(_address, _timeout, _source_address):
+            return FakeSocket(raw_response)
+
+        with fake_forwarder_upstream(create_connection=create_connection):
+            status, body, headers = await forwarder.forward_request(
                 "https://example.com",
                 "GET",
                 [],
                 None,
             )
 
-        pairs = list(headers.items(multi=True))
-        assert pairs.count(("Set-Cookie", "a=1")) == 1
-        assert pairs.count(("Set-Cookie", "b=2")) == 1
-        assert ("Connection", "X-Remove") not in pairs
-        assert ("X-Remove", "drop") not in pairs
-        assert ("X-Keep", "ok") in pairs
+        assert status == 200
+        assert body == b"ok"
+        assert headers.fields == (
+            (b"X-Bytes", b"caf\xe9"),
+            (b"Set-Cookie", b"a=1"),
+            (b"Set-Cookie", b"b=2"),
+            (b"X-Keep", b"ok"),
+        )
 
     async def test_filters_hop_by_hop_response_headers(self):
         with fake_forwarder_upstream(


### PR DESCRIPTION
## Summary

- restore auth.base response field bytes by reversing `http.client`'s ISO-8859-1 decode at the mitmproxy boundary
- keep duplicate ordering and hop-by-hop/`Connection` filtering on the existing parsed-pair path
- cover literal non-ASCII response octets, ordered duplicates, and nominated-header removal through `forward_request(...)`

## Scope

- Python mitmproxy addon only
- no API, runner protocol, queue payload, schema, persistence, migration, or frontend/backend contract changes

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/test_auth_base_forwarder.py -v` (`98 passed`)
- `.venv/bin/python -m pytest tests/ -q` (`4122 passed`)
- `git diff --check`

Closes #22284
