### PR TITLE
fix(runner): preserve auth.base response content encoding

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -841,14 +841,25 @@ async def _apply_url_rewrite(
 
     try:
         admission = take_forward_request_admission_from_flow(flow)
-        status, resp_body, resp_headers = await forward_request(
+        status, resp_raw_content, resp_headers = await forward_request(
             new_url,
             flow.request.method,
             req_headers,
             req_body,
             admission=admission,
         )
-        flow.response = http.Response.make(status, resp_body, resp_headers)
+        content_encodings = [
+            value
+            for name, value in header_pairs(resp_headers)
+            if name.lower() == "content-encoding"
+        ]
+        if content_encodings:
+            del resp_headers["Content-Encoding"]
+        # The forwarder returns representation bytes, but Response.make expects
+        # decoded content. Hide the codings while it normalizes response framing.
+        flow.response = http.Response.make(status, resp_raw_content, resp_headers)
+        if content_encodings:
+            flow.response.headers.set_all("Content-Encoding", content_encodings)
     except ForwardedRequestTooLargeError:
         _set_auth_base_request_too_large(
             flow,

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -1,6 +1,7 @@
 """auth.base rewrite forwarding handler tests."""
 
 import asyncio
+import gzip
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -142,6 +143,53 @@ class TestAuthBaseUrlRewriteForwarding:
         assert "Firewall URL rewrite:" in log_text
         assert "real-token" not in log_text
         assert "webhook/secret" not in log_text
+
+    @pytest.mark.parametrize(
+        ("content_encodings", "coded_body", "decoded_body"),
+        [
+            pytest.param(
+                ("gzip",),
+                gzip.compress(b'{"ok":true}', mtime=0),
+                b'{"ok":true}',
+                id="gzip",
+            ),
+            pytest.param(
+                ("x-first", "x-second"),
+                b"opaque-coded-response",
+                None,
+                id="repeated-unknown",
+            ),
+        ],
+    )
+    async def test_url_rewrite_preserves_encoded_response_representation(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        content_encodings: tuple[str, ...],
+        coded_body: bytes,
+        decoded_body: bytes | None,
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(real_flow, tmp_path)
+        chunked_body = b"%x\r\n" % len(coded_body) + coded_body + b"\r\n0\r\n\r\n"
+        response_headers = [("Content-Encoding", value) for value in content_encodings]
+        response_headers.append(("Transfer-Encoding", "chunked"))
+
+        with (
+            fake_forwarder_upstream(body=chunked_body, headers=response_headers),
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+        assert flow.response is not None
+        assert flow.response.raw_content == coded_body
+        assert flow.response.headers.get_all("Content-Encoding") == list(content_encodings)
+        assert flow.response.headers["Content-Length"] == str(len(coded_body))
+        assert "Transfer-Encoding" not in flow.response.headers
+        if decoded_body is not None:
+            assert flow.response.content == decoded_body
 
     async def test_url_rewrite_sends_resolved_auth_headers(
         self, headers, real_flow, mitm_ctx, tmp_path


### PR DESCRIPTION
## Summary

- preserve upstream auth-base response representation bytes while constructing the inline mitmproxy response
- restore ordered `Content-Encoding` values after response framing and `Content-Length` are normalized
- cover gzip, chunked transfer framing, and repeated unknown content codings through the real handler/forwarder test boundary

## Explicit exclusions

- no upstream `Accept-Encoding` negotiation changes
- no decode/re-encode transformation in the forwarding path
- no backend API, queue payload, persisted-data, migration, or runner protocol changes

## Validation

- `ruff format .`
- `ruff check .`
- `basedpyright -p .`
- `python3 -m pytest tests/test_firewall_rewrite_forwarding.py -v` (21 passed)
- `python3 -m pytest tests/ -q --disable-warnings` (4124 passed)

Closes #22283
