### PR TITLE
feat(connectors): use accepted server firewall metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -815,6 +815,88 @@ function buildGeneratedFirewall(args: {
   };
 }
 
+const DUPLICATE_DYNAMIC_FIREWALL_BASE = `https://${catalogTemplate("vars.SERVICE_HOST")}.example.test/v1`;
+const DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY = {
+  kind: "providerOwned",
+  suffixes: [".example.test"],
+} as const;
+
+function addDynamicFirewallVariableBinding(artifact: JsonRecord): void {
+  const connector = firstRecord(artifact.connectors, "connectors");
+  const method = firstRecord(connector.authMethods, "authMethods");
+  recordValue(method.storage, "storage").variables = ["SERVICE_HOST"];
+  recordValue(
+    recordValue(method.access, "access").envBindings,
+    "envBindings",
+  ).SERVICE_HOST = "$vars.SERVICE_HOST";
+}
+
+function addDuplicateDynamicPrivateFirewallApi(
+  artifact: JsonRecord,
+  options: { readonly conflictingHostPolicy?: boolean } = {},
+): void {
+  const connector = firstRecord(artifact.connectors, "connectors");
+  const firewall = recordValue(connector.firewall, "firewall");
+  const apis = arrayValue(firewall.apis, "firewall.apis");
+  const firstApi = firstRecord(apis, "firewall.apis");
+  firstApi.base = DUPLICATE_DYNAMIC_FIREWALL_BASE;
+  firstApi.hostPolicy = DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY;
+  const fallbackApi = structuredClone(firstApi);
+  fallbackApi.auth = {};
+  fallbackApi.permissions = [];
+  fallbackApi.hostPolicy = options.conflictingHostPolicy
+    ? { kind: "publicDestination" }
+    : DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY;
+  apis.push(fallbackApi);
+
+  const routing = recordValue(connector.routing, "routing");
+  routing.fixedHosts = [];
+  routing.baseUrlVarNames = ["SERVICE_HOST"];
+  routing.baseUrlTemplates = [
+    {
+      base: DUPLICATE_DYNAMIC_FIREWALL_BASE,
+      credentialed: true,
+      hostPolicy: DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY,
+    },
+    {
+      base: DUPLICATE_DYNAMIC_FIREWALL_BASE,
+      credentialed: false,
+      hostPolicy: fallbackApi.hostPolicy,
+    },
+  ];
+  routing.apis = [
+    {
+      base: DUPLICATE_DYNAMIC_FIREWALL_BASE,
+      environmentNames: ["SERVICE_HOST", "SERVICE_TOKEN"],
+      routes: [{ permissionName: "items.read", rule: "GET /items" }],
+    },
+    {
+      base: DUPLICATE_DYNAMIC_FIREWALL_BASE,
+      environmentNames: ["SERVICE_HOST"],
+      routes: [],
+    },
+  ];
+  recordValue(connector.diagnostics, "diagnostics").apiCount = 2;
+}
+
+function addDuplicateDynamicRunnerFirewallApi(
+  artifact: JsonRecord,
+  options: { readonly conflictingHostPolicy?: boolean } = {},
+): void {
+  const firewall = firstRecord(artifact.firewalls, "firewalls");
+  const apis = arrayValue(firewall.apis, "firewall.apis");
+  const firstApi = firstRecord(apis, "firewall.apis");
+  firstApi.base = DUPLICATE_DYNAMIC_FIREWALL_BASE;
+  firstApi.hostPolicy = DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY;
+  const fallbackApi = structuredClone(firstApi);
+  fallbackApi.auth = {};
+  fallbackApi.permissions = [];
+  fallbackApi.hostPolicy = options.conflictingHostPolicy
+    ? { kind: "publicDestination" }
+    : DUPLICATE_DYNAMIC_FIREWALL_HOST_POLICY;
+  apis.push(fallbackApi);
+}
+
 function buildRelease(options: ReleaseFixtureOptions): ReleaseFixture {
   const connectorRef = options.connectorRef ?? "external-test";
   const label = options.label ?? "External Test";
@@ -3372,6 +3454,52 @@ describe("connector catalog valid lifecycle", () => {
     });
   });
 
+  it("merges duplicate dynamic firewall execution templates", async () => {
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.duplicate-dynamic-firewall-base",
+      connectorRef: "dynamic-firewall",
+      label: "Dynamic Firewall",
+      generatedFirewall: true,
+      mutatePrivate: addDynamicFirewallVariableBinding,
+      mutatePrivateFirewalls: addDuplicateDynamicPrivateFirewallApi,
+      mutateRunnerFirewalls: addDuplicateDynamicRunnerFirewallApi,
+    });
+    serveObjects(catalogObjects([release], release));
+
+    expect((await syncCatalog()).body).toMatchObject({
+      outcome: "accepted",
+      state: "current",
+      active: { catalogVersion: release.version },
+    });
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+    zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const diagnostic = await accept(
+      setupApp({ context })(zeroConnectorCheckContract).check({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          mode: "url",
+          method: "GET",
+          url: "https://tenant.example.test/v1/items",
+          connectorRef: "dynamic-firewall",
+        },
+      }),
+      [200],
+    );
+    expect(diagnostic.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        connectorRef: "dynamic-firewall",
+        label: "Dynamic Firewall",
+      },
+      permission: {
+        kind: "matched",
+        permissions: [{ name: "items.read" }],
+      },
+    });
+  });
+
   it("accepts canonical firewall bases with authority parameters", async () => {
     configureSource();
     const base = "https://{awsHost+}.amazonaws.com";
@@ -4458,6 +4586,27 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const auth = recordValue(api.auth, "firewall api auth");
             recordValue(auth.headers, "firewall auth headers")["X-Unknown"] =
               catalogTemplate("secrets.UNKNOWN_SECRET");
+          },
+        });
+      },
+    },
+    {
+      name: "conflicting duplicate dynamic firewall host policies",
+      expected: "relationship-mismatch",
+      release: () => {
+        return buildRelease({
+          version: "firewall-dynamic-base-host-policy-conflict",
+          generatedFirewall: true,
+          mutatePrivate: addDynamicFirewallVariableBinding,
+          mutatePrivateFirewalls: (artifact) => {
+            addDuplicateDynamicPrivateFirewallApi(artifact, {
+              conflictingHostPolicy: true,
+            });
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            addDuplicateDynamicRunnerFirewallApi(artifact, {
+              conflictingHostPolicy: true,
+            });
           },
         });
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -3647,6 +3647,22 @@ describe("connector catalog executable compatibility", () => {
       ],
     });
 
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+    zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const diagnostic = await accept(
+      setupApp({ context })(zeroConnectorCheckContract).check({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          mode: "environment",
+          environmentName: "TEST_OAUTH_DEVICE_TOKEN",
+        },
+      }),
+      [200],
+    );
+    expect(diagnostic.body).toStrictEqual({
+      outcome: "unknown-environment",
+    });
+
     const allFiltered = buildRelease({
       version: "2026-07-15.all-filtered",
       connectorRef: "future-auth",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -4463,7 +4463,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
     {
-      name: "cross-connector firewall fixed host collision",
+      name: "normalized cross-connector firewall fixed host collision",
       expected: "relationship-mismatch",
       release: () => {
         const secondConnectorRef = "collision-b";
@@ -4507,13 +4507,22 @@ describe("connector catalog rejection and latest-valid retention", () => {
             );
             second.connectorRef = secondConnectorRef;
             second.label = "Collision B";
-            recordValue(second.firewall, "firewall").name = secondConnectorRef;
+            const firewall = recordValue(second.firewall, "firewall");
+            firewall.name = secondConnectorRef;
+            firstRecord(firewall.apis, "firewall.apis").base =
+              "https://API.EXAMPLE.TEST./v1";
+            const routing = recordValue(second.routing, "routing");
+            routing.fixedHosts = ["api.example.test."];
+            firstRecord(routing.apis, "routing.apis").base =
+              "https://API.EXAMPLE.TEST./v1";
             connectors.push(second);
           },
           mutateRunnerFirewalls: (artifact) => {
             const firewalls = arrayValue(artifact.firewalls, "firewalls");
             const second = structuredClone(firstRecord(firewalls, "firewalls"));
             second.name = secondConnectorRef;
+            firstRecord(second.apis, "firewall.apis").base =
+              "https://API.EXAMPLE.TEST./v1";
             firewalls.push(second);
           },
         });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -9,7 +9,9 @@ import {
   zeroConnectorsSearchContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { zeroConnectorCheckContract } from "@vm0/api-contracts/contracts/zero-connector-check";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
+import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import {
   zeroWorkflowAutomationsContract,
   zeroWorkflowsCollectionContract,
@@ -2015,6 +2017,10 @@ describe("connector catalog valid lifecycle", () => {
       version: "2026-07-15.external-run-materialization",
       connectorRef,
       label: "External Runtime",
+      generatedFirewall: true,
+      mutatePrivateFirewalls: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").billable = true;
+      },
     });
     serveObjects(catalogObjects([release], release));
     await syncCatalog();
@@ -2055,6 +2061,61 @@ describe("connector catalog valid lifecycle", () => {
     );
 
     const callsBeforeRun = context.mocks.s3.send.mock.calls.length;
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const check = await accept(
+      setupApp({ context })(zeroConnectorCheckContract).check({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          mode: "url",
+          method: "GET",
+          url: "https://api.example.test/v1/items",
+          connectorRef,
+        },
+      }),
+      [200],
+    );
+    expect(check.body).toMatchObject({
+      outcome: "resolved",
+      mode: "url",
+      connector: {
+        connectorRef,
+        label: "External Runtime",
+      },
+      base: "https://api.example.test/v1",
+      relativePath: "/items",
+      permission: {
+        kind: "matched",
+        permissions: [{ name: "items.read" }],
+      },
+    });
+    const hostCollision = await connectorsApi.requestCreateCustomConnector(
+      actor,
+      {
+        displayName: "External Host Collision",
+        prefixes: ["https://api.example.test/custom/"],
+        headerName: "Authorization",
+        headerTemplate: "Bearer {{secret}}",
+      },
+      [400],
+    );
+    expectApiError(hostCollision.body);
+    expect(hostCollision.body.error.message).toContain("api.example.test");
+    expect(hostCollision.body.error.message).toContain("External Runtime");
+    const grants = await accept(
+      setupApp({ context })(zeroUserPermissionGrantsContract).apply({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorRef,
+          mode: "replace",
+          grants: [{ permission: "items.read", action: "deny" }],
+        },
+      }),
+      [200],
+    );
+    expect(grants.body).toMatchObject([
+      { connectorRef, permission: "items.read", action: "deny" },
+    ]);
     const run = await runs.createRun(actor, {
       agentId: agent.agentId,
       prompt: "Use the externally sourced connector credential",
@@ -2074,6 +2135,17 @@ describe("connector catalog valid lifecycle", () => {
     expect(claim.environment?.SERVICE_TOKEN).toBeTruthy();
     expect(claim.secretConnectorMap).toMatchObject({
       SERVICE_TOKEN: connectorRef,
+    });
+    expect(claim.firewalls).toContainEqual({
+      kind: "builtin",
+      name: connectorRef,
+    });
+    expect(claim.billableFirewalls).toContain(connectorRef);
+    expect(claim.networkPolicies?.[connectorRef]).toStrictEqual({
+      allow: [],
+      deny: ["items.read"],
+      ask: [],
+      unknownPolicy: "deny",
     });
     expect(
       claim.storageManifest?.storages.some((storage) => {
@@ -3272,12 +3344,17 @@ describe("connector catalog valid lifecycle", () => {
       schemaVersion: 1,
       catalogVersion: release.version,
       externalConnectorCount: 1,
+      staticServerFirewallCount: expect.any(Number),
+      externalServerFirewallCount: 0,
+      staticServerFirewallDigest: expect.stringMatching(/^sha256:/),
+      externalServerFirewallDigest: expect.stringMatching(/^sha256:/),
     });
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforePublicRead);
     const logged = JSON.stringify(context.mocks.axiomLogging.debug.mock.calls);
     expect(logged).not.toContain(userId);
     expect(logged).not.toContain(orgId);
     expect(logged).not.toContain(PRIVATE_VALUE);
+    expect(logged).not.toContain("placeholder-token");
   });
 
   it("accepts a complete generated firewall projection", async () => {
@@ -4365,6 +4442,63 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const auth = recordValue(api.auth, "firewall api auth");
             recordValue(auth.headers, "firewall auth headers")["X-Unknown"] =
               catalogTemplate("secrets.UNKNOWN_SECRET");
+          },
+        });
+      },
+    },
+    {
+      name: "cross-connector firewall fixed host collision",
+      expected: "relationship-mismatch",
+      release: () => {
+        const secondConnectorRef = "collision-b";
+        return buildRelease({
+          version: "firewall-fixed-host-collision",
+          connectorRef: "collision-a",
+          generatedFirewall: true,
+          mutatePublic: (artifact) => {
+            const connectors = arrayValue(artifact.connectors, "connectors");
+            const second = structuredClone(
+              firstRecord(connectors, "connectors"),
+            );
+            second.connectorRef = secondConnectorRef;
+            second.label = "Collision B";
+            connectors.push(second);
+          },
+          mutatePrivate: (artifact) => {
+            const connectors = arrayValue(artifact.connectors, "connectors");
+            const second = structuredClone(
+              firstRecord(connectors, "connectors"),
+            );
+            second.connectorRef = secondConnectorRef;
+            const method = firstRecord(second.authMethods, "authMethods");
+            recordValue(method.storage, "storage").secrets = [
+              "SECOND_SECRET_TOKEN",
+            ];
+            firstRecord(
+              recordValue(method.grant, "grant").fields,
+              "grant.fields",
+            ).privateName = "SECOND_SECRET_TOKEN";
+            recordValue(
+              recordValue(method.access, "access").envBindings,
+              "envBindings",
+            ).SERVICE_TOKEN = "$secrets.SECOND_SECRET_TOKEN";
+            connectors.push(second);
+          },
+          mutatePrivateFirewalls: (artifact) => {
+            const connectors = arrayValue(artifact.connectors, "connectors");
+            const second = structuredClone(
+              firstRecord(connectors, "connectors"),
+            );
+            second.connectorRef = secondConnectorRef;
+            second.label = "Collision B";
+            recordValue(second.firewall, "firewall").name = secondConnectorRef;
+            connectors.push(second);
+          },
+          mutateRunnerFirewalls: (artifact) => {
+            const firewalls = arrayValue(artifact.firewalls, "firewalls");
+            const second = structuredClone(firstRecord(firewalls, "firewalls"));
+            second.name = secondConnectorRef;
+            firewalls.push(second);
           },
         });
       },

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -67,6 +67,7 @@ import {
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
+import { loadConnectorRuntimeSnapshot } from "../services/connector-catalog-runtime.service";
 import {
   networkPolicyRefreshesRecord,
   mergeNetworkPolicyRefreshes,
@@ -1148,8 +1149,19 @@ async function refreshClaimNetworkPolicies(args: {
 }): Promise<
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
 > {
+  const networkPolicyConnectorRefs = Object.keys(
+    args.storedContext.networkPolicies ?? {},
+  );
+  if (networkPolicyConnectorRefs.length === 0) {
+    return {
+      networkPolicies: args.storedContext.networkPolicies,
+      networkPolicyRefreshes: undefined,
+    };
+  }
+  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(args.db);
   const connectorRefs = networkPolicyRefreshConnectorRefs(
-    Object.keys(args.storedContext.networkPolicies ?? {}),
+    connectorCatalogSnapshot.serverFirewalls,
+    networkPolicyConnectorRefs,
   );
   if (connectorRefs.length === 0) {
     return {
@@ -1170,6 +1182,7 @@ async function refreshClaimNetworkPolicies(args: {
           agentId: args.run.agentId,
         },
         connectorRefs,
+        connectorCatalogSnapshot,
       );
       return {
         networkPolicies: mergeNetworkPolicyRefreshes(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -43,14 +43,10 @@ import {
   type ConnectorRuntimeBindingEntry,
 } from "@vm0/connectors/connector-utils";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
-import {
-  getFirewallExecutionMetadata,
-  isFirewallExecutionMetadataConnectorType,
-  loadFirewallPermissionIndex,
-  type FirewallExecutionMetadata,
-  type FirewallExecutionMetadataConnectorType,
-  type FirewallPermissionIndex,
-} from "@vm0/connectors/firewall-metadata/server";
+import type {
+  ConnectorServerFirewallExecutionMetadata,
+  ConnectorServerFirewallPermissionIndex,
+} from "./connector-server-firewall-catalog.service";
 import {
   canonicalizeFirewallBaseUrlVarsForExecution,
   extractSecretNamesFromApis,
@@ -3617,22 +3613,30 @@ function allAllowPolicyForPermissions(
   };
 }
 
-async function loadRequiredFirewallPermissionIndex(
-  type: string,
-): Promise<FirewallPermissionIndex> {
-  const index = await loadFirewallPermissionIndex(type);
+async function loadRequiredFirewallPermissionIndex(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly connectorRef: string;
+}): Promise<ConnectorServerFirewallPermissionIndex> {
+  const index = await args.snapshot.serverFirewalls.loadPermissionIndex(
+    args.connectorRef,
+  );
   if (!index) {
-    throw new Error(`Missing firewall permission metadata: ${type}`);
+    throw new Error(
+      `Missing connector server firewall permission metadata: ${args.connectorRef}`,
+    );
   }
   return index;
 }
 
 function getRequiredFirewallExecutionMetadata(
-  type: FirewallExecutionMetadataConnectorType,
-): FirewallExecutionMetadata {
-  const metadata = getFirewallExecutionMetadata(type);
+  snapshot: ConnectorRuntimeSnapshot,
+  connectorRef: string,
+): ConnectorServerFirewallExecutionMetadata {
+  const metadata = snapshot.serverFirewalls.getExecutionMetadata(connectorRef);
   if (!metadata) {
-    throw new Error(`Missing firewall execution metadata: ${type}`);
+    throw new Error(
+      `Missing connector server firewall execution metadata: ${connectorRef}`,
+    );
   }
   return metadata;
 }
@@ -3691,15 +3695,15 @@ function baseUrlValidationAuth(
 }
 
 function builtinFirewallEntryForMetadata(
-  metadata: FirewallExecutionMetadata,
+  metadata: ConnectorServerFirewallExecutionMetadata,
   vars: Record<string, string> | undefined,
 ): ExecutionFirewallEntry {
   if (metadata.baseUrlVarNames.length === 0) {
-    return { kind: "builtin", name: metadata.type };
+    return { kind: "builtin", name: metadata.connectorRef };
   }
 
   const validationFirewall: Firewall = {
-    name: metadata.type,
+    name: metadata.connectorRef,
     apis: metadata.baseUrlTemplates.map((template) => {
       return {
         base: template.base,
@@ -3715,7 +3719,7 @@ function builtinFirewallEntryForMetadata(
     [validationFirewall],
     vars,
   );
-  return { kind: "builtin", name: metadata.type, baseUrlVars };
+  return { kind: "builtin", name: metadata.connectorRef, baseUrlVars };
 }
 
 function inlineFirewallEntry(
@@ -3806,8 +3810,8 @@ function modelProviderPermissionManifest(
 }
 
 interface BuiltinConnectorManifestSource {
-  readonly metadata: FirewallExecutionMetadata;
-  readonly permissionIndex: FirewallPermissionIndex;
+  readonly metadata: ConnectorServerFirewallExecutionMetadata;
+  readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
 }
 
 function applyBuiltinConnectorMetadataPolicies(
@@ -3821,7 +3825,7 @@ function applyBuiltinConnectorMetadataPolicies(
   const billableFirewalls: string[] = [];
 
   for (const source of sources) {
-    const name = source.metadata.type;
+    const name = source.metadata.connectorRef;
     const permissionNames = [...source.permissionIndex.permissionNames];
     const defaultPolicy = defaultFirewallPolicyForPermissionIndex(
       source.permissionIndex,
@@ -3859,6 +3863,7 @@ function applyBuiltinConnectorMetadataPolicies(
 }
 
 async function buildPermissionManifest(args: {
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly vars: Record<string, string> | undefined;
@@ -3869,13 +3874,13 @@ async function buildPermissionManifest(args: {
 }): Promise<PermissionManifest | undefined> {
   const connectorTypes =
     args.connectorTypes ??
-    Object.keys(args.permissionPolicies ?? {}).filter(
-      isFirewallExecutionMetadataConnectorType,
-    );
+    Object.keys(args.permissionPolicies ?? {}).filter((connectorRef) => {
+      return args.connectorCatalogSnapshot.serverFirewalls.has(connectorRef);
+    });
   const connectorBaseUrlVars = mergeRecords(args.vars, args.connectorVars);
-  const builtinConnectorTypes = connectorTypes.filter(
-    isFirewallExecutionMetadataConnectorType,
-  );
+  const builtinConnectorTypes = connectorTypes.filter((connectorRef) => {
+    return args.connectorCatalogSnapshot.serverFirewalls.has(connectorRef);
+  });
 
   const builtinSources = await measureApiDispatchTiming(
     args.timing,
@@ -3884,9 +3889,14 @@ async function buildPermissionManifest(args: {
     async () => {
       return await Promise.all(
         builtinConnectorTypes.map(async (type) => {
-          const metadata = getRequiredFirewallExecutionMetadata(type);
-          const permissionIndex =
-            await loadRequiredFirewallPermissionIndex(type);
+          const metadata = getRequiredFirewallExecutionMetadata(
+            args.connectorCatalogSnapshot,
+            type,
+          );
+          const permissionIndex = await loadRequiredFirewallPermissionIndex({
+            snapshot: args.connectorCatalogSnapshot,
+            connectorRef: type,
+          });
           return { metadata, permissionIndex };
         }),
       );
@@ -6422,6 +6432,7 @@ function validateRunEnvironmentReferences(args: {
 }
 
 async function buildPreparedPermissionManifest(args: {
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly body: CreateRunBody;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly storedConnectorMetadataContext: ConnectorRuntimeContext;
@@ -6430,6 +6441,7 @@ async function buildPreparedPermissionManifest(args: {
 }): Promise<PermissionManifest | undefined | CreateRunErrorResult> {
   const result = await settle(
     buildPermissionManifest({
+      connectorCatalogSnapshot: args.connectorCatalogSnapshot,
       modelProvider: args.modelProvider,
       permissionPolicies: args.body.permissionPolicies,
       vars: args.body.vars,
@@ -6745,13 +6757,14 @@ async function prepareRunRuntimeContext(args: {
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
+  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
   readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
   readonly bodyContext: PreparedRunBodyContext;
 }): Promise<PreparedRuntimeContext | CreateRunErrorResult> {
   const { body, resolved, requestedFramework, featureSwitchContext } =
     args.bodyContext;
-  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(args.db);
+  const connectorCatalogSnapshot = await connectorCatalogSnapshotForRun(args);
   args.signal.throwIfAborted();
   const connectorScope = connectorScopeForRuntimeSnapshot(
     args.connectorScope,
@@ -6815,6 +6828,7 @@ async function prepareRunRuntimeContext(args: {
     "nested",
     async () => {
       return await buildPreparedPermissionManifest({
+        connectorCatalogSnapshot,
         body,
         modelProvider,
         storedConnectorMetadataContext,
@@ -6869,6 +6883,16 @@ async function prepareRunRuntimeContext(args: {
   };
 }
 
+async function connectorCatalogSnapshotForRun(args: {
+  readonly db: Db;
+  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
+}): Promise<ConnectorRuntimeSnapshot> {
+  return (
+    args.preloadedConnectorCatalogSnapshot ??
+    (await loadConnectorRuntimeSnapshot(args.db))
+  );
+}
+
 function prepareRunOutputMetadata(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
@@ -6901,13 +6925,24 @@ function prepareRunOutputMetadata(args: {
   };
 }
 
-function prepareRunContext(
-  db: Db,
-  args: CreateAgentRunArgs,
-  timing: ApiDispatchTimingCollector,
-  signal: AbortSignal,
-  preloadedFeatureSwitchContext: FeatureSwitchContext | undefined,
-): Computed<Promise<PreparedRunContext | CreateRunErrorResult>> {
+function prepareRunContext(input: {
+  readonly db: Db;
+  readonly args: CreateAgentRunArgs;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly signal: AbortSignal;
+  readonly preloadedFeatureSwitchContext: FeatureSwitchContext | undefined;
+  readonly preloadedConnectorCatalogSnapshot:
+    | ConnectorRuntimeSnapshot
+    | undefined;
+}): Computed<Promise<PreparedRunContext | CreateRunErrorResult>> {
+  const {
+    db,
+    args,
+    timing,
+    signal,
+    preloadedFeatureSwitchContext,
+    preloadedConnectorCatalogSnapshot,
+  } = input;
   return computed(
     async (get): Promise<PreparedRunContext | CreateRunErrorResult> => {
       const initialBody = initialRunBody(args);
@@ -6938,6 +6973,7 @@ function prepareRunContext(
         db,
         createArgs: args,
         connectorScope: bodyContext.connectorScope,
+        preloadedConnectorCatalogSnapshot,
         timing,
         signal,
         bodyContext,
@@ -7546,6 +7582,7 @@ interface PrepareAgentRunArgs {
   readonly timing: ApiDispatchTimingCollector;
   readonly checkOrgPlanStatusBeforeContext: boolean;
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
+  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
 }
 
 interface CompleteAgentRunArgs {
@@ -7597,13 +7634,15 @@ export const prepareAgentRun$ = command(
       "top_level",
       async () => {
         return await get(
-          prepareRunContext(
+          prepareRunContext({
             db,
             args,
             timing,
             signal,
-            input.preloadedFeatureSwitchContext,
-          ),
+            preloadedFeatureSwitchContext: input.preloadedFeatureSwitchContext,
+            preloadedConnectorCatalogSnapshot:
+              input.preloadedConnectorCatalogSnapshot,
+          }),
         );
       },
     );

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { normalizeConnectorFixedHost } from "@vm0/connectors/firewall-metadata/server";
 
 import {
@@ -380,6 +382,22 @@ function validateFirewallProjection(args: {
     throw new Error(
       `Firewall label mismatch: ${args.publicConnector.connectorRef}`,
     );
+  }
+  const baseUrlTemplates = new Map<
+    string,
+    (typeof args.privateFirewall.routing.baseUrlTemplates)[number]
+  >();
+  for (const template of args.privateFirewall.routing.baseUrlTemplates) {
+    const existing = baseUrlTemplates.get(template.base);
+    if (
+      existing &&
+      !isDeepStrictEqual(existing.hostPolicy, template.hostPolicy)
+    ) {
+      throw new Error(
+        `Firewall base URL host policies conflict: ${args.publicConnector.connectorRef} (${template.base})`,
+      );
+    }
+    baseUrlTemplates.set(template.base, template);
   }
   validateFirewallBindings(args);
   if (

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -1,3 +1,5 @@
+import { normalizeConnectorFixedHost } from "@vm0/connectors/firewall-metadata/server";
+
 import {
   type ConnectorCatalogIntegrityArtifact,
   type ConnectorCatalogPrivateArtifact,
@@ -428,7 +430,13 @@ function validateFirewallSemantics(args: {
       privateConnector,
       privateFirewall: connector,
     });
-    for (const host of connector.routing.fixedHosts) {
+    for (const rawHost of connector.routing.fixedHosts) {
+      const host = normalizeConnectorFixedHost(rawHost);
+      if (!host) {
+        throw new Error(
+          `Firewall fixed host is invalid: ${connector.connectorRef}`,
+        );
+      }
       const existingOwner = fixedHostOwners.get(host);
       if (
         existingOwner !== undefined &&

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/relationships.ts
@@ -407,6 +407,7 @@ function validateFirewallSemantics(args: {
       return [connector.connectorRef, connector];
     }),
   );
+  const fixedHostOwners = new Map<string, string>();
   for (const connector of args.privateFirewallsArtifact.connectors) {
     validateFirewallGeneratorResult({
       connectorRef: connector.connectorRef,
@@ -427,6 +428,18 @@ function validateFirewallSemantics(args: {
       privateConnector,
       privateFirewall: connector,
     });
+    for (const host of connector.routing.fixedHosts) {
+      const existingOwner = fixedHostOwners.get(host);
+      if (
+        existingOwner !== undefined &&
+        existingOwner !== connector.connectorRef
+      ) {
+        throw new Error(
+          `Firewall fixed host collision: ${host} (${existingOwner}, ${connector.connectorRef})`,
+        );
+      }
+      fixedHostOwners.set(host, connector.connectorRef);
+    }
   }
 }
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -46,7 +46,6 @@ import type { ReadonlyDb } from "../external/db";
 import { settle } from "../utils";
 import type {
   ConnectorCatalogPrivateArtifact,
-  ConnectorCatalogPrivateFirewallsArtifact,
   ConnectorCatalogPublicArtifact,
   ConnectorCatalogRunnerFirewallsArtifact,
 } from "./connector-catalog-artifacts/artifacts";
@@ -64,6 +63,11 @@ import {
   getStaticConnectorCatalogResolutionDetail,
   getStaticPublicConnectorCatalogDetail,
 } from "./connector-catalog-reader.service";
+import {
+  createExternalConnectorServerFirewallCatalog,
+  createStaticConnectorServerFirewallCatalog,
+  type ConnectorServerFirewallCatalog,
+} from "./connector-server-firewall-catalog.service";
 
 type AcceptedPrivateConnector =
   ConnectorCatalogPrivateArtifact["connectors"][number];
@@ -72,8 +76,6 @@ type AcceptedPrivateAuthMethod =
 type AcceptedPrivateSkill = AcceptedPrivateConnector["skill"];
 type AcceptedPublicAuthMethod =
   ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
-type AcceptedServerFirewall =
-  ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
 type AcceptedRunnerFirewall =
   ConnectorCatalogRunnerFirewallsArtifact["firewalls"][number];
 
@@ -100,7 +102,6 @@ export interface ConnectorRuntimeConnector {
     ConnectorRuntimeMethod
   >;
   readonly skill: AcceptedPrivateSkill | null;
-  readonly serverFirewall: AcceptedServerFirewall | null;
   readonly runnerFirewall: AcceptedRunnerFirewall | null;
 }
 
@@ -109,6 +110,7 @@ interface ConnectorRuntimeSnapshotBase {
     ConnectorCatalogRef,
     ConnectorRuntimeConnector
   >;
+  readonly serverFirewalls: ConnectorServerFirewallCatalog;
 }
 
 export type ConnectorRuntimeSnapshot =
@@ -579,7 +581,6 @@ const staticRuntimeSnapshot = singleton(() => {
         catalogConnector,
         methods,
         skill: null,
-        serverFirewall: null,
         runnerFirewall: null,
       });
     }
@@ -587,6 +588,8 @@ const staticRuntimeSnapshot = singleton(() => {
       identity: { source: "static" },
       acceptedSnapshot: null,
       connectors,
+      serverFirewalls:
+        createStaticConnectorServerFirewallCatalog(CONNECTOR_TYPE_KEYS),
     };
   })();
 });
@@ -597,11 +600,6 @@ function externalRuntimeSnapshot(
   const privateByRef = new Map(
     acceptedSnapshot.privateArtifact.connectors.map((connector) => {
       return [connector.connectorRef, connector];
-    }),
-  );
-  const serverFirewallByRef = new Map(
-    acceptedSnapshot.privateFirewallsArtifact.connectors.map((firewall) => {
-      return [firewall.connectorRef, firewall];
     }),
   );
   const runnerFirewallByRef = new Map(
@@ -663,16 +661,29 @@ function externalRuntimeSnapshot(
       catalogConnector,
       methods,
       skill: privateConnector.skill,
-      serverFirewall:
-        serverFirewallByRef.get(publicConnector.connectorRef) ?? null,
       runnerFirewall:
         runnerFirewallByRef.get(publicConnector.connectorRef) ?? null,
     });
   }
+  const runtimeMethodsByRef = new Map(
+    [...connectors.entries()].map(([connectorRef, connector]) => {
+      return [
+        connectorRef,
+        [...connector.methods.values()].map((method) => {
+          return method.method;
+        }),
+      ];
+    }),
+  );
   return {
     identity: { source: "external", ...acceptedSnapshot.identity },
     acceptedSnapshot,
     connectors,
+    serverFirewalls: createExternalConnectorServerFirewallCatalog({
+      publicArtifact: acceptedSnapshot.publicArtifact,
+      privateFirewallsArtifact: acceptedSnapshot.privateFirewallsArtifact,
+      runtimeMethodsByRef,
+    }),
   };
 }
 
@@ -753,6 +764,14 @@ function runtimeShadowDigest(methods: readonly RuntimeShadowMethod[]): string {
     .digest("hex")}`;
 }
 
+async function serverFirewallShadowDigest(
+  snapshot: ConnectorRuntimeSnapshot,
+): Promise<string> {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(await snapshot.serverFirewalls.shadowProjection()))
+    .digest("hex")}`;
+}
+
 async function compareRuntimeSnapshots(
   staticSnapshot: ConnectorRuntimeSnapshot,
   db: ReadonlyDb,
@@ -772,15 +791,30 @@ async function compareRuntimeSnapshots(
   const externalMethods = runtimeShadowMethods(result.value);
   const staticDigest = runtimeShadowDigest(staticMethods);
   const externalDigest = runtimeShadowDigest(externalMethods);
+  const [staticServerFirewallDigest, externalServerFirewallDigest] =
+    await Promise.all([
+      serverFirewallShadowDigest(staticSnapshot),
+      serverFirewallShadowDigest(result.value),
+    ]);
   log.debug("Connector runtime catalog shadow comparison completed", {
     type: "connector_runtime_catalog_shadow_comparison",
-    outcome: staticDigest === externalDigest ? "match" : "difference",
+    outcome:
+      staticDigest === externalDigest &&
+      staticServerFirewallDigest === externalServerFirewallDigest
+        ? "match"
+        : "difference",
     staticConnectorCount: staticSnapshot.connectors.size,
     externalConnectorCount: result.value.connectors.size,
     staticMethodCount: staticMethods.length,
     externalMethodCount: externalMethods.length,
     staticDigest,
     externalDigest,
+    staticServerFirewallCount:
+      staticSnapshot.serverFirewalls.connectorRefs.length,
+    externalServerFirewallCount:
+      result.value.serverFirewalls.connectorRefs.length,
+    staticServerFirewallDigest,
+    externalServerFirewallDigest,
     ...(result.value.identity.source === "external"
       ? {
           sourceId: result.value.identity.sourceId,

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -4,26 +4,16 @@ import type {
   ConnectorCheckRequest,
 } from "@vm0/api-contracts/contracts/zero-connector-check";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
-  getAvailableConnectorAuthMethodIds,
   connectorAuthMethodRuntimeMetadata,
-  getConnectorEnvBindingEntries,
+  type ConnectorRuntimeBindingEntry,
 } from "@vm0/connectors/connector-utils";
-import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
 import {
   matchFirewallBaseUrl,
   matchFirewallRequestDecision,
   type FirewallRequestDecision,
 } from "@vm0/connectors/firewall-rule-matcher";
-import {
-  FIREWALL_ROUTING_METADATA_INDEX,
-  type FirewallRoutingRouteMetadata,
-} from "@vm0/connectors/firewall-metadata/routing";
-import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import type { NetworkPolicies } from "@vm0/connectors/firewall-types";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { connectors } from "@vm0/db/schema/connector";
@@ -45,9 +35,12 @@ import {
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { zeroRunContext } from "./zero-run-detail.service";
 import {
+  getConnectorRuntimeConnector,
+  listConnectorRuntimeVisibleRefs,
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
+import type { FirewallRoutingRouteMetadata } from "./connector-server-firewall-catalog.service";
 import {
   connectorCredentialVariableReadCondition,
   resolveConnectorCredentialAccess,
@@ -57,21 +50,21 @@ import {
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ConnectorCheckIdentity {
-  readonly connectorRef: ConnectorType;
+  readonly connectorRef: ConnectorCatalogRef;
   readonly label: string;
   readonly visibility: "available" | "unavailable";
   readonly credentialResolution: "network-boundary" | "none";
 }
 
 interface ConnectorCheckRoutingConfig {
-  readonly type: ConnectorType;
+  readonly type: ConnectorCatalogRef;
   readonly candidates: readonly ConnectorDiagnosticBaseCandidate[];
   readonly hasUnresolvedDynamicBase: boolean;
 }
 
 interface StoredRuntimeState {
   readonly baseUrlVarsByType: ReadonlyMap<
-    ConnectorType,
+    ConnectorCatalogRef,
     Readonly<Record<string, string>> | null
   >;
 }
@@ -122,8 +115,16 @@ type RunContextInlinePermission =
     ? Permission
     : never;
 
-function isConnectorType(value: string): value is ConnectorType {
-  return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, value);
+interface ConnectorCheckCatalogContext {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly visibleConnectorRefs: ReadonlySet<ConnectorCatalogRef>;
+}
+
+function isConnectorRef(
+  snapshot: ConnectorRuntimeSnapshot,
+  value: string,
+): value is ConnectorCatalogRef {
+  return snapshot.connectors.has(value);
 }
 
 function baseKey(value: string): string {
@@ -131,28 +132,36 @@ function baseKey(value: string): string {
 }
 
 function connectorCredentialResolution(
-  type: ConnectorType,
+  snapshot: ConnectorRuntimeSnapshot,
+  connectorRef: ConnectorCatalogRef,
 ): "network-boundary" | "none" {
-  return (getFirewallExecutionMetadata(type)?.secretPlaceholderNames.length ??
-    0) > 0
+  return (snapshot.serverFirewalls.getExecutionMetadata(connectorRef)
+    ?.secretPlaceholderNames.length ?? 0) > 0
     ? "network-boundary"
     : "none";
 }
 
 function connectorIdentity(
-  type: ConnectorType,
-  featureStates: FeatureStates,
+  connectorRef: ConnectorCatalogRef,
+  catalogContext: ConnectorCheckCatalogContext,
 ): ConnectorCheckIdentity {
+  const connector = getConnectorRuntimeConnector(
+    catalogContext.snapshot,
+    connectorRef,
+  );
+  if (!connector) {
+    throw new Error(`Missing connector runtime metadata: ${connectorRef}`);
+  }
   return {
-    connectorRef: type,
-    label: CONNECTOR_TYPES[type].label,
-    visibility:
-      getAvailableConnectorAuthMethodIds(type, featureStates, {
-        apiAuthMethodPolicy: "include",
-      }).length > 0
-        ? "available"
-        : "unavailable",
-    credentialResolution: connectorCredentialResolution(type),
+    connectorRef,
+    label: connector.catalogConnector.label,
+    visibility: catalogContext.visibleConnectorRefs.has(connectorRef)
+      ? "available"
+      : "unavailable",
+    credentialResolution: connectorCredentialResolution(
+      catalogContext.snapshot,
+      connectorRef,
+    ),
   };
 }
 
@@ -170,14 +179,14 @@ function pendingStoredConnectorRuntimes(
     readonly userId: string;
     readonly snapshot: ConnectorRuntimeSnapshot;
   },
-): ReadonlyMap<ConnectorType, PendingStoredConnectorRuntime | null> {
+): ReadonlyMap<ConnectorCatalogRef, PendingStoredConnectorRuntime | null> {
   const pending = new Map<
-    ConnectorType,
+    ConnectorCatalogRef,
     PendingStoredConnectorRuntime | null
   >();
 
   for (const row of rows) {
-    if (!isConnectorType(row.type)) {
+    if (!isConnectorRef(args.snapshot, row.type)) {
       continue;
     }
     if (pending.has(row.type)) {
@@ -200,7 +209,8 @@ function pendingStoredConnectorRuntimes(
     }
     const { access } = accessResult;
     const requiredRuntimeNames =
-      getFirewallExecutionMetadata(row.type)?.baseUrlVarNames ?? [];
+      args.snapshot.serverFirewalls.getExecutionMetadata(row.type)
+        ?.baseUrlVarNames ?? [];
     if (requiredRuntimeNames.length === 0) {
       pending.set(row.type, {
         access,
@@ -291,7 +301,7 @@ async function loadStoredRuntimeState(
       }),
     );
     const baseUrlVarsByType = new Map<
-      ConnectorType,
+      ConnectorCatalogRef,
       Readonly<Record<string, string>> | null
     >();
     for (const [type, pendingState] of pending) {
@@ -420,7 +430,7 @@ function inlineApiEnvironmentNames(
 
 function configFromInlineRunContext(
   firewall: RunContextInlineFirewall,
-  type: ConnectorType,
+  type: ConnectorCatalogRef,
   view: ConnectorDiagnosticCatalogView | null,
 ): ConnectorCheckRoutingConfig {
   return {
@@ -461,17 +471,21 @@ function completeRunBaseUrlVars(
 
 async function loadRunRoutingConfigs(
   runContext: RunContextResponse,
+  snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig[]> {
   const viewPromises = new Map<
-    ConnectorType,
+    ConnectorCatalogRef,
     Promise<ConnectorDiagnosticCatalogView | null>
   >();
   const loadView = (
-    type: ConnectorType,
+    type: ConnectorCatalogRef,
   ): Promise<ConnectorDiagnosticCatalogView | null> => {
     let promise = viewPromises.get(type);
     if (!promise) {
-      promise = loadConnectorDiagnosticCatalogView(type);
+      promise = loadConnectorDiagnosticCatalogView(
+        snapshot.serverFirewalls,
+        type,
+      );
       viewPromises.set(type, promise);
     }
     return promise;
@@ -479,7 +493,7 @@ async function loadRunRoutingConfigs(
 
   const configs: ConnectorCheckRoutingConfig[] = [];
   for (const firewall of runContext.firewalls) {
-    if (!isConnectorType(firewall.name)) {
+    if (!snapshot.serverFirewalls.has(firewall.name)) {
       continue;
     }
     const type = firewall.name;
@@ -495,7 +509,7 @@ async function loadRunRoutingConfigs(
     configs.push(configFromCatalogView(view, baseUrlVars, false));
   }
 
-  const merged = new Map<ConnectorType, ConnectorCheckRoutingConfig>();
+  const merged = new Map<ConnectorCatalogRef, ConnectorCheckRoutingConfig>();
   for (const config of configs) {
     const existing = merged.get(config.type);
     merged.set(config.type, {
@@ -512,10 +526,14 @@ async function loadRunRoutingConfigs(
 }
 
 async function catalogConfig(
-  type: ConnectorType,
+  type: ConnectorCatalogRef,
   state: StoredRuntimeState,
+  snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig | null> {
-  const view = await loadConnectorDiagnosticCatalogView(type);
+  const view = await loadConnectorDiagnosticCatalogView(
+    snapshot.serverFirewalls,
+    type,
+  );
   if (!view) {
     return null;
   }
@@ -528,17 +546,27 @@ async function catalogConfig(
 
 async function loadGlobalCatalogConfigs(
   request: ParsedConnectorDiagnosticRequest,
-  requestedType: ConnectorType | undefined,
+  requestedType: ConnectorCatalogRef | undefined,
   state: StoredRuntimeState,
+  snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig[]> {
   let bestScore: number | null = null;
-  const ownerTypes = new Set<ConnectorType>();
+  const ownerTypes = new Set<ConnectorCatalogRef>();
 
-  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
-    const baseUrlVars = state.baseUrlVarsByType.get(metadata.type) ?? null;
+  for (const connectorRef of snapshot.serverFirewalls.connectorRefs) {
+    const metadata =
+      snapshot.serverFirewalls.getRoutingIndexMetadata(connectorRef);
+    const execution =
+      snapshot.serverFirewalls.getExecutionMetadata(connectorRef);
+    if (!metadata || !execution) {
+      throw new Error(
+        `Missing indexed connector server firewall metadata for ${connectorRef}`,
+      );
+    }
+    const baseUrlVars = state.baseUrlVarsByType.get(connectorRef) ?? null;
     for (const api of metadata.apis) {
       const resolution = resolveConnectorDiagnosticBase(
-        metadata.type,
+        execution,
         api.base,
         baseUrlVars,
         { allowStructuralDynamic: true },
@@ -558,19 +586,19 @@ async function loadGlobalCatalogConfigs(
         ownerTypes.clear();
       }
       if (match.score === bestScore) {
-        ownerTypes.add(metadata.type);
+        ownerTypes.add(connectorRef);
       }
     }
   }
 
   if (ownerTypes.size === 0 && requestedType) {
-    const selected = await catalogConfig(requestedType, state);
+    const selected = await catalogConfig(requestedType, state, snapshot);
     return selected ? [selected] : [];
   }
 
   const configs = await Promise.all(
     [...ownerTypes].sort().map(async (type) => {
-      const config = await catalogConfig(type, state);
+      const config = await catalogConfig(type, state, snapshot);
       if (!config) {
         throw new Error(`Missing indexed firewall metadata for ${type}`);
       }
@@ -634,12 +662,27 @@ function environmentNamesForWinningCandidates(
   return found ? [...names].sort() : null;
 }
 
+function connectorEnvironmentBindings(
+  snapshot: ConnectorRuntimeSnapshot,
+  connectorRef: ConnectorCatalogRef,
+): readonly ConnectorRuntimeBindingEntry[] {
+  const connector = getConnectorRuntimeConnector(snapshot, connectorRef);
+  if (!connector) {
+    return [];
+  }
+  return [...connector.methods.values()].flatMap((runtimeMethod) => {
+    return connectorAuthMethodRuntimeMetadata(runtimeMethod.method)
+      .runtimeBindings;
+  });
+}
+
 function environmentValueRefs(
-  type: ConnectorType,
+  snapshot: ConnectorRuntimeSnapshot,
+  type: ConnectorCatalogRef,
   environmentName: string,
 ): ReadonlySet<string> {
   return new Set(
-    getConnectorEnvBindingEntries(type)
+    connectorEnvironmentBindings(snapshot, type)
       .filter((entry) => {
         return entry.envName === environmentName;
       })
@@ -650,16 +693,21 @@ function environmentValueRefs(
 }
 
 function environmentNameSupportsRoute(
-  type: ConnectorType,
+  snapshot: ConnectorRuntimeSnapshot,
+  type: ConnectorCatalogRef,
   environmentName: string,
   routeEnvironmentNames: readonly string[],
 ): boolean {
-  const requestedRefs = environmentValueRefs(type, environmentName);
+  const requestedRefs = environmentValueRefs(snapshot, type, environmentName);
   return routeEnvironmentNames.some((routeEnvironmentName) => {
     if (routeEnvironmentName === environmentName) {
       return true;
     }
-    const routeRefs = environmentValueRefs(type, routeEnvironmentName);
+    const routeRefs = environmentValueRefs(
+      snapshot,
+      type,
+      routeEnvironmentName,
+    );
     return [...requestedRefs].some((valueRef) => {
       return routeRefs.has(valueRef);
     });
@@ -706,7 +754,7 @@ function unavailablePolicy(
 }
 
 function permissionPolicy(
-  type: ConnectorType,
+  type: ConnectorCatalogRef,
   permission: string,
   timeline: ConnectorCheckTimeline,
   configured: boolean,
@@ -735,7 +783,7 @@ function permissionPolicy(
 }
 
 function unknownPolicy(
-  type: ConnectorType,
+  type: ConnectorCatalogRef,
   timeline: ConnectorCheckTimeline,
   configured: boolean,
 ): ConnectorCheckPolicy {
@@ -764,7 +812,7 @@ function unknownPolicy(
 }
 
 function decisionPermissionResult(
-  type: ConnectorType,
+  type: ConnectorCatalogRef,
   decision: Exclude<
     FirewallRequestDecision,
     { readonly kind: "no_match" | "ambiguous" }
@@ -827,10 +875,11 @@ function displayBaseForDecision(
 }
 
 function connectorTypeForEnvironmentName(
+  snapshot: ConnectorRuntimeSnapshot,
   environmentName: string,
-): ConnectorType | null {
-  const owners = CONNECTOR_TYPE_KEYS.filter((type) => {
-    return getConnectorEnvBindingEntries(type).some((entry) => {
+): ConnectorCatalogRef | null {
+  const owners = [...snapshot.connectors.keys()].filter((type) => {
+    return connectorEnvironmentBindings(snapshot, type).some((entry) => {
       return entry.envName === environmentName;
     });
   });
@@ -849,10 +898,10 @@ function policyMap(timeline: ConnectorCheckTimeline): NetworkPolicies | null {
 }
 
 function noMatchDiagnostic(
-  requestedType: ConnectorType | undefined,
+  requestedType: ConnectorCatalogRef | undefined,
   configs: readonly ConnectorCheckRoutingConfig[],
   timeline: ConnectorCheckTimeline,
-  featureStates: FeatureStates,
+  catalogContext: ConnectorCheckCatalogContext,
 ): ConnectorCheckDiagnosticResult {
   const selectedConfig = requestedType
     ? configs.find((config) => {
@@ -862,7 +911,7 @@ function noMatchDiagnostic(
   if (requestedType && selectedConfig?.hasUnresolvedDynamicBase) {
     return {
       outcome: "unresolved-dynamic-base",
-      connector: connectorIdentity(requestedType, featureStates),
+      connector: connectorIdentity(requestedType, catalogContext),
     };
   }
   return {
@@ -873,16 +922,24 @@ function noMatchDiagnostic(
 
 function ambiguousDiagnostic(
   decision: Extract<FirewallRequestDecision, { readonly kind: "ambiguous" }>,
+  catalogContext: ConnectorCheckCatalogContext,
 ): ConnectorCheckDiagnosticResult {
   return {
     outcome: "ambiguous",
     candidates: decision.candidates.map((candidate) => {
-      if (!isConnectorType(candidate)) {
+      if (!isConnectorRef(catalogContext.snapshot, candidate)) {
         throw new Error("Matched an unknown connector firewall");
+      }
+      const connector = getConnectorRuntimeConnector(
+        catalogContext.snapshot,
+        candidate,
+      );
+      if (!connector) {
+        throw new Error(`Missing connector runtime metadata: ${candidate}`);
       }
       return {
         connectorRef: candidate,
-        label: CONNECTOR_TYPES[candidate].label,
+        label: connector.catalogConnector.label,
       };
     }),
   };
@@ -898,35 +955,46 @@ type UrlEnvironmentSelection =
       readonly diagnostic: ConnectorCheckDiagnosticResult;
     };
 
-function selectUrlEnvironmentNames(
-  type: ConnectorType,
-  config: ConnectorCheckRoutingConfig,
-  parsed: ParsedConnectorDiagnosticRequest,
-  requestedEnvironmentName: string | undefined,
-  identity: ConnectorCheckIdentity,
-): UrlEnvironmentSelection {
-  const environmentNames = environmentNamesForWinningCandidates(config, parsed);
-  if (requestedEnvironmentName === undefined) {
+function selectUrlEnvironmentNames(args: {
+  readonly catalogContext: ConnectorCheckCatalogContext;
+  readonly type: ConnectorCatalogRef;
+  readonly config: ConnectorCheckRoutingConfig;
+  readonly parsed: ParsedConnectorDiagnosticRequest;
+  readonly requestedEnvironmentName: string | undefined;
+  readonly identity: ConnectorCheckIdentity;
+}): UrlEnvironmentSelection {
+  const environmentNames = environmentNamesForWinningCandidates(
+    args.config,
+    args.parsed,
+  );
+  if (args.requestedEnvironmentName === undefined) {
     return {
       kind: "selected",
       environmentNames:
         environmentNames === null ? null : [...environmentNames],
     };
   }
-  const owned = getConnectorEnvBindingEntries(type).some((entry) => {
-    return entry.envName === requestedEnvironmentName;
+  const owned = connectorEnvironmentBindings(
+    args.catalogContext.snapshot,
+    args.type,
+  ).some((entry) => {
+    return entry.envName === args.requestedEnvironmentName;
   });
   if (!owned) {
     return {
       kind: "diagnostic",
-      diagnostic: { outcome: "environment-not-owned", connector: identity },
+      diagnostic: {
+        outcome: "environment-not-owned",
+        connector: args.identity,
+      },
     };
   }
   if (
     environmentNames !== null &&
     !environmentNameSupportsRoute(
-      type,
-      requestedEnvironmentName,
+      args.catalogContext.snapshot,
+      args.type,
+      args.requestedEnvironmentName,
       environmentNames,
     )
   ) {
@@ -934,14 +1002,14 @@ function selectUrlEnvironmentNames(
       kind: "diagnostic",
       diagnostic: {
         outcome: "environment-not-used",
-        connector: identity,
+        connector: args.identity,
         environmentNames: [...environmentNames],
       },
     };
   }
   return {
     kind: "selected",
-    environmentNames: [requestedEnvironmentName],
+    environmentNames: [args.requestedEnvironmentName],
   };
 }
 
@@ -954,13 +1022,13 @@ interface ResolvedUrlDiagnosticArgs {
   >;
   readonly configs: readonly ConnectorCheckRoutingConfig[];
   readonly timeline: ConnectorCheckTimeline;
-  readonly featureStates: FeatureStates;
+  readonly catalogContext: ConnectorCheckCatalogContext;
 }
 
 function resolvedUrlDiagnostic(
   args: ResolvedUrlDiagnosticArgs,
 ): ConnectorCheckDiagnosticResult {
-  const { request, parsed, decision, configs, timeline, featureStates } = args;
+  const { request, parsed, decision, configs, timeline, catalogContext } = args;
   if (decision.kind === "block" && decision.reason === "unsafe_path") {
     return { outcome: "unsafe-input", reason: "unsafe-path" };
   }
@@ -973,14 +1041,14 @@ function resolvedUrlDiagnostic(
       `Invalid connector diagnostic decision: ${decision.reason}`,
     );
   }
-  if (!isConnectorType(decision.firewallName)) {
+  if (!isConnectorRef(catalogContext.snapshot, decision.firewallName)) {
     throw new Error("Matched an unknown connector firewall");
   }
   const type = decision.firewallName;
   if (request.connectorRef !== undefined && type !== request.connectorRef) {
     return {
       outcome: "connector-mismatch",
-      connector: connectorIdentity(type, featureStates),
+      connector: connectorIdentity(type, catalogContext),
     };
   }
   const config = configs.find((entry) => {
@@ -990,14 +1058,15 @@ function resolvedUrlDiagnostic(
     throw new Error(`Missing selected connector routing config for ${type}`);
   }
 
-  const identity = connectorIdentity(type, featureStates);
-  const environmentSelection = selectUrlEnvironmentNames(
+  const identity = connectorIdentity(type, catalogContext);
+  const environmentSelection = selectUrlEnvironmentNames({
+    catalogContext,
     type,
     config,
     parsed,
-    request.environmentName,
+    requestedEnvironmentName: request.environmentName,
     identity,
-  );
+  });
   if (environmentSelection.kind === "diagnostic") {
     return environmentSelection.diagnostic;
   }
@@ -1018,17 +1087,25 @@ async function resolveUrlMode(
   request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>,
   parsed: ParsedConnectorDiagnosticRequest,
   timeline: ConnectorCheckTimeline,
-  featureStates: FeatureStates,
+  catalogContext: ConnectorCheckCatalogContext,
 ): Promise<ConnectorCheckDiagnosticResult> {
   const requestedType = request.connectorRef;
-  if (requestedType !== undefined && !isConnectorType(requestedType)) {
+  if (
+    requestedType !== undefined &&
+    !isConnectorRef(catalogContext.snapshot, requestedType)
+  ) {
     return { outcome: "unknown-connector" };
   }
 
   const configs =
     timeline.kind === "run"
-      ? await loadRunRoutingConfigs(timeline.context)
-      : await loadGlobalCatalogConfigs(parsed, requestedType, timeline.state);
+      ? await loadRunRoutingConfigs(timeline.context, catalogContext.snapshot)
+      : await loadGlobalCatalogConfigs(
+          parsed,
+          requestedType,
+          timeline.state,
+          catalogContext.snapshot,
+        );
   const decision = matchFirewallRequestDecision(
     configsToDecisionFirewalls(configs),
     parsed.method,
@@ -1040,10 +1117,10 @@ async function resolveUrlMode(
   );
 
   if (decision.kind === "no_match") {
-    return noMatchDiagnostic(requestedType, configs, timeline, featureStates);
+    return noMatchDiagnostic(requestedType, configs, timeline, catalogContext);
   }
   if (decision.kind === "ambiguous") {
-    return ambiguousDiagnostic(decision);
+    return ambiguousDiagnostic(decision, catalogContext);
   }
   return resolvedUrlDiagnostic({
     request,
@@ -1051,22 +1128,25 @@ async function resolveUrlMode(
     decision,
     configs,
     timeline,
-    featureStates,
+    catalogContext,
   });
 }
 
 async function resolveEnvironmentMode(
   request: Extract<ConnectorCheckRequest, { readonly mode: "environment" }>,
   timeline: ConnectorCheckTimeline,
-  featureStates: FeatureStates,
+  catalogContext: ConnectorCheckCatalogContext,
 ): Promise<ConnectorCheckDiagnosticResult> {
-  const type = connectorTypeForEnvironmentName(request.environmentName);
+  const type = connectorTypeForEnvironmentName(
+    catalogContext.snapshot,
+    request.environmentName,
+  );
   if (!type) {
     return { outcome: "unknown-environment" };
   }
   const configs =
     timeline.kind === "run"
-      ? await loadRunRoutingConfigs(timeline.context)
+      ? await loadRunRoutingConfigs(timeline.context, catalogContext.snapshot)
       : [];
   const config = configs.find((entry) => {
     return entry.type === type;
@@ -1074,7 +1154,7 @@ async function resolveEnvironmentMode(
   return {
     outcome: "resolved",
     mode: "environment",
-    connector: connectorIdentity(type, featureStates),
+    connector: connectorIdentity(type, catalogContext),
     environmentName: request.environmentName,
     run: runStatus(timeline, config),
     permission:
@@ -1107,6 +1187,10 @@ export const resolveConnectorCheck$ = command(
       parsed = parseResult;
     }
 
+    const db = set(writeDb$);
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+
     let timeline: ConnectorCheckTimeline;
     if (args.stateSource.kind === "run") {
       const runContext = await get(
@@ -1126,15 +1210,11 @@ export const resolveConnectorCheck$ = command(
     } else {
       const state =
         args.request.mode === "url"
-          ? await (async () => {
-              const db = set(writeDb$);
-              const snapshot = await loadConnectorRuntimeSnapshot(db);
-              return await loadStoredRuntimeState(db, {
-                orgId: args.orgId,
-                userId: args.userId,
-                snapshot,
-              });
-            })()
+          ? await loadStoredRuntimeState(db, {
+              orgId: args.orgId,
+              userId: args.userId,
+              snapshot,
+            })
           : { baseUrlVarsByType: new Map() };
       signal.throwIfAborted();
       timeline = { kind: "stored", state };
@@ -1146,6 +1226,15 @@ export const resolveConnectorCheck$ = command(
       args.userId,
     );
     signal.throwIfAborted();
+    const visibleConnectorRefs = await listConnectorRuntimeVisibleRefs({
+      snapshot,
+      featureStates,
+    });
+    signal.throwIfAborted();
+    const catalogContext: ConnectorCheckCatalogContext = {
+      snapshot,
+      visibleConnectorRefs: new Set(visibleConnectorRefs),
+    };
     let diagnostic: ConnectorCheckDiagnosticResult;
     if (args.request.mode === "url") {
       if (!parsed) {
@@ -1155,13 +1244,13 @@ export const resolveConnectorCheck$ = command(
         args.request,
         parsed,
         timeline,
-        featureStates,
+        catalogContext,
       );
     } else {
       diagnostic = await resolveEnvironmentMode(
         args.request,
         timeline,
-        featureStates,
+        catalogContext,
       );
     }
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -670,10 +670,14 @@ function connectorEnvironmentBindings(
   if (!connector) {
     return [];
   }
-  return [...connector.methods.values()].flatMap((runtimeMethod) => {
-    return connectorAuthMethodRuntimeMetadata(runtimeMethod.method)
-      .runtimeBindings;
-  });
+  return [...connector.methods.values()]
+    .filter((runtimeMethod) => {
+      return runtimeMethod.executable;
+    })
+    .flatMap((runtimeMethod) => {
+      return connectorAuthMethodRuntimeMetadata(runtimeMethod.method)
+        .runtimeBindings;
+    });
 }
 
 function environmentValueRefs(

--- a/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
@@ -1,12 +1,4 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import {
-  loadFirewallRoutingMetadata,
-  type FirewallRoutingRouteMetadata,
-} from "@vm0/connectors/firewall-metadata/routing";
-import {
-  getFirewallExecutionMetadata,
-  type FirewallExecutionMetadata,
-} from "@vm0/connectors/firewall-metadata/server";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   FirewallBaseUrlResolutionError,
   hasUnsafeFirewallPath,
@@ -15,6 +7,11 @@ import {
 } from "@vm0/connectors/firewall-types";
 
 import { safeSync, safeUrlParse } from "../utils";
+import type {
+  ConnectorServerFirewallCatalog,
+  ConnectorServerFirewallExecutionMetadata,
+  FirewallRoutingRouteMetadata,
+} from "./connector-server-firewall-catalog.service";
 
 const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
@@ -30,10 +27,11 @@ export interface ConnectorDiagnosticCatalogApi {
 }
 
 export interface ConnectorDiagnosticCatalogView {
-  readonly type: ConnectorType;
+  readonly type: ConnectorCatalogRef;
   readonly label: string;
   readonly baseUrlVarNames: readonly string[];
   readonly apis: readonly ConnectorDiagnosticCatalogApi[];
+  readonly executionMetadata: ConnectorServerFirewallExecutionMetadata;
 }
 
 export interface ConnectorDiagnosticBaseCandidate {
@@ -96,14 +94,14 @@ function sameNames(left: readonly string[], right: readonly string[]): boolean {
 }
 
 function executionTemplatesByBase(
-  metadata: FirewallExecutionMetadata,
+  metadata: ConnectorServerFirewallExecutionMetadata,
 ): ReadonlyMap<string, ConnectorDiagnosticExecutionTemplate> {
   const templates = new Map<string, ConnectorDiagnosticExecutionTemplate>();
   for (const template of metadata.baseUrlTemplates) {
     const key = baseKey(template.base);
     if (templates.has(key)) {
       throw new Error(
-        `Duplicate firewall execution base template for ${metadata.type}`,
+        `Duplicate firewall execution base template for ${metadata.connectorRef}`,
       );
     }
     templates.set(key, {
@@ -117,16 +115,19 @@ function executionTemplatesByBase(
 }
 
 export async function loadConnectorDiagnosticCatalogView(
+  catalog: ConnectorServerFirewallCatalog,
   connectorRef: string,
 ): Promise<ConnectorDiagnosticCatalogView | null> {
-  const routing = await loadFirewallRoutingMetadata(connectorRef);
+  const routing = await catalog.loadRoutingMetadata(connectorRef);
   if (!routing) {
     return null;
   }
 
-  const execution = getFirewallExecutionMetadata(routing.type);
-  if (!execution || execution.type !== routing.type) {
-    throw new Error(`Missing firewall execution metadata for ${routing.type}`);
+  const execution = catalog.getExecutionMetadata(routing.connectorRef);
+  if (!execution || execution.connectorRef !== routing.connectorRef) {
+    throw new Error(
+      `Missing firewall execution metadata for ${routing.connectorRef}`,
+    );
   }
 
   const executionTemplates = executionTemplatesByBase(execution);
@@ -144,7 +145,7 @@ export async function loadConnectorDiagnosticCatalogView(
       names.length === 0 ? null : (executionTemplates.get(key) ?? null);
     if (names.length > 0 && !executionTemplate) {
       throw new Error(
-        `Missing firewall execution base template for ${routing.type}`,
+        `Missing firewall execution base template for ${routing.connectorRef}`,
       );
     }
     if (executionTemplate) {
@@ -161,14 +162,17 @@ export async function loadConnectorDiagnosticCatalogView(
     !sameNames([...routingBaseUrlVarNames], execution.baseUrlVarNames) ||
     executionTemplates.size !== dynamicBaseKeys.size
   ) {
-    throw new Error(`Mismatched firewall base metadata for ${routing.type}`);
+    throw new Error(
+      `Mismatched firewall base metadata for ${routing.connectorRef}`,
+    );
   }
 
   return {
-    type: routing.type,
+    type: routing.connectorRef,
     label: routing.label,
     baseUrlVarNames: [...routingBaseUrlVarNames].sort(),
     apis,
+    executionMetadata: execution,
   };
 }
 
@@ -267,15 +271,16 @@ function dynamicTemplateToPattern(base: string): string | null {
 }
 
 function executionTemplateForBase(
-  type: ConnectorType,
+  metadata: ConnectorServerFirewallExecutionMetadata,
   base: string,
 ): ConnectorDiagnosticExecutionTemplate {
-  const execution = getFirewallExecutionMetadata(type);
-  const template = execution?.baseUrlTemplates.find((entry) => {
+  const template = metadata.baseUrlTemplates.find((entry) => {
     return baseKey(entry.base) === baseKey(base);
   });
   if (!template) {
-    throw new Error(`Missing firewall execution base template for ${type}`);
+    throw new Error(
+      `Missing firewall execution base template for ${metadata.connectorRef}`,
+    );
   }
   return {
     credentialed: template.credentialed,
@@ -295,7 +300,7 @@ interface ConnectorDiagnosticBaseResolution {
 }
 
 export function resolveConnectorDiagnosticBase(
-  type: ConnectorType,
+  executionMetadata: ConnectorServerFirewallExecutionMetadata,
   base: string,
   baseUrlVars: Readonly<Record<string, string>> | null,
   options: { readonly allowStructuralDynamic: boolean },
@@ -312,11 +317,11 @@ export function resolveConnectorDiagnosticBase(
     };
   }
 
-  const executionTemplate = executionTemplateForBase(type, base);
+  const executionTemplate = executionTemplateForBase(executionMetadata, base);
   if (baseUrlVars) {
     const resolution = safeSync(() => {
       return resolveFirewallBaseUrlTemplate({
-        serviceName: type,
+        serviceName: executionMetadata.connectorRef,
         base,
         vars: baseUrlVars,
         credentialed: executionTemplate.credentialed,
@@ -374,7 +379,7 @@ export function buildConnectorDiagnosticBaseCandidates(
 
   for (const api of view.apis) {
     const resolution = resolveConnectorDiagnosticBase(
-      view.type,
+      view.executionMetadata,
       api.base,
       baseUrlVars,
       options,

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 
 import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
@@ -383,6 +384,36 @@ function externalPlaceholderValues(args: {
   return sortedStringRecord(Object.entries(placeholderValues));
 }
 
+function externalBaseUrlTemplates(
+  firewall: AcceptedServerFirewall,
+): readonly ConnectorServerFirewallExecutionBaseUrlTemplate[] {
+  const templates = new Map<
+    string,
+    ConnectorServerFirewallExecutionBaseUrlTemplate
+  >();
+  for (const template of firewall.routing.baseUrlTemplates) {
+    const existing = templates.get(template.base);
+    if (
+      existing &&
+      !isDeepStrictEqual(existing.hostPolicy, template.hostPolicy)
+    ) {
+      throw new Error(
+        `Accepted connector server firewall base URL host policies conflict: ${firewall.connectorRef} (${template.base})`,
+      );
+    }
+    templates.set(template.base, {
+      base: template.base,
+      credentialed: (existing?.credentialed ?? false) || template.credentialed,
+      ...(template.hostPolicy === undefined
+        ? {}
+        : { hostPolicy: template.hostPolicy }),
+    });
+  }
+  return [...templates.values()].sort((left, right) => {
+    return compareStrings(left.base, right.base);
+  });
+}
+
 function externalExecutionMetadata(args: {
   readonly firewall: AcceptedServerFirewall;
   readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
@@ -395,7 +426,7 @@ function externalExecutionMetadata(args: {
     connectorRef: args.firewall.connectorRef,
     billable: args.firewall.billable,
     baseUrlVarNames: args.firewall.routing.baseUrlVarNames,
-    baseUrlTemplates: args.firewall.routing.baseUrlTemplates,
+    baseUrlTemplates: externalBaseUrlTemplates(args.firewall),
     secretPlaceholderNames: Object.keys(placeholderValues),
     placeholderValues,
   };

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -1,0 +1,872 @@
+import { createHash } from "node:crypto";
+
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  connectorAuthMethodRuntimeMetadata,
+  type ConnectorRuntimeBindingEntry,
+} from "@vm0/connectors/connector-utils";
+import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
+import {
+  createFirewallMetadataPolicyResolver,
+  getFirewallPermissionSummary,
+  type FirewallMetadataPolicyResolver,
+  type FirewallPermissionDefaultPolicyMetadata,
+} from "@vm0/connectors/firewall-metadata";
+import {
+  getFirewallRoutingIndexMetadata,
+  loadFirewallRoutingMetadata,
+  type FirewallRoutingApiMetadata,
+  type FirewallRoutingIndexApiMetadata,
+  type FirewallRoutingRouteMetadata,
+} from "@vm0/connectors/firewall-metadata/routing";
+import {
+  getBuiltinConnectorHostOwner,
+  getFirewallExecutionMetadata,
+  listBuiltinConnectorFixedHostOwners,
+  loadFirewallPermissionIndex,
+} from "@vm0/connectors/firewall-metadata/server";
+import {
+  extractSecretNamesFromApis,
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallBaseHostPolicy,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+
+import type {
+  ConnectorCatalogPrivateFirewallsArtifact,
+  ConnectorCatalogPublicArtifact,
+} from "./connector-catalog-artifacts/artifacts";
+import { safeUrlParse } from "../utils";
+
+const POLICY_VALUES = ["allow", "deny", "ask"] as const;
+const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
+  "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
+
+type AcceptedServerFirewall =
+  ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
+
+export interface ConnectorServerFirewallPermissionIndex {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+  readonly permissionNames: ReadonlySet<string>;
+  readonly permissionDescriptions: ReadonlyMap<string, string>;
+  readonly defaultPolicy: FirewallPermissionDefaultPolicyMetadata;
+  readonly unknownPolicy: FirewallPolicyValue;
+  readonly policyResolver: FirewallMetadataPolicyResolver;
+  hasPermission(name: string): boolean;
+  permissionDescription(name: string): string | null;
+}
+
+export interface ConnectorServerFirewallExecutionBaseUrlTemplate {
+  readonly base: string;
+  readonly credentialed: boolean;
+  readonly hostPolicy?: FirewallBaseHostPolicy;
+}
+
+export interface ConnectorServerFirewallExecutionMetadata {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly billable: boolean;
+  readonly baseUrlVarNames: readonly string[];
+  readonly baseUrlTemplates: readonly ConnectorServerFirewallExecutionBaseUrlTemplate[];
+  readonly secretPlaceholderNames: readonly string[];
+  readonly placeholderValues: Readonly<Record<string, string>>;
+}
+
+export interface ConnectorServerFirewallRoutingIndexMetadata {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+  readonly apis: readonly FirewallRoutingIndexApiMetadata[];
+}
+
+export interface ConnectorServerFirewallRoutingMetadata {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+  readonly apis: readonly FirewallRoutingApiMetadata[];
+}
+
+export interface ConnectorServerFirewallHostOwner {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+}
+
+interface ConnectorServerFirewallShadowItem {
+  readonly connectorRef: ConnectorCatalogRef;
+  readonly label: string;
+  readonly billable: boolean;
+  readonly permissionCount: number;
+  readonly hasCategories: boolean;
+  readonly hasDefaultPolicyOverrides: boolean;
+  readonly permissionDigest: string;
+  readonly routingDigest: string;
+  readonly routingBases: readonly string[];
+  readonly baseUrlVarNames: readonly string[];
+  readonly baseUrlTemplates: readonly ConnectorServerFirewallExecutionBaseUrlTemplate[];
+  readonly secretPlaceholderNames: readonly string[];
+}
+
+interface ConnectorServerFirewallShadowHostOwner {
+  readonly host: string;
+  readonly connectorRef: ConnectorCatalogRef;
+}
+
+export interface ConnectorServerFirewallShadowProjection {
+  readonly items: readonly ConnectorServerFirewallShadowItem[];
+  readonly fixedHostOwners: readonly ConnectorServerFirewallShadowHostOwner[];
+}
+
+export interface ConnectorServerFirewallCatalog {
+  readonly connectorRefs: readonly ConnectorCatalogRef[];
+  has(connectorRef: string): boolean;
+  getExecutionMetadata(
+    connectorRef: string,
+  ): ConnectorServerFirewallExecutionMetadata | null;
+  loadPermissionIndex(
+    connectorRef: string,
+  ): Promise<ConnectorServerFirewallPermissionIndex | null>;
+  getRoutingIndexMetadata(
+    connectorRef: string,
+  ): ConnectorServerFirewallRoutingIndexMetadata | null;
+  loadRoutingMetadata(
+    connectorRef: string,
+  ): Promise<ConnectorServerFirewallRoutingMetadata | null>;
+  getFixedHostOwner(host: string): ConnectorServerFirewallHostOwner | null;
+  shadowProjection(): Promise<ConnectorServerFirewallShadowProjection>;
+}
+
+interface ExternalConnectorServerFirewallEntry {
+  readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
+  readonly executionMetadata: ConnectorServerFirewallExecutionMetadata;
+  readonly routingIndexMetadata: ConnectorServerFirewallRoutingIndexMetadata;
+  readonly routingMetadata: ConnectorServerFirewallRoutingMetadata;
+  readonly shadowItem: ConnectorServerFirewallShadowItem;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortedUniqueStrings(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort(compareStrings);
+}
+
+function sortedStringRecord(
+  entries: Iterable<readonly [string, string]>,
+): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    [...entries].sort(([left], [right]) => {
+      return compareStrings(left, right);
+    }),
+  );
+}
+
+function sameStrings(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+function choosePermissionDefault(
+  policies: Readonly<Record<string, FirewallPolicyValue>>,
+): FirewallPolicyValue {
+  const counts = new Map<FirewallPolicyValue, number>(
+    POLICY_VALUES.map((value) => {
+      return [value, 0];
+    }),
+  );
+  for (const value of Object.values(policies)) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return POLICY_VALUES.reduce<FirewallPolicyValue>((best, candidate) => {
+    return (counts.get(candidate) ?? 0) > (counts.get(best) ?? 0)
+      ? candidate
+      : best;
+  }, "allow");
+}
+
+function compactDefaultPolicy(args: {
+  readonly permissionNames: readonly string[];
+  readonly defaultAllowed: readonly string[] | null;
+  readonly defaultUnknownPolicy: FirewallPolicyValue;
+}): FirewallPermissionDefaultPolicyMetadata {
+  const allowed = args.defaultAllowed
+    ? new Set<string>(args.defaultAllowed)
+    : null;
+  const policies = Object.fromEntries(
+    args.permissionNames.map((permission): [string, FirewallPolicyValue] => {
+      return [
+        permission,
+        allowed === null || allowed.has(permission) ? "allow" : "deny",
+      ];
+    }),
+  );
+  const permissionDefault = choosePermissionDefault(policies);
+  const permissionOverrides: Partial<
+    Record<FirewallPolicyValue, readonly string[]>
+  > = {};
+  for (const value of POLICY_VALUES) {
+    if (value === permissionDefault) {
+      continue;
+    }
+    const permissions = Object.entries(policies)
+      .filter(([, policy]) => {
+        return policy === value;
+      })
+      .map(([permission]) => {
+        return permission;
+      })
+      .sort(compareStrings);
+    if (permissions.length > 0) {
+      permissionOverrides[value] = permissions;
+    }
+  }
+  return {
+    permissionDefault,
+    ...(Object.keys(permissionOverrides).length > 0
+      ? { permissionOverrides }
+      : {}),
+    unknownPolicy: args.defaultUnknownPolicy,
+  };
+}
+
+function hasDefaultPolicyOverrides(
+  defaultPolicy: FirewallPermissionDefaultPolicyMetadata,
+): boolean {
+  return (
+    defaultPolicy.permissionDefault !== "allow" ||
+    defaultPolicy.unknownPolicy !== "allow" ||
+    Object.keys(defaultPolicy.permissionOverrides ?? {}).length > 0
+  );
+}
+
+function shadowDetailDigest(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex")}`;
+}
+
+function permissionShadowDigest(
+  index: ConnectorServerFirewallPermissionIndex,
+): string {
+  return shadowDetailDigest({
+    permissions: [...index.permissionNames].sort(compareStrings).map((name) => {
+      return {
+        name,
+        description: index.permissionDescription(name),
+        policy: index.policyResolver.permission(name),
+      };
+    }),
+    unknownPolicy: index.policyResolver.unknown(),
+  });
+}
+
+function routingShadowDigest(
+  metadata: ConnectorServerFirewallRoutingMetadata,
+): string {
+  return shadowDetailDigest(metadata.apis);
+}
+
+function externalPermissionIndex(
+  firewall: AcceptedServerFirewall,
+): ConnectorServerFirewallPermissionIndex {
+  const permissions = new Map<string, string | undefined>();
+  for (const api of firewall.firewall.apis) {
+    for (const permission of api.permissions ?? []) {
+      if (!permissions.has(permission.name)) {
+        permissions.set(permission.name, permission.description);
+      }
+    }
+  }
+  const defaultPolicy = compactDefaultPolicy({
+    permissionNames: [...permissions.keys()].sort(compareStrings),
+    defaultAllowed: firewall.defaultAllowed,
+    defaultUnknownPolicy: firewall.defaultUnknownPolicy,
+  });
+  permissions.delete(UNKNOWN_PERMISSION_GRANT);
+  const permissionNames = [...permissions.keys()].sort(compareStrings);
+  const permissionDescriptions = new Map<string, string>();
+  for (const [name, description] of permissions) {
+    if (description !== undefined) {
+      permissionDescriptions.set(name, description);
+    }
+  }
+  const policyResolver = createFirewallMetadataPolicyResolver({
+    defaultPolicy,
+  });
+  const permissionNameSet = new Set(permissionNames);
+  return {
+    connectorRef: firewall.connectorRef,
+    label: firewall.label,
+    permissionNames: permissionNameSet,
+    permissionDescriptions,
+    defaultPolicy,
+    unknownPolicy: defaultPolicy.unknownPolicy,
+    policyResolver,
+    hasPermission: (name) => {
+      return permissionNameSet.has(name);
+    },
+    permissionDescription: (name) => {
+      return permissionDescriptions.get(name) ?? null;
+    },
+  };
+}
+
+function runtimeBindingEntries(
+  methods: readonly ConnectorAuthMethodRuntimeConfig[],
+): readonly ConnectorRuntimeBindingEntry[] {
+  return methods.flatMap((method) => {
+    return connectorAuthMethodRuntimeMetadata(method).runtimeBindings;
+  });
+}
+
+function expandedExternalPlaceholders(args: {
+  readonly firewall: AcceptedServerFirewall["firewall"];
+  readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
+}): Readonly<Record<string, string>> {
+  const expanded: Record<string, string> = {
+    ...args.firewall.placeholders,
+  };
+  const bindings = runtimeBindingEntries(args.methods);
+  for (const [name, value] of Object.entries(
+    args.firewall.placeholders ?? {},
+  )) {
+    const bindingValueRefs = bindings
+      .filter((binding) => {
+        return binding.envName === name;
+      })
+      .map((binding) => {
+        return binding.valueRef;
+      });
+    for (const valueRef of bindingValueRefs) {
+      if (!valueRef.startsWith("$secrets.")) {
+        continue;
+      }
+      const rawName = valueRef.slice("$secrets.".length);
+      if (!expanded[rawName]) {
+        expanded[rawName] = value;
+      }
+      for (const binding of bindings) {
+        if (binding.valueRef === valueRef && !expanded[binding.envName]) {
+          expanded[binding.envName] = value;
+        }
+      }
+    }
+    const rawValueRef = `$secrets.${name}`;
+    for (const binding of bindings) {
+      if (binding.valueRef === rawValueRef && !expanded[binding.envName]) {
+        expanded[binding.envName] = value;
+      }
+    }
+  }
+  return expanded;
+}
+
+function externalPlaceholderValues(args: {
+  readonly firewall: AcceptedServerFirewall["firewall"];
+  readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
+}): Readonly<Record<string, string>> {
+  const expanded = expandedExternalPlaceholders(args);
+  const placeholderValues: Record<string, string> = {};
+  for (const name of extractSecretNamesFromApis(args.firewall.apis)) {
+    placeholderValues[name] =
+      expanded[name] ?? DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
+  }
+  for (const [name, value] of Object.entries(expanded)) {
+    placeholderValues[name] = value;
+  }
+  return sortedStringRecord(Object.entries(placeholderValues));
+}
+
+function externalExecutionMetadata(args: {
+  readonly firewall: AcceptedServerFirewall;
+  readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
+}): ConnectorServerFirewallExecutionMetadata {
+  const placeholderValues = externalPlaceholderValues({
+    firewall: args.firewall.firewall,
+    methods: args.methods,
+  });
+  return {
+    connectorRef: args.firewall.connectorRef,
+    billable: args.firewall.billable,
+    baseUrlVarNames: args.firewall.routing.baseUrlVarNames,
+    baseUrlTemplates: args.firewall.routing.baseUrlTemplates,
+    secretPlaceholderNames: Object.keys(placeholderValues),
+    placeholderValues,
+  };
+}
+
+function externalRoutingIndexMetadata(
+  firewall: AcceptedServerFirewall,
+): ConnectorServerFirewallRoutingIndexMetadata {
+  return {
+    connectorRef: firewall.connectorRef,
+    label: firewall.label,
+    apis: firewall.routing.apis.map((api) => {
+      return { base: api.base };
+    }),
+  };
+}
+
+function externalRoutingMetadata(
+  firewall: AcceptedServerFirewall,
+): ConnectorServerFirewallRoutingMetadata {
+  return {
+    connectorRef: firewall.connectorRef,
+    label: firewall.label,
+    apis: firewall.routing.apis.map((api) => {
+      return {
+        base: api.base,
+        environmentNames: api.environmentNames,
+        routes: api.routes,
+      };
+    }),
+  };
+}
+
+function trimTrailingDots(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 46) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function stripHostnameTrailingDot(host: string): string {
+  const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
+  if (portStart === -1) {
+    return trimTrailingDots(host);
+  }
+  return `${trimTrailingDots(host.slice(0, portStart))}${host.slice(portStart)}`;
+}
+
+function normalizeFixedHost(host: string): string | null {
+  const trimmedHost = host.trim();
+  if (trimmedHost.length === 0) {
+    return null;
+  }
+  const url = safeUrlParse(
+    trimmedHost.includes("://") ? trimmedHost : `https://${trimmedHost}`,
+  );
+  return url
+    ? stripHostnameTrailingDot(url.host.toLowerCase())
+    : stripHostnameTrailingDot(trimmedHost.toLowerCase());
+}
+
+function externalShadowItem(args: {
+  readonly firewall: AcceptedServerFirewall;
+  readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
+  readonly executionMetadata: ConnectorServerFirewallExecutionMetadata;
+  readonly routingIndexMetadata: ConnectorServerFirewallRoutingIndexMetadata;
+  readonly routingMetadata: ConnectorServerFirewallRoutingMetadata;
+}): ConnectorServerFirewallShadowItem {
+  return {
+    connectorRef: args.firewall.connectorRef,
+    label: args.firewall.label,
+    billable: args.firewall.billable,
+    permissionCount: args.firewall.diagnostics.permissionCount,
+    hasCategories: args.firewall.categories !== null,
+    hasDefaultPolicyOverrides: hasDefaultPolicyOverrides(
+      args.permissionIndex.defaultPolicy,
+    ),
+    permissionDigest: permissionShadowDigest(args.permissionIndex),
+    routingDigest: routingShadowDigest(args.routingMetadata),
+    routingBases: args.routingIndexMetadata.apis.map((api) => {
+      return api.base;
+    }),
+    baseUrlVarNames: args.executionMetadata.baseUrlVarNames,
+    baseUrlTemplates: args.executionMetadata.baseUrlTemplates,
+    secretPlaceholderNames: args.executionMetadata.secretPlaceholderNames,
+  };
+}
+
+function staticPermissionIndex(
+  connectorRef: ConnectorCatalogRef,
+  index: NonNullable<Awaited<ReturnType<typeof loadFirewallPermissionIndex>>>,
+): ConnectorServerFirewallPermissionIndex {
+  return {
+    connectorRef,
+    label: index.label,
+    permissionNames: index.permissionNames,
+    permissionDescriptions: index.permissionDescriptions,
+    defaultPolicy: index.defaultPolicy,
+    unknownPolicy: index.unknownPolicy,
+    policyResolver: index.policyResolver,
+    hasPermission: index.hasPermission,
+    permissionDescription: index.permissionDescription,
+  };
+}
+
+function staticExecutionMetadata(
+  connectorRef: ConnectorCatalogRef,
+): ConnectorServerFirewallExecutionMetadata | null {
+  const metadata = getFirewallExecutionMetadata(connectorRef);
+  if (!metadata) {
+    return null;
+  }
+  return {
+    connectorRef,
+    billable: metadata.billable,
+    baseUrlVarNames: metadata.baseUrlVarNames,
+    baseUrlTemplates: metadata.baseUrlTemplates,
+    secretPlaceholderNames: metadata.secretPlaceholderNames,
+    placeholderValues: metadata.placeholderValues,
+  };
+}
+
+function staticRoutingIndexMetadata(
+  connectorRef: ConnectorCatalogRef,
+): ConnectorServerFirewallRoutingIndexMetadata | null {
+  const metadata = getFirewallRoutingIndexMetadata(connectorRef);
+  if (!metadata) {
+    return null;
+  }
+  return {
+    connectorRef,
+    label: metadata.label,
+    apis: metadata.apis,
+  };
+}
+
+async function staticRoutingMetadata(
+  connectorRef: ConnectorCatalogRef,
+): Promise<ConnectorServerFirewallRoutingMetadata | null> {
+  const metadata = await loadFirewallRoutingMetadata(connectorRef);
+  if (!metadata) {
+    return null;
+  }
+  return {
+    connectorRef,
+    label: metadata.label,
+    apis: metadata.apis,
+  };
+}
+
+function staticCompactMetadata(connectorRef: ConnectorCatalogRef): {
+  readonly execution: ConnectorServerFirewallExecutionMetadata;
+  readonly routing: ConnectorServerFirewallRoutingIndexMetadata;
+  readonly summary: NonNullable<
+    ReturnType<typeof getFirewallPermissionSummary>
+  >;
+} | null {
+  const execution = staticExecutionMetadata(connectorRef);
+  const routing = staticRoutingIndexMetadata(connectorRef);
+  const summary = getFirewallPermissionSummary(connectorRef);
+  if (!execution && !routing && !summary) {
+    return null;
+  }
+  if (!execution || !routing || !summary) {
+    throw new Error(
+      `Static connector server firewall metadata is incomplete: ${connectorRef}`,
+    );
+  }
+  return { execution, routing, summary };
+}
+
+export function createStaticConnectorServerFirewallCatalog(
+  connectorRefs: readonly ConnectorCatalogRef[],
+): ConnectorServerFirewallCatalog {
+  const compactMetadata = new Map<
+    ConnectorCatalogRef,
+    NonNullable<ReturnType<typeof staticCompactMetadata>>
+  >();
+  for (const connectorRef of connectorRefs) {
+    const metadata = staticCompactMetadata(connectorRef);
+    if (metadata) {
+      compactMetadata.set(connectorRef, metadata);
+    }
+  }
+  const refs = sortedUniqueStrings(compactMetadata.keys());
+  const refSet = new Set<string>(refs);
+  const fixedHostOwners = listBuiltinConnectorFixedHostOwners()
+    .filter((owner) => {
+      return refSet.has(owner.type);
+    })
+    .map((owner) => {
+      return { host: owner.host, connectorRef: owner.type };
+    })
+    .sort((left, right) => {
+      return (
+        compareStrings(left.host, right.host) ||
+        compareStrings(left.connectorRef, right.connectorRef)
+      );
+    });
+  return {
+    connectorRefs: refs,
+    has: (connectorRef) => {
+      return refSet.has(connectorRef);
+    },
+    getExecutionMetadata: (connectorRef) => {
+      return compactMetadata.get(connectorRef)?.execution ?? null;
+    },
+    loadPermissionIndex: async (connectorRef) => {
+      if (!refSet.has(connectorRef)) {
+        return null;
+      }
+      const index = await loadFirewallPermissionIndex(connectorRef);
+      if (!index) {
+        throw new Error(
+          `Static connector server firewall permission metadata is missing: ${connectorRef}`,
+        );
+      }
+      return staticPermissionIndex(connectorRef, index);
+    },
+    getRoutingIndexMetadata: (connectorRef) => {
+      return compactMetadata.get(connectorRef)?.routing ?? null;
+    },
+    loadRoutingMetadata: async (connectorRef) => {
+      if (!refSet.has(connectorRef)) {
+        return null;
+      }
+      const metadata = await staticRoutingMetadata(connectorRef);
+      if (!metadata) {
+        throw new Error(
+          `Static connector server firewall routing metadata is missing: ${connectorRef}`,
+        );
+      }
+      return metadata;
+    },
+    getFixedHostOwner: (host) => {
+      const owner = getBuiltinConnectorHostOwner(host);
+      return owner && refSet.has(owner.type)
+        ? { connectorRef: owner.type, label: owner.label }
+        : null;
+    },
+    shadowProjection: async () => {
+      const items = await Promise.all(
+        refs.map(async (connectorRef) => {
+          const metadata = compactMetadata.get(connectorRef);
+          const permissionIndex =
+            await loadFirewallPermissionIndex(connectorRef);
+          const routingMetadata = await staticRoutingMetadata(connectorRef);
+          if (!metadata || !permissionIndex || !routingMetadata) {
+            throw new Error(
+              `Static connector server firewall metadata is missing: ${connectorRef}`,
+            );
+          }
+          return {
+            connectorRef,
+            label: metadata.summary.label,
+            billable: metadata.execution.billable,
+            permissionCount: metadata.summary.permissionCount,
+            hasCategories: metadata.summary.hasCategories,
+            hasDefaultPolicyOverrides:
+              metadata.summary.hasDefaultPolicyOverrides,
+            permissionDigest: permissionShadowDigest(
+              staticPermissionIndex(connectorRef, permissionIndex),
+            ),
+            routingDigest: routingShadowDigest(routingMetadata),
+            routingBases: metadata.routing.apis.map((api) => {
+              return api.base;
+            }),
+            baseUrlVarNames: metadata.execution.baseUrlVarNames,
+            baseUrlTemplates: metadata.execution.baseUrlTemplates,
+            secretPlaceholderNames: metadata.execution.secretPlaceholderNames,
+          };
+        }),
+      );
+      return {
+        items,
+        fixedHostOwners,
+      };
+    },
+  };
+}
+
+function externalEntries(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runtimeMethodsByRef: ReadonlyMap<
+    ConnectorCatalogRef,
+    readonly ConnectorAuthMethodRuntimeConfig[]
+  >;
+}): ReadonlyMap<ConnectorCatalogRef, ExternalConnectorServerFirewallEntry> {
+  const expectedRefs = args.publicArtifact.connectors
+    .filter((connector) => {
+      return connector.firewall.kind === "generated";
+    })
+    .map((connector) => {
+      return connector.connectorRef;
+    })
+    .sort(compareStrings);
+  const actualRefs = args.privateFirewallsArtifact.connectors
+    .map((firewall) => {
+      return firewall.connectorRef;
+    })
+    .sort(compareStrings);
+  if (!sameStrings(expectedRefs, actualRefs)) {
+    throw new Error(
+      "Accepted connector server firewall identities are incomplete",
+    );
+  }
+  const entries = new Map<
+    ConnectorCatalogRef,
+    ExternalConnectorServerFirewallEntry
+  >();
+  for (const firewall of args.privateFirewallsArtifact.connectors) {
+    if (entries.has(firewall.connectorRef)) {
+      throw new Error(
+        `Duplicate accepted connector server firewall: ${firewall.connectorRef}`,
+      );
+    }
+    const methods = args.runtimeMethodsByRef.get(firewall.connectorRef);
+    if (!methods) {
+      throw new Error(
+        `Accepted connector server firewall runtime is missing: ${firewall.connectorRef}`,
+      );
+    }
+    const permissionIndex = externalPermissionIndex(firewall);
+    const executionMetadata = externalExecutionMetadata({
+      firewall,
+      methods,
+    });
+    const routingIndexMetadata = externalRoutingIndexMetadata(firewall);
+    const routingMetadata = externalRoutingMetadata(firewall);
+    entries.set(firewall.connectorRef, {
+      permissionIndex,
+      executionMetadata,
+      routingIndexMetadata,
+      routingMetadata,
+      shadowItem: externalShadowItem({
+        firewall,
+        permissionIndex,
+        executionMetadata,
+        routingIndexMetadata,
+        routingMetadata,
+      }),
+    });
+  }
+  return entries;
+}
+
+function externalFixedHostOwners(
+  firewalls: readonly AcceptedServerFirewall[],
+): ReadonlyMap<string, ConnectorServerFirewallHostOwner> {
+  const owners = new Map<string, ConnectorServerFirewallHostOwner>();
+  for (const firewall of firewalls) {
+    for (const rawHost of firewall.routing.fixedHosts) {
+      const host = normalizeFixedHost(rawHost);
+      if (!host) {
+        throw new Error(
+          `Accepted connector server firewall fixed host is invalid: ${firewall.connectorRef}`,
+        );
+      }
+      const existing = owners.get(host);
+      if (existing && existing.connectorRef !== firewall.connectorRef) {
+        throw new Error(
+          `Accepted connector server firewall fixed host collision: ${host} (${existing.connectorRef}, ${firewall.connectorRef})`,
+        );
+      }
+      owners.set(host, {
+        connectorRef: firewall.connectorRef,
+        label: firewall.label,
+      });
+    }
+  }
+  return owners;
+}
+
+export function createExternalConnectorServerFirewallCatalog(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
+  readonly runtimeMethodsByRef: ReadonlyMap<
+    ConnectorCatalogRef,
+    readonly ConnectorAuthMethodRuntimeConfig[]
+  >;
+}): ConnectorServerFirewallCatalog {
+  const entries = externalEntries(args);
+  const connectorRefs = [...entries.keys()].sort(compareStrings);
+  const fixedHostOwners = externalFixedHostOwners(
+    args.privateFirewallsArtifact.connectors,
+  );
+  return {
+    connectorRefs,
+    has: (connectorRef) => {
+      return entries.has(connectorRef);
+    },
+    getExecutionMetadata: (connectorRef) => {
+      return entries.get(connectorRef)?.executionMetadata ?? null;
+    },
+    loadPermissionIndex: (connectorRef) => {
+      return Promise.resolve(
+        entries.get(connectorRef)?.permissionIndex ?? null,
+      );
+    },
+    getRoutingIndexMetadata: (connectorRef) => {
+      return entries.get(connectorRef)?.routingIndexMetadata ?? null;
+    },
+    loadRoutingMetadata: (connectorRef) => {
+      return Promise.resolve(
+        entries.get(connectorRef)?.routingMetadata ?? null,
+      );
+    },
+    getFixedHostOwner: (host) => {
+      const normalized = normalizeFixedHost(host);
+      return normalized ? (fixedHostOwners.get(normalized) ?? null) : null;
+    },
+    shadowProjection: () => {
+      return Promise.resolve({
+        items: connectorRefs.map((connectorRef) => {
+          const entry = entries.get(connectorRef);
+          if (!entry) {
+            throw new Error(
+              `Accepted connector server firewall is missing: ${connectorRef}`,
+            );
+          }
+          return entry.shadowItem;
+        }),
+        fixedHostOwners: [...fixedHostOwners.entries()]
+          .map(([host, owner]) => {
+            return { host, connectorRef: owner.connectorRef };
+          })
+          .sort((left, right) => {
+            return (
+              compareStrings(left.host, right.host) ||
+              compareStrings(left.connectorRef, right.connectorRef)
+            );
+          }),
+      });
+    },
+  };
+}
+
+export async function expandConnectorServerFirewallPolicies(args: {
+  readonly catalog: ConnectorServerFirewallCatalog;
+  readonly stored: FirewallPolicies | null;
+  readonly connectorRefs: readonly string[];
+}): Promise<FirewallPolicies | null> {
+  const indexes = await Promise.all(
+    args.connectorRefs.map((connectorRef) => {
+      return args.catalog.loadPermissionIndex(connectorRef);
+    }),
+  );
+  let resolved = args.stored;
+  for (const index of indexes) {
+    if (!index) {
+      continue;
+    }
+    const policies = Object.fromEntries(
+      [...index.permissionNames].map((permission) => {
+        return [permission, index.policyResolver.permission(permission)];
+      }),
+    );
+    const existing = resolved?.[index.connectorRef];
+    resolved = {
+      ...resolved,
+      [index.connectorRef]: {
+        policies: { ...policies, ...existing?.policies },
+        ...(existing?.unknownPolicy !== undefined
+          ? { unknownPolicy: existing.unknownPolicy }
+          : { unknownPolicy: index.policyResolver.unknown() }),
+      },
+    };
+  }
+  return resolved;
+}
+
+export type { FirewallRoutingRouteMetadata };

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -596,6 +596,9 @@ export function createStaticConnectorServerFirewallCatalog(
         compareStrings(left.connectorRef, right.connectorRef)
       );
     });
+  let shadowProjectionPromise:
+    | Promise<ConnectorServerFirewallShadowProjection>
+    | undefined;
   return {
     connectorRefs: refs,
     has: (connectorRef) => {
@@ -637,43 +640,43 @@ export function createStaticConnectorServerFirewallCatalog(
         ? { connectorRef: owner.type, label: owner.label }
         : null;
     },
-    shadowProjection: async () => {
-      const items = await Promise.all(
-        refs.map(async (connectorRef) => {
-          const metadata = compactMetadata.get(connectorRef);
-          const permissionIndex =
-            await loadFirewallPermissionIndex(connectorRef);
-          const routingMetadata = await staticRoutingMetadata(connectorRef);
-          if (!metadata || !permissionIndex || !routingMetadata) {
-            throw new Error(
-              `Static connector server firewall metadata is missing: ${connectorRef}`,
-            );
-          }
-          return {
-            connectorRef,
-            label: metadata.summary.label,
-            billable: metadata.execution.billable,
-            permissionCount: metadata.summary.permissionCount,
-            hasCategories: metadata.summary.hasCategories,
-            hasDefaultPolicyOverrides:
-              metadata.summary.hasDefaultPolicyOverrides,
-            permissionDigest: permissionShadowDigest(
-              staticPermissionIndex(connectorRef, permissionIndex),
-            ),
-            routingDigest: routingShadowDigest(routingMetadata),
-            routingBases: metadata.routing.apis.map((api) => {
-              return api.base;
-            }),
-            baseUrlVarNames: metadata.execution.baseUrlVarNames,
-            baseUrlTemplates: metadata.execution.baseUrlTemplates,
-            secretPlaceholderNames: metadata.execution.secretPlaceholderNames,
-          };
-        }),
-      );
-      return {
-        items,
-        fixedHostOwners,
-      };
+    shadowProjection: () => {
+      shadowProjectionPromise ??= (async () => {
+        const items = await Promise.all(
+          refs.map(async (connectorRef) => {
+            const metadata = compactMetadata.get(connectorRef);
+            const permissionIndex =
+              await loadFirewallPermissionIndex(connectorRef);
+            const routingMetadata = await staticRoutingMetadata(connectorRef);
+            if (!metadata || !permissionIndex || !routingMetadata) {
+              throw new Error(
+                `Static connector server firewall metadata is missing: ${connectorRef}`,
+              );
+            }
+            return {
+              connectorRef,
+              label: metadata.summary.label,
+              billable: metadata.execution.billable,
+              permissionCount: metadata.summary.permissionCount,
+              hasCategories: metadata.summary.hasCategories,
+              hasDefaultPolicyOverrides:
+                metadata.summary.hasDefaultPolicyOverrides,
+              permissionDigest: permissionShadowDigest(
+                staticPermissionIndex(connectorRef, permissionIndex),
+              ),
+              routingDigest: routingShadowDigest(routingMetadata),
+              routingBases: metadata.routing.apis.map((api) => {
+                return api.base;
+              }),
+              baseUrlVarNames: metadata.execution.baseUrlVarNames,
+              baseUrlTemplates: metadata.execution.baseUrlTemplates,
+              secretPlaceholderNames: metadata.execution.secretPlaceholderNames,
+            };
+          }),
+        );
+        return { items, fixedHostOwners };
+      })();
+      return shadowProjectionPromise;
     },
   };
 }
@@ -784,6 +787,27 @@ export function createExternalConnectorServerFirewallCatalog(args: {
   const fixedHostOwners = externalFixedHostOwners(
     args.privateFirewallsArtifact.connectors,
   );
+  const shadowProjection: ConnectorServerFirewallShadowProjection = {
+    items: connectorRefs.map((connectorRef) => {
+      const entry = entries.get(connectorRef);
+      if (!entry) {
+        throw new Error(
+          `Accepted connector server firewall is missing: ${connectorRef}`,
+        );
+      }
+      return entry.shadowItem;
+    }),
+    fixedHostOwners: [...fixedHostOwners.entries()]
+      .map(([host, owner]) => {
+        return { host, connectorRef: owner.connectorRef };
+      })
+      .sort((left, right) => {
+        return (
+          compareStrings(left.host, right.host) ||
+          compareStrings(left.connectorRef, right.connectorRef)
+        );
+      }),
+  };
   return {
     connectorRefs,
     has: (connectorRef) => {
@@ -810,27 +834,7 @@ export function createExternalConnectorServerFirewallCatalog(args: {
       return normalized ? (fixedHostOwners.get(normalized) ?? null) : null;
     },
     shadowProjection: () => {
-      return Promise.resolve({
-        items: connectorRefs.map((connectorRef) => {
-          const entry = entries.get(connectorRef);
-          if (!entry) {
-            throw new Error(
-              `Accepted connector server firewall is missing: ${connectorRef}`,
-            );
-          }
-          return entry.shadowItem;
-        }),
-        fixedHostOwners: [...fixedHostOwners.entries()]
-          .map(([host, owner]) => {
-            return { host, connectorRef: owner.connectorRef };
-          })
-          .sort((left, right) => {
-            return (
-              compareStrings(left.host, right.host) ||
-              compareStrings(left.connectorRef, right.connectorRef)
-            );
-          }),
-      });
+      return Promise.resolve(shadowProjection);
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -24,6 +24,7 @@ import {
   getFirewallExecutionMetadata,
   listBuiltinConnectorFixedHostOwners,
   loadFirewallPermissionIndex,
+  normalizeConnectorFixedHost,
 } from "@vm0/connectors/firewall-metadata/server";
 import {
   extractSecretNamesFromApis,
@@ -37,7 +38,6 @@ import type {
   ConnectorCatalogPrivateFirewallsArtifact,
   ConnectorCatalogPublicArtifact,
 } from "./connector-catalog-artifacts/artifacts";
-import { safeUrlParse } from "../utils";
 
 const POLICY_VALUES = ["allow", "deny", "ask"] as const;
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
@@ -429,35 +429,6 @@ function externalRoutingMetadata(
   };
 }
 
-function trimTrailingDots(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 46) {
-    end -= 1;
-  }
-  return end === value.length ? value : value.slice(0, end);
-}
-
-function stripHostnameTrailingDot(host: string): string {
-  const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
-  if (portStart === -1) {
-    return trimTrailingDots(host);
-  }
-  return `${trimTrailingDots(host.slice(0, portStart))}${host.slice(portStart)}`;
-}
-
-function normalizeFixedHost(host: string): string | null {
-  const trimmedHost = host.trim();
-  if (trimmedHost.length === 0) {
-    return null;
-  }
-  const url = safeUrlParse(
-    trimmedHost.includes("://") ? trimmedHost : `https://${trimmedHost}`,
-  );
-  return url
-    ? stripHostnameTrailingDot(url.host.toLowerCase())
-    : stripHostnameTrailingDot(trimmedHost.toLowerCase());
-}
-
 function externalShadowItem(args: {
   readonly firewall: AcceptedServerFirewall;
   readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
@@ -753,7 +724,7 @@ function externalFixedHostOwners(
   const owners = new Map<string, ConnectorServerFirewallHostOwner>();
   for (const firewall of firewalls) {
     for (const rawHost of firewall.routing.fixedHosts) {
-      const host = normalizeFixedHost(rawHost);
+      const host = normalizeConnectorFixedHost(rawHost);
       if (!host) {
         throw new Error(
           `Accepted connector server firewall fixed host is invalid: ${firewall.connectorRef}`,
@@ -830,7 +801,7 @@ export function createExternalConnectorServerFirewallCatalog(args: {
       );
     },
     getFixedHostOwner: (host) => {
-      const normalized = normalizeFixedHost(host);
+      const normalized = normalizeConnectorFixedHost(host);
       return normalized ? (fixedHostOwners.get(normalized) ?? null) : null;
     },
     shadowProjection: () => {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -1,8 +1,4 @@
-import {
-  isFirewallServerMetadataConnectorType,
-  loadFirewallPermissionIndex,
-  type FirewallServerMetadataConnectorType,
-} from "@vm0/connectors/firewall-metadata/server";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
@@ -28,6 +24,8 @@ import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { getLocalToday, resolveUserTimezones } from "./local-day";
 import { tapError } from "../utils";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import type { ConnectorServerFirewallCatalog } from "./connector-server-firewall-catalog.service";
 
 const L = logger("CronAggregateInsights");
 const OTHER_USAGE_AGENT_NAME = "Other usage";
@@ -49,7 +47,7 @@ type NetworkInsightAction = "ALLOW" | "DENY" | "BLOCK";
 
 interface NetworkInsightRow {
   readonly runId: string;
-  readonly firewallName: FirewallServerMetadataConnectorType;
+  readonly firewallName: ConnectorCatalogRef;
   readonly firewallPermission: string;
   readonly action: NetworkInsightAction;
 }
@@ -252,27 +250,16 @@ interface CurrentOrgMemberScope {
 }
 
 type PermissionLabelResolver = (
-  firewallName: FirewallServerMetadataConnectorType,
+  firewallName: ConnectorCatalogRef,
   permissionName: string,
 ) => Promise<string>;
 
-function createPermissionLabelResolver(): PermissionLabelResolver {
-  const indexes = new Map<
-    FirewallServerMetadataConnectorType,
-    ReturnType<typeof loadFirewallPermissionIndex>
-  >();
-
+function createPermissionLabelResolver(
+  catalog: ConnectorServerFirewallCatalog,
+): PermissionLabelResolver {
   return async (firewallName, permissionName) => {
     const key = `${firewallName}:${permissionName}`;
-    const cached = indexes.get(firewallName);
-    const load =
-      cached ??
-      (() => {
-        const index = loadFirewallPermissionIndex(firewallName);
-        indexes.set(firewallName, index);
-        return index;
-      })();
-    const index = await load;
+    const index = await catalog.loadPermissionIndex(firewallName);
     return index?.permissionDescription(permissionName) ?? key;
   };
 }
@@ -297,6 +284,7 @@ function networkInsightRunId(value: unknown): string | null {
 
 function normalizeNetworkInsightRows(
   values: readonly unknown[],
+  catalog: ConnectorServerFirewallCatalog,
 ): NormalizedNetworkInsightRows {
   const rows: NetworkInsightRow[] = [];
   let invalidRows = 0;
@@ -319,7 +307,7 @@ function normalizeNetworkInsightRows(
     const firewallNameValue = value.firewall_name;
     if (
       typeof firewallNameValue !== "string" ||
-      !isFirewallServerMetadataConnectorType(firewallNameValue)
+      !catalog.has(firewallNameValue)
     ) {
       invalidFirewallNames++;
       continue;
@@ -1109,6 +1097,7 @@ async function loadWindowUsageData(
 function queryWindowNetworkData(
   db: Db,
   scope: WindowScope,
+  catalog: ConnectorServerFirewallCatalog,
   signal: AbortSignal,
 ): Computed<Promise<NetworkQueryResult>> {
   return computed(async (get): Promise<NetworkQueryResult> => {
@@ -1140,7 +1129,10 @@ function queryWindowNetworkData(
       )) ?? [];
     signal.throwIfAborted();
 
-    const normalizedNetworkRows = normalizeNetworkInsightRows(rawNetworkRows);
+    const normalizedNetworkRows = normalizeNetworkInsightRows(
+      rawNetworkRows,
+      catalog,
+    );
     logSkippedNetworkInsightRows(normalizedNetworkRows.stats);
 
     const networkRunIds = [
@@ -1180,7 +1172,7 @@ function queryWindowNetworkData(
     const userNetworkMap = await aggregateNetworkDataPerUser(
       normalizedNetworkRows.rows,
       runIdToInfo,
-      createPermissionLabelResolver(),
+      createPermissionLabelResolver(catalog),
     );
     signal.throwIfAborted();
 
@@ -1230,28 +1222,36 @@ async function upsertWindowInsights(
   return upserted;
 }
 
-function processWindowGroup(
-  db: Db,
-  clerk: ClerkLike,
-  group: WindowGroup,
-  currentOrgMembers: CurrentOrgMemberScope,
-  signal: AbortSignal,
-): Computed<
+function processWindowGroup(args: {
+  readonly db: Db;
+  readonly clerk: ClerkLike;
+  readonly group: WindowGroup;
+  readonly currentOrgMembers: CurrentOrgMemberScope;
+  readonly catalog: ConnectorServerFirewallCatalog;
+  readonly signal: AbortSignal;
+}): Computed<
   Promise<{ readonly upserted: number; readonly networkRows: number }>
 > {
   return computed(
     async (
       get,
     ): Promise<{ readonly upserted: number; readonly networkRows: number }> => {
-      const scope = windowScope(group, currentOrgMembers);
-      const usageData = await loadWindowUsageData(db, clerk, scope, signal);
-      const networkData = await get(queryWindowNetworkData(db, scope, signal));
+      const scope = windowScope(args.group, args.currentOrgMembers);
+      const usageData = await loadWindowUsageData(
+        args.db,
+        args.clerk,
+        scope,
+        args.signal,
+      );
+      const networkData = await get(
+        queryWindowNetworkData(args.db, scope, args.catalog, args.signal),
+      );
       const upserted = await upsertWindowInsights(
-        db,
-        group,
+        args.db,
+        args.group,
         usageData,
         networkData,
-        signal,
+        args.signal,
       );
       return { upserted, networkRows: networkData.networkRows };
     },
@@ -1335,6 +1335,9 @@ export const aggregateInsights$ = command(
       return { users: 0, skipped: true };
     }
 
+    const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+
     const userTimezoneMap = await resolveUserTimezones(
       db,
       usersToAggregate,
@@ -1360,7 +1363,14 @@ export const aggregateInsights$ = command(
     let totalNetworkRows = 0;
     for (const group of windowGroups.values()) {
       const result = await get(
-        processWindowGroup(db, clerk, group, currentOrgMembers, signal),
+        processWindowGroup({
+          db,
+          clerk,
+          group,
+          currentOrgMembers,
+          catalog: connectorCatalogSnapshot.serverFirewalls,
+          signal,
+        }),
       );
       signal.throwIfAborted();
       upserted += result.upserted;

--- a/turbo/apps/api/src/signals/services/firewall-network-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/firewall-network-policy.service.ts
@@ -1,11 +1,12 @@
-import type { FirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";
 import type {
   FirewallPolicy,
   NetworkPolicy,
 } from "@vm0/connectors/firewall-types";
 
+import type { ConnectorServerFirewallPermissionIndex } from "./connector-server-firewall-catalog.service";
+
 export function defaultFirewallPolicyForPermissionIndex(
-  index: FirewallPermissionIndex,
+  index: ConnectorServerFirewallPermissionIndex,
 ): FirewallPolicy {
   const policies: FirewallPolicy["policies"] = {};
   for (const name of index.permissionNames) {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -12,7 +12,6 @@ import type {
   CustomConnectorValueInput,
   UpdateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { getBuiltinConnectorHostOwner } from "@vm0/connectors/firewall-metadata/server";
 import {
   canonicalizeFirewallBaseUrl,
   expandHostWildcardsInBaseUrl,
@@ -32,6 +31,11 @@ import {
 } from "./crypto.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
+import {
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import type { ConnectorServerFirewallCatalog } from "./connector-server-firewall-catalog.service";
 
 const L = logger("CustomConnectorService");
 
@@ -479,6 +483,7 @@ function prefixContainsPathVariable(raw: string): boolean {
 function validateAndNormalizePrefixTemplate(args: {
   readonly raw: string;
   readonly fields: readonly CustomConnectorField[];
+  readonly serverFirewalls: ConnectorServerFirewallCatalog;
 }): string | BadRequestResponse {
   const trimmed = args.raw.trim();
   if (trimmed.length === 0) {
@@ -525,7 +530,7 @@ function validateAndNormalizePrefixTemplate(args: {
     const authorityStart = schemeEnd + 3;
     const authorityEnd = canonicalPrefix.indexOf("/", authorityStart);
     const host = canonicalPrefix.slice(authorityStart, authorityEnd);
-    const builtinOwner = getBuiltinConnectorHostOwner(host);
+    const builtinOwner = args.serverFirewalls.getFixedHostOwner(host);
     if (builtinOwner) {
       const rawAuthority = normalised.slice(
         "https://".length,
@@ -647,6 +652,7 @@ function validateQueryInjections(args: {
 
 function validateDefinition(
   input: DefinitionInput,
+  serverFirewalls: ConnectorServerFirewallCatalog,
 ): ValidatedDefinition | BadRequestResponse {
   const displayName = validateDisplayName(input.displayName);
   if (isBadRequest(displayName)) {
@@ -662,7 +668,11 @@ function validateDefinition(
     return badRequestMessage("At least one prefix template is required");
   }
   for (const raw of input.prefixTemplates) {
-    const normalized = validateAndNormalizePrefixTemplate({ raw, fields });
+    const normalized = validateAndNormalizePrefixTemplate({
+      raw,
+      fields,
+      serverFirewalls,
+    });
     if (isBadRequest(normalized)) {
       return normalized;
     }
@@ -864,6 +874,7 @@ export const createCustomConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly input: CreateCustomConnectorBody;
+      readonly connectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorRow | BadRequestResponse> => {
@@ -871,7 +882,15 @@ export const createCustomConnector$ = command(
     if (isBadRequest(canonicalInput)) {
       return canonicalInput;
     }
-    const v = validateDefinition(canonicalInput);
+    const writeDb = set(writeDb$);
+    const connectorCatalogSnapshot =
+      args.connectorCatalogSnapshot ??
+      (await loadConnectorRuntimeSnapshot(writeDb));
+    signal.throwIfAborted();
+    const v = validateDefinition(
+      canonicalInput,
+      connectorCatalogSnapshot.serverFirewalls,
+    );
     if (isBadRequest(v)) {
       return v;
     }
@@ -883,7 +902,6 @@ export const createCustomConnector$ = command(
     const legacy = legacyColumns(v);
     L.debug("creating custom connector", { orgId: args.orgId, slug });
 
-    const writeDb = set(writeDb$);
     const [row] = await writeDb
       .insert(orgCustomConnectors)
       .values({
@@ -917,15 +935,23 @@ const updateCustomConnectorDefinition$ = command(
       readonly orgId: string;
       readonly id: string;
       readonly input: UpdateCustomConnectorBody;
+      readonly connectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorRow | BadRequestResponse | NotFoundResponse> => {
-    const v = validateDefinition(definitionFromUpdateInput(args.input));
+    const writeDb = set(writeDb$);
+    const connectorCatalogSnapshot =
+      args.connectorCatalogSnapshot ??
+      (await loadConnectorRuntimeSnapshot(writeDb));
+    signal.throwIfAborted();
+    const v = validateDefinition(
+      definitionFromUpdateInput(args.input),
+      connectorCatalogSnapshot.serverFirewalls,
+    );
     if (isBadRequest(v)) {
       return v;
     }
     const legacy = legacyColumns(v);
-    const writeDb = set(writeDb$);
     const [row] = await writeDb
       .update(orgCustomConnectors)
       .set({
@@ -1613,7 +1639,9 @@ function proposalUpdateInput(
 const saveProposalDefinition$ = command(
   async (
     { set },
-    args: SaveCustomConnectorProposalArgs,
+    args: SaveCustomConnectorProposalArgs & {
+      readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    },
     signal: AbortSignal,
   ): Promise<
     | CustomConnectorRow
@@ -1632,6 +1660,7 @@ const saveProposalDefinition$ = command(
           orgId: args.orgId,
           userId: args.userId,
           input: updateInput,
+          connectorCatalogSnapshot: args.connectorCatalogSnapshot,
         },
         signal,
       );
@@ -1648,6 +1677,7 @@ const saveProposalDefinition$ = command(
         orgId: args.orgId,
         id: args.proposal.connectorId,
         input: updateInput,
+        connectorCatalogSnapshot: args.connectorCatalogSnapshot,
       },
       signal,
     );
@@ -1695,8 +1725,13 @@ export const saveCustomConnectorProposal$ = command(
     args: SaveCustomConnectorProposalArgs,
     signal: AbortSignal,
   ): Promise<SaveCustomConnectorProposalResult> => {
+    const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(
+      get(db$),
+    );
+    signal.throwIfAborted();
     const proposalDefinition = validateDefinition(
       definitionFromUpdateInput(proposalUpdateInput(args.proposal)),
+      connectorCatalogSnapshot.serverFirewalls,
     );
     if (isBadRequest(proposalDefinition)) {
       return proposalDefinition;
@@ -1710,7 +1745,11 @@ export const saveCustomConnectorProposal$ = command(
       return proposalValues;
     }
 
-    const connector = await set(saveProposalDefinition$, args, signal);
+    const connector = await set(
+      saveProposalDefinition$,
+      { ...args, connectorCatalogSnapshot },
+      signal,
+    );
     signal.throwIfAborted();
     if ("status" in connector) {
       return connector;

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -6,7 +6,6 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
-import { resolveFirewallServerMetadataPolicies } from "@vm0/connectors/firewall-metadata/server";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import {
   isFeatureEnabled,
@@ -49,6 +48,11 @@ import {
   type ZeroRunBootstrapSnapshotRows,
 } from "./zero-run-bootstrap-context.service";
 import type { RunWorkflowRef } from "./zero-workflow-data.service";
+import {
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import { expandConnectorServerFirewallPolicies } from "./connector-server-firewall-catalog.service";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 type ZeroRunOrigin =
@@ -784,20 +788,26 @@ async function loadZeroRunPostAuthorizationContext(
   );
   signal.throwIfAborted();
 
+  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db);
+  signal.throwIfAborted();
   const runPermissionPolicies = await measureZeroPreCreate(
     args.timing,
     "api_dispatch_pre_create_zero_resolve_firewall_metadata",
     async () => {
-      return await resolveFirewallServerMetadataPolicies(
-        permissionGrantsToFirewallPolicies(bootstrapContext.permissionGrants),
-        [...bootstrapContext.allowedConnectorTypes],
-      );
+      return await expandConnectorServerFirewallPolicies({
+        catalog: connectorCatalogSnapshot.serverFirewalls,
+        stored: permissionGrantsToFirewallPolicies(
+          bootstrapContext.permissionGrants,
+        ),
+        connectorRefs: [...bootstrapContext.allowedConnectorTypes],
+      });
     },
   );
   signal.throwIfAborted();
 
   return {
     ...bootstrapContext,
+    connectorCatalogSnapshot,
     runPermissionPolicies,
   };
 }
@@ -952,6 +962,7 @@ interface ZeroRunAfterPreCreateBase {
   readonly zeroWebSearchEnabled: boolean;
   readonly zeroMailEnabled: boolean;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
   readonly allowedCustomConnectorIds: readonly string[];
@@ -1004,6 +1015,7 @@ const createAgentRunAfterZeroPreCreate$ = command(
         timing: input.timing,
         checkOrgPlanStatusBeforeContext: false,
         preloadedFeatureSwitchContext: input.featureSwitchContext,
+        preloadedConnectorCatalogSnapshot: input.connectorCatalogSnapshot,
       },
       signal,
     );
@@ -1059,6 +1071,7 @@ export const createZeroIntegrationRun$ = command(
       allowedCustomConnectorIds,
       workflows,
       runPermissionPolicies,
+      connectorCatalogSnapshot,
     } = await loadZeroRunPostAuthorizationContext(
       db,
       {
@@ -1084,6 +1097,7 @@ export const createZeroIntegrationRun$ = command(
         zeroWebSearchEnabled,
         zeroMailEnabled,
         runPermissionPolicies,
+        connectorCatalogSnapshot,
         workflows,
         allowedConnectorTypes,
         allowedCustomConnectorIds,
@@ -1147,6 +1161,7 @@ export const createZeroRun$ = command(
       allowedCustomConnectorIds,
       workflows,
       runPermissionPolicies,
+      connectorCatalogSnapshot,
       triggerAgentId,
     } = await loadZeroRunPostAuthorizationContext(
       db,
@@ -1173,6 +1188,7 @@ export const createZeroRun$ = command(
         zeroWebSearchEnabled,
         zeroMailEnabled,
         runPermissionPolicies,
+        connectorCatalogSnapshot,
         triggerAgentId,
         workflows,
         allowedConnectorTypes,

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -1,8 +1,4 @@
 import { command } from "ccstate";
-import {
-  isFirewallExecutionMetadataConnectorType,
-  loadFirewallPermissionIndex,
-} from "@vm0/connectors/firewall-metadata/server";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -43,6 +39,11 @@ import {
   defaultFirewallPolicyForPermissionIndex,
   networkPolicyForFirewallPolicy,
 } from "./firewall-network-policy.service";
+import {
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSnapshot,
+} from "./connector-catalog-runtime.service";
+import type { ConnectorServerFirewallCatalog } from "./connector-server-firewall-catalog.service";
 
 type UserPermissionGrantRow = typeof userPermissionGrants.$inferSelect;
 type StoredPermissionGrantRow = UserPermissionGrantRow;
@@ -258,27 +259,36 @@ function resolvedConnectorFirewallPolicies(
   return permissionGrantsToFirewallPolicies(grants) ?? {};
 }
 
-function isNetworkPolicyRefreshConnectorRef(connectorRef: string): boolean {
-  return isFirewallExecutionMetadataConnectorType(connectorRef);
-}
-
 export function networkPolicyRefreshConnectorRefs(
+  catalog: ConnectorServerFirewallCatalog,
   connectorRefs: readonly string[],
 ): string[] {
-  return [...new Set(connectorRefs.filter(isNetworkPolicyRefreshConnectorRef))];
+  return [
+    ...new Set(
+      connectorRefs.filter((connectorRef) => {
+        return catalog.has(connectorRef);
+      }),
+    ),
+  ];
 }
 
 export async function resolveActiveNetworkPolicyRefreshes(
   db: ReadonlyDb,
   scope: UserPermissionGrantScope,
   connectorRefs: readonly string[],
+  preloadedSnapshot?: ConnectorRuntimeSnapshot,
   checkedAt: Date = nowDate(),
 ): Promise<readonly ActiveNetworkPolicyRefresh[]> {
   if (connectorRefs.length === 0) {
     return [];
   }
 
-  const uniqueConnectorRefs = networkPolicyRefreshConnectorRefs(connectorRefs);
+  const snapshot =
+    preloadedSnapshot ?? (await loadConnectorRuntimeSnapshot(db));
+  const uniqueConnectorRefs = networkPolicyRefreshConnectorRefs(
+    snapshot.serverFirewalls,
+    connectorRefs,
+  );
   if (uniqueConnectorRefs.length === 0) {
     return [];
   }
@@ -295,7 +305,7 @@ export async function resolveActiveNetworkPolicyRefreshes(
     uniqueConnectorRefs.map(async (connectorRef) => {
       return {
         connectorRef,
-        index: await loadFirewallPermissionIndex(connectorRef),
+        index: await snapshot.serverFirewalls.loadPermissionIndex(connectorRef),
       };
     }),
   );
@@ -458,8 +468,9 @@ async function lockVisibleAgentForUpdate(
 
 async function validateApplyUserPermissionGrants(
   apply: ApplyUserPermissionGrantsRequest,
+  catalog: ConnectorServerFirewallCatalog,
 ): Promise<ValidationErrorResponse | null> {
-  const index = await loadFirewallPermissionIndex(apply.connectorRef);
+  const index = await catalog.loadPermissionIndex(apply.connectorRef);
   if (!index) {
     return validationError(`Unknown connector ref: ${apply.connectorRef}`);
   }
@@ -651,13 +662,14 @@ function applyPermissionGrantResponseScope(
 async function applyRowsAndPublishNetworkPolicyRefreshes(
   db: Db,
   args: ApplyUserPermissionGrantsArgs,
+  serverFirewalls: ConnectorServerFirewallCatalog,
 ): Promise<readonly StoredPermissionGrantRow[] | NotFoundResponse> {
   const rows = await applyVisibleGrantRows(db, args);
   if ("status" in rows) {
     return rows;
   }
 
-  if (!isNetworkPolicyRefreshConnectorRef(args.apply.connectorRef)) {
+  if (!serverFirewalls.has(args.apply.connectorRef)) {
     return rows;
   }
 
@@ -711,14 +723,23 @@ export const applyUserPermissionGrants$ = command(
     args: ApplyUserPermissionGrantsArgs,
     signal: AbortSignal,
   ): Promise<ApplyUserPermissionGrantsResult> => {
-    const validation = await validateApplyUserPermissionGrants(args.apply);
+    const writeDb = set(writeDb$);
+    const snapshot = await loadConnectorRuntimeSnapshot(writeDb);
+    signal.throwIfAborted();
+    const validation = await validateApplyUserPermissionGrants(
+      args.apply,
+      snapshot.serverFirewalls,
+    );
     signal.throwIfAborted();
     if (validation) {
       return validation;
     }
 
-    const writeDb = set(writeDb$);
-    const rows = await applyRowsAndPublishNetworkPolicyRefreshes(writeDb, args);
+    const rows = await applyRowsAndPublishNetworkPolicyRefreshes(
+      writeDb,
+      args,
+      snapshot.serverFirewalls,
+    );
     signal.throwIfAborted();
 
     if ("status" in rows) {

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -78,7 +78,7 @@ function stripHostnameTrailingDot(host: string): string {
   return `${hostname}${host.slice(portStart)}`;
 }
 
-function normalizeBuiltinConnectorHostLookupKey(host: string): string | null {
+export function normalizeConnectorFixedHost(host: string): string | null {
   const trimmedHost = host.trim();
   if (trimmedHost.length === 0) {
     return null;
@@ -133,7 +133,7 @@ export function getFirewallExecutionMetadata(
 export function getBuiltinConnectorHostOwner(
   host: string,
 ): BuiltinConnectorHostOwner | null {
-  const normalizedHost = normalizeBuiltinConnectorHostLookupKey(host);
+  const normalizedHost = normalizeConnectorFixedHost(host);
   if (!normalizedHost) {
     return null;
   }

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -36,6 +36,10 @@ export interface BuiltinConnectorHostOwner {
   readonly label: string;
 }
 
+export interface BuiltinConnectorFixedHostOwner extends BuiltinConnectorHostOwner {
+  readonly host: string;
+}
+
 export interface FirewallPermissionIndex {
   readonly type: FirewallPermissionDetailMetadata["type"];
   readonly label: string;
@@ -147,6 +151,22 @@ export function getBuiltinConnectorHostOwner(
     type,
     label: FIREWALL_PERMISSION_METADATA_SUMMARIES[type].label,
   };
+}
+
+export function listBuiltinConnectorFixedHostOwners(): readonly BuiltinConnectorFixedHostOwner[] {
+  return Object.entries(builtinFirewallFixedHostOwnerLookup).flatMap(
+    ([host, type]) => {
+      return isFirewallServerMetadataConnectorType(type)
+        ? [
+            {
+              host,
+              type,
+              label: FIREWALL_PERMISSION_METADATA_SUMMARIES[type].label,
+            },
+          ]
+        : [];
+    },
+  );
 }
 
 async function loadFirewallPermissionDetail(


### PR DESCRIPTION
## Summary

- add one snapshot-owned server firewall catalog with equivalent static and accepted external backends
- use the selected snapshot for run policy/materialization, diagnostics, permission refreshes, fixed-host ownership, and network attribution
- reject normalized cross-connector fixed-host collisions and compare deterministic sanitized server-firewall behavior in shadow mode
- merge duplicate dynamic base templates with equivalent host policies, while rejecting conflicting duplicate policies before activation

Production remains on the existing default `CONNECTOR_CATALOG_SOURCE_MODE=static`. This PR does not activate the external catalog, change API or runner schemas, add request-path R2 reads, or migrate model-provider firewall behavior.

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm knip --workspace api --workspace @vm0/connectors`
- current head: `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts --maxWorkers=1 --silent=passed-only` (84 passed)
- current head: `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts --maxWorkers=1 --silent=passed-only` (29 passed)
- broader focused API coverage: catalog sync, run lifecycle, permission grants, connector checks, custom connectors, insights, and runner firewalls (261 passed)
- broader connector workspace coverage: 1,286 passed
- full API suite attempt passed 2,299/2,303 tests; the four local failures were cross-file database contention/timeouts and all passed when rerun serially, including the artifact cron case after isolating stale rows left by the interrupted run
- pre-commit hooks passed repository Knip and full Turbo type checks
- current-head CI passed: Turbo, security, crates, CodeQL/Semgrep, runner image builds, and CLI/runner E2E

Closes #21876

Parent delivery: #19396
