### PR TITLE
docs(runner): clarify name validation lifecycle

### DIFF
--- a/crates/runner/src/cmd/service/target.rs
+++ b/crates/runner/src/cmd/service/target.rs
@@ -13,7 +13,7 @@ pub(crate) struct RunnerServiceUnit {
 }
 
 impl RunnerServiceUnit {
-    /// Build a validated runner systemd unit identity from the user-supplied suffix.
+    /// Build a validated runner systemd unit identity from a suffix.
     ///
     /// Validates the suffix with [`crate::runner_dirname::validate_name`] so
     /// that runner directory names and service name suffixes follow the same

--- a/crates/runner/src/runner_dirname.rs
+++ b/crates/runner/src/runner_dirname.rs
@@ -10,13 +10,16 @@
 //! `Path::join`, and a bare `..` segment escapes once the kernel resolves
 //! it.
 //!
-//! Unlike `group` and `profile`, runner directory names are not persisted
-//! in `runner.yaml` (only the resolved `RunnerConfig.base_dir: PathBuf`
-//! is). Validation therefore happens once at the CLI boundary in
-//! `runner config`; there is no config-load checkpoint to mirror.
+//! `runner config --runner-dirname` validates the directory name before
+//! resolving it into `RunnerConfig.base_dir`. Only that resolved path is
+//! persisted in `runner.yaml`, so config loading has no original name to
+//! revalidate.
 //!
-//! No matching server-side schema exists — runner directory names are
-//! purely a runner-local concern.
+//! Independently supplied or discovered systemd service suffixes have a
+//! separate lifecycle: `RunnerServiceUnit::from_suffix` validates each suffix
+//! when constructing the service identity.
+//!
+//! Neither input has a matching server-side schema; both are runner-local.
 
 use crate::error::{RunnerError, RunnerResult};
 


### PR DESCRIPTION
## Summary

- distinguish one-time `runner config --runner-dirname` validation from the independent service-suffix lifecycle
- identify `RunnerServiceUnit::from_suffix` as the service identity validation boundary
- make the constructor wording source-neutral because suffixes may be supplied directly or discovered locally
- preserve the existing config persistence and runner-local schema rationale

## Scope

- documentation only
- no validator, call-site, API, schema, persisted-data, protocol, or deployment behavior changes
- no new tests because executable behavior is unchanged and existing config/service integration coverage already exercises the contract

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner runner_dirname::tests` (13 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::target::tests` (5 passed)
- `git diff --check`
- pre-commit Cargo fmt, workspace Clippy, workspace Rustdoc, file-size, and generated-firewall checks

Closes #22322
