### PR TITLE
perf(ci): skip runner image target cache

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -263,6 +263,9 @@ jobs:
           workspaces: crates -> target
           shared-key: ${{ matrix.cacheSuffix }}-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # sccache provides compiler artifact reuse without restoring the
+          # multi-gigabyte cross-compilation target directory.
+          cache-targets: false
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel


### PR DESCRIPTION
## Summary

- stop restoring the Cargo `target` directory in Runner Image jobs
- retain Cargo registry caching through `rust-cache` and compiler artifact reuse through `sccache`
- leave the Crates check, coverage, NBD, and release caches unchanged

## Motivation

Recent exact cache hits restored approximately 1,976 MB for x86_64 and 2,029 MB for arm64. The restore steps took 54 seconds and 42 seconds respectively, with most of the time spent extracting the cross-compilation target archives. Runner Image already enables `sccache`, so this change removes the overlapping target archive and lets CI measure the resulting end-to-end trade-off.

## Validation

- parsed `.github/workflows/runner-image.yml` with PyYAML
- `actionlint .github/workflows/runner-image.yml` (v1.7.12)
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/runner-image.yml`
- `git diff --check`

Relates to #22340
