### PR TITLE
test(vsock-guest): isolate exec tests from host cgroups

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -330,7 +330,7 @@ jobs:
           cd crates
           cargo run -p ably-subscriber --example smoke_test
 
-      - name: Run vsock-guest production identity test
+      - name: Run vsock-guest production configuration tests
         if: |
           needs.detect.outputs.vsock-test-changed == 'true' ||
           needs.detect.outputs.ci-changed == 'true'
@@ -367,6 +367,10 @@ jobs:
             /sbin/guest-write-file
 
           cd crates
+          cargo test -p vsock-guest --release --no-default-features \
+            --lib \
+            exec_operation::tests::stdout_drain_spawn_failure_returns_wait_failed_and_cleans_registry -- \
+            --exact
           HOME=/root USER=root LOGNAME=root \
             cargo test -p vsock-guest --release --no-default-features \
               --test production_identity -- \

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -121,7 +121,10 @@ pub(crate) fn verify_exec_process_containment_empty() -> Result<(), ProcessConta
 }
 
 fn use_test_noop_backend() -> bool {
-    cfg!(feature = "test-support")
+    // Library unit tests do not own the guest cgroup hierarchy. Controlled
+    // containment tests exercise real behavior through caller-provided paths.
+    cfg!(test)
+        || cfg!(feature = "test-support")
         || (cfg!(debug_assertions) && !Path::new(EXEC_CGROUP_BASE_PATH).is_dir())
 }
 


### PR DESCRIPTION
## Summary

- make `vsock-guest` library unit tests select the existing no-op process-containment backend without consulting the host cgroup layout
- add a focused release/no-default-feature CI regression that exercises the unit-test predicate without `test-support` or the debug path fallback
- preserve fail-closed cgroup behavior for every non-test debug and release guest build

## Scope

This changes only unit-test backend selection and its CI regression gate. It does not add a runtime containment fallback, worker/provider abstraction, API or protocol change, schema migration, or persisted-data change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc -p vsock-guest --all-features --no-deps`
- `cargo test -p vsock-guest --lib exec_operation::tests --no-default-features`
- `cargo test -p vsock-guest --lib process_containment::tests --no-default-features`
- `cargo test -p vsock-guest --lib --no-default-features`
- `cargo test -p vsock-guest --release --no-default-features --lib exec_operation::tests::stdout_drain_spawn_failure_returns_wait_failed_and_cleans_registry -- --exact`
- `cargo test -p vsock-guest --all-targets --all-features`
- `cargo test -p vsock-guest --all-targets --no-default-features`
- pre-commit workspace Cargo formatting, Clippy, documentation, file-size, and commit-message hooks

Closes #22287
