### PR TITLE
refactor(chat): remove mobile unread thread shortcuts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -204,7 +204,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
           switches: {
             [FeatureSwitchKey.AgentUnreadIndicators]: true,
             [FeatureSwitchKey.ChatThreadUnifiedSearch]: true,
-            [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -216,11 +215,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeTruthy();
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
-    ).toBeTruthy();
-    expect(
-      ownerUpdate.body.switches[
-        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
-      ],
     ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
@@ -234,9 +228,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeTruthy();
-    expect(
-      peerRead.body.switches[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
-    ).toBeUndefined();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const outsiderRead = await accept(
@@ -248,11 +239,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
     expect(
       outsiderRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
-    ).toBeUndefined();
-    expect(
-      outsiderRead.body.switches[
-        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
-      ],
     ).toBeUndefined();
 
     const peerUpdate = await accept(
@@ -273,11 +259,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeFalsy();
-    expect(
-      peerUpdate.body.switches[
-        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
-      ],
-    ).toBeUndefined();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const ownerReadAfterPeerUpdate = await accept(
@@ -294,11 +275,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
         FeatureSwitchKey.ChatThreadUnifiedSearch
       ],
     ).toBeFalsy();
-    expect(
-      ownerReadAfterPeerUpdate.body.switches[
-        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
-      ],
-    ).toBeTruthy();
     expect(
       ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.Dummy],
     ).toBeFalsy();
@@ -319,11 +295,6 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerReadAfterDelete.body.switches[
         FeatureSwitchKey.ChatThreadUnifiedSearch
-      ],
-    ).toBeUndefined();
-    expect(
-      peerReadAfterDelete.body.switches[
-        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
       ],
     ).toBeUndefined();
     expect(

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -13,10 +13,6 @@ import {
   reloadChatUnreadStateCounter$,
 } from "../chat-thread-list-reload.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
-import {
-  sidebarActiveThreadIds$,
-  eventDrivenChatThreads$,
-} from "./chat-thread-event-sourcing.ts";
 
 type UnreadSnapshot = readonly { threadId: string; unreadAt: string }[];
 
@@ -94,41 +90,6 @@ export const unreadAgentIds$ = computed(
     const client = get(zeroClient$)(chatThreadsContract);
     const result = await accept(client.unreadAgents(), [200]);
     return new Set(result.body.agentIds);
-  },
-);
-
-interface CurrentAgentUnreadChatThread {
-  readonly id: string;
-  readonly title: string | null;
-  readonly hasActiveRun: boolean;
-}
-
-export const currentAgentUnreadChatThreads$ = computed(
-  async (get): Promise<readonly CurrentAgentUnreadChatThread[]> => {
-    const features = get(featureSwitch$);
-    if (!features[FeatureSwitchKey.MobileUnreadChatThreadShortcuts]) {
-      return [];
-    }
-    const agentId = await get(currentChatAgentId$);
-    if (!agentId) {
-      return [];
-    }
-    const unreadThreadIds = await get(sidebarUnreadThreadIds$);
-    if (unreadThreadIds.size === 0) {
-      return [];
-    }
-    const activeRunThreadIds = await get(sidebarActiveThreadIds$);
-    return (await get(eventDrivenChatThreads$))
-      .filter((thread) => {
-        return thread.agentId === agentId && unreadThreadIds.has(thread.id);
-      })
-      .map((thread) => {
-        return {
-          id: thread.id,
-          title: thread.title,
-          hasActiveRun: activeRunThreadIds.has(thread.id),
-        };
-      });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,15 +1,8 @@
-import {
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  within,
-} from "@testing-library/react";
-import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { screen, waitForElementToBeRemoved } from "@testing-library/react";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -20,9 +13,8 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { reloadConnectors$ } from "../../../signals/external/connectors.ts";
-import { pathname } from "../../../signals/location.ts";
 import { setIdeationActiveTab$ } from "../../../signals/zero-page/zero-ideation.ts";
-import { PLACEHOLDER, threadListSnapshot } from "./chat-test-helpers.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -64,70 +56,6 @@ function mockConnectorCatalogStatus(connectorRefs: readonly string[]): void {
   context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
     return respond(200, {
       connectors: connectorRefs.map(publicConnectorStatusItem),
-    });
-  });
-}
-
-function mockUnreadShortcutThreads(): void {
-  const currentAgentUnreadThreadId = "b0000000-0000-4000-a000-000000000901";
-  const currentAgentRunningThreadId = "b0000000-0000-4000-a000-000000000902";
-  const otherAgentUnreadThreadId = "b0000000-0000-4000-a000-000000000903";
-  const otherAgentId = "c0000000-0000-4000-a000-000000000099";
-  const threads = [
-    {
-      id: currentAgentUnreadThreadId,
-      title: "Unread research brief",
-      agent: { id: agentId, avatarUrl: null },
-      createdAt: "2026-06-01T00:00:00Z",
-      updatedAt: "2026-06-01T00:03:00Z",
-      pinnedAt: null,
-    },
-    {
-      id: currentAgentRunningThreadId,
-      title: "Running incident follow-up",
-      agent: { id: agentId, avatarUrl: null },
-      createdAt: "2026-06-01T00:00:00Z",
-      updatedAt: "2026-06-01T00:02:00Z",
-      pinnedAt: null,
-    },
-    {
-      id: otherAgentUnreadThreadId,
-      title: "Other agent unread chat",
-      agent: { id: otherAgentId, avatarUrl: null },
-      createdAt: "2026-06-01T00:00:00Z",
-      updatedAt: "2026-06-01T00:01:00Z",
-      pinnedAt: null,
-    },
-  ];
-
-  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
-    return respond(200, {
-      chatThreads: threadListSnapshot(threads),
-      latestEventId: null,
-    });
-  });
-  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
-    return respond(200, { events: [], hasMore: false });
-  });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [currentAgentRunningThreadId] });
-  });
-  context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
-    return respond(200, {
-      unreads: [
-        {
-          threadId: currentAgentUnreadThreadId,
-          unreadAt: "2026-06-01T00:03:00Z",
-        },
-        {
-          threadId: currentAgentRunningThreadId,
-          unreadAt: "2026-06-01T00:02:00Z",
-        },
-        {
-          threadId: otherAgentUnreadThreadId,
-          unreadAt: "2026-06-01T00:01:00Z",
-        },
-      ],
     });
   });
 }
@@ -405,70 +333,6 @@ describe("zero ideation page", () => {
 
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
-  });
-
-  it("shows current-agent unread chat shortcuts on mobile behind the feature switch", async () => {
-    mockConnectorCatalogStatus([]);
-    mockUnreadShortcutThreads();
-
-    detachedSetupPage({
-      context,
-      path: `/agents/${agentId}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: true,
-      },
-    });
-
-    const unreadRegion = await screen.findByRole("region", {
-      name: "Unread chats",
-    });
-    expect(unreadRegion).toHaveClass("md:hidden");
-    expect(within(unreadRegion).queryByText("Unread chats")).toBeNull();
-    expect(within(unreadRegion).queryByText("2")).toBeNull();
-    expect(
-      within(unreadRegion).getByText("Unread research brief"),
-    ).toBeInTheDocument();
-    expect(
-      within(unreadRegion).getByText("Running incident follow-up"),
-    ).toBeInTheDocument();
-    expect(within(unreadRegion).getAllByLabelText("Running")).toHaveLength(1);
-    expect(within(unreadRegion).queryByText("Unread")).toBeNull();
-    expect(within(unreadRegion).queryByText("Running now")).toBeNull();
-    expect(
-      screen.queryByText("Other agent unread chat"),
-    ).not.toBeInTheDocument();
-
-    const shortcut = within(unreadRegion)
-      .getByText("Unread research brief")
-      .closest("a");
-    if (!shortcut) {
-      throw new Error("Unread research shortcut not found");
-    }
-    click(shortcut);
-
-    await waitFor(() => {
-      expect(pathname()).toBe("/chats/b0000000-0000-4000-a000-000000000901");
-    });
-  });
-
-  it("hides current-agent unread chat shortcuts when the feature switch is off", async () => {
-    mockConnectorCatalogStatus([]);
-    mockUnreadShortcutThreads();
-
-    detachedSetupPage({
-      context,
-      path: `/agents/${agentId}/chat`,
-      featureSwitches: {
-        [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: false,
-      },
-    });
-
-    await expect(
-      screen.findByPlaceholderText(PLACEHOLDER),
-    ).resolves.toBeInTheDocument();
-    expect(
-      screen.queryByRole("region", { name: "Unread chats" }),
-    ).not.toBeInTheDocument();
   });
 
   it("keeps the last resolved suggested prompt catalog while a reload is pending", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -9,13 +9,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
-import {
-  IconArrowUpRight,
-  IconChevronRight,
-  IconLoader2,
-  IconPin,
-  IconUserPlus,
-} from "@tabler/icons-react";
+import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -41,8 +35,6 @@ import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
 import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import {
   replaceWorkflowPromptDraftTarget$,
@@ -91,7 +83,6 @@ import { updateUserModelPreference$ } from "../../signals/external/user-model-pr
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 import { queueCurrentAgentDraftSync$ } from "../../signals/zero-page/agent-draft.ts";
-import { currentAgentUnreadChatThreads$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 
 function getTagline(
   agentName: string,
@@ -360,58 +351,6 @@ function IdeasUseCasesButton() {
         <IconArrowUpRight size={14} stroke={2} />
       </div>
     </button>
-  );
-}
-
-function MobileUnreadThreadShortcuts() {
-  const features = useGet(featureSwitch$);
-  const enabled =
-    features[FeatureSwitchKey.MobileUnreadChatThreadShortcuts] ?? false;
-  const unreadThreads = useLastResolved(currentAgentUnreadChatThreads$) ?? [];
-
-  if (!enabled || unreadThreads.length === 0) {
-    return null;
-  }
-
-  return (
-    <section
-      className="md:hidden flex flex-col gap-2"
-      aria-label="Unread chats"
-    >
-      <div className="zero-card divide-y divide-border/60 overflow-hidden">
-        {unreadThreads.map((thread) => {
-          return (
-            <Link
-              key={thread.id}
-              pathname="/chats/:threadId"
-              options={{ pathParams: { threadId: thread.id } }}
-              className="flex min-h-12 items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-muted/40"
-            >
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-semibold leading-5 text-foreground">
-                  {thread.title ?? "New chat"}
-                </span>
-              </span>
-              {thread.hasActiveRun ? (
-                <IconLoader2
-                  size={14}
-                  stroke={1.8}
-                  className="shrink-0 animate-spin text-primary"
-                  aria-label="Running"
-                />
-              ) : (
-                <IconChevronRight
-                  size={16}
-                  stroke={1.8}
-                  className="shrink-0 text-muted-foreground"
-                  aria-hidden
-                />
-              )}
-            </Link>
-          );
-        })}
-      </div>
-    </section>
   );
 }
 
@@ -759,8 +698,6 @@ export function AgentChatPage() {
             onOpenChange={workflowPrompt.onReplaceDialogOpenChange}
             onConfirm={workflowPrompt.onConfirmReplaceDraft}
           />
-
-          <MobileUnreadThreadShortcuts />
 
           <SuggestedPromptsGrid onSelectPrompt={handleInputChange} />
         </div>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -64,7 +64,6 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   DesktopX64Download = "desktopX64Download",
   AgentUnreadIndicators = "agentUnreadIndicators",
-  MobileUnreadChatThreadShortcuts = "mobileUnreadChatThreadShortcuts",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ComposerChatThreadSuggestions = "composerChatThreadSuggestions",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -141,9 +141,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
-    expect(
-      staffOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
-    ).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
@@ -177,9 +174,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
-    expect(
-      otherOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
-    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -370,12 +370,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show unread chat thread shortcuts between the mobile agent chat composer and suggested prompt cards.",
-    enabled: false,
-  },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- Remove the retired mobile unread chat shortcut feature switch from the shared key enum and registry.
- Delete the mobile-only agent chat shortcut UI and its dedicated unread-thread selector.
- Remove feature-specific app, core, and API test coverage while preserving the shared unread indicator infrastructure.

## User impact

The dormant mobile shortcut path is no longer shipped or exposed through feature-switch APIs. Existing sidebar unread indicators and shared unread state remain unchanged.

## Verification

- pnpm exec prettier --write on all changed files
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types
- NODE_OPTIONS=--max-old-space-size=3072 pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/connectors
- pnpm knip --workspace @vm0/core
- pnpm knip --workspace api
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx
- pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts