### PR TITLE
feat(chat): add structured prompt editor codecs

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -1,0 +1,392 @@
+import type { JSONContent } from "@tiptap/core";
+import type {
+  GenerationTemplateRequest,
+  PersistedAttachment,
+  UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "./test-helpers.ts";
+import { createDraftSignals } from "../zero-page/chat-draft.ts";
+import { createWorkflowComposerSignals } from "../zero-page/tiptap-workflow-composer.ts";
+import {
+  editorDocToMessageDocument,
+  messageDocumentToEditorDoc,
+  messageDocumentToPrompt,
+} from "../zero-page/user-message-document-codec.ts";
+
+const context = testContext();
+const THREAD_ID = "1fe7f3cc-40b9-49f2-8f86-5f07d8d8dfd8";
+
+function presentationTemplate(): GenerationTemplateRequest {
+  return {
+    type: "presentation",
+    selection: {
+      templateId: "pitch-deck",
+      colorSystemId: "color-system:modern-blue",
+      previewUrl: "https://example.com/pitch-deck.png",
+    },
+  };
+}
+
+function persistedAttachments(): readonly PersistedAttachment[] {
+  return [
+    {
+      id: "file-one",
+      url: "https://example.com/file-one.pdf",
+      filename: "file-one.pdf",
+      contentType: "application/pdf",
+      size: 100,
+    },
+    {
+      id: "file-two",
+      url: "https://example.com/file-two.txt",
+      filename: "file-two.txt",
+      contentType: "text/plain",
+      size: 20,
+    },
+  ];
+}
+
+function workflowComposerDocument(content: JSONContent) {
+  const composer = createWorkflowComposerSignals(createDraftSignals());
+  context.signal.addEventListener("abort", () => {
+    composer.editor.destroy();
+  });
+  return composer.editor.schema.nodeFromJSON(content);
+}
+
+describe("user message document codec", () => {
+  it("round-trips the supported composer nodes through the business document", () => {
+    const editorDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        {
+          type: "templateAttachment",
+          attrs: {
+            templateType: "presentation",
+            title: "Pitch deck",
+            category: "slides",
+            previewImageUrl: "https://example.com/pitch-deck.png",
+          },
+        },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "  Review " },
+            {
+              type: "chatThreadMention",
+              attrs: { threadId: THREAD_ID, title: "Project Alpha" },
+            },
+            { type: "text", text: " then" },
+            { type: "hardBreak" },
+            { type: "text", text: "continue  " },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "last" }],
+        },
+      ],
+    });
+
+    const template = presentationTemplate();
+    const attachments = persistedAttachments();
+    const structured = editorDocToMessageDocument(editorDocument, {
+      generationTemplate: template,
+      attachments,
+    });
+    expect(structured).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "template",
+          titleSnapshot: "Pitch deck",
+          template,
+        },
+        {
+          type: "file",
+          fileId: "file-one",
+          filenameSnapshot: "file-one.pdf",
+          contentType: "application/pdf",
+        },
+        {
+          type: "file",
+          fileId: "file-two",
+          filenameSnapshot: "file-two.txt",
+          contentType: "text/plain",
+        },
+        { type: "text", text: "  Review " },
+        {
+          type: "chat_thread",
+          threadId: THREAD_ID,
+          titleSnapshot: "Project Alpha",
+        },
+        { type: "text", text: " then\ncontinue  \nlast" },
+      ],
+    });
+    expect(messageDocumentToPrompt(structured)).toBe(
+      `  Review [Project Alpha](/chats/${THREAD_ID}) then\ncontinue  \nlast`,
+    );
+
+    const restored = messageDocumentToEditorDoc(structured);
+    expect(restored).toStrictEqual({
+      type: "doc",
+      content: [
+        {
+          type: "templateAttachment",
+          attrs: {
+            templateType: "presentation",
+            title: "Pitch deck",
+            category: "slides",
+            previewImageUrl: "https://example.com/pitch-deck.png",
+          },
+        },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "  Review " },
+            {
+              type: "chatThreadMention",
+              attrs: { threadId: THREAD_ID, title: "Project Alpha" },
+            },
+            { type: "text", text: " then" },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "continue  " }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "last" }],
+        },
+      ],
+    });
+    if (!restored) {
+      throw new Error("Expected the structured document to restore");
+    }
+
+    expect(
+      editorDocToMessageDocument(workflowComposerDocument(restored), {
+        generationTemplate: template,
+        attachments,
+      }),
+    ).toStrictEqual(structured);
+  });
+
+  it("normalizes paragraph boundaries and hard breaks without trimming", () => {
+    const editorDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        { type: "paragraph" },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: " a" },
+            { type: "hardBreak" },
+            { type: "text", text: "b " },
+          ],
+        },
+        { type: "paragraph" },
+      ],
+    });
+
+    const structured = editorDocToMessageDocument(editorDocument);
+    expect(structured).toStrictEqual({
+      version: 1,
+      parts: [{ type: "text", text: "\n a\nb \n" }],
+    });
+    expect(messageDocumentToEditorDoc(structured)).toStrictEqual({
+      type: "doc",
+      content: [
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: " a" }] },
+        { type: "paragraph", content: [{ type: "text", text: "b " }] },
+        { type: "paragraph" },
+      ],
+    });
+  });
+
+  it("keeps file-only messages in external attachment state", () => {
+    const structured = editorDocToMessageDocument(
+      workflowComposerDocument({
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      }),
+      { attachments: persistedAttachments().slice(0, 1) },
+    );
+
+    expect(structured).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "file",
+          fileId: "file-one",
+          filenameSnapshot: "file-one.pdf",
+          contentType: "application/pdf",
+        },
+      ],
+    });
+    expect(messageDocumentToEditorDoc(structured)).toStrictEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+    expect(messageDocumentToPrompt(structured)).toBe("");
+  });
+
+  it("returns null for malformed or unsupported documents", () => {
+    const unsupportedEditorDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        {
+          type: "feedbackItem",
+          attrs: {
+            feedbackId: 1,
+            quote: "Unsupported",
+            showDivider: false,
+            fill: false,
+          },
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Unsupported" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(editorDocToMessageDocument(unsupportedEditorDocument)).toBeNull();
+
+    const templateDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        {
+          type: "templateAttachment",
+          attrs: {
+            templateType: "presentation",
+            title: "Pitch deck",
+            category: "slides",
+            previewImageUrl: null,
+          },
+        },
+      ],
+    });
+    expect(editorDocToMessageDocument(templateDocument)).toBeNull();
+    expect(
+      editorDocToMessageDocument(
+        workflowComposerDocument({
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "x" }] },
+          ],
+        }),
+        { generationTemplate: presentationTemplate() },
+      ),
+    ).toBeNull();
+
+    const malformed = { version: 1, parts: [] };
+    expect(messageDocumentToEditorDoc(malformed)).toBeNull();
+    expect(messageDocumentToPrompt(malformed)).toBeNull();
+  });
+
+  it("restores each template variant to the shared attachment node", () => {
+    const templates: readonly UserMessageDocument[] = [
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Illustration style",
+            template: {
+              type: "illustration",
+              selection: { illustrationStyleId: "paper-cut" },
+            },
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Video style",
+            template: {
+              type: "video",
+              selection: { stylePresetId: "cinematic" },
+            },
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Workflow template",
+            template: {
+              type: "workflow",
+              selection: { workflowTemplateId: "weekly-report" },
+            },
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            type: "template",
+            titleSnapshot: "Website template",
+            template: {
+              type: "website",
+              selection: { websiteTemplateId: "launch-page" },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(
+      templates.map((document) => {
+        return messageDocumentToEditorDoc(document)?.content?.[0];
+      }),
+    ).toStrictEqual([
+      {
+        type: "templateAttachment",
+        attrs: {
+          templateType: "illustration",
+          title: "Illustration style",
+          category: "illustration",
+          previewImageUrl: null,
+        },
+      },
+      {
+        type: "templateAttachment",
+        attrs: {
+          templateType: "video",
+          title: "Video style",
+          category: "video",
+          previewImageUrl: null,
+        },
+      },
+      {
+        type: "templateAttachment",
+        attrs: {
+          templateType: "workflow",
+          title: "Workflow template",
+          category: "workflow",
+          previewImageUrl: null,
+        },
+      },
+      {
+        type: "templateAttachment",
+        attrs: {
+          templateType: "website",
+          title: "Website template",
+          category: "website",
+          previewImageUrl: null,
+        },
+      },
+    ]);
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -43,6 +43,10 @@ import {
   type SlashWorkflowRange,
 } from "./workflow-composer-domain.ts";
 import {
+  CHAT_THREAD_MENTION_NODE_NAME,
+  TEMPLATE_ATTACHMENT_NODE_NAME,
+} from "./user-message-document-codec.ts";
+import {
   createTemplatePreviewRuntime,
   type TemplatePreviewRuntime,
 } from "./template-preview-runtime.ts";
@@ -144,8 +148,6 @@ export interface WorkflowComposerEventHandlers {
 }
 
 const FEEDBACK_ITEM_NODE_NAME = "feedbackItem";
-const TEMPLATE_ATTACHMENT_NODE_NAME = "templateAttachment";
-const CHAT_THREAD_MENTION_NODE_NAME = "chatThreadMention";
 const CHAT_THREAD_MENTION_CLASS =
   "rounded bg-primary/10 px-1 text-primary whitespace-nowrap";
 

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -1,0 +1,294 @@
+import type { JSONContent } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import {
+  userMessageDocumentSchema,
+  type GenerationTemplateRequest,
+  type GenerationTemplateType,
+  type PersistedAttachment,
+  type UserMessageDocument,
+  type UserMessagePart,
+} from "@vm0/api-contracts/contracts/chat-threads";
+
+import { serializeChatThreadMention } from "./chat-thread-suggestion-domain.ts";
+
+export const CHAT_THREAD_MENTION_NODE_NAME = "chatThreadMention";
+export const TEMPLATE_ATTACHMENT_NODE_NAME = "templateAttachment";
+
+export interface EditorDocumentContext {
+  readonly generationTemplate?: GenerationTemplateRequest;
+  readonly attachments?: readonly PersistedAttachment[];
+}
+
+function appendTextPart(parts: UserMessagePart[], text: string): void {
+  if (text.length === 0) {
+    return;
+  }
+  const previous = parts.at(-1);
+  if (previous?.type === "text") {
+    parts[parts.length - 1] = {
+      type: "text",
+      text: previous.text + text,
+    };
+    return;
+  }
+  parts.push({ type: "text", text });
+}
+
+function chatThreadPart(node: ProseMirrorNode): UserMessagePart | null {
+  const threadId: unknown = node.attrs.threadId;
+  const title: unknown = node.attrs.title;
+  if (typeof threadId !== "string" || typeof title !== "string") {
+    return null;
+  }
+  return {
+    type: "chat_thread",
+    threadId,
+    titleSnapshot: title,
+  };
+}
+
+function templatePart(
+  node: ProseMirrorNode,
+  generationTemplate: GenerationTemplateRequest | undefined,
+): UserMessagePart | null {
+  const templateType: unknown = node.attrs.templateType;
+  const title: unknown = node.attrs.title;
+  if (
+    generationTemplate === undefined ||
+    templateType !== generationTemplate.type ||
+    typeof title !== "string"
+  ) {
+    return null;
+  }
+  return {
+    type: "template",
+    titleSnapshot: title,
+    template: generationTemplate,
+  };
+}
+
+function appendParagraphParts(
+  paragraph: ProseMirrorNode,
+  parts: UserMessagePart[],
+): boolean {
+  for (let index = 0; index < paragraph.childCount; index++) {
+    const node = paragraph.child(index);
+    if (node.isText) {
+      if (typeof node.text !== "string") {
+        return false;
+      }
+      appendTextPart(parts, node.text);
+      continue;
+    }
+    if (node.type.name === "hardBreak") {
+      appendTextPart(parts, "\n");
+      continue;
+    }
+    if (node.type.name === CHAT_THREAD_MENTION_NODE_NAME) {
+      const part = chatThreadPart(node);
+      if (!part) {
+        return false;
+      }
+      parts.push(part);
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function appendFileParts(
+  parts: UserMessagePart[],
+  attachments: readonly PersistedAttachment[],
+): void {
+  for (const attachment of attachments) {
+    parts.push({
+      type: "file",
+      fileId: attachment.id,
+      filenameSnapshot: attachment.filename,
+      contentType: attachment.contentType,
+    });
+  }
+}
+
+/**
+ * Converts the current composer snapshot into its editor-independent business
+ * document. External files are normalized after the leading template chip and
+ * before the text body, matching their current composer presentation order.
+ */
+export function editorDocToMessageDocument(
+  document: ProseMirrorNode,
+  context: EditorDocumentContext = {},
+): UserMessageDocument | null {
+  if (document.type.name !== "doc") {
+    return null;
+  }
+
+  const parts: UserMessagePart[] = [];
+  const attachments = context.attachments ?? [];
+  let filesAppended = false;
+  let templateCount = 0;
+  let paragraphCount = 0;
+  for (let index = 0; index < document.childCount; index++) {
+    const node = document.child(index);
+    if (node.type.name === "paragraph") {
+      paragraphCount += 1;
+      continue;
+    }
+    if (node.type.name !== TEMPLATE_ATTACHMENT_NODE_NAME) {
+      return null;
+    }
+    templateCount += 1;
+  }
+  if (templateCount > 1) {
+    return null;
+  }
+
+  let paragraphIndex = 0;
+  for (let index = 0; index < document.childCount; index++) {
+    const node = document.child(index);
+    if (node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME) {
+      const part = templatePart(node, context.generationTemplate);
+      if (!part) {
+        return null;
+      }
+      parts.push(part);
+      continue;
+    }
+    if (!filesAppended) {
+      appendFileParts(parts, attachments);
+      filesAppended = true;
+    }
+    if (!appendParagraphParts(node, parts)) {
+      return null;
+    }
+    paragraphIndex += 1;
+    if (paragraphIndex < paragraphCount) {
+      appendTextPart(parts, "\n");
+    }
+  }
+  if (!filesAppended) {
+    appendFileParts(parts, attachments);
+  }
+  if (templateCount === 0 && context.generationTemplate !== undefined) {
+    return null;
+  }
+
+  const parsed = userMessageDocumentSchema.safeParse({ version: 1, parts });
+  return parsed.success ? parsed.data : null;
+}
+
+function templateCategory(type: GenerationTemplateType): string {
+  return type === "presentation" ? "slides" : type;
+}
+
+function templatePreviewImageUrl(
+  template: GenerationTemplateRequest,
+): string | null {
+  return template.type === "presentation"
+    ? (template.selection.previewUrl ?? null)
+    : null;
+}
+
+function templateNode(part: Extract<UserMessagePart, { type: "template" }>) {
+  return {
+    type: TEMPLATE_ATTACHMENT_NODE_NAME,
+    attrs: {
+      templateType: part.template.type,
+      title: part.titleSnapshot,
+      category: templateCategory(part.template.type),
+      previewImageUrl: templatePreviewImageUrl(part.template),
+    },
+  } satisfies JSONContent;
+}
+
+/**
+ * Restores the editor-owned portion of a business document. File parts stay in
+ * the existing external attachment state and therefore do not become Tiptap
+ * nodes. Newlines are canonically restored as paragraph boundaries.
+ */
+export function messageDocumentToEditorDoc(value: unknown): JSONContent | null {
+  const parsed = userMessageDocumentSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+
+  const content: JSONContent[] = [];
+  let paragraphContent: JSONContent[] = [];
+  let trailingParagraph = false;
+  let templateCount = 0;
+  const flushParagraph = () => {
+    content.push(
+      paragraphContent.length > 0
+        ? { type: "paragraph", content: paragraphContent }
+        : { type: "paragraph" },
+    );
+    paragraphContent = [];
+    trailingParagraph = false;
+  };
+
+  for (const part of parsed.data.parts) {
+    if (part.type === "text") {
+      const lines = part.text.split("\n");
+      for (const [index, line] of lines.entries()) {
+        if (line.length > 0) {
+          paragraphContent.push({ type: "text", text: line });
+          trailingParagraph = false;
+        }
+        if (index < lines.length - 1) {
+          flushParagraph();
+          trailingParagraph = true;
+        }
+      }
+      continue;
+    }
+    if (part.type === "chat_thread") {
+      paragraphContent.push({
+        type: CHAT_THREAD_MENTION_NODE_NAME,
+        attrs: {
+          threadId: part.threadId,
+          title: part.titleSnapshot,
+        },
+      });
+      trailingParagraph = false;
+      continue;
+    }
+    if (part.type === "template") {
+      templateCount += 1;
+      if (templateCount > 1) {
+        return null;
+      }
+      if (paragraphContent.length > 0) {
+        flushParagraph();
+      }
+      content.push(templateNode(part));
+    }
+  }
+
+  if (paragraphContent.length > 0 || trailingParagraph) {
+    flushParagraph();
+  }
+  if (content.length === 0) {
+    content.push({ type: "paragraph" });
+  }
+  return { type: "doc", content };
+}
+
+/** Serializes the business document to the same plain prompt representation. */
+export function messageDocumentToPrompt(value: unknown): string | null {
+  const parsed = userMessageDocumentSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data.parts
+    .map((part) => {
+      if (part.type === "text") {
+        return part.text;
+      }
+      if (part.type === "chat_thread") {
+        return serializeChatThreadMention(part.threadId, part.titleSnapshot);
+      }
+      return "";
+    })
+    .join("");
+}


### PR DESCRIPTION
## Summary

- add explicit `editorDocToMessageDocument`, `messageDocumentToEditorDoc`, and `messageDocumentToPrompt` codecs for the stable `UserMessageDocument` contract
- map text, `chatThreadMention`, and the shared block-level `templateAttachment` while taking template identity from the existing generation-template state
- keep files in the existing external attachment model and normalize them after a leading template and before the text body
- normalize both paragraph boundaries and hard breaks to `\n`, merge adjacent text parts without trimming, and return `null` for malformed or unsupported documents so callers can retain the legacy path

## Scope

- This PR only introduces the codecs and tests; it does not write `structuredPrompt`, render structured messages, or restore server drafts yet.
- Sequenced after #22357 in the rollout plan, but its code dependency is only the contract introduced by merged #22347.

## Verification

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/user-message-document-codec.test.ts` — 5 tests passed

Part of #22314
