### PR TITLE
perf(api): avoid eager workflow queue encryption

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -247,6 +247,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       );
       for (const actionType of [
         "api_dispatch_pre_create_zero_workflow_automation_entrypoint_gap",
+        "api_dispatch_pre_create_zero_workflow_automation_queue_admission",
         "api_dispatch_pre_create_zero_workflow_event_background_start_gap",
         "api_dispatch_pre_create_zero_workflow_event_load_source_state",
         "api_dispatch_pre_create_zero_workflow_event_load_automations",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -45,6 +45,20 @@ interface SecretKmsProbe {
   readonly generateDataKeyCalls: number;
 }
 
+function generateDataKeyOutput(
+  command: GenerateDataKeyCommand,
+): GenerateDataKeyCommandOutput {
+  return {
+    $metadata: {},
+    KeyId: command.input.KeyId,
+    CiphertextBlob: Buffer.from(
+      `encrypted-data-key:${command.input.KeyId}`,
+      "utf8",
+    ),
+    Plaintext: TEST_DATA_KEY,
+  };
+}
+
 function useSecretKmsProbe(
   overrideGenerateDataKey?: (
     command: GenerateDataKeyCommand,
@@ -66,18 +80,7 @@ function useSecretKmsProbe(
         command,
         generateDataKeyCalls,
       );
-      return (
-        overridden ??
-        Promise.resolve({
-          $metadata: {},
-          KeyId: command.input.KeyId,
-          CiphertextBlob: Buffer.from(
-            `encrypted-data-key:${command.input.KeyId}`,
-            "utf8",
-          ),
-          Plaintext: TEST_DATA_KEY,
-        })
-      );
+      return overridden ?? Promise.resolve(generateDataKeyOutput(command));
     }
 
     return Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY });
@@ -183,10 +186,11 @@ async function createWebhookAutomation(
 async function postWorkflowWebhook(
   automation: WebhookAutomation,
   payload: string,
+  signal: AbortSignal = context.signal,
 ): Promise<{ readonly status: number; readonly body: unknown }> {
   const rawBody = JSON.stringify({ event: payload });
   const timestamp = Math.floor(now() / 1000);
-  const response = await createApp({ signal: context.signal }).request(
+  const response = await createApp({ signal }).request(
     `/api/webhooks/workflow-automations/${automation.token}`,
     {
       method: "POST",
@@ -400,6 +404,59 @@ describe("workflow queue", () => {
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
+  });
+
+  it("finishes required queue persistence when the request aborts during encryption", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+    );
+
+    const kmsStarted = createDeferredPromise<void>(context.signal);
+    const releaseKms = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!kmsStarted.settled()) {
+        kmsStarted.resolve(undefined);
+      }
+      if (!releaseKms.settled()) {
+        releaseKms.resolve(undefined);
+      }
+    });
+    async function encryptAfterRelease(
+      command: GenerateDataKeyCommand,
+    ): Promise<GenerateDataKeyCommandOutput> {
+      await releaseKms.promise;
+      return generateDataKeyOutput(command);
+    }
+    const kms = useSecretKmsProbe((command, callNumber) => {
+      if (callNumber !== 1) {
+        return undefined;
+      }
+      kmsStarted.resolve(undefined);
+      return encryptAfterRelease(command);
+    });
+
+    const requestController = new AbortController();
+    const secondRequest = postWorkflowWebhook(
+      automation,
+      "second",
+      requestController.signal,
+    );
+    await kmsStarted.promise;
+    const abortError = new Error("request aborted during queue encryption");
+    abortError.name = "AbortError";
+    requestController.abort(abortError);
+    releaseKms.resolve(undefined);
+
+    await expect(secondRequest).resolves.toStrictEqual({
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+    expect(kms.generateDataKeyCalls).toBe(1);
+
+    await completeRunThroughSandbox(scenario, firstRunId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
   });
 
   it("starts directly when failed queue encryption becomes unnecessary", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1,14 +1,26 @@
 import { createHash } from "node:crypto";
 
+import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
 import { chatMessagesContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { onTestFinished } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import {
+  setSecretKmsClientForTests,
+  type SecretKmsClient,
+} from "../../../lib/secret-kms-client";
 import { mockNow, now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -27,6 +39,58 @@ const WORKFLOW_NAME = "workflow-queue-workflow";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
   "/api/cron/execute-workflow-automations";
 const CRON_SECRET = "test-cron-secret";
+const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+interface SecretKmsProbe {
+  readonly generateDataKeyCalls: number;
+}
+
+function useSecretKmsProbe(
+  overrideGenerateDataKey?: (
+    command: GenerateDataKeyCommand,
+    callNumber: number,
+  ) => Promise<GenerateDataKeyCommandOutput> | undefined,
+): SecretKmsProbe {
+  let generateDataKeyCalls = 0;
+
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(
+    command: GenerateDataKeyCommand | DecryptCommand,
+  ): Promise<GenerateDataKeyCommandOutput | DecryptCommandOutput> {
+    if (command instanceof GenerateDataKeyCommand) {
+      generateDataKeyCalls += 1;
+      const overridden = overrideGenerateDataKey?.(
+        command,
+        generateDataKeyCalls,
+      );
+      return (
+        overridden ??
+        Promise.resolve({
+          $metadata: {},
+          KeyId: command.input.KeyId,
+          CiphertextBlob: Buffer.from(
+            `encrypted-data-key:${command.input.KeyId}`,
+            "utf8",
+          ),
+          Plaintext: TEST_DATA_KEY,
+        })
+      );
+    }
+
+    return Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY });
+  }
+
+  const client: SecretKmsClient = { send };
+  setSecretKmsClientForTests(client);
+  return {
+    get generateDataKeyCalls() {
+      return generateDataKeyCalls;
+    },
+  };
+}
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };
@@ -217,14 +281,18 @@ describe("workflow queue", () => {
   it("queues webhook events behind the active run and drains one per completion", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
+    const kms = useSecretKmsProbe();
 
     const first = await postWorkflowWebhook(automation, "first");
     const firstRunId = expectAcceptedRunId(first);
+    expect(kms.generateDataKeyCalls).toBe(2);
 
     // The workflow is busy: the next two events are accepted into the queue
     // without creating runs.
     expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "second"));
+    expect(kms.generateDataKeyCalls).toBe(3);
     expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "third"));
+    expect(kms.generateDataKeyCalls).toBe(4);
     await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
       firstRunId,
     ]);
@@ -236,6 +304,8 @@ describe("workflow queue", () => {
   });
 
   it("coalesces schedule ticks: at most one pending tick per automation", async () => {
+    // Keep this global cron scan before schedules created by parallel test files.
+    mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const webhookAutomation = await createWebhookAutomation(scenario);
 
@@ -256,15 +326,18 @@ describe("workflow queue", () => {
     if (!created.body.nextRunAt) {
       throw new Error("Expected a scheduled next run");
     }
+    const kms = useSecretKmsProbe();
 
     // Occupy the workflow with a webhook-triggered run.
     const busyRunId = expectAcceptedRunId(
       await postWorkflowWebhook(webhookAutomation, "busy"),
     );
+    expect(kms.generateDataKeyCalls).toBe(2);
 
     // Two due ticks while busy: the second coalesces into the pending one.
     mockNow(Date.parse(created.body.nextRunAt) + 60_000);
     await executeDueWorkflowAutomations();
+    expect(kms.generateDataKeyCalls).toBe(3);
     const updated = await accept(
       automationsClient().update({
         headers: authHeaders(),
@@ -282,8 +355,10 @@ describe("workflow queue", () => {
     if (!updated.body.nextRunAt) {
       throw new Error("Expected the updated automation to re-arm");
     }
+    const coalescedKms = useSecretKmsProbe();
     mockNow(Date.parse(updated.body.nextRunAt) + 60_000);
     await executeDueWorkflowAutomations();
+    expect(coalescedKms.generateDataKeyCalls).toBe(0);
 
     await completeRunThroughSandbox(scenario, busyRunId);
     const afterBusy = await workflowRunIds(webhookAutomation.threadId);
@@ -294,6 +369,55 @@ describe("workflow queue", () => {
     await expect(
       workflowRunIds(webhookAutomation.threadId),
     ).resolves.toHaveLength(2);
+  });
+
+  it("starts directly when failed queue encryption becomes unnecessary", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+    );
+
+    const kmsStarted = createDeferredPromise<void>(context.signal);
+    const releaseKms = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!kmsStarted.settled()) {
+        kmsStarted.resolve(undefined);
+      }
+      if (!releaseKms.settled()) {
+        releaseKms.resolve(undefined);
+      }
+    });
+    async function failKmsAfterRelease(): Promise<GenerateDataKeyCommandOutput> {
+      await releaseKms.promise;
+      throw new Error("queue payload encryption failed");
+    }
+    const kms = useSecretKmsProbe((_command, callNumber) => {
+      if (callNumber !== 1) {
+        return undefined;
+      }
+      kmsStarted.resolve(undefined);
+      return failKmsAfterRelease();
+    });
+
+    const secondRequest = postWorkflowWebhook(automation, "second");
+    await kmsStarted.promise;
+    expect(kms.generateDataKeyCalls).toBe(1);
+    await completeRunThroughSandbox(scenario, firstRunId);
+    releaseKms.resolve(undefined);
+
+    const secondRunId = expectAcceptedRunId(await secondRequest);
+    expect(kms.generateDataKeyCalls).toBe(3);
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      firstRunId,
+      secondRunId,
+    ]);
+
+    await completeRunThroughSandbox(scenario, secondRunId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      firstRunId,
+      secondRunId,
+    ]);
   });
 
   it("drains queued user chat messages before workflow events", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -371,6 +371,37 @@ describe("workflow queue", () => {
     ).resolves.toHaveLength(2);
   });
 
+  it("propagates queue encryption failure while persistence remains necessary", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+    );
+
+    const encryptionError = new Error("queue payload encryption failed");
+    const kms = useSecretKmsProbe((_command, callNumber) => {
+      return callNumber === 1 ? Promise.reject(encryptionError) : undefined;
+    });
+
+    const failed = await postWorkflowWebhook(automation, "second");
+    expect(failed).toStrictEqual({
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+    expect(kms.generateDataKeyCalls).toBe(1);
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(
+      encryptionError,
+    );
+
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      firstRunId,
+    ]);
+    await completeRunThroughSandbox(scenario, firstRunId);
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      firstRunId,
+    ]);
+  });
+
   it("starts directly when failed queue encryption becomes unnecessary", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -64,6 +64,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_teams_entrypoint_gap"
   | "api_dispatch_pre_create_zero_teams_create_run"
   | "api_dispatch_pre_create_zero_workflow_automation_entrypoint_gap"
+  | "api_dispatch_pre_create_zero_workflow_automation_queue_admission"
   | "api_dispatch_pre_create_zero_workflow_automation_check_active_run"
   | "api_dispatch_pre_create_zero_workflow_automation_check_target_access"
   | "api_dispatch_pre_create_zero_workflow_automation_resolve_model_context"

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -11,6 +11,7 @@ import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import type { Db, ReadonlyDb } from "../external/db";
+import { settle } from "../utils";
 import {
   decryptPersistentSecretsMap,
   encryptPersistentSecretsMap,
@@ -156,28 +157,26 @@ async function pendingTickExistsForAutomation(
 }
 
 type WorkflowQueueAdmission = "proceed" | "enqueued";
+type WorkflowQueueAdmissionAttempt =
+  | { readonly kind: "proceed" }
+  | { readonly kind: "enqueued" }
+  | { readonly kind: "payload-required" };
 
-/**
- * Decide whether a fired automation event may create its run now or must wait in
- * the chat message queue. Serialized per chat thread via an advisory lock.
- * Schedule ticks coalesce per automation: at most one pending tick.
- */
-export async function admitWorkflowAutomationEvent(
+interface WorkflowQueueAdmissionArgs {
+  readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
+  readonly chatThreadId: string;
+  readonly triggerSource: TriggerSource;
+  readonly triggerBrief: string | undefined;
+  readonly params: WorkflowQueueEventParams;
+  readonly signal: AbortSignal;
+}
+
+async function attemptWorkflowQueueAdmission(
   db: Db,
-  args: {
-    readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
-    readonly chatThreadId: string;
-    readonly triggerSource: TriggerSource;
-    readonly triggerBrief: string | undefined;
-    readonly params: WorkflowQueueEventParams;
-  },
-): Promise<WorkflowQueueAdmission> {
+  args: WorkflowQueueAdmissionArgs,
+  encryptedParams: string | undefined,
+): Promise<WorkflowQueueAdmissionAttempt> {
   const { automation } = args;
-  const encryptedParams = await encryptWorkflowQueueEventParams(args.params, {
-    userId: automation.ownerUserId,
-    orgId: automation.orgId,
-  });
-
   return await db.transaction(async (tx) => {
     await tx.execute(chatMessageQueueLock(args.chatThreadId));
 
@@ -189,7 +188,7 @@ export async function admitWorkflowAutomationEvent(
         args.chatThreadId,
       );
       if (!busy && !(await pendingWorkflowEventExists(tx, args.chatThreadId))) {
-        return "proceed";
+        return { kind: "proceed" };
       }
     }
 
@@ -197,7 +196,11 @@ export async function admitWorkflowAutomationEvent(
       automation.kind === "schedule" &&
       (await pendingTickExistsForAutomation(tx, automation.id))
     ) {
-      return "enqueued";
+      return { kind: "enqueued" };
+    }
+
+    if (encryptedParams === undefined) {
+      return { kind: "payload-required" };
     }
 
     await tx.insert(chatMessageQueue).values({
@@ -210,8 +213,58 @@ export async function admitWorkflowAutomationEvent(
       triggerBrief: args.triggerBrief ?? null,
       encryptedParams,
     });
-    return "enqueued";
+    return { kind: "enqueued" };
   });
+}
+
+/**
+ * Decide whether a fired automation event may create its run now or must wait in
+ * the chat message queue. Serialized per chat thread via an advisory lock.
+ * Schedule ticks coalesce per automation: at most one pending tick.
+ * Queue payload encryption runs only after a locked attempt requires it and
+ * outside the transaction; the subsequent locked attempt owns the final state.
+ */
+export async function admitWorkflowAutomationEvent(
+  db: Db,
+  args: WorkflowQueueAdmissionArgs,
+): Promise<WorkflowQueueAdmission> {
+  const { automation } = args;
+  const initial = await attemptWorkflowQueueAdmission(db, args, undefined);
+  args.signal.throwIfAborted();
+  if (initial.kind !== "payload-required") {
+    return initial.kind;
+  }
+
+  const encryptedParamsResult = await settle(
+    encryptWorkflowQueueEventParams(args.params, {
+      userId: automation.ownerUserId,
+      orgId: automation.orgId,
+    }),
+    args.signal,
+  );
+  if (!encryptedParamsResult.ok) {
+    const retryWithoutPayload = await attemptWorkflowQueueAdmission(
+      db,
+      args,
+      undefined,
+    );
+    args.signal.throwIfAborted();
+    if (retryWithoutPayload.kind !== "payload-required") {
+      return retryWithoutPayload.kind;
+    }
+    throw encryptedParamsResult.error;
+  }
+
+  const final = await attemptWorkflowQueueAdmission(
+    db,
+    args,
+    encryptedParamsResult.value,
+  );
+  args.signal.throwIfAborted();
+  if (final.kind === "payload-required") {
+    throw new Error("Workflow queue admission still required encrypted params");
+  }
+  return final.kind;
 }
 
 export interface ClaimedWorkflowQueueEvent {

--- a/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-message-queue.service.ts
@@ -168,7 +168,6 @@ interface WorkflowQueueAdmissionArgs {
   readonly triggerSource: TriggerSource;
   readonly triggerBrief: string | undefined;
   readonly params: WorkflowQueueEventParams;
-  readonly signal: AbortSignal;
 }
 
 async function attemptWorkflowQueueAdmission(
@@ -230,7 +229,6 @@ export async function admitWorkflowAutomationEvent(
 ): Promise<WorkflowQueueAdmission> {
   const { automation } = args;
   const initial = await attemptWorkflowQueueAdmission(db, args, undefined);
-  args.signal.throwIfAborted();
   if (initial.kind !== "payload-required") {
     return initial.kind;
   }
@@ -240,7 +238,6 @@ export async function admitWorkflowAutomationEvent(
       userId: automation.ownerUserId,
       orgId: automation.orgId,
     }),
-    args.signal,
   );
   if (!encryptedParamsResult.ok) {
     const retryWithoutPayload = await attemptWorkflowQueueAdmission(
@@ -248,7 +245,6 @@ export async function admitWorkflowAutomationEvent(
       args,
       undefined,
     );
-    args.signal.throwIfAborted();
     if (retryWithoutPayload.kind !== "payload-required") {
       return retryWithoutPayload.kind;
     }
@@ -260,7 +256,6 @@ export async function admitWorkflowAutomationEvent(
     args,
     encryptedParamsResult.value,
   );
-  args.signal.throwIfAborted();
   if (final.kind === "payload-required") {
     throw new Error("Workflow queue admission still required encrypted params");
   }

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -383,27 +383,36 @@ async function buildTimedWorkflowAutomationRunInput(args: {
 async function enqueueWorkflowAutomationEventIfBusy(input: {
   readonly db: Db;
   readonly args: RunWorkflowAutomationNowArgs;
+  readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
 }): Promise<boolean> {
-  const { db, args, signal } = input;
+  const { db, args, signal, timing } = input;
   const { automation, chatThreadId } = args.due;
   if (args.bypassWorkflowQueue === true) {
     return false;
   }
-  const admission = await admitWorkflowAutomationEvent(db, {
-    automation,
-    chatThreadId,
-    triggerSource: args.triggerSource ?? "workflow-schedule",
-    triggerBrief: args.triggerBrief,
-    params: {
-      version: 1,
-      prompt: args.prompt,
-      appendSystemPrompt: args.appendSystemPrompt,
-      callbacks: args.callbacks,
-      recordLastRunId: args.recordLastRunId,
-      recordLastRunAt: args.recordLastRunAt,
+  const admission = await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_pre_create_zero_workflow_automation_queue_admission",
+    "nested",
+    async () => {
+      return await admitWorkflowAutomationEvent(db, {
+        automation,
+        chatThreadId,
+        triggerSource: args.triggerSource ?? "workflow-schedule",
+        triggerBrief: args.triggerBrief,
+        params: {
+          version: 1,
+          prompt: args.prompt,
+          appendSystemPrompt: args.appendSystemPrompt,
+          callbacks: args.callbacks,
+          recordLastRunId: args.recordLastRunId,
+          recordLastRunAt: args.recordLastRunAt,
+        },
+        signal,
+      });
     },
-  });
+  );
   signal.throwIfAborted();
   if (admission === "enqueued") {
     await publishChatThreadWorkflowQueueChangedSafely(
@@ -474,6 +483,7 @@ export const runWorkflowAutomationNow$ = command(
     const enqueued = await enqueueWorkflowAutomationEventIfBusy({
       db,
       args,
+      timing,
       signal,
     });
     if (enqueued) {

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -409,7 +409,6 @@ async function enqueueWorkflowAutomationEventIfBusy(input: {
           recordLastRunId: args.recordLastRunId,
           recordLastRunAt: args.recordLastRunAt,
         },
-        signal,
       });
     },
   );


### PR DESCRIPTION
## Summary

- classify workflow queue admission under the existing per-thread lock before preparing an encrypted queue payload
- encrypt only when persistence is still required, then re-evaluate under the lock before inserting
- recheck admission after a KMS failure so a concurrent direct/coalesced transition can complete without a stale failure
- preserve durable queue admission when request cancellation occurs during required encryption
- record complete queue-admission timing and cover direct, enqueue, coalescing, persistent KMS failure, cancellation, and concurrent-transition behavior with API integration tests

## Compatibility

- no database schema or migration changes
- no public API, runner protocol, queue payload, or ciphertext format changes
- KMS calls remain outside database transactions
- direct-run ownership behavior tracked by #21046 is intentionally unchanged

## Validation

- `pnpm -F @vm0/db db:migrate`
- focused Vitest run for `zero-workflow-queue.test.ts` and `webhooks-github-workflow.test.ts` (7/7 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api build`
- commit hooks: Prettier, Knip, repository type checks, and commitlint

A local unsharded API-suite diagnostic completed 2,289/2,294 tests. Its remaining shared-state failures passed independently on fresh databases (40/40, 22/22, and 5/5); the PR's isolated 8-shard CI run is the authoritative full-suite validation.

Closes #22349

Parent: #21674
