### PR TITLE
test(mitm-addon): reject lossy x usage assertions

### DIFF
--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -89,6 +89,7 @@ class TestXConnectorResponsePipeline:
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category)
         assert by_category == {"posts.read": 1, "user.read": 1}
 
     @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
@@ -108,6 +109,7 @@ class TestXConnectorResponsePipeline:
         payloads = self._call_and_get_billing(flow)
 
         by_category = {event["category"]: event["quantity"] for event in payloads}
+        assert len(payloads) == len(by_category)
         assert by_category == {"posts.read": 1, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
@@ -268,10 +270,11 @@ class TestXConnectorResponsePipeline:
         # 4. Verify billing payloads
         payloads = webhook.usage_events()
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        # 3 tweets primary + 0 from includes.tweets (none here) = 3
-        assert by_cat["posts.read"] == 3
-        # 3 users from includes
-        assert by_cat["user.read"] == 3
+        assert len(payloads) == len(by_cat)
+        assert by_cat == {
+            "posts.read": 3,  # 3 primary tweets; no includes.tweets
+            "user.read": 3,  # 3 users from includes
+        }
 
     def test_full_streaming_pipeline_counts_final_line_without_newline(
         self, tmp_path, real_flow, mitm_ctx, headers
@@ -290,6 +293,7 @@ class TestXConnectorResponsePipeline:
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert len(payloads) == len(by_cat)
         assert by_cat == {"posts.read": 2, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata
 
@@ -353,6 +357,7 @@ class TestXConnectorResponsePipeline:
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert len(payloads) == len(by_cat)
         assert by_cat == {"posts.read": 1, "media.read": 1}
 
     @pytest.mark.parametrize(
@@ -385,6 +390,7 @@ class TestXConnectorResponsePipeline:
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert len(payloads) == len(by_cat)
         assert by_cat == {"posts.read": 1, "user.read": 1}
 
     def test_full_streaming_pipeline_bounds_unknown_include_categories(
@@ -414,13 +420,13 @@ class TestXConnectorResponsePipeline:
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
-        assert by_cat["posts.read"] == 71
-        assert by_cat["user.read"] == 1
-        assert by_cat["includes.future_0"] == 1
-        assert by_cat["includes.future_63"] == 1
-        assert "includes.future_64" not in by_cat
-        assert by_cat["includes.__overflow__"] == 6
-        assert len(by_cat) == 67
+        assert len(payloads) == len(by_cat)
+        assert by_cat == {
+            "posts.read": 71,
+            "user.read": 1,
+            **{f"includes.future_{index}": 1 for index in range(64)},
+            "includes.__overflow__": 6,
+        }
         assert all(len(category) <= 100 for category in by_cat)
 
     def test_response_logs_incremental_x_json_parse_error(self, tmp_path, real_flow, mitm_ctx):
@@ -576,8 +582,8 @@ class TestXConnectorErrorPipeline:
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
         payloads = webhook.usage_events()
         by_cat = {p["category"]: p["quantity"] for p in payloads}
-        assert by_cat["posts.read"] == 2  # not 3; partial trailing dropped
-        assert by_cat["user.read"] == 1
+        assert len(payloads) == len(by_cat)
+        assert by_cat == {"posts.read": 2, "user.read": 1}
         assert "connector_response_report_on_interruption" not in flow.metadata
 
     def test_full_pipeline_stream_error_counts_complete_final_line_without_newline(
@@ -598,5 +604,6 @@ class TestXConnectorErrorPipeline:
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
+        assert len(payloads) == len(by_cat)
         assert by_cat == {"posts.read": 2, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
@@ -62,6 +62,7 @@ def test_logs_expansions_includes(x_usage, tmp_path, real_flow):
     )
     payloads = x_usage.call_and_get_billing(flow)
     by_cat = {p["category"]: p["quantity"] for p in payloads}
+    assert len(payloads) == len(by_cat)
     assert by_cat == {"posts.read": 1, "user.read": 1, "media.read": 2}
 
 
@@ -90,6 +91,7 @@ def test_posts_usage_events_as_one_batch(x_usage, tmp_path, real_flow):
     assert payload["runId"] == "run-abc-123"
     assert "idempotencyKey" not in payload
     by_cat = {event["category"]: event for event in payload["events"]}
+    assert len(payload["events"]) == len(by_cat)
     assert set(by_cat) == {"posts.read", "user.read"}
     assert by_cat["posts.read"]["kind"] == "connector"
     assert by_cat["posts.read"]["provider"] == "x"
@@ -145,12 +147,13 @@ def test_bounds_unknown_include_categories_before_buffering(x_usage, tmp_path, r
         for body in bodies
         for event in body["events"]
     )
-    by_cat = {event["category"]: event["quantity"] for body in bodies for event in body["events"]}
-    assert len(by_cat) == 65
-    assert "includes.future_0" in by_cat
-    assert "includes.future_63" in by_cat
-    assert "includes.future_64" not in by_cat
-    assert by_cat["includes.__overflow__"] == 37
+    events = [event for body in bodies for event in body["events"]]
+    by_cat = {event["category"]: event["quantity"] for event in events}
+    assert len(events) == len(by_cat)
+    assert by_cat == {
+        **{f"includes.future_{index}": 1 for index in range(64)},
+        "includes.__overflow__": 37,
+    }
     assert all(len(category) <= 100 for category in by_cat)
 
 
@@ -172,6 +175,7 @@ def test_overlong_unknown_include_key_uses_overflow_category(x_usage, tmp_path, 
     payloads = x_usage.call_and_get_billing(flow)
     by_cat = {p["category"]: p["quantity"] for p in payloads}
 
+    assert len(payloads) == len(by_cat)
     assert by_cat == {"posts.read": 1, "includes.__overflow__": 4}
     assert all(len(category) <= 100 for category in by_cat)
 
@@ -255,6 +259,7 @@ def test_logs_expansions_users_and_referenced_tweets(x_usage, tmp_path, real_flo
     )
     payloads = x_usage.call_and_get_billing(flow)
     by_cat = {p["category"]: p["quantity"] for p in payloads}
+    assert len(payloads) == len(by_cat)
     assert by_cat == {
         "posts.read": 3,  # 1 primary + 2 referenced tweets
         "user.read": 2,
@@ -283,6 +288,7 @@ def test_handles_unknown_includes_key(x_usage, tmp_path, real_flow):
     )
     payloads = x_usage.call_and_get_billing(flow)
     by_cat = {p["category"]: p["quantity"] for p in payloads}
+    assert len(payloads) == len(by_cat)
     # 1 primary (posts.read) + 1 users include (mapped to user.read)
     # + 3 unknown-widget includes (emitted as `includes.future_widget`).
     assert by_cat == {

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -32,9 +32,11 @@ def test_x_stream_mixed_rows_bills_valid_counts_and_logs_risk(x_usage, tmp_path,
     }
     payloads = x_usage.call_and_get_billing(flow)
     by_cat = {p["category"]: p["quantity"] for p in payloads}
-    # tweet.read primary 50 + 12 from includes.tweets = 62
-    assert by_cat["posts.read"] == 62
-    assert by_cat["user.read"] == 47
+    assert len(payloads) == len(by_cat)
+    assert by_cat == {
+        "posts.read": 62,  # 50 primary + 12 from includes.tweets
+        "user.read": 47,
+    }
 
     [entry] = [
         entry
@@ -127,6 +129,7 @@ def test_legacy_x_json_fallback_extracts_selective_field_counts(x_usage, tmp_pat
     payloads = x_usage.call_and_get_billing(flow)
 
     by_cat = {p["category"]: p["quantity"] for p in payloads}
+    assert len(payloads) == len(by_cat)
     assert by_cat == {"posts.read": 2, "user.read": 1}
 
 


### PR DESCRIPTION
## Summary

- reject duplicate X usage categories before relying on category-keyed test projections
- compare complete webhook category/quantity output for stream lifecycle, fallback, and include-boundary scenarios
- extend the same invariant across pipeline and direct X usage integration tests

## Exclusions

- no runtime billing or usage-buffer behavior changes
- no webhook schema, API, runner protocol, database schema, migration, or persisted-data changes
- no blanket uniqueness rule for model-provider or source-preserving usage flows

## Validation

- `ruff format --check tests/test_x_connector_pipeline.py tests/x_connector_usage/test_reads.py tests/x_connector_usage/test_unparseable.py`
- `ruff check tests/test_x_connector_pipeline.py tests/x_connector_usage/test_reads.py tests/x_connector_usage/test_unparseable.py`
- `basedpyright`
- `pytest -q tests/test_x_connector_pipeline.py tests/x_connector_usage` (`209 passed`)

Closes #22329
