### PR TITLE
fix: simplify email draft sidebar metadata and attachments

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -223,9 +223,11 @@ describe("chat message action cards", () => {
           from: "sender@example.com",
           to: ["recipient@example.com"],
           cc: ["copy@example.com"],
-          bcc: [],
+          bcc: ["hidden@example.com"],
           subject: "Hello",
           body: "Mail body",
+          replyTo: "reply-only@example.com",
+          inReplyTo: "<thread-message@example.com>",
           status: sent ? "sent" : "draft",
           detailAvailable: true,
           gmailDraftId: "r-test-draft",
@@ -237,7 +239,7 @@ describe("chat message action cards", () => {
                 sentAt: "2026-07-14T10:01:00.000Z",
               }
             : {}),
-          references: [],
+          references: ["<reference-message@example.com>"],
           attachments: [
             {
               filename: "report.pdf",
@@ -261,16 +263,18 @@ describe("chat message action cards", () => {
           from: "sender@example.com",
           to: ["recipient@example.com"],
           cc: ["copy@example.com"],
-          bcc: [],
+          bcc: ["hidden@example.com"],
           subject: "Hello",
           body: "Mail body",
+          replyTo: "reply-only@example.com",
+          inReplyTo: "<thread-message@example.com>",
           status: "sent",
           detailAvailable: true,
           gmailDraftId: "r-test-draft",
           gmailThreadId: "gmail-thread-id",
           gmailMessageId: "gmail-message-id",
           sentGmailMessageId: "gmail-sent-message-id",
-          references: [],
+          references: ["<reference-message@example.com>"],
           attachments: [
             {
               filename: "report.pdf",
@@ -344,8 +348,18 @@ describe("chat message action cards", () => {
     let sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(within(sidebar).getByText("sender@example.com")).toBeInTheDocument();
     expect(within(sidebar).getByText("copy@example.com")).toBeInTheDocument();
+    expect(within(sidebar).getByText("hidden@example.com")).toBeInTheDocument();
     expect(within(sidebar).getByText("Mail body")).toBeInTheDocument();
     expect(within(sidebar).getByText("report.pdf")).toBeInTheDocument();
+    expect(within(sidebar).getByText("242 KB")).toBeInTheDocument();
+    expect(within(sidebar).queryByText(/application\/pdf/u)).toBeNull();
+    expect(within(sidebar).queryByText("reply-only@example.com")).toBeNull();
+    expect(
+      within(sidebar).queryByText("<thread-message@example.com>"),
+    ).toBeNull();
+    expect(
+      within(sidebar).queryByText("<reference-message@example.com>"),
+    ).toBeNull();
     expect(within(sidebar).queryByRole("textbox")).not.toBeInTheDocument();
     expect(draftRequests).toBe(1);
     await user.click(await waitForButtonByText("Send", sidebar));
@@ -427,6 +441,8 @@ describe("chat message action cards", () => {
     await user.click(card);
     const sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(draftRequests).toBe(1);
+    expect(within(sidebar).queryByText("Cc")).toBeNull();
+    expect(within(sidebar).queryByText("Bcc")).toBeNull();
     await user.click(await waitForButtonByText("Delete", sidebar));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -71,6 +71,22 @@ function DetailField({
   );
 }
 
+function formatAttachmentSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB"] as const;
+  let value = bytes / 1024;
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i]!;
+    if (value < 1024 || i === units.length - 1) {
+      return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
+    }
+    value = value / 1024;
+  }
+  return `${bytes} B`;
+}
+
 function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
   const attachments = draft.version === 3 ? draft.attachments : [];
   return (
@@ -105,7 +121,7 @@ function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
               return (
                 <div
                   key={`${attachment.filename}-${attachment.contentType}-${attachment.size}`}
-                  className="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2.5"
+                  className="flex items-center gap-3 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 py-2.5"
                 >
                   <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
                     <IconPaperclip size={15} />
@@ -115,8 +131,7 @@ function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
                       {attachment.filename}
                     </span>
                     <span className="block truncate text-xs text-muted-foreground">
-                      {attachment.contentType} ·{" "}
-                      {attachment.size.toLocaleString()} bytes
+                      {formatAttachmentSize(attachment.size)}
                     </span>
                   </span>
                 </div>
@@ -124,15 +139,6 @@ function MailDraftDetails({ draft }: { readonly draft: ZeroMailDraft }) {
             })}
           </div>
         </div>
-      ) : null}
-      {draft.replyTo ? (
-        <DetailField label="Reply-to" value={draft.replyTo} />
-      ) : null}
-      {draft.inReplyTo ? (
-        <DetailField label="In-reply-to" value={draft.inReplyTo} />
-      ) : null}
-      {draft.references.length > 0 ? (
-        <DetailField label="References" value={draft.references.join(" ")} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

- keep the email draft sidebar focused on sender, recipients, subject, and message by omitting reply-only mail headers
- continue showing Cc and Bcc directly below To only when those recipient lists are present
- present attachments as compact neutral rows with the filename and a human-readable size instead of MIME type and raw bytes

## User impact

Email drafts are easier to scan because internal reply metadata is hidden and attachment details use familiar file sizes.

## Verification

- `pnpm exec prettier --write apps/platform/src/views/zero-page/mail-draft-sidebar.tsx apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --silent=passed-only` (24 tests passed)

Full local Vitest and a local dev server were not run, per repository PR verification guidance.
