### PR TITLE
feat(api): mount external connector skills by exact version

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -5,6 +5,10 @@ import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/con
 import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 import { zeroSteamPlayerContract } from "@vm0/api-contracts/contracts/zero-steam-player";
 import {
+  testSystemStoragePresignedUrlCacheStateContract,
+  type TestSystemStoragePresignedUrlCacheStateActionBody,
+} from "@vm0/api-contracts/contracts/test-system-storage-presigned-url-cache-state";
+import {
   zeroConnectorOpenIdStartContract,
   zeroConnectorsSearchContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
@@ -18,6 +22,7 @@ import {
   zeroWorkflowsDetailContract,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { HttpResponse, http } from "msw";
 import {
   afterEach,
@@ -29,6 +34,7 @@ import {
 } from "vitest";
 
 import { createApp } from "../../../app-factory";
+import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
@@ -56,6 +62,7 @@ import {
 import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
 
 const context = testContext();
 const zeroMocks = createZeroRouteMocks(context);
@@ -703,8 +710,10 @@ function setArtifactAuthMethods(
   firstRecord(artifact.connectors, "connectors").authMethods = methods;
 }
 
-function buildBundledSkill(connectorRef: string): JsonRecord {
-  const versionId = "a".repeat(64);
+function buildBundledSkill(
+  connectorRef: string,
+  versionId = "a".repeat(64),
+): JsonRecord {
   const storageName = `connector-skill@${connectorRef}`;
   const prefix = `__system__/volume/${storageName}/${versionId}`;
   return {
@@ -1182,6 +1191,72 @@ function cronHeaders(secret = CRON_SECRET): { readonly authorization: string } {
 
 function cronClient() {
   return setupApp({ context })(cronConnectorCatalogContract);
+}
+
+interface VolumeStorageState {
+  readonly s3_prefix: string;
+  readonly size: number;
+  readonly file_count: number;
+  readonly head_version_id: string | null;
+}
+
+function systemStorageStateClient() {
+  return setupAppWithRoutes({
+    context,
+    routes: testSystemStoragePresignedUrlCacheStateRoutes,
+  })(testSystemStoragePresignedUrlCacheStateContract);
+}
+
+async function systemStorageStateAction(
+  body: TestSystemStoragePresignedUrlCacheStateActionBody,
+) {
+  return await accept(systemStorageStateClient().action({ body }), [200]);
+}
+
+async function readVolumeStorageState(args: {
+  readonly orgId: string;
+  readonly storageName: string;
+}): Promise<VolumeStorageState | null> {
+  const response = await systemStorageStateAction({
+    action: "read-storage-state",
+    org_id: args.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: args.storageName,
+  });
+  return response.body.storage_state ?? null;
+}
+
+async function restoreVolumeStorageState(args: {
+  readonly orgId: string;
+  readonly storageName: string;
+  readonly previous: VolumeStorageState | null;
+}): Promise<void> {
+  await systemStorageStateAction({
+    action: "restore-storage-state",
+    org_id: args.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: args.storageName,
+    previous: args.previous,
+  });
+}
+
+async function seedVolumeStorageVersion(args: {
+  readonly orgId: string;
+  readonly storageName: string;
+  readonly versionId: string;
+  readonly s3Prefix: string;
+  readonly s3Key: string;
+}): Promise<void> {
+  await systemStorageStateAction({
+    action: "seed-storage-version",
+    org_id: args.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: args.storageName,
+    version_id: args.versionId,
+    s3_prefix: args.s3Prefix,
+    s3_key: args.s3Key,
+    archive_size: 321,
+  });
 }
 
 async function syncCatalog() {
@@ -2259,6 +2334,196 @@ describe("connector catalog valid lifecycle", () => {
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeRun);
     await runs.requestCancelRun(actor, run.runId, [200]);
   }, 15_000);
+
+  it("mounts an external connector skill from its exact system version", async () => {
+    const connectorRef = `external-skill-${randomUUID().slice(0, 8)}`;
+    const storageName = `connector-skill@${connectorRef}`;
+    const selectedVersionId = createHash("sha256")
+      .update(`selected:${randomUUID()}`)
+      .digest("hex");
+    const otherVersionId = createHash("sha256")
+      .update(`other:${randomUUID()}`)
+      .digest("hex");
+    const newerVersionId = createHash("sha256")
+      .update(`newer:${randomUUID()}`)
+      .digest("hex");
+    const canonicalPrefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
+    configureSource();
+    const release = buildRelease({
+      version: "2026-07-15.external-exact-skill",
+      connectorRef,
+      label: "External Exact Skill",
+      mutatePrivate: (artifact) => {
+        firstRecord(artifact.connectors, "connectors").skill =
+          buildBundledSkill(connectorRef, selectedVersionId);
+      },
+    });
+    serveObjects(catalogObjects([release], release));
+    await syncCatalog();
+    mockEnv("CONNECTOR_CATALOG_SOURCE_MODE", "external");
+
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped test actor");
+    }
+    const runtimeOrgId = actor.orgId;
+    const previousSystemState = await readVolumeStorageState({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+    });
+    const previousRuntimeState = await readVolumeStorageState({
+      orgId: runtimeOrgId,
+      storageName,
+    });
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "External exact connector skill agent",
+      visibility: "private",
+    });
+    let successfulRunId: string | undefined;
+    onTestFinished(async () => {
+      context.mocks.s3.send.mockResolvedValue({ Contents: [] });
+      if (successfulRunId) {
+        await runs.requestCancelRun(actor, successfulRunId, [200, 404]);
+      }
+      await systemStorageStateAction({
+        action: "cleanup",
+        object_key_prefix: canonicalPrefix,
+      });
+      await restoreVolumeStorageState({
+        orgId: SYSTEM_ORG_ID,
+        storageName,
+        previous: previousSystemState,
+      });
+      await restoreVolumeStorageState({
+        orgId: runtimeOrgId,
+        storageName,
+        previous: previousRuntimeState,
+      });
+      await connectorsApi.deleteConnectorByType(
+        actor,
+        connectorRef,
+        [204, 404],
+      );
+      await bdd.deleteAgent(actor, agent.agentId);
+    });
+    await connectorsApi.connectManualGrant(
+      actor,
+      connectorRef,
+      "api-token",
+      { credential: "catalog-skill-secret" },
+      agent.agentId,
+    );
+
+    const createSkillRun = async () => {
+      return await runs.createRun(actor, {
+        agentId: agent.agentId,
+        prompt: "Use the connector skill",
+        modelProvider: "anthropic-api-key",
+      });
+    };
+    const expectRegistrationFailure = async () => {
+      const failed = await createSkillRun();
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: "Connector skill registration is unavailable",
+      });
+    };
+
+    await seedVolumeStorageVersion({
+      orgId: runtimeOrgId,
+      storageName,
+      versionId: selectedVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/${selectedVersionId}`,
+    });
+    await expectRegistrationFailure();
+    await restoreVolumeStorageState({
+      orgId: runtimeOrgId,
+      storageName,
+      previous: previousRuntimeState,
+    });
+
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: otherVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/${otherVersionId}`,
+    });
+    await expectRegistrationFailure();
+
+    const wrongPrefix = `${SYSTEM_ORG_ID}/volume/wrong-${storageName}`;
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: selectedVersionId,
+      s3Prefix: wrongPrefix,
+      s3Key: `${wrongPrefix}/${selectedVersionId}`,
+    });
+    await expectRegistrationFailure();
+
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: selectedVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/wrong-${selectedVersionId}`,
+    });
+    await expectRegistrationFailure();
+
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: selectedVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/${selectedVersionId}`,
+    });
+    await seedVolumeStorageVersion({
+      orgId: SYSTEM_ORG_ID,
+      storageName,
+      versionId: newerVersionId,
+      s3Prefix: canonicalPrefix,
+      s3Key: `${canonicalPrefix}/${newerVersionId}`,
+    });
+
+    const run = await createSkillRun();
+    successfulRunId = run.runId;
+    expect(run.status).not.toBe("failed");
+    await runs.heartbeatRunner(runnerGroup);
+    await expect
+      .poll(
+        async () => {
+          return (await runs.pollRunner(runnerGroup)).body.job?.runId;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(run.runId);
+    const claim = await runs.claimRunnerJob(run.runId);
+    const mountedSkills =
+      claim.storageManifest?.storages.filter((storage) => {
+        return (
+          storage.mountPath === `/home/user/.claude/skills/${connectorRef}`
+        );
+      }) ?? [];
+    expect(mountedSkills).toHaveLength(1);
+    expect(mountedSkills[0]).toMatchObject({
+      name: storageName,
+      mountPath: `/home/user/.claude/skills/${connectorRef}`,
+      vasStorageName: storageName,
+      vasVersionId: selectedVersionId,
+      archiveSize: 321,
+      archiveUrl: expect.any(String),
+    });
+    await runs.requestCancelRun(actor, run.runId, [200]);
+    successfulRunId = undefined;
+  }, 30_000);
 
   it("executes an external device grant with catalog-owned storage", async () => {
     mockTestOAuthDeviceConnectorProvider();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -771,21 +771,11 @@ function skillMountPath(
 // declared in the compose — a run can execute on a provider whose framework
 // differs from the compose, and skills mounted at the wrong path are invisible
 // to the agent.
-function buildSystemSkillVolumes(
-  connectorTypes: readonly ConnectorCatalogRef[],
+function buildLegacySystemSkillVolumes(
+  skillNames: readonly string[],
   framework: SupportedFramework,
 ): readonly AdditionalVolume[] {
-  const seedNames = [...SEED_SKILLS, GOAL_SKILL_NAME];
-  // Exact catalog skill selection is owned by #21815. Until then, preserve
-  // the existing vm0-skills mounts only for locally known connector names.
-  const staticConnectorSkillNames = connectorTypes.flatMap((connectorRef) => {
-    const parsed = connectorTypeSchema.safeParse(connectorRef);
-    return parsed.success ? [parsed.data] : [];
-  });
-  const allSkillNames = [
-    ...new Set([...seedNames, ...staticConnectorSkillNames]),
-  ];
-  return allSkillNames.flatMap((skillName) => {
+  return [...new Set(skillNames)].flatMap((skillName) => {
     const url = resolveSkillRef(skillName);
     const parsed = parseGitHubTreeUrl(url);
     if (!parsed) {
@@ -798,6 +788,35 @@ function buildSystemSkillVolumes(
         system: true,
       },
     ];
+  });
+}
+
+function buildExternalConnectorSkillVolumes(
+  connectorTypes: readonly ConnectorCatalogRef[],
+  snapshot: ConnectorRuntimeSnapshot,
+  framework: SupportedFramework,
+): readonly PreparedAdditionalVolume[] {
+  if (snapshot.identity.source !== "external") {
+    throw new Error("External connector skill snapshot is unavailable");
+  }
+  return connectorTypes.flatMap((connectorRef) => {
+    const connector = getConnectorRuntimeConnector(snapshot, connectorRef);
+    if (!connector?.skill) {
+      throw new Error("External connector skill metadata is unavailable");
+    }
+    if (connector.skill.kind === "none") {
+      return [];
+    }
+    const prepared: PreparedAdditionalVolume = {
+      volume: {
+        name: connector.skill.storageName,
+        version: connector.skill.versionId,
+        mountPath: skillMountPath(framework, connectorRef),
+        system: true,
+      },
+      source: "connector_skill",
+    };
+    return [prepared];
   });
 }
 
@@ -822,17 +841,43 @@ function buildInjectedSkillVolumes(
   args: {
     readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
     readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   framework: SupportedFramework,
 ): readonly PreparedAdditionalVolume[] | undefined {
   if (!args.injectSkillVolumes) {
     return undefined;
   }
+  const connectorTypes = args.allowedConnectorTypes ?? [];
+  const seedSkillNames = [...SEED_SKILLS, GOAL_SKILL_NAME];
+  const systemSkillVolumes =
+    args.connectorCatalogSnapshot.identity.source === "external"
+      ? [
+          ...(prepareAdditionalVolumesWithSource(
+            buildLegacySystemSkillVolumes(seedSkillNames, framework),
+            "system_skill",
+          ) ?? []),
+          ...buildExternalConnectorSkillVolumes(
+            connectorTypes,
+            args.connectorCatalogSnapshot,
+            framework,
+          ),
+        ]
+      : (prepareAdditionalVolumesWithSource(
+          buildLegacySystemSkillVolumes(
+            [
+              ...seedSkillNames,
+              ...connectorTypes.flatMap((connectorRef) => {
+                const parsed = connectorTypeSchema.safeParse(connectorRef);
+                return parsed.success ? [parsed.data] : [];
+              }),
+            ],
+            framework,
+          ),
+          "system_skill",
+        ) ?? []);
   return [
-    ...(prepareAdditionalVolumesWithSource(
-      buildSystemSkillVolumes(args.allowedConnectorTypes ?? [], framework),
-      "system_skill",
-    ) ?? []),
+    ...systemSkillVolumes,
     ...(prepareAdditionalVolumesWithSource(
       buildWorkflowSkillVolumes(args.injectSkillVolumes.workflows, framework),
       "workflow_skill",
@@ -6463,6 +6508,7 @@ async function buildPreparedPermissionManifest(args: {
 function preparedRunAdditionalVolumes(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
@@ -6474,6 +6520,7 @@ function preparedRunAdditionalVolumes(args: {
       {
         injectSkillVolumes: args.createArgs.injectSkillVolumes,
         allowedConnectorTypes: args.connectorScope.allowedConnectorTypes,
+        connectorCatalogSnapshot: args.connectorCatalogSnapshot,
       },
       args.framework,
     ),
@@ -6503,6 +6550,7 @@ interface PreparedRuntimeContext {
   readonly billableFirewalls: readonly string[];
   readonly modelUsageProvider: string | undefined;
   readonly connectorScope: EffectiveConnectorScope;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
 }
 
 function connectorScopeForRuntimeSnapshot(
@@ -6880,6 +6928,7 @@ async function prepareRunRuntimeContext(args: {
     billableFirewalls: modelUsageContext.billableFirewalls,
     modelUsageProvider: modelUsageContext.modelUsageProvider,
     connectorScope,
+    connectorCatalogSnapshot,
   };
 }
 
@@ -6896,6 +6945,7 @@ async function connectorCatalogSnapshotForRun(args: {
 function prepareRunOutputMetadata(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
@@ -6908,6 +6958,7 @@ function prepareRunOutputMetadata(args: {
   const additionalVolumes = preparedRunAdditionalVolumes({
     createArgs: args.createArgs,
     connectorScope: args.connectorScope,
+    connectorCatalogSnapshot: args.connectorCatalogSnapshot,
     framework: args.framework,
     featureSwitchContext: args.featureSwitchContext,
     body: args.body,
@@ -7021,6 +7072,7 @@ function prepareRunContext(input: {
             prepareRunOutputMetadata({
               createArgs: args,
               connectorScope: runtimeContext.connectorScope,
+              connectorCatalogSnapshot: runtimeContext.connectorCatalogSnapshot,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
               body,

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1337,7 +1337,7 @@ function resolveLatestVersion(
 async function resolveExactVersion(
   db: Db,
   storage: StorageIndexEntry,
-  resolvedOrgId: string,
+  lookup: StorageLookup,
   version: string,
 ): Promise<StorageResolution | null> {
   const [match] = await db
@@ -1354,6 +1354,10 @@ async function resolveExactVersion(
       and(
         eq(storageVersions.storageId, storage.storageId),
         eq(storageVersions.id, version),
+        eq(storages.orgId, lookup.orgId),
+        eq(storages.userId, lookup.userId),
+        eq(storages.name, lookup.name),
+        eq(storages.type, lookup.type),
       ),
     )
     .limit(1);
@@ -1365,7 +1369,7 @@ async function resolveExactVersion(
         s3Key: match.s3Key,
         archiveSize: match.archiveSize,
         fileCount: match.fileCount,
-        resolvedOrgId,
+        resolvedOrgId: lookup.orgId,
       }
     : null;
 }
@@ -1383,12 +1387,7 @@ async function resolvePinnedVersion(
     throw new Error(`Storage "${lookup.name}" not found in database`);
   }
 
-  const exactMatch = await resolveExactVersion(
-    db,
-    storage,
-    lookup.orgId,
-    version,
-  );
+  const exactMatch = await resolveExactVersion(db, storage, lookup, version);
   if (exactMatch) {
     return exactMatch;
   }
@@ -1611,12 +1610,7 @@ async function resolveConnectorSkillStorageInput(args: {
   if (!storage) {
     throw connectorSkillRegistrationError();
   }
-  const resolved = await resolveExactVersion(
-    args.db,
-    storage,
-    SYSTEM_ORG_ID,
-    version,
-  );
+  const resolved = await resolveExactVersion(args.db, storage, lookup, version);
   if (!resolved) {
     throw connectorSkillRegistrationError();
   }

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1343,11 +1343,13 @@ async function resolveExactVersion(
   const [match] = await db
     .select({
       id: storageVersions.id,
+      s3Prefix: storages.s3Prefix,
       s3Key: storageVersions.s3Key,
       archiveSize: storageVersions.archiveSize,
       fileCount: storageVersions.fileCount,
     })
     .from(storageVersions)
+    .innerJoin(storages, eq(storageVersions.storageId, storages.id))
     .where(
       and(
         eq(storageVersions.storageId, storage.storageId),
@@ -1359,7 +1361,7 @@ async function resolveExactVersion(
     ? {
         storageId: storage.storageId,
         versionId: match.id,
-        s3Prefix: storage.s3Prefix,
+        s3Prefix: match.s3Prefix,
         s3Key: match.s3Key,
         archiveSize: match.archiveSize,
         fileCount: match.fileCount,

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -48,6 +48,7 @@ type ComputedGetter = <T>(computedValue: Computed<T>) => T;
 type StorageManifestEntryKind = "compose" | "additional" | "artifact";
 export type StorageManifestSource =
   | "system_skill"
+  | "connector_skill"
   | "workflow_skill"
   | "request_additional_volume"
   | "compose_additional_volume"
@@ -129,6 +130,7 @@ interface ResolvedVolume {
 interface StorageResolution {
   readonly storageId: string;
   readonly versionId: string;
+  readonly s3Prefix: string;
   readonly s3Key: string;
   readonly archiveSize: number;
   readonly fileCount: number;
@@ -151,6 +153,7 @@ interface ArtifactStorageRow {
 interface StorageIndexEntry {
   readonly storageId: string;
   readonly headVersionId: string | null;
+  readonly s3Prefix: string;
   readonly headVersion: {
     readonly id: string;
     readonly s3Key: string;
@@ -247,6 +250,7 @@ const STORAGE_MANIFEST_COUNT_BUCKET_DIMENSIONS = [
 ] as const;
 const STORAGE_MANIFEST_SOURCES = [
   "system_skill",
+  "connector_skill",
   "workflow_skill",
   "request_additional_volume",
   "compose_additional_volume",
@@ -292,6 +296,7 @@ function storageManifestCountBucket(count: number): StorageManifestCountBucket {
 function emptyStorageManifestSourceCounts(): StorageManifestSourceCounts {
   return {
     system_skill: 0,
+    connector_skill: 0,
     workflow_skill: 0,
     request_additional_volume: 0,
     compose_additional_volume: 0,
@@ -1085,6 +1090,7 @@ async function loadStorageIndex(
       type: storages.type,
       storageId: storages.id,
       headVersionId: storages.headVersionId,
+      s3Prefix: storages.s3Prefix,
       versionId: storageVersions.id,
       s3Key: storageVersions.s3Key,
       archiveSize: storageVersions.archiveSize,
@@ -1110,6 +1116,7 @@ async function loadStorageIndex(
     index.set(storageIndexKey(row.orgId, row.userId, row.name, row.type), {
       storageId: row.storageId,
       headVersionId: row.headVersionId,
+      s3Prefix: row.s3Prefix,
       headVersion:
         row.versionId &&
         row.s3Key &&
@@ -1319,11 +1326,46 @@ function resolveLatestVersion(
   return {
     storageId: entry.storageId,
     versionId: entry.headVersion.id,
+    s3Prefix: entry.s3Prefix,
     s3Key: entry.headVersion.s3Key,
     archiveSize: entry.headVersion.archiveSize,
     fileCount: entry.headVersion.fileCount,
     resolvedOrgId: lookup.orgId,
   };
+}
+
+async function resolveExactVersion(
+  db: Db,
+  storage: StorageIndexEntry,
+  resolvedOrgId: string,
+  version: string,
+): Promise<StorageResolution | null> {
+  const [match] = await db
+    .select({
+      id: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+    })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storage.storageId),
+        eq(storageVersions.id, version),
+      ),
+    )
+    .limit(1);
+  return match
+    ? {
+        storageId: storage.storageId,
+        versionId: match.id,
+        s3Prefix: storage.s3Prefix,
+        s3Key: match.s3Key,
+        archiveSize: match.archiveSize,
+        fileCount: match.fileCount,
+        resolvedOrgId,
+      }
+    : null;
 }
 
 async function resolvePinnedVersion(
@@ -1339,30 +1381,14 @@ async function resolvePinnedVersion(
     throw new Error(`Storage "${lookup.name}" not found in database`);
   }
 
-  const [exactMatch] = await db
-    .select({
-      id: storageVersions.id,
-      s3Key: storageVersions.s3Key,
-      archiveSize: storageVersions.archiveSize,
-      fileCount: storageVersions.fileCount,
-    })
-    .from(storageVersions)
-    .where(
-      and(
-        eq(storageVersions.storageId, storage.storageId),
-        eq(storageVersions.id, version),
-      ),
-    )
-    .limit(1);
+  const exactMatch = await resolveExactVersion(
+    db,
+    storage,
+    lookup.orgId,
+    version,
+  );
   if (exactMatch) {
-    return {
-      storageId: storage.storageId,
-      versionId: exactMatch.id,
-      s3Key: exactMatch.s3Key,
-      archiveSize: exactMatch.archiveSize,
-      fileCount: exactMatch.fileCount,
-      resolvedOrgId: lookup.orgId,
-    };
+    return exactMatch;
   }
 
   if (
@@ -1405,6 +1431,7 @@ async function resolvePinnedVersion(
   return {
     storageId: storage.storageId,
     versionId: match.id,
+    s3Prefix: storage.s3Prefix,
     s3Key: match.s3Key,
     archiveSize: match.archiveSize,
     fileCount: match.fileCount,
@@ -1523,7 +1550,11 @@ async function resolveAdditionalStorageInput(args: {
   readonly index: StorageIndex;
   readonly runtimeOrgId: string;
   readonly volume: AdditionalVolume;
+  readonly source: StorageManifestSource;
 }): Promise<ResolvedManifestStorageInput | null> {
+  if (args.source === "connector_skill") {
+    return await resolveConnectorSkillStorageInput(args);
+  }
   const resolvedResult = await settle(
     resolveVolumeStorage({
       db: args.db,
@@ -1547,6 +1578,60 @@ async function resolveAdditionalStorageInput(args: {
     mountPath: args.volume.mountPath,
     vasStorageName: args.volume.name,
     resolved: resolvedResult.value,
+  };
+}
+
+const CONNECTOR_SKILL_REGISTRATION_ERROR =
+  "Connector skill registration is unavailable";
+
+function connectorSkillRegistrationError(): Error {
+  return new Error(CONNECTOR_SKILL_REGISTRATION_ERROR);
+}
+
+async function resolveConnectorSkillStorageInput(args: {
+  readonly db: Db;
+  readonly index: StorageIndex;
+  readonly volume: AdditionalVolume;
+}): Promise<ResolvedManifestStorageInput> {
+  const version = args.volume.version;
+  if (
+    !args.volume.system ||
+    version === undefined ||
+    !/^[a-f0-9]{64}$/u.test(version)
+  ) {
+    throw connectorSkillRegistrationError();
+  }
+
+  const lookup = volumeStorageLookup(SYSTEM_ORG_ID, args.volume);
+  const storage = args.index.get(
+    storageIndexKey(lookup.orgId, lookup.userId, lookup.name, lookup.type),
+  );
+  if (!storage) {
+    throw connectorSkillRegistrationError();
+  }
+  const resolved = await resolveExactVersion(
+    args.db,
+    storage,
+    SYSTEM_ORG_ID,
+    version,
+  );
+  if (!resolved) {
+    throw connectorSkillRegistrationError();
+  }
+
+  const expectedPrefix = `${SYSTEM_ORG_ID}/volume/${args.volume.name}`;
+  if (
+    resolved.s3Prefix !== expectedPrefix ||
+    resolved.s3Key !== `${expectedPrefix}/${version}`
+  ) {
+    throw connectorSkillRegistrationError();
+  }
+
+  return {
+    name: args.volume.name,
+    mountPath: args.volume.mountPath,
+    vasStorageName: args.volume.name,
+    resolved,
   };
 }
 
@@ -1855,6 +1940,7 @@ async function buildAdditionalStorageEntry(args: {
       index: args.index,
       runtimeOrgId: args.runtimeOrgId,
       volume: args.volume,
+      source: args.source,
     });
   });
   if (input) {
@@ -1898,9 +1984,12 @@ function normalizeAdditionalVolumeSources(args: {
   if (!args.sources) {
     return undefined;
   }
-  return args.sources.length === (args.volumes?.length ?? 0)
-    ? args.sources
-    : undefined;
+  if (args.sources.length !== (args.volumes?.length ?? 0)) {
+    throw new Error(
+      "Additional volume source count must match additional volume count",
+    );
+  }
+  return args.sources;
 }
 
 async function resolveStorageManifestInputs(
@@ -1990,6 +2079,9 @@ function storageManifestLookups(args: {
   readonly userId: string;
   readonly composeVolumes: readonly ResolvedVolume[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly additionalVolumeSources:
+    | readonly StorageManifestSource[]
+    | undefined;
   readonly artifacts: readonly ContextArtifact[];
 }): readonly StorageLookup[] {
   const lookups: StorageLookup[] = [];
@@ -2000,7 +2092,14 @@ function storageManifestLookups(args: {
     }
     lookups.push(volumeStorageLookup(args.agentOrgId, volume));
   }
-  for (const volume of args.additionalVolumes ?? []) {
+  for (const [index, volume] of (args.additionalVolumes ?? []).entries()) {
+    if (
+      additionalVolumeSourceAt(args.additionalVolumeSources, index) ===
+      "connector_skill"
+    ) {
+      lookups.push(volumeStorageLookup(SYSTEM_ORG_ID, volume));
+      continue;
+    }
     if (volume.system) {
       lookups.push(volumeStorageLookup(SYSTEM_ORG_ID, volume));
     }
@@ -2061,10 +2160,6 @@ async function resolveStorageManifestEntryPlans(args: {
   readonly phaseTimings: StorageManifestEntryPhaseTimings;
 }): Promise<ResolvedStorageManifestEntryPlans> {
   const input = args.input;
-  const additionalVolumeSources = normalizeAdditionalVolumeSources({
-    volumes: input.additionalVolumes,
-    sources: input.additionalVolumeSources,
-  });
   const [composePlans, additionalPlans, artifactInputs] = await Promise.all([
     measureApiDispatchTiming(
       input.timing,
@@ -2097,7 +2192,10 @@ async function resolveStorageManifestEntryPlans(args: {
               index: input.storageIndex,
               runtimeOrgId: input.runtimeOrgId,
               volume,
-              source: additionalVolumeSourceAt(additionalVolumeSources, index),
+              source: additionalVolumeSourceAt(
+                input.additionalVolumeSources,
+                index,
+              ),
               phaseTiming: args.phaseTimings.additional,
               stats: input.stats,
             });
@@ -2279,6 +2377,10 @@ export function prepareAgentRunStorageManifest(
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const { artifacts, composeVolumes } =
       await resolveStorageManifestInputs(args);
+    const additionalVolumeSources = normalizeAdditionalVolumeSources({
+      volumes: args.additionalVolumes,
+      sources: args.additionalVolumeSources,
+    });
     args.stats?.recordRequestedInputs({
       composeCount: composeVolumes.length,
       additionalCount: args.additionalVolumes?.length ?? 0,
@@ -2303,6 +2405,7 @@ export function prepareAgentRunStorageManifest(
         userId: args.userId,
         composeVolumes,
         additionalVolumes: args.additionalVolumes,
+        additionalVolumeSources,
         artifacts,
       }),
       timing: args.timing,
@@ -2317,7 +2420,7 @@ export function prepareAgentRunStorageManifest(
       userId: args.userId,
       composeVolumes,
       additionalVolumes: args.additionalVolumes,
-      additionalVolumeSources: args.additionalVolumeSources,
+      additionalVolumeSources,
       artifacts,
       timing: args.timing,
       stats: args.stats,


### PR DESCRIPTION
## Summary

- preserve the accepted connector runtime snapshot through run output preparation
- mount external bundled connector skills as exact, immutable system-volume versions while keeping explicit no-skill descriptors unmounted
- validate system ownership, canonical registration prefix, and exact version key before dispatch, with a sanitized fail-closed error
- preserve static and shadow URL-derived/current-head behavior and all unrelated optional volume semantics
- add route-level coverage for tenant fallback denial, missing versions, malformed registrations, newer HEAD immunity, and the unchanged runner manifest

## Compatibility and exclusions

- `CONNECTOR_CATALOG_SOURCE_MODE` still defaults to `static`; this does not activate the external catalog
- no database migration, persisted shape, API/runner protocol, upload path, archive construction, or connector-catalog R2 read is added
- existing seed, workflow, request, compose, checkpoint, presign-cache, and runner extraction behavior remains unchanged

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts` (85 passed)
- `pnpm -F api lint`
- `pnpm -F api exec tsc --noEmit --incremental false`
- `pnpm prettier --check apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/agent-run-storage.service.ts apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts`
- `pnpm knip --workspace api`
- repository pre-commit checks, including full Knip and workspace type checking

Closes #21815

Parent delivery: #19396
