### PR TITLE
refactor(runner): remove legacy r2 rootfs gc

### DIFF
--- a/crates/runner/src/cmd/gc/mod.rs
+++ b/crates/runner/src/cmd/gc/mod.rs
@@ -36,10 +36,10 @@ use version_service_locks::gc_orphaned_version_service_locks;
 use versions::{analyze_version_gc, gc_versions_with_analysis};
 use workspaces::gc_workspace_orphans;
 
-/// Default TTL for completed R2 image objects. Older objects are deleted by
-/// `gc_r2`. 7 days comfortably covers our typical release cadence: an image
+/// Default TTL for completed R2 template objects. Older objects are deleted by
+/// `gc_r2`. 7 days comfortably covers our typical release cadence: a template
 /// from the last week's release is still useful for a host that just spun
-/// up. If a host has been offline >7 days and the cached image got swept,
+/// up. If a host has been offline >7 days and the cached template got swept,
 /// the next `runner build` does a one-time local rebuild + re-upload — slow
 /// but correct.
 const R2_DEFAULT_KEEP_DAYS: u64 = 7;
@@ -57,10 +57,9 @@ pub struct GcArgs {
     /// Keep the N most recent unused versions (by modification time)
     #[arg(long)]
     keep_latest: Option<usize>,
-    /// TTL for R2 image cache objects (in days). Objects older than this
-    /// are deleted from the legacy `runner-images/` prefix and the shared
-    /// `runner-templates/` prefix on R2. Default: 7 days.
-    /// Minimum: 1 — `0` would wipe even the just-uploaded image.
+    /// TTL for R2 template cache objects (in days). Objects older than this
+    /// are deleted from the `runner-templates/` prefix on R2. Default: 7 days.
+    /// Minimum: 1 — `0` would wipe even the just-uploaded template.
     #[arg(long, default_value_t = R2_DEFAULT_KEEP_DAYS, value_parser = clap::value_parser!(u64).range(1..))]
     r2_keep_days: u64,
     /// Version name to protect from GC (e.g. "v0.78.3").

--- a/crates/runner/src/cmd/gc/mod.rs
+++ b/crates/runner/src/cmd/gc/mod.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::*;
     use clap::Parser;
 
-    /// `--r2-keep-days 0` would wipe even just-uploaded images. Verify the
+    /// `--r2-keep-days 0` would wipe even just-uploaded templates. Verify the
     /// clap range validator rejects it (catches a regression if the
     /// `value_parser` annotation is dropped).
     #[derive(Parser)]

--- a/crates/runner/src/cmd/gc/r2.rs
+++ b/crates/runner/src/cmd/gc/r2.rs
@@ -4,7 +4,7 @@ use crate::r2_cache::R2ImageCache;
 
 use super::report::{GcReport, human_bytes};
 
-/// Delete R2 image cache objects older than `keep_days`. Errors (R2 not
+/// Delete R2 template cache objects older than `keep_days`. Errors (R2 not
 /// configured, network blip, etc.) are logged and swallowed: GC must not
 /// fail the deploy because the cache layer is misconfigured. Returns the
 /// successful full-pass report, or an empty report on init or scan failure. A
@@ -29,7 +29,7 @@ pub(super) async fn gc_r2(keep_days: u64, dry_run: bool) -> GcReport {
         // No safe dry-run: list_objects_v2 + counting age would still cost
         // R2 reads, and we can't filter without making the call. Surface the
         // intent and skip the destructive part.
-        info!("[dry-run] would delete R2 image objects older than {keep_days} days");
+        info!("[dry-run] would delete R2 template objects older than {keep_days} days");
         return GcReport::default();
     }
 

--- a/crates/runner/src/r2_cache/gc.rs
+++ b/crates/runner/src/r2_cache/gc.rs
@@ -1,16 +1,12 @@
 use aws_sdk_s3::types::{Delete, ObjectIdentifier};
 
-use super::{
-    R2Error, R2ImageCache, io_other,
-    keys::{LEGACY_ROOTFS_KEY_PREFIX, TEMPLATE_KEY_PREFIX},
-};
+use super::{R2Error, R2ImageCache, io_other, keys::TEMPLATE_KEY_PREFIX};
 
 impl R2ImageCache {
-    /// Delete legacy rootfs objects and shared template objects older
-    /// than `max_age`. Returns `(deleted_count, freed_bytes)`. Attempts to
-    /// scan `runner-images/` and `runner-templates/`; on a full pass, each
-    /// prefix costs at least one LIST, paginated prefixes cost one LIST per
-    /// page, and DELETE is issued only for pages with expired objects.
+    /// Delete shared template objects older than `max_age`. Returns
+    /// `(deleted_count, freed_bytes)`. A full pass costs at least one LIST,
+    /// paginated results cost one LIST per page, and DELETE is issued only for
+    /// pages with expired objects.
     /// Idempotent under concurrent fleet execution: hosts can attempt the same
     /// scan and `DeleteObjects` returns success for already-absent keys (S3
     /// spec). Per-host returned counts are best-effort and are not fleet-unique
@@ -21,17 +17,10 @@ impl R2ImageCache {
     pub async fn gc_older_than(&self, max_age: std::time::Duration) -> Result<(u64, u64), R2Error> {
         let cutoff = cutoff_unix_secs(std::time::SystemTime::now(), max_age)?;
 
-        let mut total_deleted = 0u64;
-        let mut total_freed = 0u64;
-        for prefix in [LEGACY_ROOTFS_KEY_PREFIX, TEMPLATE_KEY_PREFIX] {
-            let (deleted, freed) = self.gc_prefix_older_than(prefix, cutoff).await?;
-            total_deleted = total_deleted.saturating_add(deleted);
-            total_freed = total_freed.saturating_add(freed);
-        }
-        Ok((total_deleted, total_freed))
+        self.gc_template_objects_older_than(cutoff).await
     }
 
-    async fn gc_prefix_older_than(&self, prefix: &str, cutoff: i64) -> Result<(u64, u64), R2Error> {
+    async fn gc_template_objects_older_than(&self, cutoff: i64) -> Result<(u64, u64), R2Error> {
         let mut continuation_token: Option<String> = None;
         let mut total_deleted = 0u64;
         let mut total_freed = 0u64;
@@ -40,7 +29,7 @@ impl R2ImageCache {
                 .client
                 .list_objects_v2()
                 .bucket(&self.bucket)
-                .prefix(prefix);
+                .prefix(TEMPLATE_KEY_PREFIX);
             if let Some(token) = continuation_token.as_ref() {
                 req = req.continuation_token(token);
             }

--- a/crates/runner/src/r2_cache/keys.rs
+++ b/crates/runner/src/r2_cache/keys.rs
@@ -1,4 +1,3 @@
-pub(super) const LEGACY_ROOTFS_KEY_PREFIX: &str = "runner-images/";
 pub(super) const TEMPLATE_KEY_PREFIX: &str = "runner-templates/";
 
 pub(super) fn key_for_template_hash(hash: &str) -> String {

--- a/crates/runner/src/r2_cache/mod.rs
+++ b/crates/runner/src/r2_cache/mod.rs
@@ -55,10 +55,9 @@
 //!
 //! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
 //! deploy playbook runs after every release). Default TTL is 7 days. Each
-//! host attempts the same scan independently over the legacy rootfs prefix
-//! (`runner-images/`) and the shared template prefix (`runner-templates/`).
-//! Request cost for a full pass scales with scanned prefixes and pagination:
-//! at least one LIST per prefix, one additional LIST per extra page, and one
+//! host attempts the same scan independently over the shared template prefix
+//! (`runner-templates/`). Request cost for a full pass scales with pagination:
+//! at least one LIST, one additional LIST per extra page, and one
 //! batched DELETE for each page that contains expired objects. `DeleteObjects`
 //! is idempotent for already-absent keys, so concurrent fleet execution is
 //! safe; per-host deleted-count and freed-byte logs are best-effort and are

--- a/crates/runner/src/r2_cache/tests/gc.rs
+++ b/crates/runner/src/r2_cache/tests/gc.rs
@@ -122,7 +122,7 @@ fn select_expired_empty_page_returns_empty() {
 /// `gc_older_than` MUST follow `continuation_token` across multiple
 /// `list_objects_v2` pages. Regression here would silently under-delete
 /// (first page processed, subsequent pages dropped) — fleet cache grows
-/// unbounded with orphaned image objects.
+/// unbounded with orphaned template objects.
 #[tokio::test]
 async fn gc_paginates_across_two_pages() {
     use aws_sdk_s3::Client;
@@ -138,14 +138,14 @@ async fn gc_paginates_across_two_pages() {
         .next_continuation_token("tok1")
         .contents(
             Object::builder()
-                .key("runner-images/a.tar.zst")
+                .key("runner-templates/a.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(100)
                 .build(),
         )
         .contents(
             Object::builder()
-                .key("runner-images/b.tar.zst")
+                .key("runner-templates/b.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(200)
                 .build(),
@@ -155,48 +155,31 @@ async fn gc_paginates_across_two_pages() {
         .is_truncated(false)
         .contents(
             Object::builder()
-                .key("runner-images/c.tar.zst")
+                .key("runner-templates/c.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(300)
                 .build(),
         )
         .build();
-    let empty_template_page = ListObjectsV2Output::builder().is_truncated(false).build();
-
-    let legacy_page1_list = mock!(Client::list_objects_v2)
-        .match_requests(|req| {
-            req.prefix() == Some("runner-images/") && req.continuation_token().is_none()
-        })
-        .sequence()
-        .output(move || page1.clone())
-        .build();
-    let legacy_page2_list = mock!(Client::list_objects_v2)
-        .match_requests(|req| {
-            req.prefix() == Some("runner-images/") && req.continuation_token() == Some("tok1")
-        })
-        .sequence()
-        .output(move || page2.clone())
-        .build();
-    let template_list = mock!(Client::list_objects_v2)
+    let page1_list = mock!(Client::list_objects_v2)
         .match_requests(|req| {
             req.prefix() == Some("runner-templates/") && req.continuation_token().is_none()
         })
         .sequence()
-        .output(move || empty_template_page.clone())
+        .output(move || page1.clone())
+        .build();
+    let page2_list = mock!(Client::list_objects_v2)
+        .match_requests(|req| {
+            req.prefix() == Some("runner-templates/") && req.continuation_token() == Some("tok1")
+        })
+        .sequence()
+        .output(move || page2.clone())
         .build();
     // Quiet-mode delete responses don't echo successes; no `errors`.
     let delete =
         mock!(Client::delete_objects).then_output(|| DeleteObjectsOutput::builder().build());
 
-    let cache = mock_cache(
-        "test-bucket",
-        &[
-            &legacy_page1_list,
-            &legacy_page2_list,
-            &template_list,
-            &delete,
-        ],
-    );
+    let cache = mock_cache("test-bucket", &[&page1_list, &page2_list, &delete]);
 
     let (deleted, freed) = cache
         .gc_older_than(std::time::Duration::from_secs(1))
@@ -206,70 +189,16 @@ async fn gc_paginates_across_two_pages() {
     assert_eq!(deleted, 3, "2 objects from page1 + 1 from page2");
     assert_eq!(freed, 600, "100 + 200 + 300");
     assert_eq!(
-        legacy_page1_list.num_calls(),
+        page1_list.num_calls(),
         1,
-        "first legacy LIST has no continuation token"
+        "first template LIST has no continuation token"
     );
     assert_eq!(
-        legacy_page2_list.num_calls(),
+        page2_list.num_calls(),
         1,
-        "second legacy LIST carries tok1"
-    );
-    assert_eq!(
-        template_list.num_calls(),
-        1,
-        "template prefix is scanned without a continuation token"
-    );
-    assert_eq!(
-        legacy_page1_list.num_calls() + legacy_page2_list.num_calls() + template_list.num_calls(),
-        3,
-        "pagination followed next_token and template prefix was scanned"
+        "second template LIST carries tok1"
     );
     assert_eq!(delete.num_calls(), 2, "one delete per non-empty page");
-}
-
-/// `gc_older_than` must also clean the shared template prefix. A
-/// regression here would leave the new cache family unbounded even though
-/// legacy `runner-images/` objects continue to be swept.
-#[tokio::test]
-async fn gc_deletes_shared_template_objects() {
-    use aws_sdk_s3::Client;
-    use aws_sdk_s3::operation::delete_objects::DeleteObjectsOutput;
-    use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
-    use aws_sdk_s3::primitives::DateTime;
-    use aws_sdk_s3::types::Object;
-
-    let empty_legacy_page = ListObjectsV2Output::builder().is_truncated(false).build();
-    let template_page = ListObjectsV2Output::builder()
-        .is_truncated(false)
-        .contents(
-            Object::builder()
-                .key("runner-templates/template.tar.zst")
-                .last_modified(DateTime::from_secs(0))
-                .size(123)
-                .build(),
-        )
-        .build();
-
-    let list = mock!(Client::list_objects_v2)
-        .sequence()
-        .output(move || empty_legacy_page.clone())
-        .output(move || template_page.clone())
-        .build();
-    let delete =
-        mock!(Client::delete_objects).then_output(|| DeleteObjectsOutput::builder().build());
-
-    let cache = mock_cache("test-bucket", &[&list, &delete]);
-
-    let (deleted, freed) = cache
-        .gc_older_than(std::time::Duration::from_secs(1))
-        .await
-        .unwrap();
-
-    assert_eq!(deleted, 1);
-    assert_eq!(freed, 123);
-    assert_eq!(list.num_calls(), 2, "legacy and template prefixes scanned");
-    assert_eq!(delete.num_calls(), 1, "template object delete issued");
 }
 
 /// `gc_older_than` MUST exclude per-key failures from `deleted_count` so
@@ -288,42 +217,37 @@ async fn gc_excludes_per_key_failures_from_count() {
         .is_truncated(false)
         .contents(
             Object::builder()
-                .key("runner-images/a.tar.zst")
+                .key("runner-templates/a.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(10)
                 .build(),
         )
         .contents(
             Object::builder()
-                .key("runner-images/b.tar.zst")
+                .key("runner-templates/b.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(20)
                 .build(),
         )
         .contents(
             Object::builder()
-                .key("runner-images/c.tar.zst")
+                .key("runner-templates/c.tar.zst")
                 .last_modified(DateTime::from_secs(0))
                 .size(30)
                 .build(),
         )
         .build();
-    let empty_template_page = ListObjectsV2Output::builder().is_truncated(false).build();
     let delete_resp = DeleteObjectsOutput::builder()
         .errors(
             S3Error::builder()
-                .key("runner-images/b.tar.zst")
+                .key("runner-templates/b.tar.zst")
                 .code("AccessDenied")
                 .message("denied")
                 .build(),
         )
         .build();
 
-    let list = mock!(Client::list_objects_v2)
-        .sequence()
-        .output(move || page.clone())
-        .output(move || empty_template_page.clone())
-        .build();
+    let list = mock!(Client::list_objects_v2).then_output(move || page.clone());
     let delete = mock!(Client::delete_objects).then_output(move || delete_resp.clone());
 
     let cache = mock_cache("test-bucket", &[&list, &delete]);


### PR DESCRIPTION
## Context

The legacy `runner-images/` full-rootfs cache was replaced by `runner-templates/` on May 3, 2026. A read-only R2 listing confirmed that the legacy prefix is empty (0 objects, 0 bytes), so the cleanup compatibility path no longer has data to manage.

## Changes

- stop listing the retired `runner-images/` prefix during R2 garbage collection
- simplify R2 GC to scan only `runner-templates/`
- update runner GC documentation, help text, and logs
- keep pagination and per-key failure coverage focused on template objects

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`