### PR TITLE
perf: align session-history sidecar capacity with resume limit

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -23,7 +23,7 @@ use guest_contracts::diagnostics::{CliTerminationReason, FailureClass, FailureDi
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -88,18 +88,13 @@ fn helper_exit_code_from_args() -> Option<i32> {
                     metadata_path,
                     export_path,
                 ) {
-                    Ok(session_history_identity::SessionHistorySidecarExportOutcome::Exported(
-                        metadata,
-                    )) => match serde_json::to_string(&metadata) {
+                    Ok(metadata) => match serde_json::to_string(&metadata) {
                         Ok(json) => {
                             println!("{json}");
                             SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS
                         }
                         Err(_) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
                     },
-                    Ok(
-                        session_history_identity::SessionHistorySidecarExportOutcome::Unavailable,
-                    ) => SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE,
                     Err(error) => session_history_identity_helper_exit_code(&error),
                 },
             )

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -127,16 +127,11 @@ pub(crate) enum SessionHistoryCheckpointSource {
 
 pub(crate) struct PreparedSessionHistorySidecar {
     pub(crate) digest: SessionHistoryDigest,
-    source: PreparedSessionHistorySidecarSource,
-}
-
-pub(crate) enum PreparedSessionHistorySidecarSource {
-    Exportable(SessionHistoryCheckpointSource),
-    RawTooLarge,
+    source: SessionHistoryCheckpointSource,
 }
 
 impl PreparedSessionHistorySidecar {
-    pub(crate) fn into_source(self) -> PreparedSessionHistorySidecarSource {
+    pub(crate) fn into_source(self) -> SessionHistoryCheckpointSource {
         self.source
     }
 }
@@ -185,28 +180,26 @@ pub(crate) fn read_session_history_checkpoint_source_from_payload_bounded(
 pub(crate) fn prepare_session_history_sidecar_from_payload_bounded(
     payload: &str,
     max_decoded_bytes: u64,
-    max_sidecar_bytes: u64,
+    max_encoded_bytes: u64,
 ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
     match resolve_session_history_source(payload)? {
         ResolvedSessionHistorySource::Codex(session) if session.is_zstd() => {
-            if session.encoded_len()? <= max_sidecar_bytes {
-                let encoded = session.into_zstd_bytes(max_sidecar_bytes)?;
+            if session.encoded_len()? <= max_encoded_bytes {
+                let encoded = session.into_zstd_bytes(max_encoded_bytes)?;
                 let digest = digest_zstd_session_history_bytes(&encoded, max_decoded_bytes)?;
                 Ok(PreparedSessionHistorySidecar {
                     digest,
-                    source: PreparedSessionHistorySidecarSource::Exportable(
-                        SessionHistoryCheckpointSource::CodexZstd { encoded },
-                    ),
+                    source: SessionHistoryCheckpointSource::CodexZstd { encoded },
                 })
             } else {
                 ResolvedSessionHistorySource::Codex(session)
                     .open_decoded_reader()?
-                    .prepare_sidecar(max_decoded_bytes, max_sidecar_bytes)
+                    .prepare_sidecar(max_decoded_bytes)
             }
         }
         source => source
             .open_decoded_reader()?
-            .prepare_sidecar(max_decoded_bytes, max_sidecar_bytes),
+            .prepare_sidecar(max_decoded_bytes),
     }
 }
 
@@ -755,19 +748,16 @@ impl DecodedSessionHistoryReader {
     fn prepare_sidecar(
         self,
         max_decoded_bytes: u64,
-        max_sidecar_bytes: u64,
     ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
         match self {
-            Self::Plain { path, reader } => prepare_session_history_sidecar_reader(
-                reader,
-                max_decoded_bytes,
-                max_sidecar_bytes,
-                |error| read_history_error(&path, error),
-            ),
+            Self::Plain { path, reader } => {
+                prepare_session_history_sidecar_reader(reader, max_decoded_bytes, |error| {
+                    read_history_error(&path, error)
+                })
+            }
             Self::Zstd(reader) => prepare_session_history_sidecar_reader(
                 reader,
                 max_decoded_bytes,
-                max_sidecar_bytes,
                 zstd_session_history_error,
             ),
         }
@@ -857,12 +847,11 @@ fn digest_zstd_session_history_bytes(
 fn prepare_session_history_sidecar_reader(
     mut reader: impl Read,
     max_decoded_bytes: u64,
-    max_sidecar_bytes: u64,
     map_error: impl Fn(io::Error) -> AgentError,
 ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
     let mut hasher = Sha256::new();
     let mut size_bytes = 0u64;
-    let mut raw_bytes = Some(Vec::new());
+    let mut raw_bytes = Vec::new();
     let mut buffer = [0u8; 8192];
 
     loop {
@@ -884,27 +873,15 @@ fn prepare_session_history_sidecar_reader(
             )))
         })?;
         hasher.update(chunk);
-        if size_bytes <= max_sidecar_bytes {
-            if let Some(raw_bytes) = raw_bytes.as_mut() {
-                raw_bytes.extend_from_slice(chunk);
-            }
-        } else {
-            raw_bytes = None;
-        }
+        raw_bytes.extend_from_slice(chunk);
     }
 
-    let source = match raw_bytes {
-        Some(raw_bytes) => PreparedSessionHistorySidecarSource::Exportable(
-            SessionHistoryCheckpointSource::Decoded(raw_bytes),
-        ),
-        None => PreparedSessionHistorySidecarSource::RawTooLarge,
-    };
     Ok(PreparedSessionHistorySidecar {
         digest: SessionHistoryDigest {
             size_bytes,
             sha256_hex: hex::encode(hasher.finalize()),
         },
-        source,
+        source: SessionHistoryCheckpointSource::Decoded(raw_bytes),
     })
 }
 
@@ -1025,7 +1002,7 @@ mod tests {
         let history = br#"{"type":"session_meta","timestamp":"2026-07-02T10:00:00Z"}"#;
         let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
         let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
-        std::fs::write(path, compressed).unwrap();
+        std::fs::write(path, &compressed).unwrap();
         let payload = codex_marker_payload(&sessions_dir, thread_id);
 
         let bytes =
@@ -1070,7 +1047,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_preparation_handles_raw_export_boundaries() {
+    fn sidecar_preparation_enforces_raw_decoded_limit() {
         let dir = tempfile::tempdir().unwrap();
         let history = b"abcde";
         let path = write_history_file(&dir, "history.jsonl", history);
@@ -1082,40 +1059,16 @@ mod tests {
         )
         .unwrap();
         match prepared.into_source() {
-            PreparedSessionHistorySidecarSource::Exportable(
-                SessionHistoryCheckpointSource::Decoded(bytes),
-            ) => assert_eq!(bytes, history),
-            PreparedSessionHistorySidecarSource::Exportable(
-                SessionHistoryCheckpointSource::CodexZstd { .. },
-            ) => {
+            SessionHistoryCheckpointSource::Decoded(bytes) => assert_eq!(bytes, history),
+            SessionHistoryCheckpointSource::CodexZstd { .. } => {
                 panic!("literal history must use the raw representation")
             }
-            PreparedSessionHistorySidecarSource::RawTooLarge => {
-                panic!("literal history at the export limit must remain exportable")
-            }
         }
-
-        let prepared = prepare_session_history_sidecar_from_payload_bounded(
-            path.to_str().unwrap(),
-            history.len() as u64,
-            (history.len() - 1) as u64,
-        )
-        .unwrap();
-
-        assert_eq!(prepared.digest.size_bytes, history.len() as u64);
-        assert_eq!(
-            prepared.digest.sha256_hex,
-            hex::encode(Sha256::digest(history))
-        );
-        assert!(matches!(
-            prepared.into_source(),
-            PreparedSessionHistorySidecarSource::RawTooLarge
-        ));
 
         let result = prepare_session_history_sidecar_from_payload_bounded(
             path.to_str().unwrap(),
             (history.len() - 1) as u64,
-            (history.len() - 1) as u64,
+            history.len() as u64,
         );
         assert!(matches!(
             result,
@@ -1124,7 +1077,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_preparation_falls_back_to_raw_when_codex_zstd_exceeds_export_limit() {
+    fn sidecar_preparation_handles_codex_zstd_encoded_limit_and_raw_fallback() {
         let dir = tempfile::tempdir().unwrap();
         let sessions_dir = dir.path().join("sessions");
         let day_dir = sessions_dir.join("2026").join("07").join("02");
@@ -1134,8 +1087,23 @@ mod tests {
         let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
         assert!(compressed.len() > history.len());
         let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
-        std::fs::write(path, compressed).unwrap();
+        std::fs::write(path, &compressed).unwrap();
         let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let prepared = prepare_session_history_sidecar_from_payload_bounded(
+            &payload,
+            history.len() as u64,
+            compressed.len() as u64,
+        )
+        .unwrap();
+        match prepared.into_source() {
+            SessionHistoryCheckpointSource::CodexZstd { encoded } => {
+                assert_eq!(encoded, compressed)
+            }
+            SessionHistoryCheckpointSource::Decoded(_) => {
+                panic!("encoded body at the export limit must retain native zstd")
+            }
+        }
 
         let prepared = prepare_session_history_sidecar_from_payload_bounded(
             &payload,
@@ -1150,16 +1118,9 @@ mod tests {
             hex::encode(Sha256::digest(history))
         );
         match prepared.into_source() {
-            PreparedSessionHistorySidecarSource::Exportable(
-                SessionHistoryCheckpointSource::Decoded(bytes),
-            ) => assert_eq!(bytes, history),
-            PreparedSessionHistorySidecarSource::Exportable(
-                SessionHistoryCheckpointSource::CodexZstd { .. },
-            ) => {
+            SessionHistoryCheckpointSource::Decoded(bytes) => assert_eq!(bytes, history),
+            SessionHistoryCheckpointSource::CodexZstd { .. } => {
                 panic!("encoded body above the export limit must fall back to raw")
-            }
-            PreparedSessionHistorySidecarSource::RawTooLarge => {
-                panic!("decoded body within the export limit must remain exportable")
             }
         }
     }

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -15,8 +15,8 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SESSION_HISTORY_SIDECAR_MAX_BYTES,
-    SessionHistorySidecarExportMetadata, SessionHistorySidecarRepresentation,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SessionHistorySidecarExportMetadata,
+    SessionHistorySidecarRepresentation,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
@@ -77,22 +77,17 @@ pub fn verify_final_session_history_identity_file(
 pub fn export_final_session_history_sidecar_file(
     metadata_path: impl AsRef<Path>,
     export_path: impl AsRef<Path>,
-) -> Result<SessionHistorySidecarExportOutcome, FinalSessionHistoryIdentityVerifyError> {
+) -> Result<SessionHistorySidecarExportMetadata, FinalSessionHistoryIdentityVerifyError> {
     let identity = read_final_session_history_identity(metadata_path)?;
     verify_final_session_history_identity_constraints(&identity)?;
     let prepared = session_history::prepare_session_history_sidecar_from_payload_bounded(
         &identity.history_marker_payload,
         identity.history_size_bytes,
-        SESSION_HISTORY_SIDECAR_MAX_BYTES,
+        RESUME_SESSION_HISTORY_MAX_BYTES,
     )
     .map_err(map_session_history_digest_error)?;
     verify_final_session_history_digest(&identity, &prepared.digest)?;
-    let source = match prepared.into_source() {
-        session_history::PreparedSessionHistorySidecarSource::Exportable(source) => source,
-        session_history::PreparedSessionHistorySidecarSource::RawTooLarge => {
-            return Ok(SessionHistorySidecarExportOutcome::Unavailable);
-        }
-    };
+    let source = prepared.into_source();
     let (representation, bytes) = match source {
         session_history::SessionHistoryCheckpointSource::Decoded(bytes) => {
             (SessionHistorySidecarRepresentation::Raw, bytes)
@@ -104,20 +99,10 @@ pub fn export_final_session_history_sidecar_file(
     crate::paths::write_private(export_path.as_ref(), &bytes)
         .map_err(AgentError::from)
         .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
-    Ok(SessionHistorySidecarExportOutcome::Exported(
-        SessionHistorySidecarExportMetadata {
-            representation,
-            encoded_size: bytes.len() as u64,
-        },
-    ))
-}
-
-/// Result of exporting a final verified session-history sidecar.
-pub enum SessionHistorySidecarExportOutcome {
-    /// A verified sidecar file and its metadata were created.
-    Exported(SessionHistorySidecarExportMetadata),
-    /// Final history identity was verified, but no representation fits the export limit.
-    Unavailable,
+    Ok(SessionHistorySidecarExportMetadata {
+        representation,
+        encoded_size: bytes.len() as u64,
+    })
 }
 
 fn read_final_session_history_identity(

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -9,8 +9,7 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE,
-    SESSION_HISTORY_SIDECAR_MAX_BYTES, SessionHistorySidecarExportMetadata,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SessionHistorySidecarExportMetadata,
     SessionHistorySidecarRepresentation,
 };
 #[cfg(target_os = "linux")]
@@ -306,18 +305,16 @@ fn export_session_history_sidecar_reads_native_codex_zstd_once() -> TestResult {
 }
 
 #[test]
-fn export_session_history_sidecar_reports_verified_unavailable_for_oversized_raw() -> TestResult {
+fn export_session_history_sidecar_rejects_metadata_above_resume_limit_before_reading() -> TestResult
+{
     let dir = tempfile::tempdir()?;
-    let history_size = SESSION_HISTORY_SIDECAR_MAX_BYTES + 1;
-    let history_path = dir.path().join("oversized-history.jsonl");
-    let history_file = std::fs::File::create(&history_path)?;
-    history_file.set_len(history_size)?;
+    let history_path = dir.path().join("missing-oversized-history.jsonl");
     let identity = FinalSessionHistoryIdentity::new(
         FinalSessionHistoryFramework::ClaudeCode,
         "a".repeat(64),
         FinalSessionHistoryRefKind::Blob,
-        sha256_zero_bytes(history_size)?,
-        history_size,
+        "b".repeat(64),
+        RESUME_SESSION_HISTORY_MAX_BYTES + 1,
         history_path.to_string_lossy(),
     )?;
     let metadata_path = write_metadata(dir.path(), "oversized-identity.json", &identity)?;
@@ -327,7 +324,7 @@ fn export_session_history_sidecar_reports_verified_unavailable_for_oversized_raw
 
     assert_eq!(
         output.status.code(),
-        Some(SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE),
+        Some(SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE),
         "stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -357,37 +354,6 @@ fn export_session_history_sidecar_keeps_source_read_failures() -> TestResult {
     assert_eq!(
         output.status.code(),
         Some(SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ),
-        "stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(!export_path.exists());
-    Ok(())
-}
-
-#[test]
-fn export_session_history_sidecar_rejects_oversized_mismatch_before_unavailable() -> TestResult {
-    let dir = tempfile::tempdir()?;
-    let history_size = SESSION_HISTORY_SIDECAR_MAX_BYTES + 1;
-    let history_path = dir.path().join("oversized-mismatched-history.jsonl");
-    let history_file = std::fs::File::create(&history_path)?;
-    history_file.set_len(history_size)?;
-    let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
-        "a".repeat(64),
-        FinalSessionHistoryRefKind::Blob,
-        "b".repeat(64),
-        history_size,
-        history_path.to_string_lossy(),
-    )?;
-    let metadata_path = write_metadata(dir.path(), "oversized-mismatch-identity.json", &identity)?;
-    let export_path = dir.path().join("oversized-mismatch-sidecar");
-
-    let output = run_export_helper(&metadata_path, &export_path)?;
-
-    assert_eq!(
-        output.status.code(),
-        Some(SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH),
         "stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -451,18 +417,6 @@ fn expectation_args(
 
 fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
-}
-
-fn sha256_zero_bytes(mut size: u64) -> TestResult<String> {
-    let mut hasher = Sha256::new();
-    let zeroes = [0u8; 8192];
-    let chunk_size = u64::try_from(zeroes.len())?;
-    while size >= chunk_size {
-        hasher.update(zeroes);
-        size -= chunk_size;
-    }
-    hasher.update(vec![0u8; usize::try_from(size)?]);
-    Ok(hex::encode(hasher.finalize()))
 }
 
 fn run_helper(case: &VerifyCase) -> Result<Output, std::io::Error> {

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -33,12 +33,6 @@ pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ: i32 = 7;
 pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH: i32 = 8;
 /// Guest helper exit code for local history exceeding the guest verification budget.
 pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE: i32 = 9;
-/// Guest helper exit code for verified sidecar export unavailability.
-pub const SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE: i32 = 10;
-
-/// Maximum native sidecar bytes runner can copy from guest to host.
-pub const SESSION_HISTORY_SIDECAR_MAX_BYTES: u64 = 64 * 1024 * 1024;
-
 /// Framework that owns a final session-history file.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -388,9 +382,8 @@ mod tests {
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
-                SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE,
             ],
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         );
     }
 

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -11,7 +11,7 @@ use sandbox::{
 };
 use sandbox_mock::MockSandboxFactory;
 
-const QUEUED_COPY_FILE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const QUEUED_COPY_FILE_MAX_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(in crate::executor::tests) struct DestroyPanicFactory {
     pub(in crate::executor::tests) inner: MockSandboxFactory,

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryRefKind, SESSION_HISTORY_SIDECAR_MAX_BYTES,
+    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
 };
 use serde::{Deserialize, Serialize};
 use tokio::fs;
@@ -69,7 +70,7 @@ impl WorkspaceSessionHistorySidecarMetadata {
         if self.version != SESSION_HISTORY_SIDECAR_FORMAT_VERSION {
             return Err(WorkspaceSessionHistorySidecarMiss::InvalidMetadata);
         }
-        if self.encoded_size == 0 || self.encoded_size > SESSION_HISTORY_SIDECAR_MAX_BYTES {
+        if self.encoded_size == 0 || self.encoded_size > RESUME_SESSION_HISTORY_MAX_BYTES {
             return Err(WorkspaceSessionHistorySidecarMiss::InvalidMetadata);
         }
         let fields = expected
@@ -195,7 +196,7 @@ impl SessionWorkspaceCache {
         if !tmp_metadata.is_file()
             || tmp_metadata.len() != source.encoded_size
             || source.encoded_size == 0
-            || source.encoded_size > SESSION_HISTORY_SIDECAR_MAX_BYTES
+            || source.encoded_size > RESUME_SESSION_HISTORY_MAX_BYTES
         {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             self.prune_session_history_sidecar(cache_key).await?;

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::{MetadataExt, symlink};
 
-use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use api_contracts::generated::constants::runners::{
+    RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
+};
 
 use super::fs::{
     allocated_bytes, has_copy_headroom, local_timestamp, sparse_copy_with_timeout,
@@ -1811,6 +1813,7 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
         SessionMismatch,
         InvalidHash,
         InvalidSize,
+        EncodedTooLarge,
     }
 
     for case in [
@@ -1823,6 +1826,7 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
         InvalidSidecarCase::SessionMismatch,
         InvalidSidecarCase::InvalidHash,
         InvalidSidecarCase::InvalidSize,
+        InvalidSidecarCase::EncodedTooLarge,
     ] {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
@@ -1857,7 +1861,8 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
             InvalidSidecarCase::UnsupportedRepresentation
             | InvalidSidecarCase::SessionMismatch
             | InvalidSidecarCase::InvalidHash
-            | InvalidSidecarCase::InvalidSize => {
+            | InvalidSidecarCase::InvalidSize
+            | InvalidSidecarCase::EncodedTooLarge => {
                 let mut metadata: serde_json::Value =
                     serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
                 match case {
@@ -1873,6 +1878,9 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
                     }
                     InvalidSidecarCase::InvalidSize => {
                         metadata["historySizeBytes"] = 0.into();
+                    }
+                    InvalidSidecarCase::EncodedTooLarge => {
+                        metadata["encodedSize"] = (RESUME_SESSION_HISTORY_MAX_BYTES + 1).into();
                     }
                     unexpected => {
                         panic!("unexpected grouped invalid sidecar case: {unexpected:?}")

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -2,12 +2,10 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use futures_util::FutureExt;
-use guest_contracts::session_history_identity::{
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE, SESSION_HISTORY_SIDECAR_MAX_BYTES,
-    SessionHistorySidecarExportMetadata,
-};
-use sandbox::{CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, Sandbox};
+use guest_contracts::session_history_identity::SessionHistorySidecarExportMetadata;
+use sandbox::{CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 use shell_quote::quote_shell_arg;
 use tokio::fs;
 use tracing::warn;
@@ -23,8 +21,6 @@ use crate::workspace_mount::freeze_workspace_drive;
 const SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
 const SESSION_HISTORY_SIDECAR_COPY_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_HISTORY_SIDECAR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
-const SESSION_HISTORY_SIDECAR_EXPORT_EXPECTED_EXIT_CODES: &[i32] =
-    &[SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE];
 
 enum WorkspacePromotionAction {
     Promoted,
@@ -246,7 +242,7 @@ async fn export_session_history_sidecar(
         timeout: SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT,
         env: &env,
         sudo: false,
-        expected_exit_codes: SESSION_HISTORY_SIDECAR_EXPORT_EXPECTED_EXIT_CODES,
+        expected_exit_codes: &[],
         stdin_bytes: None,
         output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
     };
@@ -270,16 +266,6 @@ async fn export_session_history_sidecar(
             return None;
         }
     };
-    if matches!(
-        result.termination,
-        ExecTermination::Exited {
-            exit_code: SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE
-        }
-    ) {
-        cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-            .await;
-        return None;
-    }
     if !helper_exec_succeeded(&result) {
         warn!(
             run_id = %promotion.run_id(),
@@ -299,7 +285,7 @@ async fn export_session_history_sidecar(
     ) {
         Ok(metadata)
             if metadata.encoded_size > 0
-                && metadata.encoded_size <= SESSION_HISTORY_SIDECAR_MAX_BYTES =>
+                && metadata.encoded_size <= RESUME_SESSION_HISTORY_MAX_BYTES =>
         {
             metadata
         }
@@ -338,7 +324,7 @@ async fn export_session_history_sidecar(
             &export_path,
             sidecar_source.tmp_path(),
             CopyFileOptions {
-                max_bytes: SESSION_HISTORY_SIDECAR_MAX_BYTES,
+                max_bytes: RESUME_SESSION_HISTORY_MAX_BYTES,
                 timeout: SESSION_HISTORY_SIDECAR_COPY_TIMEOUT,
                 missing_ok: false,
             },

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -4,12 +4,13 @@ use super::*;
 use std::sync::Arc;
 use std::time::Duration;
 
-use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use api_contracts::generated::constants::runners::{
+    RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
+};
 use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE, SessionHistorySidecarExportMetadata,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ, SessionHistorySidecarExportMetadata,
     SessionHistorySidecarRepresentation,
 };
 use sandbox::{
@@ -339,6 +340,7 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     let copy_calls = sandbox.copy_file_calls();
     assert_eq!(copy_calls.len(), 1);
     assert!(copy_calls[0].path.ends_with("/session-history-sidecar"));
+    assert_eq!(copy_calls[0].max_bytes, RESUME_SESSION_HISTORY_MAX_BYTES);
     let sidecar_entry_dir = copy_calls[0].host_path.parent().unwrap();
     let sidecar_metadata_path = sidecar_entry_dir.join("session-history.metadata.json");
     if !sidecar_metadata_path.is_file() {
@@ -372,70 +374,6 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn active_workspace_promotion_skips_verified_unavailable_sidecar_without_warning() {
-    let session_id = "sess-active-sidecar-unavailable";
-    let history = br#"{"type":"message","content":"oversized"}"#;
-    let restored_identity = test_restored_session_identity(session_id, history);
-    let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
-        session_id,
-        Some(&restored_identity),
-    )
-    .await;
-    let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
-    sandbox.push_exec_result(Ok(ExecResult::new(
-        SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE,
-        Vec::new(),
-        Vec::new(),
-    )));
-
-    let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
-        &sandbox,
-        fixture.promotion,
-    ))
-    .await;
-
-    assert!(promoted);
-    assert!(sandbox.copy_file_calls().is_empty());
-    assert!(!has_captured_event(
-        &events,
-        "workspace image cache session history sidecar export failed"
-    ));
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 3);
-    assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
-    assert_eq!(
-        exec_calls[0].expected_exit_codes,
-        [SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE]
-    );
-    assert!(exec_calls[1].cmd.contains("rm -f --"));
-    assert!(exec_calls[1].expected_exit_codes.is_empty());
-    assert!(exec_calls[2].sudo);
-    assert!(exec_calls[2].expected_exit_codes.is_empty());
-
-    let lease = fixture
-        .cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id: RunId::new_v4(),
-                sandbox_id: SandboxId::new_v4(),
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
-            },
-            workspace_drive_required: true,
-        })
-        .await;
-    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
-    assert!(
-        lease
-            .probe_session_history_sidecar(&restored_identity)
-            .await
-            .is_err()
-    );
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn active_workspace_promotion_keeps_history_read_failure_warning() {
     let session_id = "sess-active-sidecar-read-failure";
     let history = br#"{"type":"message","content":"read failure"}"#;
@@ -466,10 +404,7 @@ async fn active_workspace_promotion_keeps_history_read_failure_warning() {
     );
     let exec_calls = sandbox.exec_calls();
     assert_eq!(exec_calls.len(), 3);
-    assert_eq!(
-        exec_calls[0].expected_exit_codes,
-        [SESSION_HISTORY_SIDECAR_EXPORT_EXIT_UNAVAILABLE]
-    );
+    assert!(exec_calls[0].expected_exit_codes.is_empty());
 }
 
 #[tokio::test]
@@ -878,13 +813,4 @@ fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Capture
                 .is_some_and(|actual| actual == message)
         })
         .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
-}
-
-fn has_captured_event(events: &[CapturedEvent], message: &str) -> bool {
-    events.iter().any(|event| {
-        event
-            .fields
-            .get("message")
-            .is_some_and(|actual| actual == message)
-    })
 }

--- a/crates/sandbox-mock/src/support.rs
+++ b/crates/sandbox-mock/src/support.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use ::sandbox::{Result, SandboxError, SandboxOperation, SandboxOperationReason};
 
-pub(crate) const MOCK_COPY_FILE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+pub(crate) const MOCK_COPY_FILE_MAX_BYTES: u64 = 128 * 1024 * 1024;
 
 /// Ignore mutex poisoning and take the lock anyway.
 ///

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -35,8 +35,9 @@ pub(crate) use state::Operations;
 pub(crate) const DEFAULT_EXEC_CAPTURE_LIMIT_BYTES: u32 = 1024 * 1024;
 pub(crate) const SMALL_EXEC_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const DEFAULT_EXEC_STREAM_CAPACITY: usize = 32;
-// Large enough for the current 64 MiB guest-log copy cap even when the guest
-// emits stream events at the exec-operation drainer's 8 KiB read granularity.
+// Provides 64 MiB of headroom at the guest drainer's 8 KiB read granularity.
+// Larger bounded copies rely on concurrent draining and fail explicitly if
+// the queue overflows rather than reserving unbounded memory.
 pub(crate) const MAX_EXEC_STREAM_CAPACITY: usize = 8192;
 const EXEC_OPERATION_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const EXEC_OPERATION_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -23,7 +23,7 @@ const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
 const COPY_TEMP_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 pub(super) const COPY_FILE_STREAM_CHUNK_LIMIT: u32 = 64 * 1024;
-pub(super) const COPY_FILE_STREAM_MAX_BYTES: u64 = 64 * 1024 * 1024;
+pub(super) const COPY_FILE_STREAM_MAX_BYTES: u64 = 128 * 1024 * 1024;
 // Copying is the one built-in streaming consumer that must tolerate the host
 // reader briefly outrunning the temp-file writer without failing the exec operation.
 const COPY_FILE_STREAM_QUEUE_CAPACITY: usize = exec_operation::MAX_EXEC_STREAM_CAPACITY;
@@ -804,11 +804,12 @@ mod tests {
     }
 
     #[test]
-    fn copy_file_stream_settings_cover_max_copy_without_queue_overflow() {
-        assert_eq!(
-            COPY_FILE_STREAM_MAX_BYTES,
-            COPY_FILE_STREAM_CHUNK_LIMIT as u64 * 1024
-        );
+    fn copy_file_stream_settings_keep_configured_chunk_headroom() {
+        // Actual guest reads may produce smaller frames, so bounded runtime
+        // overflow handling remains the correctness guard.
+        let configured_max_chunks =
+            COPY_FILE_STREAM_MAX_BYTES.div_ceil(COPY_FILE_STREAM_CHUNK_LIMIT as u64);
+        assert!(configured_max_chunks < COPY_FILE_STREAM_QUEUE_CAPACITY as u64);
         assert_eq!(
             COPY_FILE_STREAM_QUEUE_CAPACITY,
             exec_operation::test_support::MAX_STREAM_CAPACITY

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -126,21 +126,29 @@ async fn copy_file_streams_to_temp_then_renames() {
     std::fs::set_permissions(&fixture.host_path, std::fs::Permissions::from_mode(0o640)).unwrap();
     let mut old_file = std::fs::File::open(&fixture.host_path).unwrap();
     let old_metadata = old_file.metadata().unwrap();
-    let copy_task = fixture.spawn_copy("/tmp/vm0-system-run.log", default_copy_options());
+    let copy_task = fixture.spawn_copy(
+        "/tmp/vm0-system-run.log",
+        copy_options(
+            file_impl::test_support::COPY_FILE_STREAM_MAX_BYTES,
+            5000,
+            false,
+        ),
+    );
 
     let start = fixture.expect_start().await;
     fixture.assert_readiness(NormalOperationReadiness::Busy);
     assert_eq!(start.label, "copy-file");
     assert_eq!(
-        start.command,
-        "if test -f '/tmp/vm0-system-run.log'; then cat 2>/dev/null < '/tmp/vm0-system-run.log' || { test -f '/tmp/vm0-system-run.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
-    );
-    assert_eq!(
         start.stdout,
         ExecOutputPolicy::Stream {
-            limit_bytes: 1024,
+            limit_bytes: u32::try_from(file_impl::test_support::COPY_FILE_STREAM_MAX_BYTES)
+                .unwrap(),
             chunk_limit_bytes: file_impl::test_support::COPY_FILE_STREAM_CHUNK_LIMIT,
         }
+    );
+    assert_eq!(
+        start.command,
+        "if test -f '/tmp/vm0-system-run.log'; then cat 2>/dev/null < '/tmp/vm0-system-run.log' || { test -f '/tmp/vm0-system-run.log' || exit 66; printf '%s\\n' 'failed to read file' >&2; exit 1; }; else exit 66; fi"
     );
     send_exec_output(
         &mut fixture.guest,


### PR DESCRIPTION
## Summary

- raise the bounded guest-to-host `copy_file` ceiling to 128 MiB while preserving streaming, cancellation, overflow detection, cleanup, and atomic publication
- use the shared `RESUME_SESSION_HISTORY_MAX_BYTES` contract for workspace session-history sidecar export, copy, validation, and publication
- remove the now-unreachable sidecar-unavailable helper state and cover raw/zstd boundaries plus runner fallback behavior

This closes the 64–128 MiB sidecar gap observed in production while keeping R2 authoritative for any real export, copy, validation, or restore failure.

## Compatibility and exclusions

- unrelated `copy_file` callers retain their existing caller-selected limits
- the bounded stream queue and 30-second sidecar copy timeout are unchanged
- existing sidecars remain readable; older runners safely treat newly larger optional sidecars as cache misses
- no API payload, database schema, migration, queue payload, R2 format, or cache metadata-version change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host -p sandbox-mock -p guest-contracts -p guest-agent -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --no-deps -p vsock-host -p sandbox-mock -p guest-contracts -p guest-agent -p runner`
- `git diff --check`

Closes #22383
