### PR TITLE
fix(teams): correct channel context, files, and install events

### DIFF
--- a/turbo/apps/api/src/lib/teams-bot-activity.ts
+++ b/turbo/apps/api/src/lib/teams-bot-activity.ts
@@ -32,6 +32,7 @@ interface ActivityBase {
   readonly conversationId: string;
   readonly conversationType: string | null;
   readonly teamId: string | null;
+  readonly teamAadGroupId: string | null;
   readonly teamName: string | null;
   readonly channelId: string | null;
   readonly timestamp: string | null;
@@ -248,6 +249,7 @@ function activityBase(
       ? readString(conversation, "conversationType")
       : null,
     teamId: team ? readString(team, "id") : null,
+    teamAadGroupId: team ? readString(team, "aadGroupId") : null,
     teamName: team ? readString(team, "name") : null,
     channelId: channel ? readString(channel, "id") : null,
     timestamp,

--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -475,6 +477,11 @@ function teamsGraphUserUrl(userId: string): string {
   return url.toString();
 }
 
+function teamsGraphShareContentUrl(sharedUrl: string): string {
+  const shareId = `u!${Buffer.from(sharedUrl, "utf8").toString("base64url")}`;
+  return `${graphBaseUrl()}/shares/${encodeURIComponent(shareId)}/driveItem/content`;
+}
+
 function shouldAuthorizeTeamsFileDownload(url: string): boolean {
   const parsed = safeUrlParse(url);
   if (!parsed) {
@@ -535,13 +542,25 @@ async function fetchTeamsGraphJson<T>(args: {
 export async function fetchTeamsFile(args: {
   readonly tenantId: string;
   readonly url: string;
+  readonly downloadMode?: "graph";
   readonly signal: AbortSignal;
 }): Promise<FetchTeamsFileResult> {
   const headers: Record<string, string> = {
     accept: "application/octet-stream",
   };
+  let url = args.url;
 
-  if (shouldAuthorizeTeamsFileDownload(args.url)) {
+  if (args.downloadMode === "graph") {
+    const accessToken = await fetchTeamsGraphAccessToken({
+      tenantId: args.tenantId,
+      signal: args.signal,
+    });
+    if (accessToken.kind === "teams-error") {
+      return accessToken;
+    }
+    url = teamsGraphShareContentUrl(args.url);
+    headers.authorization = `Bearer ${accessToken.accessToken}`;
+  } else if (shouldAuthorizeTeamsFileDownload(args.url)) {
     const accessToken = await fetchTeamsBotAccessToken(args.signal);
     if (accessToken.kind === "teams-error") {
       return accessToken;
@@ -550,7 +569,7 @@ export async function fetchTeamsFile(args: {
   }
 
   const responseResult = await settle(
-    fetch(args.url, {
+    fetch(url, {
       method: "GET",
       headers,
       signal: args.signal,

--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -66,6 +66,7 @@ const teamsGraphMentionSchema = z
 const teamsGraphMessageSchema = z
   .object({
     id: z.string().optional(),
+    replyToId: z.string().nullable().optional(),
     createdDateTime: z.string().nullable().optional(),
     messageType: z.string().nullable().optional(),
     from: z
@@ -91,6 +92,31 @@ const teamsGraphMessageSchema = z
 const teamsGraphMessagesResponseSchema = z
   .object({
     value: z.array(teamsGraphMessageSchema),
+  })
+  .passthrough();
+
+const teamsGraphChatSchema = z
+  .object({
+    id: z.string().min(1),
+    chatType: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const teamsGraphUserInstalledAppSchema = z
+  .object({
+    id: z.string().min(1),
+    teamsApp: z
+      .object({
+        externalId: z.string().nullable().optional(),
+      })
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+const teamsGraphUserInstalledAppsResponseSchema = z
+  .object({
+    value: z.array(teamsGraphUserInstalledAppSchema),
   })
   .passthrough();
 
@@ -469,6 +495,40 @@ function teamsGraphChannelMessageUrl(args: {
     url.searchParams.set("$top", String(args.limit));
   }
   return url.toString();
+}
+
+function teamsGraphChatMessagesUrl(args: {
+  readonly chatId: string;
+  readonly limit: number;
+}): string {
+  const url = new URL(
+    `${graphBaseUrl()}/chats/${encodeURIComponent(args.chatId)}/messages`,
+  );
+  url.searchParams.set("$top", String(args.limit));
+  url.searchParams.set("$orderby", "createdDateTime desc");
+  return url.toString();
+}
+
+function teamsGraphUserInstalledAppsUrl(args: {
+  readonly userId: string;
+  readonly teamsAppId: string;
+}): string {
+  const url = new URL(
+    `${graphBaseUrl()}/users/${encodeURIComponent(args.userId)}/teamwork/installedApps`,
+  );
+  const teamsAppId = args.teamsAppId.replaceAll("'", "''");
+  url.searchParams.set("$filter", `teamsApp/externalId eq '${teamsAppId}'`);
+  url.searchParams.set("$expand", "teamsApp");
+  return url.toString();
+}
+
+function teamsGraphUserInstalledAppChatUrl(args: {
+  readonly userId: string;
+  readonly installationId: string;
+}): string {
+  return `${graphBaseUrl()}/users/${encodeURIComponent(
+    args.userId,
+  )}/teamwork/installedApps/${encodeURIComponent(args.installationId)}/chat`;
 }
 
 function teamsGraphUserUrl(userId: string): string {
@@ -971,6 +1031,75 @@ export async function fetchTeamsChannelMessages(args: {
     return result;
   }
   return { kind: "ok", messages: result.data.value };
+}
+
+async function fetchTeamsChatMessages(args: {
+  readonly tenantId: string;
+  readonly chatId: string;
+  readonly limit: number;
+  readonly signal: AbortSignal;
+}): Promise<FetchTeamsGraphMessagesResult> {
+  const result = await fetchTeamsGraphJson({
+    tenantId: args.tenantId,
+    url: teamsGraphChatMessagesUrl({
+      chatId: args.chatId,
+      limit: args.limit,
+    }),
+    schema: teamsGraphMessagesResponseSchema,
+    signal: args.signal,
+  });
+  if (result.kind === "teams-error") {
+    return result;
+  }
+  return { kind: "ok", messages: [...result.data.value].reverse() };
+}
+
+export async function fetchTeamsPersonalChatMessages(args: {
+  readonly tenantId: string;
+  readonly userId: string;
+  readonly teamsAppId: string;
+  readonly limit: number;
+  readonly signal: AbortSignal;
+}): Promise<FetchTeamsGraphMessagesResult> {
+  const installedAppsResult = await fetchTeamsGraphJson({
+    tenantId: args.tenantId,
+    url: teamsGraphUserInstalledAppsUrl({
+      userId: args.userId,
+      teamsAppId: args.teamsAppId,
+    }),
+    schema: teamsGraphUserInstalledAppsResponseSchema,
+    signal: args.signal,
+  });
+  if (installedAppsResult.kind === "teams-error") {
+    return installedAppsResult;
+  }
+  const installedApp = installedAppsResult.data.value.find((candidate) => {
+    return candidate.teamsApp?.externalId === args.teamsAppId;
+  });
+  if (!installedApp) {
+    return teamsApiError(404, "Microsoft Teams personal app not installed");
+  }
+  const chatResult = await fetchTeamsGraphJson({
+    tenantId: args.tenantId,
+    url: teamsGraphUserInstalledAppChatUrl({
+      userId: args.userId,
+      installationId: installedApp.id,
+    }),
+    schema: teamsGraphChatSchema,
+    signal: args.signal,
+  });
+  if (chatResult.kind === "teams-error") {
+    return chatResult;
+  }
+  if (chatResult.data.chatType !== "oneOnOne") {
+    return teamsApiError(404, "Microsoft Teams personal chat not found");
+  }
+  return await fetchTeamsChatMessages({
+    tenantId: args.tenantId,
+    chatId: chatResult.data.id,
+    limit: args.limit,
+    signal: args.signal,
+  });
 }
 
 export async function fetchTeamsChannelMessage(args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -244,6 +244,12 @@ function teamsApiMocks(args: {
         });
       },
     ),
+    http.get(
+      "https://graph.microsoft.com/v1.0/users/:userId/teamwork/installedApps",
+      () => {
+        return HttpResponse.json({ value: [] });
+      },
+    ),
   );
 
   return { tokenRequests, postedActivities, reactionRequests };
@@ -417,6 +423,47 @@ async function dispatchTeamsRun(args: {
   return await runIdForPrompt(actor, args.text);
 }
 
+async function dispatchTeamsPersonalRun(args: {
+  readonly fixture: TeamsConnectFixture;
+  readonly activityId: string;
+  readonly threadId?: string;
+  readonly text: string;
+}): Promise<string> {
+  const response = await postTeamsActivityForTest({
+    signal: context.signal,
+    activity: teamsMessageActivityForTest(args.fixture, {
+      id: args.activityId,
+      conversation: {
+        id: `a:personal-${args.fixture.teamsUserId}`,
+        conversationType: "personal",
+      },
+      channelData: {
+        tenant: {
+          id: args.fixture.teamsTenantId,
+          name: args.fixture.teamsTenantName,
+        },
+        teamsAppId: BOT_APP_ID,
+      },
+      text: args.text,
+      entities: [],
+      replyToId: args.threadId ?? null,
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = recordFromUnknown(
+    await response.json(),
+    "Expected Teams bot response object",
+  );
+  expect(body).not.toHaveProperty("dispatch");
+  await flushWaitUntilForTest();
+  const actor = authOrgApi.user({
+    userId: args.fixture.userId,
+    orgId: args.fixture.orgId,
+    orgRole: "org:admin",
+  });
+  return await runIdForPrompt(actor, args.text);
+}
+
 async function claimTeamsRun(args: {
   readonly runnerGroup: string;
   readonly runId: string;
@@ -517,6 +564,72 @@ afterEach(async () => {
 });
 
 describe("Teams org internal callbacks", () => {
+  it("starts a new agent session for each top-level personal message", async () => {
+    const teams = await setupConnectedTeamsActor();
+    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const firstRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-first",
+      text: "remember this DM context",
+    });
+    const firstClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: firstRunId,
+    });
+    clearTeamsApiCalls(teamsApi);
+    await completeSandboxRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      exitCode: 0,
+    });
+
+    const secondRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-second",
+      text: "use the previous DM context",
+    });
+    const secondClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: secondRunId,
+    });
+
+    expect(secondClaim.resumeSession).toBeNull();
+  });
+
+  it("resumes the same agent session within a personal message thread", async () => {
+    const teams = await setupConnectedTeamsActor();
+    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const rootActivityId = "activity-personal-thread-root";
+    const firstRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: rootActivityId,
+      text: "remember this personal thread context",
+    });
+    const firstClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: firstRunId,
+    });
+    clearTeamsApiCalls(teamsApi);
+    const cliAgentSessionId = await completeSandboxRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      exitCode: 0,
+    });
+
+    const secondRunId = await dispatchTeamsPersonalRun({
+      fixture: teams.fixture,
+      activityId: "activity-personal-thread-reply",
+      threadId: rootActivityId,
+      text: "use the personal thread context",
+    });
+    const secondClaim = await claimTeamsRun({
+      runnerGroup: teams.runnerGroup,
+      runId: secondRunId,
+    });
+
+    expect(secondClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+  });
+
   it("posts completed run replies and persists Teams thread sessions", async () => {
     const teams = await setupConnectedTeamsActor({ zeroDebug: true });
     const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -52,6 +52,7 @@ const TEAMS_BOT_PATH = "http://api.test/api/zero/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
+const TEAMS_AAD_GROUP_ID = "22222222-2222-2222-2222-222222222222";
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
 const APP_ORIGIN = "https://app.vm0.test";
 const KEY_ID = "teams-test-key";
@@ -336,10 +337,11 @@ function teamsGraphHistoryHandlers(args: {
     }),
     http.get(
       "https://graph.microsoft.com/v1.0/teams/:teamId/channels/:channelId/messages",
-      ({ request }) => {
+      ({ params, request }) => {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
+        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
         requests.push("channel-messages");
         return HttpResponse.json({
           value: args.channelMessages.map(teamsGraphMessage),
@@ -352,6 +354,7 @@ function teamsGraphHistoryHandlers(args: {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
+        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
         const messageId =
           typeof params.messageId === "string" ? params.messageId : "";
         requests.push(`thread-replies:${messageId}`);
@@ -366,6 +369,7 @@ function teamsGraphHistoryHandlers(args: {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
+        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
         const messageId =
           typeof params.messageId === "string" ? params.messageId : "";
         requests.push(`thread-root:${messageId}`);
@@ -470,7 +474,11 @@ function teamsMessageActivity(
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: TEAMS_AAD_GROUP_ID,
+        name: fixture.teamsTeamName,
+      },
       channel: { id: "19:channel@thread.tacv2", name: "General" },
       teamsAppId: "teams-app-test",
     },
@@ -545,6 +553,36 @@ function teamsBotInstalledActivity(
     },
     recipient: { id: "28:bot-1", name: "Zero" },
     membersAdded: [{ id: "28:bot-1", name: "Zero" }],
+  };
+}
+
+function teamsBotInstallationAddedActivity(
+  fixture: TeamsConnectFixture = botFixture(),
+): Record<string, unknown> {
+  return {
+    type: "installationUpdate",
+    action: "add",
+    id: "activity-installation-add-1",
+    timestamp: "2026-06-30T09:15:00.000Z",
+    serviceUrl: fixture.serviceUrl,
+    channelId: "msteams",
+    conversation: {
+      id: "19:thread@thread.tacv2",
+      conversationType: "channel",
+    },
+    channelData: {
+      tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
+      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
+      channel: { id: "19:channel@thread.tacv2", name: "General" },
+      teamsAppId: "teams-app-test",
+    },
+    from: {
+      id: fixture.teamsUserId,
+      name: "Ada Lovelace",
+      aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: "ada@example.com",
+    },
+    recipient: { id: "28:bot-1", name: "Zero" },
   };
 }
 
@@ -833,6 +871,7 @@ describe("POST /api/zero/teams/bot", () => {
         conversationId: "19:thread@thread.tacv2",
         conversationType: "channel",
         teamId: "team-1",
+        teamAadGroupId: TEAMS_AAD_GROUP_ID,
         teamName: "Team One",
         channelId: "19:channel@thread.tacv2",
         threadId: "root-activity",
@@ -972,17 +1011,23 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
   });
 
-  it("sends a welcome message when Teams adds the bot in team scope", async () => {
+  it("sends one team welcome across installation and members-added events", async () => {
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
-    const response = await postTeamsActivity({
+    const installationResponse = await postTeamsActivity({
+      activity: teamsBotInstallationAddedActivity(),
+      token: teamsToken(),
+    });
+    const membersAddedResponse = await postTeamsActivity({
       activity: teamsBotInstalledActivity(),
       token: teamsToken(),
     });
 
-    expect(response.status).toBe(200);
-    await response.json();
+    expect(installationResponse.status).toBe(200);
+    expect(membersAddedResponse.status).toBe(200);
+    await installationResponse.json();
+    await membersAddedResponse.json();
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
@@ -1018,7 +1063,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     const response = await postTeamsActivity({
       activity: {
-        ...teamsBotInstalledActivity(),
+        ...teamsBotInstallationAddedActivity(),
         id: "activity-install-personal",
         conversation: {
           id: "a:personal-29:user-1",
@@ -1262,7 +1307,7 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests[0]?.body).not.toHaveProperty("text");
   });
 
-  it("injects Teams file attachments into the run prompt and downloads them", async () => {
+  it("downloads Teams channel reference attachments through Graph", async () => {
     botFrameworkHandlers();
     const fixture = await trackTeamsFixture(
       Promise.resolve(teamsConnectFixture()),
@@ -1289,31 +1334,25 @@ describe("POST /api/zero/teams/bot", () => {
     clearTeamsBotAuthCacheForTest();
     botFrameworkHandlers();
     teamsOutboundHandlers(fixture.serviceUrl);
+    teamsGraphHistoryHandlers({
+      tenantId: fixture.teamsTenantId,
+      channelMessages: [],
+      threadRoots: {},
+      threadReplies: {},
+    });
 
-    const downloadUrl = "https://contoso.sharepoint.com/sites/docs/spec.png";
+    const contentUrl = "https://contoso.sharepoint.com/sites/docs/spec.png";
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-file-dm",
-        conversation: {
-          id: "a:personal-conversation",
-          conversationType: "personal",
-        },
-        channelData: {
-          tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-          teamsAppId: "teams-app-test",
-        },
+        id: "activity-file-channel",
         text: "please inspect this",
-        entities: [],
         replyToId: null,
         attachments: [
           {
-            contentType: "application/vnd.microsoft.teams.file.download.info",
+            id: "channel-attachment-1",
+            contentType: "reference",
+            contentUrl,
             name: "spec.png",
-            content: {
-              downloadUrl,
-              uniqueId: "drive-item-1",
-              fileType: "png",
-            },
           },
         ],
       }),
@@ -1344,20 +1383,29 @@ describe("POST /api/zero/teams/bot", () => {
     const fileIdMatch = claim.prompt.match(/ {3}\[ID\] ([^\n]+)/u);
     const fileId = fileIdMatch?.[1];
     expect(fileId).toBeTruthy();
-    expect(fileId).not.toContain(downloadUrl);
+    expect(fileId).not.toContain(contentUrl);
 
     const fileBytes = Buffer.from("teams file bytes");
+    const expectedShareId = `u!${Buffer.from(contentUrl, "utf8").toString(
+      "base64url",
+    )}`;
     server.use(
-      http.get(downloadUrl, ({ request }) => {
-        expect(request.headers.get("authorization")).toBeNull();
-        return new HttpResponse(fileBytes, {
-          status: 200,
-          headers: {
-            "content-type": "image/png",
-            "content-length": String(fileBytes.length),
-          },
-        });
-      }),
+      http.get(
+        "https://graph.microsoft.com/v1.0/shares/:shareId/driveItem/content",
+        ({ params, request }) => {
+          expect(params.shareId).toBe(expectedShareId);
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer teams-graph-token",
+          );
+          return new HttpResponse(fileBytes, {
+            status: 200,
+            headers: {
+              "content-type": "image/png",
+              "content-length": String(fileBytes.length),
+            },
+          });
+        },
+      ),
     );
 
     const app = createAppWithRoutes({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -1,4 +1,5 @@
 import {
+  createHmac,
   createSign,
   generateKeyPairSync,
   randomUUID,
@@ -237,6 +238,7 @@ function teamsOutboundHandlers(serviceUrl: string): TeamsOutboundRequests {
 
 interface TeamsGraphMessageFixture {
   readonly id: string;
+  readonly replyToId?: string | null;
   readonly text: string;
   readonly createdDateTime: string;
   readonly senderId?: string;
@@ -258,6 +260,7 @@ function teamsGraphMessage(
 ): Record<string, unknown> {
   return {
     id: message.id,
+    replyToId: message.replyToId ?? null,
     createdDateTime: message.createdDateTime,
     messageType: "message",
     from: {
@@ -310,6 +313,9 @@ function teamsGraphUserMap(
 
 function teamsGraphHistoryHandlers(args: {
   readonly tenantId: string;
+  readonly teamsAppId?: string;
+  readonly personalChatId?: string;
+  readonly chatMessages?: readonly TeamsGraphMessageFixture[];
   readonly channelMessages: readonly TeamsGraphMessageFixture[];
   readonly threadRoots: Readonly<Record<string, TeamsGraphMessageFixture>>;
   readonly threadReplies: Readonly<
@@ -317,7 +323,12 @@ function teamsGraphHistoryHandlers(args: {
   >;
 }): string[] {
   const requests: string[] = [];
+  const personalChatId =
+    args.personalChatId ?? "19:personal-chat@unq.gbl.spaces";
+  const personalInstallationId = "personal-app-installation";
+  const teamsAppId = args.teamsAppId ?? "teams-app-test";
   const users = teamsGraphUserMap([
+    ...(args.chatMessages ?? []),
     ...args.channelMessages,
     ...Object.values(args.threadRoots),
     ...Object.values(args.threadReplies).flat(),
@@ -335,6 +346,62 @@ function teamsGraphHistoryHandlers(args: {
         expires_in: 3600,
       });
     }),
+    http.get(
+      "https://graph.microsoft.com/v1.0/users/:userId/teamwork/installedApps",
+      ({ params, request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer teams-graph-token",
+        );
+        const url = new URL(request.url);
+        expect(url.searchParams.get("$filter")).toBe(
+          `teamsApp/externalId eq '${teamsAppId}'`,
+        );
+        expect(url.searchParams.get("$expand")).toBe("teamsApp");
+        const userId = typeof params.userId === "string" ? params.userId : "";
+        requests.push(`personal-installed-apps:${userId}`);
+        return HttpResponse.json({
+          value: args.chatMessages
+            ? [
+                {
+                  id: personalInstallationId,
+                  teamsApp: { externalId: teamsAppId },
+                },
+              ]
+            : [],
+        });
+      },
+    ),
+    http.get(
+      "https://graph.microsoft.com/v1.0/users/:userId/teamwork/installedApps/:installationId/chat",
+      ({ params, request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer teams-graph-token",
+        );
+        expect(params.installationId).toBe(personalInstallationId);
+        const userId = typeof params.userId === "string" ? params.userId : "";
+        requests.push(`personal-app-chat:${userId}`);
+        return HttpResponse.json({
+          id: personalChatId,
+          chatType: "oneOnOne",
+        });
+      },
+    ),
+    http.get(
+      "https://graph.microsoft.com/v1.0/chats/:chatId/messages",
+      ({ params, request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer teams-graph-token",
+        );
+        expect(request.url).toContain("%24top=50");
+        expect(request.url).toContain("%24orderby=createdDateTime+desc");
+        const chatId = typeof params.chatId === "string" ? params.chatId : "";
+        expect(chatId).toBe(personalChatId);
+        requests.push(`chat-messages:${chatId}`);
+        return HttpResponse.json({
+          value: (args.chatMessages ?? []).map(teamsGraphMessage),
+        });
+      },
+    ),
     http.get(
       "https://graph.microsoft.com/v1.0/teams/:teamId/channels/:channelId/messages",
       ({ params, request }) => {
@@ -405,6 +472,14 @@ function encodeJwtPart(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
 }
 
+function legacyTeamsFileId(payload: Readonly<Record<string, unknown>>): string {
+  const encodedPayload = encodeJwtPart(payload);
+  const signature = createHmac("sha256", "a".repeat(64))
+    .update(encodedPayload)
+    .digest("base64url");
+  return `${encodedPayload}.${signature}`;
+}
+
 function signJwt(args: {
   readonly payload: Record<string, unknown>;
   readonly privateKey: KeyObject;
@@ -444,6 +519,7 @@ function teamsToken(
 function zeroToken(args: {
   readonly userId: string;
   readonly orgId: string;
+  readonly runId?: string;
   readonly capabilities?: readonly string[];
 }): string {
   const seconds = Math.floor(now() / 1000);
@@ -451,7 +527,7 @@ function zeroToken(args: {
     scope: "zero",
     userId: args.userId,
     orgId: args.orgId,
-    runId: `run_${randomUUID()}`,
+    runId: args.runId ?? `run_${randomUUID()}`,
     capabilities: (args.capabilities ?? ["teams:write"]) as never,
     iat: seconds,
     exp: seconds + 60,
@@ -1384,6 +1460,7 @@ describe("POST /api/zero/teams/bot", () => {
     const fileId = fileIdMatch?.[1];
     expect(fileId).toBeTruthy();
     expect(fileId).not.toContain(contentUrl);
+    expect(fileId).toMatch(/^teams_file_[A-Za-z0-9_-]{22}$/u);
 
     const fileBytes = Buffer.from("teams file bytes");
     const expectedShareId = `u!${Buffer.from(contentUrl, "utf8").toString(
@@ -1421,6 +1498,7 @@ describe("POST /api/zero/teams/bot", () => {
           authorization: `Bearer ${zeroToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
+            runId,
           })}`,
         },
       },
@@ -1432,6 +1510,108 @@ describe("POST /api/zero/teams/bot", () => {
     expect(downloadResponse.headers.get("x-file-name")).toBe("spec.png");
     const receivedBytes = Buffer.from(await downloadResponse.arrayBuffer());
     expect(receivedBytes.equals(fileBytes)).toBeTruthy();
+  });
+
+  it("uses short file ids for Teams personal attachments", async () => {
+    const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
+    const downloadUrl = new URL(
+      "https://contoso.sharepoint.com/_layouts/15/download.aspx",
+    );
+    downloadUrl.searchParams.set("tempauth", "a".repeat(1400));
+    const fileBytes = Buffer.from("teams personal file bytes");
+    server.use(
+      http.get(downloadUrl.origin + downloadUrl.pathname, () => {
+        return new HttpResponse(fileBytes, {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-length": String(fileBytes.length),
+          },
+        });
+      }),
+    );
+
+    const response = await postTeamsActivity({
+      activity: {
+        ...teamsPersonalMessageActivity({
+          fixture,
+          id: "activity-personal-file",
+          text: "inspect this personal attachment",
+        }),
+        attachments: [
+          {
+            id: "personal-attachment-1",
+            contentType: "application/vnd.microsoft.teams.file.download.info",
+            content: {
+              downloadUrl: downloadUrl.toString(),
+              fileName: "personal.png",
+            },
+          },
+        ],
+      },
+      token: teamsToken(),
+    });
+    expect(response.status).toBe(200);
+    await readTeamsBotResponseAndFlush(response);
+
+    const list = await runsApi.listAgentRuns(actor, { limit: 20 });
+    const run = list.runs.find((item) => {
+      return item.prompt.includes("inspect this personal attachment");
+    });
+    if (!run) {
+      throw new Error("Expected Teams personal file run");
+    }
+    await runsApi.heartbeatRunner(runnerGroup);
+    const claim = await runsApi.claimRunnerJob(run.id);
+    const fileId = claim.prompt.match(/ {3}\[ID\] ([^\n]+)/u)?.[1];
+    expect(fileId).toMatch(/^teams_file_[A-Za-z0-9_-]{22}$/u);
+    expect(fileId?.length).toBeLessThan(64);
+
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: ROUTES,
+    });
+    const downloadResponse = await app.request(
+      `/api/zero/integrations/teams/download-file?${new URLSearchParams({
+        file_id: fileId ?? "",
+      }).toString()}`,
+      {
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+            runId: run.id,
+          })}`,
+        },
+      },
+    );
+
+    expect(downloadResponse.status).toBe(200);
+    expect(downloadResponse.headers.get("x-file-name")).toBe("personal.png");
+    expect(
+      Buffer.from(await downloadResponse.arrayBuffer()).equals(fileBytes),
+    ).toBeTruthy();
+
+    const legacyFileId = legacyTeamsFileId({
+      tenantId: fixture.teamsTenantId,
+      url: downloadUrl.toString(),
+      name: "personal.png",
+      contentType: "image/png",
+    });
+    const legacyDownloadResponse = await app.request(
+      `/api/zero/integrations/teams/download-file?${new URLSearchParams({
+        file_id: legacyFileId,
+      }).toString()}`,
+      {
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+          })}`,
+        },
+      },
+    );
+    expect(legacyDownloadResponse.status).toBe(200);
   });
 
   it("preserves non-bot Teams mentions in message text", async () => {
@@ -2234,6 +2414,89 @@ describe("POST /api/zero/teams/bot", () => {
     expect(graphRequests).toContain("thread-root:root-dispatch");
     expect(graphRequests).toContain("thread-replies:root-dispatch");
     expect(graphRequests).toContain(`user:${fixture.teamsUserId}`);
+  });
+
+  it("includes recent Teams personal messages in the run context", async () => {
+    const { fixture, actor, runnerGroup, outboundRequests } =
+      await setupConnectedTeamsBotActor();
+    const personalChatId = "19:personal-test@unq.gbl.spaces";
+    const graphRequests = teamsGraphHistoryHandlers({
+      tenantId: fixture.teamsTenantId,
+      teamsAppId: BOT_APP_ID,
+      personalChatId,
+      chatMessages: [
+        {
+          id: "activity-personal-thread-current",
+          text: "continue this private task",
+          createdDateTime: "2026-06-30T09:13:00.000Z",
+          senderId: fixture.teamsUserId,
+        },
+        {
+          id: "activity-personal-thread-prior-reply",
+          text: "the target is staging",
+          createdDateTime: "2026-06-30T09:12:00.000Z",
+          senderId: fixture.teamsUserId,
+        },
+        {
+          id: "activity-unrelated-personal-root",
+          text: "unrelated private task",
+          createdDateTime: "2026-06-30T09:11:00.000Z",
+          senderId: fixture.teamsUserId,
+        },
+        {
+          id: "activity-personal-thread-root",
+          text: "remember the private deployment target",
+          createdDateTime: "2026-06-30T09:10:00.000Z",
+          senderId: fixture.teamsUserId,
+        },
+      ],
+      channelMessages: [],
+      threadRoots: {},
+      threadReplies: {},
+    });
+    outboundRequests.splice(0, outboundRequests.length);
+
+    const response = await postTeamsActivity({
+      activity: {
+        ...teamsPersonalMessageActivity({
+          fixture,
+          id: "activity-personal-thread-current",
+          text: "continue this private task",
+        }),
+        channelData: {
+          tenant: {
+            id: fixture.teamsTenantId,
+            name: fixture.teamsTenantName,
+          },
+        },
+      },
+      token: teamsToken(),
+    });
+    expect(response.status).toBe(200);
+    const body = await readTeamsBotResponseAndFlush(response);
+    expect(body).not.toHaveProperty("dispatch");
+    const runId = await runIdForPrompt(actor, "continue this private task");
+    await runsApi.heartbeatRunner(runnerGroup);
+    const claim = await runsApi.claimRunnerJob(runId);
+    const threadContext = promptSection(
+      claim.appendSystemPrompt ?? "",
+      "# Microsoft Teams Thread Context",
+    );
+
+    expect(claim.prompt).toBe("continue this private task");
+    expect(threadContext).toContain("remember the private deployment target");
+    expect(threadContext).toContain("the target is staging");
+    expect(threadContext).toContain("unrelated private task");
+    expect(threadContext).not.toContain("continue this private task");
+    expect(graphRequests).toContain(
+      `personal-installed-apps:${fixture.teamsAadObjectId}`,
+    );
+    expect(graphRequests).toContain(
+      `personal-app-chat:${fixture.teamsAadObjectId}`,
+    );
+    expect(graphRequests).toContain(`chat-messages:${personalChatId}`);
+
+    await runsApi.requestCancelRun(actor, runId, [200]);
   });
 
   it("includes Teams thread computer use host bindings in queued zero tokens", async () => {

--- a/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
@@ -94,6 +94,7 @@ function buildActivity(body: TestTeamsDispatchProbeBody): TeamsInboundActivity {
     conversationId: body.conversation_id,
     conversationType,
     teamId: body.team_id ?? null,
+    teamAadGroupId: body.team_id ?? null,
     teamName: body.team_name ?? null,
     channelId: body.channel_id ?? null,
     timestamp: new Date(now()).toISOString(),

--- a/turbo/apps/api/src/signals/routes/zero-integrations-teams-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-teams-download-file.ts
@@ -2,16 +2,23 @@ import { command } from "ccstate";
 import { initContract } from "@vm0/api-contracts/contracts/trpc-contract";
 import { authHeadersSchema } from "@vm0/api-contracts/contracts/base";
 import { apiErrorSchema } from "@vm0/api-contracts/contracts/errors";
+import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { inferMimetype } from "../../lib/mimetype";
+import type { AuthContext } from "../../types/auth";
+import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
+import { db$, type ReadonlyDb } from "../external/db";
 import { fetchTeamsFile } from "../external/teams-bot-client";
 import {
   decodeTeamsFileToken,
+  teamsFileTokenPayloadSchema,
   type TeamsFileTokenPayload,
 } from "../services/teams-file-token";
+import { teamsOrgCallbackPayloadSchema } from "../services/teams-org-callback-payload";
 import type { RouteEntry } from "../route-entry";
 import { safeUriComponentDecode } from "../utils";
 
@@ -132,6 +139,55 @@ function sanitizeDownloadFilename(filename: string): string {
   return filename.trim().replace(/[/\\]/gu, "_").slice(0, 255) || "teams-file";
 }
 
+async function teamsFilePayloadForRun(args: {
+  readonly db: ReadonlyDb;
+  readonly runId: string;
+  readonly fileId: string;
+}): Promise<TeamsFileTokenPayload | null> {
+  const [callback] = await args.db
+    .select({ payload: agentRunCallbacks.payload })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, args.runId),
+        eq(agentRunCallbacks.internalKind, "teams:org"),
+      ),
+    )
+    .limit(1);
+  if (!callback) {
+    return null;
+  }
+  const parsed = teamsOrgCallbackPayloadSchema.safeParse(callback.payload);
+  const file = parsed.success
+    ? parsed.data.files?.find((candidate) => {
+        return candidate.fileId === args.fileId;
+      })
+    : undefined;
+  return file ? teamsFileTokenPayloadSchema.parse(file) : null;
+}
+
+async function resolveTeamsFilePayload(args: {
+  readonly db: ReadonlyDb;
+  readonly fileId: string;
+  readonly runId: string | undefined;
+}): Promise<TeamsFileTokenPayload | null> {
+  const signedPayload = decodeTeamsFileToken(args.fileId);
+  if (signedPayload) {
+    return signedPayload;
+  }
+  return args.runId
+    ? await teamsFilePayloadForRun({
+        db: args.db,
+        runId: args.runId,
+        fileId: args.fileId,
+      })
+    : null;
+}
+
+function runIdFromAuth(auth: AuthContext): string | undefined {
+  return "runId" in auth ? auth.runId : undefined;
+}
+
 function resolveFilename(args: {
   readonly payload: TeamsFileTokenPayload;
   readonly response: Response;
@@ -153,7 +209,12 @@ const download$ = command(async ({ get }, signal: AbortSignal) => {
     return jsonResponse(400, "file_id is required", "BAD_REQUEST");
   }
 
-  const payload = decodeTeamsFileToken(query.file_id);
+  const payload = await resolveTeamsFilePayload({
+    db: get(db$),
+    fileId: query.file_id,
+    runId: runIdFromAuth(get(authContext$)),
+  });
+  signal.throwIfAborted();
   if (!payload) {
     return jsonResponse(400, "Invalid Microsoft Teams file id", "BAD_REQUEST");
   }

--- a/turbo/apps/api/src/signals/routes/zero-integrations-teams-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/zero-integrations-teams-download-file.ts
@@ -168,6 +168,9 @@ const download$ = command(async ({ get }, signal: AbortSignal) => {
   const downloadResult = await fetchTeamsFile({
     tenantId: payload.tenantId,
     url: payload.url,
+    downloadMode:
+      payload.downloadMode ??
+      (payload.contentType === "reference" ? "graph" : undefined),
     signal,
   });
   signal.throwIfAborted();
@@ -219,8 +222,10 @@ const download$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const filename = resolveFilename({ payload, response: downloadResponse });
+  const payloadContentType =
+    payload.contentType === "reference" ? null : payload.contentType;
   const contentType =
-    payload.contentType ?? responseContentType ?? inferMimetype(filename);
+    payloadContentType ?? responseContentType ?? inferMimetype(filename);
 
   const headers = new Headers();
   headers.set("Content-Type", contentType);

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -139,7 +139,7 @@ type TeamsDispatchReplySource =
 type TeamsMessageActivity = Extract<TeamsInboundActivity, { kind: "message" }>;
 type TeamsInstallWelcomeActivity = Extract<
   TeamsInboundActivity,
-  { kind: "conversation_update" | "installation_update" }
+  { kind: "installation_update" }
 >;
 type TeamsInstallation = typeof teamsOrgInstallations.$inferSelect;
 
@@ -177,19 +177,9 @@ function dispatchReplyContent(dispatch: TeamsDispatchReplySource): {
 function teamsInstallWelcomeActivity(
   activity: TeamsInboundActivity,
 ): TeamsInstallWelcomeActivity | null {
-  if (activity.kind === "installation_update") {
-    return activity.action === "add" ? activity : null;
-  }
-  if (activity.kind !== "conversation_update") {
-    return null;
-  }
-  if (activity.action !== "members_added") {
-    return null;
-  }
-  const botAdded = activity.membersAdded.some((member) => {
-    return member.id === activity.recipient.id;
-  });
-  return botAdded ? activity : null;
+  return activity.kind === "installation_update" && activity.action === "add"
+    ? activity
+    : null;
 }
 
 function buildTeamsInstallWelcomeMention(

--- a/turbo/apps/api/src/signals/services/teams-file-token.ts
+++ b/turbo/apps/api/src/signals/services/teams-file-token.ts
@@ -8,6 +8,7 @@ import { safeJsonParse } from "../utils";
 const teamsFileTokenPayloadSchema = z.object({
   tenantId: z.string().min(1),
   url: z.string().url(),
+  downloadMode: z.literal("graph").optional(),
   id: z.string().min(1).optional(),
   name: z.string().min(1).optional(),
   contentType: z.string().min(1).optional(),

--- a/turbo/apps/api/src/signals/services/teams-file-token.ts
+++ b/turbo/apps/api/src/signals/services/teams-file-token.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { env } from "../../lib/env";
 import { safeJsonParse } from "../utils";
 
-const teamsFileTokenPayloadSchema = z.object({
+export const teamsFileTokenPayloadSchema = z.object({
   tenantId: z.string().min(1),
   url: z.string().url(),
   downloadMode: z.literal("graph").optional(),
@@ -33,14 +33,6 @@ function constantTimeEqual(left: string, right: string): boolean {
     leftBuffer.byteLength === rightBuffer.byteLength &&
     timingSafeEqual(leftBuffer, rightBuffer)
   );
-}
-
-export function encodeTeamsFileToken(payload: TeamsFileTokenPayload): string {
-  const parsed = teamsFileTokenPayloadSchema.parse(payload);
-  const encodedPayload = Buffer.from(JSON.stringify(parsed), "utf8").toString(
-    "base64url",
-  );
-  return `${encodedPayload}.${signatureFor(encodedPayload)}`;
 }
 
 export function decodeTeamsFileToken(

--- a/turbo/apps/api/src/signals/services/teams-org-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/teams-org-callback-payload.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+import { teamsFileTokenPayloadSchema } from "./teams-file-token";
+
+const teamsOrgCallbackFileSchema = teamsFileTokenPayloadSchema.extend({
+  fileId: z.string().min(1),
+});
+
 export const teamsOrgCallbackPayloadSchema = z
   .object({
     tenantId: z.string().min(1),
@@ -20,6 +26,7 @@ export const teamsOrgCallbackPayloadSchema = z
     botName: z.string().nullable(),
     agentId: z.string().min(1),
     existingSessionId: z.string().nullable(),
+    files: z.array(teamsOrgCallbackFileSchema).optional(),
   })
   .passthrough();
 

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -90,6 +90,7 @@ const TEAMS_AGENT_PICKER_ORG_DEFAULT_VALUE = "__org_default__";
 const TEAMS_THINKING_REACTION_TYPE = "1f4ad_thoughtballoon";
 const TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE =
   "application/vnd.microsoft.teams.file.download.info";
+const TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE = "reference";
 
 type TeamsBotCommand = "help" | "connect" | "disconnect" | "switch" | "model";
 type TeamsCardAction = "switch_agent" | "switch_model";
@@ -132,6 +133,11 @@ interface TeamsPromptFile {
   readonly sourceId?: string;
   readonly name: string;
   readonly contentType: string;
+}
+
+interface TeamsAttachmentDownload {
+  readonly url: string;
+  readonly mode: "graph" | undefined;
 }
 
 type EffectiveComposeResolution =
@@ -455,11 +461,21 @@ function recordFromUnknown(
 
 function teamsAttachmentDownloadUrl(
   attachment: TeamsInboundAttachment,
-): string | null {
-  return (
-    stringRecordValue(attachment.content, "downloadUrl") ??
-    attachment.contentUrl
-  );
+): TeamsAttachmentDownload | null {
+  const directUrl = stringRecordValue(attachment.content, "downloadUrl");
+  if (directUrl) {
+    return { url: directUrl, mode: undefined };
+  }
+  if (!attachment.contentUrl) {
+    return null;
+  }
+  return {
+    url: attachment.contentUrl,
+    mode:
+      attachment.contentType === TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE
+        ? "graph"
+        : undefined,
+  };
 }
 
 function teamsAttachmentName(attachment: TeamsInboundAttachment): string {
@@ -477,7 +493,8 @@ function teamsAttachmentContentType(
 ): string {
   if (
     attachment.contentType &&
-    attachment.contentType !== TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE
+    attachment.contentType !== TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE &&
+    attachment.contentType !== TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE
   ) {
     return attachment.contentType;
   }
@@ -493,8 +510,8 @@ function teamsPromptFile(
   activity: TeamsMessageActivity,
   attachment: TeamsInboundAttachment,
 ): TeamsPromptFile | null {
-  const url = teamsAttachmentDownloadUrl(attachment);
-  if (!url || !URL.canParse(url)) {
+  const download = teamsAttachmentDownloadUrl(attachment);
+  if (!download || !URL.canParse(download.url)) {
     return null;
   }
 
@@ -503,7 +520,8 @@ function teamsPromptFile(
   return {
     fileId: encodeTeamsFileToken({
       tenantId: activity.tenantId,
-      url,
+      url: download.url,
+      downloadMode: download.mode,
       id: attachment.id ?? undefined,
       name,
       contentType,
@@ -553,13 +571,24 @@ function graphAttachmentContent(
 
 function teamsGraphAttachmentDownloadUrl(
   attachment: TeamsGraphAttachment,
-): string | null {
+): TeamsAttachmentDownload | null {
   const content = graphAttachmentContent(attachment);
-  return (
-    stringRecordValue(content, "downloadUrl") ??
-    attachment.contentUrl ??
-    stringRecordValue(content, "contentUrl")
-  );
+  const directUrl = stringRecordValue(content, "downloadUrl");
+  if (directUrl) {
+    return { url: directUrl, mode: undefined };
+  }
+  const contentUrl =
+    attachment.contentUrl ?? stringRecordValue(content, "contentUrl");
+  if (!contentUrl) {
+    return null;
+  }
+  return {
+    url: contentUrl,
+    mode:
+      attachment.contentType === TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE
+        ? "graph"
+        : undefined,
+  };
 }
 
 function teamsGraphAttachmentName(attachment: TeamsGraphAttachment): string {
@@ -579,7 +608,8 @@ function teamsGraphAttachmentContentType(
   const content = graphAttachmentContent(attachment);
   if (
     attachment.contentType &&
-    attachment.contentType !== TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE
+    attachment.contentType !== TEAMS_FILE_DOWNLOAD_INFO_CONTENT_TYPE &&
+    attachment.contentType !== TEAMS_REFERENCE_ATTACHMENT_CONTENT_TYPE
   ) {
     return attachment.contentType;
   }
@@ -595,8 +625,8 @@ function teamsGraphPromptFile(
   tenantId: string,
   attachment: TeamsGraphAttachment,
 ): TeamsPromptFile | null {
-  const url = teamsGraphAttachmentDownloadUrl(attachment);
-  if (!url || !URL.canParse(url)) {
+  const download = teamsGraphAttachmentDownloadUrl(attachment);
+  if (!download || !URL.canParse(download.url)) {
     return null;
   }
 
@@ -605,7 +635,8 @@ function teamsGraphPromptFile(
   return {
     fileId: encodeTeamsFileToken({
       tenantId,
-      url,
+      url: download.url,
+      downloadMode: download.mode,
       id: attachment.id ?? undefined,
       name,
       contentType,
@@ -1334,7 +1365,7 @@ async function fetchTeamsThreadRootMessage(args: {
   const { activity } = args;
   if (
     !isTeamsThreadReply(activity) ||
-    !activity.teamId ||
+    !activity.teamAadGroupId ||
     !activity.channelId
   ) {
     return null;
@@ -1342,7 +1373,7 @@ async function fetchTeamsThreadRootMessage(args: {
 
   const rootResult = await fetchTeamsChannelMessage({
     tenantId: activity.tenantId,
-    teamId: activity.teamId,
+    teamId: activity.teamAadGroupId,
     channelId: activity.channelId,
     messageId: activity.threadId,
     signal: args.signal,
@@ -1351,6 +1382,7 @@ async function fetchTeamsThreadRootMessage(args: {
     L.warn("Teams thread root context fetch failed", {
       tenantId: activity.tenantId,
       teamId: activity.teamId,
+      teamAadGroupId: activity.teamAadGroupId,
       channelId: activity.channelId,
       threadId: activity.threadId,
       status: rootResult.status,
@@ -1368,13 +1400,13 @@ async function fetchTeamsThreadContext(args: {
   readonly signal: AbortSignal;
 }): Promise<string> {
   const { activity } = args;
-  if (!args.rootMessage || !activity.teamId || !activity.channelId) {
+  if (!args.rootMessage || !activity.teamAadGroupId || !activity.channelId) {
     return "";
   }
 
   const repliesResult = await fetchTeamsChannelMessageReplies({
     tenantId: activity.tenantId,
-    teamId: activity.teamId,
+    teamId: activity.teamAadGroupId,
     channelId: activity.channelId,
     messageId: activity.threadId,
     limit: 100,
@@ -1384,6 +1416,7 @@ async function fetchTeamsThreadContext(args: {
     L.warn("Teams thread replies context fetch failed", {
       tenantId: activity.tenantId,
       teamId: activity.teamId,
+      teamAadGroupId: activity.teamAadGroupId,
       channelId: activity.channelId,
       threadId: activity.threadId,
       status: repliesResult.status,
@@ -1429,15 +1462,15 @@ async function fetchRecentTeamsChannelContext(args: {
   readonly signal: AbortSignal;
 }): Promise<string> {
   const { activity } = args;
-  const teamId = activity.teamId;
+  const teamAadGroupId = activity.teamAadGroupId;
   const channelId = activity.channelId;
-  if (!teamId || !channelId) {
+  if (!teamAadGroupId || !channelId) {
     return "";
   }
 
   const result = await fetchTeamsChannelMessages({
     tenantId: activity.tenantId,
-    teamId,
+    teamId: teamAadGroupId,
     channelId,
     limit: 10,
     signal: args.signal,
@@ -1446,6 +1479,7 @@ async function fetchRecentTeamsChannelContext(args: {
     L.warn("Teams channel context fetch failed", {
       tenantId: activity.tenantId,
       teamId: activity.teamId,
+      teamAadGroupId: activity.teamAadGroupId,
       channelId: activity.channelId,
       status: result.status,
       error: result.error,

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -33,6 +33,7 @@ import {
   fetchTeamsChannelMessageReplies,
   fetchTeamsChannelMessages,
   fetchTeamsUsers,
+  fetchTeamsPersonalChatMessages,
   sendTeamsReaction,
   sendTeamsTypingActivity,
   type TeamsAdaptiveCard,
@@ -55,7 +56,7 @@ import {
   teamsOrgCallbackPayloadSchema,
   type TeamsOrgCallbackPayload,
 } from "./teams-org-callback-payload";
-import { encodeTeamsFileToken } from "./teams-file-token";
+import type { TeamsFileTokenPayload } from "./teams-file-token";
 import {
   updateUserModelPreference$,
   userModelPreference,
@@ -133,11 +134,17 @@ interface TeamsPromptFile {
   readonly sourceId?: string;
   readonly name: string;
   readonly contentType: string;
+  readonly payload: TeamsFileTokenPayload;
 }
 
 interface TeamsAttachmentDownload {
   readonly url: string;
   readonly mode: "graph" | undefined;
+}
+
+interface TeamsPromptContext {
+  readonly text: string;
+  readonly files: readonly TeamsPromptFile[];
 }
 
 type EffectiveComposeResolution =
@@ -517,18 +524,20 @@ function teamsPromptFile(
 
   const name = teamsAttachmentName(attachment);
   const contentType = teamsAttachmentContentType(attachment, name);
+  const payload: TeamsFileTokenPayload = {
+    tenantId: activity.tenantId,
+    url: download.url,
+    downloadMode: download.mode,
+    id: attachment.id ?? undefined,
+    name,
+    contentType,
+  };
   return {
-    fileId: encodeTeamsFileToken({
-      tenantId: activity.tenantId,
-      url: download.url,
-      downloadMode: download.mode,
-      id: attachment.id ?? undefined,
-      name,
-      contentType,
-    }),
+    fileId: `teams_file_${randomBytes(16).toString("base64url")}`,
     sourceId: attachment.id ?? undefined,
     name,
     contentType,
+    payload,
   };
 }
 
@@ -632,18 +641,20 @@ function teamsGraphPromptFile(
 
   const name = teamsGraphAttachmentName(attachment);
   const contentType = teamsGraphAttachmentContentType(attachment, name);
+  const payload: TeamsFileTokenPayload = {
+    tenantId,
+    url: download.url,
+    downloadMode: download.mode,
+    id: attachment.id ?? undefined,
+    name,
+    contentType,
+  };
   return {
-    fileId: encodeTeamsFileToken({
-      tenantId,
-      url: download.url,
-      downloadMode: download.mode,
-      id: attachment.id ?? undefined,
-      name,
-      contentType,
-    }),
+    fileId: `teams_file_${randomBytes(16).toString("base64url")}`,
     sourceId: attachment.id ?? undefined,
     name,
     contentType,
+    payload,
   };
 }
 
@@ -1153,6 +1164,18 @@ function formatTeamsContext(
   )}\n\n---`;
 }
 
+function formattedTeamsContext(
+  text: string,
+  messages: readonly TeamsContextMessage[],
+): TeamsPromptContext {
+  return {
+    text,
+    files: messages.flatMap((message) => {
+      return message.files;
+    }),
+  };
+}
+
 function plainTeamsMentionLabel(mentionText: string): string {
   return mentionText
     .replace(/<at[^>]*>/giu, "")
@@ -1398,10 +1421,10 @@ async function fetchTeamsThreadContext(args: {
   readonly activity: TeamsMessageActivity;
   readonly rootMessage: TeamsGraphMessage | null;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<TeamsPromptContext> {
   const { activity } = args;
   if (!args.rootMessage || !activity.teamAadGroupId || !activity.channelId) {
-    return "";
+    return { text: "", files: [] };
   }
 
   const repliesResult = await fetchTeamsChannelMessageReplies({
@@ -1422,7 +1445,7 @@ async function fetchTeamsThreadContext(args: {
       status: repliesResult.status,
       error: repliesResult.error,
     });
-    return "";
+    return { text: "", files: [] };
   }
 
   const messages = [args.rootMessage, ...repliesResult.messages];
@@ -1432,13 +1455,15 @@ async function fetchTeamsThreadContext(args: {
     signal: args.signal,
   });
 
-  return formatTeamsThreadContext(
-    teamsContextMessages(
-      activity.tenantId,
-      messages,
-      currentTeamsActivityIds(activity),
-      userInfoMap,
-    ),
+  const contextMessages = teamsContextMessages(
+    activity.tenantId,
+    messages,
+    currentTeamsActivityIds(activity),
+    userInfoMap,
+  );
+  return formattedTeamsContext(
+    formatTeamsThreadContext(contextMessages),
+    contextMessages,
   );
 }
 
@@ -1460,12 +1485,12 @@ async function fetchRecentTeamsChannelContext(args: {
   readonly activity: TeamsMessageActivity;
   readonly beforeMessage: TeamsGraphMessage | null;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<TeamsPromptContext> {
   const { activity } = args;
   const teamAadGroupId = activity.teamAadGroupId;
   const channelId = activity.channelId;
   if (!teamAadGroupId || !channelId) {
-    return "";
+    return { text: "", files: [] };
   }
 
   const result = await fetchTeamsChannelMessages({
@@ -1484,7 +1509,7 @@ async function fetchRecentTeamsChannelContext(args: {
       status: result.status,
       error: result.error,
     });
-    return "";
+    return { text: "", files: [] };
   }
 
   const messages = teamsMessagesBeforeReference(
@@ -1497,18 +1522,67 @@ async function fetchRecentTeamsChannelContext(args: {
     signal: args.signal,
   });
 
-  return formatRecentTeamsChannelContext(
-    teamsContextMessages(
-      activity.tenantId,
-      messages,
-      recentChannelContextExcludedIds(activity),
-      userInfoMap,
-    ),
+  const contextMessages = teamsContextMessages(
+    activity.tenantId,
+    messages,
+    recentChannelContextExcludedIds(activity),
+    userInfoMap,
+  );
+  return formattedTeamsContext(
+    formatRecentTeamsChannelContext(contextMessages),
+    contextMessages,
   );
 }
 
 function isTeamsDirectMessage(activity: TeamsMessageActivity): boolean {
   return activity.conversationType === "personal";
+}
+
+async function fetchTeamsDirectMessageThreadContext(args: {
+  readonly activity: TeamsMessageActivity;
+  readonly signal: AbortSignal;
+}): Promise<TeamsPromptContext> {
+  const { activity } = args;
+  const userId = activity.sender.aadObjectId;
+  const teamsAppId = activity.teamsAppId ?? env("MICROSOFT_TEAMS_BOT_APP_ID");
+  if (!userId || !teamsAppId) {
+    return { text: "", files: [] };
+  }
+
+  const result = await fetchTeamsPersonalChatMessages({
+    tenantId: activity.tenantId,
+    userId,
+    teamsAppId,
+    limit: 50,
+    signal: args.signal,
+  });
+  if (result.kind === "teams-error") {
+    L.warn("Teams direct message thread context fetch failed", {
+      tenantId: activity.tenantId,
+      conversationId: activity.conversationId,
+      threadId: activity.threadId,
+      status: result.status,
+      error: result.error,
+    });
+    return { text: "", files: [] };
+  }
+
+  const messages = result.messages;
+  const userInfoMap = await fetchTeamsGraphUserInfoMap({
+    tenantId: activity.tenantId,
+    messages,
+    signal: args.signal,
+  });
+  const contextMessages = teamsContextMessages(
+    activity.tenantId,
+    messages,
+    currentTeamsActivityIds(activity),
+    userInfoMap,
+  );
+  return formattedTeamsContext(
+    formatTeamsThreadContext(contextMessages),
+    contextMessages,
+  );
 }
 
 function shouldDispatchTeamsMessage(activity: TeamsMessageActivity): boolean {
@@ -1531,28 +1605,33 @@ function teamsValidationFallbackNotice(args: {
 async function fetchTeamsPromptContext(args: {
   readonly activity: TeamsMessageActivity;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<TeamsPromptContext> {
+  if (isTeamsDirectMessage(args.activity)) {
+    return await fetchTeamsDirectMessageThreadContext(args);
+  }
+
   const threadRootMessage = await fetchTeamsThreadRootMessage({
     activity: args.activity,
     signal: args.signal,
   });
-  const recentChannelContext = isTeamsDirectMessage(args.activity)
-    ? ""
-    : await fetchRecentTeamsChannelContext({
-        activity: args.activity,
-        beforeMessage: threadRootMessage,
-        signal: args.signal,
-      });
+  const recentChannelContext = await fetchRecentTeamsChannelContext({
+    activity: args.activity,
+    beforeMessage: threadRootMessage,
+    signal: args.signal,
+  });
   const threadContext = await fetchTeamsThreadContext({
     activity: args.activity,
     rootMessage: threadRootMessage,
     signal: args.signal,
   });
-  return [recentChannelContext, threadContext]
-    .filter((context) => {
-      return context.length > 0;
-    })
-    .join("\n\n");
+  return {
+    text: [recentChannelContext.text, threadContext.text]
+      .filter((context) => {
+        return context.length > 0;
+      })
+      .join("\n\n"),
+    files: [...recentChannelContext.files, ...threadContext.files],
+  };
 }
 
 function buildTeamsPrompt(args: {
@@ -1590,6 +1669,7 @@ function callbackPayload(args: {
   readonly connection: TeamsConnection;
   readonly composeId: string;
   readonly existingSessionId: string | undefined;
+  readonly files: readonly TeamsPromptFile[];
 }): TeamsOrgCallbackPayload {
   return teamsOrgCallbackPayloadSchema.parse({
     tenantId: args.activity.tenantId,
@@ -1610,7 +1690,17 @@ function callbackPayload(args: {
     botName: args.activity.recipient?.name ?? args.installation.botName,
     agentId: args.composeId,
     existingSessionId: args.existingSessionId ?? null,
+    files: args.files.map((file) => {
+      return { fileId: file.fileId, ...file.payload };
+    }),
   });
+}
+
+function promptForTeamsRun(args: {
+  readonly activity: TeamsMessageActivity;
+  readonly promptFiles: readonly TeamsPromptFile[];
+}): string {
+  return appendTeamsFilesToPrompt(args.activity.text, args.promptFiles);
 }
 
 const runAgentForTeams$ = command(
@@ -1624,7 +1714,8 @@ const runAgentForTeams$ = command(
       readonly agentLabel: string;
       readonly sessionId: string | undefined;
       readonly computerUseHostId: string | undefined;
-      readonly threadContext: string;
+      readonly promptFiles: readonly TeamsPromptFile[];
+      readonly promptContext: TeamsPromptContext;
       readonly apiStartTime: number;
       readonly modelRoute: IntegrationModelRoutePin | undefined;
       readonly timing: ApiDispatchTimingCollector;
@@ -1646,7 +1737,7 @@ const runAgentForTeams$ = command(
           orgRole: "member",
         },
         body: {
-          prompt: args.activity.text,
+          prompt: promptForTeamsRun(args),
           agentId: args.composeId,
           sessionId: args.sessionId,
           ...(args.modelRoute?.modelProviderType
@@ -1658,7 +1749,7 @@ const runAgentForTeams$ = command(
         appendSystemPrompt: buildTeamsPrompt({
           activity: args.activity,
           installation: args.installation,
-          threadContext: args.threadContext,
+          threadContext: args.promptContext.text,
         }),
         userInfoExtras: {
           teamsUserDisplayName: args.activity.sender.name ?? undefined,
@@ -1683,6 +1774,7 @@ const runAgentForTeams$ = command(
               connection: args.connection,
               composeId: args.composeId,
               existingSessionId: args.sessionId,
+              files: [...args.promptFiles, ...args.promptContext.files],
             }),
           },
         ],
@@ -2082,6 +2174,7 @@ const runResolvedTeamsAgentForActivity$ = command(
     args: {
       readonly db: Db;
       readonly prompt: string;
+      readonly promptFiles: readonly TeamsPromptFile[];
       readonly activity: TeamsMessageActivity;
       readonly installation: BoundTeamsInstallation;
       readonly connection: TeamsConnection;
@@ -2119,7 +2212,7 @@ const runResolvedTeamsAgentForActivity$ = command(
     });
     signal.throwIfAborted();
 
-    const threadContext = await fetchTeamsPromptContext({
+    const promptContext = await fetchTeamsPromptContext({
       activity: args.activity,
       signal,
     });
@@ -2135,7 +2228,8 @@ const runResolvedTeamsAgentForActivity$ = command(
         agentLabel: agentLabel(args.effectiveCompose.agent),
         sessionId: runThreadContext.existingSessionId,
         computerUseHostId: runThreadContext.computerUseHostId,
-        threadContext,
+        promptFiles: args.promptFiles,
+        promptContext,
         apiStartTime: args.apiStartTime,
         modelRoute,
         timing: args.timing,
@@ -2275,7 +2369,8 @@ export const dispatchTeamsMessageToAgent$ = command(
       runResolvedTeamsAgentForActivity$,
       {
         db,
-        prompt: appendTeamsFilesToPrompt(prompt, promptFiles),
+        prompt,
+        promptFiles,
         activity,
         installation: boundInstallation,
         connection,

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
@@ -29,6 +29,7 @@ const teamsActivityBaseSchema = z.object({
   conversationId: z.string(),
   conversationType: z.string().nullable(),
   teamId: z.string().nullable(),
+  teamAadGroupId: z.string().nullable(),
   teamName: z.string().nullable(),
   channelId: z.string().nullable(),
   timestamp: z.string().nullable(),


### PR DESCRIPTION
## Summary

- use the Teams AAD group ID for Microsoft Graph channel and thread history requests
- download Teams channel reference attachments through the Microsoft Graph shares API while preserving existing DM file behavior
- send the install welcome only for `installationUpdate/add` so overlapping Teams events do not produce duplicate messages

## Operational requirement

The Teams Entra application needs the Microsoft Graph `Files.Read.All` application permission with tenant admin consent for channel file downloads.

## Test plan

- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- pre-commit full repository type checks
