### PR TITLE
fix(api): await required axiom ingestion

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -6,6 +6,11 @@ import { mockStripeClient } from "../signals/external/stripe-client";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type BooleanMock = Mock<(...args: unknown[]) => boolean>;
+type RequiredAxiomIngest = (
+  dataset: string,
+  events: readonly Record<string, unknown>[],
+) => Promise<boolean>;
+type RequiredAxiomIngestMock = Mock<RequiredAxiomIngest>;
 type SignalTimerDelayOptions = { readonly signal?: AbortSignal };
 type SignalTimerDelayMock = Mock<
   (ms: number, options?: SignalTimerDelayOptions) => Promise<void>
@@ -37,10 +42,13 @@ type PinnedRequestCallback = (
 
 export interface ApiTestMocks {
   readonly axiom: {
+    readonly datasetName: Mock<(name: string) => string>;
     readonly flush: AsyncMock;
     readonly ingest: BooleanMock;
+    readonly requiredIngest: RequiredAxiomIngestMock;
     readonly query: AsyncMock;
     readonly sdkIngest: UnknownMock;
+    readonly useRealSdk: Mock<() => boolean>;
   };
   readonly axiomLogging: {
     readonly debug: SyncMock;
@@ -228,11 +236,19 @@ export interface ApiTestMocks {
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
+    datasetName: vi.fn<(name: string) => string>(),
     flush: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     ingest: vi.fn<(...args: unknown[]) => boolean>(),
+    requiredIngest: vi.fn<RequiredAxiomIngest>(),
     query: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     sdkIngest: vi.fn<(...args: unknown[]) => unknown>(),
+    useRealSdk: vi.fn<() => boolean>(),
   };
+  axiom.datasetName.mockImplementation((name) => {
+    return name;
+  });
+  axiom.requiredIngest.mockResolvedValue(true);
+  axiom.useRealSdk.mockReturnValue(false);
 
   const clerk = {
     authenticateRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -855,7 +871,7 @@ vi.mock("../signals/external/axiom", () => {
       return apiTestMocks.axiom.query(apl, options);
     },
     getDatasetName: (name: string) => {
-      return name;
+      return apiTestMocks.axiom.datasetName(name);
     },
     ingestToAxiom: (
       dataset: string,
@@ -863,15 +879,29 @@ vi.mock("../signals/external/axiom", () => {
     ) => {
       return apiTestMocks.axiom.ingest(dataset, events);
     },
+    ingestRequiredToAxiom: (
+      dataset: string,
+      events: readonly Record<string, unknown>[],
+    ) => {
+      return apiTestMocks.axiom.requiredIngest(dataset, events);
+    },
     flushAxiom: (options?: unknown) => {
       return apiTestMocks.axiom.flush(options);
     },
   };
 });
 
-vi.mock("@axiomhq/js", () => {
+vi.mock("@axiomhq/js", async () => {
+  const actual =
+    await vi.importActual<typeof import("@axiomhq/js")>("@axiomhq/js");
+  type AxiomOptions = ConstructorParameters<typeof actual.Axiom>[0];
+
   return {
-    Axiom: vi.fn(function () {
+    ...actual,
+    Axiom: vi.fn(function (options: AxiomOptions) {
+      if (apiTestMocks.axiom.useRealSdk()) {
+        return new actual.Axiom(options);
+      }
       return {
         flush: apiTestMocks.axiom.flush,
         ingest: apiTestMocks.axiom.sdkIngest,
@@ -912,10 +942,18 @@ export function resetApiTestMocks(): void {
     token: "test-ably-token",
   });
   apiTestMocks.axiom.flush.mockReset();
+  apiTestMocks.axiom.datasetName.mockReset();
+  apiTestMocks.axiom.datasetName.mockImplementation((name) => {
+    return name;
+  });
   apiTestMocks.axiom.ingest.mockReset();
   apiTestMocks.axiom.ingest.mockReturnValue(true);
+  apiTestMocks.axiom.requiredIngest.mockReset();
+  apiTestMocks.axiom.requiredIngest.mockResolvedValue(true);
   apiTestMocks.axiom.query.mockReset();
   apiTestMocks.axiom.sdkIngest.mockReset();
+  apiTestMocks.axiom.useRealSdk.mockReset();
+  apiTestMocks.axiom.useRealSdk.mockReturnValue(false);
   apiTestMocks.axiomLogging.debug.mockReset();
   apiTestMocks.axiomLogging.info.mockReset();
   apiTestMocks.axiomLogging.warn.mockReset();

--- a/turbo/apps/api/src/signals/external/__tests__/axiom-delivery.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom-delivery.test.ts
@@ -1,0 +1,204 @@
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { testContext } from "../../../__tests__/test-context";
+
+const context = testContext();
+const { flushAxiom, ingestRequiredToAxiom, ingestToAxiom } =
+  await vi.importActual<typeof import("../axiom")>("../axiom");
+
+interface CapturedAxiomRequest {
+  readonly authorization: string | null;
+  readonly body: string;
+  readonly contentType: string | null;
+  readonly dataset: string;
+}
+
+function successfulIngestStatus(ingested: number): Record<string, unknown> {
+  return {
+    ingested,
+    failed: 0,
+    failures: [],
+    processedBytes: 1,
+    blocksCreated: 0,
+    walLength: ingested,
+  };
+}
+
+beforeEach(() => {
+  context.mocks.axiom.useRealSdk.mockReturnValue(true);
+});
+
+describe("required Axiom delivery", () => {
+  it("awaits the real SDK request with the selected token and NDJSON body", async () => {
+    const requests: CapturedAxiomRequest[] = [];
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/:dataset/ingest",
+        async ({ params, request }) => {
+          requests.push({
+            authorization: request.headers.get("authorization"),
+            body: await request.text(),
+            contentType: request.headers.get("content-type"),
+            dataset: String(params.dataset),
+          });
+          return HttpResponse.json(successfulIngestStatus(2));
+        },
+      ),
+    );
+
+    await expect(
+      ingestRequiredToAxiom("vm0-agent-run-events-dev", [
+        { sequenceNumber: 1 },
+        { sequenceNumber: 2 },
+      ]),
+    ).resolves.toBeTruthy();
+
+    expect(requests).toStrictEqual([
+      {
+        authorization: "Bearer xaat-test-sessions",
+        body: '{"sequenceNumber":1}\n{"sequenceNumber":2}',
+        contentType: "application/x-ndjson",
+        dataset: "vm0-agent-run-events-dev",
+      },
+    ]);
+  });
+
+  it("rejects a real SDK 5xx callback with request-local context", async () => {
+    let attempts = 0;
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/:dataset/ingest", () => {
+        attempts += 1;
+        return HttpResponse.json(
+          { message: "forced Axiom failure" },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(
+      ingestRequiredToAxiom("vm0-agent-run-events-dev", [{ id: "event" }]),
+    ).rejects.toMatchObject({
+      message:
+        'Required Axiom ingest failed for sessions dataset "vm0-agent-run-events-dev"',
+      cause: expect.objectContaining({ message: "forced Axiom failure" }),
+    });
+    expect(attempts).toBe(2);
+  });
+
+  it("rejects a response that reports failed events", async () => {
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/:dataset/ingest", () => {
+        return HttpResponse.json({
+          ingested: 1,
+          failed: 1,
+          failures: [{ error: "invalid event", index: 1 }],
+          processedBytes: 1,
+          blocksCreated: 0,
+          walLength: 1,
+        });
+      }),
+    );
+
+    await expect(
+      ingestRequiredToAxiom("vm0-sandbox-telemetry-system-dev", [
+        { id: "accepted" },
+        { id: "rejected" },
+      ]),
+    ).rejects.toMatchObject({
+      message:
+        'Required Axiom ingest failed for telemetry dataset "vm0-sandbox-telemetry-system-dev"',
+      cause: expect.objectContaining({
+        message: "Axiom reported 1 failed event(s)",
+      }),
+    });
+  });
+
+  it("keeps overlapping delivery outcomes isolated", async () => {
+    let started = 0;
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/:dataset/ingest",
+        ({ params }) => {
+          started += 1;
+          if (String(params.dataset).includes("agent-run-events")) {
+            return HttpResponse.json(
+              { message: "sessions delivery failed" },
+              { status: 400 },
+            );
+          }
+          return HttpResponse.json(successfulIngestStatus(1));
+        },
+      ),
+    );
+
+    const results = await Promise.allSettled([
+      ingestRequiredToAxiom("vm0-agent-run-events-dev", [{ id: "sessions" }]),
+      ingestRequiredToAxiom("vm0-sandbox-telemetry-system-dev", [
+        { id: "telemetry" },
+      ]),
+    ]);
+
+    expect(results).toStrictEqual([
+      {
+        status: "rejected",
+        reason: expect.objectContaining({
+          message:
+            'Required Axiom ingest failed for sessions dataset "vm0-agent-run-events-dev"',
+          cause: expect.objectContaining({
+            message: "sessions delivery failed",
+          }),
+        }),
+      },
+      { status: "fulfilled", value: true },
+    ]);
+    expect(started).toBe(2);
+  });
+
+  it("returns false without making a request when the token is absent", async () => {
+    let requests = 0;
+    mockOptionalEnv("AXIOM_TOKEN_SESSIONS", undefined);
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/:dataset/ingest", () => {
+        requests += 1;
+        return HttpResponse.json(successfulIngestStatus(1));
+      }),
+    );
+
+    await expect(
+      ingestRequiredToAxiom("vm0-agent-run-events-dev", [{ id: "event" }]),
+    ).resolves.toBeFalsy();
+    expect(requests).toBe(0);
+  });
+});
+
+describe("best-effort Axiom delivery", () => {
+  it("logs SDK delivery errors without rejecting the drain", async () => {
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/:dataset/ingest", () => {
+        return HttpResponse.json(
+          { message: "best-effort delivery failed" },
+          { status: 400 },
+        );
+      }),
+    );
+
+    expect(
+      ingestToAxiom("vm0-api-request-log-dev", [{ path: "/health" }]),
+    ).toBeTruthy();
+    await expect(flushAxiom({ client: "telemetry" })).resolves.toBeUndefined();
+
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      "Best-effort Axiom delivery failed",
+      expect.objectContaining({
+        client: "telemetry",
+        context: "axiom",
+        error: expect.objectContaining({
+          message: "best-effort delivery failed",
+        }),
+      }),
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -1,6 +1,7 @@
 import { computed, type Computed } from "ccstate";
-import { Axiom } from "@axiomhq/js";
+import { Axiom, AxiomWithoutBatching } from "@axiomhq/js";
 import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { singleton } from "../../lib/singleton";
 import {
   getAxiomTokenEnvNameForApl,
@@ -9,13 +10,38 @@ import {
 
 const AXIOM_API_ORIGIN = "https://api.axiom.co";
 const AXIOM_QUERY_TIMEOUT_MS = 120_000;
+const L = logger("axiom");
+
+type AxiomClientName = "sessions" | "telemetry";
+
+interface AxiomDatasetTarget {
+  readonly client: AxiomClientName;
+  readonly token: string;
+}
+
+function logBestEffortDeliveryError(
+  client: AxiomClientName,
+  error: unknown,
+): void {
+  L.error("Best-effort Axiom delivery failed", { client, error });
+}
 
 const sessionsAxiomClient = singleton(() => {
-  return new Axiom({ token: env("AXIOM_TOKEN_SESSIONS") });
+  return new Axiom({
+    token: env("AXIOM_TOKEN_SESSIONS"),
+    onError(error) {
+      logBestEffortDeliveryError("sessions", error);
+    },
+  });
 });
 
 const telemetryAxiomClient = singleton(() => {
-  return new Axiom({ token: env("AXIOM_TOKEN_TELEMETRY") });
+  return new Axiom({
+    token: env("AXIOM_TOKEN_TELEMETRY"),
+    onError(error) {
+      logBestEffortDeliveryError("telemetry", error);
+    },
+  });
 });
 
 export function getDatasetName(base: string): string {
@@ -30,12 +56,24 @@ function axiomClientForApl(apl: string): Axiom {
   return telemetryAxiomClient();
 }
 
-function axiomClientForDataset(dataset: string): Axiom | null {
+function axiomTargetForDataset(dataset: string): AxiomDatasetTarget | null {
   const tokenEnvName = getAxiomTokenEnvNameForDataset(dataset);
-  if (!optionalEnv(tokenEnvName)) {
+  const token = optionalEnv(tokenEnvName);
+  if (!token) {
     return null;
   }
-  if (tokenEnvName === "AXIOM_TOKEN_SESSIONS") {
+  return {
+    client: tokenEnvName === "AXIOM_TOKEN_SESSIONS" ? "sessions" : "telemetry",
+    token,
+  };
+}
+
+function axiomClientForDataset(dataset: string): Axiom | null {
+  const target = axiomTargetForDataset(dataset);
+  if (!target) {
+    return null;
+  }
+  if (target.client === "sessions") {
     return sessionsAxiomClient();
   }
   return telemetryAxiomClient();
@@ -53,9 +91,49 @@ export function ingestToAxiom(
   return true;
 }
 
+function requiredIngestError(
+  target: AxiomDatasetTarget,
+  dataset: string,
+  cause: unknown,
+): Error {
+  return new Error(
+    `Required Axiom ingest failed for ${target.client} dataset "${dataset}"`,
+    { cause },
+  );
+}
+
+export async function ingestRequiredToAxiom(
+  dataset: string,
+  events: readonly Record<string, unknown>[],
+): Promise<boolean> {
+  const target = axiomTargetForDataset(dataset);
+  if (!target) {
+    return false;
+  }
+
+  let reportedError: Error | undefined;
+  const client = new AxiomWithoutBatching({
+    token: target.token,
+    onError(error) {
+      reportedError ??= error;
+    },
+  });
+  const status = await client.ingest(dataset, [...events]);
+  if (reportedError) {
+    throw requiredIngestError(target, dataset, reportedError);
+  }
+  if (status.failed > 0) {
+    throw requiredIngestError(
+      target,
+      dataset,
+      new Error(`Axiom reported ${status.failed} failed event(s)`),
+    );
+  }
+  return true;
+}
+
 interface FlushAxiomOptions {
-  readonly throwOnError?: boolean;
-  readonly client?: "all" | "sessions" | "telemetry";
+  readonly client?: "all" | AxiomClientName;
 }
 
 export async function flushAxiom(
@@ -89,17 +167,13 @@ export async function flushAxiom(
       return flush.promise;
     }),
   );
-  const errors: unknown[] = [];
   for (const [index, result] of results.entries()) {
     if (result.status === "rejected") {
-      errors.push({
-        client: flushes[index]?.name ?? "unknown",
-        error: result.reason,
-      });
+      const name = flushes[index]?.name;
+      if (name === "sessions" || name === "telemetry") {
+        logBestEffortDeliveryError(name, result.reason);
+      }
     }
-  }
-  if (options.throwOnError && errors.length > 0) {
-    throw new AggregateError(errors, "Axiom flush failed");
   }
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/axiom-required-delivery.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/axiom-required-delivery.test.ts
@@ -1,0 +1,152 @@
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { testContext } from "../../../__tests__/test-context";
+import { createBddApi, expectApiError } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+
+const context = testContext();
+const webhooks = createWebhookCallbackApi(context);
+const { getDatasetName, ingestRequiredToAxiom } = await vi.importActual<
+  typeof import("../../external/axiom")
+>("../../external/axiom");
+
+function successfulIngestStatus(ingested: number): Record<string, unknown> {
+  return {
+    ingested,
+    failed: 0,
+    failures: [],
+    processedBytes: 1,
+    blocksCreated: 0,
+    walLength: ingested,
+  };
+}
+
+describe("required Axiom route delivery", () => {
+  it("rejects real SDK failures, succeeds on retry, and preserves telemetry token policy", async () => {
+    const bdd = createBddApi(context);
+    const connectors = createConnectorBddApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    let acceptAgentEvents = true;
+    let acceptSandboxTelemetry = true;
+    let agentEventAttempts = 0;
+    let sandboxTelemetryAttempts = 0;
+    context.mocks.axiom.useRealSdk.mockReturnValue(true);
+    context.mocks.axiom.datasetName.mockImplementation(getDatasetName);
+    context.mocks.axiom.requiredIngest.mockImplementation(
+      ingestRequiredToAxiom,
+    );
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.MemoryViewer]: false,
+    });
+
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/:dataset/ingest",
+        async ({ params, request }) => {
+          const dataset = String(params.dataset);
+          const body = await request.text();
+          const eventCount = body.length === 0 ? 0 : body.split("\n").length;
+          if (dataset === "vm0-agent-run-events-dev") {
+            agentEventAttempts += 1;
+            if (!acceptAgentEvents) {
+              return HttpResponse.json(
+                { message: "agent events unavailable" },
+                { status: 500 },
+              );
+            }
+          }
+          if (dataset === "vm0-sandbox-telemetry-system-dev") {
+            sandboxTelemetryAttempts += 1;
+            if (!acceptSandboxTelemetry) {
+              return HttpResponse.json(
+                { message: "sandbox telemetry unavailable" },
+                { status: 500 },
+              );
+            }
+          }
+          return HttpResponse.json(successfulIngestStatus(eventCount));
+        },
+      ),
+    );
+
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Required Axiom Delivery Agent",
+      visibility: "private",
+    });
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "verify required Axiom delivery",
+      modelProvider: "anthropic-api-key",
+    });
+    const headers = {
+      authorization: `Bearer ${runs.sandboxTokenForRun(actor, run.runId)}`,
+    };
+    const events = {
+      runId: run.runId,
+      events: [{ type: "system", sequenceNumber: 1 }],
+    } satisfies Parameters<typeof webhooks.requestAgentEvents>[0];
+
+    acceptAgentEvents = false;
+    const failed = await webhooks.requestAgentEvents(events, headers, [500]);
+    expectApiError(failed.body);
+    expect(failed.body.error.message).toBe(
+      "Required event consumer dispatch failed: axiom",
+    );
+    expect(agentEventAttempts).toBe(2);
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      'Event consumer "axiom" failed',
+      expect.objectContaining({
+        context: "webhook:events",
+        error: expect.objectContaining({
+          message:
+            'Required Axiom ingest failed for sessions dataset "vm0-agent-run-events-dev"',
+          cause: expect.objectContaining({
+            message: "agent events unavailable",
+          }),
+        }),
+        runId: run.runId,
+      }),
+    );
+
+    acceptAgentEvents = true;
+    const recovered = await webhooks.requestAgentEvents(events, headers, [200]);
+    expect(recovered.body).toStrictEqual({
+      received: 1,
+      firstSequence: 1,
+      lastSequence: 1,
+    });
+
+    acceptSandboxTelemetry = false;
+    const telemetryFailed = await webhooks.requestAgentTelemetry(
+      { runId: run.runId, systemLog: "sandbox booted" },
+      headers,
+      [500],
+    );
+    expect(telemetryFailed.status).toBe(500);
+    expect(sandboxTelemetryAttempts).toBe(2);
+
+    mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", undefined);
+    const telemetrySkipped = await webhooks.requestAgentTelemetry(
+      { runId: run.runId, systemLog: "sandbox still running" },
+      headers,
+      [200],
+    );
+    expect(telemetrySkipped.body).toStrictEqual({
+      success: true,
+      id: run.runId,
+    });
+    expect(sandboxTelemetryAttempts).toBe(2);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8701,8 +8701,10 @@ describe("HOOK-02: event-consumer dispatch failures", () => {
       authorization: `Bearer ${claim.sandboxToken}`,
     };
 
-    context.mocks.axiom.flush.mockResolvedValue(undefined);
-    context.mocks.axiom.flush.mockRejectedValueOnce(new Error("axiom down"));
+    context.mocks.axiom.requiredIngest.mockResolvedValue(true);
+    context.mocks.axiom.requiredIngest.mockRejectedValueOnce(
+      new Error("axiom down"),
+    );
     const failed = await webhooks.requestAgentEvents(
       {
         runId: run.runId,
@@ -9393,11 +9395,10 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
       sandboxHeaders,
       [200],
     );
-    const networkIngestCall = context.mocks.axiom.ingest.mock.calls.find(
-      ([dataset]) => {
+    const networkIngestCall =
+      context.mocks.axiom.requiredIngest.mock.calls.find(([dataset]) => {
         return dataset === "sandbox-telemetry-network";
-      },
-    );
+      });
     expect(networkIngestCall).toBeDefined();
     expect(networkIngestCall?.[1]).toHaveLength(2);
     expect(networkIngestCall?.[1]).toStrictEqual([

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1101,16 +1101,14 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
         { type: "tool_result", sequenceNumber: 2, result: "ok" },
       ],
     };
-    context.mocks.axiom.ingest.mockReturnValue(true);
-    context.mocks.axiom.flush.mockResolvedValue(undefined);
-
+    context.mocks.axiom.requiredIngest.mockResolvedValue(true);
     const ingested = await api.requestAgentEvents(body, headers, [200]);
     expect(ingested.body).toStrictEqual({
       received: 2,
       firstSequence: 1,
       lastSequence: 2,
     });
-    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
+    expect(context.mocks.axiom.requiredIngest).toHaveBeenCalledWith(
       "agent-run-events",
       [
         {
@@ -1133,22 +1131,19 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
         },
       ],
     );
-    expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
-      throwOnError: true,
-      client: "sessions",
-    });
-
-    context.mocks.axiom.ingest.mockReturnValueOnce(false);
+    context.mocks.axiom.requiredIngest.mockResolvedValueOnce(false);
     const unconfigured = await api.requestAgentEvents(body, headers, [500]);
     expectApiError(unconfigured.body);
     expect(unconfigured.body.error.message).toBe(
       "Required event consumer dispatch failed: axiom",
     );
 
-    context.mocks.axiom.flush.mockRejectedValueOnce(new Error("axiom down"));
-    const flushFailed = await api.requestAgentEvents(body, headers, [500]);
-    expectApiError(flushFailed.body);
-    expect(flushFailed.body.error.message).toBe(
+    context.mocks.axiom.requiredIngest.mockRejectedValueOnce(
+      new Error("axiom down"),
+    );
+    const ingestFailed = await api.requestAgentEvents(body, headers, [500]);
+    expectApiError(ingestFailed.body);
+    expect(ingestFailed.body.error.message).toBe(
       "Required event consumer dispatch failed: axiom",
     );
   });

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -22,7 +22,7 @@ import { authorization$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { db$, writeDb$ } from "../external/db";
-import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
+import { getDatasetName, ingestRequiredToAxiom } from "../external/axiom";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import type { RouteEntry } from "../route-entry";
 import { dispatchProgressCallbacks$ } from "../services/agent-run-callbacks.service";
@@ -356,23 +356,24 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
     return notFound("Agent run not found");
   }
 
-  let telemetryBuffered = false;
+  const telemetryIngestions: Promise<boolean>[] = [];
 
   if (body.systemLog) {
-    telemetryBuffered =
-      ingestToAxiom(getDatasetName(SANDBOX_TELEMETRY_SYSTEM_DATASET), [
+    telemetryIngestions.push(
+      ingestRequiredToAxiom(getDatasetName(SANDBOX_TELEMETRY_SYSTEM_DATASET), [
         {
           _time: nowDate().toISOString(),
           runId: body.runId,
           userId: auth.userId,
           log: body.systemLog,
         },
-      ]) || telemetryBuffered;
+      ]),
+    );
   }
 
   if (body.metrics && body.metrics.length > 0) {
-    telemetryBuffered =
-      ingestToAxiom(
+    telemetryIngestions.push(
+      ingestRequiredToAxiom(
         getDatasetName(SANDBOX_TELEMETRY_METRICS_DATASET),
         body.metrics.map((metric) => {
           return {
@@ -386,12 +387,13 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
             disk_total: metric.disk_total,
           };
         }),
-      ) || telemetryBuffered;
+      ),
+    );
   }
 
   if (body.networkLogs && body.networkLogs.length > 0) {
-    telemetryBuffered =
-      ingestToAxiom(
+    telemetryIngestions.push(
+      ingestRequiredToAxiom(
         getDatasetName(SANDBOX_TELEMETRY_NETWORK_DATASET),
         body.networkLogs.map(({ timestamp, ...rest }) => {
           return {
@@ -401,11 +403,12 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
             userId: auth.userId,
           };
         }),
-      ) || telemetryBuffered;
+      ),
+    );
   }
 
-  if (telemetryBuffered) {
-    await flushAxiom({ client: "telemetry", throwOnError: true });
+  if (telemetryIngestions.length > 0) {
+    await Promise.all(telemetryIngestions);
     signal.throwIfAborted();
   }
 

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -1,8 +1,7 @@
 import { command } from "ccstate";
 
 import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
-import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
-import { tapError } from "../utils";
+import { getDatasetName, ingestRequiredToAxiom } from "../external/axiom";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 
@@ -21,30 +20,17 @@ export const ingestAxiomEvents$ = command(
       };
     });
 
-    const ingested = ingestToAxiom(
+    const ingested = await ingestRequiredToAxiom(
       getDatasetName(AGENT_RUN_EVENTS_DATASET),
       axiomEvents,
     );
+    signal.throwIfAborted();
     if (!ingested) {
       return {
         status: 503 as const,
         body: {
           error: "Axiom agent-run-events dataset is not configured",
         },
-      };
-    }
-
-    const flushed = await tapError(
-      (async () => {
-        await flushAxiom({ throwOnError: true, client: "sessions" });
-        return true;
-      })(),
-    );
-    signal.throwIfAborted();
-    if (!flushed) {
-      return {
-        status: 503 as const,
-        body: { error: "Axiom agent-run-events flush failed" },
       };
     }
 


### PR DESCRIPTION
## Summary

- add a request-local, awaited `AxiomWithoutBatching` path for required delivery and reject SDK callback or partial-ingest failures with client, dataset, and cause context
- use required delivery for agent event ingestion and configured sandbox telemetry while preserving each caller's existing missing-token policy
- keep shared batching explicitly best-effort, log delivery failures, and remove the misleading `flushAxiom({ throwOnError: true })` contract
- cover the installed SDK's resolve-after-error behavior, overlapping requests, route retry, telemetry failure, and best-effort logging at the external HTTP boundary

## Compatibility and risk

- no API shape, webhook payload, queue payload, runner protocol, database schema, persisted state, frontend, or dependency change
- delivery remains at-least-once: an ambiguous network outcome can cause a sender retry and duplicate an event that Axiom already accepted

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/external/__tests__/axiom-delivery.test.ts src/signals/external/__tests__/axiom.test.ts src/signals/routes/__tests__/axiom-required-delivery.test.ts src/signals/routes/__tests__/cron-summarize-memory.test.ts --maxWorkers=1 --silent=passed-only` (14 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only -t 'dispatches agent event batches to Axiom in-process|surfaces required event-consumer failures and recovers on retry|reports artifacts, volumes, model usage, and telemetry through sandbox webhooks'` (3 passed)

The local full API suite reached 2300/2303 tests. Its three failures were existing parallel-sensitive cases in chat lock counting, the global memory cron sweep, and unordered connector reads; each is outside the changed Axiom paths, while the affected tests pass on a freshly migrated isolated database. PR CI remains the merge gate.

Closes #22319
