### PR TITLE
feat: unify pending chat items below the composer

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
+++ b/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
@@ -6,7 +6,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-workflow-queue";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { openHeaderAutomationSidebar$ } from "./header-automation-sidebar.ts";
 
 export interface WorkflowQueueSignals {
   readonly queue$: Computed<Promise<WorkflowQueueResponse | null>>;
@@ -24,7 +23,6 @@ export function createWorkflowQueueSignals(
   threadId: string,
 ): WorkflowQueueSignals {
   const reloadVersion$ = state(0);
-  const lastPendingCount$ = state(0);
 
   const reload$ = command(({ set }) => {
     set(reloadVersion$, (version) => {
@@ -93,17 +91,8 @@ export function createWorkflowQueueSignals(
   const handleChanged$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
       set(reload$);
-      const queue = await get(queue$);
+      await get(queue$);
       signal.throwIfAborted();
-      if (!queue) {
-        return false;
-      }
-      const pending = queue.pending.length;
-      const previous = get(lastPendingCount$);
-      set(lastPendingCount$, pending);
-      if (previous === 0 && pending > 0) {
-        set(openHeaderAutomationSidebar$, threadId);
-      }
       return false;
     },
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -316,9 +316,7 @@ describe("chat lifecycle", () => {
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
     await waitFor(() => {
-      expect(
-        screen.queryByText("1 message waiting to send"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("1 message waiting")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
       expect(screen.getByText(prompt)).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -445,7 +445,7 @@ describe("chat run queue", () => {
     await user.click(screen.getByLabelText("Send"));
 
     await waitFor(() => {
-      expect(screen.getByText("1 message waiting to send")).toBeInTheDocument();
+      expect(screen.getByText("1 message waiting")).toBeInTheDocument();
       expect(screen.getByLabelText("Queued message")).toHaveTextContent(
         "(see attached files)",
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -509,7 +509,7 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Follow up when the queued run starts"),
       ).toBeInTheDocument();
-      expect(screen.getByText("1 message waiting to send")).toBeInTheDocument();
+      expect(screen.getByText("1 message waiting")).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -144,8 +144,9 @@ describe("workflow queue panel", () => {
     await setupWorkflowQueuePage();
 
     await waitFor(() => {
-      expect(screen.getByText("4 items waiting")).toBeInTheDocument();
-      expect(screen.getByText("Messages run first")).toBeInTheDocument();
+      expect(
+        screen.getByText("1 message and 2 events waiting"),
+      ).toBeInTheDocument();
       expect(screen.getByText("Nightly sync")).toBeInTheDocument();
       expect(screen.getByText("Webhook event third")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import {
   zeroWorkflowQueueContract,
   type WorkflowQueueResponse,
@@ -65,17 +65,50 @@ function buttonByLabel(label: string): HTMLElement {
   return button;
 }
 
-async function openAutomationsPanel(): Promise<void> {
+async function setupWorkflowQueuePage({
+  openSidebar = false,
+}: {
+  openSidebar?: boolean;
+} = {}): Promise<void> {
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
     threadTitle: "Workflow queue thread",
-    historyMessages: [
+    chatMessages: [
       {
+        id: "msg-workflow-running-user",
         role: "user",
         content: "Automation run",
+        runId: "run-workflow-1",
         createdAt: "2026-07-10T00:59:00Z",
       },
+      {
+        id: "msg-workflow-running-assistant",
+        role: "assistant",
+        content: null,
+        runId: "run-workflow-1",
+        createdAt: "2026-07-10T00:59:01Z",
+      },
+      {
+        id: "msg-queued-user",
+        role: "user",
+        content: "Review the queued customer reply",
+        runId: undefined,
+        createdAt: "2026-07-10T01:00:00Z",
+      },
+      {
+        id: "msg-active-goal",
+        role: "assistant",
+        content: null,
+        runId: undefined,
+        goalEvent: {
+          type: "state",
+          status: "active",
+          objectiveBrief: "Keep customer follow-ups under four hours",
+        },
+        createdAt: "2026-07-10T01:00:01Z",
+      },
     ],
+    activeRunIds: ["run-workflow-1"],
   });
   setMockWorkflowAutomations([
     createMockWorkflowAutomation({
@@ -90,6 +123,9 @@ async function openAutomationsPanel(): Promise<void> {
     path: `/chats/${THREAD_ID}`,
   });
 
+  if (!openSidebar) {
+    return;
+  }
   await waitFor(() => {
     expect(buttonByLabel("Automations")).toBeInTheDocument();
   });
@@ -100,23 +136,46 @@ async function openAutomationsPanel(): Promise<void> {
 }
 
 describe("workflow queue panel", () => {
-  it("shows the pending badge, running event, and FIFO pending list", async () => {
+  it("shows messages, automation events, and the active goal in one bottom queue", async () => {
     context.mocks.api(zeroWorkflowQueueContract.get, ({ respond }) => {
       return respond(200, queueResponse());
     });
 
-    await openAutomationsPanel();
+    await setupWorkflowQueuePage();
 
     await waitFor(() => {
-      const badges = screen.getAllByTestId("workflow-queue-badge");
-      expect(badges.length).toBeGreaterThan(0);
-      expect(badges[0]).toHaveTextContent("2");
-      expect(screen.getByTestId("workflow-queue-section")).toBeInTheDocument();
-      expect(screen.getByText("2 waiting")).toBeInTheDocument();
-      expect(screen.getByText("Webhook event busy")).toBeInTheDocument();
+      expect(screen.getByText("4 items waiting")).toBeInTheDocument();
+      expect(screen.getByText("Messages run first")).toBeInTheDocument();
       expect(screen.getByText("Webhook event second")).toBeInTheDocument();
       expect(screen.getByText("Webhook event third")).toBeInTheDocument();
     });
+
+    const goalRow = screen.getByLabelText("Active goal");
+    const list = goalRow.closest('[role="list"]');
+    expect(list).not.toBeNull();
+    const rows = within(list as HTMLElement).getAllByRole("listitem");
+    expect(
+      rows.map((row) => {
+        return row.getAttribute("aria-label");
+      }),
+    ).toStrictEqual([
+      "Queued message",
+      "Pending automation event",
+      "Pending automation event",
+      "Active goal",
+    ]);
+    expect(
+      screen.queryByTestId("workflow-queue-badge"),
+    ).not.toBeInTheDocument();
+
+    click(buttonByLabel("Automations"));
+    const sidebar = await screen.findByTestId("automation-sidebar");
+    expect(
+      within(sidebar).queryByTestId("workflow-queue-section"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(sidebar).queryByText("Webhook event busy"),
+    ).not.toBeInTheDocument();
   });
 
   it("skips a single pending event", async () => {
@@ -136,13 +195,13 @@ describe("workflow queue panel", () => {
       },
     );
 
-    await openAutomationsPanel();
+    await setupWorkflowQueuePage();
     await waitFor(() => {
       expect(screen.getByText("Webhook event second")).toBeInTheDocument();
     });
 
     const skipButtons = queryAllByRoleFast("button").filter((candidate) => {
-      return candidate.getAttribute("aria-label") === "Skip queued event";
+      return candidate.getAttribute("aria-label") === "Skip automation event";
     });
     expect(skipButtons).toHaveLength(2);
     click(skipButtons[0]!);
@@ -174,15 +233,15 @@ describe("workflow queue panel", () => {
       );
     });
 
-    await openAutomationsPanel();
+    await setupWorkflowQueuePage();
     await waitFor(() => {
-      expect(buttonByLabel("Pause queue")).toBeInTheDocument();
+      expect(buttonByLabel("Pause automation events")).toBeInTheDocument();
     });
-    click(buttonByLabel("Pause queue"));
+    click(buttonByLabel("Pause automation events"));
 
     await waitFor(() => {
-      expect(screen.getByText(/Queue paused/)).toBeInTheDocument();
-      expect(buttonByLabel("Resume queue")).toBeInTheDocument();
+      expect(screen.getByText(/Automation events paused/)).toBeInTheDocument();
+      expect(buttonByLabel("Resume automation events")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -38,7 +38,7 @@ function queueResponse(
         id: EVENT_ID_1,
         automationId: "e0000001-0000-4000-a000-000000000001",
         triggerSource: "workflow-event",
-        triggerBrief: "Webhook event second",
+        triggerBrief: null,
         createdAt: "2026-07-10T01:01:00Z",
       },
       {
@@ -146,7 +146,7 @@ describe("workflow queue panel", () => {
     await waitFor(() => {
       expect(screen.getByText("4 items waiting")).toBeInTheDocument();
       expect(screen.getByText("Messages run first")).toBeInTheDocument();
-      expect(screen.getByText("Webhook event second")).toBeInTheDocument();
+      expect(screen.getByText("Nightly sync")).toBeInTheDocument();
       expect(screen.getByText("Webhook event third")).toBeInTheDocument();
     });
 
@@ -197,7 +197,7 @@ describe("workflow queue panel", () => {
 
     await setupWorkflowQueuePage();
     await waitFor(() => {
-      expect(screen.getByText("Webhook event second")).toBeInTheDocument();
+      expect(screen.getByText("Nightly sync")).toBeInTheDocument();
     });
 
     const skipButtons = queryAllByRoleFast("button").filter((candidate) => {
@@ -208,9 +208,7 @@ describe("workflow queue panel", () => {
 
     await waitFor(() => {
       expect(skippedEventId).toBe(EVENT_ID_1);
-      expect(
-        screen.queryByText("Webhook event second"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Nightly sync")).not.toBeInTheDocument();
       expect(screen.getByText("Webhook event third")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -24,15 +24,18 @@ import {
   IconAdjustmentsHorizontal,
   IconAlertTriangle,
   IconArrowUp,
+  IconBolt,
   IconColorSwatch,
   IconDeviceDesktop,
   IconDownload,
+  IconDots,
   IconPresentation,
   IconLoader2,
   IconLink,
   IconMicrophone,
   IconPaperclip,
   IconPalette,
+  IconPlayerPause,
   IconPlayerPlay,
   IconPlayerStop,
   IconPlug,
@@ -58,6 +61,10 @@ import {
   Button,
   Card,
   CardContent,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
   Popover,
   PopoverClose,
@@ -329,6 +336,18 @@ export interface ZeroChatComposerProps {
   queuedItems?: QueuedComposerItem[];
   /** Cancels a queued message (routed to the recall flow by the caller). */
   onRemoveQueuedItem?: (id: string) => void;
+  /** Pending workflow events, rendered after queued messages. */
+  workflowEventItems?: WorkflowEventComposerItem[];
+  /** Skips one pending workflow event. */
+  onRemoveWorkflowEvent?: (id: string) => void;
+  /** Whether workflow event processing is paused for this thread. */
+  workflowEventsPaused?: boolean;
+  /** Optional server-provided reason for the paused workflow event queue. */
+  workflowEventsPauseReason?: string | null;
+  /** Pauses or resumes workflow event processing without affecting messages. */
+  onSetWorkflowEventsPaused?: (paused: boolean) => void;
+  /** Clears every pending workflow event without affecting messages. */
+  onClearWorkflowEvents?: () => void;
   /**
    * The thread's active goal. Rendered as a row beneath the queued messages in
    * the strip above the composer — a goal runs only once the queue drains, so it
@@ -341,6 +360,11 @@ export interface ZeroChatComposerProps {
 }
 
 export interface QueuedComposerItem {
+  id: string;
+  text: string;
+}
+
+export interface WorkflowEventComposerItem {
   id: string;
   text: string;
 }
@@ -502,10 +526,10 @@ function ComposerQueueGlyph() {
   );
 }
 
-// A single strip row — a queued message or the active goal. Both share one
-// layout so they read as the same kind of pending item; only the leading icon
-// distinguishes them. Queued messages keep the inline popover; goals open a
-// modal because their full objective is fetched lazily by thread.
+// A single strip row — a queued message, workflow event, or active goal. All
+// share one layout so they read as the same kind of pending item; only the
+// leading icon distinguishes them. Goals open a modal because their full
+// objective is fetched lazily by thread.
 function ComposerStripRow({
   kind,
   text,
@@ -513,17 +537,38 @@ function ComposerStripRow({
   onOpenDetail,
   removeAriaLabel,
 }: {
-  kind: "queued" | "goal";
+  kind: "queued" | "workflow-event" | "goal";
   text: string;
   onRemove?: () => void;
   onOpenDetail?: () => void;
   removeAriaLabel: string;
 }) {
   const isGoal = kind === "goal";
+  const isWorkflowEvent = kind === "workflow-event";
+  const itemAriaLabel = isGoal
+    ? "Active goal"
+    : isWorkflowEvent
+      ? "Pending automation event"
+      : "Queued message";
+  const aboutAriaLabel = isGoal
+    ? "About this goal"
+    : isWorkflowEvent
+      ? "About this automation event"
+      : "About this queued message";
+  const itemTitle = isGoal
+    ? "Goal"
+    : isWorkflowEvent
+      ? "Automation event"
+      : "Queued message";
+  const itemDescription = isGoal
+    ? "Runs after the queue drains and keeps running until you cancel it."
+    : isWorkflowEvent
+      ? "Waits behind queued messages and runs once the current run finishes."
+      : "Waits in line and sends once the current run finishes.";
   return (
     <div
       role="listitem"
-      aria-label={isGoal ? "Active goal" : "Queued message"}
+      aria-label={itemAriaLabel}
       className="group flex items-center gap-2 rounded-md pl-2 pr-1 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent"
     >
       {isGoal && onOpenDetail ? (
@@ -548,12 +593,12 @@ function ComposerStripRow({
               <button
                 type="button"
                 className="shrink-0 rounded-md p-1 text-emerald-800 transition-colors hover:bg-[hsl(var(--gray-200))] focus-visible:bg-[hsl(var(--gray-200))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                aria-label={
-                  isGoal ? "About this goal" : "About this queued message"
-                }
+                aria-label={aboutAriaLabel}
               >
                 {isGoal ? (
                   <IconTarget size={16} stroke={1.5} aria-hidden="true" />
+                ) : isWorkflowEvent ? (
+                  <IconBolt size={16} stroke={1.5} aria-hidden="true" />
                 ) : (
                   <ComposerQueueGlyph />
                 )}
@@ -565,12 +610,10 @@ function ComposerStripRow({
               className="w-80 rounded-lg p-3"
             >
               <p className="text-xs font-semibold text-foreground">
-                {isGoal ? "Goal" : "Queued message"}
+                {itemTitle}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                {isGoal
-                  ? "Runs after the queue drains and keeps running until you cancel it."
-                  : "Waits in line and sends once the current run finishes."}
+                {itemDescription}
               </p>
               <div className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
                 {text}
@@ -658,39 +701,135 @@ function ActiveGoalObjectiveDialog({ threadId }: { threadId?: string }) {
   );
 }
 
-function QueuedMessagesStrip({
+function PendingItemsStripHeader({
+  count,
+  label,
+  workflowEventCount,
+  workflowEventsPaused,
+  onSetWorkflowEventsPaused,
+  onClearWorkflowEvents,
+}: {
+  count: number;
+  label: string;
+  workflowEventCount: number;
+  workflowEventsPaused: boolean;
+  onSetWorkflowEventsPaused?: (paused: boolean) => void;
+  onClearWorkflowEvents?: () => void;
+}) {
+  const showWorkflowControls =
+    onSetWorkflowEventsPaused !== undefined &&
+    (workflowEventCount > 0 || workflowEventsPaused);
+  return (
+    <div className="flex items-center gap-2 px-5 pt-3 pb-2">
+      <div className="min-w-0 flex-1">
+        <span className="text-sm text-muted-foreground">
+          {count > 0 ? label : "Automation events paused"}
+        </span>
+        {workflowEventCount > 0 ? (
+          <span className="ml-2 text-xs text-muted-foreground/70">
+            Messages run first
+          </span>
+        ) : null}
+      </div>
+      {showWorkflowControls ? (
+        <button
+          type="button"
+          className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={
+            workflowEventsPaused
+              ? "Resume automation events"
+              : "Pause automation events"
+          }
+          onClick={() => {
+            onSetWorkflowEventsPaused?.(!workflowEventsPaused);
+          }}
+        >
+          {workflowEventsPaused ? (
+            <IconPlayerPlay size={14} stroke={1.5} />
+          ) : (
+            <IconPlayerPause size={14} stroke={1.5} />
+          )}
+          {workflowEventsPaused ? "Resume events" : "Pause events"}
+        </button>
+      ) : null}
+      {workflowEventCount > 0 && onClearWorkflowEvents ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Automation event queue actions"
+            >
+              <IconDots size={16} stroke={1.5} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={onClearWorkflowEvents}
+            >
+              Clear automation events ({workflowEventCount})
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </div>
+  );
+}
+
+function PendingItemsStrip({
   items,
   onRemove,
+  workflowEvents,
+  onRemoveWorkflowEvent,
+  workflowEventsPaused,
+  workflowEventsPauseReason,
+  onSetWorkflowEventsPaused,
+  onClearWorkflowEvents,
   activeGoal,
   onCancelGoal,
   onOpenGoal,
 }: {
   items: QueuedComposerItem[] | undefined;
   onRemove?: (id: string) => void;
+  workflowEvents: WorkflowEventComposerItem[] | undefined;
+  onRemoveWorkflowEvent?: (id: string) => void;
+  workflowEventsPaused: boolean;
+  workflowEventsPauseReason?: string | null;
+  onSetWorkflowEventsPaused?: (paused: boolean) => void;
+  onClearWorkflowEvents?: () => void;
   activeGoal?: ActiveGoalComposerItem;
   onCancelGoal?: () => void;
   onOpenGoal?: () => void;
 }) {
   const queued = items ?? [];
-  if (queued.length === 0 && !activeGoal) {
+  const events = workflowEvents ?? [];
+  const count = queued.length + events.length + (activeGoal ? 1 : 0);
+  const onlyMessages = events.length === 0 && !activeGoal;
+  const label = onlyMessages
+    ? `${count} ${count === 1 ? "message" : "messages"} waiting to send`
+    : `${count} ${count === 1 ? "item" : "items"} waiting`;
+  if (count === 0 && !workflowEventsPaused) {
     return null;
   }
-  const count = queued.length;
-  const label = `${count} ${count === 1 ? "message" : "messages"} waiting to send`;
   return (
     <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50 dark:bg-gray-100">
-      {count > 0 ? (
-        <div className="px-5 pt-3 pb-2">
-          <span className="text-sm text-muted-foreground">{label}</span>
+      <PendingItemsStripHeader
+        count={count}
+        label={label}
+        workflowEventCount={events.length}
+        workflowEventsPaused={workflowEventsPaused}
+        onSetWorkflowEventsPaused={onSetWorkflowEventsPaused}
+        onClearWorkflowEvents={onClearWorkflowEvents}
+      />
+      {workflowEventsPaused ? (
+        <div className="mx-4 mb-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+          Automation events paused
+          {workflowEventsPauseReason ? `: ${workflowEventsPauseReason}` : ""}.
+          New events keep queueing and run after you resume.
         </div>
       ) : null}
-      <div
-        className={cn(
-          "max-h-[200px] overflow-y-auto px-2 pb-7",
-          count > 0 ? "pt-1" : "pt-3",
-        )}
-        role="list"
-      >
+      <div className="max-h-[200px] overflow-y-auto px-2 pb-7 pt-1" role="list">
         {queued.map((item) => {
           return (
             <ComposerStripRow
@@ -704,10 +843,22 @@ function QueuedMessagesStrip({
             />
           );
         })}
-        {/* The active goal sits last — below every queued message — because a
-            goal only runs once the queue drains, so it reads as lower priority
-            than the queue. Like a queued message it can be cancelled; cancelling
-            blocks the goal so it no longer runs behind the queue. */}
+        {events.map((event) => {
+          return (
+            <ComposerStripRow
+              key={event.id}
+              kind="workflow-event"
+              text={event.text}
+              onRemove={() => {
+                onRemoveWorkflowEvent?.(event.id);
+              }}
+              removeAriaLabel="Skip automation event"
+            />
+          );
+        })}
+        {/* The active goal sits last — below queued messages and workflow events
+            — because it only runs once the queue drains. Like other pending
+            items it can be cancelled from the strip. */}
         {activeGoal ? (
           <ComposerStripRow
             kind="goal"
@@ -6613,6 +6764,12 @@ export function useZeroChatComposer({
   submitBlocker,
   queuedItems,
   onRemoveQueuedItem,
+  workflowEventItems,
+  onRemoveWorkflowEvent,
+  workflowEventsPaused = false,
+  workflowEventsPauseReason,
+  onSetWorkflowEventsPaused,
+  onClearWorkflowEvents,
   activeGoal,
   onCancelActiveGoal,
 }: ZeroChatComposerProps) {
@@ -6991,9 +7148,15 @@ export function useZeroChatComposer({
         onChange={handleFileChange}
       />
       <div className={cn("relative flex flex-col", className)}>
-        <QueuedMessagesStrip
+        <PendingItemsStrip
           items={queuedItems}
           onRemove={onRemoveQueuedItem}
+          workflowEvents={workflowEventItems}
+          onRemoveWorkflowEvent={onRemoveWorkflowEvent}
+          workflowEventsPaused={workflowEventsPaused}
+          workflowEventsPauseReason={workflowEventsPauseReason}
+          onSetWorkflowEventsPaused={onSetWorkflowEventsPaused}
+          onClearWorkflowEvents={onClearWorkflowEvents}
           activeGoal={activeGoal}
           onCancelGoal={onCancelActiveGoal}
           onOpenGoal={

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -725,11 +725,6 @@ function PendingItemsStripHeader({
         <span className="text-sm text-muted-foreground">
           {count > 0 ? label : "Automation events paused"}
         </span>
-        {workflowEventCount > 0 ? (
-          <span className="ml-2 text-xs text-muted-foreground/70">
-            Messages run first
-          </span>
-        ) : null}
       </div>
       {showWorkflowControls ? (
         <button
@@ -804,24 +799,28 @@ function PendingItemsStrip({
 }) {
   const queued = items ?? [];
   const events = workflowEvents ?? [];
-  const count = queued.length + events.length + (activeGoal ? 1 : 0);
-  const onlyMessages = events.length === 0 && !activeGoal;
-  const label = onlyMessages
-    ? `${count} ${count === 1 ? "message" : "messages"} waiting to send`
-    : `${count} ${count === 1 ? "item" : "items"} waiting`;
-  if (count === 0 && !workflowEventsPaused) {
+  const count = queued.length + events.length;
+  const messageLabel = `${queued.length} ${queued.length === 1 ? "message" : "messages"}`;
+  const eventLabel = `${events.length} ${events.length === 1 ? "event" : "events"}`;
+  const label =
+    queued.length > 0 && events.length > 0
+      ? `${messageLabel} and ${eventLabel} waiting`
+      : `${queued.length > 0 ? messageLabel : eventLabel} waiting`;
+  if (count === 0 && !activeGoal && !workflowEventsPaused) {
     return null;
   }
   return (
     <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50 dark:bg-gray-100">
-      <PendingItemsStripHeader
-        count={count}
-        label={label}
-        workflowEventCount={events.length}
-        workflowEventsPaused={workflowEventsPaused}
-        onSetWorkflowEventsPaused={onSetWorkflowEventsPaused}
-        onClearWorkflowEvents={onClearWorkflowEvents}
-      />
+      {count > 0 || workflowEventsPaused ? (
+        <PendingItemsStripHeader
+          count={count}
+          label={label}
+          workflowEventCount={events.length}
+          workflowEventsPaused={workflowEventsPaused}
+          onSetWorkflowEventsPaused={onSetWorkflowEventsPaused}
+          onClearWorkflowEvents={onClearWorkflowEvents}
+        />
+      ) : null}
       {workflowEventsPaused ? (
         <div className="mx-4 mb-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
           Automation events paused

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3844,6 +3844,8 @@ function useChatComposerQueue(
 
 function useChatComposerWorkflowEvents(thread: ChatThreadSignals) {
   const queue = useLastResolved(thread.workflowQueue.queue$);
+  const workflowAutomations =
+    useLastResolved(thread.headerAutomations.automations$) ?? [];
   const skipEvent = useSet(thread.workflowQueue.skipEvent$);
   const clearEvents = useSet(thread.workflowQueue.clear$);
   const setEventsPaused = useSet(thread.workflowQueue.setPaused$);
@@ -3853,11 +3855,22 @@ function useChatComposerWorkflowEvents(thread: ChatThreadSignals) {
       return event.id;
     }) ?? [],
   );
+  const workflowLabelsByAutomationId = new Map(
+    workflowAutomations.map((automation) => {
+      return [
+        automation.id,
+        automation.workflowDisplayName?.trim() || automation.workflowName,
+      ] as const;
+    }),
+  );
   const workflowEventItems: WorkflowEventComposerItem[] =
     queue?.pending.map((event) => {
       return {
         id: event.id,
-        text: event.triggerBrief ?? event.triggerSource,
+        text:
+          event.triggerBrief?.trim() ||
+          workflowLabelsByAutomationId.get(event.automationId) ||
+          "Automation event",
       };
     }) ?? [];
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -34,7 +34,6 @@ import {
   IconPhoto,
   IconChartLine,
   IconPlayerPlay,
-  IconPlayerPause,
   IconVideo,
   IconCopy,
   IconDeviceDesktop,
@@ -273,6 +272,7 @@ import {
   useZeroChatComposer,
   type ZeroChatComposerProps,
   type QueuedComposerItem,
+  type WorkflowEventComposerItem,
 } from "./zero-chat-composer.tsx";
 import { ChatFeedbackSelection } from "./zero-chat-feedback-selection.tsx";
 import {
@@ -374,8 +374,6 @@ export function AutomationMenuButton({
     workflowAutomationsLoadable.state === "hasData"
       ? workflowAutomationsLoadable.data
       : (lastResolvedAutomations ?? []);
-  const queue = useLastResolved(thread.workflowQueue.queue$);
-  const pendingCount = queue?.pending.length ?? 0;
   const open = openThreadId === thread.threadId;
 
   // Show the opener when the thread has a workflow automation.
@@ -391,7 +389,7 @@ export function AutomationMenuButton({
           <button
             type="button"
             className={cn(
-              "relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-150",
+              "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-150",
               open
                 ? "bg-primary/10 text-primary"
                 : "text-muted-foreground/70 hover:bg-accent hover:text-foreground",
@@ -404,14 +402,6 @@ export function AutomationMenuButton({
             }}
           >
             <IconClock size={18} />
-            {pendingCount > 0 ? (
-              <span
-                className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium leading-none text-primary-foreground"
-                data-testid="workflow-queue-badge"
-              >
-                {pendingCount > 99 ? "99+" : pendingCount}
-              </span>
-            ) : null}
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Open automations</TooltipContent>
@@ -2293,123 +2283,6 @@ function HeaderGmailLabelAutomationEditForm({
     </form>
   );
 }
-function HeaderWorkflowQueueSection({ thread }: { thread: ChatThreadSignals }) {
-  const queue = useLastResolved(thread.workflowQueue.queue$);
-  const pageSignal = useGet(pageSignal$);
-  const skipEvent = useSet(thread.workflowQueue.skipEvent$);
-  const clearQueue = useSet(thread.workflowQueue.clear$);
-  const setPaused = useSet(thread.workflowQueue.setPaused$);
-
-  if (!queue) {
-    return null;
-  }
-  const paused = queue.pausedAt !== null;
-  if (!queue.running && queue.pending.length === 0 && !paused) {
-    return null;
-  }
-
-  return (
-    <section
-      className="rounded-lg border border-border/60 bg-muted/20 p-3"
-      aria-label="Workflow queue"
-      data-testid="workflow-queue-section"
-    >
-      <div className="flex items-center gap-2">
-        <div className="min-w-0 flex-1 text-xs font-medium text-foreground">
-          Queue
-          {queue.pending.length > 0 ? (
-            <span className="ml-1 text-muted-foreground">
-              {queue.pending.length} waiting
-            </span>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-          aria-label={paused ? "Resume queue" : "Pause queue"}
-          onClick={() => {
-            detach(setPaused(!paused, pageSignal), Reason.DomCallback);
-          }}
-        >
-          {paused ? (
-            <IconPlayerPlay size={13} />
-          ) : (
-            <IconPlayerPause size={13} />
-          )}
-          {paused ? "Resume" : "Pause"}
-        </button>
-        {queue.pending.length > 0 ? (
-          <button
-            type="button"
-            className="inline-flex h-6 items-center rounded-md px-1.5 text-xs text-muted-foreground hover:bg-muted/60 hover:text-destructive"
-            onClick={() => {
-              detach(clearQueue(pageSignal), Reason.DomCallback);
-            }}
-          >
-            Clear queue ({queue.pending.length})
-          </button>
-        ) : null}
-      </div>
-
-      {paused ? (
-        <div className="mt-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-          Queue paused{queue.pauseReason ? `: ${queue.pauseReason}` : ""}. New
-          events keep queueing and run after you resume.
-        </div>
-      ) : null}
-
-      {queue.running ? (
-        <div className="mt-2 flex items-start gap-2 text-xs">
-          <span className="mt-1 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary" />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-foreground">
-              {queue.running.triggerBrief ?? "Running automation"}
-            </div>
-            <div className="text-muted-foreground">
-              {queue.running.status === "running" ? "Running" : "Starting"}
-              {" · "}
-              {formatHeaderWorkflowAutomationRun(queue.running.createdAt)}
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      {queue.pending.length > 0 ? (
-        <ul className="mt-2 grid gap-1">
-          {queue.pending.map((event, index) => {
-            return (
-              <li
-                key={event.id}
-                className="flex items-center gap-2 rounded-md px-1 py-0.5 text-xs hover:bg-muted/40"
-              >
-                <span className="w-4 shrink-0 text-right text-muted-foreground">
-                  {index + 1}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-foreground">
-                  {event.triggerBrief ?? event.triggerSource}
-                </span>
-                <span className="shrink-0 text-muted-foreground">
-                  {formatHeaderWorkflowAutomationRun(event.createdAt)}
-                </span>
-                <button
-                  type="button"
-                  className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/60 hover:text-destructive"
-                  aria-label="Skip queued event"
-                  onClick={() => {
-                    detach(skipEvent(event.id, pageSignal), Reason.DomCallback);
-                  }}
-                >
-                  <IconX size={12} />
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
-    </section>
-  );
-}
-
 function HeaderAutomationSidebar({ thread }: { thread: ChatThreadSignals }) {
   const workflowAutomations$ = thread.headerAutomations.automations$;
   const workflowAutomationsLoadable = useLastLoadable(workflowAutomations$);
@@ -2455,21 +2328,16 @@ function HeaderAutomationSidebar({ thread }: { thread: ChatThreadSignals }) {
             No automations yet.
           </div>
         ) : (
-          <div className="grid gap-6">
-            <HeaderWorkflowQueueSection thread={thread} />
-            {workflowAutomations.length > 0 ? (
-              <div className="grid gap-3">
-                {workflowAutomations.map((automation) => {
-                  return (
-                    <HeaderWorkflowAutomationCard
-                      key={automation.id}
-                      automation={automation}
-                      headerAutomations={thread.headerAutomations}
-                    />
-                  );
-                })}
-              </div>
-            ) : null}
+          <div className="grid gap-3">
+            {workflowAutomations.map((automation) => {
+              return (
+                <HeaderWorkflowAutomationCard
+                  key={automation.id}
+                  automation={automation}
+                  headerAutomations={thread.headerAutomations}
+                />
+              );
+            })}
           </div>
         )}
       </div>
@@ -3974,6 +3842,46 @@ function useChatComposerQueue(
   return { queuedItems, onRemoveQueuedItem };
 }
 
+function useChatComposerWorkflowEvents(thread: ChatThreadSignals) {
+  const queue = useLastResolved(thread.workflowQueue.queue$);
+  const skipEvent = useSet(thread.workflowQueue.skipEvent$);
+  const clearEvents = useSet(thread.workflowQueue.clear$);
+  const setEventsPaused = useSet(thread.workflowQueue.setPaused$);
+  const pageSignal = useGet(pageSignal$);
+  const pendingEventIds = new Set(
+    queue?.pending.map((event) => {
+      return event.id;
+    }) ?? [],
+  );
+  const workflowEventItems: WorkflowEventComposerItem[] =
+    queue?.pending.map((event) => {
+      return {
+        id: event.id,
+        text: event.triggerBrief ?? event.triggerSource,
+      };
+    }) ?? [];
+
+  const onRemoveWorkflowEvent = (id: string) => {
+    if (!pendingEventIds.has(id)) {
+      return;
+    }
+    detach(skipEvent(id, pageSignal), Reason.DomCallback);
+  };
+
+  return {
+    workflowEventItems,
+    onRemoveWorkflowEvent,
+    workflowEventsPaused: queue ? queue.pausedAt !== null : false,
+    workflowEventsPauseReason: queue?.pauseReason,
+    onSetWorkflowEventsPaused: (paused: boolean) => {
+      detach(setEventsPaused(paused, pageSignal), Reason.DomCallback);
+    },
+    onClearWorkflowEvents: () => {
+      detach(clearEvents(pageSignal), Reason.DomCallback);
+    },
+  };
+}
+
 // The thread's active goal (folded from goal-state markers, no separate
 // poll) plus its cancel handler. Cancelling pauses the goal through the goal API;
 // the backend then emits a goal_event marker, so the row folds away.
@@ -4262,6 +4170,7 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
     thread,
     queuedMessageItems,
   );
+  const workflowEvents = useChatComposerWorkflowEvents(thread);
   const { activeGoal, onCancelActiveGoal } = useChatComposerActiveGoal(
     thread,
     pageSignal,
@@ -4320,6 +4229,7 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
     submitBlocker: submitBlockerProps,
     queuedItems,
     onRemoveQueuedItem,
+    ...workflowEvents,
     activeGoal,
     onCancelActiveGoal,
   };


### PR DESCRIPTION
## Summary

- render pending user messages, workflow events, and the active goal in one composer queue, preserving message-first execution order
- describe pending work by type (for example, `1 message and 2 events waiting`) while excluding the active goal from the waiting count
- move workflow event pause, resume, skip, and clear controls into the bottom queue
- keep the Automations sidebar focused on configuration cards by removing its queue, running state, pending badge, and automatic open behavior

## User-visible impact

Pending work now has one consistent home below the conversation. The queue heading names the pending message and event counts directly, while the active goal remains visible without being treated as waiting work. Active automation runs remain visible in the chat transcript, and the right sidebar is reserved for automation configuration.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx src/views/zero-page/__tests__/chat-run-queue.test.tsx src/views/zero-page/__tests__/chat-run-results.test.tsx src/views/zero-page/__tests__/workflow-queue-panel.test.tsx` (38 tests)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- Prettier 3.8.1 on changed files
