### PR TITLE
feat(platform): render structured user messages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
@@ -24,7 +24,8 @@ const SECOND_THREAD_ID = "b0000000-0000-4000-a000-000000000732";
 const FIRST_MESSAGE_ID = "00000000-0000-4000-8000-000000000731";
 const FIRST_MESSAGE = "Persist this remote response for thread re-entry";
 const STRUCTURED_MESSAGE_ID = "00000000-0000-4000-8000-000000000733";
-const STRUCTURED_MESSAGE = "Use the source thread for context";
+const STRUCTURED_MESSAGE = "Legacy structured content should stay hidden";
+const STRUCTURED_REFERENCE_TITLE = "Archived IndexedDB source";
 function structuredPromptFixture(): UserMessageDocument {
   return {
     version: 1,
@@ -33,7 +34,7 @@ function structuredPromptFixture(): UserMessageDocument {
       {
         type: "chat_thread",
         threadId: FIRST_THREAD_ID,
-        titleSnapshot: "IndexedDB source thread",
+        titleSnapshot: STRUCTURED_REFERENCE_TITLE,
       },
       { type: "text", text: " for context" },
     ],
@@ -95,6 +96,7 @@ describe("chat message persistence", () => {
                 id: STRUCTURED_MESSAGE_ID,
                 role: "user",
                 content: STRUCTURED_MESSAGE,
+                runId: "d0000000-0000-4000-a000-000000000731",
                 structuredPrompt,
                 createdAt: "2026-06-09T10:00:00Z",
               },
@@ -102,6 +104,7 @@ describe("chat message persistence", () => {
                 id: FIRST_MESSAGE_ID,
                 role: "assistant",
                 content: FIRST_MESSAGE,
+                runId: "d0000000-0000-4000-a000-000000000731",
                 createdAt: "2026-06-09T10:01:00Z",
               },
             ],
@@ -140,9 +143,13 @@ describe("chat message persistence", () => {
       await expect(
         screen.findByText(FIRST_MESSAGE),
       ).resolves.toBeInTheDocument();
-      await expect(
-        screen.findByText(STRUCTURED_MESSAGE),
-      ).resolves.toBeInTheDocument();
+      await waitFor(() => {
+        const reference = document.querySelector(
+          `a[aria-label="Open chat ${STRUCTURED_REFERENCE_TITLE}"]`,
+        );
+        expect(reference).toHaveAttribute("href", `/chats/${FIRST_THREAD_ID}`);
+      });
+      expect(screen.queryByText(STRUCTURED_MESSAGE)).not.toBeInTheDocument();
       await waitFor(async () => {
         const structuredMessage: unknown = await testDb.get(
           CHAT_MESSAGES_STORE,
@@ -176,7 +183,11 @@ describe("chat message persistence", () => {
       await waitFor(() => {
         expect(document.title).toBe("IndexedDB source thread | VM0");
         expect(screen.getByText(FIRST_MESSAGE)).toBeInTheDocument();
-        expect(screen.getByText(STRUCTURED_MESSAGE)).toBeInTheDocument();
+        const reference = document.querySelector(
+          `a[aria-label="Open chat ${STRUCTURED_REFERENCE_TITLE}"]`,
+        );
+        expect(reference).toHaveAttribute("href", `/chats/${FIRST_THREAD_ID}`);
+        expect(screen.queryByText(STRUCTURED_MESSAGE)).not.toBeInTheDocument();
       });
     } finally {
       blockedRemote.resolve();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-persistence.test.tsx
@@ -5,6 +5,7 @@ import {
   chatThreadMessagesContract,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -132,6 +133,7 @@ describe("chat message persistence", () => {
       detachedSetupPage({
         context,
         path: `/chats/${FIRST_THREAD_ID}`,
+        featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
         user: { id: "idb-reentry-user", fullName: "IndexedDB Test User" },
         org: {
           activeOrg: { id: "idb-reentry-org", name: "IndexedDB Test Org" },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-user-messages.test.tsx
@@ -1,0 +1,120 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+describe("structured user messages", () => {
+  it("renders ordered snapshots and keeps the legacy Markdown fallback", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000741";
+    const referencedThreadId = "b0000000-0000-4000-a000-000000000742";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Structured message rendering",
+      chatMessages: [
+        {
+          id: "00000000-0000-4000-8000-000000000741",
+          role: "user",
+          content: "Legacy structured body should stay hidden",
+          runId: "d0000000-0000-4000-a000-000000000741",
+          generationTemplate: {
+            type: "presentation",
+            selection: { templateId: "retired-template" },
+          },
+          attachFiles: [
+            {
+              id: "file-live",
+              filename: "renamed-report.pdf",
+              url: "/f/test-user/file-live/renamed-report.pdf",
+              contentType: "application/pdf",
+              size: 42,
+            },
+          ],
+          structuredPrompt: {
+            version: 1,
+            parts: [
+              { type: "text", text: "Start " },
+              {
+                type: "chat_thread",
+                threadId: referencedThreadId,
+                titleSnapshot: "Archived source",
+              },
+              { type: "text", text: " with " },
+              {
+                type: "template",
+                titleSnapshot: "Archived deck",
+                template: {
+                  type: "presentation",
+                  selection: { templateId: "retired-template" },
+                },
+              },
+              { type: "text", text: " and " },
+              {
+                type: "file",
+                fileId: "file-live",
+                filenameSnapshot: "original-report.pdf",
+                contentType: "application/pdf",
+              },
+              { type: "text", text: ", then " },
+              {
+                type: "file",
+                fileId: "file-deleted",
+                filenameSnapshot: "deleted-notes.txt",
+                contentType: "text/plain",
+              },
+              { type: "text", text: ".\nUse **literal** <span>." },
+            ],
+          },
+          createdAt: "2026-07-21T10:00:00Z",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000743",
+          role: "user",
+          content: "Legacy **bold** remains",
+          runId: "d0000000-0000-4000-a000-000000000743",
+          createdAt: "2026-07-21T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const structuredMessage = await waitFor(() => {
+      const element = document.querySelector("[data-structured-user-message]");
+      expect(element).toBeInstanceOf(HTMLElement);
+      return element as HTMLElement;
+    });
+    expect(structuredMessage.textContent).toBe(
+      "Start Archived source with Presentation·Archived deck and " +
+        "PDForiginal-report.pdf, then TXTdeleted-notes.txt.\n" +
+        "Use **literal** <span>.",
+    );
+    expect(structuredMessage.querySelector("strong")).toBeNull();
+
+    const threadLink = structuredMessage.querySelector(
+      'a[aria-label="Open chat Archived source"]',
+    );
+    expect(threadLink).toHaveAttribute("href", `/chats/${referencedThreadId}`);
+    expect(
+      screen.getByLabelText("Message template Archived deck"),
+    ).toBeInTheDocument();
+    expect(
+      structuredMessage.querySelector(
+        'button[aria-label="Download original-report.pdf"]',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("File deleted-notes.txt")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Legacy structured body should stay hidden"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Retired template")).not.toBeInTheDocument();
+    expect(screen.queryByText("renamed-report.pdf")).not.toBeInTheDocument();
+
+    const legacyBold = await screen.findByText("bold");
+    expect(legacyBold.tagName).toBe("STRONG");
+    expect(screen.getByText("Legacy", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-user-messages.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -80,7 +81,11 @@ describe("structured user messages", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
 
     const structuredMessage = await waitFor(() => {
       const element = document.querySelector("[data-structured-user-message]");
@@ -116,5 +121,40 @@ describe("structured user messages", () => {
     const legacyBold = await screen.findByText("bold");
     expect(legacyBold.tagName).toBe("STRONG");
     expect(screen.getByText("Legacy", { exact: false })).toBeInTheDocument();
+  });
+
+  it("uses the legacy renderer when the feature switch is disabled", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000744";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Structured message disabled",
+      chatMessages: [
+        {
+          id: "00000000-0000-4000-8000-000000000744",
+          role: "user",
+          content: "Legacy **fallback** stays",
+          runId: "d0000000-0000-4000-a000-000000000744",
+          structuredPrompt: {
+            version: 1,
+            parts: [{ type: "text", text: "Structured content stays hidden" }],
+          },
+          createdAt: "2026-07-21T10:02:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: false },
+    });
+
+    const legacyBold = await screen.findByText("fallback");
+    expect(legacyBold.tagName).toBe("STRONG");
+    expect(screen.getByText("Legacy", { exact: false })).toBeInTheDocument();
+    expect(
+      screen.queryByText("Structured content stays hidden"),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector("[data-structured-user-message]")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -111,8 +111,10 @@ import type {
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { emptyArtifactImg, emptyChatImg } from "./platform-assets.ts";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   captureRecommendedFollowupSelected,
   captureRecommendedFollowupsShown,
@@ -6627,8 +6629,13 @@ function PagedUserMessage({
   message: EnrichedChatMessage;
   thread: ChatThreadSignals;
 }) {
+  const featureSwitches = useGet(featureSwitch$);
+  const structuredPromptEnabled =
+    featureSwitches[FeatureSwitchKey.StructuredPrompt] ?? false;
   const structuredPrompt =
-    message.role === "user" ? message.structuredPrompt : undefined;
+    structuredPromptEnabled && message.role === "user"
+      ? message.structuredPrompt
+      : undefined;
   const content = message.content ?? "";
   // Two attachment sources coexist: the structured `attachFiles` field
   // (current flow) and legacy `[Attached file: ...](url)` inline lines left

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -88,6 +88,9 @@ import type {
   ChatThreadArtifactFile,
   ChatMessageUsagePayload,
   GenerationTemplateRequest,
+  ResolvedAttachFile,
+  UserMessageDocument,
+  UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type {
   ChatThreadWorkflowAutomation,
@@ -6370,6 +6373,148 @@ function UserMessageGenerationTemplate({
   );
 }
 
+const STRUCTURED_REFERENCE_CHIP_CLASS =
+  "inline-flex max-w-[240px] items-center gap-1 rounded-md border " +
+  "border-foreground/15 bg-background/80 px-1.5 py-0.5 align-middle " +
+  "text-xs font-medium";
+
+function StructuredTemplateIcon({
+  type,
+}: {
+  type: GenerationTemplateRequest["type"];
+}) {
+  if (type === "video") {
+    return <IconVideo size={14} stroke={1.8} className="shrink-0" />;
+  }
+  if (type === "illustration") {
+    return <IconPhoto size={14} stroke={1.8} className="shrink-0" />;
+  }
+  if (type === "workflow") {
+    return <IconRoute size={14} stroke={1.8} className="shrink-0" />;
+  }
+  if (type === "website") {
+    return <IconWorld size={14} stroke={1.8} className="shrink-0" />;
+  }
+  return <IconPresentation size={14} stroke={1.8} className="shrink-0" />;
+}
+
+function StructuredTemplateReference({
+  part,
+}: {
+  part: Extract<UserMessagePart, { type: "template" }>;
+}) {
+  const typeLabel = generationTemplateTypeLabel(part.template);
+  return (
+    <span
+      aria-label={`Message template ${part.titleSnapshot}`}
+      className={STRUCTURED_REFERENCE_CHIP_CLASS}
+      title={`${typeLabel ?? part.template.type} · ${part.titleSnapshot}`}
+    >
+      <StructuredTemplateIcon type={part.template.type} />
+      <span className="shrink-0 text-muted-foreground">
+        {typeLabel ?? part.template.type}
+      </span>
+      <span className="text-muted-foreground">·</span>
+      <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+    </span>
+  );
+}
+
+function StructuredFileReference({
+  part,
+  attachment,
+}: {
+  part: Extract<UserMessagePart, { type: "file" }>;
+  attachment: ResolvedAttachFile | undefined;
+}) {
+  if (attachment) {
+    return (
+      <span className="inline-flex align-middle">
+        <FileAttachmentChip
+          contentType={part.contentType}
+          filename={part.filenameSnapshot}
+          url={attachment.url}
+        />
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-label={`File ${part.filenameSnapshot}`}
+      className={`${STRUCTURED_REFERENCE_CHIP_CLASS} h-7`}
+      title={part.filenameSnapshot}
+    >
+      <FilePreviewIcon
+        filename={part.filenameSnapshot}
+        contentType={part.contentType}
+        size="sm"
+        className="shrink-0"
+        testId="structured-message-file-icon"
+      />
+      <span className="min-w-0 truncate">{part.filenameSnapshot}</span>
+    </span>
+  );
+}
+
+function StructuredUserMessagePart({
+  part,
+  attachments,
+}: {
+  part: UserMessagePart;
+  attachments: readonly ResolvedAttachFile[];
+}): ReactNode {
+  if (part.type === "text") {
+    return <span>{part.text}</span>;
+  }
+  if (part.type === "chat_thread") {
+    return (
+      <Link
+        pathname={ROUTES.chat}
+        options={{ pathParams: { threadId: part.threadId } }}
+        aria-label={`Open chat ${part.titleSnapshot}`}
+        className={`${STRUCTURED_REFERENCE_CHIP_CLASS} text-primary transition-colors hover:bg-foreground/10`}
+        title={part.titleSnapshot}
+      >
+        <IconMessageCircle size={14} stroke={1.8} className="shrink-0" />
+        <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+      </Link>
+    );
+  }
+  if (part.type === "template") {
+    return <StructuredTemplateReference part={part} />;
+  }
+  const attachment = attachments.find((candidate) => {
+    return candidate.id === part.fileId;
+  });
+  return <StructuredFileReference part={part} attachment={attachment} />;
+}
+
+function StructuredUserMessage({
+  document,
+  attachments,
+}: {
+  document: UserMessageDocument;
+  attachments: readonly ResolvedAttachFile[];
+}) {
+  const partOccurrences = new Map<string, number>();
+  return (
+    <div data-structured-user-message="" className="whitespace-pre-wrap">
+      {document.parts.map((part) => {
+        const identity = JSON.stringify(part);
+        const occurrence = (partOccurrences.get(identity) ?? 0) + 1;
+        partOccurrences.set(identity, occurrence);
+        return (
+          <StructuredUserMessagePart
+            key={`${identity}:${String(occurrence)}`}
+            part={part}
+            attachments={attachments}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 function WorkflowUserMessage({
   message,
 }: {
@@ -6482,6 +6627,8 @@ function PagedUserMessage({
   message: EnrichedChatMessage;
   thread: ChatThreadSignals;
 }) {
+  const structuredPrompt =
+    message.role === "user" ? message.structuredPrompt : undefined;
   const content = message.content ?? "";
   // Two attachment sources coexist: the structured `attachFiles` field
   // (current flow) and legacy `[Attached file: ...](url)` inline lines left
@@ -6540,25 +6687,38 @@ function PagedUserMessage({
       <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex flex-col items-end w-full">
-          <UserMessageGenerationTemplate
-            generationTemplate={message.generationTemplate}
-          />
-          <UserMessageAttachments
-            attachments={allAttachments}
-            onImageClick={openLightbox}
-          />
-          {bodyBlocks.length > 0 && (
+          {structuredPrompt ? (
             <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
               <div className="px-4 py-3">
-                <BodyContentBlocks
-                  blocks={bodyBlocks}
-                  openLightbox={openLightbox}
-                  hardBreaks
-                  escapeMarkdownHtml
-                  markdownMediaPreview={false}
+                <StructuredUserMessage
+                  document={structuredPrompt}
+                  attachments={message.attachFiles ?? []}
                 />
               </div>
             </div>
+          ) : (
+            <>
+              <UserMessageGenerationTemplate
+                generationTemplate={message.generationTemplate}
+              />
+              <UserMessageAttachments
+                attachments={allAttachments}
+                onImageClick={openLightbox}
+              />
+              {bodyBlocks.length > 0 && (
+                <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
+                  <div className="px-4 py-3">
+                    <BodyContentBlocks
+                      blocks={bodyBlocks}
+                      openLightbox={openLightbox}
+                      hardBreaks
+                      escapeMarkdownHtml
+                      markdownMediaPreview={false}
+                    />
+                  </div>
+                </div>
+              )}
+            </>
           )}
           <UserMessageActions
             canCopy={canCopy}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -55,6 +55,7 @@ export enum FeatureSwitchKey {
   Vm0Model = "vm0Model",
   RealAgentInPreview = "realAgentInPreview",
   ComposerUploadPopover = "composerUploadPopover",
+  StructuredPrompt = "structuredPrompt",
 
   ZapierConnector = "zapierConnector",
   MemoryViewer = "memoryViewer",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -36,6 +36,7 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.ComposerUploadPopover, {})).toBe(
       false,
     );
+    expect(isFeatureEnabled(FeatureSwitchKey.StructuredPrompt, {})).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.PresentationElementDragging, {}),
     ).toBe(false);
@@ -136,6 +137,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationElementDragging]).toBe(
       true,
@@ -166,6 +168,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -317,6 +317,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     userOverridable: false,
   },
+  [FeatureSwitchKey.StructuredPrompt]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Enable structured user prompt rendering, sends, and drafts while preserving the legacy content fallback.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- render optional `structuredPrompt.parts` in stored order for user messages, with plain text plus chat, template, and file reference chips
- use stored snapshots for stable labels while resolving chat routes from `threadId` and downloads from current file metadata when available
- preserve deleted references as non-interactive snapshot chips and retain the existing template, attachment, and Markdown rendering path when `structuredPrompt` is absent
- cover mixed ordered content, renamed and deleted references, legacy fallback, and IndexedDB rehydration
- gate structured rendering behind the new `StructuredPrompt` feature switch, with staff-org rollout and explicit enabled/disabled coverage

## Compatibility

- this is a read-only rendering change; structured writes remain scoped to a later PR
- when the switch is disabled, every message uses the unchanged legacy renderer even if `structuredPrompt` is present
- when enabled, messages without `structuredPrompt` continue through the unchanged legacy renderer
- structured payload validation and invalid-cache fallback remain at the API and IndexedDB boundaries introduced by the earlier schema PRs

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types` (12/13 workspace tasks passed; the unrelated API task hit the default Node heap limit)
- `node --max-old-space-size=4096 ../../node_modules/typescript/bin/tsc --noEmit` from `apps/api`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-structured-user-messages.test.tsx src/views/zero-page/__tests__/chat-message-persistence.test.tsx`

Part of #22314
