### PR TITLE
feat(artifacts): expose artifact update timestamps

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -586,6 +586,7 @@ describe("GET /api/zero/artifacts", () => {
           fileId: prepared.url,
           url: prepared.url,
           size: hostedFile.size,
+          updatedAt: expect.any(String),
           artifactKind: "hosted-site",
         }),
         expect.objectContaining({
@@ -595,6 +596,7 @@ describe("GET /api/zero/artifacts", () => {
           url: standaloneUpload.url,
           size: 256,
           contentType: "text/plain",
+          updatedAt: expect.any(String),
         }),
       ]),
     );

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -166,6 +166,7 @@ const artifactListSqlRowSchema = z.object({
   preview_image_url: z.string().nullable(),
   metadata: z.unknown(),
   created_at: pgTimestampWithoutTimezoneToDateSchema,
+  updated_at: pgTimestampWithoutTimezoneToDateSchema,
   cursor_created_at: z.string(),
   cursor_updated_at: z.string().optional(),
   thread_id: z.string(),
@@ -1089,6 +1090,7 @@ function toArtifactItem(row: ArtifactListSqlRow): ArtifactItem {
     size: row.size_bytes ?? 0,
     url: row.url,
     createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
     ...(row.preview_image_url
       ? { previewImageUrl: row.preview_image_url }
       : {}),
@@ -1265,6 +1267,7 @@ async function listChangedArtifacts(args: {
         ${runUploadedFiles.previewImageUrl} AS preview_image_url,
         ${runUploadedFiles.metadata} AS metadata,
         ${runUploadedFiles.createdAt} AS created_at,
+        ${runUploadedFiles.updatedAt} AS updated_at,
         to_char(
           ${runUploadedFiles.createdAt},
           'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
@@ -1337,6 +1340,7 @@ async function listArtifactHistory(args: {
         ${runUploadedFiles.previewImageUrl} AS preview_image_url,
         ${runUploadedFiles.metadata} AS metadata,
         ${runUploadedFiles.createdAt} AS created_at,
+        ${runUploadedFiles.updatedAt} AS updated_at,
         ${chatThreads.id} AS thread_id,
         ${chatThreads.title} AS thread_title,
         ${zeroAgents.id} AS agent_id,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -340,6 +340,7 @@ describe("artifacts contract", () => {
       contentType: "text/html",
       url: "https://static.vm0.io/artifacts/launch-plan.html",
       createdAt: "2026-07-07T00:00:00.000Z",
+      updatedAt: "2026-07-08T00:00:00.000Z",
       artifactKind: "hosted-site",
       googleDriveSync: {
         status: "synced",

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -69,7 +69,7 @@ const artifactItemSchema = z.object({
   url: z.string(),
   previewImageUrl: z.string().optional(),
   createdAt: z.string(),
-  // Remove optionality after older API instances can no longer serve responses.
+  // Require this after the API-only preparation release is deployed.
   updatedAt: z.string().optional(),
   artifactKind: hostedArtifactKindSchema.optional(),
   googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -69,6 +69,8 @@ const artifactItemSchema = z.object({
   url: z.string(),
   previewImageUrl: z.string().optional(),
   createdAt: z.string(),
+  // Remove optionality after older API instances can no longer serve responses.
+  updatedAt: z.string().optional(),
   artifactKind: hostedArtifactKindSchema.optional(),
   googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),
 });


### PR DESCRIPTION
## Summary

- Return `run_uploaded_files.updated_at` as `ArtifactItem.updatedAt` in full and incremental Artifact responses.
- Keep the field optional in the shared schema for this API-only preparation release; the client follow-up #22411 requires it after this API is deployed.
- Add contract and API behavior coverage for the new field.

## Rollout

- This PR is stacked on #22381. Deploy #22381 first so favorite changes no longer touch `run_uploaded_files.updated_at`.
- This PR does not change Platform or IndexedDB and does not enable same-URL winner selection.
- Deploy this PR before #22411. The follow-up removes the temporary schema optionality when it releases the consuming client.
- Existing `updated_at` values are used as-is; there is no migration or historical backfill.

## Verification

- Full repository type check passed (`13/13` tasks); affected API and contract type/lint checks passed.
- API contract tests passed (`24/24`).
- The targeted API BDD test was added and attempted locally, but setup could not connect to PostgreSQL (`ECONNREFUSED`); it is left to PR CI's database environment.
