### PR TITLE
fix: connect chat connector cards directly

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -7,10 +7,18 @@ import { customConnectorProposalSchema } from "@vm0/api-contracts/contracts/zero
 import {
   connectorCatalogDisplayMetadataByRef$,
   connectorCatalogStatusByRef$,
-  connectors$,
   type ConnectorCatalogDisplayMetadata,
 } from "../external/connectors.ts";
-import { setSelectedConnectorType$ } from "../zero-page/settings/connectors.ts";
+import {
+  allConnectorTypes$,
+  connectConnectorNoAuth$,
+  connectConnectorOAuthAuthCode$,
+  getConnectorStatusConnectLaunchMode,
+  getOnlyAvailableStatusBrowserAuthMethodDetail,
+  getOnlyAvailableStatusNoAuthMethod,
+  setSelectedConnectorType$,
+  type ConnectorTypeWithStatus,
+} from "../zero-page/settings/connectors.ts";
 import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-type.ts";
 import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authorizations.ts";
 import { jsonParseBase64UrlOr } from "../utils.ts";
@@ -138,6 +146,19 @@ export function createCustomConnectorSignals(
   return descriptor;
 }
 
+function getDirectConnectMethod(connector: ConnectorTypeWithStatus) {
+  const launchMode = getConnectorStatusConnectLaunchMode(connector);
+  if (launchMode === "browser-auth") {
+    const authMethod = getOnlyAvailableStatusBrowserAuthMethodDetail(connector);
+    return authMethod ? { kind: "browser-auth" as const, authMethod } : null;
+  }
+  if (launchMode === "no-auth") {
+    const authMethod = getOnlyAvailableStatusNoAuthMethod(connector);
+    return authMethod ? { kind: "no-auth" as const, authMethod } : null;
+  }
+  return null;
+}
+
 export function createConnectorSignals(
   descriptor: ConnectorActionDescriptor,
 ): ConnectorSignals {
@@ -208,10 +229,59 @@ export function createConnectorSignals(
       return;
     }
 
-    await get(connectors$);
+    const connectorTypes = await get(allConnectorTypes$);
     signal.throwIfAborted();
-    set(activeChatConnectorActionState$, descriptor);
-    set(setSelectedConnectorType$, descriptor.connectorRef);
+    const connector = connectorTypes.find((item) => {
+      return item.type === descriptor.connectorRef;
+    });
+    if (!connector) {
+      return;
+    }
+
+    const directConnectMethod = getDirectConnectMethod(connector);
+    if (!directConnectMethod) {
+      set(activeChatConnectorActionState$, descriptor);
+      set(setSelectedConnectorType$, descriptor.connectorRef);
+      return;
+    }
+
+    const connectOptions = {
+      connectorLabel: connector.label,
+      agentId: descriptor.agentId,
+    };
+    const connectionCompleted =
+      directConnectMethod.kind === "browser-auth"
+        ? await set(
+            connectConnectorOAuthAuthCode$,
+            descriptor.connectorRef,
+            directConnectMethod.authMethod,
+            connectOptions,
+            signal,
+          )
+        : await set(
+            connectConnectorNoAuth$,
+            {
+              type: descriptor.connectorRef,
+              authMethod: directConnectMethod.authMethod,
+              options: connectOptions,
+            },
+            signal,
+          );
+    if (
+      connectionCompleted &&
+      descriptor.callbackPrompt &&
+      descriptor.threadId
+    ) {
+      await set(
+        runChatActionCallback$,
+        {
+          threadId: descriptor.threadId,
+          agentId: descriptor.agentId,
+          callbackPrompt: descriptor.callbackPrompt,
+        },
+        signal,
+      );
+    }
   });
 
   return {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1,5 +1,9 @@
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import { zeroConnectorManualGrantContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorManualGrantContract,
+  zeroConnectorNoAuthGrantContract,
+  zeroConnectorOauthStartContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
   zeroConnectorCatalogContract,
@@ -371,6 +375,210 @@ describe("chat message action cards", () => {
     sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Send", sidebar)).toBeNull();
     expect(draftRequests).toBe(2);
+  });
+
+  it("connects a single OAuth connector directly and resumes the chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = `${THREAD_ID}-direct-oauth`;
+    const callbackPrompt = "Re-check GitHub access, then continue";
+    const connectorUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
+    const sentPrompts: string[] = [];
+    let connected = false;
+    let authorized = false;
+    const authWindow = context.mocks.browser.authWindow();
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    context.mocks.data.connectors([]);
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            connectorRef: "github",
+            label: "GitHub",
+            connected,
+            connectionStatus: connected ? "connected" : "not-connected",
+            connection: connected
+              ? {
+                  authMethod: "oauth",
+                  externalUsername: "octocat",
+                  externalEmail: null,
+                  reconnectReason: null,
+                }
+              : null,
+            authMethods: [
+              {
+                id: "oauth",
+                label: "OAuth",
+                description: null,
+                grantKind: "auth-code",
+                manualFields: [],
+                startOptions: [],
+              },
+            ],
+            singleAuthCodeAuthMethodId: "oauth",
+          }),
+        ],
+      });
+    });
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        enabledTypes: authorized ? ["github"] : [],
+      });
+    });
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ body, respond }) => {
+        expect(body).toStrictEqual({
+          authMethod: "oauth",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+        });
+        connected = true;
+        authorized = true;
+        context.mocks.data.connectors([
+          connectedConnector({
+            type: "github",
+            authMethod: "oauth",
+            externalUsername: "octocat",
+            updatedAt: "2026-01-01T00:00:01Z",
+          }),
+        ]);
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/github/authorize",
+        });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Direct OAuth connector",
+      chatMessages: [
+        {
+          id: "msg-user-direct-oauth",
+          role: "user",
+          content: "Use GitHub",
+          runId: "run-direct-oauth",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-direct-oauth",
+          role: "assistant",
+          content: connectorUrl,
+          runId: "run-direct-oauth",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onSendRequest: ({ prompt }) => {
+        sentPrompts.push(prompt);
+      },
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const connectorCard = await screen.findByTestId("connector-action-card");
+    await user.click(await waitForButtonByText("Connect", connectorCard));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/github/authorize",
+      );
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "GitHub" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(sentPrompts).toStrictEqual([callbackPrompt]);
+      expect(within(connectorCard).getByText("Connected")).toBeInTheDocument();
+    });
+  });
+
+  it("enables a single no-auth connector directly", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = `${THREAD_ID}-direct-no-auth`;
+    const connectorUrl = `https://app.vm0.ai/connectors/stripe/authorize?agentId=${AGENT_ID}`;
+    let connected = false;
+    let authorized = false;
+    let connectCalls = 0;
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicConnectorStatusItem({
+            connectorRef: "stripe",
+            label: "Public Stripe",
+            connected,
+            connectionStatus: connected ? "connected" : "not-connected",
+            authMethods: [
+              {
+                id: "api",
+                label: "Public catalog",
+                description: null,
+                grantKind: "none",
+                manualFields: [],
+                startOptions: [],
+              },
+            ],
+          }),
+        ],
+      });
+    });
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        enabledTypes: authorized ? ["stripe"] : [],
+      });
+    });
+    context.mocks.api(
+      zeroConnectorNoAuthGrantContract.connect,
+      ({ body, params, respond }) => {
+        connectCalls += 1;
+        expect(params.type).toBe("stripe");
+        expect(body).toStrictEqual({
+          authMethod: "api",
+          agentId: AGENT_ID,
+          authorizeAgent: true,
+        });
+        connected = true;
+        authorized = true;
+        return respond(
+          200,
+          connectedConnector({ type: "stripe", authMethod: "api" }),
+        );
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Direct no-auth connector",
+      chatMessages: [
+        {
+          id: "msg-user-direct-no-auth",
+          role: "user",
+          content: "Use public Stripe data",
+          runId: "run-direct-no-auth",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-direct-no-auth",
+          role: "assistant",
+          content: connectorUrl,
+          runId: "run-direct-no-auth",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const connectorCard = await screen.findByTestId("connector-action-card");
+    await user.click(await waitForButtonByText("Connect", connectorCard));
+
+    await waitFor(() => {
+      expect(connectCalls).toBe(1);
+      expect(within(connectorCard).getByText("Connected")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Public Stripe" }),
+    ).not.toBeInTheDocument();
   });
 
   it("reloads the shared mail draft after deleting it", async () => {


### PR DESCRIPTION
## Summary

- launch the only available OAuth/OpenID flow directly from connector cards in chat messages
- enable single no-auth connectors without opening the intermediate connection dialog
- preserve the existing modal for multi-method, manual-token, device, and external-code connectors
- keep target-agent authorization and callback prompt continuation attached to successful connections

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx` (26 tests passed)
