### PR TITLE
feat: enable composer chat thread suggestions for all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,6 +12,9 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ComposerChatThreadSuggestions, {}),
+    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -156,7 +159,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ComposerChatThreadSuggestions]).toBe(
-      false,
+      true,
     );
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -375,8 +375,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Suggest titled chat threads from the current agent when typing @ in the chat composer.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.SidebarManageIconCollapse]: {
     maintainer: "ming@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `composerChatThreadSuggestions` for every user instead of limiting it to staff organizations
- update core feature-switch coverage for both context-free and non-staff organization evaluation

## Implementation

- keep the existing feature switch and user override behavior intact
- set the core rollout default to globally enabled and remove the staff organization allowlist

## Verification

- `corepack pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `corepack pnpm -F @vm0/core lint`
- `corepack pnpm -F @vm0/core check-types`
- `corepack pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (23 tests passed)
- `corepack pnpm knip --workspace @vm0/core`

Full local Vitest and a local dev server were not run, per the vm0 PR verification policy.
