### PR TITLE
docs(guest-mock-codex): document app server contract

### DIFF
--- a/crates/guest-mock-codex/src/app_server/mod.rs
+++ b/crates/guest-mock-codex/src/app_server/mod.rs
@@ -20,9 +20,10 @@ const METHOD_NOT_FOUND: i64 = -32601;
 /// `listen` must be exactly `stdio://`. The function locks process stdin and
 /// stdout, then synchronously processes newline-delimited JSON-RPC messages on
 /// the calling thread. The loop normally returns when stdin reaches EOF or the
-/// configured scenario requests a stop. Depending on the selected scenario,
-/// EOF can instead park the thread indefinitely or start a helper process that
-/// continues holding stderr after this function returns.
+/// configured scenario requests a stop. Selected scenarios can instead park
+/// the thread indefinitely, either while handling a message or after EOF, or
+/// start a helper process that continues holding stderr after this function
+/// returns.
 ///
 /// Mock behavior is selected by `MOCK_CODEX_APP_SERVER_SCENARIO`.
 ///

--- a/crates/guest-mock-codex/src/app_server/mod.rs
+++ b/crates/guest-mock-codex/src/app_server/mod.rs
@@ -15,6 +15,24 @@ use std::thread;
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
 
+/// Run the mock Codex app server over process stdio.
+///
+/// `listen` must be exactly `stdio://`. The function locks process stdin and
+/// stdout, then synchronously processes newline-delimited JSON-RPC messages on
+/// the calling thread. The loop normally returns when stdin reaches EOF or the
+/// configured scenario requests a stop. Depending on the selected scenario,
+/// EOF can instead park the thread indefinitely or start a helper process that
+/// continues holding stderr after this function returns.
+///
+/// Mock behavior is selected by `MOCK_CODEX_APP_SERVER_SCENARIO`.
+///
+/// # Errors
+///
+/// Returns an error when `listen` is unsupported, the environment names an
+/// unsupported scenario, stdin cannot be read, an input message cannot be
+/// decoded or validated, a response cannot be serialized or written to stdout,
+/// stdout cannot be flushed, or a scenario-specific helper process cannot be
+/// started.
 pub fn run_app_server(listen: &str) -> io::Result<()> {
     if listen != "stdio://" {
         return Err(io::Error::new(

--- a/crates/guest-mock-codex/src/app_server/mod.rs
+++ b/crates/guest-mock-codex/src/app_server/mod.rs
@@ -30,10 +30,10 @@ const METHOD_NOT_FOUND: i64 = -32601;
 /// # Errors
 ///
 /// Returns an error when `listen` is unsupported, the environment names an
-/// unsupported scenario, stdin cannot be read, an input message cannot be
-/// decoded or validated, a response cannot be serialized or written to stdout,
-/// stdout cannot be flushed, or a scenario-specific helper process cannot be
-/// started.
+/// unsupported scenario, stdin cannot be read, an input line cannot be decoded
+/// as JSON, a client response is invalid, input events cannot be persisted, a
+/// response cannot be serialized or written to stdout, stdout cannot be
+/// flushed, or a scenario-specific helper process cannot be started.
 pub fn run_app_server(listen: &str) -> io::Result<()> {
     if listen != "stdio://" {
         return Err(io::Error::new(


### PR DESCRIPTION
## Summary

- document the exact `stdio://` transport and synchronous stdio lifecycle of `run_app_server`
- describe scenario-selected blocking, helper-process behavior, and the complete propagated error surface
- keep runtime behavior, public signatures, protocols, and tests unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-mock-codex --all-targets --all-features`
- `cargo doc -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-mock-codex --all-features`
- repository pre-commit Rust formatting, workspace documentation, and workspace Clippy hooks

Closes #22412
