### PR TITLE
chore(api): prefer additional drizzle helper leaves

### DIFF
--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -144,18 +144,29 @@ returned fields independently of `.set({...})`. Likewise, raw SQL passed to
 `insert(...).select(...)` is the write source rather than a returned field; only
 a subsequent `returning(...)` introduces a result-mapping boundary.
 
-Use typed operators such as `eq`, `gt`, `isNull`, and `isNotNull` instead of an
-equivalent SQL tag. They preserve the schema relationship between a column and
-its bound value. Likewise, use `max(column)` or `min(column)` for the exact
-aggregate form when the helper preserves the required decoder and nullability
-contract. Keep an existing outer `.mapWith(...)` when it owns a stricter or more
-specific contract than the helper's inferred result.
+Use typed operators such as `eq`, `gt`, `isNull`, `isNotNull`, and `like`
+instead of an equivalent SQL tag. They make the operation explicit and, when
+the helper supports it, preserve the schema relationship between a column and
+its bound value. Pass value arrays directly to `inArray(column, values)`; do not
+rebuild parameter lists with `sql.join(...)`. Use `asc(...)` and `desc(...)` for
+ordering leaves, and use `arrayContains(...)` when the left operand is an
+array-valued schema column and an SQL wrapper intentionally constructs the
+right JSON value.
+
+Likewise, use `sum(...)`, `count(...)`, `countDistinct(...)`, `max(...)`, or
+`min(...)` for an exact aggregate leaf. Keep an existing outer SQL cast,
+`FILTER`, `COALESCE`, alias, and `.mapWith(...)` when that outer expression owns
+a stricter result decoder or nullability contract. Keep literal predicates as
+literals when changing them into helper arguments would introduce a parameter
+and alter planner-visible query shape; a `LIKE ... ESCAPE` suffix also remains
+outside the `like(...)` leaf.
 
 This preference also applies to a replaceable leaf inside otherwise irreducible
 SQL. Interpolate the typed operator in place of that leaf while retaining the
 outer tag for surrounding CTE, CASE, join, filter, cast, grouping, or statement
-syntax. Do not replace outer composition with `and(...)` or `or(...)` when their
-`SQL | undefined` result would weaken a required concrete `SQL` contract.
+syntax. Use `and(...)` and `or(...)` for a fixed boolean tree only when its
+direct consumer accepts their `SQL | undefined` result; do not use them when
+that result would weaken a required concrete `SQL` contract.
 Keep SQL syntax that belongs to an operand inside that operand. For example,
 write ``gte(events.createdAt, sql`${timestamp}::timestamp`)`` rather than
 placing the cast after the interpolated `gte(...)` fragment.

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -28,6 +28,7 @@ import {
   isNull,
   lt,
   notInArray,
+  or,
   sql,
   type SQL,
 } from "drizzle-orm";
@@ -440,14 +441,14 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       ...(snapshotOrder === undefined
         ? {}
         : {
-            setWhere: sql`
-              ${isNull(runnerState.heartbeatGeneration)}
-              OR ${lt(runnerState.heartbeatGeneration, snapshotOrder.generation)}
-              OR (
-                ${eq(runnerState.heartbeatGeneration, snapshotOrder.generation)}
-                AND ${lt(runnerState.heartbeatSequence, snapshotOrder.sequence)}
-              )
-            `,
+            setWhere: or(
+              isNull(runnerState.heartbeatGeneration),
+              lt(runnerState.heartbeatGeneration, snapshotOrder.generation),
+              and(
+                eq(runnerState.heartbeatGeneration, snapshotOrder.generation),
+                lt(runnerState.heartbeatSequence, snapshotOrder.sequence),
+              ),
+            ),
           }),
     });
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
@@ -5,7 +5,7 @@ import {
 import { systemStoragePresignedUrlCache } from "@vm0/db/schema/system-storage-presigned-url-cache";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
@@ -42,7 +42,7 @@ function escapedLikePrefix(value: string): string {
 function objectKeyPrefixCondition(prefix: string) {
   return and(
     eq(systemStoragePresignedUrlCache.scope, "system_storage"),
-    sql`${systemStoragePresignedUrlCache.objectKey} like ${escapedLikePrefix(prefix)} escape '\\'`,
+    sql`${like(systemStoragePresignedUrlCache.objectKey, escapedLikePrefix(prefix))} escape '\\'`,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/test-workflow-skill-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-workflow-skill-storage-presigned-url-cache-state.ts
@@ -4,7 +4,7 @@ import {
 } from "@vm0/api-contracts/contracts/test-workflow-skill-storage-presigned-url-cache-state";
 import { systemStoragePresignedUrlCache } from "@vm0/db/schema/system-storage-presigned-url-cache";
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -42,7 +42,7 @@ function escapedLikePrefix(value: string): string {
 function objectKeyPrefixCondition(prefix: string) {
   return and(
     eq(systemStoragePresignedUrlCache.scope, "workflow_skill_storage"),
-    sql`${systemStoragePresignedUrlCache.objectKey} like ${escapedLikePrefix(prefix)} escape '\\'`,
+    sql`${like(systemStoragePresignedUrlCache.objectKey, escapedLikePrefix(prefix))} escape '\\'`,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -50,7 +50,7 @@ function latestRunFinishCreatedAtSql() {
     FROM ${chatMessages}
     WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
       AND ${isNotNull(chatMessages.runLifecycleEvent)}
-    ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
+    ORDER BY ${desc(chatMessages.createdAt)}, ${desc(chatMessages.id)}
     LIMIT 1
   )`;
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { chatThreadMarkReadContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -19,7 +19,7 @@ function latestRunFinishCreatedAtSql() {
     FROM ${chatMessages}
     WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
       AND ${isNotNull(chatMessages.runLifecycleEvent)}
-    ORDER BY ${chatMessages.createdAt} DESC, ${chatMessages.id} DESC
+    ORDER BY ${desc(chatMessages.createdAt)}, ${desc(chatMessages.id)}
     LIMIT 1
   )`;
 }

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -11,6 +11,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { command, computed, type Computed } from "ccstate";
 import {
   and,
+  countDistinct,
   eq,
   gte,
   inArray,
@@ -893,7 +894,7 @@ async function queryCompletedRunCounts(
       agentName: sql`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`
         .mapWith(pgTextDecoder)
         .as("agent_name"),
-      runs: sql`COUNT(DISTINCT ${agentRuns.id})::int`
+      runs: sql`${countDistinct(agentRuns.id)}::int`
         .mapWith(pgIntegerDecoder)
         .as("runs"),
     })

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { eq, gte, lt, sql } from "drizzle-orm";
+import { eq, gte, inArray, lt, sql, sum } from "drizzle-orm";
 import { CRON_AGGREGATE_MODEL_STATS_MAX_HOURS } from "@vm0/api-contracts/contracts/cron";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
@@ -65,16 +65,11 @@ function getModelAliasEntries() {
   return Object.entries(VM0_MODEL_ALIAS_TO_MODEL);
 }
 
-function getModelStatsModelIdSql() {
-  return sql.join(
-    [
-      ...Object.keys(VM0_MODEL_TO_PROVIDER),
-      ...Object.keys(VM0_MODEL_ALIAS_TO_MODEL),
-    ].map((model) => {
-      return sql`${model}`;
-    }),
-    sql`, `,
-  );
+function getModelStatsModelIds(): string[] {
+  return [
+    ...Object.keys(VM0_MODEL_TO_PROVIDER),
+    ...Object.keys(VM0_MODEL_ALIAS_TO_MODEL),
+  ];
 }
 
 interface ModelStatsAggregationResult {
@@ -164,7 +159,7 @@ async function replaceModelStats(
   windowEnd: Date,
 ): Promise<number> {
   const observationModelExpr = modelUsageObservationModelExpression();
-  const modelStatsModelIdSql = getModelStatsModelIdSql();
+  const modelStatsModelIds = getModelStatsModelIds();
   const windowStartParam = utcTimestampParam(windowStart);
   const windowEndParam = utcTimestampParam(windowEnd);
 
@@ -173,7 +168,7 @@ async function replaceModelStats(
       DELETE FROM ${modelStat}
       WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
         AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
-        AND ${modelStat.model} IN (${modelStatsModelIdSql})
+        AND ${inArray(modelStat.model, modelStatsModelIds)}
     `);
 
     const { rowCount } = await tx.execute(sql`
@@ -196,7 +191,7 @@ async function replaceModelStats(
         FROM ${modelUsageObservation}
         WHERE ${gte(modelUsageObservation.observedAt, sql`${windowStartParam}::timestamp`)}
           AND ${lt(modelUsageObservation.observedAt, sql`${windowEndParam}::timestamp`)}
-          AND ${modelUsageObservation.model} IN (${modelStatsModelIdSql})
+          AND ${inArray(modelUsageObservation.model, modelStatsModelIds)}
           AND ${modelUsageObservation.category} IN (
             ${TOKEN_CATEGORY_INPUT},
             ${TOKEN_CATEGORY_OUTPUT},
@@ -292,8 +287,7 @@ async function selectModelRankings(
   const previousEnd = window.start;
   const previousStart = new Date(previousEnd.getTime() - duration);
   const modelExpr = modelStatModelExpression();
-  const currentModelStatsModelIdSql = getModelStatsModelIdSql();
-  const previousModelStatsModelIdSql = getModelStatsModelIdSql();
+  const modelStatsModelIds = getModelStatsModelIds();
   const windowStartParam = utcTimestampParam(window.start);
   const windowEndParam = utcTimestampParam(window.end);
   const previousStartParam = utcTimestampParam(previousStart);
@@ -306,22 +300,22 @@ async function selectModelRankings(
       SELECT
         ${modelExpr} AS model,
         COALESCE(SUM(${modelStat.inputTokens} + ${modelStat.cacheReadInputTokens} + ${modelStat.cacheCreationInputTokens}), 0)::bigint AS input_tokens,
-        COALESCE(SUM(${modelStat.outputTokens}), 0)::bigint AS output_tokens,
-        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS total_tokens
+        COALESCE(${sum(modelStat.outputTokens)}, 0)::bigint AS output_tokens,
+        COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS total_tokens
       FROM ${modelStat}
       WHERE ${gte(modelStat.hourStart, sql`${windowStartParam}::timestamp`)}
         AND ${lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`)}
-        AND ${modelStat.model} IN (${currentModelStatsModelIdSql})
+        AND ${inArray(modelStat.model, modelStatsModelIds)}
       GROUP BY 1
     ),
     previous_period AS (
       SELECT
         ${modelExpr} AS model,
-        COALESCE(SUM(${modelStat.totalTokens}), 0)::bigint AS previous_total_tokens
+        COALESCE(${sum(modelStat.totalTokens)}, 0)::bigint AS previous_total_tokens
       FROM ${modelStat}
       WHERE ${gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`)}
         AND ${lt(modelStat.hourStart, sql`${previousEndParam}::timestamp`)}
-        AND ${modelStat.model} IN (${previousModelStatsModelIdSql})
+        AND ${inArray(modelStat.model, modelStatsModelIds)}
       GROUP BY 1
     )
     SELECT

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -10,7 +10,7 @@ import {
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
-import { and, eq, inArray, isNotNull, lte, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, lte } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -838,7 +838,7 @@ export const executeDueMorningBriefs$ = command(
           lte(morningBriefSchedules.nextRunAt, currentTime),
         ),
       )
-      .orderBy(sql`${morningBriefSchedules.nextRunAt} asc`)
+      .orderBy(asc(morningBriefSchedules.nextRunAt))
       .limit(CLAIM_LIMIT);
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/org-concurrency-entitlements.service.ts
@@ -1,5 +1,5 @@
 import { orgConcurrencySubscriptions } from "@vm0/db/schema/org-concurrency-subscription";
-import { and, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, sql, sum } from "drizzle-orm";
 
 import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
@@ -74,7 +74,7 @@ export async function activePaidConcurrencySlots(
   const [row] = await db
     .select({
       slots:
-        sql`COALESCE(SUM(${orgConcurrencySubscriptions.slots}), 0)::int`.mapWith(
+        sql`COALESCE(${sum(orgConcurrencySubscriptions.slots)}, 0)::int`.mapWith(
           pgIntegerDecoder,
         ),
     })

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -3,6 +3,7 @@ import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import {
   and,
+  arrayContains,
   eq,
   gt,
   isNotNull,
@@ -39,33 +40,36 @@ function reusableSandboxCondition(args: {
         'historyGenerationRunId', cast(${args.historyGenerationRunId} as text)
       )`
       : sql`jsonb_build_object('profile', cast(${args.profile} as text))`;
-  return sql`${runnerState.heldSessionStates} @> jsonb_build_array(
+  const heldSessionStates = sql`jsonb_build_array(
     jsonb_build_object(
       'sessionId', cast(${args.sessionId} as text),
       'reusableSandbox', ${reusableSandbox}
     )
   )`;
+  return arrayContains(runnerState.heldSessionStates, heldSessionStates);
 }
 
 function capableWorkspaceCondition(args: {
   readonly sessionId: SQLWrapper;
   readonly profile: SQLWrapper;
 }): SQL {
-  return sql`(
-    ${runnerState.heldSessionStates} @> jsonb_build_array(
-      jsonb_build_object(
-        'sessionId', cast(${args.sessionId} as text),
-        'workspaceCaches', jsonb_build_array(
-          jsonb_build_object(
-            'profile', cast(${args.profile} as text),
-            'workspaceAffinityVersion', 1
-          )
+  const heldSessionStates = sql`jsonb_build_array(
+    jsonb_build_object(
+      'sessionId', cast(${args.sessionId} as text),
+      'workspaceCaches', jsonb_build_array(
+        jsonb_build_object(
+          'profile', cast(${args.profile} as text),
+          'workspaceAffinityVersion', 1
         )
       )
     )
-    AND ${runnerState.admittableProfiles} @> jsonb_build_array(
-      cast(${args.profile} as text)
-    )
+  )`;
+  const admittableProfiles = sql`jsonb_build_array(
+    cast(${args.profile} as text)
+  )`;
+  return sql`(
+    ${arrayContains(runnerState.heldSessionStates, heldSessionStates)}
+    AND ${arrayContains(runnerState.admittableProfiles, admittableProfiles)}
   )`;
 }
 

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -297,12 +297,6 @@ async function touchRecentlyUsedCacheRows(
   const orderedCacheKeys = [...cacheKeys].sort((left, right) => {
     return left.localeCompare(right);
   });
-  const cacheKeySql = sql.join(
-    orderedCacheKeys.map((cacheKey) => {
-      return sql`${cacheKey}`;
-    }),
-    sql`, `,
-  );
   const issuedAtTimestamp = timestampWithoutTimeZone(issuedAt);
   const touchCutoffTimestamp = timestampWithoutTimeZone(touchCutoff(issuedAt));
   await db.execute(sql`
@@ -310,7 +304,7 @@ async function touchRecentlyUsedCacheRows(
       SELECT ${systemStoragePresignedUrlCache.cacheKey}
       FROM ${systemStoragePresignedUrlCache}
       WHERE
-        ${systemStoragePresignedUrlCache.cacheKey} IN (${cacheKeySql})
+        ${inArray(systemStoragePresignedUrlCache.cacheKey, orderedCacheKeys)}
         AND ${lte(systemStoragePresignedUrlCache.lastRequestedAt, sql`${touchCutoffTimestamp}::timestamp`)}
       ORDER BY ${systemStoragePresignedUrlCache.cacheKey}
       FOR UPDATE OF ${systemStoragePresignedUrlCache}

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -16,6 +16,7 @@ import {
   lte,
   or,
   sql,
+  sum,
 } from "drizzle-orm";
 
 import { pgIntegerDecoder } from "../../lib/db-structured-result";
@@ -641,7 +642,7 @@ export function zeroBillingStatus(
       db
         .select({
           total:
-            sql`COALESCE(SUM(${creditExpiresRecord.remaining}), 0)::int`.mapWith(
+            sql`COALESCE(${sum(creditExpiresRecord.remaining)}, 0)::int`.mapWith(
               pgIntegerDecoder,
             ),
         })

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -1,6 +1,6 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
-import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -94,9 +94,9 @@ async function selectIncompleteRoundFrontier(
             )
           )
         ORDER BY
-          ${chatMessages.createdAt} DESC,
-          ${chatMessages.sequenceNumber} DESC NULLS FIRST,
-          ${chatMessages.id} DESC
+          ${desc(chatMessages.createdAt)},
+          ${desc(chatMessages.sequenceNumber)} NULLS FIRST,
+          ${desc(chatMessages.id)}
         LIMIT 1
       ) AS candidate
       WHERE incomplete_frontier.depth < ${INCOMPLETE_ROUND_LIMIT + 1}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -712,22 +712,13 @@ function toPagedMessage(
 
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
 
-function activeRunStatusSqlList() {
-  return sql.join(
-    ACTIVE_RUN_STATUSES.map((status) => {
-      return sql`${status}`;
-    }),
-    sql`, `,
-  );
-}
-
 function noActiveRunsForCurrentThreadCondition() {
   return sql`NOT EXISTS (
     SELECT 1
     FROM ${zeroRuns}
     INNER JOIN ${agentRuns} ON ${eq(agentRuns.id, zeroRuns.id)}
     WHERE ${eq(zeroRuns.chatThreadId, chatThreads.id)}
-      AND ${agentRuns.status} IN (${activeRunStatusSqlList()})
+      AND ${inArray(agentRuns.status, ACTIVE_RUN_STATUSES)}
   )`;
 }
 
@@ -1238,7 +1229,7 @@ async function listChangedArtifacts(args: {
               SELECT ${chatMessages.chatThreadId}
               FROM ${chatMessages}
               WHERE ${eq(chatMessages.runId, zeroRuns.id)}
-              ORDER BY ${chatMessages.createdAt} ASC
+              ORDER BY ${asc(chatMessages.createdAt)}
               LIMIT 1
             )
           )
@@ -1258,7 +1249,7 @@ async function listChangedArtifacts(args: {
         WHERE ${sql.join(fileConditions, sql` AND `)}
           AND ${lowerBoundClause}
           AND ${lt(effectiveUpdatedAt, sql`${args.syncUntil}::timestamptz AT TIME ZONE 'UTC'`)}
-        ORDER BY ${effectiveUpdatedAt} ASC, ${runUploadedFiles.id} ASC
+        ORDER BY ${asc(effectiveUpdatedAt)}, ${asc(runUploadedFiles.id)}
         LIMIT ${args.limit + 1}
       )
       SELECT
@@ -1299,7 +1290,7 @@ async function listChangedArtifacts(args: {
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
             WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${chatMessages.createdAt} ASC
+            ORDER BY ${asc(chatMessages.createdAt)}
             LIMIT 1
           )
         )
@@ -1365,7 +1356,7 @@ async function listArtifactHistory(args: {
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
             WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${chatMessages.createdAt} ASC
+            ORDER BY ${asc(chatMessages.createdAt)}
             LIMIT 1
           )
         )
@@ -1375,7 +1366,7 @@ async function listArtifactHistory(args: {
         ON ${eq(zeroAgents.id, agentComposes.id)}
       WHERE ${sql.join(conditions, sql` AND `)}
       ${keysetClause}
-    ORDER BY ${runUploadedFiles.createdAt} DESC, ${runUploadedFiles.id} DESC
+    ORDER BY ${desc(runUploadedFiles.createdAt)}, ${desc(runUploadedFiles.id)}
       LIMIT ${args.limit + 1}
     `,
     artifactListSqlRowSchema,
@@ -1498,7 +1489,7 @@ async function artifactUrlIsVisible(
             SELECT ${chatMessages.chatThreadId}
             FROM ${chatMessages}
             WHERE ${eq(chatMessages.runId, runUploadedFiles.runId)}
-            ORDER BY ${chatMessages.createdAt} ASC
+            ORDER BY ${asc(chatMessages.createdAt)}
             LIMIT 1
           )
         )

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-message.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, count, eq, isNotNull, max, sql, sum } from "drizzle-orm";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import {
   chatMessages,
@@ -70,22 +70,22 @@ async function loadUsageMessageContext(tx: WriteTx, runId: string) {
       runGroupId: zeroRuns.runGroupId,
       userId: chatThreads.userId,
       pendingCount:
-        sql`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'pending')::int`.mapWith(
+        sql`${count(usageEvent.id)} FILTER (WHERE ${usageEvent.status} = 'pending')::int`.mapWith(
           pgIntegerDecoder,
         ),
       processedCount:
-        sql`COUNT(${usageEvent.id}) FILTER (WHERE ${usageEvent.status} = 'processed')::int`.mapWith(
+        sql`${count(usageEvent.id)} FILTER (WHERE ${usageEvent.status} = 'processed')::int`.mapWith(
           pgIntegerDecoder,
         ),
       totalCredits:
-        sql`COALESCE(SUM(${usageCreditsExpression()}) FILTER (WHERE ${usageEvent.status} = 'processed'), 0)::bigint`.mapWith(
+        sql`COALESCE(${sum(usageCreditsExpression())} FILTER (WHERE ${usageEvent.status} = 'processed'), 0)::bigint`.mapWith(
           pgInt8ToSafeIntegerDecoder,
         ),
       settledAt: sql`COALESCE(
-        MAX(${usageEvent.processedAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
-        MAX(${usageEvent.createdAt}) FILTER (WHERE ${usageEvent.status} = 'processed'),
-        MAX(${agentRuns.completedAt}),
-        MAX(${agentRuns.createdAt})
+        ${max(usageEvent.processedAt)} FILTER (WHERE ${usageEvent.status} = 'processed'),
+        ${max(usageEvent.createdAt)} FILTER (WHERE ${usageEvent.status} = 'processed'),
+        ${max(agentRuns.completedAt)},
+        ${max(agentRuns.createdAt)}
       )`.mapWith(agentRuns.createdAt),
     })
     .from(agentRuns)
@@ -110,7 +110,7 @@ async function loadUsageBreakdownRows(tx: WriteTx, runId: string) {
           pgTextDecoder,
         ),
       credits:
-        sql`COALESCE(SUM(${usageCreditsExpression()}), 0)::bigint`.mapWith(
+        sql`COALESCE(${sum(usageCreditsExpression())}, 0)::bigint`.mapWith(
           pgInt8ToSafeIntegerDecoder,
         ),
     })

--- a/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-reporting-ledger.ts
@@ -2,6 +2,7 @@ import {
   and,
   eq,
   gte,
+  inArray,
   isNotNull,
   lt,
   max,
@@ -195,13 +196,7 @@ export function mergedRunModel(events: UsageEventRunUsageTotalsSubquery) {
 }
 
 function usageEventTokenSum(categories: readonly string[], alias: string) {
-  const list = sql.join(
-    categories.map((category) => {
-      return sql`${category}`;
-    }),
-    sql`, `,
-  );
-  return sql`COALESCE(SUM(CASE WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)} AND ${usageEvent.category} IN (${list}) THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
+  return sql`COALESCE(SUM(CASE WHEN ${eq(usageEvent.kind, MODEL_USAGE_KIND)} AND ${inArray(usageEvent.category, categories)} THEN ${usageEvent.quantity} ELSE 0 END), 0)::bigint`
     .mapWith(pgInt8ToSafeIntegerDecoder)
     .as(alias);
 }

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -28,12 +28,13 @@ const ruleTester = new RuleTester({
 
 const drizzlePreamble = `
   import { relations } from "drizzle-orm";
-  import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+  import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
   const users = pgTable("users", {
     id: integer("id").notNull(),
     name: text("name").notNull(),
     deletedAt: timestamp("deleted_at"),
+    tags: jsonb("tags").$type<string[]>().notNull(),
   });
   const usersRelations = relations(users, () => ({}));
   type DrizzleDatabase =
@@ -60,8 +61,11 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         sql\`1 + \${users.id} = \${value}\`;
         sql\`\${users.id} = \${value} + 1\`;
         sql\`\${gte(users.deletedAt, sql\`\${"2026-01-01"}::timestamp\`)}\`;
-        sql\`MAX(\${users.id}) FILTER (WHERE \${users.id} > 0)\`;
+        sql\`MAX(\${users.id} + 1) FILTER (WHERE \${users.id} > 0)\`;
+        sql\`MAX(\${users.id}) OVER (ORDER BY id)\`;
         sql\`MAX(\${fragment})\`;
+        sql\`SUM(\${users.id})\`;
+        sql\`SELECT MIN(\${users.id}) FROM \${users}\`;
         sql\`\${users.id}\`;
       `,
     },
@@ -85,6 +89,48 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           where: (fields, operators) =>
             operators.sql\`length(\${fields.name}) > 0\`,
         });
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        const ids = [1, 2];
+        const subquery = sql\`SELECT \${users.id} FROM \${users}\`;
+        const arbitraryJoin = sql.join([subquery], sql\`, \`);
+        const transformedList = sql.join(
+          ids.map((id) => sql\`\${id + 1}\`),
+          sql\`, \`,
+        );
+        let mutableList = sql.join(
+          ids.map((id) => sql\`\${id}\`),
+          sql\`, \`,
+        );
+        function listWithArgument(values: number[]) {
+          return sql.join(
+            values.map((value) => sql\`\${value}\`),
+            sql\`, \`,
+          );
+        }
+        function concrete(value: SQL): SQL {
+          return value;
+        }
+        const condition = eq(users.id, 1);
+        sql\`\${users.id} LIKE \${1}\`;
+        sql\`\${users.id} IN (\${subquery})\`;
+        sql\`\${users.id} IN (\${arbitraryJoin})\`;
+        sql\`\${users.id} IN (\${transformedList})\`;
+        sql\`\${users.id} IN (\${mutableList})\`;
+        sql\`\${users.id} IN (\${listWithArgument(ids)})\`;
+        sql\`\${users.name} NOT LIKE \${"prefix%"}\`;
+        sql\`\${users.name} ILIKE \${"prefix%"}\`;
+        sql\`\${users.id} NOT IN (\${mutableList})\`;
+        sql\`SELECT \${users.id} DESC\`;
+        sql\`ORDER BY \${users.id} DESCENDING\`;
+        concrete(sql\`\${condition} AND \${condition}\`);
+        sql\`\${condition} AND NOT \${condition}\`;
+        sql\`\${users.name} @> \${sql\`jsonb_build_array('tag')\`}\`;
+        sql\`\${condition} @> \${sql\`jsonb_build_array('tag')\`}\`;
+        void mutableList;
       `,
     },
   ],
@@ -202,6 +248,90 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         { messageId: "typedApi", data: { helper: "isNotNull" } },
         { messageId: "typedApi", data: { helper: "max" } },
       ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { eq, sql, type SQL } from "drizzle-orm";
+        const names = ["one", "two"];
+        const nameList = sql.join(
+          names.map((name) => sql\`\${name}\`),
+          sql\`, \`,
+        );
+        function nameSqlList() {
+          return sql.join(
+            names.map((name) => sql\`\${name}\`),
+            sql\`, \`,
+          );
+        }
+        function optional(value: SQL | undefined): SQL | undefined {
+          return value;
+        }
+        const condition = eq(users.id, 1);
+        const jsonArray = sql\`jsonb_build_array(\${"tag"})\`;
+        sql\`\${users.name} LIKE \${"prefix%"} ESCAPE '\\\\'\`;
+        sql\`\${users.name} IN (\${nameList})\`;
+        sql\`\${users.name} IN (\${nameSqlList()})\`;
+        sql\`ORDER BY \${users.name} ASC, \${users.id} DESC NULLS FIRST\`;
+        sql\`COALESCE(SUM(\${users.id}), 0)\`;
+        sql\`COUNT(\${users.id}) FILTER (WHERE \${condition})::int\`;
+        sql\`MAX(\${users.deletedAt}) FILTER (WHERE \${condition})\`;
+        sql\`SELECT COUNT(\${users.id}), COUNT(DISTINCT \${users.name}), MAX(\${users.id}) FROM \${users}\`;
+        optional(sql\`(\${condition} AND \${condition}) OR \${condition}\`);
+        sql\`\${users.tags} @> \${jsonArray}\`;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "like" } },
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "asc" } },
+        { messageId: "typedApi", data: { helper: "desc" } },
+        { messageId: "typedApi", data: { helper: "sum" } },
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "max" } },
+        { messageId: "typedApi", data: { helper: "count" } },
+        { messageId: "typedApi", data: { helper: "countDistinct" } },
+        { messageId: "typedApi", data: { helper: "max" } },
+        { messageId: "typedApi", data: { helper: "or" } },
+        { messageId: "typedApi", data: { helper: "arrayContains" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as query, type SQLWrapper } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        const names = ["one", "two"];
+        const nameList = drizzle.sql.join(
+          names.map((name) => drizzle.sql\`\${name}\`),
+          drizzle.sql\`, \`,
+        );
+        query\`\${users.name} LIKE \${"prefix%"}\`;
+        drizzle.sql\`\${users.name} IN (\${nameList})\`;
+        drizzle.sql\`ORDER BY \${users.name} ASC, COALESCE(SUM(\${users.id}), 0)\`;
+        function contains<T extends typeof users.tags>(column: T, value: SQLWrapper) {
+          query\`\${column} @> \${value}\`;
+        }
+        void contains;
+      `,
+      errors: [
+        { messageId: "typedApi", data: { helper: "like" } },
+        { messageId: "typedApi", data: { helper: "inArray" } },
+        { messageId: "typedApi", data: { helper: "asc" } },
+        { messageId: "typedApi", data: { helper: "sum" } },
+        { messageId: "typedApi", data: { helper: "arrayContains" } },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${fields.name} LIKE \${"prefix%"}\`,
+        });
+        db.query.users.findMany({
+          where: (fields, operators) =>
+            operators.sql\`\${operators.eq(fields.id, 1)} AND \${operators.isNotNull(fields.name)}\`,
+        });
+      `,
+      errors: [{ messageId: "typedApi", data: { helper: "like" } }],
     },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/drizzle.ts
+++ b/turbo/packages/eslint-rules/src/api/drizzle.ts
@@ -127,3 +127,19 @@ export function isDrizzleColumnType(
   const brandType = propertyType(checker, metadataType, "brand", location);
   return brandType?.isStringLiteral() === true && brandType.value === "Column";
 }
+
+export function isDrizzleArrayColumnType(
+  checker: TypeChecker,
+  type: Type,
+  location: Node,
+): boolean {
+  if (!isDrizzleColumnType(checker, type, location)) {
+    return false;
+  }
+  const metadataType = propertyType(checker, type, "_", location);
+  if (metadataType === undefined) {
+    return false;
+  }
+  const dataType = propertyType(checker, metadataType, "data", location);
+  return dataType !== undefined && checker.isArrayType(dataType);
+}

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1,10 +1,36 @@
 import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
-import { type Node, type Type } from "typescript";
+import {
+  isArrowFunction,
+  isBlock,
+  isCallExpression,
+  isExpression,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isNoSubstitutionTemplateLiteral,
+  isPropertyAccessExpression,
+  isReturnStatement,
+  isSpreadElement,
+  isTaggedTemplateExpression,
+  isTemplateExpression,
+  isVariableDeclaration,
+  isVariableDeclarationList,
+  NodeFlags,
+  TypeFlags,
+  type Expression as TypeScriptExpression,
+  type Node,
+  type Type,
+  type VariableDeclaration,
+} from "typescript";
 
 import {
+  isDrizzleArrayColumnType,
   isDrizzleColumnType,
   isDrizzleSqlTag,
+  isDrizzleSymbol,
   isDrizzleWrapperType,
+  isNamedDrizzleSignature,
+  resolvedSymbol,
 } from "../drizzle.ts";
 import { createRule } from "../utils.ts";
 
@@ -16,6 +42,9 @@ const COMPARISON_HELPERS = new Map<string, string>([
   ["<", "lt"],
   ["<=", "lte"],
 ]);
+
+type BooleanToken = "operand" | "and" | "or" | "(" | ")";
+type BooleanExpressionKind = "operand" | "and" | "or";
 
 function quasiText(node: TSESTree.TemplateElement): string {
   return node.value.cooked ?? node.value.raw;
@@ -81,6 +110,190 @@ function hasPredicateRightBoundary(quasi: string): boolean {
   );
 }
 
+function hasPatternRightBoundary(quasi: string): boolean {
+  const escape = /^\s+ESCAPE\s+'(?:''|[^'])*'/i.exec(quasi);
+  return hasPredicateRightBoundary(
+    escape === null ? quasi : quasi.slice(escape[0].length),
+  );
+}
+
+function membershipRightBoundary(quasi: string): boolean {
+  const close = /^\s*\)/.exec(quasi);
+  return (
+    close !== null && hasPredicateRightBoundary(quasi.slice(close[0].length))
+  );
+}
+
+function hasOrderingLeftBoundary(quasi: string): boolean {
+  const prefix = quasi.trimEnd();
+  return (
+    prefix === "" ||
+    prefix.endsWith(",") ||
+    prefix.endsWith("(") ||
+    /\bORDER\s+BY$/i.test(prefix)
+  );
+}
+
+interface OrderingMatch {
+  helper: "asc" | "desc";
+}
+
+function orderingMatch(quasi: string): OrderingMatch | undefined {
+  const direction = /^\s+(ASC|DESC)\b/i.exec(quasi);
+  if (direction === null) {
+    return undefined;
+  }
+  let length = direction[0].length;
+  const nulls = /^\s+NULLS\s+(?:FIRST|LAST)\b/i.exec(quasi.slice(length));
+  if (nulls !== null) {
+    length += nulls[0].length;
+  }
+  const suffix = quasi.slice(length).trimStart();
+  if (
+    suffix !== "" &&
+    !/^[,);]/.test(suffix) &&
+    !/^(?:FETCH|FOR|LIMIT|OFFSET)\b/i.test(suffix)
+  ) {
+    return undefined;
+  }
+  return {
+    helper: direction[1]?.toLowerCase() === "asc" ? "asc" : "desc",
+  };
+}
+
+interface AggregateMatch {
+  helper: "count" | "countDistinct" | "max" | "min" | "sum";
+  start: number;
+}
+
+function aggregateMatch(quasi: string): AggregateMatch | undefined {
+  const countDistinct = /\bCOUNT\s*\(\s*DISTINCT\s*$/i.exec(quasi);
+  if (countDistinct !== null) {
+    return { helper: "countDistinct", start: countDistinct.index };
+  }
+  const aggregate = /\b(SUM|COUNT|MAX|MIN)\s*\(\s*$/i.exec(quasi);
+  if (aggregate === null) {
+    return undefined;
+  }
+  const helper = aggregate[1]?.toLowerCase();
+  if (
+    helper !== "sum" &&
+    helper !== "count" &&
+    helper !== "max" &&
+    helper !== "min"
+  ) {
+    return undefined;
+  }
+  return { helper, start: aggregate.index };
+}
+
+function aggregateRemainder(quasi: string): string | undefined {
+  const close = /^\s*\)/.exec(quasi);
+  return close === null ? undefined : quasi.slice(close[0].length);
+}
+
+function tokenizeBooleanQuasi(quasi: string): BooleanToken[] | undefined {
+  const tokens: BooleanToken[] = [];
+  let offset = 0;
+  while (offset < quasi.length) {
+    const whitespace = /^\s+/.exec(quasi.slice(offset));
+    if (whitespace !== null) {
+      offset += whitespace[0].length;
+      continue;
+    }
+    const character = quasi[offset];
+    if (character === "(" || character === ")") {
+      tokens.push(character);
+      offset += 1;
+      continue;
+    }
+    const operator = /^(AND|OR)\b/i.exec(quasi.slice(offset));
+    if (operator === null) {
+      return undefined;
+    }
+    tokens.push(operator[1]?.toLowerCase() === "and" ? "and" : "or");
+    offset += operator[0].length;
+  }
+  return tokens;
+}
+
+function booleanTokens(quasis: readonly string[]): BooleanToken[] | undefined {
+  const tokens: BooleanToken[] = [];
+  for (let index = 0; index < quasis.length; index += 1) {
+    const quasiTokens = tokenizeBooleanQuasi(quasis[index] ?? "");
+    if (quasiTokens === undefined) {
+      return undefined;
+    }
+    tokens.push(...quasiTokens);
+    if (index < quasis.length - 1) {
+      tokens.push("operand");
+    }
+  }
+  return tokens;
+}
+
+function booleanHelper(quasis: readonly string[]): "and" | "or" | undefined {
+  const tokens = booleanTokens(quasis);
+  if (tokens === undefined) {
+    return undefined;
+  }
+  const parsedTokens = tokens;
+  let offset = 0;
+
+  function primary(): BooleanExpressionKind | undefined {
+    const token = parsedTokens[offset];
+    if (token === "operand") {
+      offset += 1;
+      return "operand";
+    }
+    if (token !== "(") {
+      return undefined;
+    }
+    offset += 1;
+    const expression = disjunction();
+    if (expression === undefined || parsedTokens[offset] !== ")") {
+      return undefined;
+    }
+    offset += 1;
+    return expression;
+  }
+
+  function conjunction(): BooleanExpressionKind | undefined {
+    let expression = primary();
+    if (expression === undefined) {
+      return undefined;
+    }
+    while (parsedTokens[offset] === "and") {
+      offset += 1;
+      if (primary() === undefined) {
+        return undefined;
+      }
+      expression = "and";
+    }
+    return expression;
+  }
+
+  function disjunction(): BooleanExpressionKind | undefined {
+    let expression = conjunction();
+    if (expression === undefined) {
+      return undefined;
+    }
+    while (parsedTokens[offset] === "or") {
+      offset += 1;
+      if (conjunction() === undefined) {
+        return undefined;
+      }
+      expression = "or";
+    }
+    return expression;
+  }
+
+  const expression = disjunction();
+  return offset === parsedTokens.length && expression !== "operand"
+    ? expression
+    : undefined;
+}
+
 export const preferDrizzleApis = createRule({
   name: "prefer-drizzle-apis",
   defaultOptions: [],
@@ -120,6 +333,249 @@ export const preferDrizzleApis = createRule({
       });
     }
 
+    function isStringOrDrizzleWrapper(type: Type): boolean {
+      if (type.isUnion()) {
+        return type.types.every(isStringOrDrizzleWrapper);
+      }
+      if ((type.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0) {
+        return false;
+      }
+      if ((type.flags & TypeFlags.TypeParameter) !== 0) {
+        const constraint = checker.getBaseConstraintOfType(type);
+        return constraint !== undefined && isStringOrDrizzleWrapper(constraint);
+      }
+      return (
+        (type.flags & TypeFlags.StringLike) !== 0 ||
+        isDrizzleWrapperType(checker, type)
+      );
+    }
+
+    function isOptionalDrizzleContext(type: Type | undefined): boolean {
+      if (type === undefined || !type.isUnion()) {
+        return false;
+      }
+      let hasUndefined = false;
+      let hasWrapper = false;
+      for (const member of type.types) {
+        if ((member.flags & TypeFlags.Undefined) !== 0) {
+          hasUndefined = true;
+        } else if (
+          (member.flags & (TypeFlags.Any | TypeFlags.Unknown)) !== 0 ||
+          !isDrizzleWrapperType(checker, member)
+        ) {
+          return false;
+        } else {
+          hasWrapper = true;
+        }
+      }
+      return hasUndefined && hasWrapper;
+    }
+
+    function isConstVariable(declaration: VariableDeclaration): boolean {
+      return (
+        isVariableDeclarationList(declaration.parent) &&
+        (declaration.parent.flags & NodeFlags.Const) !== 0
+      );
+    }
+
+    function isDrizzleSqlTagNode(node: TypeScriptExpression): boolean {
+      const symbolLocation = isPropertyAccessExpression(node)
+        ? node.name
+        : node;
+      const symbol = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(symbolLocation),
+      );
+      if (symbol?.getName() === "sql" && isDrizzleSymbol(checker, symbol)) {
+        return true;
+      }
+      return checker
+        .getTypeAtLocation(node)
+        .getCallSignatures()
+        .some((signature) => {
+          return isNamedDrizzleSignature(signature, "sql");
+        });
+    }
+
+    function returnedExpression(
+      node: TypeScriptExpression,
+    ): TypeScriptExpression | undefined {
+      if (!isArrowFunction(node) && !isFunctionExpression(node)) {
+        return undefined;
+      }
+      if (!isBlock(node.body)) {
+        return node.body;
+      }
+      if (node.body.statements.length !== 1) {
+        return undefined;
+      }
+      const statement = node.body.statements[0];
+      return statement !== undefined &&
+        isReturnStatement(statement) &&
+        statement.expression !== undefined
+        ? statement.expression
+        : undefined;
+    }
+
+    function isParameterSqlTemplate(
+      node: TypeScriptExpression,
+      parameter: Node,
+    ): boolean {
+      if (
+        !isTaggedTemplateExpression(node) ||
+        !isDrizzleSqlTagNode(node.tag) ||
+        !isTemplateExpression(node.template) ||
+        node.template.head.text !== "" ||
+        node.template.templateSpans.length !== 1
+      ) {
+        return false;
+      }
+      const span = node.template.templateSpans[0];
+      if (
+        span?.literal.text !== "" ||
+        !isIdentifier(span.expression) ||
+        !isIdentifier(parameter)
+      ) {
+        return false;
+      }
+      return (
+        resolvedSymbol(
+          checker,
+          checker.getSymbolAtLocation(span.expression),
+        ) === resolvedSymbol(checker, checker.getSymbolAtLocation(parameter))
+      );
+    }
+
+    function isParameterFragmentMap(node: TypeScriptExpression): boolean {
+      if (
+        !isCallExpression(node) ||
+        !isPropertyAccessExpression(node.expression) ||
+        node.expression.name.text !== "map" ||
+        node.arguments.length !== 1
+      ) {
+        return false;
+      }
+      const collectionType = checker.getTypeAtLocation(
+        node.expression.expression,
+      );
+      if (
+        !checker.isArrayType(collectionType) &&
+        !checker.isTupleType(collectionType)
+      ) {
+        return false;
+      }
+      const callback = node.arguments[0];
+      if (callback === undefined || isSpreadElement(callback)) {
+        return false;
+      }
+      const expression = returnedExpression(callback);
+      const parameter =
+        (isArrowFunction(callback) || isFunctionExpression(callback)) &&
+        callback.parameters.length === 1
+          ? callback.parameters[0]?.name
+          : undefined;
+      return (
+        expression !== undefined &&
+        parameter !== undefined &&
+        isParameterSqlTemplate(expression, parameter)
+      );
+    }
+
+    function isCommaSqlTemplate(node: TypeScriptExpression): boolean {
+      return (
+        isTaggedTemplateExpression(node) &&
+        isDrizzleSqlTagNode(node.tag) &&
+        isNoSubstitutionTemplateLiteral(node.template) &&
+        node.template.text.trim() === ","
+      );
+    }
+
+    function isParameterListSqlJoin(node: TypeScriptExpression): boolean {
+      if (
+        !isCallExpression(node) ||
+        !isPropertyAccessExpression(node.expression) ||
+        node.expression.name.text !== "join" ||
+        !isDrizzleSqlTagNode(node.expression.expression) ||
+        node.arguments.length !== 2
+      ) {
+        return false;
+      }
+      const values = node.arguments[0];
+      const separator = node.arguments[1];
+      return (
+        values !== undefined &&
+        separator !== undefined &&
+        !isSpreadElement(values) &&
+        !isSpreadElement(separator) &&
+        isParameterFragmentMap(values) &&
+        isCommaSqlTemplate(separator)
+      );
+    }
+
+    function parameterListOrigin(
+      node: TypeScriptExpression,
+      visited: Set<Node>,
+    ): boolean {
+      if (visited.has(node)) {
+        return false;
+      }
+      visited.add(node);
+      if (isParameterListSqlJoin(node)) {
+        return true;
+      }
+
+      if (isIdentifier(node)) {
+        const declaration = resolvedSymbol(
+          checker,
+          checker.getSymbolAtLocation(node),
+        )?.valueDeclaration;
+        return (
+          declaration !== undefined &&
+          isVariableDeclaration(declaration) &&
+          declaration.getSourceFile() === node.getSourceFile() &&
+          isConstVariable(declaration) &&
+          declaration.initializer !== undefined &&
+          parameterListOrigin(declaration.initializer, visited)
+        );
+      }
+
+      if (
+        !isCallExpression(node) ||
+        node.arguments.length !== 0 ||
+        !isIdentifier(node.expression)
+      ) {
+        return false;
+      }
+      const declaration = resolvedSymbol(
+        checker,
+        checker.getSymbolAtLocation(node.expression),
+      )?.valueDeclaration;
+      if (
+        declaration === undefined ||
+        !isFunctionDeclaration(declaration) ||
+        declaration.getSourceFile() !== node.getSourceFile() ||
+        declaration.parameters.length !== 0 ||
+        declaration.body === undefined ||
+        declaration.body.statements.length !== 1
+      ) {
+        return false;
+      }
+      const statement = declaration.body.statements[0];
+      return (
+        statement !== undefined &&
+        isReturnStatement(statement) &&
+        statement.expression !== undefined &&
+        parameterListOrigin(statement.expression, visited)
+      );
+    }
+
+    function hasParameterListOrigin(node: TSESTree.Expression): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return (
+        isExpression(tsNode) && parameterListOrigin(tsNode, new Set<Node>())
+      );
+    }
+
     return {
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
         if (!isDrizzleSqlTag(checker, services, node.tag)) {
@@ -129,56 +585,127 @@ export const preferDrizzleApis = createRule({
         const quasis = node.quasi.quasis.map(quasiText);
         const expressions = node.quasi.expressions;
         for (let index = 0; index < expressions.length - 1; index += 1) {
-          if (
-            !hasPredicateLeftBoundary(quasis[index] ?? "") ||
-            !hasPredicateRightBoundary(quasis[index + 2] ?? "")
-          ) {
+          const leftNode = expressions[index];
+          const rightNode = expressions[index + 1];
+          if (leftNode === undefined || rightNode === undefined) {
             continue;
           }
-          const helper = COMPARISON_HELPERS.get(
-            quasis[index + 1]?.trim() ?? "",
-          );
-          if (helper !== undefined) {
-            const leftExpression = expressions[index];
-            const left = expressionType(leftExpression);
-            if (isDrizzleWrapperType(checker, left.type)) {
-              report(leftExpression, helper);
+          const left = expressionType(leftNode);
+          const right = expressionType(rightNode);
+          const middle = quasis[index + 1] ?? "";
+          const suffix = quasis[index + 2] ?? "";
+          if (
+            hasPredicateLeftBoundary(quasis[index] ?? "") &&
+            hasPredicateRightBoundary(suffix)
+          ) {
+            const comparison = COMPARISON_HELPERS.get(middle.trim());
+            if (
+              comparison !== undefined &&
+              isDrizzleWrapperType(checker, left.type)
+            ) {
+              report(leftNode, comparison);
             }
+          }
+          if (
+            middle.trim().toUpperCase() === "LIKE" &&
+            hasPredicateLeftBoundary(quasis[index] ?? "") &&
+            hasPatternRightBoundary(suffix) &&
+            isDrizzleWrapperType(checker, left.type) &&
+            isStringOrDrizzleWrapper(right.type)
+          ) {
+            report(leftNode, "like");
+          }
+          if (
+            /^\s+IN\s*\(\s*$/i.test(middle) &&
+            hasPredicateLeftBoundary(quasis[index] ?? "") &&
+            membershipRightBoundary(suffix) &&
+            isDrizzleColumnType(checker, left.type, left.location) &&
+            hasParameterListOrigin(rightNode)
+          ) {
+            report(leftNode, "inArray");
+          }
+          if (
+            middle.trim() === "@>" &&
+            hasPredicateLeftBoundary(quasis[index] ?? "") &&
+            hasPredicateRightBoundary(suffix) &&
+            isDrizzleArrayColumnType(checker, left.type, left.location) &&
+            isDrizzleWrapperType(checker, right.type)
+          ) {
+            report(leftNode, "arrayContains");
           }
         }
 
         for (let index = 0; index < expressions.length; index += 1) {
-          const match = nullPredicateMatch(quasis[index + 1] ?? "");
+          const expressionNode = expressions[index];
+          if (expressionNode === undefined) {
+            continue;
+          }
+          const expression = expressionType(expressionNode);
+          const prefix = quasis[index] ?? "";
+          const suffix = quasis[index + 1] ?? "";
+
+          const nullMatch = nullPredicateMatch(suffix);
           if (
-            match === undefined ||
-            !hasPredicateLeftBoundary(quasis[index] ?? "") ||
-            !hasPredicateRightBoundary(
-              (quasis[index + 1] ?? "").slice(match.length),
-            )
+            nullMatch !== undefined &&
+            hasPredicateLeftBoundary(prefix) &&
+            hasPredicateRightBoundary(suffix.slice(nullMatch.length)) &&
+            isDrizzleWrapperType(checker, expression.type)
+          ) {
+            report(expressionNode, nullMatch.helper);
+          }
+
+          const order = orderingMatch(suffix);
+          if (
+            order !== undefined &&
+            hasOrderingLeftBoundary(prefix) &&
+            isDrizzleWrapperType(checker, expression.type)
+          ) {
+            report(expressionNode, order.helper);
+          }
+
+          const aggregate = aggregateMatch(prefix);
+          const aggregateSuffix = aggregateRemainder(suffix);
+          if (
+            aggregate === undefined ||
+            aggregateSuffix === undefined ||
+            /^\s*OVER\b/i.test(aggregateSuffix) ||
+            !isDrizzleWrapperType(checker, expression.type)
           ) {
             continue;
           }
-          const expressionNode = expressions[index];
-          const expression = expressionType(expressionNode);
-          if (isDrizzleWrapperType(checker, expression.type)) {
-            report(expressionNode, match.helper);
+          const isWholeAggregate =
+            expressions.length === 1 &&
+            prefix.slice(0, aggregate.start).trim() === "" &&
+            aggregateSuffix.trim() === "";
+          if (!isWholeAggregate) {
+            if (aggregate.helper !== "min") {
+              report(expressionNode, aggregate.helper);
+            }
+          } else if (
+            (aggregate.helper === "max" || aggregate.helper === "min") &&
+            isDrizzleColumnType(checker, expression.type, expression.location)
+          ) {
+            report(node, aggregate.helper);
           }
         }
 
-        if (expressions.length !== 1 || quasis.length !== 2) {
+        const boolean = booleanHelper(quasis);
+        if (boolean === undefined) {
           return;
         }
-
-        const expression = expressionType(expressions[0]);
-        const prefix = quasis[0] ?? "";
-        const aggregateSuffix = quasis[1] ?? "";
-        const aggregate = /^\s*(MAX|MIN)\s*\(\s*$/i.exec(prefix);
         if (
-          aggregate !== null &&
-          /^\s*\)\s*$/.test(aggregateSuffix) &&
-          isDrizzleColumnType(checker, expression.type, expression.location)
+          !expressions.every((expressionNode) => {
+            return isDrizzleWrapperType(
+              checker,
+              expressionType(expressionNode).type,
+            );
+          })
         ) {
-          report(node, aggregate[1]?.toLowerCase() ?? "");
+          return;
+        }
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        if (isOptionalDrizzleContext(checker.getContextualType(tsNode))) {
+          report(node, boolean);
         }
       },
     };


### PR DESCRIPTION
## Summary

- extend the type-aware `api/prefer-drizzle-apis` rule with conservative matchers for current dynamic `LIKE`, parameter-list `IN`, ordering, aggregate, optional boolean-composition, and array-containment leaves
- replace the qualifying API SQL leaves with `like`, direct-array `inArray`, `asc` / `desc`, aggregate helpers, `and` / `or`, and `arrayContains` while retaining surrounding casts, filters, decoders, suffixes, and irreducible SQL
- document the helper and result-boundary guidance in the existing database-development skill

## Safety and scope

- membership lint follows only immutable local array-to-parameter `sql.join(...)` construction; subqueries, transformed fragments, mutable values, and uninspectable provenance remain valid
- boolean lint requires a complete wrapper-only grammar and a TypeScript contextual type of Drizzle `SQL | undefined`
- containment lint requires a branded array-valued Drizzle column and an explicit SQL-wrapper right operand
- representative `PgDialect.sqlToQuery(...)` comparisons preserved parameter count, order, values, and SQL semantics; differences are limited to keyword casing and redundant outer boolean parentheses
- no schema, migration, persisted-data, API-contract, feature-switch, or deployment-compatibility change

## Validation

- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F @vm0/eslint-rules test -- --maxWorkers=4 --silent=passed-only` (665 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/storage-presigned-url-cache.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts src/signals/routes/__tests__/zero-usage-runs.test.ts src/signals/routes/__tests__/cron-aggregate-insights.test.ts src/signals/routes/__tests__/zero-billing-status.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/chat-files.bdd.test.ts --maxWorkers=4 --silent=passed-only` (116 tests)
- focused runner heartbeat/session-affinity tests (4 tests)
- focused artifact listing/keyset/incremental pagination tests (5 tests)
- `pnpm knip`
- pre-commit hook, including repository formatting, cached Knip, and full Turbo type checking

Closes #22389

Parent context: #22310
