### PR TITLE
refactor(sandbox-fc): centralize startup orchestration

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -896,6 +896,81 @@ impl FirecrackerSandbox {
         )
     }
 
+    /// Spawn a prepared Firecracker command and adopt it into the sandbox runtime.
+    ///
+    /// Callers retain boot-mode-specific command arguments. Once spawning succeeds,
+    /// this method installs runtime ownership before any later fallible operation;
+    /// [`Sandbox::start`] remains responsible for cleanup when startup fails.
+    async fn spawn_and_wait_for_api(
+        &mut self,
+        mut command: tokio::process::Command,
+        api_sock: &Path,
+        runtime_cancel: CancellationToken,
+        boot_mode: &str,
+    ) -> sandbox::Result<ApiClient> {
+        let child = command
+            .current_dir(self.sandbox_paths.workspace())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .process_group(0)
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| SandboxError::Start {
+                message: format!(
+                    "spawn firecracker: {e} (boot_mode={boot_mode}, api_sock={})",
+                    api_sock.display()
+                ),
+            })?;
+
+        self.process_group_pid = child.id();
+        self.runtime.set_process(monitor_process(
+            &self.id,
+            child,
+            Arc::clone(&self.state),
+            Arc::clone(&self.state_publish_lock),
+            self.state_tx.clone(),
+            Arc::clone(&self.guest),
+            runtime_cancel,
+        ));
+
+        let client = ApiClient::new(api_sock).map_err(|e| SandboxError::Start {
+            message: format!(
+                "create API client: {e} (boot_mode={boot_mode}, api_sock={})",
+                api_sock.display()
+            ),
+        })?;
+        tokio::select! {
+            result = client.wait_for_ready(API_READY_TIMEOUT) => {
+                result.map_err(|e| {
+                    let sock_dir_exists_after = api_sock.parent().is_some_and(Path::exists);
+                    SandboxError::Start {
+                        message: format!(
+                            "API not ready: {e} (boot_mode={boot_mode}, api_sock={}, sock_dir_exists_after={sock_dir_exists_after})",
+                            api_sock.display()
+                        ),
+                    }
+                })?;
+                set_private_runtime_socket_mode(api_sock).map_err(|e| SandboxError::Start {
+                    message: format!(
+                        "restrict API socket permissions: {e} (boot_mode={boot_mode}, api_sock={})",
+                        api_sock.display()
+                    ),
+                })?;
+            }
+            state = wait_for_process_exit(self.state_tx.subscribe()) => {
+                return Err(SandboxError::Start {
+                    message: format!(
+                        "firecracker process exited before API became ready (boot_mode={boot_mode}, state={state}, api_sock={})",
+                        api_sock.display()
+                    ),
+                });
+            }
+        }
+
+        Ok(client)
+    }
+
     /// Start using a fresh boot with `--config-file --api-sock`.
     async fn start_fresh(
         &mut self,
@@ -915,63 +990,19 @@ impl FirecrackerSandbox {
 
         let api_sock = self.sock_paths.api_sock();
 
-        let child = tokio::process::Command::new("ip")
+        let mut command = tokio::process::Command::new("ip");
+        command
             .args(["netns", "exec"])
             .arg(self.network.name())
             .arg(&self.factory_config.binary_path)
             .args(["--config-file"])
             .arg(self.sandbox_paths.config())
             .args(["--api-sock"])
-            .arg(&api_sock)
-            .current_dir(self.sandbox_paths.workspace())
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .process_group(0)
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| SandboxError::Start {
-                message: format!("spawn firecracker: {e}"),
-            })?;
+            .arg(&api_sock);
 
-        self.process_group_pid = child.id();
-        self.runtime.set_process(monitor_process(
-            &self.id,
-            child,
-            Arc::clone(&self.state),
-            Arc::clone(&self.state_publish_lock),
-            self.state_tx.clone(),
-            Arc::clone(&self.guest),
-            runtime_cancel,
-        ));
-
-        // Wait for API socket readiness so the balloon controller can connect.
-        let client = ApiClient::new(&api_sock).map_err(|e| SandboxError::Start {
-            message: format!("create API client: {e}"),
-        })?;
-        tokio::select! {
-            result = client.wait_for_ready(API_READY_TIMEOUT) => {
-                result.map_err(|e| {
-                    SandboxError::Start {
-                        message: format!(
-                            "API not ready: {e} (api_sock={})",
-                            api_sock.display()
-                        ),
-                    }
-                })?;
-                set_private_runtime_socket_mode(&api_sock).map_err(|e| SandboxError::Start {
-                    message: format!("restrict API socket permissions: {e}"),
-                })?;
-            }
-            state = wait_for_process_exit(self.state_tx.subscribe()) => {
-                return Err(SandboxError::Start {
-                    message: format!(
-                        "firecracker process exited before API became ready (state={state}, api_sock={})",
-                        api_sock.display()
-                    ),
-                });
-            }
-        }
+        let client = self
+            .spawn_and_wait_for_api(command, &api_sock, runtime_cancel, "fresh boot")
+            .await?;
 
         info!(id = %self.id, "firecracker started (fresh boot)");
         Ok(client)
@@ -1043,7 +1074,10 @@ impl FirecrackerSandbox {
         //
         // `umount` clears any stale mount inherited from the parent
         // namespace (e.g. from a crashed snapshot creation).
-        let child = tokio::process::Command::new("unshare")
+        let snapshot_str = snapshot.snapshot_path.display().to_string();
+        let memory_str = snapshot.memory_path.display().to_string();
+        let mut command = tokio::process::Command::new("unshare");
+        command
             .args(UNSHARE_MOUNT_ARGS)
             .args(["bash", "-c", SNAPSHOT_RESTORE_INNER_CMD, "_"])
             .arg(self.sock_paths.vsock_dir()) // $1
@@ -1054,61 +1088,12 @@ impl FirecrackerSandbox {
             .arg(&snapshot.workspace_drive_bind_path) // $6
             .arg(self.network.name()) // $7
             .arg(&self.factory_config.binary_path) // $8
-            .arg(&api_sock) // $9
-            .current_dir(self.sandbox_paths.workspace())
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .process_group(0)
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| SandboxError::Start {
-                message: format!("spawn firecracker: {e}"),
-            })?;
+            .arg(&api_sock); // $9
 
-        self.process_group_pid = child.id();
-        self.runtime.set_process(monitor_process(
-            &self.id,
-            child,
-            Arc::clone(&self.state),
-            Arc::clone(&self.state_publish_lock),
-            self.state_tx.clone(),
-            Arc::clone(&self.guest),
-            runtime_cancel,
-        ));
+        let client = self
+            .spawn_and_wait_for_api(command, &api_sock, runtime_cancel, "snapshot restore")
+            .await?;
 
-        // Wait for Firecracker API to be ready, but bail early if the
-        // process crashes before the socket appears.
-        let client = ApiClient::new(&api_sock).map_err(|e| SandboxError::Start {
-            message: format!("create API client: {e}"),
-        })?;
-        tokio::select! {
-            result = client.wait_for_ready(API_READY_TIMEOUT) => {
-                result.map_err(|e| {
-                    let sock_dir_after = sock_dir.exists();
-                    SandboxError::Start {
-                        message: format!(
-                            "API not ready: {e} (api_sock={}, sock_dir_exists_after={sock_dir_after})",
-                            api_sock.display()
-                        ),
-                    }
-                })?;
-                set_private_runtime_socket_mode(&api_sock).map_err(|e| SandboxError::Start {
-                    message: format!("restrict API socket permissions: {e}"),
-                })?;
-            }
-            state = wait_for_process_exit(self.state_tx.subscribe()) => {
-                return Err(SandboxError::Start {
-                    message: format!(
-                        "firecracker process exited before API became ready (state={state}, api_sock={})",
-                        api_sock.display()
-                    ),
-                });
-            }
-        }
-
-        let snapshot_str = snapshot.snapshot_path.display().to_string();
-        let memory_str = snapshot.memory_path.display().to_string();
         load_snapshot_and_apply_rate_limits(
             &client,
             &snapshot_str,

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
+use crate::api::test_support::{MockFirecrackerApi, MockResponse};
 use crate::config::{RateLimiterConfig, TokenBucketConfig};
 use sandbox::ExecTermination;
+use std::os::unix::fs::PermissionsExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::time::Instant;
@@ -3049,6 +3051,96 @@ async fn process_monitor_reports_startup_exit_as_stopped() {
     );
 
     handle.wait().await;
+}
+
+#[tokio::test]
+async fn spawn_and_wait_for_api_adopts_process_and_secures_socket() {
+    let workspace = tempfile::tempdir().unwrap();
+    let mut sandbox = test_sandbox_with_state(SandboxState::Created);
+    sandbox.sandbox_paths = SandboxPaths::new(workspace.path().to_path_buf());
+
+    let mut api = MockFirecrackerApi::repeating(MockResponse::ok());
+    std::fs::set_permissions(api.socket_path(), std::fs::Permissions::from_mode(0o666)).unwrap();
+
+    let mut command = tokio::process::Command::new("bash");
+    command.args(["-c", "sleep 60"]);
+
+    let _client = sandbox
+        .spawn_and_wait_for_api(
+            command,
+            api.socket_path(),
+            CancellationToken::new(),
+            "fresh boot",
+        )
+        .await
+        .unwrap();
+
+    let request = api.next_request().await;
+    assert_eq!(request.method, "GET", "raw request: {}", request.raw);
+    assert_eq!(request.path, "/", "raw request: {}", request.raw);
+    assert_eq!(
+        std::fs::metadata(api.socket_path())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let pid = i32::try_from(sandbox.host_process_pid().unwrap()).unwrap();
+    let pid = nix::unistd::Pid::from_raw(pid);
+    assert!(nix::sys::signal::kill(pid, None).is_ok());
+
+    sandbox.runtime.kill_process().await;
+
+    assert!(nix::sys::signal::kill(pid, None).is_err());
+}
+
+#[tokio::test]
+async fn spawn_and_wait_for_api_reports_process_exit_before_readiness() {
+    let workspace = tempfile::tempdir().unwrap();
+    let api_dir = tempfile::tempdir().unwrap();
+    let api_sock = api_dir.path().join("missing.sock");
+    let mut sandbox = test_sandbox_with_state(SandboxState::Created);
+    sandbox.sandbox_paths = SandboxPaths::new(workspace.path().to_path_buf());
+
+    let mut command = tokio::process::Command::new("bash");
+    command.args(["-c", "exit 23"]);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(1),
+        sandbox.spawn_and_wait_for_api(
+            command,
+            &api_sock,
+            CancellationToken::new(),
+            "snapshot restore",
+        ),
+    )
+    .await
+    .expect("process exit should win before API readiness timeout");
+    let error = match result {
+        Ok(_) => panic!("startup should fail when the child exits"),
+        Err(error) => error,
+    };
+    let SandboxError::Start { message } = error else {
+        panic!("expected startup error");
+    };
+    assert!(
+        message.contains("firecracker process exited before API became ready"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("boot_mode=snapshot restore"),
+        "got: {message}"
+    );
+    assert!(message.contains("state=stopped"), "got: {message}");
+    assert!(
+        message.contains(&format!("api_sock={}", api_sock.display())),
+        "got: {message}"
+    );
+    assert!(sandbox.host_process_pid().is_some());
+
+    sandbox.runtime.kill_process().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- centralize the common Firecracker spawn, process-adoption, API-readiness, and socket-hardening lifecycle used by fresh boot and snapshot restore
- keep boot-mode-specific command construction and snapshot loading explicit
- preserve actionable boot-mode and socket context in startup failures
- add process-and-Unix-socket tests for successful adoption and early child exit

## Scope

The helper takes ownership immediately after a successful spawn, records the process-group leader PID, installs the process monitor, races API readiness against process exit, and restricts the ready API socket to mode `0600`.

Snapshot creation remains unchanged because it uses a distinct `SnapshotProcess` ownership and diagnostic model. Public APIs, persisted data, and deployment protocols are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -p sandbox-fc --quiet` (736 passed)
- pre-commit workspace Rust formatting, Clippy, and documentation hooks

Closes #22413
