### PR TITLE
feat(chat): write structured prompts across send paths

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -4,6 +4,7 @@ import type {
   CodexServiceTier,
   GenerationTemplateRequest,
   PersistedAttachment,
+  UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
 export interface ChatThreadRealtimeHandlers {
@@ -50,6 +51,7 @@ export interface AppendQueuedMessageArgs {
   runOptions?: ChatRunOptionsRequest;
   realAgentInPreview?: boolean;
   generationTemplate: GenerationTemplateRequest | undefined;
+  structuredPrompt?: UserMessageDocument;
   computerUseHostId?: string | null;
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -1,5 +1,6 @@
 import type { Command, Computed } from "ccstate";
 import type {
+  GenerationTemplateRequest,
   PagedChatMessage,
   ChatThreadArtifactRun,
   ChatThreadDraft,
@@ -17,6 +18,7 @@ import type { HeaderAutomationSignals } from "./header-automation-menu.ts";
 import type { WorkflowQueueSignals } from "./workflow-queue.ts";
 import type { MailDraftSignals } from "./mail-draft.ts";
 import type { ComposerConnectorSignals } from "../zero-page/zero-connectors.ts";
+import type { EditorDocumentSnapshot } from "../zero-page/user-message-document-codec.ts";
 
 type RecommendedFollowup = NonNullable<
   Extract<PagedChatMessage, { role: "assistant" }>["recommendedFollowups"]
@@ -53,6 +55,14 @@ export interface SendMessageOptions {
   readonly revokesMessageId?: string;
   readonly includeDraftAttachments?: boolean;
   readonly computerUseHostId?: string | null;
+  readonly generationTemplate?: GenerationTemplateRequest;
+  readonly editorDocument?: EditorDocumentSnapshot;
+}
+
+export interface QueueMessageOptions {
+  readonly computerUseHostId: string | null | undefined;
+  readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly editorDocument: EditorDocumentSnapshot;
 }
 
 export interface ChatThreadSignals {
@@ -88,7 +98,7 @@ export interface ChatThreadSignals {
   composerSendButtonStatus$: Computed<Promise<ComposerSendButtonStatus>>;
   queueMessage$: Command<
     Promise<boolean>,
-    [string, string | null | undefined, AbortSignal]
+    [string, QueueMessageOptions, AbortSignal]
   >;
   recallMessage$: Command<Promise<void>, [string, AbortSignal]>;
   cancelRun$: Command<Promise<void>, [AbortSignal]>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -51,6 +51,7 @@ import {
   type GenerationTemplateRequest,
   type ChatThreadArtifactRun,
   type PagedChatMessage,
+  type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
@@ -126,6 +127,7 @@ import type {
   ChatThreadSignals,
   ComposerSendButtonStatus,
   MessageImageGroupProjection,
+  QueueMessageOptions,
   QueuedChatMessageItem,
   RecommendedFollowupSource,
   SendMessageOptions,
@@ -2972,12 +2974,62 @@ function prepareTextOnlyUserMessage(
   };
 }
 
+function structuredPromptForSend({
+  enabled,
+  editorDocument,
+  generationTemplate,
+  attachments,
+}: {
+  readonly enabled: boolean;
+  readonly editorDocument: SendMessageOptions["editorDocument"];
+  readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly attachments: PagedChatMessage["attachFiles"];
+}): UserMessageDocument | undefined {
+  if (!enabled || !editorDocument) {
+    return undefined;
+  }
+  return (
+    editorDocument.toMessageDocument({
+      generationTemplate,
+      attachments,
+    }) ?? undefined
+  );
+}
+
+function queueStructured(
+  features: Partial<Record<FeatureSwitchKey, boolean>>,
+  options: QueueMessageOptions,
+  result: PreparedSendMessageResult,
+): UserMessageDocument | undefined {
+  return structuredPromptForSend({
+    enabled: features[FeatureSwitchKey.StructuredPrompt] ?? false,
+    editorDocument: options.editorDocument,
+    generationTemplate: options.generationTemplate,
+    attachments: result.attachments,
+  });
+}
+
+function queueRuntimeOptions(
+  features: Partial<Record<FeatureSwitchKey, boolean>>,
+  modelSelection: ModelProviderSelection | null,
+) {
+  return {
+    runOptions: runOptionsFromModelProviderSelection(
+      modelSelection,
+      features[FeatureSwitchKey.CodexFastMode] ?? false,
+    ),
+    realAgentInPreviewEnabled:
+      features[FeatureSwitchKey.RealAgentInPreview] ?? false,
+  };
+}
+
 function createSendOptimisticMessageEntry({
   threadId,
   clientMessageId,
   createdAt,
   result,
   generationTemplate,
+  structuredPrompt,
   options,
 }: {
   threadId: string;
@@ -2985,6 +3037,7 @@ function createSendOptimisticMessageEntry({
   createdAt: string;
   result: PreparedSendMessageResult;
   generationTemplate: GenerationTemplateRequest | undefined;
+  structuredPrompt: UserMessageDocument | undefined;
   options: SendMessageOptions | undefined;
 }): OptimisticChatMessageInput {
   return {
@@ -2996,6 +3049,7 @@ function createSendOptimisticMessageEntry({
       content: result.prompt,
       attachFiles: result.attachments,
       generationTemplate,
+      ...(structuredPrompt ? { structuredPrompt } : {}),
       ...sendMessageRevocationPatch(options),
       createdAt,
     },
@@ -3020,6 +3074,7 @@ function sendMessageRequestBody(params: {
   readonly codexFastModeEnabled: boolean;
   readonly realAgentInPreviewEnabled: boolean;
   readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly structuredPrompt: UserMessageDocument | undefined;
   readonly options: SendMessageOptions | undefined;
 }) {
   const runOptions = runOptionsFromModelProviderSelection(
@@ -3036,6 +3091,9 @@ function sendMessageRequestBody(params: {
     ...(runOptions ? { runOptions } : {}),
     ...(params.realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
     generationTemplate: params.generationTemplate,
+    ...(params.structuredPrompt
+      ? { structuredPrompt: params.structuredPrompt }
+      : {}),
     ...(params.options && "computerUseHostId" in params.options
       ? { computerUseHostId: params.options.computerUseHostId ?? null }
       : {}),
@@ -3058,6 +3116,7 @@ function createAppendOptimisticSendMessage(
         readonly createdAt: string;
         readonly result: PreparedSendMessageResult;
         readonly generationTemplate: GenerationTemplateRequest | undefined;
+        readonly structuredPrompt: UserMessageDocument | undefined;
         readonly options: SendMessageOptions | undefined;
       },
     ) => {
@@ -3075,6 +3134,7 @@ function createAppendOptimisticSendMessage(
           createdAt: args.createdAt,
           result: args.result,
           generationTemplate: args.generationTemplate,
+          structuredPrompt: args.structuredPrompt,
           options: args.options,
         }),
       );
@@ -3136,6 +3196,7 @@ const postSendMessage$ = command(
       readonly result: PreparedSendMessageResult;
       readonly modelSelection: ModelProviderSelection | null;
       readonly generationTemplate: GenerationTemplateRequest | undefined;
+      readonly structuredPrompt: UserMessageDocument | undefined;
       readonly options: SendMessageOptions | undefined;
       readonly flushDraftClear$: Command<Promise<void>, [AbortSignal]>;
     },
@@ -3161,6 +3222,7 @@ const postSendMessage$ = command(
             codexFastModeEnabled,
             realAgentInPreviewEnabled,
             generationTemplate: args.generationTemplate,
+            structuredPrompt: args.structuredPrompt,
             options: args.options,
           }),
           fetchOptions: { signal },
@@ -3192,7 +3254,9 @@ function createPerformSendMessage(deps: SendMessageDeps) {
       request: ValidatedSendMessageRequest,
       signal: AbortSignal,
     ): Promise<boolean> => {
-      const generationTemplate = get(draft.generationTemplate$);
+      const generationTemplate = request.options?.editorDocument
+        ? request.options.generationTemplate
+        : get(draft.generationTemplate$);
       const result =
         request.options?.includeDraftAttachments === false
           ? prepareTextOnlyUserMessage(request.prompt)
@@ -3213,6 +3277,13 @@ function createPerformSendMessage(deps: SendMessageDeps) {
         return false;
       }
       signal.throwIfAborted();
+      const features = get(featureSwitch$);
+      const structuredPrompt = structuredPromptForSend({
+        enabled: features[FeatureSwitchKey.StructuredPrompt] ?? false,
+        editorDocument: request.options?.editorDocument,
+        generationTemplate,
+        attachments: result.attachments,
+      });
       set(cancelDraftSync$);
       set(draft.clear$);
       const clientMessageId = crypto.randomUUID();
@@ -3226,6 +3297,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
         createdAt,
         result,
         generationTemplate,
+        structuredPrompt,
         options: request.options,
       });
       animationFrame(
@@ -3244,6 +3316,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
           result,
           modelSelection: request.modelSelection,
           generationTemplate,
+          structuredPrompt,
           options: request.options,
           flushDraftClear$,
         },
@@ -3355,7 +3428,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
     async (
       { get, set },
       prompt: string,
-      computerUseHostId: string | null | undefined,
+      options: QueueMessageOptions,
       signal: AbortSignal,
     ): Promise<boolean> => {
       L.debug("queueMessage$ start", { threadId, promptLen: prompt.length });
@@ -3371,8 +3444,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         L.debug("queueMessage$ no thread metadata, abort", { threadId });
         return false;
       }
-      const generationTemplate = get(draft.generationTemplate$);
-
+      const generationTemplate = options.generationTemplate;
       const modelSelectionResult = await set(modelSelectionForSend$, signal);
       signal.throwIfAborted();
       if (!modelSelectionResult.available) {
@@ -3396,6 +3468,9 @@ function createQueueMessage(deps: QueueMessageDeps) {
       }
       signal.throwIfAborted();
 
+      const features = get(featureSwitch$);
+      const structuredPrompt = queueStructured(features, options, result);
+
       set(cancelDraftSync$);
       set(draft.clear$);
 
@@ -3417,6 +3492,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
           content: result.prompt,
           attachFiles: result.attachments,
           generationTemplate,
+          ...(structuredPrompt ? { structuredPrompt } : {}),
           createdAt: nowIso,
         },
       });
@@ -3427,14 +3503,9 @@ function createQueueMessage(deps: QueueMessageDeps) {
         { signal },
       );
 
-      const features = get(featureSwitch$);
-      const codexFastModeEnabled =
-        features[FeatureSwitchKey.CodexFastMode] ?? false;
-      const realAgentInPreviewEnabled =
-        features[FeatureSwitchKey.RealAgentInPreview] ?? false;
-      const runOptions = runOptionsFromModelProviderSelection(
+      const { runOptions, realAgentInPreviewEnabled } = queueRuntimeOptions(
+        features,
         modelSelection,
-        codexFastModeEnabled,
       );
       const [, persistedMessage] = await Promise.all([
         set(flushDraftClear$, signal),
@@ -3451,7 +3522,10 @@ function createQueueMessage(deps: QueueMessageDeps) {
             ...(runOptions ? { runOptions } : {}),
             ...(realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
             generationTemplate,
-            ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
+            ...(structuredPrompt ? { structuredPrompt } : {}),
+            ...(options.computerUseHostId === undefined
+              ? {}
+              : { computerUseHostId: options.computerUseHostId }),
           },
           signal,
         ),

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -8,6 +8,7 @@ import {
   type ChatThreadEvent,
   type GenerationTemplateRequest,
   type PagedChatMessage,
+  type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPoliciesResponse } from "@vm0/api-contracts/contracts/model-providers";
 import type { UserModelPreferenceResponse } from "@vm0/api-contracts/contracts/zero-user-model-preference";
@@ -50,6 +51,7 @@ import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing
 import { chatPageModelSelection$ } from "../zero-page/zero-chat-page.ts";
 import { selectedModelAvailable$ } from "../zero-page/model-first-personal-oauth.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import type { EditorDocumentSnapshot } from "../zero-page/user-message-document-codec.ts";
 
 export type NewChatThreadPane = "main" | "sidebar";
 
@@ -65,6 +67,7 @@ interface SendNewThreadMessageRequest {
   agentId: string;
   prompt: string;
   generationTemplate: GenerationTemplateRequest | undefined;
+  editorDocument?: EditorDocumentSnapshot;
   computerUseHostId?: string | null;
   routeSearchParams?: URLSearchParams;
 }
@@ -86,11 +89,13 @@ function createNewThreadOptimisticMessageEntry({
   clientMessageId,
   prepared,
   generationTemplate,
+  structuredPrompt,
 }: {
   threadId: string;
   clientMessageId: string;
   prepared: PreparedNewThreadPayload;
   generationTemplate: GenerationTemplateRequest | undefined;
+  structuredPrompt: UserMessageDocument | undefined;
 }): OptimisticChatMessageInput {
   return {
     threadId,
@@ -101,6 +106,7 @@ function createNewThreadOptimisticMessageEntry({
       content: prepared.prompt,
       attachFiles: prepared.attachments,
       generationTemplate,
+      ...(structuredPrompt ? { structuredPrompt } : {}),
       createdAt: nowDate().toISOString(),
     },
   };
@@ -115,6 +121,7 @@ function newThreadSendBody({
   codexFastModeEnabled,
   realAgentInPreviewEnabled,
   generationTemplate,
+  structuredPrompt,
   computerUseHostId,
 }: {
   agentId: string;
@@ -125,6 +132,7 @@ function newThreadSendBody({
   codexFastModeEnabled: boolean;
   realAgentInPreviewEnabled: boolean;
   generationTemplate: GenerationTemplateRequest | undefined;
+  structuredPrompt: UserMessageDocument | undefined;
   computerUseHostId?: string | null;
 }) {
   const runOptions = runOptionsFromModelProviderSelection(
@@ -140,6 +148,7 @@ function newThreadSendBody({
     ...(runOptions ? { runOptions } : {}),
     ...(realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
     generationTemplate,
+    ...(structuredPrompt ? { structuredPrompt } : {}),
     ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
     attachFiles: prepared.attachFiles,
   };
@@ -453,6 +462,15 @@ const sendNewThreadMessage$ = command(
     if (!prepared) {
       return null;
     }
+    const features = get(featureSwitch$);
+    const structuredPrompt =
+      (features[FeatureSwitchKey.StructuredPrompt] ?? false) &&
+      request.editorDocument
+        ? (request.editorDocument.toMessageDocument({
+            generationTemplate,
+            attachments: prepared.attachments,
+          }) ?? undefined)
+        : undefined;
     const threadId = crypto.randomUUID();
     const clientMessageId = crypto.randomUUID();
     const chatThreadEventId = crypto.randomUUID();
@@ -464,6 +482,7 @@ const sendNewThreadMessage$ = command(
           clientMessageId,
           prepared,
           generationTemplate,
+          structuredPrompt,
         }),
       ),
     );
@@ -500,10 +519,11 @@ const sendNewThreadMessage$ = command(
       clientMessageId,
       prepared,
       modelSelection: resolvedModelSelection,
-      codexFastModeEnabled: codexFastModeSwitchEnabled(get(featureSwitch$)),
+      codexFastModeEnabled: codexFastModeSwitchEnabled(features),
       realAgentInPreviewEnabled:
-        get(featureSwitch$)[FeatureSwitchKey.RealAgentInPreview] ?? false,
+        features[FeatureSwitchKey.RealAgentInPreview] ?? false,
       generationTemplate,
+      structuredPrompt,
       computerUseHostId,
     });
     const sendResult = (async (): Promise<SendNewThreadMessageResult> => {

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -151,6 +151,7 @@ const appendQueuedMessage$ = command(
       chatThreadSortEventId,
       hasTextContent,
       generationTemplate,
+      structuredPrompt,
       computerUseHostId,
       runOptions,
       realAgentInPreview,
@@ -168,6 +169,7 @@ const appendQueuedMessage$ = command(
           clientMessageId,
           chatThreadSortEventId,
           generationTemplate,
+          ...(structuredPrompt ? { structuredPrompt } : {}),
           ...(runOptions ? { runOptions } : {}),
           ...(realAgentInPreview ? { realAgentInPreview: true } : {}),
           ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
@@ -184,6 +186,7 @@ const appendQueuedMessage$ = command(
       content,
       attachFiles: attachments ?? undefined,
       generationTemplate,
+      ...(structuredPrompt ? { structuredPrompt } : {}),
       createdAt: result.body.createdAt ?? nowDate().toISOString(),
     };
   },

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -44,7 +44,9 @@ import {
 } from "./workflow-composer-domain.ts";
 import {
   CHAT_THREAD_MENTION_NODE_NAME,
+  createEditorDocumentSnapshot,
   TEMPLATE_ATTACHMENT_NODE_NAME,
+  type EditorDocumentSnapshot,
 } from "./user-message-document-codec.ts";
 import {
   createTemplatePreviewRuntime,
@@ -83,6 +85,11 @@ interface WorkflowHighlightStorage {
   workflowNames: readonly string[];
 }
 
+export interface WorkflowComposerSubmissionSnapshot {
+  readonly prompt: string;
+  readonly editorDocument: EditorDocumentSnapshot;
+}
+
 export interface WorkflowComposerSignals {
   readonly editor: Editor;
   readonly templatePreview: TemplatePreviewRuntime;
@@ -115,7 +122,10 @@ export interface WorkflowComposerSignals {
   readonly insertPromptMarkdown$: Command<void, [string]>;
   readonly insertText$: Command<void, [string]>;
   readonly appendText$: Command<void, [string]>;
-  readonly readInputForSubmission$: Command<Promise<string>, [AbortSignal]>;
+  readonly readInputForSubmission$: Command<
+    Promise<WorkflowComposerSubmissionSnapshot>,
+    [AbortSignal]
+  >;
   readonly setTemplateAttachmentLifecycleRef$: Command<
     (() => void) | undefined,
     [HTMLButtonElement | null]
@@ -145,6 +155,20 @@ export interface WorkflowComposerEventHandlers {
     event: ClipboardEvent,
     currentTarget: HTMLElement,
   ) => boolean;
+}
+
+function createReadInputForSubmissionCommand(
+  editor: Editor,
+  compositionGate: CompositionGate,
+) {
+  return command((_context, signal: AbortSignal) => {
+    return compositionGate.runWhenSettled(() => {
+      return {
+        prompt: workflowComposerDocToString(editor),
+        editorDocument: createEditorDocumentSnapshot(editor.state.doc),
+      };
+    }, signal);
+  });
 }
 
 const FEEDBACK_ITEM_NODE_NAME = "feedbackItem";
@@ -1528,11 +1552,10 @@ export function createWorkflowComposerSignals(
     activeChatThreadSuggestionRange$,
   );
   const textCommands = createInsertTextCommands(editor);
-  const readInputForSubmission$ = command((_context, signal: AbortSignal) => {
-    return compositionGate.runWhenSettled(() => {
-      return workflowComposerDocToString(editor);
-    }, signal);
-  });
+  const readInputForSubmission$ = createReadInputForSubmissionCommand(
+    editor,
+    compositionGate,
+  );
   const hasInput$ = computed((get) => {
     return get(draft.hasInput$) || get(feedback.active$);
   });

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -19,6 +19,12 @@ export interface EditorDocumentContext {
   readonly attachments?: readonly PersistedAttachment[];
 }
 
+export interface EditorDocumentSnapshot {
+  readonly toMessageDocument: (
+    context?: EditorDocumentContext,
+  ) => UserMessageDocument | null;
+}
+
 function appendTextPart(parts: UserMessagePart[], text: string): void {
   if (text.length === 0) {
     return;
@@ -176,6 +182,21 @@ export function editorDocToMessageDocument(
 
   const parsed = userMessageDocumentSchema.safeParse({ version: 1, parts });
   return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Freezes the immutable ProseMirror document selected for one submission while
+ * allowing external attachment ids to be supplied after upload/model filtering
+ * settles. The returned value never crosses an API or persistence boundary.
+ */
+export function createEditorDocumentSnapshot(
+  document: ProseMirrorNode,
+): EditorDocumentSnapshot {
+  return Object.freeze({
+    toMessageDocument(context: EditorDocumentContext = {}) {
+      return editorDocToMessageDocument(document, context);
+    },
+  });
 }
 
 function templateCategory(type: GenerationTemplateType): string {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-prompt-writing.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-structured-prompt-writing.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type {
+  PersistedAttachment,
+  UserMessageDocument,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+
+import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  activeRunComposer,
+  mockChatLifecycle,
+  PLACEHOLDER,
+  sendMessageInUI,
+} from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000951";
+
+interface SentMessageCapture {
+  readonly prompt?: string;
+  readonly structuredPrompt?: UserMessageDocument;
+  readonly attachFiles?: readonly {
+    readonly id: string;
+    readonly filename: string;
+    readonly contentType: string;
+    readonly size: number;
+  }[];
+}
+
+interface QueuedMessageCapture {
+  readonly content?: string;
+  readonly structuredPrompt?: UserMessageDocument;
+  readonly attachments?: readonly PersistedAttachment[];
+}
+
+describe("structured prompt writes", () => {
+  it("writes one ordered snapshot for a new-thread message", async () => {
+    const user = userEvent.setup({ delay: null });
+    let sent: SentMessageCapture | null = null;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        sent = body;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-brief",
+      filename: "brief.txt",
+      contentType: "text/plain",
+      size: 12,
+      url: "https://cdn.vm7.io/artifacts/test/upload-brief/brief.txt",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
+
+    const composer = await screen.findByPlaceholderText(PLACEHOLDER);
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) {
+      throw new Error("File input not found");
+    }
+    await user.upload(
+      fileInput,
+      new File(["launch brief"], "brief.txt", { type: "text/plain" }),
+    );
+    await screen.findByLabelText("Remove brief.txt");
+    await sendMessageInUI(user, composer, "Review the launch brief");
+
+    await waitFor(() => {
+      expect(sent).toMatchObject({
+        prompt: "Review the launch brief",
+        structuredPrompt: {
+          version: 1,
+          parts: [
+            {
+              type: "file",
+              fileId: "upload-brief",
+              filenameSnapshot: "brief.txt",
+              contentType: "text/plain",
+            },
+            { type: "text", text: "Review the launch brief" },
+          ],
+        },
+      });
+    });
+  });
+
+  it.each([
+    { enabled: true, label: "enabled" },
+    { enabled: false, label: "disabled" },
+  ])(
+    "applies the $label switch state to existing-thread writes",
+    async ({ enabled }) => {
+      const user = userEvent.setup({ delay: null });
+      let sent: SentMessageCapture | null = null;
+      mockChatLifecycle(context, {
+        threadId: THREAD_ID,
+        onRunCreate: (body) => {
+          sent = body;
+        },
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/chats/${THREAD_ID}`,
+        featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: enabled },
+      });
+
+      const composer = await screen.findByRole("textbox", {
+        name: "Message",
+      });
+      await sendMessageInUI(user, composer, "Keep the legacy prompt too");
+
+      await waitFor(() => {
+        expect(sent).not.toBeNull();
+      });
+      if (enabled) {
+        expect(sent).toMatchObject({
+          prompt: "Keep the legacy prompt too",
+          structuredPrompt: {
+            version: 1,
+            parts: [{ type: "text", text: "Keep the legacy prompt too" }],
+          },
+        });
+      } else {
+        expect(sent).not.toHaveProperty("structuredPrompt");
+      }
+    },
+  );
+
+  it("queues the committed IME snapshot with the enabled switch", async () => {
+    let queued: QueuedMessageCapture | null = null;
+    const appendGate = context.mocks.deferred<void>();
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      appendGate: appendGate.promise,
+      chatMessages: [
+        {
+          id: "msg-active-user",
+          role: "user",
+          content: "Start the active run",
+          runId: "run-active",
+          createdAt: "2026-07-21T10:00:00Z",
+        },
+        {
+          id: "msg-active-assistant",
+          role: "assistant",
+          content: null,
+          runId: "run-active",
+          createdAt: "2026-07-21T10:00:01Z",
+        },
+      ],
+      activeRunIds: ["run-active"],
+      onQueuedMessageAppend: (body) => {
+        queued = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.StructuredPrompt]: true },
+    });
+
+    await screen.findByLabelText("Stop");
+    const composer = await activeRunComposer();
+    await fill(composer, "排");
+    fireEvent.compositionStart(composer, { data: "排" });
+    const paragraph = composer.querySelector("p");
+    if (!paragraph) {
+      throw new Error("Composer paragraph not found");
+    }
+    paragraph.textContent = "排队完整内容";
+
+    fireEvent.click(screen.getByLabelText("Send"));
+    expect(queued).toBeNull();
+
+    fireEvent.compositionEnd(composer, { data: "排队完整内容" });
+    fireEvent.input(composer, {
+      data: "排队完整内容",
+      inputType: "insertCompositionText",
+      isComposing: false,
+    });
+
+    await waitFor(() => {
+      expect(queued).toMatchObject({
+        content: "排队完整内容",
+        structuredPrompt: {
+          version: 1,
+          parts: [{ type: "text", text: "排队完整内容" }],
+        },
+      });
+    });
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "排队完整内容",
+    );
+    expect(composer).toHaveTextContent("");
+    appendGate.resolve();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -21,6 +21,7 @@ import {
   type GenerationTemplateRequest,
   type PagedChatMessage,
   type PersistedAttachment,
+  type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { logsByIdContract } from "@vm0/api-contracts/contracts/logs";
 import {
@@ -400,6 +401,7 @@ export function mockChatLifecycle(
       attachments?: PersistedAttachment[];
       clientMessageId: string;
       generationTemplate?: GenerationTemplateRequest;
+      structuredPrompt?: UserMessageDocument;
       modelSelection?: ModelSelectionRequest | null;
       runOptions?: ChatRunOptionsRequest;
     }) => void;
@@ -447,6 +449,7 @@ export function mockChatLifecycle(
       }[];
       hasTextContent?: boolean;
       generationTemplate?: GenerationTemplateRequest;
+      structuredPrompt?: UserMessageDocument;
       model?: string;
       modelSelection?: ModelSelectionRequest | null;
       runOptions?: ChatRunOptionsRequest;
@@ -484,6 +487,7 @@ export function mockChatLifecycle(
   let resultContent = "";
   let threadListOverride: ThreadListItem[] | null = null;
   let runPrompt: string | null = null;
+  let runStructuredPrompt: UserMessageDocument | undefined;
   let runUserMessageId = "msg-user-sent";
   let runAssociated = false;
   let threadTitle: string | null = options?.threadTitle ?? null;
@@ -631,6 +635,9 @@ export function mockChatLifecycle(
         id: runUserMessageId,
         role: "user",
         content: runPrompt ?? "Hello",
+        ...(runStructuredPrompt
+          ? { structuredPrompt: runStructuredPrompt }
+          : {}),
         runId: MOCK_RUN_ID,
         createdAt: "2026-03-10T00:00:01Z",
       });
@@ -672,6 +679,7 @@ export function mockChatLifecycle(
     clientMessageId?: string;
     hasTextContent?: boolean;
     generationTemplate?: GenerationTemplateRequest;
+    structuredPrompt?: UserMessageDocument;
     model?: string;
     runOptions?: ChatRunOptionsRequest;
   }) => {
@@ -689,6 +697,7 @@ export function mockChatLifecycle(
       attachments: attachFiles,
       clientMessageId,
       generationTemplate: body.generationTemplate,
+      structuredPrompt: body.structuredPrompt,
       modelSelection,
       runOptions: body.runOptions,
     });
@@ -702,6 +711,9 @@ export function mockChatLifecycle(
       content: body.prompt ?? "",
       attachFiles,
       generationTemplate: body.generationTemplate,
+      ...(body.structuredPrompt
+        ? { structuredPrompt: body.structuredPrompt }
+        : {}),
       createdAt: now,
     });
     return { runId: null, threadId, createdAt: now };
@@ -718,6 +730,7 @@ export function mockChatLifecycle(
     }[];
     hasTextContent?: boolean;
     generationTemplate?: GenerationTemplateRequest;
+    structuredPrompt?: UserMessageDocument;
     model?: string;
     runOptions?: ChatRunOptionsRequest;
     computerUseHostId?: string | null;
@@ -729,6 +742,7 @@ export function mockChatLifecycle(
     if (body.prompt) {
       runPrompt = body.prompt;
     }
+    runStructuredPrompt = body.structuredPrompt;
     rememberRunUserMessageId(body.clientMessageId);
     const modelSelection = modelSelectionFromBody(body);
     options?.onRunCreate?.({ ...body, modelSelection });

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -83,6 +83,7 @@ import { updateUserModelPreference$ } from "../../signals/external/user-model-pr
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 import { queueCurrentAgentDraftSync$ } from "../../signals/zero-page/agent-draft.ts";
+import type { EditorDocumentSnapshot } from "../../signals/zero-page/user-message-document-codec.ts";
 
 function getTagline(
   agentName: string,
@@ -502,6 +503,7 @@ function useAgentChatSendMessage({
   onSend: (
     message: string,
     selectedGenerationTemplate: GenerationTemplateRequest | undefined,
+    editorDocument: EditorDocumentSnapshot,
   ) => void;
   submissionLoading: boolean;
 } {
@@ -509,7 +511,7 @@ function useAgentChatSendMessage({
   const rootSignal = useGet(rootSignal$);
 
   return {
-    onSend: (message, selectedGenerationTemplate) => {
+    onSend: (message, selectedGenerationTemplate, editorDocument) => {
       if (!currentChatAgentId) {
         return;
       }
@@ -521,6 +523,7 @@ function useAgentChatSendMessage({
               agentId: currentChatAgentId,
               prompt: message,
               generationTemplate: selectedGenerationTemplate,
+              editorDocument,
               ...(selectedComputerUseHostId
                 ? { computerUseHostId: selectedComputerUseHostId }
                 : {}),

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -100,6 +100,7 @@ import {
 import type { DraftSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import type {
   ComposerTemplateAttachment,
+  WorkflowComposerSubmissionSnapshot,
   WorkflowComposerSignals,
 } from "../../signals/zero-page/tiptap-workflow-composer.ts";
 import type { TemplatePreviewRuntime } from "../../signals/zero-page/template-preview-runtime.ts";
@@ -256,10 +257,12 @@ export interface ZeroChatComposerProps {
   onSend: (
     message: string,
     generationTemplate: GenerationTemplateRequest | undefined,
+    editorDocument: WorkflowComposerSubmissionSnapshot["editorDocument"],
   ) => void;
   onQueue?: (
     message: string,
     generationTemplate: GenerationTemplateRequest | undefined,
+    editorDocument: WorkflowComposerSubmissionSnapshot["editorDocument"],
   ) => void;
   sending?: boolean;
   queueWhileSending?: boolean;
@@ -7042,15 +7045,15 @@ export function useZeroChatComposer({
       detach(ensurePushSubscription(rootSignal), Reason.DomCallback);
     }
     const submitCurrentInput = async () => {
-      const currentInput = await readInputForSubmission(pageSignal);
-      const prompt = currentInput.trim();
+      const submission = await readInputForSubmission(pageSignal);
+      const prompt = submission.prompt.trim();
       if (prompt.length === 0 && visibleAttachments.length === 0) {
         return;
       }
       if (sendAction === "send") {
-        onSend(prompt, templatePicker?.value);
+        onSend(prompt, templatePicker?.value, submission.editorDocument);
       } else {
-        onQueue?.(prompt, templatePicker?.value);
+        onQueue?.(prompt, templatePicker?.value, submission.editorDocument);
       }
     };
     detach(submitCurrentInput(), Reason.DomCallback);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -91,6 +91,7 @@ import type {
   UserMessageDocument,
   UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type { EditorDocumentSnapshot } from "../../signals/zero-page/user-message-document-codec.ts";
 import type {
   ChatThreadWorkflowAutomation,
   ZeroWorkflowSchedule,
@@ -3997,14 +3998,22 @@ function useChatThreadComposerSendState({
   const generationTemplate = useGet(thread.draft.generationTemplate$);
   const setGenerationTemplate = useSet(thread.draft.setGenerationTemplate$);
 
-  const handleSend = (text: string) => {
+  const handleSend = (
+    text: string,
+    generationTemplate: GenerationTemplateRequest | undefined,
+    editorDocument: EditorDocumentSnapshot,
+  ) => {
     detach(
       (async () => {
         const computerUsePatch =
           computerUseHostIdForSend === undefined
             ? {}
             : { computerUseHostId: computerUseHostIdForSend };
-        const sent = await send(text, { ...computerUsePatch }, rootSignal);
+        const sent = await send(
+          text,
+          { ...computerUsePatch, generationTemplate, editorDocument },
+          rootSignal,
+        );
         if (sent) {
           clearComputerUseHostOverride();
         }
@@ -4013,11 +4022,19 @@ function useChatThreadComposerSendState({
     );
   };
 
-  const handleQueue = (text: string) => {
+  const handleQueue = (
+    text: string,
+    generationTemplate: GenerationTemplateRequest | undefined,
+    editorDocument: EditorDocumentSnapshot,
+  ) => {
     detach(
       (async () => {
         const computerUseHostId = computerUseHostIdForSend;
-        const queued = await queueMessage(text, computerUseHostId, rootSignal);
+        const queued = await queueMessage(
+          text,
+          { computerUseHostId, generationTemplate, editorDocument },
+          rootSignal,
+        );
         if (queued) {
           clearComputerUseHostOverride();
         }


### PR DESCRIPTION
## Summary

- capture an immutable composer document after IME composition settles, then serialize it after attachment upload and model filtering resolve
- carry the same structured prompt through new-thread, existing-thread, queued, optimistic, request, and queued-message persistence paths while retaining the legacy prompt
- reuse the StructuredPrompt feature switch so disabled clients omit the field entirely and preserve the production write path

## Verification

- app lint
- app production and test type-checks
- app knip
- structured prompt writing tests: 4 passed
- message document codec tests: 5 passed
- chat queue regression tests: 9 passed

Part of #22314