### PR TITLE
fix(platform): close mobile sidebar after agent selection

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -219,12 +219,9 @@ function pinnedAgentLink(
   container: HTMLElement,
   name: string,
 ): HTMLAnchorElement {
-  const card = within(container)
-    .getAllByTestId("pinned-agent-card")
-    .find((candidate) => {
-      return candidate.textContent?.trim() === name;
-    });
-  const link = card?.querySelector("a");
+  const link = queryAllByRoleFast("link", container).find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
   if (!(link instanceof HTMLAnchorElement)) {
     throw new Error(`${name} pinned agent link not found`);
   }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -207,6 +207,30 @@ function sidebar(): HTMLElement {
   return screen.getByRole("navigation", { name: "Sidebar" });
 }
 
+function mobileSidebar(): HTMLElement {
+  const drawer = screen.getByLabelText("Collapse sidebar").closest("aside");
+  if (!(drawer instanceof HTMLElement)) {
+    throw new Error("Mobile sidebar not found");
+  }
+  return drawer;
+}
+
+function pinnedAgentLink(
+  container: HTMLElement,
+  name: string,
+): HTMLAnchorElement {
+  const card = within(container)
+    .getAllByTestId("pinned-agent-card")
+    .find((candidate) => {
+      return candidate.textContent?.trim() === name;
+    });
+  const link = card?.querySelector("a");
+  if (!(link instanceof HTMLAnchorElement)) {
+    throw new Error(`${name} pinned agent link not found`);
+  }
+  return link;
+}
+
 function setupSidebarPage(
   options: Parameters<typeof detachedSetupPage>[0],
 ): void {
@@ -1526,6 +1550,78 @@ describe("zero sidebar", () => {
 
     expect(createRequests).toBe(0);
   });
+
+  it.each([
+    { label: "single-column", threeColumnNav: false },
+    { label: "three-column", threeColumnNav: true },
+  ])(
+    "closes the $label mobile sidebar after selecting a pinned agent",
+    async ({ threeColumnNav }) => {
+      prepareAgentTeam();
+      context.mocks.data.userPreferences({
+        pinnedAgentIds: [RESEARCH_AGENT_ID],
+      });
+      const openedTargets = context.mocks.browser.open();
+
+      setupSidebarPage({
+        context,
+        path: `/agents/${AGENT_ID}/chat`,
+        featureSwitches: {
+          [FeatureSwitchKey.ThreeColumnNav]: threeColumnNav,
+        },
+      });
+
+      await waitFor(() => {
+        expect(
+          pinnedAgentLink(mobileSidebar(), "Research Agent"),
+        ).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Open menu"));
+      await waitFor(() => {
+        expect(mobileSidebar()).toHaveAttribute(
+          "data-sidebar-expanded",
+          "true",
+        );
+      });
+
+      fireEvent.click(pinnedAgentLink(mobileSidebar(), "Research Agent"), {
+        metaKey: true,
+      });
+      await waitFor(() => {
+        expect(openedTargets.calls).toStrictEqual([
+          expect.objectContaining({
+            target: "_blank",
+            url: expect.stringContaining(`/agents/${RESEARCH_AGENT_ID}/chat`),
+          }),
+        ]);
+        expect(mobileSidebar()).toHaveAttribute(
+          "data-sidebar-expanded",
+          "true",
+        );
+      });
+
+      click(pinnedAgentLink(mobileSidebar(), "Zero"));
+      await waitFor(() => {
+        expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+        expect(mobileSidebar()).not.toHaveAttribute("data-sidebar-expanded");
+      });
+
+      click(screen.getByLabelText("Open menu"));
+      await waitFor(() => {
+        expect(mobileSidebar()).toHaveAttribute(
+          "data-sidebar-expanded",
+          "true",
+        );
+      });
+
+      click(pinnedAgentLink(mobileSidebar(), "Research Agent"));
+      await waitFor(() => {
+        expect(pathname()).toBe(`/agents/${RESEARCH_AGENT_ID}/chat`);
+        expect(mobileSidebar()).not.toHaveAttribute("data-sidebar-expanded");
+      });
+    },
+  );
 
   it("opens the agent picker from the global shortcut", async () => {
     prepareAgentTeam();

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -215,6 +215,7 @@ export function PinnedAgentListSection({
   });
 
   const openAgentListDialog = useSet(openAgentListDialog$);
+  const setExpanded = useSet(setSidebarExpanded$);
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
@@ -372,6 +373,12 @@ export function PinnedAgentListSection({
                   <Link
                     pathname="/agents/:agentId/chat"
                     options={{ pathParams: { agentId: agent.id } }}
+                    onClick={(e) => {
+                      if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                        return;
+                      }
+                      setExpanded(false);
+                    }}
                     className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                       hasSideActions ? "pl-2 pr-8" : "px-2"
                     } ${


### PR DESCRIPTION
## Summary

- close the mobile sidebar when a pinned agent is selected normally
- preserve Meta, Ctrl, and Shift modified-click new-tab behavior
- cover active-agent and cross-agent selection in both single-column and three-column mobile navigation

## Scope

- keeps drawer dismissal in the vertical pinned-agent view interaction
- leaves the desktop-only horizontal pinned-agent list unchanged
- does not change shared Link, router, signals, APIs, persistence, or deployment behavior

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --maxWorkers=1` — 45 tests passed
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm knip`
- pre-commit hooks, including cached full Knip and full Turbo type checks

Closes #22410
