### PR TITLE
fix(e2e): prevent staging onboarding navigation loops

### DIFF
--- a/e2e/playwright/lib/onboarding-handoff-url.test.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.test.ts
@@ -70,3 +70,13 @@ test("rewrites the staging app handoff to the Cloudflare staging app", () => {
 
   assert.equal(rewrittenUrl, "https://staging-app.omby.ai/prompt");
 });
+
+test("does not rewrite the configured staging app to itself", () => {
+  const rewrittenUrl = rewritePreviewAppFallbackUrl(
+    new URL("https://staging-app.omby.ai/?vm0_source=onboarding"),
+    "https://staging-app.omby.ai",
+    "https://staging-www.omby.ai",
+  );
+
+  assert.equal(rewrittenUrl, null);
+});

--- a/e2e/playwright/lib/onboarding-handoff-url.ts
+++ b/e2e/playwright/lib/onboarding-handoff-url.ts
@@ -21,11 +21,15 @@ function withExpectedPreviewAppOrigin(
   appOrigin: string,
   onboardingOrigin: string,
 ): URL | null {
+  const appUrl = new URL(appOrigin);
+  if (url.origin === appUrl.origin) {
+    return null;
+  }
+
   if (url.origin !== previewAppFallbackOrigin(onboardingOrigin)) {
     return null;
   }
 
-  const appUrl = new URL(appOrigin);
   const rewrittenUrl = new URL(url.toString());
   rewrittenUrl.protocol = appUrl.protocol;
   rewrittenUrl.host = appUrl.host;


### PR DESCRIPTION
## Summary

- stop the onboarding fallback helper from returning a rewrite when the browser is already on the configured app origin
- preserve real cross-origin rewrites for PR and staging preview handoffs
- add regression coverage for the `staging-www.omby.ai` to `staging-app.omby.ai` main-branch flow

## User-visible impact

Main-branch Playwright onboarding checks no longer loop by repeatedly navigating from `staging-app.omby.ai` back to the same URL after the WWW preview migration to omby.ai. This restores coverage for both standard and paid onboarding without changing their deployed URL configuration.

## Verification

- `pnpm dlx prettier@3.8.1 --check e2e/playwright/lib/onboarding-handoff-url.ts e2e/playwright/lib/onboarding-handoff-url.test.ts`
- `pnpm --dir e2e check-types`
- `pnpm --dir e2e test` (12 tests passed)
- Full local Vitest and a local dev server were not run, per repository PR verification guidance; the PR pipeline will run the broader checks.

## Context

- Follow-up to the failure in [Turbo run 29833564947](https://github.com/vm0-ai/vm0/actions/runs/29833564947/job/88644917828).
