### PR TITLE
test(platform): stabilize inline feedback attachment submission

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -9,6 +9,7 @@ import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  click,
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
@@ -1012,16 +1013,14 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
 
-    await user.click(await screen.findByLabelText("Template"));
-    await user.click(
+    click(await screen.findByLabelText("Template"));
+    click(
       await screen.findByLabelText(
         `Preview ${template.title} at current slide`,
       ),
     );
-    await user.click(await screen.findByLabelText("Select style Gold Luxe"));
-    await user.click(
-      await screen.findByLabelText(`Select template ${template.title}`),
-    );
+    click(await screen.findByLabelText("Select style Gold Luxe"));
+    click(await screen.findByLabelText(`Select template ${template.title}`));
     await waitFor(() => {
       expect(
         screen.getByLabelText(`Remove template ${templateChipLabel}`),
@@ -1049,10 +1048,12 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    click(buttonByText("Provide feedback"));
 
-    await findFeedbackNote();
-    await user.keyboard("Use the attached brief as supporting context.");
+    pastePlainText(
+      await findFeedbackNote(),
+      "Use the attached brief as supporting context.",
+    );
     expect(
       screen.getByLabelText(`Remove template ${templateChipLabel}`),
     ).toBeInTheDocument();
@@ -1060,7 +1061,7 @@ describe("chat inline feedback", () => {
       screen.getByLabelText("Remove feedback-brief.txt"),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText("Send"));
+    click(screen.getByLabelText("Send"));
 
     await waitFor(() => {
       expect(sentBodies[0]).toMatchObject({


### PR DESCRIPTION
## Summary

- replace per-character typing in the template-and-attachment inline feedback test with the existing plain-text paste helper
- use the existing fast click helper for template picker, feedback, and send controls while keeping `user.upload` for the file input
- preserve the page-level production bootstrap, MSW request path, and assertions for the submitted template, attachment, and feedback prompt

This is test-only and does not change user-visible behavior. It reduces happy-dom event simulation overhead that was pushing the test against Vitest's 5-second timeout under coverage and shard contention.

## Verification

- `pnpm exec prettier --write apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` — 16 passed
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx -t "sends inline feedback with selected template and draft attachments" --coverage.enabled --coverage.reporter=json` — passed in 2.19s test time
