### PR TITLE
refactor: clarify connector identity names

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -12,8 +12,8 @@ import type {
   ScopeDiffResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import { githubOauthContract } from "@vm0/api-contracts/contracts/github-oauth";
@@ -1163,7 +1163,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestReadConnectorByType(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupApp({ context })(zeroConnectorsByTypeContract);
@@ -1175,7 +1175,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async readConnectorByType(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
     ): Promise<ConnectorResponse> {
       const response = await api.requestReadConnectorByType(actor, type, [200]);
       expectStatus(response, 200);
@@ -1184,7 +1184,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async deleteConnectorByType(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       statuses: readonly (204 | 401 | 404)[] = [204],
     ): Promise<void> {
       const client = setupApp({ context })(zeroConnectorsByTypeContract);
@@ -1196,7 +1196,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestScopeDiff(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupApp({ context })(zeroConnectorScopeDiffContract);
@@ -1211,7 +1211,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async readScopeDiff(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
     ): Promise<ScopeDiffResponse> {
       const response = await api.requestScopeDiff(actor, type, [200]);
       expectStatus(response, 200);
@@ -1220,8 +1220,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestManualGrant(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       values: Readonly<Record<string, string>>,
       options: {
         readonly statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[];
@@ -1247,8 +1247,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async connectManualGrant(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       values: Readonly<Record<string, string>>,
       agentId?: string,
     ): Promise<ConnectorResponse> {
@@ -1265,8 +1265,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestOauthStart(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       options: {
         readonly statuses: readonly (200 | 400 | 401 | 403 | 500)[];
         readonly agentId?: string;
@@ -1290,8 +1290,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startOauth(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       agentId?: string,
     ): Promise<ConnectorOauthStartResponse> {
       const response = await api.requestOauthStart(actor, type, authMethod, {
@@ -1396,8 +1396,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestDeviceAuthStart(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       options: Readonly<Record<string, string>> | undefined,
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
     ) {
@@ -1416,8 +1416,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startDeviceAuth(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       options?: Readonly<Record<string, string>>,
     ): Promise<ConnectorOauthDeviceAuthSessionStartResponse> {
       const response = await api.requestDeviceAuthStart(
@@ -1433,7 +1433,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestDeviceAuthPoll(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       sessionId: string,
       sessionToken: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
@@ -1453,7 +1453,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async pollDeviceAuth(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       sessionId: string,
       sessionToken: string,
     ): Promise<ConnectorOauthDeviceAuthSessionPollResponse> {
@@ -1470,8 +1470,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestExternalCodeStart(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
     ) {
       const client = setupApp({ context })(
@@ -1489,7 +1489,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async requestExternalCodeComplete(
       actor: ApiTestUser | null,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       args: {
         readonly sessionId: string;
         readonly sessionToken: string;
@@ -1512,8 +1512,8 @@ export function createConnectorBddApi(context: TestContext) {
 
     async startExternalCode(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
-      authMethod: ConnectorCatalogAuthMethodId,
+      type: ConnectorRef,
+      authMethod: ConnectorAuthMethodId,
     ): Promise<ConnectorExternalCodeSessionStartResponse> {
       const response = await api.requestExternalCodeStart(
         actor,
@@ -1527,7 +1527,7 @@ export function createConnectorBddApi(context: TestContext) {
 
     async completeExternalCode(
       actor: ApiTestUser,
-      type: ConnectorCatalogRef,
+      type: ConnectorRef,
       args: {
         readonly sessionId: string;
         readonly sessionToken: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { ConnectorAuthMethodId } from "@vm0/connectors/connectors";
+import type { ConnectorRegistryAuthMethodId } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethodAuthCodeGrantConfig } from "@vm0/connectors/connector-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -95,7 +95,7 @@ function expectCloudflareAuthorizationScopes(authorizationUrl: URL): void {
 async function requestOauthStart(
   type: string,
   options: {
-    readonly authMethod?: ConnectorAuthMethodId;
+    readonly authMethod?: ConnectorRegistryAuthMethodId;
     readonly authenticated?: boolean;
     readonly headers?: HeadersInit;
     readonly origin?: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -295,6 +295,20 @@ describe("zero user permission grants", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({ context })(zeroUserPermissionGrantsContract);
 
+    const malformedConnector = await accept(
+      client.apply({
+        body: {
+          agentId,
+          connectorRef: "INVALID_REF",
+          mode: "patch",
+          grants: [{ permission: SLACK_READ_PERMISSION, action: "allow" }],
+        },
+        headers: AUTH_HEADERS,
+      }),
+      [400],
+    );
+    expect(malformedConnector.body.error.code).toBe("BAD_REQUEST");
+
     const unknownConnector = await accept(
       client.apply({
         body: {

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -6,9 +6,9 @@ import {
   cliAuthTestTokenContract,
 } from "@vm0/api-contracts/contracts/cli-auth-test";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogAuthMethodId,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
 import {
@@ -73,13 +73,13 @@ function stringError(status: 400 | 404, error: string) {
 }
 
 function parseConnectorRefs(connectorTypes: readonly string[]): {
-  readonly connectorRefs: readonly ConnectorCatalogRef[];
+  readonly connectorRefs: readonly ConnectorRef[];
   readonly invalidTypes: readonly string[];
 } {
-  const connectorRefs: ConnectorCatalogRef[] = [];
+  const connectorRefs: ConnectorRef[] = [];
   const invalidTypes: string[] = [];
   for (const type of connectorTypes) {
-    const result = connectorCatalogRefSchema.safeParse(type);
+    const result = connectorRefSchema.safeParse(type);
     if (result.success) {
       connectorRefs.push(result.data);
     } else {
@@ -94,8 +94,8 @@ function connectorOutputTargetKey(target: ConnectorOutputTarget): string {
 }
 
 function testConnectorTokenOutputs(args: {
-  readonly connectorRef: ConnectorCatalogRef;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly connectorRef: ConnectorRef;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly accessToken: string;
   readonly refreshToken: string | undefined;
@@ -238,7 +238,7 @@ const createTestConnector$ = command(
       );
     }
 
-    const connectorParsed = connectorCatalogRefSchema.safeParse(
+    const connectorParsed = connectorRefSchema.safeParse(
       bodyResult.data.connectorName,
     );
     if (!connectorParsed.success) {

--- a/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-type-callback.ts
@@ -1,8 +1,8 @@
 import { command } from "ccstate";
 import { connectorsTypeCallbackContract } from "@vm0/api-contracts/contracts/connectors-type-callback";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  type ConnectorCatalogRef,
+  connectorAuthMethodIdSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   connectorGrantScopes,
@@ -87,7 +87,7 @@ type CompleteOpenIdCallbackInput = {
 type ResolveCallbackStateInput = {
   readonly origin: string;
   readonly type: string;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly storedState: StoredOAuthState;
   readonly resolver: ConnectorActionResolver;
 };
@@ -95,7 +95,7 @@ type ResolveCallbackStateInput = {
 type ResolveOpenIdCallbackStateInput = {
   readonly origin: string;
   readonly type: string;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly storedState: StoredOAuthState;
   readonly resolver: ConnectorActionResolver;
 };
@@ -237,7 +237,7 @@ async function verifyOpenIdForConnector(args: {
 
 function resolveConnectorWithGrant(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly grantKind: "auth-code" | "openid-auth";
   readonly origin: string;
   readonly type: string;
@@ -279,7 +279,7 @@ function resolveConnectorWithGrant(args: {
 async function claimStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -311,7 +311,7 @@ async function claimStoredOAuthStateForCallback(args: {
 async function rejectInvalidStoredOAuthStateForCallback(args: {
   readonly db: Db;
   readonly state: string;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly origin: string;
   readonly type: string;
   readonly signal: AbortSignal;
@@ -342,7 +342,7 @@ function invalidStoredAuthMethodResponse(
 
 async function resolveStoredCallbackMethod(args: {
   readonly resolver: ConnectorActionResolver;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethod: string;
   readonly expectedGrantKind: "auth-code" | "openid-auth";
   readonly origin: string;
@@ -354,7 +354,7 @@ async function resolveStoredCallbackMethod(args: {
     }
   | { readonly ok: false; readonly response: Response }
 > {
-  const authMethodResult = connectorCatalogAuthMethodIdSchema.safeParse(
+  const authMethodResult = connectorAuthMethodIdSchema.safeParse(
     args.authMethod,
   );
   if (!authMethodResult.success) {
@@ -384,7 +384,7 @@ async function resolveStoredCallbackMethod(args: {
 
 async function linkGithubIntegrationAfterConnectorConnect(args: {
   readonly db: Db;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly identity: CallbackIdentity;
   readonly token: ConnectorAuthProviderGrantResult;
   readonly signal: AbortSignal;
@@ -683,7 +683,7 @@ const handleOpenIdConnectorCallback$ = command(
   async (
     { get, set },
     args: {
-      readonly type: ConnectorCatalogRef;
+      readonly type: ConnectorRef;
       readonly query: ConnectorCallbackQuery;
       readonly origin: string;
       readonly snapshot: ConnectorRuntimeSnapshot;
@@ -769,7 +769,7 @@ const handleOpenIdConnectorCallback$ = command(
 );
 
 function authCodeCallbackPreflight(args: {
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly request: Request;
   readonly origin: string;
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -803,7 +803,7 @@ const handleAuthCodeConnectorCallback$ = command(
   async (
     { get, set },
     args: {
-      readonly type: ConnectorCatalogRef;
+      readonly type: ConnectorRef;
       readonly query: ConnectorCallbackQuery;
       readonly request: Request;
       readonly origin: string;

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -1,6 +1,6 @@
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -13,7 +13,7 @@ import { and, eq } from "drizzle-orm";
 import type { ReadonlyDb } from "../external/db";
 
 export interface AgentConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
+  readonly allowedConnectorTypes: readonly ConnectorRef[];
   readonly allowedCustomConnectorIds: readonly string[];
 }
 
@@ -75,7 +75,7 @@ export function agentConnectorScopeFromRows(args: {
   readonly customConnectorRows: readonly AgentCustomConnectorRow[];
 }): AgentConnectorScope {
   const allowedConnectorTypes = args.connectorRows.flatMap((row) => {
-    const parsed = connectorCatalogRefSchema.safeParse(row.connectorType);
+    const parsed = connectorRefSchema.safeParse(row.connectorType);
     return parsed.success ? [parsed.data] : [];
   });
   const allowedCustomConnectorIds = args.customConnectorRows.map((row) => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -10,8 +10,8 @@ import {
 } from "@vm0/api-contracts/contracts/runners";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   getDefaultModel,
@@ -375,13 +375,13 @@ interface ResolvedCompose {
 type ConnectorScopeSource = "explicit" | "zero_agent" | "legacy_all" | "empty";
 
 interface EffectiveConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+  readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
   readonly allowedCustomConnectorIds: readonly string[] | undefined;
   readonly source: ConnectorScopeSource;
 }
 
 interface ExplicitConnectorScope {
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
+  readonly allowedConnectorTypes: readonly ConnectorRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly source?: Exclude<ConnectorScopeSource, "legacy_all" | "empty">;
 }
@@ -624,7 +624,7 @@ interface ConnectorRuntimeContext {
   readonly secretConnectorMetadataMap:
     | Record<string, SecretConnectorMetadata>
     | undefined;
-  readonly connectorTypes: readonly ConnectorCatalogRef[];
+  readonly connectorTypes: readonly ConnectorRef[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
 
@@ -787,7 +787,7 @@ function buildLegacySystemSkillVolumes(
 }
 
 function buildExternalConnectorSkillVolumes(
-  connectorTypes: readonly ConnectorCatalogRef[],
+  connectorTypes: readonly ConnectorRef[],
   snapshot: ConnectorRuntimeSnapshot,
   framework: SupportedFramework,
 ): readonly PreparedAdditionalVolume[] {
@@ -835,7 +835,7 @@ function buildWorkflowSkillVolumes(
 function buildInjectedSkillVolumes(
   args: {
     readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   framework: SupportedFramework,
@@ -2206,9 +2206,9 @@ function filterSecretConnectorMetadataMap(args: {
 
 interface StoredConnectorRuntimeRow {
   readonly access: ConnectorCredentialAccess;
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly connectorStateRevision: bigint;
-  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly needsReconnect: boolean;
   readonly tokenExpiresAt: Date | null;
@@ -2240,9 +2240,9 @@ const storedConnectorVariableValuesDecoder = zodDriverValueDecoder(
 
 interface ConnectorEnvBindingSet {
   readonly access: ConnectorCredentialAccess;
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly connectorStateRevision: bigint;
-  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly runtimeBindings: readonly ConnectorRuntimeBindingEntry[];
 }
 
@@ -2292,7 +2292,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
 
 function allowedStoredConnectorRows(
   rows: readonly StoredConnectorRuntimeRowCandidate[],
-  allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined,
+  allowedConnectorTypes: readonly ConnectorRef[] | undefined,
   snapshot: ConnectorRuntimeSnapshot,
   now: Date,
 ): readonly StoredConnectorRuntimeRow[] {
@@ -2913,7 +2913,7 @@ async function loadStoredConnectorMaterializationPlan(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
     readonly scopeSource: ConnectorScopeSource;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
@@ -2946,7 +2946,7 @@ function storedConnectorSnapshotQuery(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
   },
 ) {
   const selectedConnectors = db.$with("stored_connector_candidates").as(
@@ -3053,7 +3053,7 @@ async function loadStoredConnectorSnapshotRows(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -3083,7 +3083,7 @@ async function loadStoredConnectorSnapshotRows(
 
 function buildStoredConnectorMaterializationPlan(args: {
   readonly connectorRows: readonly StoredConnectorRuntimeRowCandidate[];
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+  readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
 }): StoredConnectorMaterializationPlan | null {
   const allowedConnectorRows = allowedStoredConnectorRows(
@@ -3106,7 +3106,7 @@ function buildStoredConnectorMaterializationPlan(args: {
 function materializeStoredConnectorSnapshotRows(
   args: {
     readonly rows: readonly StoredConnectorMaterializationSnapshotRow[];
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
@@ -3190,7 +3190,7 @@ async function loadStoredConnectorMaterializationSnapshot(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorTypes: readonly ConnectorCatalogRef[] | undefined;
+    readonly allowedConnectorTypes: readonly ConnectorRef[] | undefined;
     readonly scopeSource: ConnectorScopeSource;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
@@ -3822,7 +3822,7 @@ async function buildPermissionManifest(args: {
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly connectorVars?: Record<string, string>;
-  readonly connectorTypes?: readonly ConnectorCatalogRef[];
+  readonly connectorTypes?: readonly ConnectorRef[];
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<PermissionManifest | undefined> {

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -9,8 +9,8 @@ import {
 import type { ConnectorReconnectReason } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { SecretConnectorMetadata } from "@vm0/api-contracts/contracts/runners";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   connectorAuthMethodAccessMetadata,
@@ -429,8 +429,8 @@ type PreparedRefreshTokenContext =
 type ConnectorPreparedRefreshTokenContext = {
   readonly sourceType: "connector";
   readonly connectorId: string;
-  readonly connectorRef: ConnectorCatalogRef;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly connectorRef: ConnectorRef;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly authClient?: ConnectorAuthClient;
   readonly context: RefreshTokenContext;
@@ -539,7 +539,7 @@ interface RefreshSourceState {
 interface ConnectorAccessState extends RefreshSourceState {
   readonly access: ConnectorCredentialAccess;
   readonly connectorId: string;
-  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly storageVersion: number;
   readonly runtimeMethod: ConnectorRuntimeMethod;
   readonly accessMetadata: ConnectorAuthMethodAccessMetadata;

--- a/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { and, eq, or } from "drizzle-orm";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -133,7 +133,7 @@ export const authorizeConnectedConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly agentId: string | null;
-      readonly connectorType: ConnectorCatalogRef;
+      readonly connectorType: ConnectorRef;
     },
     signal: AbortSignal,
   ): Promise<AuthorizeConnectedConnectorResult> => {

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -1,7 +1,7 @@
 import { computed, type Computed } from "ccstate";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   PublicConnectorCatalogAuthMethodDetail,
@@ -46,14 +46,14 @@ export type ConnectorActionResolutionFailure =
 
 export type ResolvedConnectorRef = {
   readonly ok: true;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly catalogConnector: PublicConnectorCatalogDetail;
   readonly runtimeConnector: ConnectorRuntimeConnector;
   readonly snapshot: ConnectorRuntimeSnapshot;
 };
 
 export type ResolvedConnectorActionMethod = ResolvedConnectorRef & {
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly runtimeMethod: ConnectorRuntimeMethod;
@@ -73,7 +73,7 @@ export type ConnectorRefsResolution =
       readonly connectors: readonly ResolvedConnectorRef[];
     }
   | (ConnectorRefResolutionFailure & {
-      readonly connectorRef: ConnectorCatalogRef;
+      readonly connectorRef: ConnectorRef;
     });
 
 /**
@@ -89,27 +89,27 @@ export type ConnectorRefsResolution =
  */
 export interface ConnectorActionResolver {
   readonly resolveRef: (args: {
-    readonly connectorRef: ConnectorCatalogRef;
+    readonly connectorRef: ConnectorRef;
     readonly requireExecutable: boolean;
   }) => ConnectorRefResolution;
   readonly resolveMethod: (args: {
-    readonly connectorRef: ConnectorCatalogRef;
-    readonly authMethodId: ConnectorCatalogAuthMethodId;
+    readonly connectorRef: ConnectorRef;
+    readonly authMethodId: ConnectorAuthMethodId;
     readonly expectedGrantKind: ConnectorCatalogGrantKind;
   }) => ConnectorActionMethodResolution;
   readonly resolveNewActionMethod: (args: {
-    readonly connectorRef: ConnectorCatalogRef;
-    readonly authMethodId: ConnectorCatalogAuthMethodId;
+    readonly connectorRef: ConnectorRef;
+    readonly authMethodId: ConnectorAuthMethodId;
     readonly expectedGrantKind: ConnectorCatalogGrantKind;
   }) => ConnectorActionMethodResolution;
   readonly resolveRefs: (args: {
-    readonly connectorRefs: readonly ConnectorCatalogRef[];
+    readonly connectorRefs: readonly ConnectorRef[];
     readonly requireExecutable: boolean;
   }) => ConnectorRefsResolution;
 }
 
 function resolvedRef(args: {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly requireExecutable: boolean;
   readonly runtimeConnector: ConnectorRuntimeConnector;
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -133,7 +133,7 @@ function resolvedRef(args: {
 
 function executableMethod(args: {
   readonly resolvedRef: ResolvedConnectorRef;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
 }): ResolvedConnectorActionMethod | ConnectorActionResolutionFailure {
   const runtimeMethod = getConnectorRuntimeMethod({

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import {
   artifactKeySchema,
-  connectorCatalogRefSchema,
+  connectorRefSchema,
   connectorCatalogVersionSchema,
   digestSchema,
   privateNameSchema,
@@ -203,7 +203,7 @@ const publicFirewallMetadataSchema = z.discriminatedUnion("kind", [
 
 const publicConnectorCatalogArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: z.string().min(1),
@@ -310,7 +310,7 @@ const privateConnectorSkillSchema = z.discriminatedUnion("kind", [
 
 const privateConnectorCatalogArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     skill: privateConnectorSkillSchema,
     authMethods: z.array(privateAuthMethodSchema).min(1),
   })
@@ -395,7 +395,7 @@ const firewallDiagnosticsSchema = z
 
 const privateFirewallArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     label: z.string().min(1),
     billable: z.boolean(),
     firewall: firewallConfigSchema,
@@ -429,7 +429,7 @@ const runnerFirewallApiSchema = z
 
 const runnerFirewallArtifactConnectorSchema = z
   .object({
-    name: connectorCatalogRefSchema,
+    name: connectorRefSchema,
     apis: z.array(runnerFirewallApiSchema).min(1),
   })
   .strict();

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/artifacts.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import {
   artifactKeySchema,
+  connectorCatalogRefSchema,
   connectorCatalogVersionSchema,
-  connectorRefSchema,
   digestSchema,
   privateNameSchema,
 } from "./common";
@@ -203,7 +203,7 @@ const publicFirewallMetadataSchema = z.discriminatedUnion("kind", [
 
 const publicConnectorCatalogArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorRefSchema,
+    connectorRef: connectorCatalogRefSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: z.string().min(1),
@@ -310,7 +310,7 @@ const privateConnectorSkillSchema = z.discriminatedUnion("kind", [
 
 const privateConnectorCatalogArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorRefSchema,
+    connectorRef: connectorCatalogRefSchema,
     skill: privateConnectorSkillSchema,
     authMethods: z.array(privateAuthMethodSchema).min(1),
   })
@@ -395,7 +395,7 @@ const firewallDiagnosticsSchema = z
 
 const privateFirewallArtifactConnectorSchema = z
   .object({
-    connectorRef: connectorRefSchema,
+    connectorRef: connectorCatalogRefSchema,
     label: z.string().min(1),
     billable: z.boolean(),
     firewall: firewallConfigSchema,
@@ -429,7 +429,7 @@ const runnerFirewallApiSchema = z
 
 const runnerFirewallArtifactConnectorSchema = z
   .object({
-    name: connectorRefSchema,
+    name: connectorCatalogRefSchema,
     apis: z.array(runnerFirewallApiSchema).min(1),
   })
   .strict();

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
@@ -1,9 +1,9 @@
 import { connectorCatalogRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 
-export const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+export { connectorCatalogRefSchema };
 
-export const connectorRefSchema = connectorCatalogRefSchema;
+export const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
 
 export const privateNameSchema = z.string().regex(/^[A-Z][A-Z0-9_]*$/u);
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/common.ts
@@ -1,7 +1,7 @@
-import { connectorCatalogRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
+import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 
-export { connectorCatalogRefSchema };
+export { connectorRefSchema };
 
 export const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -8,7 +8,7 @@ import {
 import { z } from "zod";
 
 import { safeUrlParse } from "../../utils";
-import { connectorCatalogRefSchema, privateNameSchema } from "./common";
+import { connectorRefSchema, privateNameSchema } from "./common";
 
 const TEMPLATE_REFERENCE_PATTERN = /\b(secrets|vars)\.([A-Z][A-Z0-9_]*)\b/gu;
 const DIRECT_TEMPLATE_PATTERN =
@@ -169,7 +169,7 @@ const firewallApiSchema = z
 
 export const firewallConfigSchema = z
   .object({
-    name: connectorCatalogRefSchema,
+    name: connectorRefSchema,
     description: z.string().min(1).optional(),
     placeholders: z.record(privateNameSchema, z.string()).optional(),
     apis: z.array(firewallApiSchema).min(1),
@@ -185,7 +185,7 @@ export const firewallCategoriesSchema = z
 
 const firewallGeneratorResultSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     firewall: firewallConfigSchema,
     categories: firewallCategoriesSchema.nullable(),
     defaultAllowed: z.array(z.string().min(1)).nullable(),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/firewall.ts
@@ -8,7 +8,7 @@ import {
 import { z } from "zod";
 
 import { safeUrlParse } from "../../utils";
-import { connectorRefSchema, privateNameSchema } from "./common";
+import { connectorCatalogRefSchema, privateNameSchema } from "./common";
 
 const TEMPLATE_REFERENCE_PATTERN = /\b(secrets|vars)\.([A-Z][A-Z0-9_]*)\b/gu;
 const DIRECT_TEMPLATE_PATTERN =
@@ -169,7 +169,7 @@ const firewallApiSchema = z
 
 export const firewallConfigSchema = z
   .object({
-    name: connectorRefSchema,
+    name: connectorCatalogRefSchema,
     description: z.string().min(1).optional(),
     placeholders: z.record(privateNameSchema, z.string()).optional(),
     apis: z.array(firewallApiSchema).min(1),
@@ -185,7 +185,7 @@ export const firewallCategoriesSchema = z
 
 const firewallGeneratorResultSchema = z
   .object({
-    connectorRef: connectorRefSchema,
+    connectorRef: connectorCatalogRefSchema,
     firewall: firewallConfigSchema,
     categories: firewallCategoriesSchema.nullable(),
     defaultAllowed: z.array(z.string().min(1)).nullable(),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -1,8 +1,8 @@
 import { connectorCatalogAuthMethodIdSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 import {
+  connectorCatalogRefSchema,
   connectorCatalogVersionSchema,
-  connectorRefSchema,
   privateNameSchema,
 } from "./common";
 
@@ -53,7 +53,7 @@ const categorySourceSchema = z
 export const catalogSourceSchema = z
   .object({
     catalogVersion: connectorCatalogVersionSchema,
-    connectorRefs: z.array(connectorRefSchema).min(1),
+    connectorRefs: z.array(connectorCatalogRefSchema).min(1),
     categoryMetadata: z
       .object({
         categories: z.array(categorySourceSchema).min(1),
@@ -251,7 +251,7 @@ export const connectorAuthMethodSourceSchema = z
 
 export const connectorSourceSchema = z
   .object({
-    ref: connectorRefSchema,
+    ref: connectorCatalogRefSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: connectorCategoryIdSchema,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/source.ts
@@ -1,7 +1,7 @@
-import { connectorCatalogAuthMethodIdSchema } from "@vm0/api-contracts/contracts/connector-identity";
+import { connectorAuthMethodIdSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import { z } from "zod";
 import {
-  connectorCatalogRefSchema,
+  connectorRefSchema,
   connectorCatalogVersionSchema,
   privateNameSchema,
 } from "./common";
@@ -14,7 +14,7 @@ export const connectorFeatureSwitchKeySchema = z
 export const internalOptionNameSchema = z
   .string()
   .regex(/^[a-zA-Z][a-zA-Z0-9_]*$/u);
-export const connectorAuthMethodIdSchema = connectorCatalogAuthMethodIdSchema;
+export { connectorAuthMethodIdSchema };
 const connectorCategoryIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/u);
 const connectorGenerationTypeSchema = z.enum([
   "audio",
@@ -53,7 +53,7 @@ const categorySourceSchema = z
 export const catalogSourceSchema = z
   .object({
     catalogVersion: connectorCatalogVersionSchema,
-    connectorRefs: z.array(connectorCatalogRefSchema).min(1),
+    connectorRefs: z.array(connectorRefSchema).min(1),
     categoryMetadata: z
       .object({
         categories: z.array(categorySourceSchema).min(1),
@@ -251,7 +251,7 @@ export const connectorAuthMethodSourceSchema = z
 
 export const connectorSourceSchema = z
   .object({
-    ref: connectorCatalogRefSchema,
+    ref: connectorRefSchema,
     label: z.string().min(1),
     description: z.string().min(1),
     category: connectorCategoryIdSchema,

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -3,7 +3,7 @@ import {
   type ConnectorCatalogCompatibilityReason,
   type ConnectorCatalogFilteredAuthMethod,
 } from "@vm0/api-contracts/contracts/cron";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import type {
@@ -636,7 +636,7 @@ export function getAcceptedConnectorCatalogAvailableDetail(args: {
 export function listAcceptedConnectorCatalogAvailableRefs(args: {
   readonly snapshot: AcceptedConnectorCatalogSnapshot;
   readonly featureStates: ConnectorFeatureStates;
-}): readonly ConnectorCatalogRef[] {
+}): readonly ConnectorRef[] {
   return effectiveConnectors({
     catalog: args.snapshot,
     featureStates: args.featureStates,

--- a/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-form-fields.service.ts
@@ -1,5 +1,5 @@
 import type {
-  ConnectorAuthMethodId,
+  ConnectorRegistryAuthMethodId,
   ConnectorAuthMethodRuntimeConfig,
   ConnectorDeviceAuthStartOptionConfig,
   ConnectorDeviceAuthStartOptions,
@@ -45,7 +45,7 @@ function formatPublicFieldList(names: readonly string[]): string {
 
 export function getPublicManualGrantFieldDescriptors(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: ConnectorRegistryAuthMethodId,
 ): readonly PublicManualGrantFieldDescriptor[] | null {
   const method = getConnectorAuthMethod(type, authMethod);
   if (method?.grant.kind !== "manual") {
@@ -71,7 +71,7 @@ function publicManualGrantFieldDescriptors(
 
 export function getPublicDeviceAuthStartOptionDescriptors(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: ConnectorRegistryAuthMethodId,
 ): readonly PublicDeviceAuthStartOptionDescriptor[] | null {
   const method = getConnectorAuthMethod(type, authMethod);
   if (method?.grant.kind !== "device-auth") {

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -21,7 +21,7 @@ import {
   CONNECTOR_TYPES,
   connectorDisplayCategoryMetadataForItems,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -116,7 +116,7 @@ function listStaticConnectorCatalogReferenceMetadata(
 function availableAuthMethodsForCatalog(
   type: ConnectorType,
   args: StaticConnectorCatalogReadArgs,
-): ConnectorAuthMethodId[] {
+): ConnectorRegistryAuthMethodId[] {
   return getAvailableConnectorAuthMethodIds(type, args.featureStates, {
     apiAuthMethodPolicy: args.apiAuthMethodPolicy ?? "include",
   });
@@ -167,7 +167,7 @@ function publicTextOrNull(
 }
 
 function authMethodSummaryForCatalog(
-  id: ConnectorAuthMethodId,
+  id: ConnectorRegistryAuthMethodId,
   method: ConnectorAuthMethodConfig,
   privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogAuthMethodSummary {
@@ -181,7 +181,7 @@ function authMethodSummaryForCatalog(
 
 function manualFieldsForCatalog(
   type: ConnectorType,
-  id: ConnectorAuthMethodId,
+  id: ConnectorRegistryAuthMethodId,
   method: ConnectorAuthMethodConfig,
   privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogManualField[] {
@@ -206,7 +206,7 @@ function manualFieldsForCatalog(
 
 function startOptionsForCatalog(
   type: ConnectorType,
-  id: ConnectorAuthMethodId,
+  id: ConnectorRegistryAuthMethodId,
   method: ConnectorAuthMethodConfig,
 ): PublicConnectorCatalogStartOption[] {
   if (method.grant.kind !== "device-auth") {
@@ -231,7 +231,7 @@ function startOptionsForCatalog(
 
 function authMethodDetailForCatalog(
   type: ConnectorType,
-  id: ConnectorAuthMethodId,
+  id: ConnectorRegistryAuthMethodId,
   method: ConnectorAuthMethodConfig,
   privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogAuthMethodDetail {
@@ -244,7 +244,7 @@ function authMethodDetailForCatalog(
 
 function connectorCatalogItem(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
+  authMethods: readonly ConnectorRegistryAuthMethodId[],
 ): PublicConnectorCatalogItem {
   const config = CONNECTOR_TYPES[type];
   const privateNames = new Set(getConnectorPrivateNames(type, authMethods));
@@ -268,7 +268,7 @@ function connectorCatalogItem(
 
 function connectorCatalogDetail(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
+  authMethods: readonly ConnectorRegistryAuthMethodId[],
 ): PublicConnectorCatalogDetail {
   const item = connectorCatalogItem(type, authMethods);
   const privateNames = new Set(getConnectorPrivateNames(type, authMethods));
@@ -299,8 +299,8 @@ function connectionForCatalogStatus(
 
 function singleAuthCodeAuthMethodId(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
-): ConnectorAuthMethodId | null {
+  authMethods: readonly ConnectorRegistryAuthMethodId[],
+): ConnectorRegistryAuthMethodId | null {
   const [authMethod] = authMethods;
   if (authMethods.length !== 1 || !authMethod) {
     return null;
@@ -322,7 +322,7 @@ function connectorAuthMethodSupportsRefresh(
 
 function connectorCatalogStatusItem(args: {
   readonly type: ConnectorType;
-  readonly authMethods: readonly ConnectorAuthMethodId[];
+  readonly authMethods: readonly ConnectorRegistryAuthMethodId[];
   readonly connector: ConnectorResponse | null;
 }): PublicConnectorCatalogStatusItem {
   const detail = connectorCatalogDetail(args.type, args.authMethods);

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   PublicConnectorCatalogAuthMethodDetail,
@@ -81,8 +81,8 @@ export type ConnectorRuntimeSnapshotIdentity =
   | ({ readonly source: "external" } & ExternalCatalogIdentity);
 
 export interface ConnectorRuntimeMethod {
-  readonly connectorRef: ConnectorCatalogRef;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly connectorRef: ConnectorRef;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly availableForNewActions: boolean;
@@ -92,20 +92,14 @@ export interface ConnectorRuntimeMethod {
 }
 
 export interface ConnectorRuntimeConnector {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly catalogConnector: PublicConnectorCatalogDetail;
-  readonly methods: ReadonlyMap<
-    ConnectorCatalogAuthMethodId,
-    ConnectorRuntimeMethod
-  >;
+  readonly methods: ReadonlyMap<ConnectorAuthMethodId, ConnectorRuntimeMethod>;
   readonly skill: AcceptedPrivateSkill | null;
 }
 
 interface ConnectorRuntimeSnapshotBase {
-  readonly connectors: ReadonlyMap<
-    ConnectorCatalogRef,
-    ConnectorRuntimeConnector
-  >;
+  readonly connectors: ReadonlyMap<ConnectorRef, ConnectorRuntimeConnector>;
   readonly serverFirewalls: ConnectorServerFirewallCatalog;
 }
 
@@ -514,7 +508,7 @@ function runtimeMethod(args: {
 }
 
 function runtimeMethodEntry(args: {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly catalogMethod: PublicConnectorCatalogAuthMethodDetail;
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly availableForNewActions: boolean;
@@ -540,20 +534,14 @@ function runtimeMethodEntry(args: {
 
 const staticRuntimeSnapshot = singleton(() => {
   return (async (): Promise<ConnectorRuntimeSnapshot> => {
-    const connectors = new Map<
-      ConnectorCatalogRef,
-      ConnectorRuntimeConnector
-    >();
+    const connectors = new Map<ConnectorRef, ConnectorRuntimeConnector>();
     for (const connectorRef of CONNECTOR_TYPE_KEYS) {
       const catalogConnector =
         await getStaticConnectorCatalogResolutionDetail(connectorRef);
       if (catalogConnector === null) {
         throw new Error(`Static connector catalog is missing ${connectorRef}`);
       }
-      const methods = new Map<
-        ConnectorCatalogAuthMethodId,
-        ConnectorRuntimeMethod
-      >();
+      const methods = new Map<ConnectorAuthMethodId, ConnectorRuntimeMethod>();
       for (const catalogMethod of catalogConnector.authMethods) {
         const method = getConnectorAuthMethod(connectorRef, catalogMethod.id);
         if (method === undefined) {
@@ -597,7 +585,7 @@ function externalRuntimeSnapshot(
       return [connector.connectorRef, connector];
     }),
   );
-  const connectors = new Map<ConnectorCatalogRef, ConnectorRuntimeConnector>();
+  const connectors = new Map<ConnectorRef, ConnectorRuntimeConnector>();
 
   for (const publicConnector of acceptedSnapshot.publicArtifact.connectors) {
     const privateConnector = privateByRef.get(publicConnector.connectorRef);
@@ -618,10 +606,7 @@ function externalRuntimeSnapshot(
         return [method.id, method];
       }),
     );
-    const methods = new Map<
-      ConnectorCatalogAuthMethodId,
-      ConnectorRuntimeMethod
-    >();
+    const methods = new Map<ConnectorAuthMethodId, ConnectorRuntimeMethod>();
     for (const publicMethod of publicConnector.authMethods) {
       const privateMethod = privateMethods.get(publicMethod.id);
       const catalogMethod = catalogMethods.get(publicMethod.id);
@@ -921,7 +906,7 @@ async function getConnectorRuntimeAvailableCatalogDetail(args: {
 export async function listConnectorRuntimeVisibleRefs(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly featureStates: ConnectorFeatureStates;
-}): Promise<readonly ConnectorCatalogRef[]> {
+}): Promise<readonly ConnectorRef[]> {
   if (args.snapshot.identity.source === "external") {
     const acceptedSnapshot = args.snapshot.acceptedSnapshot;
     if (acceptedSnapshot === null) {
@@ -932,7 +917,7 @@ export async function listConnectorRuntimeVisibleRefs(args: {
       featureStates: args.featureStates,
     });
   }
-  const refs: ConnectorCatalogRef[] = [];
+  const refs: ConnectorRef[] = [];
   for (const connector of args.snapshot.connectors.values()) {
     const available = await getConnectorRuntimeAvailableCatalogDetail({
       snapshot: args.snapshot,
@@ -948,9 +933,9 @@ export async function listConnectorRuntimeVisibleRefs(args: {
 
 export function filterConnectorRuntimeConfiguredRefs(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
-  readonly visibleRefs: readonly ConnectorCatalogRef[];
+  readonly visibleRefs: readonly ConnectorRef[];
   readonly readEnv: ConnectorEnvReader;
-}): readonly ConnectorCatalogRef[] {
+}): readonly ConnectorRef[] {
   if (args.snapshot.identity.source === "external") {
     return args.visibleRefs;
   }

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -4,7 +4,7 @@ import type {
   ConnectorCheckRequest,
 } from "@vm0/api-contracts/contracts/zero-connector-check";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   connectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
@@ -50,21 +50,21 @@ import {
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
 interface ConnectorCheckIdentity {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly visibility: "available" | "unavailable";
   readonly credentialResolution: "network-boundary" | "none";
 }
 
 interface ConnectorCheckRoutingConfig {
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly candidates: readonly ConnectorDiagnosticBaseCandidate[];
   readonly hasUnresolvedDynamicBase: boolean;
 }
 
 interface StoredRuntimeState {
   readonly baseUrlVarsByType: ReadonlyMap<
-    ConnectorCatalogRef,
+    ConnectorRef,
     Readonly<Record<string, string>> | null
   >;
 }
@@ -117,13 +117,13 @@ type RunContextInlinePermission =
 
 interface ConnectorCheckCatalogContext {
   readonly snapshot: ConnectorRuntimeSnapshot;
-  readonly visibleConnectorRefs: ReadonlySet<ConnectorCatalogRef>;
+  readonly visibleConnectorRefs: ReadonlySet<ConnectorRef>;
 }
 
 function isConnectorRef(
   snapshot: ConnectorRuntimeSnapshot,
   value: string,
-): value is ConnectorCatalogRef {
+): value is ConnectorRef {
   return snapshot.connectors.has(value);
 }
 
@@ -133,7 +133,7 @@ function baseKey(value: string): string {
 
 function connectorCredentialResolution(
   snapshot: ConnectorRuntimeSnapshot,
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
 ): "network-boundary" | "none" {
   return (snapshot.serverFirewalls.getExecutionMetadata(connectorRef)
     ?.secretPlaceholderNames.length ?? 0) > 0
@@ -142,7 +142,7 @@ function connectorCredentialResolution(
 }
 
 function connectorIdentity(
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
   catalogContext: ConnectorCheckCatalogContext,
 ): ConnectorCheckIdentity {
   const connector = getConnectorRuntimeConnector(
@@ -179,11 +179,8 @@ function pendingStoredConnectorRuntimes(
     readonly userId: string;
     readonly snapshot: ConnectorRuntimeSnapshot;
   },
-): ReadonlyMap<ConnectorCatalogRef, PendingStoredConnectorRuntime | null> {
-  const pending = new Map<
-    ConnectorCatalogRef,
-    PendingStoredConnectorRuntime | null
-  >();
+): ReadonlyMap<ConnectorRef, PendingStoredConnectorRuntime | null> {
+  const pending = new Map<ConnectorRef, PendingStoredConnectorRuntime | null>();
 
   for (const row of rows) {
     if (!isConnectorRef(args.snapshot, row.type)) {
@@ -301,7 +298,7 @@ async function loadStoredRuntimeState(
       }),
     );
     const baseUrlVarsByType = new Map<
-      ConnectorCatalogRef,
+      ConnectorRef,
       Readonly<Record<string, string>> | null
     >();
     for (const [type, pendingState] of pending) {
@@ -430,7 +427,7 @@ function inlineApiEnvironmentNames(
 
 function configFromInlineRunContext(
   firewall: RunContextInlineFirewall,
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   view: ConnectorDiagnosticCatalogView | null,
 ): ConnectorCheckRoutingConfig {
   return {
@@ -474,11 +471,11 @@ async function loadRunRoutingConfigs(
   snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig[]> {
   const viewPromises = new Map<
-    ConnectorCatalogRef,
+    ConnectorRef,
     Promise<ConnectorDiagnosticCatalogView | null>
   >();
   const loadView = (
-    type: ConnectorCatalogRef,
+    type: ConnectorRef,
   ): Promise<ConnectorDiagnosticCatalogView | null> => {
     let promise = viewPromises.get(type);
     if (!promise) {
@@ -509,7 +506,7 @@ async function loadRunRoutingConfigs(
     configs.push(configFromCatalogView(view, baseUrlVars, false));
   }
 
-  const merged = new Map<ConnectorCatalogRef, ConnectorCheckRoutingConfig>();
+  const merged = new Map<ConnectorRef, ConnectorCheckRoutingConfig>();
   for (const config of configs) {
     const existing = merged.get(config.type);
     merged.set(config.type, {
@@ -526,7 +523,7 @@ async function loadRunRoutingConfigs(
 }
 
 async function catalogConfig(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   state: StoredRuntimeState,
   snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig | null> {
@@ -546,12 +543,12 @@ async function catalogConfig(
 
 async function loadGlobalCatalogConfigs(
   request: ParsedConnectorDiagnosticRequest,
-  requestedType: ConnectorCatalogRef | undefined,
+  requestedType: ConnectorRef | undefined,
   state: StoredRuntimeState,
   snapshot: ConnectorRuntimeSnapshot,
 ): Promise<ConnectorCheckRoutingConfig[]> {
   let bestScore: number | null = null;
-  const ownerTypes = new Set<ConnectorCatalogRef>();
+  const ownerTypes = new Set<ConnectorRef>();
 
   for (const connectorRef of snapshot.serverFirewalls.connectorRefs) {
     const metadata =
@@ -664,7 +661,7 @@ function environmentNamesForWinningCandidates(
 
 function connectorEnvironmentBindings(
   snapshot: ConnectorRuntimeSnapshot,
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
 ): readonly ConnectorRuntimeBindingEntry[] {
   const connector = getConnectorRuntimeConnector(snapshot, connectorRef);
   if (!connector) {
@@ -682,7 +679,7 @@ function connectorEnvironmentBindings(
 
 function environmentValueRefs(
   snapshot: ConnectorRuntimeSnapshot,
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   environmentName: string,
 ): ReadonlySet<string> {
   return new Set(
@@ -698,7 +695,7 @@ function environmentValueRefs(
 
 function environmentNameSupportsRoute(
   snapshot: ConnectorRuntimeSnapshot,
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   environmentName: string,
   routeEnvironmentNames: readonly string[],
 ): boolean {
@@ -758,7 +755,7 @@ function unavailablePolicy(
 }
 
 function permissionPolicy(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   permission: string,
   timeline: ConnectorCheckTimeline,
   configured: boolean,
@@ -787,7 +784,7 @@ function permissionPolicy(
 }
 
 function unknownPolicy(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   timeline: ConnectorCheckTimeline,
   configured: boolean,
 ): ConnectorCheckPolicy {
@@ -816,7 +813,7 @@ function unknownPolicy(
 }
 
 function decisionPermissionResult(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
   decision: Exclude<
     FirewallRequestDecision,
     { readonly kind: "no_match" | "ambiguous" }
@@ -881,7 +878,7 @@ function displayBaseForDecision(
 function connectorTypeForEnvironmentName(
   snapshot: ConnectorRuntimeSnapshot,
   environmentName: string,
-): ConnectorCatalogRef | null {
+): ConnectorRef | null {
   const owners = [...snapshot.connectors.keys()].filter((type) => {
     return connectorEnvironmentBindings(snapshot, type).some((entry) => {
       return entry.envName === environmentName;
@@ -902,7 +899,7 @@ function policyMap(timeline: ConnectorCheckTimeline): NetworkPolicies | null {
 }
 
 function noMatchDiagnostic(
-  requestedType: ConnectorCatalogRef | undefined,
+  requestedType: ConnectorRef | undefined,
   configs: readonly ConnectorCheckRoutingConfig[],
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
@@ -961,7 +958,7 @@ type UrlEnvironmentSelection =
 
 function selectUrlEnvironmentNames(args: {
   readonly catalogContext: ConnectorCheckCatalogContext;
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly config: ConnectorCheckRoutingConfig;
   readonly parsed: ParsedConnectorDiagnosticRequest;
   readonly requestedEnvironmentName: string | undefined;

--- a/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-diagnostic-runtime.service.ts
@@ -1,4 +1,4 @@
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   FirewallBaseUrlResolutionError,
   hasUnsafeFirewallPath,
@@ -27,7 +27,7 @@ export interface ConnectorDiagnosticCatalogApi {
 }
 
 export interface ConnectorDiagnosticCatalogView {
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly label: string;
   readonly baseUrlVarNames: readonly string[];
   readonly apis: readonly ConnectorDiagnosticCatalogApi[];

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -7,9 +7,9 @@ import type {
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  type ConnectorCatalogAuthMethodId,
-  type ConnectorCatalogRef,
+  connectorAuthMethodIdSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   resolveConnectorAuthClient,
@@ -61,8 +61,8 @@ const COMPLETING_SESSION_STALE_AFTER_MS = 30 * 60 * 1000;
 type ExternalCodeSessionRow = typeof connectorExternalCodeSessions.$inferSelect;
 
 type ExternalCodeSessionOwner = {
-  readonly type: ConnectorCatalogRef;
-  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly type: ConnectorRef;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly orgId: string;
   readonly userId: string;
 };
@@ -96,8 +96,8 @@ const connectorExternalCodeDisabled = Object.freeze({
 function externalCodeResolutionError(
   resolution: Exclude<ConnectorActionMethodResolution, { readonly ok: true }>,
   args: {
-    readonly connectorRef: ConnectorCatalogRef;
-    readonly authMethodId: ConnectorCatalogAuthMethodId;
+    readonly connectorRef: ConnectorRef;
+    readonly authMethodId: ConnectorAuthMethodId;
   },
 ) {
   switch (resolution.reason) {
@@ -179,10 +179,10 @@ function resolveRequiredAuthClient(
 
 async function resolveStoredExternalCodeMethod(args: {
   readonly resolver: ConnectorActionResolver;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethodId: string;
 }) {
-  const storedAuthMethod = connectorCatalogAuthMethodIdSchema.safeParse(
+  const storedAuthMethod = connectorAuthMethodIdSchema.safeParse(
     args.authMethodId,
   );
   if (!storedAuthMethod.success) {
@@ -241,7 +241,7 @@ async function loadOwnedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly sessionId: string;
   readonly sessionToken: string;
   readonly signal: AbortSignal;
@@ -549,7 +549,7 @@ const authorizeExternalCodeSessionConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly session: ExternalCodeSessionRow;
-      readonly connectorType: ConnectorCatalogRef;
+      readonly connectorType: ConnectorRef;
     },
     signal: AbortSignal,
   ) => {
@@ -733,8 +733,8 @@ export const startConnectorExternalCodeSession$ = command(
       readonly userId: string;
       readonly agentId: string | undefined;
       readonly authorizeAgent: true | undefined;
-      readonly type: ConnectorCatalogRef;
-      readonly authMethod: ConnectorCatalogAuthMethodId;
+      readonly type: ConnectorRef;
+      readonly authMethod: ConnectorAuthMethodId;
     },
     signal: AbortSignal,
   ) => {
@@ -851,7 +851,7 @@ export const completeConnectorExternalCodeSession$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorCatalogRef;
+      readonly type: ConnectorRef;
       readonly sessionId: string;
       readonly sessionToken: string;
       readonly code: string;

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -8,6 +8,7 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   connectorAuthMethodIdSchema,
+  connectorRefSchema,
   type ConnectorAuthMethodId,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -78,8 +79,8 @@ type CompleteSuccess = {
 };
 
 const encryptedProviderStateSchema = z.object({
-  connectorType: z.string(),
-  authMethod: z.string(),
+  connectorType: connectorRefSchema,
+  authMethod: connectorAuthMethodIdSchema,
   providerState: z.string(),
 });
 

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -8,6 +8,7 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   connectorAuthMethodIdSchema,
+  connectorRefSchema,
   type ConnectorAuthMethodId,
   type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
@@ -108,7 +109,7 @@ function deviceAuthStartResponse(args: {
 const DEVICE_AUTH_POLL_STATE_MAX_BYTES = 4096;
 
 const encryptedProviderStateSchema = z.object({
-  connectorType: z.string(),
+  connectorType: connectorRefSchema,
   deviceCode: z.string(),
   pollState: z.string().optional(),
 });

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -7,9 +7,9 @@ import type {
   ConnectorOauthDeviceAuthSessionStartResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  type ConnectorCatalogAuthMethodId,
-  type ConnectorCatalogRef,
+  connectorAuthMethodIdSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   resolveConnectorAuthClient,
@@ -86,7 +86,7 @@ type PollSuccess = {
 function deviceAuthStartResponse(args: {
   readonly sessionId: string;
   readonly sessionToken: string;
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly startResult: Awaited<
     ReturnType<typeof startConnectorDeviceAuthorizationWithMethod>
   >;
@@ -147,8 +147,8 @@ type PollClaimedSessionArgs = ResolvedDeviceAuthClient & {
 };
 
 type DeviceAuthSessionOwner = {
-  readonly type: ConnectorCatalogRef;
-  readonly authMethod: ConnectorCatalogAuthMethodId;
+  readonly type: ConnectorRef;
+  readonly authMethod: ConnectorAuthMethodId;
   readonly orgId: string;
   readonly userId: string;
 };
@@ -166,8 +166,8 @@ const connectorOauthDeviceAuthDisabled = Object.freeze({
 function deviceAuthResolutionError(
   resolution: Exclude<ConnectorActionMethodResolution, { readonly ok: true }>,
   args: {
-    readonly connectorRef: ConnectorCatalogRef;
-    readonly authMethodId: ConnectorCatalogAuthMethodId;
+    readonly connectorRef: ConnectorRef;
+    readonly authMethodId: ConnectorAuthMethodId;
   },
 ) {
   switch (resolution.reason) {
@@ -307,8 +307,8 @@ function resolveRequiredAuthClient(
 
 async function resolveRequestedDeviceAuthMethod(args: {
   readonly resolver: ConnectorActionResolver;
-  readonly connectorRef: ConnectorCatalogRef;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly connectorRef: ConnectorRef;
+  readonly authMethodId: ConnectorAuthMethodId;
 }) {
   const resolved = await args.resolver.resolveNewActionMethod({
     connectorRef: args.connectorRef,
@@ -323,10 +323,10 @@ async function resolveRequestedDeviceAuthMethod(args: {
 
 async function resolveStoredDeviceAuthMethod(args: {
   readonly resolver: ConnectorActionResolver;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly authMethodId: string;
 }) {
-  const storedAuthMethod = connectorCatalogAuthMethodIdSchema.safeParse(
+  const storedAuthMethod = connectorAuthMethodIdSchema.safeParse(
     args.authMethodId,
   );
   if (!storedAuthMethod.success) {
@@ -417,7 +417,7 @@ async function loadOwnedSession(args: {
   readonly writeDb: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly sessionId: string;
   readonly sessionToken: string;
   readonly signal: AbortSignal;
@@ -519,7 +519,7 @@ async function claimSession(args: {
 
 async function parseEncryptedProviderState(args: {
   readonly session: DeviceAuthSessionRow;
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
 }): Promise<EncryptedProviderState> {
   const decrypted = await decryptPersistentSecretValue(
     args.session.encryptedProviderState,
@@ -727,7 +727,7 @@ const authorizeDeviceSessionConnector$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly session: DeviceAuthSessionRow;
-      readonly connectorType: ConnectorCatalogRef;
+      readonly connectorType: ConnectorRef;
     },
     signal: AbortSignal,
   ) => {
@@ -884,8 +884,8 @@ export const startConnectorOauthDeviceAuthSession$ = command(
       readonly userId: string;
       readonly agentId: string | undefined;
       readonly authorizeAgent: true | undefined;
-      readonly type: ConnectorCatalogRef;
-      readonly authMethod: ConnectorCatalogAuthMethodId;
+      readonly type: ConnectorRef;
+      readonly authMethod: ConnectorAuthMethodId;
       readonly options?: Readonly<Record<string, string>>;
     },
     signal: AbortSignal,
@@ -1017,7 +1017,7 @@ export const pollConnectorOauthDeviceAuthSession$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
-      readonly type: ConnectorCatalogRef;
+      readonly type: ConnectorRef;
       readonly sessionId: string;
       readonly sessionToken: string;
     },

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,4 +1,4 @@
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
@@ -21,7 +21,7 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: ConnectorCatalogRef;
+    readonly connectorType: ConnectorRef;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
@@ -55,7 +55,7 @@ export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorType: ConnectorCatalogRef;
+    readonly connectorType: ConnectorRef;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateClaimResult> {

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   connectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
@@ -48,7 +48,7 @@ type AcceptedServerFirewall =
   ConnectorCatalogPrivateFirewallsArtifact["connectors"][number];
 
 export interface ConnectorServerFirewallPermissionIndex {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly permissionNames: ReadonlySet<string>;
   readonly permissionDescriptions: ReadonlyMap<string, string>;
@@ -66,7 +66,7 @@ export interface ConnectorServerFirewallExecutionBaseUrlTemplate {
 }
 
 export interface ConnectorServerFirewallExecutionMetadata {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly billable: boolean;
   readonly baseUrlVarNames: readonly string[];
   readonly baseUrlTemplates: readonly ConnectorServerFirewallExecutionBaseUrlTemplate[];
@@ -75,24 +75,24 @@ export interface ConnectorServerFirewallExecutionMetadata {
 }
 
 export interface ConnectorServerFirewallRoutingIndexMetadata {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly apis: readonly FirewallRoutingIndexApiMetadata[];
 }
 
 export interface ConnectorServerFirewallRoutingMetadata {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly apis: readonly FirewallRoutingApiMetadata[];
 }
 
 export interface ConnectorServerFirewallHostOwner {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
 }
 
 interface ConnectorServerFirewallShadowItem {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly billable: boolean;
   readonly permissionCount: number;
@@ -108,7 +108,7 @@ interface ConnectorServerFirewallShadowItem {
 
 interface ConnectorServerFirewallShadowHostOwner {
   readonly host: string;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
 }
 
 export interface ConnectorServerFirewallShadowProjection {
@@ -117,7 +117,7 @@ export interface ConnectorServerFirewallShadowProjection {
 }
 
 export interface ConnectorServerFirewallCatalog {
-  readonly connectorRefs: readonly ConnectorCatalogRef[];
+  readonly connectorRefs: readonly ConnectorRef[];
   has(connectorRef: string): boolean;
   getExecutionMetadata(
     connectorRef: string,
@@ -488,7 +488,7 @@ function externalShadowItem(args: {
 }
 
 function staticPermissionIndex(
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
   index: NonNullable<Awaited<ReturnType<typeof loadFirewallPermissionIndex>>>,
 ): ConnectorServerFirewallPermissionIndex {
   return {
@@ -505,7 +505,7 @@ function staticPermissionIndex(
 }
 
 function staticExecutionMetadata(
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
 ): ConnectorServerFirewallExecutionMetadata | null {
   const metadata = getFirewallExecutionMetadata(connectorRef);
   if (!metadata) {
@@ -522,7 +522,7 @@ function staticExecutionMetadata(
 }
 
 function staticRoutingIndexMetadata(
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
 ): ConnectorServerFirewallRoutingIndexMetadata | null {
   const metadata = getFirewallRoutingIndexMetadata(connectorRef);
   if (!metadata) {
@@ -536,7 +536,7 @@ function staticRoutingIndexMetadata(
 }
 
 async function staticRoutingMetadata(
-  connectorRef: ConnectorCatalogRef,
+  connectorRef: ConnectorRef,
 ): Promise<ConnectorServerFirewallRoutingMetadata | null> {
   const metadata = await loadFirewallRoutingMetadata(connectorRef);
   if (!metadata) {
@@ -549,7 +549,7 @@ async function staticRoutingMetadata(
   };
 }
 
-function staticCompactMetadata(connectorRef: ConnectorCatalogRef): {
+function staticCompactMetadata(connectorRef: ConnectorRef): {
   readonly execution: ConnectorServerFirewallExecutionMetadata;
   readonly routing: ConnectorServerFirewallRoutingIndexMetadata;
   readonly summary: NonNullable<
@@ -571,10 +571,10 @@ function staticCompactMetadata(connectorRef: ConnectorCatalogRef): {
 }
 
 export function createStaticConnectorServerFirewallCatalog(
-  connectorRefs: readonly ConnectorCatalogRef[],
+  connectorRefs: readonly ConnectorRef[],
 ): ConnectorServerFirewallCatalog {
   const compactMetadata = new Map<
-    ConnectorCatalogRef,
+    ConnectorRef,
     NonNullable<ReturnType<typeof staticCompactMetadata>>
   >();
   for (const connectorRef of connectorRefs) {
@@ -687,10 +687,10 @@ function externalEntries(args: {
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
   readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
   readonly runtimeMethodsByRef: ReadonlyMap<
-    ConnectorCatalogRef,
+    ConnectorRef,
     readonly ConnectorAuthMethodRuntimeConfig[]
   >;
-}): ReadonlyMap<ConnectorCatalogRef, ExternalConnectorServerFirewallEntry> {
+}): ReadonlyMap<ConnectorRef, ExternalConnectorServerFirewallEntry> {
   const expectedRefs = args.publicArtifact.connectors
     .filter((connector) => {
       return connector.firewall.kind === "generated";
@@ -709,10 +709,7 @@ function externalEntries(args: {
       "Accepted connector server firewall identities are incomplete",
     );
   }
-  const entries = new Map<
-    ConnectorCatalogRef,
-    ExternalConnectorServerFirewallEntry
-  >();
+  const entries = new Map<ConnectorRef, ExternalConnectorServerFirewallEntry>();
   for (const firewall of args.privateFirewallsArtifact.connectors) {
     if (entries.has(firewall.connectorRef)) {
       throw new Error(
@@ -780,7 +777,7 @@ export function createExternalConnectorServerFirewallCatalog(args: {
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
   readonly privateFirewallsArtifact: ConnectorCatalogPrivateFirewallsArtifact;
   readonly runtimeMethodsByRef: ReadonlyMap<
-    ConnectorCatalogRef,
+    ConnectorRef,
     readonly ConnectorAuthMethodRuntimeConfig[]
   >;
 }): ConnectorServerFirewallCatalog {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -1,4 +1,4 @@
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
@@ -58,7 +58,7 @@ type NetworkInsightAction = "ALLOW" | "DENY" | "BLOCK";
 
 interface NetworkInsightRow {
   readonly runId: string;
-  readonly firewallName: ConnectorCatalogRef;
+  readonly firewallName: ConnectorRef;
   readonly firewallPermission: string;
   readonly action: NetworkInsightAction;
 }
@@ -261,7 +261,7 @@ interface CurrentOrgMemberScope {
 }
 
 type PermissionLabelResolver = (
-  firewallName: ConnectorCatalogRef,
+  firewallName: ConnectorRef,
   permissionName: string,
 ) => Promise<string>;
 

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -15,7 +15,7 @@ import {
   type ConnectorEnvReader,
 } from "@vm0/connectors/connector-utils";
 import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connectors";
-import type { ConnectorCatalogAuthMethodId } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorAuthMethodId } from "@vm0/api-contracts/contracts/connector-identity";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
@@ -58,7 +58,7 @@ interface GithubOAuthState {
   readonly sig: string | null;
 }
 
-export function getGithubOAuthAuthMethod(): ConnectorCatalogAuthMethodId {
+export function getGithubOAuthAuthMethod(): ConnectorAuthMethodId {
   return GITHUB_OAUTH_AUTH_METHOD;
 }
 
@@ -372,7 +372,7 @@ export async function buildGithubUserConnectAuthorizationUrl(args: {
   readonly vm0UserId: string;
   readonly orgId: string;
   readonly origin: string;
-  readonly authMethodId: ConnectorCatalogAuthMethodId;
+  readonly authMethodId: ConnectorAuthMethodId;
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly readEnv: ConnectorEnvReader;
   readonly signal: AbortSignal;

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, or } from "drizzle-orm";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import {
   orgCustomConnectors,
@@ -18,7 +18,7 @@ import type { Db } from "../external/db";
 type UpdateUserConnectorsResult =
   | {
       readonly status: "updated";
-      readonly enabledTypes: readonly ConnectorCatalogRef[];
+      readonly enabledTypes: readonly ConnectorRef[];
     }
   | { readonly status: "agentNotFound" };
 
@@ -438,7 +438,7 @@ export async function updateUserConnectors(
     readonly orgId: string;
     readonly userId: string;
     readonly agentId: string;
-    readonly enabledTypes: readonly ConnectorCatalogRef[];
+    readonly enabledTypes: readonly ConnectorRef[];
     readonly operation?: UserConnectorUpdateOperation;
     readonly allowMissingZeroAgentForEmptyReplace: boolean;
   },

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -1,4 +1,4 @@
-import { connectorCatalogRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
+import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   agentComposes,
   agentComposeVersions,
@@ -373,7 +373,7 @@ const revokeOrgConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorCatalogRefSchema.safeParse(row.type);
+      const parsed = connectorRefSchema.safeParse(row.type);
       if (!parsed.success) {
         L.warn("unknown connector type, skipping revocation", {
           orgId,
@@ -407,7 +407,7 @@ const revokeUserConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorCatalogRefSchema.safeParse(row.type);
+      const parsed = connectorRefSchema.safeParse(row.type);
       if (!parsed.success) {
         L.warn("unknown connector type, skipping revocation", {
           userId,

--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -2,8 +2,8 @@ import { computed, type Computed } from "ccstate";
 import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -166,8 +166,8 @@ export function zeroAgentEnabledConnectorTypes(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
-}): Computed<Promise<readonly ConnectorCatalogRef[]>> {
-  return computed(async (get): Promise<readonly ConnectorCatalogRef[]> => {
+}): Computed<Promise<readonly ConnectorRef[]>> {
+  return computed(async (get): Promise<readonly ConnectorRef[]> => {
     const rows = await get(db$)
       .select({ connectorType: userConnectors.connectorType })
       .from(userConnectors)
@@ -180,7 +180,7 @@ export function zeroAgentEnabledConnectorTypes(args: {
       );
 
     return rows.map((row) => {
-      return connectorCatalogRefSchema.parse(row.connectorType);
+      return connectorRefSchema.parse(row.connectorType);
     });
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunsMainContract } from "@vm0/api-contracts/contracts/zero-runs";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
@@ -806,7 +806,7 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerAgentId: string | undefined;
   readonly workflows: readonly RunWorkflowRef[];
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
+  readonly allowedConnectorTypes: readonly ConnectorRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
@@ -879,7 +879,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
   readonly zeroMailEnabled: boolean;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly workflows: readonly RunWorkflowRef[];
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
+  readonly allowedConnectorTypes: readonly ConnectorRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
@@ -934,7 +934,7 @@ interface ZeroRunAfterPreCreateBase {
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly workflows: readonly RunWorkflowRef[];
-  readonly allowedConnectorTypes: readonly ConnectorCatalogRef[];
+  readonly allowedConnectorTypes: readonly ConnectorRef[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -4,8 +4,8 @@ import type {
   ZeroWorkflowConnectorReadinessStatus,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { getAllFeatureStates } from "@vm0/core/feature-switch";
 import {
@@ -56,7 +56,7 @@ type DetectWorkflowConnectorReadinessResult =
     };
 
 interface AutomationConnectorDependency {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly reason: string;
 }
 
@@ -107,7 +107,7 @@ function automationConnectorDependency(
 
 const modelConnectorSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     reason: z.string().trim().min(1).max(280),
   })
   .strict();
@@ -133,7 +133,7 @@ async function loadAutomationConnectorDependencies(
     readonly userId: string;
     readonly workflowId: string;
   },
-): Promise<ReadonlyMap<ConnectorCatalogRef, AutomationConnectorDependency>> {
+): Promise<ReadonlyMap<ConnectorRef, AutomationConnectorDependency>> {
   const automations = await db
     .select({ eventType: zeroWorkflowAutomations.eventType })
     .from(zeroWorkflowAutomations)
@@ -145,10 +145,7 @@ async function loadAutomationConnectorDependencies(
       ),
     );
 
-  const dependencies = new Map<
-    ConnectorCatalogRef,
-    AutomationConnectorDependency
-  >();
+  const dependencies = new Map<ConnectorRef, AutomationConnectorDependency>();
   for (const automation of automations) {
     if (!automation.eventType) {
       continue;
@@ -162,7 +159,7 @@ async function loadAutomationConnectorDependencies(
 }
 
 interface ModelCatalogEntry {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly description: string;
 }
@@ -171,7 +168,7 @@ async function detectModelConnectorDependencies(args: {
   readonly workflow: WorkflowConnectorReadinessInput;
   readonly catalog: readonly ModelCatalogEntry[];
   readonly signal: AbortSignal;
-}): Promise<ReadonlyMap<ConnectorCatalogRef, string>> {
+}): Promise<ReadonlyMap<ConnectorRef, string>> {
   const signal = AbortSignal.any([
     args.signal,
     AbortSignal.timeout(CONNECTOR_READINESS_TIMEOUT_MS),
@@ -215,7 +212,7 @@ async function detectModelConnectorDependencies(args: {
       return entry.connectorRef;
     }),
   );
-  const dependencies = new Map<ConnectorCatalogRef, string>();
+  const dependencies = new Map<ConnectorRef, string>();
   for (const connector of modelResult.connectors) {
     if (!catalogRefs.has(connector.connectorRef)) {
       throw new Error(
@@ -329,12 +326,10 @@ export const detectWorkflowConnectorReadiness$ = command(
         return [connector.connectorRef, connector];
       }),
     );
-    const enabledForAgent = new Set<ConnectorCatalogRef>(
+    const enabledForAgent = new Set<ConnectorRef>(
       agentScope.allowedConnectorTypes,
     );
-    const mergedDependencies = new Map<ConnectorCatalogRef, string>(
-      modelDependencies,
-    );
+    const mergedDependencies = new Map<ConnectorRef, string>(modelDependencies);
     for (const dependency of automationDependencies.values()) {
       mergedDependencies.set(dependency.connectorRef, dependency.reason);
     }

--- a/turbo/apps/cli/src/commands/zero/connector/check.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/check.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from "commander";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   ConnectorCheckDiagnosticResult,
   ConnectorCheckPolicy,
@@ -58,7 +58,7 @@ type UrlDiagnosticRequest = Extract<
 
 interface DiagContext {
   readonly environmentNames: readonly string[] | null;
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly connectorAvailable: boolean;
   readonly credentialResolution: "network-boundary" | "none";

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -1,7 +1,7 @@
 import { initClient } from "@vm0/api-contracts/contracts/trpc-contract";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   zeroConnectorManualGrantContract,
@@ -124,7 +124,7 @@ export async function diagnoseZeroConnectorCheck(
  * Returns null if not connected (404 response)
  */
 export async function getZeroConnector(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
 ): Promise<ConnectorResponse | null> {
   const config = await getClientConfig();
   const client = initClient(zeroConnectorsByTypeContract, config);
@@ -145,8 +145,8 @@ export async function getZeroConnector(
 }
 
 export async function connectZeroConnectorManualGrant(
-  type: ConnectorCatalogRef,
-  authMethod: ConnectorCatalogAuthMethodId,
+  type: ConnectorRef,
+  authMethod: ConnectorAuthMethodId,
   values: Record<string, string>,
 ): Promise<ConnectorResponse> {
   const config = await getClientConfig();

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -3,8 +3,8 @@ import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorAuthMethodConfig,
-  connectorAuthMethodIdSchema,
-  type ConnectorAuthMethodId,
+  connectorRegistryAuthMethodIdSchema,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import type {
@@ -26,8 +26,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isConnectorAuthMethodId(
   value: unknown,
-): value is ConnectorAuthMethodId {
-  return connectorAuthMethodIdSchema.safeParse(value).success;
+): value is ConnectorRegistryAuthMethodId {
+  return connectorRegistryAuthMethodIdSchema.safeParse(value).success;
 }
 
 function defaultPermissionSummary() {
@@ -158,7 +158,9 @@ function defaultPublicCatalogStatus() {
   });
 }
 
-function manualGrantAuthMethodFromBody(body: unknown): ConnectorAuthMethodId {
+function manualGrantAuthMethodFromBody(
+  body: unknown,
+): ConnectorRegistryAuthMethodId {
   if (isRecord(body) && isConnectorAuthMethodId(body.authMethod)) {
     return body.authMethod;
   }
@@ -167,7 +169,7 @@ function manualGrantAuthMethodFromBody(body: unknown): ConnectorAuthMethodId {
 
 function connectorManualGrantResponse(
   type: string,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: ConnectorRegistryAuthMethodId,
 ) {
   return {
     id: "00000000-0000-4000-8000-000000000001",

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,14 +1,14 @@
 import {
   CONNECTOR_TYPE_KEYS,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorType,
   CONNECTOR_TYPES,
   connectorDisplayCategoryMetadataForItems,
 } from "@vm0/connectors/connectors";
 import type {
-  ConnectorCatalogAuthMethodId,
-  ConnectorCatalogRef,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   ConnectorExternalCodeSessionStartResponse,
@@ -73,7 +73,7 @@ let mockExternalCodeSessionStartResponse:
   | undefined;
 
 function createMockOauthDeviceAuthConnector(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
 ): ConnectorResponse {
   const now = "2026-01-01T00:00:00Z";
   return {
@@ -93,7 +93,7 @@ function createMockOauthDeviceAuthConnector(
 }
 
 function defaultOauthDeviceAuthSessionStartResponse(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
 ): ConnectorOauthDeviceAuthSessionStartResponse {
   return {
     sessionId: "00000000-0000-4000-8000-000000000001",
@@ -109,8 +109,8 @@ function defaultOauthDeviceAuthSessionStartResponse(
 }
 
 function createMockLocalGrantConnector(
-  type: ConnectorCatalogRef,
-  authMethod: ConnectorCatalogAuthMethodId,
+  type: ConnectorRef,
+  authMethod: ConnectorAuthMethodId,
 ): ConnectorResponse {
   return {
     id: crypto.randomUUID(),
@@ -129,8 +129,8 @@ function createMockLocalGrantConnector(
 }
 
 function createMockExternalCodeConnector(
-  type: ConnectorCatalogRef,
-  authMethod: ConnectorCatalogAuthMethodId,
+  type: ConnectorRef,
+  authMethod: ConnectorAuthMethodId,
 ): ConnectorResponse {
   const now = "2026-01-01T00:00:00.000Z";
   return {
@@ -150,7 +150,7 @@ function createMockExternalCodeConnector(
 }
 
 function defaultExternalCodeSessionStartResponse(
-  type: ConnectorCatalogRef,
+  type: ConnectorRef,
 ): ConnectorExternalCodeSessionStartResponse {
   return {
     sessionId: "00000000-0000-4000-8000-000000000002",
@@ -283,8 +283,8 @@ function mockConnectionForCatalogStatus(
 
 function mockSingleAuthCodeAuthMethodId(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
-): ConnectorAuthMethodId | null {
+  authMethods: readonly ConnectorRegistryAuthMethodId[],
+): ConnectorRegistryAuthMethodId | null {
   const [authMethod] = authMethods;
   if (authMethods.length !== 1 || !authMethod) {
     return null;
@@ -343,7 +343,7 @@ function mockStartOptionsForCatalog(
 
 function mockConnectorCatalogStatusItem(
   type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
+  authMethods: readonly ConnectorRegistryAuthMethodId[],
   connector: ConnectorResponse | null,
 ): PublicConnectorCatalogStatusItem {
   const config = CONNECTOR_TYPES[type];

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { customConnectorProposalSchema } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
@@ -33,7 +33,7 @@ import {
 } from "./card-signal-map.ts";
 
 export interface ConnectorActionDescriptor {
-  connectorRef: ConnectorCatalogRef;
+  connectorRef: ConnectorRef;
   agentId: string;
   originalUrl: string;
   callbackPrompt: ChatActionCallback["callbackPrompt"];
@@ -98,7 +98,7 @@ export function parseConnectorAuthorizeUrl(
   );
   const connectorRef = match?.[1]?.toLowerCase();
   const agentId = url.searchParams.get("agentId");
-  const parsedConnectorRef = connectorCatalogRefSchema.safeParse(connectorRef);
+  const parsedConnectorRef = connectorRefSchema.safeParse(connectorRef);
   if (!parsedConnectorRef.success || !agentId) {
     return null;
   }

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -1,6 +1,6 @@
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { command } from "ccstate";
 import { createElement } from "react";
@@ -11,10 +11,8 @@ import { updatePage$ } from "../react-router.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import type { ConnectorRedirectingStatus } from "./connector-redirecting.ts";
 
-function connectorTypeFromPath(
-  value: string | undefined,
-): ConnectorCatalogRef | null {
-  const parsed = connectorCatalogRefSchema.safeParse(value?.toLowerCase());
+function connectorTypeFromPath(value: string | undefined): ConnectorRef | null {
+  const parsed = connectorRefSchema.safeParse(value?.toLowerCase());
   return parsed.success ? parsed.data : null;
 }
 

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -1,11 +1,11 @@
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { generateRouterPath } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 
 export type ConnectorRedirectingStatus = "redirecting" | "error";
 
 export function connectorRedirectingPath(args: {
-  readonly type: ConnectorCatalogRef;
+  readonly type: ConnectorRef;
   readonly label: string;
   readonly status?: ConnectorRedirectingStatus;
 }): string {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -1,7 +1,7 @@
 import { command, computed, state } from "ccstate";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
@@ -20,7 +20,7 @@ import {
 export const directedAuthorizeType$ = computed((get): string | null => {
   const params = get(pathParams$);
   const type = params?.type;
-  const parsed = connectorCatalogRefSchema.safeParse(
+  const parsed = connectorRefSchema.safeParse(
     typeof type === "string" ? type.toLowerCase() : null,
   );
   return parsed.success ? parsed.data : null;
@@ -57,7 +57,7 @@ export const agentEnabledTypes$ = computed(async (get) => {
 });
 
 export type DirectedAuthorizeConnectModalKey = {
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string;
   readonly signal: AbortSignal;
 };
@@ -74,7 +74,7 @@ export const setDirectedAuthorizeConnectModalKey$ = command(
 );
 
 function connectorAgentAuthorizationKey(args: {
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string;
 }): string {
   return `${args.agentId}:${args.connectorType}`;
@@ -91,7 +91,7 @@ export const justAuthorizedConnectorAgentKeys$ = computed((get) => {
 export const authorizeConnector$ = command(
   async (
     { get, set },
-    connectorType: ConnectorCatalogRef,
+    connectorType: ConnectorRef,
     agentId: string,
     signal: AbortSignal,
   ) => {
@@ -126,7 +126,7 @@ export const authorizeConnector$ = command(
 export function isJustAuthorizedConnectorAgent(
   justAuthorizedKeys: ReadonlySet<string>,
   args: {
-    readonly connectorType: ConnectorCatalogRef;
+    readonly connectorType: ConnectorRef;
     readonly agentId: string;
   },
 ): boolean {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -1,7 +1,7 @@
 import { command, computed, state } from "ccstate";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogRef,
+  connectorRefSchema,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
@@ -12,7 +12,7 @@ import { agents$ } from "../agent.ts";
 export const directedConnectType$ = computed((get): string | null => {
   const params = get(pathParams$);
   const type = params?.type;
-  const parsed = connectorCatalogRefSchema.safeParse(
+  const parsed = connectorRefSchema.safeParse(
     typeof type === "string" ? type.toLowerCase() : null,
   );
   return parsed.success ? parsed.data : null;
@@ -40,13 +40,13 @@ export const directedConnectAgentName$ = computed(async (get) => {
 });
 
 export type DirectedConnectManualGrantDialogKey = {
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string | null;
   readonly signal: AbortSignal;
 };
 
 export type DirectedConnectModalKey = {
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string | null;
   readonly signal: AbortSignal;
 };

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -9,14 +9,14 @@ import {
   type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
 import { featureSwitch$ } from "./feature-switch.ts";
 
 export interface ConnectorCatalogDisplayMetadata {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly helpText: string;
   readonly icon: PublicConnectorCatalogIcon;
@@ -103,7 +103,7 @@ export const reloadConnectors$ = command(({ set }) => {
  * Delete a connector by type.
  */
 export const deleteConnector$ = command(
-  async ({ get, set }, type: ConnectorCatalogRef, _signal: AbortSignal) => {
+  async ({ get, set }, type: ConnectorRef, _signal: AbortSignal) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroConnectorsByTypeContract);
     await accept(

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -1,9 +1,9 @@
 import { computed, type Computed } from "ccstate";
+import { CONNECTOR_CATALOG_REF_MAX_LENGTH } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { CONNECTOR_REF_MAX_LENGTH } from "@vm0/api-contracts/contracts/connector-ref";
 import { accept } from "../lib/accept.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { connectorsReloadVersion$ } from "./external/connectors.ts";
@@ -18,7 +18,7 @@ export function firewallPermissionMetadataByConnector(
 ): Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
   const key = params.connectorRef;
   return computed(async (get) => {
-    if (key.length === 0 || key.length > CONNECTOR_REF_MAX_LENGTH) {
+    if (key.length === 0 || key.length > CONNECTOR_CATALOG_REF_MAX_LENGTH) {
       return null;
     }
     get(connectorsReloadVersion$);

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -1,5 +1,5 @@
 import { computed, type Computed } from "ccstate";
-import { CONNECTOR_CATALOG_REF_MAX_LENGTH } from "@vm0/api-contracts/contracts/connector-identity";
+import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
@@ -18,7 +18,7 @@ export function firewallPermissionMetadataByConnector(
 ): Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
   const key = params.connectorRef;
   return computed(async (get) => {
-    if (key.length === 0 || key.length > CONNECTOR_CATALOG_REF_MAX_LENGTH) {
+    if (!connectorRefSchema.safeParse(key).success) {
       return null;
     }
     get(connectorsReloadVersion$);

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -1,12 +1,12 @@
 import { command, computed, state, type Computed } from "ccstate";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 
 export interface AgentConnectorAuthorizations {
   readonly agentId: string;
-  readonly enabledTypes: readonly ConnectorCatalogRef[];
+  readonly enabledTypes: readonly ConnectorRef[];
 }
 
 const internalAgentConnectorAuthorizationsReload$ = state(0);
@@ -68,7 +68,7 @@ export function agentConnectorAuthorizations(params: {
 
 export function isAgentConnectorAuthorized(params: {
   readonly agentId: string;
-  readonly connectorType: ConnectorCatalogRef;
+  readonly connectorType: ConnectorRef;
 }): Computed<Promise<boolean>> {
   return computed(async (get): Promise<boolean> => {
     const authorizations = await get(

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -22,16 +22,16 @@ export interface ConnectorAgentAccessRow {
 
 interface ConnectorAgentAuthorizationRow {
   readonly agent: TeamComposeItem;
-  readonly enabledTypes: readonly ConnectorType[];
+  readonly enabledTypes: readonly ConnectorRef[];
 }
 
 interface SetConnectorAgentAuthorizationParams {
   readonly agentId: string;
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly authorized: boolean;
 }
 
-const managedConnectorAccessTypeState$ = state<ConnectorType | null>(null);
+const managedConnectorAccessTypeState$ = state<ConnectorRef | null>(null);
 const connectorAccessManagementSearchState$ = state("");
 const connectorAccessManagementSavingAgentIdState$ = state<string | null>(null);
 const connectorAccessManagementPermissionAgentIdState$ = state<string | null>(
@@ -55,7 +55,7 @@ export const connectorAccessManagementPermissionAgentId$ = computed((get) => {
 });
 
 export const setManagedConnectorAccessType$ = command(
-  ({ set }, connectorType: ConnectorType | null) => {
+  ({ set }, connectorType: ConnectorRef | null) => {
     set(managedConnectorAccessTypeState$, connectorType);
   },
 );
@@ -116,9 +116,9 @@ export const connectorAgentAuthorizations$ = computed(
 export const connectorAuthorizedAgentsByType$ = computed(
   async (
     get,
-  ): Promise<ReadonlyMap<ConnectorType, readonly TeamComposeItem[]>> => {
+  ): Promise<ReadonlyMap<ConnectorRef, readonly TeamComposeItem[]>> => {
     const authorizations = await get(connectorAgentAuthorizations$);
-    const agentsByType = new Map<ConnectorType, TeamComposeItem[]>();
+    const agentsByType = new Map<ConnectorRef, TeamComposeItem[]>();
     for (const row of authorizations) {
       for (const connectorType of row.enabledTypes) {
         const agents = agentsByType.get(connectorType) ?? [];

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -6,9 +6,9 @@ import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  type ConnectorCatalogAuthMethodId,
-  type ConnectorCatalogRef,
+  connectorAuthMethodIdSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   zeroConnectorScopeDiffContract,
@@ -66,8 +66,6 @@ import { IN_VITEST } from "../../../env.ts";
 import { connectorRedirectingPath } from "../../connectors-page/connector-redirecting.ts";
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
-type ConnectorType = ConnectorCatalogRef;
-type ConnectorAuthMethodId = ConnectorCatalogAuthMethodId;
 
 const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
@@ -90,7 +88,7 @@ export type ConnectorConnectionStatus =
  * Uses server-authored public catalog/status data.
  */
 export interface ConnectorTypeWithStatus {
-  type: ConnectorType;
+  type: ConnectorRef;
   label: string;
   helpText: string;
   icon: PublicConnectorCatalogIcon;
@@ -287,7 +285,7 @@ export function getAvailableStatusAuthCodeAuthMethod(
   connector: ConnectorTypeWithStatus,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
-  const parsed = connectorCatalogAuthMethodIdSchema.safeParse(authMethod);
+  const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
   if (!parsed.success) {
     return null;
   }
@@ -316,7 +314,7 @@ export function getAvailableStatusBrowserAuthMethod(
   connector: ConnectorTypeWithStatus,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
-  const parsed = connectorCatalogAuthMethodIdSchema.safeParse(authMethod);
+  const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
   if (!parsed.success) {
     return null;
   }
@@ -354,7 +352,7 @@ export function getAvailableStatusNoAuthMethod(
   connector: ConnectorTypeWithStatus,
   authMethod: string,
 ): ConnectorAuthMethodId | null {
-  const parsed = connectorCatalogAuthMethodIdSchema.safeParse(authMethod);
+  const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
   if (!parsed.success) {
     return null;
   }
@@ -525,12 +523,12 @@ export const allConnectorTypes$ = computed(async (get) => {
 // Hidden connector types (removed from list by user; persisted in localStorage)
 // ---------------------------------------------------------------------------
 
-const hiddenConnectorTypes$ = computed((get): Set<ConnectorType> => {
+const hiddenConnectorTypes$ = computed((get): Set<ConnectorRef> => {
   const raw = get(hiddenConnectorTypesRaw$);
   if (!raw) {
     return new Set();
   }
-  return new Set(jsonParseOr<ConnectorType[]>(raw, []));
+  return new Set(jsonParseOr<ConnectorRef[]>(raw, []));
 });
 
 // ---------------------------------------------------------------------------
@@ -634,10 +632,10 @@ export const setConnectorsConnectionFilter$ = command(
 // Selected connector for connect modal
 // ---------------------------------------------------------------------------
 
-const internalSelectedConnectorType$ = state<ConnectorType | null>(null);
+const internalSelectedConnectorType$ = state<ConnectorRef | null>(null);
 
 type ActiveConnectorOAuthDeviceAuthState = {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly sessionId: string;
@@ -652,7 +650,7 @@ type ActiveConnectorOAuthDeviceAuthState = {
 };
 
 type ActiveConnectorExternalCodeState = {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly sessionId: string;
@@ -666,11 +664,11 @@ type ActiveConnectorExternalCodeState = {
 export type ConnectorOAuthDeviceAuthState =
   | {
       readonly status: "idle";
-      readonly connectorType: ConnectorType | null;
+      readonly connectorType: ConnectorRef | null;
     }
   | {
       readonly status: "starting";
-      readonly connectorType: ConnectorType;
+      readonly connectorType: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly requestId: string;
     }
@@ -679,7 +677,7 @@ export type ConnectorOAuthDeviceAuthState =
     })
   | {
       readonly status: "denied" | "expired" | "error";
-      readonly connectorType: ConnectorType;
+      readonly connectorType: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly message: string;
     };
@@ -687,11 +685,11 @@ export type ConnectorOAuthDeviceAuthState =
 export type ConnectorExternalCodeState =
   | {
       readonly status: "idle";
-      readonly connectorType: ConnectorType | null;
+      readonly connectorType: ConnectorRef | null;
     }
   | {
       readonly status: "starting";
-      readonly connectorType: ConnectorType;
+      readonly connectorType: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly requestId: string;
     }
@@ -700,18 +698,18 @@ export type ConnectorExternalCodeState =
     })
   | {
       readonly status: "expired" | "error";
-      readonly connectorType: ConnectorType;
+      readonly connectorType: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly message: string;
     };
 
 type ConnectorConnectFlowState = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly id: string;
 };
 
 function createIdleConnectorOAuthDeviceAuthState(
-  connectorType: ConnectorType | null = null,
+  connectorType: ConnectorRef | null = null,
 ): ConnectorOAuthDeviceAuthState {
   return { status: "idle", connectorType };
 }
@@ -722,7 +720,7 @@ const internalConnectorOAuthDeviceAuthState$ =
   );
 
 function createIdleConnectorExternalCodeState(
-  connectorType: ConnectorType | null = null,
+  connectorType: ConnectorRef | null = null,
 ): ConnectorExternalCodeState {
   return { status: "idle", connectorType };
 }
@@ -740,7 +738,7 @@ export const selectedConnectorType$ = computed((get) => {
   return get(internalSelectedConnectorType$);
 });
 export const setSelectedConnectorType$ = command(
-  ({ get, set }, type: ConnectorType | null) => {
+  ({ get, set }, type: ConnectorRef | null) => {
     set(internalSelectedConnectorType$, type);
     const deviceAuthCurrent = get(internalConnectorOAuthDeviceAuthState$);
     if (type !== deviceAuthCurrent.connectorType) {
@@ -791,7 +789,7 @@ function connectorConnectOperationIsActive({
   deviceAuthState,
   externalCodeState,
 }: {
-  readonly authCodeConnectorType: ConnectorType | null;
+  readonly authCodeConnectorType: ConnectorRef | null;
   readonly connectFlow: ConnectorConnectFlowState | null;
   readonly deviceAuthState: ConnectorOAuthDeviceAuthState;
   readonly externalCodeState: ConnectorExternalCodeState;
@@ -805,7 +803,7 @@ function connectorConnectOperationIsActive({
 }
 
 function connectorOAuthDeviceAuthStartOptionsKey(
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): string {
   return `${type}:${authMethod}`;
@@ -813,7 +811,7 @@ function connectorOAuthDeviceAuthStartOptionsKey(
 
 export const connectorOAuthDeviceAuthStartOptionValuesFor$ = computed((get) => {
   const values = get(connectorOAuthDeviceAuthStartOptionValues$);
-  return (type: ConnectorType, authMethod: ConnectorAuthMethodId) => {
+  return (type: ConnectorRef, authMethod: ConnectorAuthMethodId) => {
     return (
       values[connectorOAuthDeviceAuthStartOptionsKey(type, authMethod)] ?? {}
     );
@@ -824,7 +822,7 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
   (
     { get, set },
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly name: string;
       readonly value: string;
@@ -849,7 +847,7 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
-const internalScopeReviewType$ = state<ConnectorType | null>(null);
+const internalScopeReviewType$ = state<ConnectorRef | null>(null);
 export const scopeReviewType$ = computed((get) => {
   return get(internalScopeReviewType$);
 });
@@ -866,7 +864,7 @@ export const scopeDiff$ = computed(async (get) => {
 });
 
 export const setScopeReviewType$ = command(
-  ({ set }, type: ConnectorType | null) => {
+  ({ set }, type: ConnectorRef | null) => {
     set(internalScopeReviewType$, type);
   },
 );
@@ -922,7 +920,7 @@ type FinishConnectorConnectionOptions = PostConnectOptions & {
 const finishConnectorConnection$ = command(
   (
     { get, set },
-    type: ConnectorType,
+    type: ConnectorRef,
     options: FinishConnectorConnectionOptions = {},
   ): boolean => {
     set(internalJustConnectedTypes$, (prev) => {
@@ -959,7 +957,7 @@ const finishConnectorConnection$ = command(
 // ---------------------------------------------------------------------------
 
 type SubmitManualGrantParams = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly inputValues: Record<string, string>;
   readonly options: PostConnectOptions;
@@ -1028,7 +1026,7 @@ export const submitManualGrant$ = command(
 // ---------------------------------------------------------------------------
 
 type ConnectNoAuthParams = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
 };
@@ -1110,7 +1108,7 @@ export const connectConnectorNoAuthAndSettle$ = command(
 // Polling state (for connect flow)
 // ---------------------------------------------------------------------------
 
-const internalPollingOAuthAuthCodeConnectorType$ = state<ConnectorType | null>(
+const internalPollingOAuthAuthCodeConnectorType$ = state<ConnectorRef | null>(
   null,
 );
 const internalConnectFlowState$ = state<ConnectorConnectFlowState | null>(null);
@@ -1133,7 +1131,7 @@ export const connectFlowType$ = computed((get) => {
 export const runConnectorConnectSuccess$ = command(
   async (
     { set },
-    type: ConnectorType,
+    type: ConnectorRef,
     onSuccess: () => void | Promise<void>,
     signal: AbortSignal,
   ): Promise<void> => {
@@ -1177,7 +1175,7 @@ export const justConnectedTypes$ = computed((get) => {
 export const disconnectConnector$ = command(
   async (
     { set },
-    type: ConnectorType,
+    type: ConnectorRef,
     connectorLabel: string,
     signal: AbortSignal,
   ): Promise<void> => {
@@ -1198,7 +1196,7 @@ export const disconnectConnector$ = command(
 );
 
 function createConnectorConnectFlowState(
-  type: ConnectorType,
+  type: ConnectorRef,
 ): ConnectorConnectFlowState {
   return {
     type,
@@ -1217,7 +1215,7 @@ function secondsToMilliseconds(value: number): number {
 const OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS = IN_VITEST ? 10 : 1000;
 
 type PollConnectorOAuthDeviceAuthArgs = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly requestId: string;
   readonly createClient: ZeroClientFactory;
@@ -1225,7 +1223,7 @@ type PollConnectorOAuthDeviceAuthArgs = {
 };
 
 type ConnectConnectorOAuthDeviceAuthParams = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
   readonly startOptions?: ConnectorDeviceAuthStartOptions;
@@ -1263,7 +1261,7 @@ type PollConnectorOAuthDeviceAuthIterationOutcome = {
   readonly expired?: true;
 };
 
-function createConnectorOAuthDeviceAuthRequestId(type: ConnectorType): string {
+function createConnectorOAuthDeviceAuthRequestId(type: ConnectorRef): string {
   return `${type}-oauth-device-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
@@ -1291,7 +1289,7 @@ function getOAuthDeviceAuthTerminalMessage(
 
 function isCurrentConnectorOAuthDeviceAuthRequest(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   requestId: string,
 ): state is ActiveConnectorOAuthDeviceAuthState & {
@@ -1316,7 +1314,7 @@ export const clearConnectorOAuthDeviceAuth$ = command(({ set }) => {
 export const openConnectorOAuthDeviceAuthVerificationPage$ = command(
   (
     { get, set },
-    type: ConnectorType,
+    type: ConnectorRef,
     authMethod: ConnectorAuthMethodId,
   ): boolean => {
     const current = get(internalConnectorOAuthDeviceAuthState$);
@@ -1662,7 +1660,7 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
   async (
     { set },
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly onSuccess: () => void | Promise<void>;
       readonly options: PostConnectOptions;
@@ -1692,24 +1690,24 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
 // ---------------------------------------------------------------------------
 
 type ConnectConnectorExternalCodeParams = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly agentId?: string;
 };
 
 type CompleteConnectorExternalCodeParams = {
-  readonly type: ConnectorType;
+  readonly type: ConnectorRef;
   readonly authMethod: ConnectorAuthMethodId;
   readonly options: PostConnectOptions;
 };
 
-function createConnectorExternalCodeRequestId(type: ConnectorType): string {
+function createConnectorExternalCodeRequestId(type: ConnectorRef): string {
   return `${type}-external-code-${now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function isCurrentConnectorExternalCodeRequest(
   state: ConnectorExternalCodeState,
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   requestId: string,
 ): state is ActiveConnectorExternalCodeState & {
@@ -1735,7 +1733,7 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
   (
     { get, set },
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly code: string;
     },
@@ -1760,7 +1758,7 @@ export const setConnectorExternalCodeAuthorizationCode$ = command(
 export const openConnectorExternalCodeAuthorizationPage$ = command(
   (
     { get, set },
-    type: ConnectorType,
+    type: ConnectorRef,
     authMethod: ConnectorAuthMethodId,
   ): boolean => {
     const current = get(internalConnectorExternalCodeState$);
@@ -2070,14 +2068,14 @@ const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 
 function connectorMatchesAuthMethod(
   connector: ConnectorResponse,
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): boolean {
   return connector.type === type && connector.authMethod === authMethod;
 }
 
 function createConnectorOAuthAuthCodeChangedCommand(
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   agentId: string | undefined,
 ) {
@@ -2130,7 +2128,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
   async (
     { get },
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly method: ConnectorStatusAuthMethodDetail;
       readonly connectorLabel: string;
       readonly agentId: string | undefined;
@@ -2230,7 +2228,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
 export const connectConnectorOAuthAuthCode$ = command(
   async (
     { get, set },
-    type: ConnectorType,
+    type: ConnectorRef,
     method: ConnectorStatusAuthMethodDetail,
     options: PostConnectOptions,
     signal: AbortSignal,
@@ -2372,7 +2370,7 @@ export const connectConnectorOAuthAuthCodeAndSettle$ = command(
   async (
     { set },
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly method: ConnectorStatusAuthMethodDetail;
       readonly onSuccess: () => void | Promise<void>;
       readonly options: PostConnectOptions;

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -1,5 +1,5 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
@@ -16,36 +16,36 @@ import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 
 export interface ComposerConnectorSignals {
   readonly agentId$: Computed<Promise<string | null>>;
-  readonly authorizedConnectors$: Computed<Promise<readonly ConnectorType[]>>;
+  readonly authorizedConnectors$: Computed<Promise<readonly ConnectorRef[]>>;
   readonly authorizeConnector$: Command<
     Promise<void>,
-    [ConnectorType, AbortSignal]
+    [ConnectorRef, AbortSignal]
   >;
   readonly deauthorizeConnector$: Command<
     Promise<void>,
-    [ConnectorType, AbortSignal]
+    [ConnectorRef, AbortSignal]
   >;
   readonly showAddDialog$: Computed<boolean>;
   readonly setShowAddDialog$: Command<void, [boolean]>;
-  readonly pendingConnectType$: Computed<ConnectorType | null>;
-  readonly setPendingConnectType$: Command<void, [ConnectorType | null]>;
-  readonly selectedConnectType$: Computed<ConnectorType | null>;
-  readonly setSelectedConnectType$: Command<void, [ConnectorType | null]>;
-  readonly savingType$: Computed<ConnectorType | null>;
-  readonly setSavingType$: Command<void, [ConnectorType | null]>;
+  readonly pendingConnectType$: Computed<ConnectorRef | null>;
+  readonly setPendingConnectType$: Command<void, [ConnectorRef | null]>;
+  readonly selectedConnectType$: Computed<ConnectorRef | null>;
+  readonly setSelectedConnectType$: Command<void, [ConnectorRef | null]>;
+  readonly savingType$: Computed<ConnectorRef | null>;
+  readonly setSavingType$: Command<void, [ConnectorRef | null]>;
   readonly addDialogSearch$: Computed<string>;
   readonly setAddDialogSearch$: Command<void, [string]>;
   readonly popoverSearch$: Computed<string>;
   readonly setPopoverSearch$: Command<void, [string]>;
-  readonly popoverSortOrder$: Computed<readonly ConnectorType[] | null>;
+  readonly popoverSortOrder$: Computed<readonly ConnectorRef[] | null>;
   readonly setPopoverSortOrder$: Command<
     void,
-    [readonly ConnectorType[] | null]
+    [readonly ConnectorRef[] | null]
   >;
   readonly computerUseDownloadDialogOpen$: Computed<boolean>;
   readonly setComputerUseDownloadDialogOpen$: Command<void, [boolean]>;
-  readonly permissionConnector$: Computed<ConnectorType | null>;
-  readonly setPermissionConnector$: Command<void, [ConnectorType | null]>;
+  readonly permissionConnector$: Computed<ConnectorRef | null>;
+  readonly setPermissionConnector$: Command<void, [ConnectorRef | null]>;
   readonly permissionMetadata$: Computed<
     Promise<PublicConnectorCatalogPermissionDetail | null>
   >;
@@ -68,14 +68,14 @@ function createStateBinding<T>(initialValue: T) {
 
 interface ComposerConnectorUiState {
   readonly showAddDialog: boolean;
-  readonly pendingConnectType: ConnectorType | null;
-  readonly selectedConnectType: ConnectorType | null;
-  readonly savingType: ConnectorType | null;
+  readonly pendingConnectType: ConnectorRef | null;
+  readonly selectedConnectType: ConnectorRef | null;
+  readonly savingType: ConnectorRef | null;
   readonly addDialogSearch: string;
   readonly popoverSearch: string;
-  readonly popoverSortOrder: readonly ConnectorType[] | null;
+  readonly popoverSortOrder: readonly ConnectorRef[] | null;
   readonly computerUseDownloadDialogOpen: boolean;
-  readonly permissionConnector: ConnectorType | null;
+  readonly permissionConnector: ConnectorRef | null;
 }
 
 function initialComposerConnectorUiState(): ComposerConnectorUiState {
@@ -101,7 +101,7 @@ function createConnectorAuthorizationSignals(
   agentId$: Computed<Promise<string | null>>,
 ): ConnectorAuthorizationSignals {
   const authorizedConnectors$ = computed(
-    async (get): Promise<readonly ConnectorType[]> => {
+    async (get): Promise<readonly ConnectorRef[]> => {
       const agentId = await get(agentId$);
       if (!agentId) {
         return [];
@@ -117,7 +117,7 @@ function createConnectorAuthorizationSignals(
     async (
       { get, set },
       operation: "add" | "remove",
-      connectorType: ConnectorType,
+      connectorType: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
       const agentId = await get(agentId$);
@@ -150,7 +150,7 @@ function createConnectorAuthorizationSignals(
   const authorizeConnector$ = command(
     async (
       { set },
-      connectorType: ConnectorType,
+      connectorType: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
       await set(updateAuthorizedConnectors$, "add", connectorType, signal);
@@ -160,7 +160,7 @@ function createConnectorAuthorizationSignals(
   const deauthorizeConnector$ = command(
     async (
       { set },
-      connectorType: ConnectorType,
+      connectorType: ConnectorRef,
       signal: AbortSignal,
     ): Promise<void> => {
       await set(updateAuthorizedConnectors$, "remove", connectorType, signal);

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail-page.ts
@@ -1,17 +1,17 @@
 import { command, computed, state } from "ccstate";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 
 // ---------------------------------------------------------------------------
 // JobPermissionsTab UI state
 // ---------------------------------------------------------------------------
 
-const internalConnectorType$ = state<ConnectorType | null>(null);
+const internalConnectorType$ = state<ConnectorRef | null>(null);
 export const permConnectorType$ = computed((get) => {
   return get(internalConnectorType$);
 });
 export const setPermConnectorType$ = command(
-  ({ set }, type: ConnectorType | null) => {
+  ({ set }, type: ConnectorRef | null) => {
     set(internalConnectorType$, type);
   },
 );

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -20,7 +20,7 @@ import {
   IconMessageCircle,
   IconWand,
 } from "@tabler/icons-react";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   Button,
   Tabs,
@@ -483,8 +483,8 @@ export function ConnectedConnectorPermissions({
   setSearchActive: (active: boolean) => void;
   savingType: string | null;
   canManagePermissions: boolean;
-  onToggle: (type: ConnectorType, checked: boolean) => Promise<void>;
-  onManage: (type: ConnectorType) => void;
+  onToggle: (type: ConnectorRef, checked: boolean) => Promise<void>;
+  onManage: (type: ConnectorRef) => void;
 }) {
   return (
     <>
@@ -602,7 +602,7 @@ export function AgentPermissionsDrawer({
 }: {
   targetId: string;
   targetKind?: "agent" | "workflow";
-  connectorType: ConnectorType | null;
+  connectorType: ConnectorRef | null;
   connectorLabel: string;
   displayName: string;
   initialPolicies: FirewallPolicies;
@@ -705,7 +705,7 @@ function JobPermissionsTab({
   });
   const authorizedSet = new Set(authorizedConnectors);
 
-  const handleToggle = async (type: ConnectorType, checked: boolean) => {
+  const handleToggle = async (type: ConnectorRef, checked: boolean) => {
     if (savingType !== null) {
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   CONNECTOR_TYPE_KEYS,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -492,7 +492,7 @@ export function mockActiveTemplateThread(): void {
 export function mockConnectors(
   connectors: {
     type: ConnectorType;
-    authMethod?: ConnectorAuthMethodId;
+    authMethod?: ConnectorRegistryAuthMethodId;
     externalUsername?: string;
     oauthScopes?: string[];
   }[],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -23,9 +23,9 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
-  ConnectorAuthMethodId,
+  ConnectorRegistryAuthMethodId,
   ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -176,7 +176,7 @@ function teamAgent(
 function mockConnectors(
   connectors: {
     type: ConnectorType;
-    authMethod?: ConnectorAuthMethodId;
+    authMethod?: ConnectorRegistryAuthMethodId;
     externalUsername?: string;
     connectionStatus?: ConnectorResponse["connectionStatus"];
     reconnectReason?: ConnectorResponse["reconnectReason"];
@@ -267,7 +267,7 @@ function customConnector(
 }
 
 function publicStatusItem(args: {
-  readonly connectorRef: ConnectorCatalogRef;
+  readonly connectorRef: ConnectorRef;
   readonly label: string;
   readonly description?: string;
   readonly category?: string;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -18,8 +18,8 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
 import type {
-  ConnectorCatalogAuthMethodId as ConnectorAuthMethodId,
-  ConnectorCatalogRef as ConnectorType,
+  ConnectorAuthMethodId,
+  ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { FormEvent, ReactElement } from "react";
 import type { PublicConnectorCatalogStartOption } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -95,7 +95,7 @@ type PostConnectOptions = {
 };
 
 type SubmitManualGrantFn = (
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
   inputValues: Record<string, string>,
   options: PostConnectOptions,
@@ -103,7 +103,7 @@ type SubmitManualGrantFn = (
 ) => Promise<boolean>;
 
 type ConnectOAuthAuthCodeAndSettleFn = (
-  type: ConnectorType,
+  type: ConnectorRef,
   method: ConnectorStatusAuthMethodDetail,
   onSuccess: () => void | Promise<void>,
   options: PostConnectOptions,
@@ -112,7 +112,7 @@ type ConnectOAuthAuthCodeAndSettleFn = (
 
 type ConnectOAuthDeviceAuthAndSettleFn = (
   args: {
-    readonly type: ConnectorType;
+    readonly type: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -123,7 +123,7 @@ type ConnectOAuthDeviceAuthAndSettleFn = (
 
 type ConnectExternalCodeFn = (
   args: {
-    readonly type: ConnectorType;
+    readonly type: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly agentId?: string;
   },
@@ -132,7 +132,7 @@ type ConnectExternalCodeFn = (
 
 type CompleteExternalCodeAndSettleFn = (
   args: {
-    readonly type: ConnectorType;
+    readonly type: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -142,7 +142,7 @@ type CompleteExternalCodeAndSettleFn = (
 
 type ConnectNoAuthAndSettleFn = (
   args: {
-    readonly type: ConnectorType;
+    readonly type: ConnectorRef;
     readonly authMethod: ConnectorAuthMethodId;
     readonly onSuccess: () => void | Promise<void>;
     readonly options: PostConnectOptions;
@@ -188,7 +188,7 @@ type ConnectMethodContentEntry = {
 
 function connectorOAuthDeviceAuthFlowIsActive(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorType,
+  type: ConnectorRef,
 ): boolean {
   return (
     state.connectorType === type &&
@@ -200,7 +200,7 @@ function connectorOAuthDeviceAuthFlowIsActive(
 
 function connectorExternalCodeFlowIsActive(
   state: ConnectorExternalCodeState,
-  type: ConnectorType,
+  type: ConnectorRef,
 ): boolean {
   return (
     state.connectorType === type &&
@@ -210,7 +210,7 @@ function connectorExternalCodeFlowIsActive(
 
 function connectorOAuthDeviceAuthStateForMethod(
   state: ConnectorOAuthDeviceAuthState,
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorOAuthDeviceAuthState | null {
   if (state.connectorType !== type || state.status === "idle") {
@@ -221,7 +221,7 @@ function connectorOAuthDeviceAuthStateForMethod(
 
 function connectorExternalCodeStateForMethod(
   state: ConnectorExternalCodeState,
-  type: ConnectorType,
+  type: ConnectorRef,
   authMethod: ConnectorAuthMethodId,
 ): ConnectorExternalCodeState | null {
   if (state.connectorType !== type || state.status === "idle") {
@@ -244,7 +244,7 @@ function ManualGrantForm({
   submit,
   submitting,
 }: {
-  type: ConnectorType;
+  type: ConnectorRef;
   connectorLabel: string;
   authMethod: ConnectorAuthMethodId;
   method: ConnectorStatusAuthMethodDetail;
@@ -536,7 +536,7 @@ function OAuthDeviceAuthStartOptionsForm({
   values,
   setValue,
 }: {
-  type: ConnectorType;
+  type: ConnectorRef;
   authMethod: ConnectorAuthMethodId;
   startOptions: readonly PublicConnectorCatalogStartOption[];
   values: Record<string, string>;
@@ -1264,7 +1264,7 @@ export function ConnectModal({
 }: {
   onClose: () => void;
   onSuccess?: () => void | Promise<void>;
-  selectedType?: ConnectorType | null;
+  selectedType?: ConnectorRef | null;
   agentId?: string;
 }) {
   const globalSelectedType = useGet(selectedConnectorType$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -18,7 +18,7 @@ import {
   TooltipTrigger,
   cn,
 } from "@vm0/ui";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -48,7 +48,7 @@ import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
 
 interface ConnectorAccessManagementDialogProps {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly connectorLabel: string;
   readonly onClose: () => void;
 }
@@ -320,7 +320,7 @@ function AgentPermissionDialog({
 }: {
   readonly row: ConnectorAgentAccessRow | undefined;
   readonly metadata: PublicConnectorCatalogPermissionDetail | null;
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly connectorLabel: string;
   readonly pageSignal: AbortSignal;
   readonly applyGrantPolicies: ApplyUserPermissionGrants;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@vm0/ui";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   PublicConnectorCatalogIcon,
   PublicConnectorCatalogPermissionDetail,
@@ -104,7 +104,7 @@ interface ConnectorPermission {
 interface PermissionsDrawerProps {
   agentId: string;
   targetKind?: "agent" | "workflow";
-  connectorType: ConnectorType;
+  connectorType: ConnectorRef;
   connectorLabel: string;
   metadata$: Computed<Promise<PublicConnectorCatalogPermissionDetail | null>>;
   displayName: string;
@@ -142,7 +142,7 @@ interface PermissionsDrawerFooterProps {
 }
 
 interface InitialPermissionDrawerState {
-  readonly ref: ConnectorType;
+  readonly ref: ConnectorRef;
   readonly explicitGrants: Map<string, UserPermissionGrantResponse>;
   readonly initialPolicyKey: string;
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -5,7 +5,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import {
   allConnectorTypes$,
@@ -13,9 +13,9 @@ import {
 } from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ScopeReviewModalProps {
-  connectorType: ConnectorType | null;
+  connectorType: ConnectorRef | null;
   onClose: () => void;
-  onReconnect: (type: ConnectorType) => void;
+  onReconnect: (type: ConnectorRef) => void;
 }
 
 export function ScopeReviewModal({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -141,7 +141,7 @@ import {
   type WorkflowTemplateItem,
 } from "@vm0/core";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import { getModelImageInputSupport } from "@vm0/api-contracts/contracts/model-providers";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
@@ -415,7 +415,7 @@ type TemplatePreviewImageSize = Parameters<typeof r2ImageTransformUrl>[1];
 // ---------------------------------------------------------------------------
 
 interface ComposerConnectorItem {
-  type: ConnectorType;
+  type: ConnectorRef;
   label: string;
   helpText: string;
   icon: ConnectorTypeWithStatus["icon"];
@@ -5536,7 +5536,7 @@ function AddConnectorsDialog({
   unconnected: ConnectorTypeWithStatus[];
   pollingType: string | null;
   onClose: () => void;
-  onSelect: (type: ConnectorType) => void;
+  onSelect: (type: ConnectorRef) => void;
 }) {
   const search = useGet(signals.addDialogSearch$);
   const setSearch = useSet(signals.setAddDialogSearch$);
@@ -5801,7 +5801,7 @@ function ConnectorsPopoverButton({
   savingType: string | null;
   computerUse: ComposerComputerUse | undefined;
   onOpenAddDialog: () => void;
-  onToggle: (type: ConnectorType, checked: boolean) => void | Promise<void>;
+  onToggle: (type: ConnectorRef, checked: boolean) => void | Promise<void>;
 }) {
   const search = useGet(signals.popoverSearch$);
   const setSearch = useSet(signals.setPopoverSearch$);
@@ -6987,7 +6987,7 @@ export function useZeroChatComposer({
     };
   });
 
-  const handleConnectSuccess = async (type: ConnectorType) => {
+  const handleConnectSuccess = async (type: ConnectorRef) => {
     const label = connectorMap.get(type)?.label ?? type;
     const authorized = await tapError(
       (async () => {
@@ -7012,7 +7012,7 @@ export function useZeroChatComposer({
     return true;
   };
 
-  const handleToggle = async (type: ConnectorType, checked: boolean) => {
+  const handleToggle = async (type: ConnectorRef, checked: boolean) => {
     setSavingType(type);
     await bestEffort(
       checked ? authorizeFn(type, pageSignal) : deauthorizeFn(type, pageSignal),

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,5 +1,5 @@
 import { IconAlertCircle, IconLoader2 } from "@tabler/icons-react";
-import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   getStaticConnectorIconMetadata,
   isStaticConnectorIconType,
@@ -14,7 +14,7 @@ export function ZeroConnectorRedirectingPage({
   connectorLabel,
   status,
 }: {
-  readonly connectorType: ConnectorCatalogRef | null;
+  readonly connectorType: ConnectorRef | null;
   readonly connectorLabel: string;
   readonly status: ConnectorRedirectingStatus;
 }) {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -17,7 +17,7 @@ import {
   IconChevronDown,
   IconCheck,
 } from "@tabler/icons-react";
-import type { ConnectorCatalogRef as ConnectorType } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorRef } from "@vm0/api-contracts/contracts/connector-identity";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -548,7 +548,7 @@ function ConnectorAccessButton({
   connectorLabel,
   onClick,
 }: {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly connectorLabel: string;
   readonly onClick: () => void;
 }) {
@@ -896,7 +896,7 @@ function renderBuiltinList({
 
 function connectorLabelForType(
   connectors: readonly ConnectorTypeWithStatus[],
-  type: ConnectorType | null,
+  type: ConnectorRef | null,
 ): string | null {
   if (!type) {
     return null;
@@ -963,7 +963,7 @@ export function ZeroConnectorsPage() {
   );
   const disconnecting = disconnectLoadable.state === "loading";
 
-  const connectHandler = (type: ConnectorType) => {
+  const connectHandler = (type: ConnectorRef) => {
     const ct = filteredConnectors.find((c) => {
       return c.type === type;
     });
@@ -1006,7 +1006,7 @@ export function ZeroConnectorsPage() {
   };
 
   const disconnectHandler = async (
-    type: ConnectorType,
+    type: ConnectorRef,
     connectorLabel: string,
   ) => {
     if (disconnecting) {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,8 +1,8 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogAuthMethodId as ConnectorAuthMethodId,
-  type ConnectorCatalogRef as ConnectorType,
+  connectorRefSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -84,7 +84,7 @@ function AuthorizeAction({
 // ---------------------------------------------------------------------------
 
 function useDirectedAuthorizeParams(): {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string;
 } | null {
   const type = useGet(directedAuthorizeType$);
@@ -92,14 +92,14 @@ function useDirectedAuthorizeParams(): {
   if (!type || !agentId) {
     return null;
   }
-  const parsed = connectorCatalogRefSchema.safeParse(type);
+  const parsed = connectorRefSchema.safeParse(type);
   if (!parsed.success) {
     return null;
   }
   return { connectorType: parsed.data, agentId };
 }
 
-function useDirectedAuthorizeCatalogState(connectorType: ConnectorType | null) {
+function useDirectedAuthorizeCatalogState(connectorType: ConnectorRef | null) {
   const justConnected = useGet(justConnectedTypes$);
   const allLoadable = useLastLoadable(allConnectorTypes$);
   const catalogLoaded = allLoadable.state === "hasData";
@@ -125,7 +125,7 @@ function useDirectedAuthorizeCatalogState(connectorType: ConnectorType | null) {
 }
 
 function useDirectedAuthorizePermissionState(
-  connectorType: ConnectorType | null,
+  connectorType: ConnectorRef | null,
   agentId: string | null,
 ) {
   const justAuthorizedKeys = useGet(justAuthorizedConnectorAgentKeys$);
@@ -177,7 +177,7 @@ function canAuthorizeConnector(
 function directedAuthorizeConnectModalOpen(
   key: DirectedAuthorizeConnectModalKey | null,
   args: {
-    readonly connectorType: ConnectorType | null;
+    readonly connectorType: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },
@@ -258,18 +258,18 @@ function runDirectedAuthorize(params: {
   readonly canAuthorize: boolean;
   readonly isConnected: boolean;
   readonly item: ConnectorTypeWithStatus | undefined;
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly connectorLabel: string;
   readonly agentId: string;
   readonly authMethod: ConnectorStatusAuthMethodDetail | null;
   readonly signal: AbortSignal;
   readonly authorize: (
-    connectorType: ConnectorType,
+    connectorType: ConnectorRef,
     agentId: string,
     signal: AbortSignal,
   ) => Promise<void>;
   readonly connect: (
-    connectorType: ConnectorType,
+    connectorType: ConnectorRef,
     method: ConnectorStatusAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
@@ -279,7 +279,7 @@ function runDirectedAuthorize(params: {
   ) => Promise<boolean>;
   readonly connectNoAuth: (
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly options: {
         readonly connectorLabel?: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,8 +1,8 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
-  connectorCatalogRefSchema,
-  type ConnectorCatalogAuthMethodId as ConnectorAuthMethodId,
-  type ConnectorCatalogRef as ConnectorType,
+  connectorRefSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
@@ -67,11 +67,11 @@ import {
 
 function runDirectedConnect(params: {
   item: ConnectorTypeWithStatus;
-  connectorType: ConnectorType;
+  connectorType: ConnectorRef;
   agentId: string | null;
   signal: AbortSignal;
   connect: (
-    type: ConnectorType,
+    type: ConnectorRef,
     method: ConnectorStatusAuthMethodDetail,
     options: {
       readonly connectorLabel?: string;
@@ -81,7 +81,7 @@ function runDirectedConnect(params: {
   ) => Promise<boolean>;
   connectNoAuth: (
     args: {
-      readonly type: ConnectorType;
+      readonly type: ConnectorRef;
       readonly authMethod: ConnectorAuthMethodId;
       readonly options: {
         readonly connectorLabel?: string;
@@ -173,7 +173,7 @@ function ManualGrantForm({
   manualGrantMethod,
   onSuccess,
 }: {
-  type: ConnectorType;
+  type: ConnectorRef;
   agentId: string | null;
   connectorLabel: string;
   manualGrantMethod: ConnectorStatusAuthMethodDetail;
@@ -279,7 +279,7 @@ function ManualGrantDialog({
   onOpenChange,
   onSuccess,
 }: {
-  type: ConnectorType;
+  type: ConnectorRef;
   agentId: string | null;
   icon: ConnectorTypeWithStatus["icon"] | undefined;
   connectorLabel: string;
@@ -366,7 +366,7 @@ function DirectedConnectModal({
   onSuccess,
 }: {
   readonly open: boolean;
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly agentId: string | null;
   readonly onClose: () => void;
   readonly onSuccess: () => void | Promise<void>;
@@ -396,7 +396,7 @@ function DirectedConnectDialogs({
   setConnectModalOpen,
   onSuccess,
 }: {
-  readonly connectorType: ConnectorType;
+  readonly connectorType: ConnectorRef;
   readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
   readonly connectorLabel: string;
   readonly manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
@@ -432,16 +432,16 @@ function DirectedConnectDialogs({
   );
 }
 
-function useDirectedConnectConnectorType(): ConnectorType | null {
+function useDirectedConnectConnectorType(): ConnectorRef | null {
   const type = useGet(directedConnectType$);
   if (!type) {
     return null;
   }
-  const parsed = connectorCatalogRefSchema.safeParse(type);
+  const parsed = connectorRefSchema.safeParse(type);
   return parsed.success ? parsed.data : null;
 }
 
-function useDirectedConnectCatalogState(connectorType: ConnectorType | null): {
+function useDirectedConnectCatalogState(connectorType: ConnectorRef | null): {
   readonly item: ConnectorTypeWithStatus | undefined;
   readonly isConnected: boolean;
   readonly isLoading: boolean;
@@ -477,7 +477,7 @@ function useDirectedConnectCatalogState(connectorType: ConnectorType | null): {
 function directedConnectManualGrantDialogOpen(
   key: DirectedConnectManualGrantDialogKey | null,
   args: {
-    readonly connectorType: ConnectorType | null;
+    readonly connectorType: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },
@@ -492,7 +492,7 @@ function directedConnectManualGrantDialogOpen(
 function directedConnectModalOpen(
   key: DirectedConnectModalKey | null,
   args: {
-    readonly connectorType: ConnectorType | null;
+    readonly connectorType: ConnectorRef | null;
     readonly agentId: string | null;
     readonly signal: AbortSignal;
   },

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { initContract } from "./base";
-import { connectorCatalogAuthMethodIdSchema } from "./connector-identity";
+import { connectorAuthMethodIdSchema } from "./connector-identity";
 
 const c = initContract();
 
@@ -40,7 +40,7 @@ export const cliAuthTestConnectorContract = c.router({
     query: testEmailQuerySchema,
     body: z.object({
       connectorName: z.string(),
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       accessToken: z.string(),
       refreshToken: z.string().min(1).optional(),
       expiresIn: z.number().int().optional(),

--- a/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
+++ b/turbo/packages/api-contracts/src/contracts/cli-auth-test.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { initContract } from "./base";
-import { connectorAuthMethodIdSchema } from "./connector-identity";
+import {
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
+} from "./connector-identity";
 
 const c = initContract();
 
@@ -48,7 +51,7 @@ export const cliAuthTestConnectorContract = c.router({
     responses: {
       200: z.object({
         ok: z.literal(true),
-        connectorType: z.string(),
+        connectorType: connectorRefSchema,
         orgId: z.string(),
       }),
       400: stringErrorResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/connector-identity.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-identity.ts
@@ -1,23 +1,21 @@
 import { z } from "zod";
 
-export const CONNECTOR_CATALOG_REF_MAX_LENGTH = 64;
-export const CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH = 50;
+export const CONNECTOR_REF_MAX_LENGTH = 64;
+export const CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH = 50;
 
-const connectorCatalogIdentityPattern = /^[a-z0-9][a-z0-9-]*$/u;
+const connectorIdentityPattern = /^[a-z0-9][a-z0-9-]*$/u;
 
-export const connectorCatalogRefSchema = z
+export const connectorRefSchema = z
   .string()
   .min(1)
-  .max(CONNECTOR_CATALOG_REF_MAX_LENGTH)
-  .regex(connectorCatalogIdentityPattern);
+  .max(CONNECTOR_REF_MAX_LENGTH)
+  .regex(connectorIdentityPattern);
 
-export const connectorCatalogAuthMethodIdSchema = z
+export const connectorAuthMethodIdSchema = z
   .string()
   .min(1)
-  .max(CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH)
-  .regex(connectorCatalogIdentityPattern);
+  .max(CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH)
+  .regex(connectorIdentityPattern);
 
-export type ConnectorCatalogRef = z.infer<typeof connectorCatalogRefSchema>;
-export type ConnectorCatalogAuthMethodId = z.infer<
-  typeof connectorCatalogAuthMethodIdSchema
->;
+export type ConnectorRef = z.infer<typeof connectorRefSchema>;
+export type ConnectorAuthMethodId = z.infer<typeof connectorAuthMethodIdSchema>;

--- a/turbo/packages/api-contracts/src/contracts/connector-identity.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-identity.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-export const CONNECTOR_REF_MAX_LENGTH = 64;
-export const CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH = 50;
+const CONNECTOR_REF_MAX_LENGTH = 64;
+const CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH = 50;
 
 const connectorIdentityPattern = /^[a-z0-9][a-z0-9-]*$/u;
 

--- a/turbo/packages/api-contracts/src/contracts/connector-identity.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-identity.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 
-import { CONNECTOR_REF_MAX_LENGTH } from "./connector-ref";
-
-export const CONNECTOR_CATALOG_REF_MAX_LENGTH = CONNECTOR_REF_MAX_LENGTH;
+export const CONNECTOR_CATALOG_REF_MAX_LENGTH = 64;
 export const CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH = 50;
 
 const connectorCatalogIdentityPattern = /^[a-z0-9][a-z0-9-]*$/u;

--- a/turbo/packages/api-contracts/src/contracts/connector-ref.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-ref.ts
@@ -1,8 +1,0 @@
-import { z } from "zod";
-
-export const CONNECTOR_REF_MAX_LENGTH = 64;
-
-export const connectorRefSchema = z
-  .string()
-  .min(1)
-  .max(CONNECTOR_REF_MAX_LENGTH);

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 import {
-  connectorCatalogAuthMethodIdSchema,
-  connectorCatalogRefSchema,
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
 } from "./connector-identity";
 
 /**
@@ -29,8 +29,8 @@ export type ConnectorReconnectReason = z.infer<
 
 export const connectorResponseSchema = z.object({
   id: z.uuid(),
-  type: connectorCatalogRefSchema,
-  authMethod: connectorCatalogAuthMethodIdSchema,
+  type: connectorRefSchema,
+  authMethod: connectorAuthMethodIdSchema,
   externalId: z.string().nullable(),
   externalUsername: z.string().nullable(),
   externalEmail: z.string().nullable(),
@@ -64,8 +64,8 @@ export const connectorProvidedBindingSourceSchema = z.discriminatedUnion(
 );
 
 export const connectorProvidedBindingSchema = z.object({
-  connectorType: connectorCatalogRefSchema,
-  authMethod: connectorCatalogAuthMethodIdSchema,
+  connectorType: connectorRefSchema,
+  authMethod: connectorAuthMethodIdSchema,
   namespace: connectorProvidedBindingNamespaceSchema,
   name: z.string(),
   optional: z.boolean(),
@@ -102,7 +102,7 @@ export function guaranteedConnectorProvidedBindingNames(args: {
  */
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
-  configuredTypes: z.array(connectorCatalogRefSchema),
+  configuredTypes: z.array(connectorRefSchema),
   connectorProvidedBindings: z
     .array(connectorProvidedBindingSchema)
     .default([]),
@@ -133,7 +133,7 @@ export type ConnectorOauthStartResponse = z.infer<
 export const connectorOauthDeviceAuthSessionStartResponseSchema = z.object({
   sessionId: z.uuid(),
   sessionToken: z.string(),
-  type: connectorCatalogRefSchema,
+  type: connectorRefSchema,
   status: z.literal("pending"),
   userCode: z.string(),
   verificationUri: z.string(),
@@ -188,7 +188,7 @@ export type ConnectorOauthDeviceAuthSessionPollResponse = z.infer<
 export const connectorExternalCodeSessionStartResponseSchema = z.object({
   sessionId: z.uuid(),
   sessionToken: z.string(),
-  type: connectorCatalogRefSchema,
+  type: connectorRefSchema,
   status: z.literal("pending"),
   authorizationUrl: z.string(),
   expiresIn: z.number(),

--- a/turbo/packages/api-contracts/src/contracts/connectors-type-callback.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors-type-callback.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
-import { connectorCatalogRefSchema } from "./connector-identity";
+import { connectorRefSchema } from "./connector-identity";
 
 const c = initContract();
 
@@ -10,7 +10,7 @@ export const connectorsTypeCallbackContract = c.router({
     method: "GET",
     path: "/api/connectors/:type/callback",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     query: z
       .object({
         code: z.string().optional(),

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
+import {
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
+} from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -127,8 +131,8 @@ export const connectorCatalogCompatibilityReasonSchema = z.enum([
 ]);
 
 export const connectorCatalogFilteredAuthMethodSchema = z.object({
-  connectorRef: z.string().min(1),
-  authMethodId: z.string().min(1),
+  connectorRef: connectorRefSchema,
+  authMethodId: connectorAuthMethodIdSchema,
   reasons: z.array(connectorCatalogCompatibilityReasonSchema).min(1),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -786,7 +786,7 @@ export {
   type ConnectorDisplayCategory,
   type ConnectorDisplayCategoryGroup,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorEnvBindings,
   type ConnectorEnvBindingValue,
 } from "@vm0/connectors/connectors";
@@ -1078,12 +1078,12 @@ export {
   type ZeroConnectorCheckContract,
 } from "./zero-connector-check";
 export {
-  CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH,
-  CONNECTOR_CATALOG_REF_MAX_LENGTH,
-  connectorCatalogAuthMethodIdSchema,
-  connectorCatalogRefSchema,
-  type ConnectorCatalogAuthMethodId,
-  type ConnectorCatalogRef,
+  CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH,
+  CONNECTOR_REF_MAX_LENGTH,
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorRef,
 } from "./connector-identity";
 export {
   codexDeviceAuthScopeSchema,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1077,8 +1077,6 @@ export {
   type ZeroConnectorCheckContract,
 } from "./zero-connector-check";
 export {
-  CONNECTOR_AUTH_METHOD_ID_MAX_LENGTH,
-  CONNECTOR_REF_MAX_LENGTH,
   connectorAuthMethodIdSchema,
   connectorRefSchema,
   type ConnectorAuthMethodId,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1077,7 +1077,6 @@ export {
   type ConnectorCheckRequest,
   type ZeroConnectorCheckContract,
 } from "./zero-connector-check";
-export { CONNECTOR_REF_MAX_LENGTH, connectorRefSchema } from "./connector-ref";
 export {
   CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH,
   CONNECTOR_CATALOG_REF_MAX_LENGTH,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1037,7 +1037,6 @@ export {
   zeroConnectorNoAuthGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorsSearchContract,
-  type ConnectorSearchAuthMethod,
   type ZeroConnectorsMainContract,
   type ZeroConnectorsByTypeContract,
   type ZeroConnectorScopeDiffContract,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -6,6 +6,7 @@ import {
   networkPolicySchema,
   networkPoliciesSchema,
 } from "@vm0/connectors/firewall-types";
+import { connectorRefSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import { modelProviderCodexRuntimeConfigSchema } from "./model-providers";
 
@@ -578,7 +579,7 @@ export const runnersNetworkPolicyRefreshContract = c.router({
     }),
     body: z.object({
       connectorRefs: z
-        .array(z.string().min(1).max(64))
+        .array(connectorRefSchema)
         .min(1)
         .max(NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX),
     }),
@@ -586,7 +587,7 @@ export const runnersNetworkPolicyRefreshContract = c.router({
       200: z.object({
         refreshes: z.array(
           z.object({
-            connectorRef: z.string(),
+            connectorRef: connectorRefSchema,
             networkPolicy: networkPolicySchema,
             nextRefreshAt: z.string().datetime({ offset: true }).nullable(),
           }),

--- a/turbo/packages/api-contracts/src/contracts/user-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-connectors.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { connectorCatalogRefSchema } from "./connector-identity";
+import { connectorRefSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -11,7 +11,7 @@ const c = initContract();
  * agent.
  */
 export const userConnectorEnabledTypesSchema = z.object({
-  enabledTypes: z.array(connectorCatalogRefSchema),
+  enabledTypes: z.array(connectorRefSchema),
 });
 export type UserConnectorEnabledTypes = z.infer<
   typeof userConnectorEnabledTypesSchema

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  connectorCatalogRefSchema,
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
 } from "./connector-identity";
 import { connectorReconnectReasonSchema } from "./connector-schemas";
 import { apiErrorSchema } from "./errors";
@@ -11,7 +11,7 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 const publicConnectorCatalogAuthMethodSummarySchema = z.object({
-  id: connectorCatalogAuthMethodIdSchema,
+  id: connectorAuthMethodIdSchema,
   label: z.string(),
   description: z.string().nullable(),
   grantKind: z.enum([
@@ -57,7 +57,7 @@ const publicConnectorCatalogCategoryMetadataSchema = z.object({
 });
 
 const publicConnectorCatalogItemSchema = z.object({
-  connectorRef: connectorCatalogRefSchema,
+  connectorRef: connectorRefSchema,
   label: z.string(),
   description: z.string(),
   icon: publicConnectorCatalogIconSchema,
@@ -118,7 +118,7 @@ const publicConnectorCatalogConnectionStatusSchema = z.enum([
 ]);
 
 const publicConnectorCatalogConnectionSchema = z.object({
-  authMethod: connectorCatalogAuthMethodIdSchema,
+  authMethod: connectorAuthMethodIdSchema,
   externalUsername: z.string().nullable(),
   externalEmail: z.string().nullable(),
   reconnectReason: connectorReconnectReasonSchema.nullable(),
@@ -132,7 +132,7 @@ const publicConnectorCatalogStatusItemSchema =
     scopeMismatch: z.boolean(),
     authMethodSupportsRefresh: z.boolean(),
     tokenExpiresAt: z.string().nullable(),
-    singleAuthCodeAuthMethodId: connectorCatalogAuthMethodIdSchema.nullable(),
+    singleAuthCodeAuthMethodId: connectorAuthMethodIdSchema.nullable(),
     connectNotice: z.enum(["google-security-warning"]).nullable(),
   });
 
@@ -160,7 +160,7 @@ const publicConnectorCatalogDefaultPolicySchema = z.object({
 });
 
 const publicConnectorCatalogPermissionDetailSchema = z.object({
-  connectorRef: connectorCatalogRefSchema,
+  connectorRef: connectorRefSchema,
   label: z.string(),
   icon: publicConnectorCatalogIconSchema,
   permissionCount: z.number().int().nonnegative(),
@@ -174,7 +174,7 @@ const publicConnectorCatalogPermissionDetailResponseSchema = z.object({
 });
 
 const connectorCatalogPathParamsSchema = z.object({
-  connectorRef: connectorCatalogRefSchema,
+  connectorRef: connectorRefSchema,
 });
 
 export type PublicConnectorCatalogAuthMethodSummary = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-check.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
-import { connectorCatalogRefSchema } from "./connector-identity";
+import { connectorRefSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -13,7 +13,7 @@ const connectorCheckUrlRequestSchema = z
     mode: z.literal("url"),
     method: z.string().min(1).max(16),
     url: z.string().min(1).max(8192),
-    connectorRef: connectorCatalogRefSchema.optional(),
+    connectorRef: connectorRefSchema.optional(),
     environmentName: boundedNameSchema.optional(),
   })
   .strict();
@@ -35,7 +35,7 @@ export type ConnectorCheckRequest = z.infer<typeof connectorCheckRequestSchema>;
 
 const connectorCheckIdentitySchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     label: z.string().min(1),
     visibility: z.enum(["available", "unavailable"]),
     credentialResolution: z.enum(["network-boundary", "none"]),
@@ -44,7 +44,7 @@ const connectorCheckIdentitySchema = z
 
 const connectorCheckCandidateSchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     label: z.string().min(1),
   })
   .strict();

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import {
-  connectorCatalogAuthMethodIdSchema,
-  connectorCatalogRefSchema,
+  connectorAuthMethodIdSchema,
+  connectorRefSchema,
 } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import {
@@ -48,7 +48,7 @@ export const zeroConnectorsByTypeContract = c.router({
     method: "GET",
     path: "/api/zero/connectors/:type",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     responses: {
       200: connectorResponseSchema,
       401: apiErrorSchema,
@@ -61,7 +61,7 @@ export const zeroConnectorsByTypeContract = c.router({
     method: "DELETE",
     path: "/api/zero/connectors/:type",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     responses: {
       204: c.noBody(),
       401: apiErrorSchema,
@@ -80,7 +80,7 @@ export const zeroConnectorScopeDiffContract = c.router({
     method: "GET",
     path: "/api/zero/connectors/:type/scope-diff",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     responses: {
       200: scopeDiffResponseSchema,
       401: apiErrorSchema,
@@ -96,9 +96,9 @@ export const zeroConnectorOauthStartContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/oauth/start",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
     }),
@@ -118,9 +118,9 @@ export const zeroConnectorOpenIdStartContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/openid/start",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
     }),
@@ -140,9 +140,9 @@ export const zeroConnectorManualGrantContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/manual-grant",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
       values: z.record(z.string(), z.string()),
@@ -164,9 +164,9 @@ export const zeroConnectorNoAuthGrantContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/no-auth",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
     }),
@@ -187,9 +187,9 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/oauth/device/sessions",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
       options: z.record(z.string(), z.string()).optional(),
@@ -208,7 +208,7 @@ export const zeroConnectorOauthDeviceAuthSessionContract = c.router({
     path: "/api/zero/connectors/:type/oauth/device/sessions/:sessionId/poll",
     headers: authHeadersSchema,
     pathParams: z.object({
-      type: connectorCatalogRefSchema,
+      type: connectorRefSchema,
       sessionId: z.uuid(),
     }),
     body: connectorOauthDeviceAuthSessionPollRequestSchema,
@@ -229,9 +229,9 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
     method: "POST",
     path: "/api/zero/connectors/:type/external-code/sessions",
     headers: authHeadersSchema,
-    pathParams: z.object({ type: connectorCatalogRefSchema }),
+    pathParams: z.object({ type: connectorRefSchema }),
     body: z.object({
-      authMethod: connectorCatalogAuthMethodIdSchema,
+      authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
     }),
@@ -249,7 +249,7 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
     path: "/api/zero/connectors/:type/external-code/sessions/:sessionId/complete",
     headers: authHeadersSchema,
     pathParams: z.object({
-      type: connectorCatalogRefSchema,
+      type: connectorRefSchema,
       sessionId: z.uuid(),
     }),
     body: connectorExternalCodeSessionCompleteRequestSchema,
@@ -266,14 +266,14 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
 });
 
 export type ConnectorSearchAuthMethod = z.infer<
-  typeof connectorCatalogAuthMethodIdSchema
+  typeof connectorAuthMethodIdSchema
 >;
 
 const connectorSearchItemSchema = z.object({
-  id: connectorCatalogRefSchema,
+  id: connectorRefSchema,
   label: z.string(),
   description: z.string(),
-  authMethods: z.array(connectorCatalogAuthMethodIdSchema),
+  authMethods: z.array(connectorAuthMethodIdSchema),
 });
 
 const connectorSearchResponseSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -265,10 +265,6 @@ export const zeroConnectorExternalCodeSessionContract = c.router({
   },
 });
 
-export type ConnectorSearchAuthMethod = z.infer<
-  typeof connectorAuthMethodIdSchema
->;
-
 const connectorSearchItemSchema = z.object({
   id: connectorRefSchema,
   label: z.string(),

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -1,12 +1,18 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { connectorRefSchema } from "./connector-ref";
+import { CONNECTOR_CATALOG_REF_MAX_LENGTH } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
 const agentIdSchema = z.string().uuid();
 const permissionSchema = z.string().min(1).max(128);
+// Permission grants retain their bounded-string wire contract. Exact current
+// connector lookup and availability remain server-owned.
+const permissionGrantConnectorRefSchema = z
+  .string()
+  .min(1)
+  .max(CONNECTOR_CATALOG_REF_MAX_LENGTH);
 
 export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);
 export const userPermissionGrantApplyModeSchema = z.enum(["patch", "replace"]);
@@ -24,7 +30,7 @@ const agentPermissionGrantScopeSchema = z.object({
 export const userPermissionGrantScopeSchema = agentPermissionGrantScopeSchema;
 
 const userPermissionGrantResponseBaseSchema = z.object({
-  connectorRef: connectorRefSchema,
+  connectorRef: permissionGrantConnectorRefSchema,
   permission: permissionSchema,
   action: userPermissionGrantActionSchema,
   expiresAt: z.string().nullable(),
@@ -57,7 +63,7 @@ export const applyUserPermissionGrantSchema = z.discriminatedUnion("action", [
 export const applyUserPermissionGrantsRequestSchema =
   userPermissionGrantScopeSchema.and(
     z.object({
-      connectorRef: connectorRefSchema,
+      connectorRef: permissionGrantConnectorRefSchema,
       mode: userPermissionGrantApplyModeSchema,
       grants: z.array(applyUserPermissionGrantSchema),
     }),

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -1,18 +1,12 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { CONNECTOR_CATALOG_REF_MAX_LENGTH } from "./connector-identity";
+import { connectorRefSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
 const agentIdSchema = z.string().uuid();
 const permissionSchema = z.string().min(1).max(128);
-// Permission grants retain their bounded-string wire contract. Exact current
-// connector lookup and availability remain server-owned.
-const permissionGrantConnectorRefSchema = z
-  .string()
-  .min(1)
-  .max(CONNECTOR_CATALOG_REF_MAX_LENGTH);
 
 export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);
 export const userPermissionGrantApplyModeSchema = z.enum(["patch", "replace"]);
@@ -30,7 +24,7 @@ const agentPermissionGrantScopeSchema = z.object({
 export const userPermissionGrantScopeSchema = agentPermissionGrantScopeSchema;
 
 const userPermissionGrantResponseBaseSchema = z.object({
-  connectorRef: permissionGrantConnectorRefSchema,
+  connectorRef: connectorRefSchema,
   permission: permissionSchema,
   action: userPermissionGrantActionSchema,
   expiresAt: z.string().nullable(),
@@ -63,7 +57,7 @@ export const applyUserPermissionGrantSchema = z.discriminatedUnion("action", [
 export const applyUserPermissionGrantsRequestSchema =
   userPermissionGrantScopeSchema.and(
     z.object({
-      connectorRef: permissionGrantConnectorRefSchema,
+      connectorRef: connectorRefSchema,
       mode: userPermissionGrantApplyModeSchema,
       grants: z.array(applyUserPermissionGrantSchema),
     }),

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { connectorCatalogRefSchema } from "./connector-identity";
+import { connectorRefSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import { publicConnectorCatalogIconSchema } from "./zero-connector-catalog";
 
@@ -992,7 +992,7 @@ export type ZeroWorkflowConnectorReadinessStatus = z.infer<
 
 export const zeroWorkflowConnectorReadinessEntrySchema = z
   .object({
-    connectorRef: connectorCatalogRefSchema,
+    connectorRef: connectorRefSchema,
     label: z.string().min(1),
     icon: publicConnectorCatalogIconSchema,
     reason: z.string().min(1),

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -13,11 +13,11 @@ import {
 import {
   CONNECTOR_TYPES,
   CONNECTOR_TYPE_KEYS,
-  connectorAuthMethodIdSchema,
+  connectorRegistryAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodRuntimeConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorAuthMethodIds,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorAuthCodeGrantConfig,
@@ -498,10 +498,10 @@ describe("connector auth method config", () => {
     type MultiFixtureConfig =
       (typeof multiAuthMethodFixture)["multi-auth-method-fixture"];
 
-    expectTypeOf<ConnectorAuthMethodId>().toEqualTypeOf<
+    expectTypeOf<ConnectorRegistryAuthMethodId>().toEqualTypeOf<
       "oauth" | "openid" | "api-token" | "cli" | "api"
     >();
-    expectTypeOf<"app-credential">().not.toMatchTypeOf<ConnectorAuthMethodId>();
+    expectTypeOf<"app-credential">().not.toMatchTypeOf<ConnectorRegistryAuthMethodId>();
     expectTypeOf<"app-credential">().not.toMatchTypeOf<
       keyof ConnectorConfig["authMethods"]
     >();
@@ -947,7 +947,8 @@ describe("connector selected auth method capability checks", () => {
     for (const [rawType, methods] of Object.entries(capabilities)) {
       const type = connectorTypeSchema.parse(rawType);
       for (const [rawAuthMethod, capability] of Object.entries(methods)) {
-        const authMethod = connectorAuthMethodIdSchema.parse(rawAuthMethod);
+        const authMethod =
+          connectorRegistryAuthMethodIdSchema.parse(rawAuthMethod);
         expect(getConnectorAuthMethod(type, authMethod)).toBeDefined();
         actualCapabilities.set(`${type}:${authMethod}`, capability);
       }

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -1,7 +1,7 @@
 import {
   type ConnectorAuthCodeGrantAuthMethodId,
   type AuthCodeGrantConnectorType,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorAuthMethodRuntimeConfig,
   type ConnectorType,
   type ConnectorDeviceAuthGrantAuthMethodId,
@@ -158,7 +158,7 @@ export type ConnectorAuthProviderAccessTokenRevokeResult =
 
 type ConnectorAuthMethodIdsWithoutProviderGrant<Type extends ConnectorType> =
   Exclude<
-    ConnectorAuthMethodId,
+    ConnectorRegistryAuthMethodId,
     | ConnectorAuthMethodIdsByGrantKind<
         Type & AuthCodeGrantConnectorType,
         "auth-code"
@@ -180,7 +180,7 @@ type ConnectorAuthMethodIdsWithoutProviderGrant<Type extends ConnectorType> =
 type ConnectorAuthMethodIdsWithoutRefreshTokenAccess<
   Type extends ConnectorType,
 > = Exclude<
-  ConnectorAuthMethodId,
+  ConnectorRegistryAuthMethodId,
   ConnectorAuthMethodIdsByAccessKind<
     Type & RefreshTokenAccessConnectorType,
     "refresh-token"
@@ -189,7 +189,7 @@ type ConnectorAuthMethodIdsWithoutRefreshTokenAccess<
 
 type ConnectorAuthMethodIdsWithoutTokenRevoke<Type extends ConnectorType> =
   Exclude<
-    ConnectorAuthMethodId,
+    ConnectorRegistryAuthMethodId,
     ConnectorAuthMethodIdsByRevokeKind<
       Type & TokenRevokeConnectorType,
       "token-revoke"
@@ -252,7 +252,7 @@ type RuntimeAuthProviderEntry = {
 
 type RuntimeAuthProviderRegistration<
   Type extends ConnectorType = ConnectorType,
-  Method extends ConnectorAuthMethodId = ConnectorAuthMethodId,
+  Method extends ConnectorRegistryAuthMethodId = ConnectorRegistryAuthMethodId,
 > = {
   readonly type: Type;
   readonly authMethod: Method;
@@ -281,7 +281,10 @@ export type ConnectorAuthProviderRegistryCapabilities = Readonly<
       ConnectorType,
       Readonly<
         Partial<
-          Record<ConnectorAuthMethodId, ConnectorAuthProviderRegistryCapability>
+          Record<
+            ConnectorRegistryAuthMethodId,
+            ConnectorAuthProviderRegistryCapability
+          >
         >
       >
     >
@@ -481,14 +484,17 @@ type MutableConnectorAuthProviderRegistryCapabilities = Partial<
   Record<
     ConnectorType,
     Partial<
-      Record<ConnectorAuthMethodId, ConnectorAuthProviderRegistryCapability>
+      Record<
+        ConnectorRegistryAuthMethodId,
+        ConnectorAuthProviderRegistryCapability
+      >
     >
   >
 >;
 
 function connectorAuthProviderRegistryEntry<
   Type extends ConnectorType,
-  Method extends ConnectorAuthMethodId,
+  Method extends ConnectorRegistryAuthMethodId,
 >(
   type: Type,
   authMethod: Method,

--- a/turbo/packages/connectors/src/connector-config.ts
+++ b/turbo/packages/connectors/src/connector-config.ts
@@ -359,15 +359,19 @@ export type ConnectorAuthMethodConfig = ConnectorAuthMethodRuntimeConfig &
  * These values are connector registry keys, not lifecycle categories. Behavior
  * must be derived from the selected auth method lifecycle config.
  */
-export const CONNECTOR_AUTH_METHOD_IDS = [
+export const CONNECTOR_REGISTRY_AUTH_METHOD_IDS = [
   "oauth",
   "openid",
   "api-token",
   "cli",
   "api",
 ] as const;
-export const connectorAuthMethodIdSchema = z.enum(CONNECTOR_AUTH_METHOD_IDS);
-export type ConnectorAuthMethodId = z.infer<typeof connectorAuthMethodIdSchema>;
+export const connectorRegistryAuthMethodIdSchema = z.enum(
+  CONNECTOR_REGISTRY_AUTH_METHOD_IDS,
+);
+export type ConnectorRegistryAuthMethodId = z.infer<
+  typeof connectorRegistryAuthMethodIdSchema
+>;
 
 export type ConnectorDisplayCategory =
   | "ai-general-models"
@@ -577,7 +581,7 @@ export function connectorDisplayCategoryMetadataForItems(
 }
 
 type ConnectorAuthMethods = Partial<
-  Record<ConnectorAuthMethodId, ConnectorAuthMethodConfig>
+  Record<ConnectorRegistryAuthMethodId, ConnectorAuthMethodConfig>
 >;
 
 type ConnectorConfigBase = {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1,10 +1,10 @@
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
-  connectorAuthMethodIdSchema,
+  connectorRegistryAuthMethodIdSchema,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodRuntimeConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ConnectorAuthCodeGrantAuthMethodId,
   type ConnectorDeviceAuthGrantAuthMethodId,
   type ConnectorExternalCodeGrantAuthMethodId,
@@ -63,25 +63,25 @@ const CONNECTOR_AUTH_METHOD_PRIORITY = {
   cli: 2,
   "api-token": 3,
   api: 4,
-} as const satisfies Record<ConnectorAuthMethodId, number>;
+} as const satisfies Record<ConnectorRegistryAuthMethodId, number>;
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VARIABLE_REF_PREFIX = "$vars.";
 const DEFAULT_AUTH_CODE_CALLBACK_ORIGIN: ConnectorAuthCodeCallbackOrigin =
   "web";
 
 function connectorAuthMethodPriority(
-  authMethod: ConnectorAuthMethodId,
+  authMethod: ConnectorRegistryAuthMethodId,
 ): number {
   return CONNECTOR_AUTH_METHOD_PRIORITY[authMethod];
 }
 
 export function getConfiguredConnectorAuthMethodIds(
   type: ConnectorType,
-): ConnectorAuthMethodId[] {
+): ConnectorRegistryAuthMethodId[] {
   // Configured methods are raw registry entries; callers apply availability filters.
   return Object.keys(CONNECTOR_TYPES[type].authMethods)
     .map((authMethod) => {
-      return connectorAuthMethodIdSchema.parse(authMethod);
+      return connectorRegistryAuthMethodIdSchema.parse(authMethod);
     })
     .sort((a, b) => {
       const priorityDiff =
@@ -972,7 +972,7 @@ export function connectorAuthMethodHasGrantKind<
 
 export interface ConnectorAuthMethodRef {
   readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: ConnectorRegistryAuthMethodId;
 }
 
 export type ConnectorAuthMethodRefByGrantKind<Kind extends ConnectorGrantKind> =
@@ -1373,7 +1373,7 @@ export interface AvailableConnectorAuthMethodsOptions {
  */
 export function isConnectorAuthMethodAvailable(
   type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
+  authMethod: ConnectorRegistryAuthMethodId,
   featureStates: ConnectorFeatureStates,
 ): boolean {
   const method = getConnectorAuthMethod(type, authMethod);
@@ -1410,9 +1410,9 @@ export function getAvailableConnectorAuthMethodIds(
   type: ConnectorType,
   featureStates: ConnectorFeatureStates,
   options: AvailableConnectorAuthMethodsOptions = {},
-): ConnectorAuthMethodId[] {
+): ConnectorRegistryAuthMethodId[] {
   const apiAuthMethodPolicy = options.apiAuthMethodPolicy ?? "exclude";
-  const availableAuthMethodIds: ConnectorAuthMethodId[] = [];
+  const availableAuthMethodIds: ConnectorRegistryAuthMethodId[] = [];
   const configuredAuthMethodIds = getConfiguredConnectorAuthMethodIds(type);
 
   for (const authMethod of configuredAuthMethodIds) {
@@ -1703,7 +1703,7 @@ export function resolveConnectorAuthClientForMethod(
 
 type AnyConnectorResolvedAuthMethodClient = {
   readonly type: ConnectorType;
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: ConnectorRegistryAuthMethodId;
   readonly authClient: ConnectorAuthClient;
 };
 
@@ -1859,7 +1859,7 @@ export function getConnectorAuthMethodEnvBindings(
 }
 
 export interface ConnectorEnvBindingEntry {
-  readonly authMethod: ConnectorAuthMethodId;
+  readonly authMethod: ConnectorRegistryAuthMethodId;
   readonly envName: string;
   readonly valueRef: string;
 }

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -3,7 +3,7 @@ import type {
   ConnectorAccessKind,
   ConnectorAuthClientConfig,
   ConnectorAuthMethodConfig,
-  ConnectorAuthMethodId,
+  ConnectorRegistryAuthMethodId,
   ConnectorConfig,
   ConnectorGrantKind,
   ConnectorRevokeKind,
@@ -325,13 +325,13 @@ import { zeptomail } from "./connectors/zeptomail";
 import { zoom } from "./connectors/zoom";
 
 export {
-  CONNECTOR_AUTH_METHOD_IDS,
+  CONNECTOR_REGISTRY_AUTH_METHOD_IDS,
   CONNECTOR_DISPLAY_CATEGORY_GROUPS,
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_PLATFORM_SECRET_NAMES,
   connectorDisplayCategoryMetadataForItems,
-  connectorAuthMethodIdSchema,
+  connectorRegistryAuthMethodIdSchema,
 } from "./connector-config";
 export type {
   ConnectorAccessConfig,
@@ -342,7 +342,7 @@ export type {
   ConnectorAuthCodeGrantConfig,
   ConnectorAuthMethodConfig,
   ConnectorAuthMethodRuntimeConfig,
-  ConnectorAuthMethodId,
+  ConnectorRegistryAuthMethodId,
   ConnectorConfig,
   ConnectorDeviceAuthGrantConfig,
   ConnectorDeviceAuthStartOptionConfig,
@@ -762,7 +762,7 @@ type ConnectorAuthMethodsOf<Type extends ConnectorType> =
 
 export type ConnectorAuthMethodIds<Type extends ConnectorType> = Extract<
   keyof ConnectorAuthMethodsOf<Type>,
-  ConnectorAuthMethodId
+  ConnectorRegistryAuthMethodId
 >;
 export type ConnectorAuthMethodConfigFor<
   Type extends ConnectorType,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -557,7 +557,7 @@ export {
   type ConnectorConfig,
   type ConnectorEnvBindings,
   type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
+  type ConnectorRegistryAuthMethodId,
   type ScopeDiff,
   type ScopeDiffResponse,
   type ConnectorResponseConnectionStatus,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -621,7 +621,6 @@ export {
   type ZeroWorkflowVisibilityContract,
   type UserConnectorEnabledTypes,
   type ZeroUserConnectorsContract,
-  type ConnectorSearchAuthMethod,
   type ZeroConnectorsMainContract,
   type ZeroConnectorsByTypeContract,
   type ZeroConnectorScopeDiffContract,


### PR DESCRIPTION
## Summary

- use `ConnectorRef` and `ConnectorAuthMethodId` for server-authored connector identities across API contracts, backend, CLI, and Platform
- rename the local static auth-method subset to `ConnectorRegistryAuthMethodId` so it remains distinct from server-authored ids
- make `connector-identity.ts` the single owner of connector identity schemas and remove duplicate connector-ref and search auth-method aliases
- validate permission grants, encrypted provider state, compatibility diagnostics, runner network-policy refreshes, CLI test responses, and Platform permission metadata with the canonical identity schemas

## Compatibility

- keeps every JSON field, enum value, endpoint, and persisted value unchanged
- changes only private monorepo TypeScript export names and validation of malformed connector identities
- keeps the local executable `ConnectorType` distinct from the server-authored `ConnectorRef`
- can be deployed independently of the vm0-connectors identity-constraints PR

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/connectors test -- --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/api-contracts test -- --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/zero-user-permission-grants.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts src/signals/routes/__tests__/zero-connector-check.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cli-auth.bdd.test.ts src/signals/routes/__tests__/zero-user-permission-grants.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx --maxWorkers=4 --silent=passed-only`
