### PR TITLE
test(runner): strengthen active-job shutdown coverage

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
@@ -182,6 +182,10 @@ async fn repeated_drain_while_draining_keeps_active_job_running() {
 
     env.drain();
     wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+    assert!(
+        !run_handle.is_finished(),
+        "soft drain must wait for the active job"
+    );
 
     env.drain();
     assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
@@ -199,6 +203,7 @@ async fn repeated_drain_while_draining_keeps_active_job_running() {
         .expect("job should complete after the gate is released");
     assert_eq!(completion.exit_code, 0, "job ran to normal completion");
     assert!(completion.error.is_none(), "no cancellation error");
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     assert_run_exits_within(
         run_handle,

--- a/crates/runner/src/cmd/start/tests/main_loop/job_flow.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/job_flow.rs
@@ -53,28 +53,6 @@ async fn running_reaps_completed_jobs_without_budget_exhaustion() {
 }
 
 // -----------------------------------------------------------------------
-// Test 5: Shutdown drains running jobs before exiting
-// -----------------------------------------------------------------------
-
-#[tokio::test(start_paused = true)]
-async fn shutdown_drains_running_jobs() {
-    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let run_handle = tokio::spawn(run(config));
-
-    let run_id = RunId::new_v4();
-    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
-
-    // Wait for completion before draining.
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(completion.is_some());
-
-    shutdown(&env, run_handle).await;
-}
-
-// -----------------------------------------------------------------------
 // Test 8: Two successful jobs in sequence
 //
 // After the first job completes, discover_fut is recreated

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -2,7 +2,8 @@ use super::super::super::signals::{SignalController, SignalHandlerTask};
 use super::super::super::*;
 use super::super::support::{
     assert_run_exits_within, minimal_context, mock_run_config, mock_run_config_with_overrides,
-    push_job, shutdown, test_profiles, wait_cancel_token, wait_discover_entered, wait_status_mode,
+    push_job, shutdown, test_profiles, wait_cancel_token, wait_cancel_token_removed,
+    wait_discover_entered, wait_status_mode,
 };
 use std::sync::Arc;
 
@@ -95,21 +96,24 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
 /// than blocking on the 2h JOB_TIMEOUT.
 #[tokio::test]
 async fn hard_shutdown_cancels_active_jobs() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        gate,
-    ));
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
-    // Wait for the job to enter the gated wait — cancel token is now in the map.
-    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter the lifecycle gate");
 
     // SIGTERM equivalent: latch hard-shutdown, cancel all in-flight jobs.
     env.trigger_stopping().await;
+    assert!(token.is_cancelled(), "hard shutdown must cancel the job");
 
     assert_run_exits_within(
         run_handle,
@@ -117,6 +121,7 @@ async fn hard_shutdown_cancels_active_jobs() {
         "hard shutdown should exit within 3s — got stuck",
     )
     .await;
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     // The cancelled job reports the synthetic "cancelled by user" error.
     let comps = env.handle.completions.lock().unwrap();


### PR DESCRIPTION
## Summary

- remove the misleading job-flow test that only triggered shutdown after its job completed
- make soft-drain coverage assert the active job keeps the runner alive and its cancellation entry is cleaned up
- make hard-shutdown coverage wait for deterministic `wait_process` entry and assert cancellation plus cleanup

## Scope

This is a test-only change. It does not modify runner shutdown behavior, APIs, persisted state, or deployment compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner --bin runner repeated_drain_while_draining_keeps_active_job_running`
- `cargo test -p runner --bin runner hard_shutdown_cancels_active_jobs`
- `cargo test -p runner --bin runner`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- pre-commit hooks, including workspace Rust formatting, documentation, and Clippy checks

Closes #22414
