### PR TITLE
perf(api): collapse chat read cursor updates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1050,7 +1050,20 @@ describe("CHAT-01 chat thread read state", () => {
       });
     });
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([agentA]);
-    await chat.markThreadRead(owner, activeRun.threadId);
+    context.mocks.ably.publish.mockClear();
+    const firstRead = await chat.markThreadRead(owner, activeRun.threadId);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "chatThreadReadCursorUpdated",
+      {
+        threadId: activeRun.threadId,
+        agentId: agentA,
+        lastReadAt: firstRead.lastReadAt,
+      },
+    );
+    context.mocks.ably.publish.mockClear();
+    const repeatedRead = await chat.markThreadRead(owner, activeRun.threadId);
+    expect(repeatedRead.lastReadAt).toBe(firstRead.lastReadAt);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
 
     // An active goal suppresses the unread flag; a complete goal does not.
@@ -1277,6 +1290,9 @@ describe("CHAT-01 chat thread read state", () => {
         ]),
       },
     );
+    context.mocks.ably.publish.mockClear();
+    await chat.markAgentThreadsRead(owner, agentA);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
 
     await expect(chat.listThreadUnreads(owner, agentA)).resolves.toStrictEqual(
       [],

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-agent-read.ts
@@ -1,18 +1,18 @@
 import { command } from "ccstate";
-import { and, desc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { chatThreadMarkAgentReadContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { type Db, writeDb$ } from "../external/db";
+import { writeDb$ } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { latestRunFinishMessageSubquery } from "../services/zero-chat-thread-read-state-query";
 import type { RouteEntry } from "../route-entry";
 
 const markAgentReadBody$ = bodyResultOf(
@@ -24,35 +24,6 @@ function forbidden(message: string) {
     status: 403 as const,
     body: { error: { message, code: "FORBIDDEN" } },
   };
-}
-
-function lastRunFinishMessageSubquery(db: Pick<Db, "select">) {
-  return db
-    .select({
-      id: chatMessages.id,
-      createdAt: chatMessages.createdAt,
-    })
-    .from(chatMessages)
-    .where(
-      and(
-        eq(chatMessages.chatThreadId, chatThreads.id),
-        isNotNull(chatMessages.runLifecycleEvent),
-      ),
-    )
-    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
-    .limit(1)
-    .as("last_message");
-}
-
-function latestRunFinishCreatedAtSql() {
-  return sql`(
-    SELECT ${chatMessages.createdAt}
-    FROM ${chatMessages}
-    WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
-      AND ${isNotNull(chatMessages.runLifecycleEvent)}
-    ORDER BY ${desc(chatMessages.createdAt)}, ${desc(chatMessages.id)}
-    LIMIT 1
-  )`;
 }
 
 const markAgentReadInner$ = command(
@@ -81,45 +52,50 @@ const markAgentReadInner$ = command(
     }
 
     const writeDb = set(writeDb$);
-    const updatedThreadIds = await writeDb.transaction(async (tx) => {
-      const lastRunFinish = lastRunFinishMessageSubquery(tx);
-      const unreadRows = await tx
-        .select({
-          threadId: chatThreads.id,
-        })
-        .from(chatThreads)
-        .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-        .leftJoinLateral(lastRunFinish, sql`true`)
-        .where(
-          and(
-            eq(chatThreads.userId, auth.userId),
-            eq(zeroAgents.orgId, auth.orgId),
-            eq(chatThreads.agentComposeId, bodyResult.data.agentId),
-            isNotNull(lastRunFinish.id),
-            or(
-              isNull(chatThreads.lastReadAt),
-              gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
-            )!,
+    const latestRunFinish = latestRunFinishMessageSubquery(
+      writeDb,
+      chatThreads.id,
+    );
+    const unreadThreads = writeDb
+      .select({
+        threadId: chatThreads.id,
+        latestRunFinishAt: latestRunFinish.createdAt,
+      })
+      .from(chatThreads)
+      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
+      .crossJoinLateral(latestRunFinish)
+      .where(
+        and(
+          eq(chatThreads.userId, auth.userId),
+          eq(zeroAgents.orgId, auth.orgId),
+          eq(chatThreads.agentComposeId, bodyResult.data.agentId),
+          or(
+            isNull(chatThreads.lastReadAt),
+            gt(latestRunFinish.createdAt, chatThreads.lastReadAt),
           ),
-        );
-
-      for (const row of unreadRows) {
-        await tx
-          .update(chatThreads)
-          .set({ lastReadAt: latestRunFinishCreatedAtSql() })
-          .where(
-            and(
-              eq(chatThreads.id, row.threadId),
-              eq(chatThreads.userId, auth.userId),
-            ),
-          );
-      }
-
-      return unreadRows.map((row) => {
-        return row.threadId;
-      });
-    });
+        ),
+      )
+      .as("unread_threads");
+    const updatedRows = await writeDb
+      .update(chatThreads)
+      .set({ lastReadAt: unreadThreads.latestRunFinishAt })
+      .from(unreadThreads)
+      .where(
+        and(
+          eq(chatThreads.id, unreadThreads.threadId),
+          eq(chatThreads.userId, auth.userId),
+          eq(chatThreads.agentComposeId, bodyResult.data.agentId),
+          or(
+            isNull(chatThreads.lastReadAt),
+            gt(unreadThreads.latestRunFinishAt, chatThreads.lastReadAt),
+          ),
+        ),
+      )
+      .returning({ threadId: chatThreads.id });
     signal.throwIfAborted();
+    const updatedThreadIds = updatedRows.map((row) => {
+      return row.threadId;
+    });
 
     if (updatedThreadIds.length > 0) {
       await publishUserSignal([auth.userId], "chatThreadReadCursorUpdated", {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
-import { and, desc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { chatThreadMarkReadContract } from "@vm0/api-contracts/contracts/chat-threads";
-import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 
 import { authContext$ } from "../auth/auth-context";
@@ -10,19 +9,9 @@ import { pathParamsOf } from "../context/request";
 import { writeDb$ } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
 import { notFound } from "../../lib/error";
+import { latestRunFinishMessageSubquery } from "../services/zero-chat-thread-read-state-query";
 import { zeroChatThreadUnreads } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route-entry";
-
-function latestRunFinishCreatedAtSql() {
-  return sql`(
-    SELECT ${chatMessages.createdAt}
-    FROM ${chatMessages}
-    WHERE ${eq(chatMessages.chatThreadId, chatThreads.id)}
-      AND ${isNotNull(chatMessages.runLifecycleEvent)}
-    ORDER BY ${desc(chatMessages.createdAt)}, ${desc(chatMessages.id)}
-    LIMIT 1
-  )`;
-}
 
 const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
@@ -58,19 +47,19 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 
   const lastReadAt = thread.lastReadAt?.toISOString() ?? null;
-  const latestRunFinishAt = latestRunFinishCreatedAtSql();
+  const latestRunFinish = latestRunFinishMessageSubquery(writeDb, params.id);
   const [updated] = await writeDb
     .update(chatThreads)
-    .set({ lastReadAt: latestRunFinishAt })
+    .set({ lastReadAt: latestRunFinish.createdAt })
+    .from(latestRunFinish)
     .where(
       and(
         eq(chatThreads.id, params.id),
         eq(chatThreads.userId, auth.userId),
-        isNotNull(latestRunFinishAt),
         or(
           isNull(chatThreads.lastReadAt),
-          gt(latestRunFinishAt, chatThreads.lastReadAt),
-        )!,
+          gt(latestRunFinish.createdAt, chatThreads.lastReadAt),
+        ),
       ),
     )
     .returning({ lastReadAt: chatThreads.lastReadAt });

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-read-state-query.ts
@@ -1,0 +1,25 @@
+import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import type { chatThreads } from "@vm0/db/schema/chat-thread";
+
+import type { Db } from "../external/db";
+
+export function latestRunFinishMessageSubquery(
+  db: Pick<Db, "select">,
+  threadId: string | typeof chatThreads.id,
+) {
+  return db
+    .select({
+      createdAt: chatMessages.createdAt,
+    })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.chatThreadId, threadId),
+        isNotNull(chatMessages.runLifecycleEvent),
+      ),
+    )
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
+    .limit(1)
+    .as("latest_run_finish_message");
+}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -86,6 +86,7 @@ import {
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
 import { normalizeRecommendedFollowups } from "./zero-chat-recommended-followups.service";
+import { latestRunFinishMessageSubquery } from "./zero-chat-thread-read-state-query";
 import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 import { excludeGoalMarkerCondition } from "./zero-chat-goal-marker.service";
 import { goalObjectiveBriefFromJson } from "./zero-goal-objective-brief-normalization.service";
@@ -777,24 +778,6 @@ export function zeroChatThreadDetail(args: {
   });
 }
 
-function lastRunFinishMessageSubquery(db: Pick<Db, "select">) {
-  return db
-    .select({
-      id: chatMessages.id,
-      createdAt: chatMessages.createdAt,
-    })
-    .from(chatMessages)
-    .where(
-      and(
-        eq(chatMessages.chatThreadId, chatThreads.id),
-        isNotNull(chatMessages.runLifecycleEvent),
-      ),
-    )
-    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
-    .limit(1)
-    .as("last_message");
-}
-
 /**
  * The user's unread threads under an agent, each with the creation time of
  * the latest run-finish marker. A thread is unread only when it has at least
@@ -807,7 +790,7 @@ export function zeroChatThreadUnreads(args: {
 }): Computed<Promise<readonly { threadId: string; unreadAt: string }[]>> {
   return computed(async (get) => {
     const db = get(db$);
-    const lastRunFinish = lastRunFinishMessageSubquery(db);
+    const lastRunFinish = latestRunFinishMessageSubquery(db, chatThreads.id);
     const rows = await db
       .select({
         threadId: chatThreads.id,
@@ -819,7 +802,7 @@ export function zeroChatThreadUnreads(args: {
         and(
           eq(chatThreads.userId, args.userId),
           eq(chatThreads.agentComposeId, args.agentComposeId),
-          isNotNull(lastRunFinish.id),
+          isNotNull(lastRunFinish.createdAt),
           or(
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
@@ -832,8 +815,9 @@ export function zeroChatThreadUnreads(args: {
         ),
       );
     return rows.flatMap((row) => {
-      // Always present: the isNotNull(lastRunFinish.id) filter guarantees a
-      // joined row, but the left-lateral type keeps the column nullable.
+      // Always present: the isNotNull(lastRunFinish.createdAt) filter
+      // guarantees a joined row, but the left-lateral type keeps the column
+      // nullable.
       if (row.unreadAt === null) {
         return [];
       }
@@ -853,7 +837,7 @@ export function zeroChatThreadUnreadAgentIds(args: {
 }): Computed<Promise<readonly string[]>> {
   return computed(async (get) => {
     const db = get(db$);
-    const lastRunFinish = lastRunFinishMessageSubquery(db);
+    const lastRunFinish = latestRunFinishMessageSubquery(db, chatThreads.id);
     const rows = await db
       .selectDistinct({ agentId: chatThreads.agentComposeId })
       .from(chatThreads)
@@ -863,7 +847,7 @@ export function zeroChatThreadUnreadAgentIds(args: {
         and(
           eq(chatThreads.userId, args.userId),
           eq(zeroAgents.orgId, args.orgId),
-          isNotNull(lastRunFinish.id),
+          isNotNull(lastRunFinish.createdAt),
           or(
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),


### PR DESCRIPTION
## Summary

- replace repeated scalar SQL tags with a shared typed Drizzle builder for the latest run-finish message
- collapse agent read-cursor updates from an N+1 transaction into one atomic `UPDATE ... FROM ... RETURNING` statement
- preserve ownership checks, monotonic cursor updates, deterministic message ordering, and no-op notification behavior

## Performance and concurrency evidence

- a representative four-thread bulk update drops from seven application/database statements to one
- local PostgreSQL 17 plans retain the existing thread and run-finish-message indexes without introducing a broader scan
- a lock-contention diagnostic confirmed the final monotonic predicate is rechecked after waiting: the stale update returned zero rows and preserved the newer watermark

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/chat-files.bdd.test.ts --maxWorkers=1 --silent=passed-only` (36 tests passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full Turbo type checks (13/13 tasks passed)
- `git diff --check`

## Scope

This PR does not change schemas, migrations, APIs, feature switches, lint rules, or documentation. A repository-wide scalar-query lint rule remains a separate follow-up slice under the parent issue.

Closes #22443

Parent: #22439
