### PR TITLE
fix(runner): avoid signal reentrant flush deadlock

### DIFF
--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -30,7 +30,11 @@ _UsageFlushPhase = Literal["running", "draining", "closed"]
 # Keep this in sync with usage/counters.py and the Rust wait path in
 # crates/runner/src/proxy/flush.rs plus crates/runner/src/cmd/start/mod.rs.
 RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
-_usage_flush_requested = threading.Event()
+# The signal handler must not use a lock-backed flag: it can re-enter the main
+# thread while shutdown is consuming a request. CPython Boolean assignment is
+# sufficient for this level-triggered flag, just as Event.is_set() was an
+# unlocked read; the owner lock below still serializes flush work.
+_usage_flush_requested: bool = False
 _usage_flush_signal_lock = threading.Lock()
 # Running workers own requests under the lock. During shutdown, drain_and_close()
 # changes the phase before waiting for that lock and becomes the sole draining owner.
@@ -49,10 +53,12 @@ def handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
     only records that work is needed and lets the background worker perform
     file I/O, usage flushing, and JSONL flushing.
     """
+    global _usage_flush_requested
+
     del signum
     if _usage_flush_phase == "closed":
         return
-    _usage_flush_requested.set()
+    _usage_flush_requested = True
     _start_usage_flush_worker()
 
 
@@ -67,7 +73,7 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
         if not acquired:
             raise AssertionError("runner usage flush worker did not stop")
         try:
-            if not _usage_flush_requested.is_set():
+            if not _usage_flush_requested:
                 return
         finally:
             _usage_flush_signal_lock.release()
@@ -75,14 +81,14 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
 
 
 def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
-    global _last_jsonl_flush_request_id, _usage_flush_phase
+    global _last_jsonl_flush_request_id, _usage_flush_phase, _usage_flush_requested
 
     acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
     if not acquired:
         raise AssertionError("runner usage flush worker did not stop")
     try:
         _usage_flush_phase = "running"
-        _usage_flush_requested.clear()
+        _usage_flush_requested = False
         _last_jsonl_flush_request_id = None
     finally:
         _usage_flush_signal_lock.release()
@@ -115,22 +121,24 @@ def _start_usage_flush_worker() -> None:
 def _run_usage_flush_worker() -> None:
     """Drain coalesced runner flush requests under the worker lock.
 
-    The event can be set again while a flush is running. Loop until no request
-    is pending. After releasing the lock, restart for a running-phase signal;
-    draining-phase requests belong to ``drain_and_close()``.
+    The request flag can be set again while a flush is running. Loop until no
+    request is pending. After releasing the lock, restart for a running-phase
+    signal; draining-phase requests belong to ``drain_and_close()``.
     """
     try:
         _drain_runner_usage_flush_requests()
     finally:
         _usage_flush_signal_lock.release()
-        if _usage_flush_requested.is_set():
+        if _usage_flush_requested:
             _start_usage_flush_worker()
 
 
 def _drain_runner_usage_flush_requests() -> None:
     """Drain coalesced runner requests while the caller owns the signal lock."""
-    while _usage_flush_requested.is_set():
-        _usage_flush_requested.clear()
+    global _usage_flush_requested
+
+    while _usage_flush_requested:
+        _usage_flush_requested = False
         _flush_usage_for_runner_request()
         _flush_jsonl_for_runner_request()
 
@@ -249,6 +257,6 @@ def drain_and_close() -> None:
             _drain_runner_usage_flush_requests()
         finally:
             # Close request admission while still owning the lock, then consume
-            # any event recorded immediately before this cutoff.
+            # any request recorded immediately before this cutoff.
             _usage_flush_phase = "closed"
             _drain_runner_usage_flush_requests()

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -174,7 +174,7 @@ class TestDoneHook:
             "auth-base:shutdown:False",
             "jsonl:shutdown",
         ]
-        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested
 
     def test_signal_after_done_does_not_start_worker(self):
         mock_executor = MagicMock()
@@ -191,7 +191,7 @@ class TestDoneHook:
             runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
 
         start_worker.assert_not_called()
-        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested
 
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
@@ -231,7 +231,7 @@ class TestDoneHook:
         mock_executor.shutdown.assert_called_once_with(wait=True)
         shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
-        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested
 
         with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker") as start_worker:
             runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -1,6 +1,9 @@
 """Tests for runner-triggered usage flush hooks."""
 
 import json
+import multiprocessing
+import os
+import signal
 import threading
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -23,6 +26,7 @@ _RUNNER_USAGE_STATE_ID = "runner-state"
 _DEFAULT_USAGE_FLUSH_REQUEST_ID = "request-1"
 _DEFAULT_JSONL_FLUSH_REQUEST_ID = "jsonl-request-1"
 _REQUESTED_AT_MS = 1_770_000_000_000
+_PROCESS_EXIT_TIMEOUT_SECONDS = 5
 
 
 def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
@@ -32,6 +36,50 @@ def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
 def record_stranded_runner_usage_flush_signal() -> None:
     with patch.object(runner_flush_lifecycle, "_start_usage_flush_worker"):
         runner_flush_lifecycle.handle_runner_usage_flush_signal(0, None)
+
+
+def _run_signal_while_legacy_request_flag_lock_is_held(tmp_path: str) -> None:
+    class _LockBackedLegacyRequestFlag:
+        def __init__(self) -> None:
+            self.lock = threading.Lock()
+
+        def set(self) -> None:
+            with self.lock:
+                pass
+
+    output_dir = Path(tmp_path)
+    pending_path = output_dir / "usage-pending"
+    request_path = output_dir / "usage-flush-request"
+    usage.set_pending_path(str(pending_path), usage_state_id=_RUNNER_USAGE_STATE_ID)
+    request_path.write_text(
+        json.dumps(
+            {
+                "usageStateId": _RUNNER_USAGE_STATE_ID,
+                "flushRequestId": _DEFAULT_USAGE_FLUSH_REQUEST_ID,
+                "requestedAtMs": _REQUESTED_AT_MS,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    legacy_request_flag = _LockBackedLegacyRequestFlag()
+    with (
+        patch.object(
+            runner_flush_lifecycle,
+            "_usage_flush_requested",
+            legacy_request_flag,
+        ),
+        patch.object(runner_flush_lifecycle, "_usage_flush_phase", "draining"),
+    ):
+        signal.signal(
+            runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
+            runner_flush_lifecycle.handle_runner_usage_flush_signal,
+        )
+
+        with legacy_request_flag.lock:
+            os.kill(os.getpid(), runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL)
+
+        runner_flush_lifecycle.drain_and_close()
 
 
 @dataclass(frozen=True)
@@ -115,6 +163,39 @@ class _InstrumentedFlushOwnerLock:
 class TestRunnerUsageFlushSignal:
     """Tests for runner-triggered usage buffer flush requests."""
 
+    def test_real_signal_during_request_consumption_drains_acknowledgement(
+        self, tmp_path: Path
+    ) -> None:
+        process = multiprocessing.get_context("spawn").Process(
+            target=_run_signal_while_legacy_request_flag_lock_is_held,
+            args=(str(tmp_path),),
+            name="runner-flush-signal-reentry-regression",
+        )
+        process.start()
+        completed = False
+        try:
+            process.join(timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
+            completed = not process.is_alive()
+        finally:
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
+
+        assert completed, "runner flush signal handler deadlocked"
+        assert process.exitcode == 0
+        assert process.pid is not None
+        state = json.loads((tmp_path / "usage-pending").read_text(encoding="utf-8"))
+        assert state == {
+            "pid": process.pid,
+            "usageStateId": _RUNNER_USAGE_STATE_ID,
+            "updatedAtMs": state["updatedAtMs"],
+            "flows": 0,
+            "buffered": 0,
+            "reports": 0,
+            "flushRequestId": _DEFAULT_USAGE_FLUSH_REQUEST_ID,
+        }
+        assert isinstance(state["updatedAtMs"], int)
+
     def test_signal_handler_flushes_usage_in_background(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
@@ -185,7 +266,7 @@ class TestRunnerUsageFlushSignal:
             assert state["flushRequestId"] == "jsonl-request-1"
             assert state["path"] == str(log_path)
             assert state["pending"] == 0
-            assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+            assert not runner_flush_lifecycle._usage_flush_requested
 
         mock_executor = MagicMock()
         mock_executor.shutdown.side_effect = shutdown_usage_executor
@@ -232,7 +313,7 @@ class TestRunnerUsageFlushSignal:
             "auth-base:shutdown:False",
             "jsonl:shutdown",
         ]
-        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested
 
     def test_signal_handler_writes_snapshot_when_flush_fails(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
@@ -757,7 +838,7 @@ class TestRunnerUsageFlushSignal:
 
         runner_flush_lifecycle.reset_runner_usage_flush_state_for_tests()
 
-        assert not runner_flush_lifecycle._usage_flush_requested.is_set()
+        assert not runner_flush_lifecycle._usage_flush_requested
 
     def test_failed_signal_flush_releases_worker_for_later_signal(self, mitm_ctx):
         second_flush_completed = threading.Event()


### PR DESCRIPTION
## Summary

- replace the lock-backed `threading.Event` mutation in the `SIGUSR1` handler with a level-triggered Boolean request flag
- preserve the existing flush owner lock, worker coalescing, shutdown handoff, acknowledgement files, and retry behavior
- add a spawned-process regression that delivers a real signal while a legacy lock-backed flag is held, then requires `drain_and_close()` to write the matching usage acknowledgement

## Compatibility and scope

- no schema, migration, API, runner protocol, signal number, timeout, or persisted file format changes
- no change to the Rust runner request/acknowledgement contract
- the only runtime representation change is the addon process-local pending-request flag

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m compileall -q src tests`
- real-signal regression repeated 5 times (5/5 passed)
- `.venv/bin/python -m pytest tests/test_runner_usage_flush_signal.py tests/test_done_hook.py -v` (28 passed)
- `.venv/bin/python -m pytest tests/ -v` (4,139 passed)
- `cargo test -p runner proxy::process::tests::addon_scripts_are_embedded -- --exact` (1 passed)
- `git diff --check`

Closes #22417
