### PR TITLE
fix(runner): bound streaming zlib expansion

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -133,15 +133,18 @@ def _create_zlib_stream_decode_session(
             if decoded:
                 decoded_bytes_emitted += len(decoded)
                 feed(decoded)
-            if obj.unconsumed_tail:
-                data = obj.unconsumed_tail
-                continue
             if obj.eof:
+                # At an exact output boundary, zlib can expose the next member
+                # through both unused_data and unconsumed_tail. Reset before
+                # consulting unconsumed_tail so the next member makes progress.
                 data = obj.unused_data
                 obj = zlib.decompressobj(wbits)
                 member_in_progress = False
                 if data:
                     continue
+            if obj.unconsumed_tail:
+                data = obj.unconsumed_tail
+                continue
             return
 
     def finish_error() -> str | None:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -21,6 +21,8 @@ from body_limits import (
     DEFAULT_BODY_DECODE_LIMIT,
     LARGE_RESPONSE_DECOMPRESS_LIMIT,
     STREAM_DECODE_CHUNK_LIMIT,
+    STREAM_DECODE_EXPANSION_GRACE,
+    STREAM_DECODE_MAX_EXPANSION_RATIO,
 )
 
 # Brotli 1.2's output_buffer_limit is a soft allocation threshold, not a hard
@@ -91,26 +93,45 @@ def _create_zlib_stream_decode_session(
 ) -> StreamDecodeSession:
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     obj = zlib.decompressobj(wbits)
+    compressed_bytes_seen = 0
     decode_error: str | None = None
+    decoded_bytes_emitted = 0
     member_in_progress = False
     saw_input = False
 
     def decode(chunk: bytes) -> None:
-        nonlocal decode_error, member_in_progress, obj, saw_input
+        nonlocal compressed_bytes_seen, decode_error, decoded_bytes_emitted
+        nonlocal member_in_progress, obj, saw_input
         if decode_error is not None:
             return
         if chunk:
             saw_input = True
+            compressed_bytes_seen += len(chunk)
         data = chunk
         while data:
             member_in_progress = True
+            allowed_decoded_bytes = max(
+                STREAM_DECODE_EXPANSION_GRACE,
+                compressed_bytes_seen * STREAM_DECODE_MAX_EXPANSION_RATIO,
+            )
+            remaining_decoded_bytes = allowed_decoded_bytes - decoded_bytes_emitted
+            probing_for_additional_output = remaining_decoded_bytes == 0
+            max_length = (
+                1
+                if probing_for_additional_output
+                else min(max_decoded_chunk, remaining_decoded_bytes)
+            )
             try:
-                decoded = obj.decompress(data, max_length=max_decoded_chunk)
+                decoded = obj.decompress(data, max_length=max_length)
             except zlib.error as exc:
                 decode_error = INVALID_COMPRESSED_BODY
                 _log_streaming_decode_error(encoding, exc)
                 return
+            if probing_for_additional_output and decoded:
+                decode_error = DECODED_BODY_LIMIT_EXCEEDED
+                return
             if decoded:
+                decoded_bytes_emitted += len(decoded)
                 feed(decoded)
             if obj.unconsumed_tail:
                 data = obj.unconsumed_tail
@@ -175,9 +196,12 @@ def create_stream_decode_session(
     """Create a bounded streaming decoder session for usage-parser chunks.
 
     Usage parsers are bounded-state scanners and may need to inspect long
-    responses, so this helper does not enforce a total decoded-byte cap. It
-    bounds each decoded chunk before parser entry. Returns None when a content
-    encoding cannot be safely decoded incrementally.
+    responses, so this helper does not enforce a fixed total decoded-byte cap.
+    For gzip and deflate, one response-scoped budget bounds cumulative decoded
+    output to the larger of the streaming grace or compressed bytes seen times
+    the maximum expansion ratio. The budget is shared across callbacks and
+    concatenated members. Each decoded parser chunk is bounded independently.
+    Returns None when a content encoding cannot be safely decoded incrementally.
 
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member

--- a/crates/runner/mitm-addon/src/body_limits.py
+++ b/crates/runner/mitm-addon/src/body_limits.py
@@ -25,9 +25,18 @@ DEFAULT_BODY_DECODE_LIMIT = _SMALL_BODY_LIMIT_BYTES
 REQUEST_BODY_BILLING_INSPECTION_LIMIT = STREAM_BUFFER_LIMIT
 
 # Maximum decoded chunk size fed to incremental usage parsers. This bounds
-# transient decompressor output without truncating the total response scanned by
-# bounded-state parsers.
+# transient decompressor output independently of the response-level expansion
+# budget below.
 STREAM_DECODE_CHUNK_LIMIT = 64 * 1024  # 64 KB
+
+# Initial decoded-output allowance for streaming gzip/deflate usage inspection.
+# This permits small or initially bursty compressed bodies without imposing a
+# fixed total cap on long, low-ratio streams.
+STREAM_DECODE_EXPANSION_GRACE = 5 * 1024 * 1024  # 5 MB
+
+# Maximum cumulative decoded bytes allowed per compressed byte seen by a
+# streaming gzip/deflate response session, after the grace allowance is spent.
+STREAM_DECODE_MAX_EXPANSION_RATIO = 100
 
 # Decompression cap for production model-provider and connector JSON usage
 # fallback paths. Keep this larger than STREAM_BUFFER_LIMIT so diagnostic

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -143,9 +143,11 @@ class TestStreamDecodeFeed:
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
-    def test_zlib_expansion_budget_allows_exact_grace(self, headers, encoding):
+    def test_zlib_expansion_budget_allows_exact_grace_and_empty_member(self, headers, encoding):
         plaintext = b"A" * STREAM_DECODE_EXPANSION_GRACE
-        compressed = _compress_one_shot_body(encoding, plaintext)
+        compressed = _compress_one_shot_body(encoding, plaintext) + _compress_one_shot_body(
+            encoding, b""
+        )
         assert len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO < len(plaintext)
         chunks: list[bytes] = []
         session = create_stream_decode_session(

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -1,6 +1,7 @@
 """Tests for shared HTTP body decoding helpers."""
 
 import gzip
+import hashlib
 import zlib
 
 import brotli
@@ -15,7 +16,12 @@ from body_decoding import (
     decompress_body,
     decompress_json_usage_body,
 )
-from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
+from body_limits import (
+    DEFAULT_BODY_DECODE_LIMIT,
+    STREAM_DECODE_CHUNK_LIMIT,
+    STREAM_DECODE_EXPANSION_GRACE,
+    STREAM_DECODE_MAX_EXPANSION_RATIO,
+)
 from tests.body_decode_helpers import (
     pseudo_random_ascii,
     track_brotli_decompressor,
@@ -135,6 +141,107 @@ class TestStreamDecodeFeed:
         assert b"".join(chunks) == plaintext
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_expansion_budget_allows_exact_grace(self, headers, encoding):
+        plaintext = b"A" * STREAM_DECODE_EXPANSION_GRACE
+        compressed = _compress_one_shot_body(encoding, plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() is None
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_high_ratio_output_stops_at_expansion_budget(self, headers, encoding):
+        plaintext = b"A" * (64 * 1024 * 1024)
+        compressed = _compress_one_shot_body(encoding, plaintext)
+        expected_decoded_bytes = max(
+            STREAM_DECODE_EXPANSION_GRACE,
+            len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
+        )
+        assert expected_decoded_bytes < len(plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext[:expected_decoded_bytes]
+        assert (
+            len(chunks)
+            == (expected_decoded_bytes + STREAM_DECODE_CHUNK_LIMIT - 1) // STREAM_DECODE_CHUNK_LIMIT
+        )
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert session.finish_error() == "decoded body limit exceeded"
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext[:expected_decoded_bytes]
+        assert session.finish_error() == "decoded body limit exceeded"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_expansion_budget_is_shared_across_callbacks(self, headers, encoding):
+        plaintext = b"A" * (8 * 1024 * 1024)
+        compressed = _compress_one_shot_body(encoding, plaintext)
+        split_at = len(compressed) // 3
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed[:split_at])
+        session.feed(compressed[split_at:])
+
+        assert b"".join(chunks) == plaintext[:STREAM_DECODE_EXPANSION_GRACE]
+        assert session.finish_error() == "decoded body limit exceeded"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_concatenated_zlib_members_share_expansion_budget(self, headers, encoding):
+        first_plaintext = b"A" * (3 * 1024 * 1024)
+        second_plaintext = b"B" * (3 * 1024 * 1024)
+        first_member = _compress_one_shot_body(encoding, first_plaintext)
+        second_member = _compress_one_shot_body(encoding, second_plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(first_member)
+        assert b"".join(chunks) == first_plaintext
+        assert session.finish_error() is None
+        session.feed(second_member)
+
+        remaining = STREAM_DECODE_EXPANSION_GRACE - len(first_plaintext)
+        assert b"".join(chunks) == first_plaintext + second_plaintext[:remaining]
+        assert session.finish_error() == "decoded body limit exceeded"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_low_ratio_output_can_exceed_expansion_grace(self, headers, encoding):
+        plaintext = hashlib.shake_256(b"vm0-streaming-zlib-low-ratio").digest(
+            STREAM_DECODE_EXPANSION_GRACE + STREAM_DECODE_CHUNK_LIMIT
+        )
+        compressed = _compress_one_shot_body(encoding, plaintext)
+        assert len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO > len(plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() is None
 
     def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
         chunks: list[bytes] = []

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -146,6 +146,7 @@ class TestStreamDecodeFeed:
     def test_zlib_expansion_budget_allows_exact_grace(self, headers, encoding):
         plaintext = b"A" * STREAM_DECODE_EXPANSION_GRACE
         compressed = _compress_one_shot_body(encoding, plaintext)
+        assert len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO < len(plaintext)
         chunks: list[bytes] = []
         session = create_stream_decode_session(
             headers(("Content-Encoding", encoding)), chunks.append
@@ -161,6 +162,7 @@ class TestStreamDecodeFeed:
     def test_zlib_high_ratio_output_stops_at_expansion_budget(self, headers, encoding):
         plaintext = b"A" * (64 * 1024 * 1024)
         compressed = _compress_one_shot_body(encoding, plaintext)
+        assert len(compressed) < STREAM_DECODE_CHUNK_LIMIT
         expected_decoded_bytes = max(
             STREAM_DECODE_EXPANSION_GRACE,
             len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
@@ -191,6 +193,7 @@ class TestStreamDecodeFeed:
     def test_zlib_expansion_budget_is_shared_across_callbacks(self, headers, encoding):
         plaintext = b"A" * (8 * 1024 * 1024)
         compressed = _compress_one_shot_body(encoding, plaintext)
+        assert len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO < STREAM_DECODE_EXPANSION_GRACE
         split_at = len(compressed) // 3
         chunks: list[bytes] = []
         session = create_stream_decode_session(
@@ -199,6 +202,8 @@ class TestStreamDecodeFeed:
         assert session is not None
 
         session.feed(compressed[:split_at])
+        decoded_after_first_callback = sum(len(chunk) for chunk in chunks)
+        assert 0 < decoded_after_first_callback < STREAM_DECODE_EXPANSION_GRACE
         session.feed(compressed[split_at:])
 
         assert b"".join(chunks) == plaintext[:STREAM_DECODE_EXPANSION_GRACE]
@@ -210,6 +215,10 @@ class TestStreamDecodeFeed:
         second_plaintext = b"B" * (3 * 1024 * 1024)
         first_member = _compress_one_shot_body(encoding, first_plaintext)
         second_member = _compress_one_shot_body(encoding, second_plaintext)
+        assert (
+            len(first_member + second_member) * STREAM_DECODE_MAX_EXPANSION_RATIO
+            < STREAM_DECODE_EXPANSION_GRACE
+        )
         chunks: list[bytes] = []
         session = create_stream_decode_session(
             headers(("Content-Encoding", encoding)), chunks.append

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -13,7 +13,11 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import (
+    STREAM_BUFFER_LIMIT,
+    STREAM_DECODE_EXPANSION_GRACE,
+    STREAM_DECODE_MAX_EXPANSION_RATIO,
+)
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.model_provider_response_helpers import (
@@ -159,6 +163,51 @@ class TestModelProviderJsonStreaming:
             provider_case,
             cache_write_tokens=cache_write_tokens,
         )
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    def test_full_pipeline_zlib_expansion_limit_preserves_wire_body_and_rejects_usage(
+        self, tmp_path, real_flow, encoding_case
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            ANTHROPIC_JSON_CASE,
+            proxy_log_path=proxy_log_path,
+        )
+        payload = (
+            b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"'
+            + b"A" * (STREAM_DECODE_EXPANSION_GRACE + 1024)
+            + b'"}],"usage":{"input_tokens":50,"output_tokens":200}}'
+        )
+        compressed = gzip.compress(payload) if encoding_case == "gzip" else zlib.compress(payload)
+        allowed_decoded_bytes = max(
+            STREAM_DECODE_EXPANSION_GRACE,
+            len(compressed) * STREAM_DECODE_MAX_EXPANSION_RATIO,
+        )
+        assert allowed_decoded_bytes < len(payload)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {"content-type": "application/json", "content-encoding": encoding_case}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(compressed) == compressed
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["error"] == "decoded body limit exceeded"
 
     def test_full_pipeline_small_zstd_model_json_uses_bounded_fallback(
         self,


### PR DESCRIPTION
## Summary

- enforce a response-scoped gzip/deflate streaming budget of `max(5 MiB, compressed bytes seen * 100)` before decoded bytes enter usage parsers
- preserve the existing 64 KiB parser-chunk bound, concatenated-member handling, and byte-for-byte wire response forwarding
- route budget exhaustion through the existing `decoded body limit exceeded` finalization path so partial usage is not billed
- cover exact-limit completion, high-ratio expansion, split callbacks, concatenated members, long low-ratio responses, and the real model JSON response pipeline

## Scope

This is runner-local inspection behavior. It does not change response encoding negotiation, add a fixed total stream-size cap, rewrite client response bytes, or change API, database, queue, persisted-state, or cross-version protocol contracts.

## Validation

- `cd crates/runner/mitm-addon && python3 -m ruff format --check src tests`
- `cd crates/runner/mitm-addon && python3 -m ruff check src tests`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_body_decoding.py tests/test_model_provider_json_streaming.py -q` (113 passed)
- `cd crates/runner/mitm-addon && python3 -m pytest tests/` (4,150 passed)
- `git diff --check`

Closes #22418
