### PR TITLE
test(runner): verify hostname policy in pinned mitmdump

### DIFF
--- a/.github/scripts/firewall-hostname-policy-contract.sh
+++ b/.github/scripts/firewall-hostname-policy-contract.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+DEPS="$ROOT/crates/runner/src/deps.rs"
+PROBE="$ROOT/crates/runner/mitm-addon/scripts/firewall_hostname_policy_contract_probe.py"
+WORK_DIR=$(mktemp --directory "${RUNNER_TEMP:-/tmp}/vm0-firewall-hostname-policy.XXXXXX")
+trap 'rm -rf -- "$WORK_DIR"' EXIT
+
+case "$(uname -m)" in
+  x86_64)
+    RUST_ARCH=X86_64
+    DOWNLOAD_ARCH=x86_64
+    ;;
+  aarch64)
+    RUST_ARCH=AARCH64
+    DOWNLOAD_ARCH=aarch64
+    ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+rust_constant() {
+  local name=$1
+  local block
+  local value
+  block=$(sed -n "/^pub const ${name}:/,/;/p" "$DEPS" | tr '\n' ' ')
+  if [[ -z "$block" ]]; then
+    echo "Missing runner dependency constant: $name" >&2
+    exit 1
+  fi
+  value=${block#*=}
+  value=${value%%;*}
+  value=${value//[\"_[:space:]]/}
+  printf '%s' "$value"
+}
+
+VERSION=$(rust_constant MITMPROXY_VERSION)
+ARCHIVE_SIZE=$(rust_constant "MITMPROXY_ARCHIVE_SIZE_${RUST_ARCH}")
+ARCHIVE_SHA256=$(rust_constant "MITMPROXY_ARCHIVE_SHA256_${RUST_ARCH}")
+MITMDUMP_ENTRY=$(rust_constant MITMDUMP_TAR_ENTRY)
+MITMDUMP_SIZE=$(rust_constant "MITMDUMP_SIZE_${RUST_ARCH}")
+MITMDUMP_SHA256=$(rust_constant "MITMDUMP_SHA256_${RUST_ARCH}")
+ARCHIVE="$WORK_DIR/mitmproxy.tar.gz"
+MITMDUMP="$WORK_DIR/$MITMDUMP_ENTRY"
+
+curl \
+  --fail \
+  --location \
+  --retry 3 \
+  --retry-all-errors \
+  --retry-max-time 300 \
+  --connect-timeout 15 \
+  --max-time 240 \
+  --output "$ARCHIVE" \
+  "https://downloads.mitmproxy.org/${VERSION}/mitmproxy-${VERSION}-linux-${DOWNLOAD_ARCH}.tar.gz"
+
+if [[ $(stat --format='%s' "$ARCHIVE") != "$ARCHIVE_SIZE" ]]; then
+  echo "Pinned mitmproxy archive size mismatch" >&2
+  exit 1
+fi
+if ! echo "${ARCHIVE_SHA256}  ${ARCHIVE}" | sha256sum --check --status; then
+  echo "Pinned mitmproxy archive SHA-256 mismatch" >&2
+  exit 1
+fi
+
+tar --extract --gzip --file "$ARCHIVE" --directory "$WORK_DIR" -- "$MITMDUMP_ENTRY"
+if [[ $(stat --format='%s' "$MITMDUMP") != "$MITMDUMP_SIZE" ]]; then
+  echo "Pinned mitmdump size mismatch" >&2
+  exit 1
+fi
+if ! echo "${MITMDUMP_SHA256}  ${MITMDUMP}" | sha256sum --check --status; then
+  echo "Pinned mitmdump SHA-256 mismatch" >&2
+  exit 1
+fi
+chmod +x "$MITMDUMP"
+
+timeout --signal=TERM --kill-after=5s 60s "$MITMDUMP" -s "$PROBE"
+echo "Pinned mitmdump hostname policy contract passed (${DOWNLOAD_ARCH})"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -66,6 +66,7 @@ jobs:
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       mitm-addon-test-inputs-changed: ${{ steps.detect.outputs.mitm-addon-test-inputs-changed }}
       mitm-addon-pricing-seed-changed: ${{ steps.detect.outputs.mitm-addon-pricing-seed-changed }}
+      firewall-hostname-policy-contract-changed: ${{ steps.detect.outputs.firewall-hostname-policy-contract-changed }}
       api-contracts-rust-bindings-changed: ${{ steps.detect.outputs.api-contracts-rust-bindings-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       api-contracts-changed: ${{ steps.detect.outputs.api-contracts-changed }}
@@ -124,6 +125,14 @@ jobs:
             echo "any-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "any-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # This contract crosses the TypeScript policy and exact runner
+          # artifact boundary without forcing unrelated crate jobs to run.
+          if git diff --name-only "$BASE_REF" HEAD | grep -Eqx '(\.github/scripts/firewall-hostname-policy-contract\.sh|\.github/workflows/crates\.yml|crates/runner/src/deps\.rs|crates/runner/mitm-addon/scripts/firewall_hostname_policy_contract_probe\.py|crates/runner/mitm-addon/src/host_normalization\.py|turbo/pnpm-lock\.yaml|turbo/packages/connectors/package\.json|turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract\.(json|test\.ts)|turbo/packages/connectors/src/firewall-hostname-policy\.ts|turbo/packages/connectors/src/firewall-types\.ts)'; then
+            echo "firewall-hostname-policy-contract-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "firewall-hostname-policy-contract-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
           # The api-contracts Rust bindings are generated from selected
@@ -479,6 +488,27 @@ jobs:
           cd crates/runner/mitm-addon
           pip install ".[test]"
           python -m pytest tests/ -v
+
+  firewall-hostname-policy-contract:
+    name: Firewall hostname policy (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    needs: [detect]
+    if: needs.detect.outputs.firewall-hostname-policy-contract-changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify policy with pinned mitmdump
+        shell: bash
+        run: .github/scripts/firewall-hostname-policy-contract.sh
 
   nbd-cow-test:
     runs-on: ubuntu-latest
@@ -915,6 +945,7 @@ jobs:
       - coverage
       - api-contracts-rust-bindings
       - mitm-addon-test
+      - firewall-hostname-policy-contract
       - runner-host-groups
       - runner-build
       - runner-image-architecture-manifest
@@ -963,6 +994,7 @@ jobs:
           check_result "coverage" "${{ needs.coverage.result }}" "true"
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
+          check_result "firewall-hostname-policy-contract" "${{ needs.firewall-hostname-policy-contract.result }}" "true"
           check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"

--- a/crates/runner/mitm-addon/scripts/firewall_hostname_policy_contract_probe.py
+++ b/crates/runner/mitm-addon/scripts/firewall_hostname_policy_contract_probe.py
@@ -1,0 +1,124 @@
+"""Verify the shared hostname policy inside the pinned mitmdump runtime."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from importlib import import_module
+from pathlib import Path
+from typing import NamedTuple, Protocol, cast
+from unicodedata import unidata_version
+
+_ROOT = Path(__file__).resolve().parents[4]
+_CONTRACT_PATH = (
+    _ROOT
+    / "turbo"
+    / "packages"
+    / "connectors"
+    / "src"
+    / "__tests__"
+    / "firewall-base-url-validation-contract.json"
+)
+_ADDON_SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+_POLICY_PATTERN = re.compile(r"^vm0-uts46-(?P<unicode_version>\d+\.\d+)-v[1-9]\d*$")
+_POLICY_UNICODE_COMPONENT_COUNT = 2
+
+
+class _HostnamePolicyCase(NamedTuple):
+    name: str
+    hostname: str
+    expected_canonical_hostname: str
+
+
+class _HostNormalizerModule(Protocol):
+    def normalize_idna_hostname(self, host: str) -> str: ...
+
+
+def _require_object(value: object, location: str) -> dict[object, object]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{location} must be an object")
+    return cast(dict[object, object], value)
+
+
+def _require_string(value: object, location: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{location} must be a string")
+    return value
+
+
+def _load_contract() -> tuple[str, list[_HostnamePolicyCase]]:
+    raw_contract: object = json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+    contract = _require_object(raw_contract, "contract")
+    policy = _require_string(contract.get("hostnamePolicy"), "hostnamePolicy")
+
+    raw_cases = contract.get("hostnamePolicyCases")
+    if not isinstance(raw_cases, list):
+        raise TypeError("hostnamePolicyCases must be an array")
+    if not raw_cases:
+        raise ValueError("hostnamePolicyCases must not be empty")
+
+    cases: list[_HostnamePolicyCase] = []
+    names: set[str] = set()
+    for index, raw_case in enumerate(raw_cases):
+        location = f"hostnamePolicyCases[{index}]"
+        case = _require_object(raw_case, location)
+        name = _require_string(case.get("name"), f"{location}.name")
+        if name in names:
+            raise RuntimeError(f"duplicate hostname policy case name: {name}")
+        names.add(name)
+        cases.append(
+            _HostnamePolicyCase(
+                name=name,
+                hostname=_require_string(case.get("hostname"), f"{location}.hostname"),
+                expected_canonical_hostname=_require_string(
+                    case.get("expectedCanonicalHostname"),
+                    f"{location}.expectedCanonicalHostname",
+                ),
+            )
+        )
+
+    return policy, cases
+
+
+def _expected_unicode_version(policy: str) -> str:
+    match = _POLICY_PATTERN.fullmatch(policy)
+    if match is None:
+        raise RuntimeError(f"unsupported firewall hostname policy: {policy}")
+    return match.group("unicode_version")
+
+
+def _runtime_unicode_version() -> str:
+    components = unidata_version.split(".")
+    if len(components) < _POLICY_UNICODE_COMPONENT_COUNT:
+        raise RuntimeError(f"unexpected runtime Unicode version: {unidata_version}")
+    return ".".join(components[:_POLICY_UNICODE_COMPONENT_COUNT])
+
+
+def _load_host_normalizer() -> _HostNormalizerModule:
+    sys.path.insert(0, str(_ADDON_SRC_PATH))
+    return cast(_HostNormalizerModule, import_module("host_normalization"))
+
+
+def _main() -> None:
+    policy, cases = _load_contract()
+    expected_unicode_version = _expected_unicode_version(policy)
+    runtime_unicode_version = _runtime_unicode_version()
+    if runtime_unicode_version != expected_unicode_version:
+        raise RuntimeError(
+            "pinned mitmdump Unicode version does not match firewall hostname policy: "
+            f"expected {expected_unicode_version}, got {unidata_version}"
+        )
+
+    host_normalizer = _load_host_normalizer()
+    for case in cases:
+        actual = host_normalizer.normalize_idna_hostname(case.hostname)
+        if actual != case.expected_canonical_hostname:
+            raise RuntimeError(
+                f"hostname policy case {case.name!r} produced {actual!r}; "
+                f"expected {case.expected_canonical_hostname!r}"
+            )
+
+
+_main()
+raise SystemExit(0)

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -186,6 +186,12 @@ targets, and untrusted request authorities. The fixed backend policy must emit
 only canonical ASCII identities accepted unchanged by draining old runners; a
 policy upgrade requires deliberate compatibility analysis before deployment.
 
+The hostname policy CI gate runs focused shared vectors inside the exact
+checksum-pinned standalone mitmdump artifacts for both runner architectures.
+Any policy or artifact upgrade must keep those vectors passing on x86_64 and
+aarch64; the regular Python 3.12 addon suite does not replace this production
+runtime check.
+
 A fully dynamic secret-backed `auth.base` remains runner-validated because the
 existing auth request has no policy/capability marker that can distinguish old
 and new runs. Changing that path requires an explicit backward-compatible

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -1,5 +1,17 @@
 {
   "hostnamePolicy": "vm0-uts46-16.0-v1",
+  "hostnamePolicyCases": [
+    {
+      "name": "unicode 16 host has canonical ascii identity",
+      "hostname": "𑎀.example",
+      "expectedCanonicalHostname": "xn--pq1d.example"
+    },
+    {
+      "name": "unicode 16 a-label keeps the same identity",
+      "hostname": "xn--pq1d.example",
+      "expectedCanonicalHostname": "xn--pq1d.example"
+    }
+  ],
   "baseUrlValidationCases": [
     {
       "category": "valid",

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
@@ -18,9 +18,16 @@ const baseUrlValidationCaseSchema = z.object({
   expectedCanonicalBase: z.string().optional(),
 });
 
+const hostnamePolicyCaseSchema = z.object({
+  name: z.string(),
+  hostname: z.string(),
+  expectedCanonicalHostname: z.string(),
+});
+
 const contractSchema = z
   .object({
     hostnamePolicy: z.literal(FIREWALL_HOSTNAME_POLICY_VERSION),
+    hostnamePolicyCases: z.array(hostnamePolicyCaseSchema).min(1),
     baseUrlValidationCases: z.array(baseUrlValidationCaseSchema).min(1),
   })
   .superRefine((contract, ctx) => {
@@ -34,6 +41,18 @@ const contractSchema = z
         });
       }
       seenNames.add(testCase.name);
+    }
+
+    const seenHostnamePolicyNames = new Set<string>();
+    for (const [index, testCase] of contract.hostnamePolicyCases.entries()) {
+      if (seenHostnamePolicyNames.has(testCase.name)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["hostnamePolicyCases", index, "name"],
+          message: `duplicate case name "${testCase.name}"`,
+        });
+      }
+      seenHostnamePolicyNames.add(testCase.name);
     }
   });
 
@@ -76,6 +95,16 @@ describe("firewall base URL validation contract", () => {
   for (const testCase of contract.baseUrlValidationCases) {
     it(testCase.name, () => {
       assertValidationResult(testCase);
+    });
+  }
+});
+
+describe("firewall hostname policy contract", () => {
+  for (const testCase of contract.hostnamePolicyCases) {
+    it(testCase.name, () => {
+      expect(
+        canonicalizeFirewallBaseUrl(`https://${testCase.hostname}`, "contract"),
+      ).toBe(`https://${testCase.expectedCanonicalHostname}`);
     });
   }
 });


### PR DESCRIPTION
## Summary

- add focused Unicode 16 hostname vectors to the existing shared firewall contract and exercise them through TypeScript creation-time canonicalization
- verify current `host_normalization.py` inside both exact checksum-pinned standalone mitmdump artifacts on native x86_64 and aarch64 CI runners
- path-filter the new contract job, include it in the crates gate, and document the coordinated policy/artifact upgrade invariant

## Scope

This adds a CI-only compatibility guard. It does not change the production normalizer, runner startup, API or queue protocols, persisted data, database schema, dependencies, or request behavior. It also does not restore the former exhaustive Unicode corpus, Node matrix, generated digest, or artifact cache action.

## Validation

- exact aarch64 artifact orchestration using the pinned archive and binary identities from `crates/runner/src/deps.rs`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-base-url-validation-contract.test.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `python3 -m pytest tests/test_firewall_base_url_validation_contract.py -q`
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `pnpm knip`
- `bash -n .github/scripts/firewall-hostname-policy-contract.sh`
- `shellcheck .github/scripts/firewall-hostname-policy-contract.sh`
- `actionlint`
- `lefthook run pre-commit`

Closes #22419
