### PR TITLE
fix(runner): bound websocket message retention

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -28,14 +28,15 @@ from mitmproxy.addonmanager import Loader
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/matching/registry/
 # response_encoding_negotiation/response_streaming/runner_flush_lifecycle/terminal_usage/
-# upstream_admission/usage are imported by module (not selective `from X import ...`) so that:
+# upstream_admission/usage/websocket_retention are imported by module (not selective
+# `from X import ...`) so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
 #      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
 #      ``connector_intent.X(...)`` /
 #      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)`` /
 #      ``runner_flush_lifecycle.X(...)`` / ``terminal_usage.X(...)`` /
-#      ``upstream_admission.X(...)`` / ``usage.X(...)``, making the module boundary
-#      visible at call sites.
+#      ``upstream_admission.X(...)`` / ``usage.X(...)`` /
+#      ``websocket_retention.X(...)``, making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
@@ -63,6 +64,7 @@ import terminal_usage
 import upstream_admission
 import upstream_destination_binding
 import usage
+import websocket_retention
 from auth import (
     FirewallAuthHandlingResult,
     FirewallHeaderPhaseAuthResult,
@@ -1101,20 +1103,19 @@ def responseheaders(flow: http.HTTPFlow) -> None:
 
 
 def websocket_message(flow: http.HTTPFlow) -> None:
-    """Feed server-side WebSocket frames into model-provider usage parsers."""
+    """Bound registered WebSocket history and feed model-provider usage."""
     if not flow.websocket or not flow.websocket.messages:
         return
     if not flow_metadata.run_id(flow.metadata):
         return
-    if not response_streaming.is_model_websocket_usage_enabled(flow):
-        return
 
     message = flow.websocket.messages[-1]
+    websocket_retention.schedule_message_trim(flow)
+    if not response_streaming.is_model_websocket_usage_enabled(flow):
+        return
     if getattr(message, "from_client", False):
-        terminal_usage.schedule_model_websocket_message_trim(flow)
         return
     response_streaming.feed_model_websocket_usage(flow, message.content)
-    terminal_usage.schedule_model_websocket_message_trim(flow)
 
 
 def _response_size(flow: http.HTTPFlow) -> int:
@@ -1191,6 +1192,7 @@ def _release_terminal_flow_state(
     release_tracking: bool,
 ) -> None:
     if release_tracking:
+        websocket_retention.release_terminal_messages(flow)
         terminal_usage.release_model_websocket_terminal_state(flow)
     request_classification.pop_cached_classification(flow)
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)

--- a/crates/runner/mitm-addon/src/terminal_usage.py
+++ b/crates/runner/mitm-addon/src/terminal_usage.py
@@ -2,14 +2,12 @@
 
 from mitmproxy import http
 
-import deferred_callbacks
 import flow_metadata_keys as metadata_keys
 import response_streaming
 import usage
 
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
-_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_model_websocket_message_trim_scheduled"
 
 
 def track_flow_if_needed(
@@ -45,34 +43,7 @@ def report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
         flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
 
 
-def schedule_model_websocket_message_trim(flow: http.HTTPFlow) -> None:
-    if flow.metadata.get(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, False):
-        return
-    flow.metadata[_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED] = True
-    deferred_callbacks.call_soon(_trim_model_websocket_messages, flow)
-
-
 def release_model_websocket_terminal_state(flow: http.HTTPFlow) -> None:
-    _clear_model_websocket_messages(flow)
     if response_streaming.is_model_websocket_usage_enabled(flow):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
         response_streaming.release_model_websocket_usage_state(flow)
-
-
-def _is_model_websocket_usage_flow(flow: http.HTTPFlow) -> bool:
-    return bool(flow.websocket and response_streaming.is_model_websocket_usage_enabled(flow))
-
-
-def _trim_model_websocket_messages(flow: http.HTTPFlow) -> None:
-    flow.metadata.pop(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
-    if not _is_model_websocket_usage_flow(flow):
-        return
-    if not flow.websocket or not flow.websocket.messages:
-        return
-    flow.websocket.messages[:] = flow.websocket.messages[-1:]
-
-
-def _clear_model_websocket_messages(flow: http.HTTPFlow) -> None:
-    flow.metadata.pop(_MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
-    if _is_model_websocket_usage_flow(flow) and flow.websocket:
-        flow.websocket.messages.clear()

--- a/crates/runner/mitm-addon/src/websocket_retention.py
+++ b/crates/runner/mitm-addon/src/websocket_retention.py
@@ -1,0 +1,36 @@
+"""WebSocket message retention for registered mitmproxy flows."""
+
+from mitmproxy import http
+
+import deferred_callbacks
+import flow_metadata
+
+_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_websocket_message_trim_scheduled"
+
+
+def schedule_message_trim(flow: http.HTTPFlow) -> None:
+    if not flow_metadata.run_id(flow.metadata) or flow.websocket is None:
+        return
+    if flow.metadata.get(_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, False):
+        return
+    flow.metadata[_WEBSOCKET_MESSAGE_TRIM_SCHEDULED] = True
+    deferred_callbacks.call_soon(_trim_messages, flow)
+
+
+def release_terminal_messages(flow: http.HTTPFlow) -> None:
+    flow.metadata.pop(_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
+    if not flow_metadata.run_id(flow.metadata):
+        return
+    websocket_data = flow.websocket
+    if websocket_data is not None:
+        websocket_data.messages.clear()
+
+
+def _trim_messages(flow: http.HTTPFlow) -> None:
+    flow.metadata.pop(_WEBSOCKET_MESSAGE_TRIM_SCHEDULED, None)
+    if not flow_metadata.run_id(flow.metadata):
+        return
+    websocket_data = flow.websocket
+    if websocket_data is None or not websocket_data.messages:
+        return
+    websocket_data.messages[:] = websocket_data.messages[-1:]

--- a/crates/runner/mitm-addon/tests/test_deferred_scheduler.py
+++ b/crates/runner/mitm-addon/tests/test_deferred_scheduler.py
@@ -22,15 +22,17 @@ async def _run_ready_tasks() -> None:
     await ready.wait()
 
 
-async def test_model_websocket_trim_uses_real_event_loop_scheduler(tmp_path, mitm_ctx, real_flow):
-    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
-    mitm_addon.responseheaders(flow)
+async def test_registered_non_model_websocket_trim_uses_real_event_loop_scheduler(
+    mitm_ctx, real_flow
+):
+    flow = real_flow(with_response=False, host="example.com")
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
     old_client = append_websocket_message(flow, from_client=True, content=b"client-old")
     old_server = append_websocket_message(flow, from_client=False, content=b"server-old")
     latest_server = append_websocket_message(
         flow,
         from_client=False,
-        content=openai_websocket_usage_frame("resp_ws_latest"),
+        content=b"server-latest",
     )
     assert flow.websocket is not None
     messages = flow.websocket.messages

--- a/crates/runner/mitm-addon/tests/test_websocket_retention.py
+++ b/crates/runner/mitm-addon/tests/test_websocket_retention.py
@@ -1,4 +1,4 @@
-"""Tests for model-provider WebSocket message retention and cleanup."""
+"""Tests for registered WebSocket message retention and cleanup."""
 
 import pytest
 from mitmproxy.flow import Error
@@ -183,7 +183,7 @@ class TestModelProviderWebSocketRetentionWithUsageDelivery:
 
 
 class TestModelProviderWebSocketRetention:
-    """Retention tests without usage delivery."""
+    """Model retention tests without usage delivery."""
 
     def test_model_websocket_deferred_trim_keeps_latest_client_message(
         self,
@@ -212,13 +212,52 @@ class TestModelProviderWebSocketRetention:
         assert flow.websocket.messages == [latest_client]
         assert old_server not in flow.websocket.messages
 
-    def test_non_model_websocket_message_retention_is_unchanged(
+
+class TestRegisteredWebSocketRetention:
+    @pytest.mark.parametrize("from_client", [True, False])
+    def test_non_model_websocket_retention_is_bounded_during_sustained_traffic(
+        self,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+        from_client: bool,
+    ):
+        flow = real_flow(with_response=False, host="example.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        message_count = 32
+        message_size = 4096
+        total_bytes = 0
+        retained_bytes = 0
+
+        for index in range(message_count):
+            content = f"message-{index}".encode().ljust(message_size, b"x")
+            total_bytes += len(content)
+            latest = append_websocket_message(
+                flow,
+                from_client=from_client,
+                content=content,
+            )
+            assert flow.websocket is not None
+            messages_before_trim = list(flow.websocket.messages)
+
+            mitm_addon.websocket_message(flow)
+
+            assert flow.websocket.messages == messages_before_trim
+            assert len(deferred_websocket_trim_scheduler) == 1
+
+            run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+
+            assert flow.websocket.messages == [latest]
+            retained_bytes = sum(len(message.content) for message in flow.websocket.messages)
+            assert retained_bytes == len(content)
+
+        assert total_bytes == message_count * retained_bytes
+
+    def test_unregistered_websocket_retention_is_unchanged(
         self,
         real_flow,
         deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
     ):
         flow = real_flow(with_response=False, host="example.com")
-        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         first = append_websocket_message(flow, from_client=True, content=b"client")
         second = append_websocket_message(flow, from_client=False, content=b"server")
 
@@ -227,3 +266,44 @@ class TestModelProviderWebSocketRetention:
         assert deferred_websocket_trim_scheduler == []
         assert flow.websocket is not None
         assert flow.websocket.messages == [first, second]
+
+    def test_non_model_websocket_end_clears_final_retained_message(
+        self,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = real_flow(with_response=False, host="example.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        append_websocket_message(flow, from_client=False, content=b"server")
+
+        mitm_addon.websocket_message(flow)
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        mitm_addon.websocket_end(flow)
+
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []
+
+    def test_non_model_websocket_error_clears_final_retained_message(
+        self,
+        real_flow,
+        deferred_websocket_trim_scheduler: list[ScheduledWebSocketTrim],
+    ):
+        flow = real_flow(with_response=False, host="example.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.error = Error("connection reset by peer")
+        append_websocket_message(flow, from_client=True, content=b"client")
+
+        mitm_addon.websocket_message(flow)
+        assert len(deferred_websocket_trim_scheduler) == 1
+
+        mitm_addon.error(flow)
+
+        assert flow.websocket is not None
+        assert flow.websocket.messages == []
+
+        run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
+        assert flow.websocket.messages == []

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -953,6 +953,7 @@ PY
             "terminal_usage.py",
             "upstream_admission.py",
             "url_utils.py",
+            "websocket_retention.py",
             "logging_utils.py",
             "usage/__init__.py",
             "usage/anthropic_messages.py",

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -110,7 +110,7 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 | `test_model_provider_sse_usage.py`                      | Model provider SSE usage pipeline                                                                                    |
 | `test_model_provider_websocket_usage.py`                | Model provider WebSocket usage reporting and source reconciliation                                                   |
 | `test_model_provider_websocket_lifecycle.py`            | Model provider WebSocket HTTP upgrade and terminal usage lifecycle                                                   |
-| `test_model_provider_websocket_retention.py`            | Model provider WebSocket message retention and cleanup                                                               |
+| `test_websocket_retention.py`                           | Registered WebSocket message retention and cleanup                                                                   |
 | `test_model_provider_websocket_metadata.py`             | Model provider WebSocket usage metadata parsing                                                                      |
 | `test_model_provider_usage.py`                          | Model provider usage reporter                                                                                        |
 | `x_connector_usage/`                                    | Direct X connector usage billing, write refinement, unparseable fallback, and skip gates                             |


### PR DESCRIPTION
## Summary

- bound retained mitmproxy WebSocket history for registered model and non-model flows by deferring cleanup until the current message hook completes
- keep the latest frame available to existing model usage parsing, then clear retained frames when the WebSocket ends or errors
- preserve unregistered-flow behavior and verify the new retention module is embedded in the runner

## Scope

- this bounds retained message count; it does not truncate or impose a byte limit on an individual WebSocket frame
- no API, schema, runner protocol, or unregistered-flow behavior changes

## Validation

- `ruff format --check .`
- `ruff check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/ -q` (4,142 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`

Closes #22416
