### PR TITLE
fix: allow okou.ai and omby.ai to fetch hosted sites

### DIFF
--- a/turbo/apps/host-worker/src/index.test.ts
+++ b/turbo/apps/host-worker/src/index.test.ts
@@ -150,6 +150,23 @@ describe("hosted site worker", () => {
     expect(response.headers.get("Vary")).toBe("Origin");
   });
 
+  it.each([
+    "https://okou.ai",
+    "https://app.okou.ai",
+    "https://staging-app.omby.ai",
+  ])("allows product origin %s on hosted file responses", async (origin) => {
+    const response = await worker.fetch(
+      new Request("https://demo.sites.vm0.io/", {
+        headers: { Origin: origin },
+      }),
+      env(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(origin);
+    expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
   it("omits allow-origin for disallowed origins", async () => {
     const response = await worker.fetch(
       new Request("https://demo.sites.vm0.io/", {

--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -50,6 +50,7 @@ const CORS_HEADERS = {
 const STATIC_ALLOWED_ORIGINS = new Set([
   "https://www.vm0.ai",
   "https://vm0.ai",
+  "https://okou.ai",
   "https://app.vm7.ai:8443",
 ]);
 const DEFAULT_ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
@@ -77,7 +78,12 @@ function allowedCorsOrigin(origin: string | null): string | null {
   }
 
   const hostname = url.hostname.toLowerCase();
-  if (isSubdomainOf(hostname, "vm0.ai") || isSubdomainOf(hostname, "vm6.ai")) {
+  if (
+    isSubdomainOf(hostname, "vm0.ai") ||
+    isSubdomainOf(hostname, "okou.ai") ||
+    isSubdomainOf(hostname, "vm6.ai") ||
+    isSubdomainOf(hostname, "omby.ai")
+  ) {
     return normalizedOrigin;
   }
   if (isSubdomainOf(hostname, "vm7.ai") && url.port === "8443") {


### PR DESCRIPTION
## Summary

- allow the `okou.ai` apex and `*.okou.ai` origins to fetch hosted-site responses
- allow `*.omby.ai` preview origins to fetch hosted-site responses
- cover the production and preview product origins with Host Worker integration tests

## User impact

Hosted reports and other `sites.vm0.io` artifacts can now be fetched from Okou production and Omby preview pages without browser CORS failures. Unknown origins remain excluded.

## Verification

- `pnpm exec prettier --check apps/host-worker/src/index.ts apps/host-worker/src/index.test.ts`
- `pnpm -F @vm0/host-worker lint`
- `pnpm -F @vm0/host-worker check-types`
- `pnpm exec vitest run apps/host-worker/src/index.test.ts` (8 tests passed)
- `pnpm knip --workspace @vm0/host-worker`
- repository pre-commit checks: Prettier, Knip, and full Turbo type checks passed