### PR TITLE
fix(platform): show connector page before oauth redirect

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -47,6 +47,7 @@ import { setupCustomConnectorProposalPage$ } from "./connectors-page/custom-conn
 import { setupComputerUseAuthorizationPage$ } from "./computer-use-authorization/computer-use-authorization-page-setup.ts";
 import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-page-setup.ts";
 import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
+import { setupConnectorRedirectingPage$ } from "./connectors-page/connector-redirecting-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupSignInPage$, setupSignUpPage$ } from "./auth-page-setup.ts";
 import { setupPermissionAllowPage$ } from "./permission-allow/permission-allow-page-setup.ts";
@@ -160,6 +161,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.computerUseAuthorize,
     setup: setupAuthPageWrapper(setupComputerUseAuthorizationPage$),
+  },
+  {
+    path: ROUTES.connectorRedirecting,
+    setup: setupConnectorRedirectingPage$,
   },
   {
     path: ROUTES.directedAuthorize,

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -1,0 +1,44 @@
+import {
+  connectorCatalogRefSchema,
+  type ConnectorCatalogRef,
+} from "@vm0/api-contracts/contracts/connector-identity";
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroConnectorRedirectingPage } from "../../views/zero-page/zero-connector-redirecting-page.tsx";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { pathParams$, searchParams$ } from "../route.ts";
+import type { ConnectorRedirectingStatus } from "./connector-redirecting.ts";
+
+function connectorTypeFromPath(
+  value: string | undefined,
+): ConnectorCatalogRef | null {
+  const parsed = connectorCatalogRefSchema.safeParse(value?.toLowerCase());
+  return parsed.success ? parsed.data : null;
+}
+
+export const setupConnectorRedirectingPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(pathParams$);
+    const connectorType = connectorTypeFromPath(
+      typeof params?.type === "string" ? params.type : undefined,
+    );
+    const searchParams = get(searchParams$);
+    const connectorLabel =
+      searchParams.get("label")?.trim() || connectorType || "connector";
+    const status: ConnectorRedirectingStatus =
+      searchParams.get("status") === "error" ? "error" : "redirecting";
+
+    set(
+      updatePage$,
+      createElement(ZeroConnectorRedirectingPage, {
+        connectorType,
+        connectorLabel,
+        status,
+      }),
+    );
+    set(updateDocumentTitle$, `Connect ${connectorLabel}`);
+    await set(hideAppSkeleton$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -1,0 +1,20 @@
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import { generateRouterPath } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
+
+export type ConnectorRedirectingStatus = "redirecting" | "error";
+
+export function connectorRedirectingPath(args: {
+  readonly type: ConnectorCatalogRef;
+  readonly label: string;
+  readonly status?: ConnectorRedirectingStatus;
+}): string {
+  const pathname = generateRouterPath(ROUTES.connectorRedirecting, {
+    type: args.type,
+  });
+  const searchParams = new URLSearchParams({ label: args.label });
+  if (args.status === "error") {
+    searchParams.set("status", args.status);
+  }
+  return `${pathname}?${searchParams.toString()}`;
+}

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -22,6 +22,7 @@ export const ROUTES = {
   connectors: "/connectors",
   customConnectorProposal: "/connectors/custom/proposal",
   computerUseAuthorize: "/computer-use/authorize/:requestToken",
+  connectorRedirecting: "/connectors/:type/redirecting",
   directedConnect: "/connectors/:type/connect",
   directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -64,6 +64,7 @@ import { resetPermissionDialog$ } from "./permission-dialog.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
 import { sanitizeTokenInputRecord } from "./token-input.ts";
 import { IN_VITEST } from "../../../env.ts";
+import { connectorRedirectingPath } from "../../connectors-page/connector-redirecting.ts";
 
 const HIDDEN_CONNECTIONS_STORAGE_KEY = "vm0.connections.hiddenTypes";
 type ConnectorType = ConnectorCatalogRef;
@@ -2161,6 +2162,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     args: {
       readonly type: ConnectorType;
       readonly method: ConnectorStatusAuthMethodDetail;
+      readonly connectorLabel: string;
       readonly agentId: string | undefined;
       readonly beforeStart: (signal: AbortSignal) => Promise<void>;
     },
@@ -2171,7 +2173,11 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     // In standalone (PWA) mode, omit popup features so iOS Safari opens the
     // URL in the external browser instead of blocking it as a popup.
     const popupFeatures = standalone ? undefined : "width=600,height=700";
-    const authWindow = window.open("about:blank", "_blank", popupFeatures);
+    const redirectingPath = connectorRedirectingPath({
+      type: args.type,
+      label: args.connectorLabel,
+    });
+    const authWindow = window.open(redirectingPath, "_blank", popupFeatures);
 
     if (!authWindow && !standalone) {
       throw new Error("Failed to open authorization window");
@@ -2233,7 +2239,15 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       })(),
       () => {
         if (authWindow && !navigated) {
-          authWindow.close();
+          if (signal.aborted) {
+            authWindow.close();
+          } else {
+            authWindow.location.href = connectorRedirectingPath({
+              type: args.type,
+              label: args.connectorLabel,
+              status: "error",
+            });
+          }
         }
       },
     );
@@ -2283,6 +2297,7 @@ export const connectConnectorOAuthAuthCode$ = command(
           {
             type,
             method,
+            connectorLabel: options.connectorLabel ?? type,
             agentId: options.agentId,
             beforeStart: async (sig) => {
               await set(onConnectorChanged$, sig);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+describe("connector redirecting page", () => {
+  it("renders the provider handoff without an authenticated user", async () => {
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/redirecting?label=GitHub",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Redirecting to GitHub…" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText("You’ll continue on GitHub to authorize Zero."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Preparing a secure connection"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an actionable error when OAuth cannot start", async () => {
+    detachedSetupPage({
+      context,
+      path: "/connectors/github/redirecting?label=GitHub&status=error",
+      user: null,
+      session: null,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Couldn’t open GitHub" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText("Return to Zero and try connecting again."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Close window")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1573,6 +1573,11 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(startCount).toBe(1);
       expect(openMock.calls).toHaveLength(1);
+      expect(openMock.calls[0]).toStrictEqual({
+        url: "/connectors/stripe/redirecting?label=Public+Stripe",
+        target: "_blank",
+        features: "width=600,height=700",
+      });
       expect(authWindow.opener).toBeNull();
       expect(authWindow.location.href).toBe(
         "https://oauth.test/stripe/authorize",
@@ -1619,6 +1624,50 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       expect(authWindow.closed).toBeTruthy();
+    });
+  });
+
+  it("shows an error in the OAuth popup when the start request fails", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        description: "Public Stripe description",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "Public OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    ]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(zeroConnectorOauthStartContract.start, ({ respond }) => {
+      return respond(500, {
+        error: {
+          message: "OAuth authorization is unavailable",
+          code: "UNAVAILABLE",
+        },
+      });
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "stripe");
+    click(await screen.findByLabelText("Connect Public Stripe"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "/connectors/stripe/redirecting?label=Public+Stripe&status=error",
+      );
+      expect(authWindow.closed).toBeFalsy();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,0 +1,76 @@
+import { IconAlertCircle, IconLoader2 } from "@tabler/icons-react";
+import type { ConnectorCatalogRef } from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  getStaticConnectorIconMetadata,
+  isStaticConnectorIconType,
+} from "@vm0/connectors/static-connector-icons";
+import { Button } from "@vm0/ui/components/ui/button";
+import type { ConnectorRedirectingStatus } from "../../signals/connectors-page/connector-redirecting.ts";
+import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+
+export function ZeroConnectorRedirectingPage({
+  connectorType,
+  connectorLabel,
+  status,
+}: {
+  readonly connectorType: ConnectorCatalogRef | null;
+  readonly connectorLabel: string;
+  readonly status: ConnectorRedirectingStatus;
+}) {
+  const icon =
+    connectorType && isStaticConnectorIconType(connectorType)
+      ? getStaticConnectorIconMetadata(connectorType)
+      : undefined;
+  const hasError = status === "error";
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-background">
+      <div className="flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
+        <VM0Logo />
+        <div className="flex w-full flex-col items-center gap-4">
+          <div className="flex items-center justify-center rounded-[10px] bg-gray-50 p-2.5 dark:bg-muted">
+            <ConnectorIcon icon={icon} size={20} />
+          </div>
+          <div className="flex flex-col items-center gap-2.5">
+            <h1 className="text-lg font-medium text-foreground">
+              {hasError
+                ? `Couldn’t open ${connectorLabel}`
+                : `Redirecting to ${connectorLabel}…`}
+            </h1>
+            <p className="w-64 text-sm text-muted-foreground">
+              {hasError
+                ? "Return to Zero and try connecting again."
+                : `You’ll continue on ${connectorLabel} to authorize Zero.`}
+            </p>
+          </div>
+          {hasError ? (
+            <div className="flex flex-col items-center gap-4">
+              <div className="flex items-center gap-2 text-sm text-destructive">
+                <IconAlertCircle size={16} aria-hidden="true" />
+                <span>Unable to start the connection</span>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  window.close();
+                }}
+              >
+                Close window
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <IconLoader2
+                size={16}
+                className="animate-spin"
+                aria-hidden="true"
+              />
+              <span>Preparing a secure connection</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- replace the initial about:blank OAuth popup with a branded Platform redirecting page
- show connector identity and secure-connection progress without requiring an authenticated page wrapper
- keep the popup open with a clear retry-oriented error state when OAuth start fails, while preserving cancellation cleanup and PWA fallback behavior

## User impact

Connector authorization now opens with an immediate VM0 explanation before navigating to GitHub or another provider, so users no longer see a confusing blank browser window while Platform prepares the OAuth handoff.

## Verification

- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm exec vitest --run apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm exec vitest --run apps/platform/src/views/zero-page/__tests__/zero-connector-redirecting-page.test.tsx

Local browser verification was not run, following the repository preference to rely on the PR preview pipeline.