### PR TITLE
fix: match settings nav selected state to sidebar (drop orange highlight)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -301,14 +301,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                           className={cn(
                             "flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 focus-visible:bg-sidebar-accent focus-visible:outline-none",
                             isActive
-                              ? "text-primary-foreground font-medium"
+                              ? "bg-gray-200 text-gray-900 font-medium"
                               : "text-sidebar-foreground hover:bg-sidebar-accent",
                           )}
-                          style={
-                            isActive
-                              ? { backgroundColor: "hsl(var(--primary))" }
-                              : undefined
-                          }
                         >
                           <Icon
                             size={16}


### PR DESCRIPTION
## What

The Settings dialog left-nav marked the active section with a solid **orange** (`hsl(var(--primary))`) background and white text, which stood out from the rest of the app. The main app sidebar marks its active item with a subtle gray highlight (`bg-gray-200 text-gray-900 font-medium`).

This aligns the Settings nav's selected state with the main sidebar so the two read as one system.

## Change

`settings-dialog.tsx` desktop nav active item:
- Before: `text-primary-foreground font-medium` + inline `style={{ backgroundColor: "hsl(var(--primary))" }}`
- After: `bg-gray-200 text-gray-900 font-medium` (matches `zero-sidebar.tsx`), inline style removed

Base classes, hover, and inactive states are unchanged; the icon already renders full-opacity in the active state and inherits the new dark text color.

## Verification

Prettier clean on the changed file. No test asserted the old orange styling. Relying on the PR pipeline for lint/type/test.