### PR TITLE
fix(chat): keep structured prompt disabled by default

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -126,7 +126,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ArtifactFavorites]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplateV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.StructuredPrompt]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OrgPlanEntitlementReads]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationElementDragging]).toBe(
       true,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -343,7 +343,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable structured user prompt rendering, sends, and drafts while preserving the legacy content fallback.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- remove the staff-org allowlist from the StructuredPrompt feature switch
- keep structured prompt reading and writing disabled for every org by default
- preserve explicit per-user feature-switch overrides for manual testing
- update the feature-switch integration expectation for staff organizations

## User-visible impact

Structured prompt behavior no longer activates automatically for staff organizations. It must be explicitly enabled through a feature-switch override.

## Verification

- @vm0/core feature-switch tests: 23 passed
- @vm0/core lint: passed
- full local Vitest suite and local dev server not run per repository policy

Related to #22314