### PR TITLE
chore(api): replace exact sql-tag builder call escape hatches

### DIFF
--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -81,7 +81,7 @@ function runnerStateHas(args: {
 }): SQL {
   const runnerCondition = args.runnerId
     ? sql`AND ${eq(runnerState.runnerId, args.runnerId)}`
-    : sql``;
+    : sql.empty();
   return sql`EXISTS (
     SELECT 1
     FROM ${runnerState}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -798,12 +798,11 @@ export function zeroChatThreadUnreads(args: {
         unreadAt: lastRunFinish.createdAt,
       })
       .from(chatThreads)
-      .leftJoinLateral(lastRunFinish, sql`true`)
+      .crossJoinLateral(lastRunFinish)
       .where(
         and(
           eq(chatThreads.userId, args.userId),
           eq(chatThreads.agentComposeId, args.agentComposeId),
-          isNotNull(lastRunFinish.createdAt),
           or(
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
@@ -815,14 +814,8 @@ export function zeroChatThreadUnreads(args: {
             : [excludeCanonicalSlackChatThreads(db, chatThreads.id)]),
         ),
       );
-    return rows.flatMap((row) => {
-      // Always present: the isNotNull(lastRunFinish.createdAt) filter
-      // guarantees a joined row, but the left-lateral type keeps the column
-      // nullable.
-      if (row.unreadAt === null) {
-        return [];
-      }
-      return [{ threadId: row.threadId, unreadAt: row.unreadAt.toISOString() }];
+    return rows.map((row) => {
+      return { threadId: row.threadId, unreadAt: row.unreadAt.toISOString() };
     });
   });
 }
@@ -843,12 +836,11 @@ export function zeroChatThreadUnreadAgentIds(args: {
       .selectDistinct({ agentId: chatThreads.agentComposeId })
       .from(chatThreads)
       .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .leftJoinLateral(lastRunFinish, sql`true`)
+      .crossJoinLateral(lastRunFinish)
       .where(
         and(
           eq(chatThreads.userId, args.userId),
           eq(zeroAgents.orgId, args.orgId),
-          isNotNull(lastRunFinish.createdAt),
           or(
             isNull(chatThreads.lastReadAt),
             gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
@@ -1324,7 +1316,7 @@ async function listArtifactHistory(args: {
   // and hosted-run shadowing, so this query avoids a history-wide URL sort.
   const keysetClause = args.cursor
     ? sql`AND (${runUploadedFiles.createdAt}, ${runUploadedFiles.id}) < (${args.cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${args.cursor.rowId}::uuid)`
-    : sql``;
+    : sql.empty();
   const conditions = artifactVisibilityConditions(args.query);
   const rows = await executeRawRows(
     args.db,
@@ -1686,7 +1678,7 @@ async function loadChatSearchContexts(
       matchedChatMessage,
       sql`${matchedChatMessage.id} = chat_search_matches.message_id`,
     )
-    .innerJoinLateral(context, sql`true`)
+    .crossJoinLateral(context)
     .orderBy(resultOrdinality, asc(context.createdAt));
 
   for (const row of rows) {

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -133,8 +133,158 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         void mutableList;
       `,
     },
+    {
+      code: `${drizzlePreamble}
+        import { and, eq, isNotNull, or, sql } from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        sql\` \`;
+        sql\`true::boolean\`;
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`);
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`)
+          .where(or(isNotNull(selected.id), eq(users.id, 1)));
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`)
+          .where(
+            and(or(isNotNull(selected.id), eq(users.id, 1)), eq(users.id, 2)),
+          );
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`)
+          .where(and(isNotNull(users.deletedAt), eq(users.id, 1)));
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, eq(selected.id, users.id));
+      `,
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql, type SQL } from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        function isNotNull(value: unknown): SQL {
+          return sql\`\${value}\`;
+        }
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`)
+          .where(isNotNull(selected.id));
+      `,
+    },
+    {
+      code: `
+        function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+          return { strings, values };
+        }
+        const builder = {
+          innerJoinLateral(relation: unknown, condition: unknown) {
+            return { relation, condition };
+          },
+        };
+        sql\`\`;
+        builder.innerJoinLateral({}, sql\`true\`);
+      `,
+    },
   ],
   invalid: [
+    {
+      code: `${drizzlePreamble}
+        import { sql } from "drizzle-orm";
+        sql\`\`;
+      `,
+      errors: [{ messageId: "emptyFragment" }],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as query } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        query\`\`;
+        drizzle.sql\`\`;
+        const tag = drizzle.sql;
+        tag\`\`;
+      `,
+      errors: [
+        { messageId: "emptyFragment" },
+        { messageId: "emptyFragment" },
+        { messageId: "emptyFragment" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { isNotNull, sql } from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, sql\`true\`);
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, sql\`true\`)
+          .where(isNotNull(selected.id));
+      `,
+      errors: [
+        { messageId: "crossJoinLateral" },
+        { messageId: "crossJoinLateral" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import { sql as query } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, query\` true \`);
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, drizzle.sql\`TRUE\`);
+      `,
+      errors: [
+        { messageId: "crossJoinLateral" },
+        { messageId: "crossJoinLateral" },
+      ],
+    },
+    {
+      code: `${drizzlePreamble}
+        import {
+          and as all,
+          eq,
+          isNotNull as present,
+          sql as query,
+        } from "drizzle-orm";
+        import * as drizzle from "drizzle-orm";
+        const selected = db
+          .select({ id: users.id })
+          .from(users)
+          .as("selected_users");
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, query\`true\`)
+          .where(present(selected.id));
+        db.select()
+          .from(users)
+          .leftJoinLateral(selected, drizzle.sql\` TRUE \`)
+          .where(all(eq(users.id, 1), drizzle.isNotNull(selected.id)));
+      `,
+      errors: [
+        { messageId: "crossJoinLateral" },
+        { messageId: "crossJoinLateral" },
+      ],
+    },
     {
       code: `${drizzlePreamble}
         import { sql } from "drizzle-orm";

--- a/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/prefer-drizzle-apis.test.ts
@@ -140,6 +140,7 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
           .select({ id: users.id })
           .from(users)
           .as("selected_users");
+        const dynamicCondition = sql\`true\`;
         sql\` \`;
         sql\`true::boolean\`;
         db.select()
@@ -162,6 +163,9 @@ ruleTester.run("prefer-drizzle-apis", preferDrizzleApis, {
         db.select()
           .from(users)
           .innerJoinLateral(selected, eq(selected.id, users.id));
+        db.select()
+          .from(users)
+          .innerJoinLateral(selected, dynamicCondition);
       `,
     },
     {

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -371,12 +371,11 @@ export const preferDrizzleApis = createRule({
     }
 
     function isTrueSqlTag(node: TSESTree.Expression): boolean {
-      const quasi =
-        node.type === AST_NODE_TYPES.TaggedTemplateExpression
-          ? node.quasi.quasis[0]
-          : undefined;
+      if (node.type !== AST_NODE_TYPES.TaggedTemplateExpression) {
+        return false;
+      }
+      const quasi = node.quasi.quasis[0];
       return (
-        node.type === AST_NODE_TYPES.TaggedTemplateExpression &&
         isDrizzleSqlTag(checker, services, node.tag) &&
         node.quasi.expressions.length === 0 &&
         node.quasi.quasis.length === 1 &&

--- a/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/prefer-drizzle-apis.ts
@@ -1,4 +1,8 @@
-import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
 import {
   isArrowFunction,
   isBlock,
@@ -19,6 +23,7 @@ import {
   TypeFlags,
   type Expression as TypeScriptExpression,
   type Node,
+  type Symbol as TypeScriptSymbol,
   type Type,
   type VariableDeclaration,
 } from "typescript";
@@ -301,12 +306,16 @@ export const preferDrizzleApis = createRule({
     type: "problem",
     docs: {
       description:
-        "Prefer schema-aware Drizzle APIs for exactly equivalent SQL leaves",
+        "Prefer schema-aware Drizzle APIs for exactly equivalent SQL constructions",
       recommended: true,
       requiresTypeChecking: true,
     },
     schema: [],
     messages: {
+      crossJoinLateral:
+        "Use Drizzle crossJoinLateral(...) for this equivalent lateral join.",
+      emptyFragment:
+        "Use Drizzle sql.empty() for this intentionally empty SQL fragment.",
       typedApi: "Use Drizzle {{helper}}(...) for this equivalent SQL-tag leaf.",
     },
   },
@@ -331,6 +340,130 @@ export const preferDrizzleApis = createRule({
         messageId: "typedApi",
         data: { helper },
       });
+    }
+
+    function memberName(node: TSESTree.MemberExpression): string | undefined {
+      return !node.computed && node.property.type === AST_NODE_TYPES.Identifier
+        ? node.property.name
+        : undefined;
+    }
+
+    function isNamedDrizzleCall(
+      node: TSESTree.CallExpression,
+      name: string,
+    ): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const signature = checker.getResolvedSignature(tsNode);
+      return (
+        signature !== undefined && isNamedDrizzleSignature(signature, name)
+      );
+    }
+
+    function isDrizzleMethod(
+      node: TSESTree.MemberExpression,
+      name: string,
+    ): boolean {
+      if (memberName(node) !== name) {
+        return false;
+      }
+      const tsProperty = services.esTreeNodeToTSNodeMap.get(node.property);
+      return isDrizzleSymbol(checker, checker.getSymbolAtLocation(tsProperty));
+    }
+
+    function isTrueSqlTag(node: TSESTree.Expression): boolean {
+      const quasi =
+        node.type === AST_NODE_TYPES.TaggedTemplateExpression
+          ? node.quasi.quasis[0]
+          : undefined;
+      return (
+        node.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        isDrizzleSqlTag(checker, services, node.tag) &&
+        node.quasi.expressions.length === 0 &&
+        node.quasi.quasis.length === 1 &&
+        quasi !== undefined &&
+        quasiText(quasi).trim().toLowerCase() === "true"
+      );
+    }
+
+    function expressionSymbol(
+      node: TSESTree.Expression,
+    ): TypeScriptSymbol | undefined {
+      if (node.type !== AST_NODE_TYPES.Identifier) {
+        return undefined;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return resolvedSymbol(checker, checker.getSymbolAtLocation(tsNode));
+    }
+
+    function isRelationField(
+      node: TSESTree.Expression,
+      relationSymbol: TypeScriptSymbol | undefined,
+    ): boolean {
+      return (
+        relationSymbol !== undefined &&
+        node.type === AST_NODE_TYPES.MemberExpression &&
+        node.object.type === AST_NODE_TYPES.Identifier &&
+        expressionSymbol(node.object) === relationSymbol
+      );
+    }
+
+    function nullRejectsRelation(
+      node: TSESTree.Expression,
+      relationSymbol: TypeScriptSymbol | undefined,
+    ): boolean {
+      if (node.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (isNamedDrizzleCall(node, "isNotNull")) {
+        const argument = node.arguments[0];
+        return (
+          node.arguments.length === 1 &&
+          argument !== undefined &&
+          argument.type !== AST_NODE_TYPES.SpreadElement &&
+          isRelationField(argument, relationSymbol)
+        );
+      }
+      if (!isNamedDrizzleCall(node, "and")) {
+        return false;
+      }
+      return node.arguments.some((argument) => {
+        return (
+          argument.type !== AST_NODE_TYPES.SpreadElement &&
+          nullRejectsRelation(argument, relationSymbol)
+        );
+      });
+    }
+
+    function leftLateralIsNullRejected(
+      node: TSESTree.CallExpression,
+      relation: TSESTree.Expression,
+    ): boolean {
+      const relationSymbol = expressionSymbol(relation);
+      if (relationSymbol === undefined) {
+        return false;
+      }
+      const whereMember = node.parent;
+      if (
+        whereMember.type !== AST_NODE_TYPES.MemberExpression ||
+        whereMember.object !== node ||
+        memberName(whereMember) !== "where"
+      ) {
+        return false;
+      }
+      const whereCall = whereMember.parent;
+      if (
+        whereCall.type !== AST_NODE_TYPES.CallExpression ||
+        whereCall.callee !== whereMember ||
+        whereCall.arguments.length !== 1
+      ) {
+        return false;
+      }
+      const predicate = whereCall.arguments[0];
+      return (
+        predicate !== undefined &&
+        predicate.type !== AST_NODE_TYPES.SpreadElement &&
+        nullRejectsRelation(predicate, relationSymbol)
+      );
     }
 
     function isStringOrDrizzleWrapper(type: Type): boolean {
@@ -577,6 +710,39 @@ export const preferDrizzleApis = createRule({
     }
 
     return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+          return;
+        }
+        const method = memberName(node.callee);
+        if (method !== "innerJoinLateral" && method !== "leftJoinLateral") {
+          return;
+        }
+        if (
+          !isDrizzleMethod(node.callee, method) ||
+          node.arguments.length !== 2
+        ) {
+          return;
+        }
+        const relation = node.arguments[0];
+        const condition = node.arguments[1];
+        if (
+          relation === undefined ||
+          relation.type === AST_NODE_TYPES.SpreadElement ||
+          condition === undefined ||
+          condition.type === AST_NODE_TYPES.SpreadElement ||
+          !isTrueSqlTag(condition)
+        ) {
+          return;
+        }
+        if (
+          method === "leftJoinLateral" &&
+          !leftLateralIsNullRejected(node, relation)
+        ) {
+          return;
+        }
+        context.report({ node, messageId: "crossJoinLateral" });
+      },
       TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression): void {
         if (!isDrizzleSqlTag(checker, services, node.tag)) {
           return;
@@ -584,6 +750,14 @@ export const preferDrizzleApis = createRule({
 
         const quasis = node.quasi.quasis.map(quasiText);
         const expressions = node.quasi.expressions;
+        if (
+          expressions.length === 0 &&
+          quasis.length === 1 &&
+          quasis[0] === ""
+        ) {
+          context.report({ node, messageId: "emptyFragment" });
+          return;
+        }
         for (let index = 0; index < expressions.length - 1; index += 1) {
           const leftNode = expressions[index];
           const rightNode = expressions[index + 1];


### PR DESCRIPTION
## Summary

- replace three lateral joins whose `ON TRUE` condition is exactly represented by `crossJoinLateral(...)`
- replace two truly empty SQL tags with `sql.empty()` while preserving intentional whitespace separators
- extend the type-aware `api/prefer-drizzle-apis` rule with conservative, symbol-resolved checks for these exact substitutions

## Behavior and safety

The unread queries now use a non-null cross-lateral result, so the redundant `created_at IS NOT NULL` filters and runtime null guard are removed. The left-join lint check only reports when an immediate Drizzle `where(...)` condition null-rejects the same joined relation through resolved `isNotNull(...)`/`and(...)` calls; it deliberately does not infer through `or(...)`, raw SQL, arbitrary helpers, or unresolved symbols.

There is no schema, migration, persisted-data, API-contract, authorization, feature-switch, or deployment-compatibility change. Complete SQL statements and other SQL-tag families remain part of the parent delivery issue.

## Query-plan verification

- `sql\`\`` and `sql.empty()` rendered byte-for-byte identical queries and parameter arrays in both conditional-fragment shapes.
- Both unread query pairs kept the same plan shape, estimated cost, loops, and indexes, including `idx_chat_messages_thread_run_finish_created`; representative execution remained sub-millisecond.
- Chat search kept the same correlated nested-loop/append plan, per-side limits, result ordinality, forward/backward `idx_chat_messages_thread_created` scans, and estimated cost (`57.62`). No scan or sort was added.
- Full API ESLint measured 27.18 s versus the 28.12 s baseline, with no material runtime increase.

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F @vm0/eslint-rules exec vitest run src/api/__tests__/prefer-drizzle-apis.test.ts --maxWorkers=1 --silent=passed-only` (22 passed)
- focused `chat-threads.bdd.test.ts` unread/search coverage (4 passed)
- focused `artifacts.bdd.test.ts` keyset-pagination coverage (1 passed)
- focused `run-lifecycle.bdd.test.ts` same-session-affinity coverage (1 passed)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/eslint-rules`
- `pnpm knip --workspace api`
- `pnpm check-types`
- `git diff --check`

Closes #22444

Parent: #22439
