### PR TITLE
feat(computer-use): share chat thread grants with automations

### DIFF
--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -235,11 +235,15 @@ const resolvedAuthContext$ = command(
 );
 
 function missingCapabilityError(capability: ZeroCapability): AuthErrorResponse {
+  const message =
+    capability === "computer-use:write"
+      ? "Computer Use is not authorized for this run. Authorize a computer once in the conversation, then retry."
+      : `Missing required capability: ${capability}`;
   return {
     status: 403,
     body: {
       error: {
-        message: `Missing required capability: ${capability}`,
+        message,
         code: "FORBIDDEN",
       },
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -122,6 +122,7 @@ const trackComputerUseRun = createFixtureTracker(deleteComputerUseRunFixture);
 async function seedZeroRun(args: {
   readonly actor: ApiTestUser;
   readonly triggerSource: "web" | "slack";
+  readonly canonicalThread?: boolean;
 }): Promise<ComputerUseRunFixture> {
   const response = await requestComputerUseState(COMPUTER_USE_STATE_ROUTE, {
     method: "POST",
@@ -130,6 +131,7 @@ async function seedZeroRun(args: {
       user_id: args.actor.userId,
       org_id: requireOrg(args.actor),
       trigger_source: args.triggerSource,
+      canonical_thread: args.canonicalThread,
     }),
   });
   expect(response.status).toBe(200);
@@ -351,6 +353,52 @@ describe("FILE-03 desktop computer-use runtime", () => {
     expect(applied).toStrictEqual({
       ok: true,
       source: "slack",
+      computerUseHostId: host.hostId,
+    });
+
+    await expect(readComputerUseRunState(run.runId)).resolves.toStrictEqual({
+      source: "slack",
+      computer_use_host_id: host.hostId,
+    });
+  });
+
+  it("uses chat-thread authorization for a canonical Slack run", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const actor = bdd.user({ orgId });
+    const run = await seedZeroRun({
+      actor,
+      triggerSource: "slack",
+      canonicalThread: true,
+    });
+    if (!run.threadId) {
+      throw new Error("Expected canonical Slack run to use a chat thread");
+    }
+
+    const host = await api.startComputerUseHost(actor, {
+      hostName: "Canonical Slack Desktop",
+    });
+    mockClerkMembership(context, actor, "org:admin");
+    const token = zeroComputerUseToken({
+      userId: actor.userId,
+      orgId,
+      runId: run.runId,
+      capabilities: ["connector:read"],
+    }).token;
+
+    const created = await api.createComputerUseAuthorizationRequest({
+      bearer: token,
+    });
+    expect(created.source).toBe("chat");
+
+    const requestToken = requestTokenFromUrl(created.authorizationUrl);
+    const applied = await api.applyComputerUseAuthorizationRequest(
+      actor,
+      requestToken,
+      host.hostId,
+    );
+    expect(applied).toStrictEqual({
+      ok: true,
+      source: "chat",
       computerUseHostId: host.hostId,
     });
 
@@ -803,7 +851,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
     );
     expectApiError(missingCapability.body);
     expect(missingCapability.body.error.message).toBe(
-      "Missing required capability: computer-use:write",
+      "Computer Use is not authorized for this run. Authorize a computer once in the conversation, then retry.",
     );
 
     const ungranted = await api.requestCreateComputerUseReadCommand(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -18,6 +18,8 @@ import { mockGmailConnectorOAuth } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
@@ -28,6 +30,8 @@ const mocks = createZeroRouteMocks(context);
 const wf = createWorkflowsBddApi(context);
 const runsApi = createRunsApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
+const chatFilesApi = createChatFilesBddApi(context);
+const computerUseApi = createComputerUseBddApi(context);
 
 const WORKFLOW_NAME = "scheduler-workflow";
 const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
@@ -60,6 +64,16 @@ function expectOk(response: Response, operation: string): void {
     return;
   }
   throw new Error(`${operation} failed with ${response.status}`);
+}
+
+function zeroTokenFromClaim(
+  claim: Awaited<ReturnType<typeof runsApi.claimRunnerJob>>,
+): string {
+  const token = claim.environment?.ZERO_TOKEN;
+  if (!token || !token.startsWith("vm0_sandbox_")) {
+    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+  }
+  return token;
 }
 
 async function setup(
@@ -235,6 +249,56 @@ async function deleteWorkflowViaApi(scenario: Scenario): Promise<void> {
 }
 
 describe("zero workflow automation scheduler", () => {
+  it("inherits the chat thread computer-use grant for automation runs", async () => {
+    const scenario = await setup();
+    const automation = await createDueLoopAutomation(scenario, 3600);
+    const host = await computerUseApi.startComputerUseHost(scenario.actor, {
+      hostName: "Automation Desktop",
+    });
+    await chatFilesApi.updateThreadComputerUseHost(
+      scenario.actor,
+      automation.threadId,
+      host.hostId,
+    );
+
+    await executeDueWorkflowAutomations();
+
+    const run = await onlyWorkflowRunMessage(automation.threadId);
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    const claim = await runsApi.claimRunnerJob(run.runId);
+    await computerUseApi.requestCreateComputerUseWriteCommand(
+      { bearer: zeroTokenFromClaim(claim) },
+      [200],
+    );
+    const createdRun = await runsApi.readRun(scenario.actor, run.runId);
+    expect(createdRun.appendSystemPrompt).toContain(
+      "Computer Use is enabled for this run on Automation Desktop.",
+    );
+    await disableAutomation(automation.automationId);
+  });
+
+  it("returns actionable authorization guidance when an automation has no computer-use grant", async () => {
+    const scenario = await setup();
+    const automation = await createDueLoopAutomation(scenario, 3600);
+
+    await executeDueWorkflowAutomations();
+
+    const run = await onlyWorkflowRunMessage(automation.threadId);
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    const claim = await runsApi.claimRunnerJob(run.runId);
+    const denied = await computerUseApi.requestCreateComputerUseWriteCommand(
+      { bearer: zeroTokenFromClaim(claim) },
+      [403],
+    );
+    expect(denied.body).toMatchObject({
+      error: {
+        message:
+          "Computer Use is not authorized for this run. Authorize a computer once in the conversation, then retry.",
+      },
+    });
+    await disableAutomation(automation.automationId);
+  });
+
   it("uses agent connector authorization and permission grants for automation runs", async () => {
     const scenario = await setup();
 

--- a/turbo/apps/api/src/signals/routes/test-computer-use-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-computer-use-state.ts
@@ -115,7 +115,7 @@ async function sourceComputerUseHostId(
   db: Db,
   run: RunState,
 ): Promise<string | null> {
-  if (run.triggerSource === "web" && run.chatThreadId) {
+  if (run.chatThreadId) {
     const [thread] = await db
       .select({ computerUseHostId: chatThreads.computerUseHostId })
       .from(chatThreads)
@@ -173,12 +173,14 @@ async function seedBaseComputerUseRun(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly triggerSource: ComputerUseTriggerSource;
+  readonly canonicalThread: boolean;
   readonly signal: AbortSignal;
 }): Promise<BaseComputerUseRunSeed> {
   const composeId = randomUUID();
   const sessionId = randomUUID();
   const runId = randomUUID();
-  const threadId = args.triggerSource === "web" ? randomUUID() : null;
+  const threadId =
+    args.triggerSource === "web" || args.canonicalThread ? randomUUID() : null;
 
   await args.db.insert(agentComposes).values({
     id: composeId,
@@ -371,6 +373,7 @@ const postComputerUseState$ = command(
       userId: body.user_id,
       orgId: body.org_id,
       triggerSource: body.trigger_source,
+      canonicalThread: body.canonical_thread === true,
       signal,
     });
     const slack =

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -14,7 +14,6 @@ import {
   type ChatMessageRecommendedFollowups,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -25,7 +24,6 @@ import {
   eq,
   inArray,
   isNotNull,
-  isNull,
   lte,
   max,
   ne,
@@ -91,6 +89,7 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { shouldStartNewChatSession } from "./chat-session-continuity.service";
+import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 
 const log = logger("callback:chat");
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -1559,38 +1558,6 @@ async function loadAgentForAutoSend(
     .where(eq(zeroAgents.id, agentId))
     .limit(1);
   return agent ?? null;
-}
-
-async function loadComputerUseHostGrantForAutoSend(args: {
-  readonly db: Db;
-  readonly threadId: string;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<{
-  readonly hostId: string;
-  readonly displayName: string;
-} | null> {
-  const [host] = await args.db
-    .select({
-      hostId: computerUseHosts.id,
-      displayName: computerUseHosts.displayName,
-    })
-    .from(chatThreads)
-    .innerJoin(
-      computerUseHosts,
-      eq(chatThreads.computerUseHostId, computerUseHosts.id),
-    )
-    .where(
-      and(
-        eq(chatThreads.id, args.threadId),
-        eq(chatThreads.userId, args.userId),
-        eq(computerUseHosts.orgId, args.orgId),
-        eq(computerUseHosts.userId, args.userId),
-        isNull(computerUseHosts.revokedAt),
-      ),
-    )
-    .limit(1);
-  return host ?? null;
 }
 
 async function activeChatRunExistsForThread(

--- a/turbo/apps/api/src/signals/services/zero-chat-computer-use-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-computer-use-host.service.ts
@@ -1,0 +1,37 @@
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
+import { and, eq, isNull } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+export async function loadComputerUseHostGrantForAutoSend(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<{
+  readonly hostId: string;
+  readonly displayName: string;
+} | null> {
+  const [host] = await args.db
+    .select({
+      hostId: computerUseHosts.id,
+      displayName: computerUseHosts.displayName,
+    })
+    .from(chatThreads)
+    .innerJoin(
+      computerUseHosts,
+      eq(chatThreads.computerUseHostId, computerUseHosts.id),
+    )
+    .where(
+      and(
+        eq(chatThreads.id, args.threadId),
+        eq(chatThreads.userId, args.userId),
+        eq(computerUseHosts.orgId, args.orgId),
+        eq(computerUseHosts.userId, args.userId),
+        isNull(computerUseHosts.revokedAt),
+      ),
+    )
+    .limit(1);
+  return host ?? null;
+}

--- a/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
@@ -206,7 +206,7 @@ async function resolveRequestScope(args: {
     return "run_not_found";
   }
 
-  if (run.triggerSource === "web" && run.chatThreadId) {
+  if (run.chatThreadId) {
     return { source: "chat", chatThreadId: run.chatThreadId };
   }
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -27,6 +27,7 @@ import {
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { admitWorkflowAutomationEvent } from "./chat-message-queue.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
+import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 
 export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
 
@@ -104,6 +105,10 @@ interface WorkflowAutomationRunInput {
   readonly zeroRunMetadata: ReturnType<typeof workflowAutomationRunMetadata>;
 }
 
+type ComputerUseHostGrant = Awaited<
+  ReturnType<typeof loadComputerUseHostGrantForAutoSend>
+>;
+
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
@@ -174,6 +179,20 @@ function buildAppendSystemPrompt(workflowName: string): string {
     "This run is linked to a web chat thread; everything you output is shown to the user there.",
     "Connector permissions use the same agent-run permission settings as chat runs. If a connector request fails, do not retry blindly or assume an HTTP error came from Zero permission policy. Run `zero connector check --url <FAILED_URL> --method <METHOD> [--connector <connector-ref>]`; only when it reports a deny or ask outcome, request access with `zero connector permission-request <connector-ref> --permission <name>` and tell the user which permission this automation needs. The user chooses the grant duration in the confirmation UI. Omit query strings or fragments when they may contain secrets because permission matching does not need them.",
   ].join("\n");
+}
+
+function appendComputerUseSystemPrompt(
+  prompt: string,
+  grant: ComputerUseHostGrant,
+): string {
+  if (!grant) {
+    return prompt;
+  }
+  return [
+    prompt,
+    "# Computer Use",
+    `Computer Use is enabled for this run on ${grant.displayName}.`,
+  ].join("\n\n");
 }
 
 export function buildChatOnlyWorkflowAutomationCallbacks(
@@ -347,6 +366,7 @@ async function buildTimedWorkflowAutomationRunInput(args: {
   readonly agentId: string;
   readonly workflowName: string;
   readonly chatThreadId: string;
+  readonly computerUseHostGrant: ComputerUseHostGrant;
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<WorkflowAutomationRunInput> {
   return await measureApiDispatchTiming(
@@ -356,9 +376,11 @@ async function buildTimedWorkflowAutomationRunInput(args: {
     () => {
       return {
         prompt: args.command.prompt ?? `/${args.workflowName}`,
-        appendSystemPrompt:
+        appendSystemPrompt: appendComputerUseSystemPrompt(
           args.command.appendSystemPrompt ??
-          buildAppendSystemPrompt(args.workflowName),
+            buildAppendSystemPrompt(args.workflowName),
+          args.computerUseHostGrant,
+        ),
         callbacks:
           args.command.callbacks ??
           buildWorkflowAutomationCallbacks(
@@ -525,12 +547,21 @@ export const runWorkflowAutomationNow$ = command(
     }
     const { modelPin, effectiveModelProvider } = modelContext;
 
+    const computerUseHostGrant = await loadComputerUseHostGrantForAutoSend({
+      db,
+      threadId: chatThreadId,
+      orgId: automation.orgId,
+      userId: automation.ownerUserId,
+    });
+    signal.throwIfAborted();
+
     const runInput = await buildTimedWorkflowAutomationRunInput({
       command: args,
       automation,
       agentId,
       workflowName,
       chatThreadId,
+      computerUseHostGrant,
       timing,
     });
     signal.throwIfAborted();
@@ -559,6 +590,7 @@ export const runWorkflowAutomationNow$ = command(
         apiStartTime: args.apiStartTime,
         triggerSource: args.triggerSource ?? "workflow-schedule",
         chatThreadId,
+        computerUseHostId: computerUseHostGrant?.hostId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,

--- a/turbo/packages/api-contracts/src/contracts/test-computer-use-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-computer-use-state.ts
@@ -12,6 +12,7 @@ export const testComputerUseStatePostBodySchema = z.object({
   user_id: z.string().optional(),
   org_id: z.string().optional(),
   trigger_source: z.enum(["web", "slack", "teams"]).optional(),
+  canonical_thread: z.boolean().optional(),
 });
 
 export const testComputerUseStatePostResponseSchema = z.object({


### PR DESCRIPTION
## Summary

- resolve Computer Use authorization by `chatThreadId` before source-specific legacy scopes, so canonical Slack runs use their chat thread grant
- reuse the chat auto-send host lookup for workflow automation runs and inject the valid thread host into the run token and system prompt
- return actionable authorization guidance when a non-interactive run has no Computer Use grant
- cover canonical Slack authorization and automation grant/no-grant behavior

## Verification

- pre-commit hook: Prettier, knip, and workspace type checks passed
- targeted Oxlint and ESLint passed
- API TypeScript check passed with a 4 GB Node heap
- targeted integration tests were attempted locally but could not connect to Postgres (`ECONNREFUSED`); PR CI will run them with the test database

Closes #22292