### PR TITLE
fix(firewall): enforce ports for parameterized bases

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -52,11 +52,18 @@ _BASE_STATIC_SCORE_BONUS = 1
 
 class _BaseUrlParts(NamedTuple):
     scheme: str
-    authority: str
+    hostname: str
+    port: int | None
     path: str
     host_malformed: bool
     has_userinfo: bool
     port_malformed: bool
+
+    @property
+    def authority(self) -> str:
+        if self.port is None:
+            return self.hostname
+        return f"{self.hostname}:{self.port}"
 
 
 class _CompiledBase(NamedTuple):
@@ -181,9 +188,9 @@ def _split_base_match_url(
 
     Canonicalizes authority details that get_trusted_authority() also normalizes:
     trailing host dots are removed, default ports are omitted, and explicit ports
-    are rendered as integers. The returned path excludes query and fragment so
-    callers can apply base-path prefix semantics without accidentally comparing
-    query strings.
+    are rendered as integers. Hostname and port remain separate so host parameters
+    cannot consume port text. The returned path excludes query and fragment so callers
+    can apply base-path prefix semantics without accidentally comparing query strings.
 
     ``allow_runtime_backslash_syntax`` only bypasses the early backslash gate.
     Compiled firewall matching uses this so a backslash-bearing request can
@@ -232,13 +239,14 @@ def _split_base_match_url(
     )
     if authority_result is None:
         return None
-    authority, host_malformed = authority_result
+    hostname, normalized_port, host_malformed = authority_result
     if host_malformed and not allow_malformed_authority:
         return None
 
     return _BaseUrlParts(
         scheme=parts.scheme,
-        authority=authority,
+        hostname=hostname,
+        port=normalized_port,
         path=parts.path,
         host_malformed=host_malformed,
         has_userinfo=has_userinfo,
@@ -292,19 +300,15 @@ def _normalize_authority(
     port: int | None,
     *,
     allow_host_params: bool = False,
-) -> tuple[str, bool] | None:
+) -> tuple[str, int | None, bool] | None:
     if host is None:
         return None
     normalized_host, host_malformed = _normalize_authority_host(
         host,
         allow_host_params=allow_host_params,
     )
-    if port is None:
-        return normalized_host, host_malformed
-
-    if is_default_scheme_port(scheme, port):
-        return normalized_host, host_malformed
-    return f"{normalized_host}:{port}", host_malformed
+    normalized_port = None if port is None or is_default_scheme_port(scheme, port) else port
+    return normalized_host, normalized_port, host_malformed
 
 
 def _compile_base_segments_for_match(
@@ -560,7 +564,7 @@ def _compile_base(raw_base: str) -> _CompiledBase | None:
     path_segments: tuple[ParsedSegment, ...] = ()
     param_parse_malformed = False
     if has_params:
-        raw_host_segments = tuple(reversed(parts.authority.split(".")))
+        raw_host_segments = tuple(reversed(parts.hostname.split(".")))
         compiled_host, host_parse_malformed = _compile_base_segments_for_match(
             raw_host_segments,
             greedy_allowed_index=len(raw_host_segments) - 1,
@@ -613,8 +617,10 @@ def _match_compiled_base_url_parts(
 
     if url_parts.scheme.lower() != base.parts.scheme.lower():
         return None
+    if url_parts.port != base.parts.port:
+        return None
 
-    host_params = _match_compiled_host(url_parts.authority, base.host_segments)
+    host_params = _match_compiled_host(url_parts.hostname, base.host_segments)
     if host_params is None:
         return None
 
@@ -649,12 +655,13 @@ def _split_https_authority_parts(host: str, port: int) -> _BaseUrlParts | None:
     )
     if authority_result is None:
         return None
-    authority, host_malformed = authority_result
+    hostname, normalized_port, host_malformed = authority_result
     if host_malformed:
         return None
     return _BaseUrlParts(
         scheme="https",
-        authority=authority,
+        hostname=hostname,
+        port=normalized_port,
         path="/",
         host_malformed=False,
         has_userinfo=False,
@@ -667,7 +674,9 @@ def _match_compiled_base_authority(url_parts: _BaseUrlParts, base: _CompiledBase
         return False
     if not base.has_params:
         return url_parts.authority.lower() == base.parts.authority.lower()
-    return _match_compiled_host(url_parts.authority, base.host_segments) is not None
+    if url_parts.port != base.parts.port:
+        return False
+    return _match_compiled_host(url_parts.hostname, base.host_segments) is not None
 
 
 def match_base_url(url: str, base: str) -> tuple[str, dict] | None:

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_authority_normalization.py
@@ -253,6 +253,37 @@ def test_compiled_matches_parameterized_host_nonstandard_port_rejection():
 
 
 @pytest.mark.parametrize(
+    ("base", "port", "expected"),
+    [
+        ("https://api.{domain}", 443, True),
+        ("https://api.{domain}:443", 443, True),
+        ("https://api.{domain}:8443", 8443, True),
+        ("https://api.{domain}", 8443, False),
+        ("https://api.{domain}:8443", 443, False),
+        ("https://api.{domain}:8443", 9443, False),
+    ],
+)
+def test_compiled_parameterized_rightmost_host_param_respects_port(
+    base,
+    port,
+    expected,
+):
+    fws = wrap_firewalls(
+        [
+            {
+                "base": base,
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            }
+        ],
+        name="example",
+    )
+    compiled = compile_firewalls_or_fail(fws)
+
+    assert compiled.matches_ordinary_credential_authority("api.example", port) is expected
+
+
+@pytest.mark.parametrize(
     ("base", "host", "port"),
     [
         ("https://api.github.com", "api.github.com", 443),

--- a/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
+++ b/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
@@ -190,6 +190,14 @@ class TestMatchBaseUrl:
         )
         assert result is None
 
+    def test_rightmost_host_param_captures_only_hostname_with_declared_port(self):
+        result = matching.match_base_url(
+            "https://api.example:8443/items",
+            "https://api.{domain}:8443",
+        )
+
+        assert result == ("/items", {"domain": "example"})
+
     @pytest.mark.parametrize(
         ("url", "base"),
         [

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -105,6 +105,36 @@ def test_server_connect_retargets_credentialed_connector_host(tmp_path, mitm_ctx
     assert binding.original_address == ("203.0.113.10", 443)
 
 
+def test_server_connect_does_not_bind_parameterized_connector_to_undeclared_port(
+    tmp_path,
+    mitm_ctx,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.{domain}",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": ["GET /items"]}],
+            },
+            network_policy={
+                "allow": ["read"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    data = _data(sni="api.example", address=("203.0.113.10", 8443))
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.server_connect(data)
+
+    assert data.server.address == ("203.0.113.10", 8443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
 def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(
     tmp_path,
     mitm_ctx,

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -606,6 +606,40 @@
       }
     },
     {
+      "name": "rightmost host parameter rejects undeclared non-default port",
+      "url": "https://api.example:8443/items",
+      "base": "https://api.{domain}",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "rightmost host parameter matches declared non-default port",
+      "url": "https://api.example:8443/items",
+      "base": "https://api.{domain}:8443",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/items"
+      }
+    },
+    {
+      "name": "rightmost host parameter rejects mismatched non-default port",
+      "url": "https://api.example:9443/items",
+      "base": "https://api.{domain}:8443",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "rightmost host parameter normalizes explicit default port",
+      "url": "https://api.example/items",
+      "base": "https://api.{domain}:443",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/items"
+      }
+    },
+    {
       "name": "exact static base returns slash",
       "url": "https://api.github.com?per_page=1#ignored",
       "base": "https://api.github.com",
@@ -741,6 +775,60 @@
       },
       "expected": {
         "kind": "no_match"
+      }
+    },
+    {
+      "name": "parameterized base does not authorize an undeclared port",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.{domain}",
+              "auth": { "headers": { "Authorization": "Bearer token" } }
+            }
+          ]
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "url": "https://api.example:8443/items"
+      },
+      "expected": {
+        "kind": "no_match"
+      }
+    },
+    {
+      "name": "port does not change parameterized hostname specificity",
+      "firewalls": [
+        {
+          "name": "broad",
+          "apis": [
+            {
+              "base": "https://api.{domain}:8443",
+              "auth": {}
+            }
+          ]
+        },
+        {
+          "name": "specific",
+          "apis": [
+            {
+              "base": "https://{sub}.example:8443",
+              "auth": {}
+            }
+          ]
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "url": "https://api.example:8443/items"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "specific",
+        "base": "https://{sub}.example:8443",
+        "relativePath": "/items"
       }
     },
     {

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -1184,10 +1184,16 @@ function normalizeUrlHostname(
   return normalized;
 }
 
+interface NormalizedUrlAuthority {
+  readonly hostname: string;
+  readonly port: string | null;
+  readonly authority: string;
+}
+
 function normalizedUrlAuthority(
   parsed: URL,
   options: { allowHostParams?: boolean } = {},
-): string | null {
+): NormalizedUrlAuthority | null {
   if (parsed.username !== "" || parsed.password !== "") {
     return null;
   }
@@ -1197,7 +1203,12 @@ function normalizedUrlAuthority(
     return null;
   }
 
-  return parsed.port === "" ? hostname : `${hostname}:${parsed.port}`;
+  const port = parsed.port === "" ? null : parsed.port;
+  return {
+    hostname,
+    port,
+    authority: port === null ? hostname : `${hostname}:${port}`,
+  };
 }
 
 function matchStaticFirewallBaseUrl(
@@ -1221,12 +1232,16 @@ function matchStaticFirewallBaseUrl(
   });
   if (urlAuthority === null || baseAuthority === null) return null;
   if (baseHasParams) {
+    if (urlAuthority.port !== baseAuthority.port) return null;
     const hostParams =
       options.tolerateMalformedBaseParams === true
-        ? matchFirewallHostForMalformedBaseDecision(urlAuthority, baseAuthority)
-        : matchFirewallHost(urlAuthority, baseAuthority);
+        ? matchFirewallHostForMalformedBaseDecision(
+            urlAuthority.hostname,
+            baseAuthority.hostname,
+          )
+        : matchFirewallHost(urlAuthority.hostname, baseAuthority.hostname);
     if (hostParams === null) return null;
-  } else if (urlAuthority !== baseAuthority) {
+  } else if (urlAuthority.authority !== baseAuthority.authority) {
     return null;
   }
 
@@ -1246,7 +1261,9 @@ function matchStaticFirewallBaseUrl(
     displayBase,
     relativePath,
     score: baseUrlSpecificityScore({
-      authority: baseAuthority,
+      authority: baseHasParams
+        ? baseAuthority.hostname
+        : baseAuthority.authority,
       path: basePath,
       hasParams: baseHasParams,
       tolerateMalformedBaseParams: options.tolerateMalformedBaseParams === true,


### PR DESCRIPTION
## Summary

- keep normalized firewall hostnames and non-default ports as separate values in the runner and connectors matcher
- require parameterized bases to match the normalized request port before matching hostname parameters
- score parameterized bases from hostname segments only so a literal port cannot change hostname precedence
- add shared cross-runtime contracts plus a runner `server_connect` regression that prevents credential prebinding on undeclared ports

## Security impact

Parameterized connector credentials can no longer be authorized or prebound to a non-default port unless that port is explicitly declared by the firewall base URL.

## Scope

- the standalone `matchFirewallHost` authority-matching API is unchanged
- static base matching, persisted data, deployment protocols, and public API shapes are unchanged
- no migration or documentation update is required

## Validation

- `python3 -m ruff format --check src tests`
- `python3 -m ruff check src tests`
- `basedpyright -p .`
- `pytest tests/`
- `pnpm exec prettier --check packages/connectors/src/firewall-rule-matcher.ts packages/connectors/src/__tests__/firewall-semantics-contract.json`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test -- --reporter=dot`
- `pnpm knip --workspace @vm0/connectors`
- pre-commit full-repository Knip and TypeScript type checks

Closes #22422
