### PR TITLE
fix: log codex quota exhaustion at info

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -296,11 +296,14 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::ContextWindowExceeded);
     }
     // Subscription/usage limits are an expected quota state for both Codex
-    // (ChatGPT plan "usage limit") and Claude Code (Max plan "session limit" /
-    // "weekly limit" / org monthly spend limit), so classify them regardless of
-    // framework where the wording is shared. This lets the runner log these
-    // expected outcomes at info instead of error.
+    // (ChatGPT plan "usage limit" or API billing "quota exceeded") and Claude
+    // Code (Max plan "session limit" / "weekly limit" / org monthly spend
+    // limit), so classify them regardless of framework where the wording is
+    // shared. This lets the runner log these expected outcomes at info instead
+    // of error.
     if normalized.contains("usage limit")
+        || (matches!(framework, AgentFramework::Codex)
+            && normalized.contains("quota exceeded. check your plan and billing details"))
         || normalized.contains("session limit")
         || normalized.contains("weekly limit")
         || (matches!(framework, AgentFramework::ClaudeCode)

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -913,6 +913,16 @@ fn cli_failure_reason_classifies_codex_usage_limit() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_codex_quota_exceeded_as_usage_limit() {
+    let reason = classify_cli_failure_reason(
+        AgentFramework::Codex,
+        "Quota exceeded. Check your plan and billing details.",
+    );
+
+    assert_eq!(reason, Some(FailureReason::UsageLimit));
+}
+
+#[test]
 fn cli_failure_reason_classifies_codex_session_limit() {
     for message in [
         "You've hit your session limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits. Resets 12:50pm (Asia/Shanghai).",


### PR DESCRIPTION
## Summary

- classify the canonical Codex quota-exceeded diagnostic as the existing `usage_limit` failure reason
- reuse the runner's expected-failure path so the job failure is logged at info while preserving the failed run and diagnostic
- add regression coverage for the exact Codex message observed in production

## Scope

- no API, schema, protocol, or persisted-data changes
- no retries or failure suppression

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason_classifies_codex_quota_exceeded_as_usage_limit`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -- --test-threads=1`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`

Closes #22474
