### PR TITLE
ci: block connector source changes

### DIFF
--- a/.github/scripts/check-connector-source-freeze.sh
+++ b/.github/scripts/check-connector-source-freeze.sh
@@ -26,39 +26,49 @@ is_frozen_path() {
   return 1
 }
 
-changed_files="$(
-  git diff \
-    --find-renames \
-    --name-only \
-    --diff-filter=ACMRTUXB \
-    "$base_ref" \
-    "$head_ref" \
-    -- \
-    "${frozen_paths[@]}"
-)"
-
-rename_diff_file="$(mktemp)"
-trap 'rm -f "$rename_diff_file"' EXIT
+diff_file="$(mktemp)"
+trap 'rm -f "$diff_file"' EXIT
 git diff \
   --find-renames \
   --name-status \
   -z \
-  --diff-filter=R \
   "$base_ref" \
   "$head_ref" \
-  -- > "$rename_diff_file"
+  -- > "$diff_file"
 
-renamed_out_paths=()
+blocked_changes=()
 while IFS= read -r -d '' status; do
-  IFS= read -r -d '' old_path
-  IFS= read -r -d '' new_path
+  case "$status" in
+    R*)
+      IFS= read -r -d '' old_path
+      IFS= read -r -d '' new_path
+      if is_frozen_path "$old_path" || is_frozen_path "$new_path"; then
+        printf -v rendered_change '%q -> %q' "$old_path" "$new_path"
+        blocked_changes+=("$rendered_change")
+      fi
+      ;;
+    C*)
+      IFS= read -r -d '' old_path
+      IFS= read -r -d '' new_path
+      if is_frozen_path "$new_path"; then
+        printf -v rendered_change '%q -> %q' "$old_path" "$new_path"
+        blocked_changes+=("$rendered_change")
+      fi
+      ;;
+    D*)
+      IFS= read -r -d '' _
+      ;;
+    *)
+      IFS= read -r -d '' changed_path
+      if is_frozen_path "$changed_path"; then
+        printf -v rendered_change '%q' "$changed_path"
+        blocked_changes+=("$rendered_change")
+      fi
+      ;;
+  esac
+done < "$diff_file"
 
-  if [[ "$status" == R* ]] && is_frozen_path "$old_path" && ! is_frozen_path "$new_path"; then
-    renamed_out_paths+=("$old_path" "$new_path")
-  fi
-done < "$rename_diff_file"
-
-if [ -z "$changed_files" ] && [ "${#renamed_out_paths[@]}" -eq 0 ]; then
+if [ "${#blocked_changes[@]}" -eq 0 ]; then
   echo "Connector source freeze validated."
   exit 0
 fi
@@ -69,14 +79,7 @@ else
   echo "ERROR: Connector source data in vm0 is frozen." >&2
 fi
 
-if [ -n "$changed_files" ]; then
-  printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
-fi
-for ((index = 0; index < ${#renamed_out_paths[@]}; index += 2)); do
-  printf '  %q -> %q\n' \
-    "${renamed_out_paths[$index]}" \
-    "${renamed_out_paths[$((index + 1))]}" >&2
-done
+printf '  %s\n' "${blocked_changes[@]}" >&2
 echo "" >&2
 echo "Make connector source changes in https://github.com/vm0-ai/vm0-connectors instead." >&2
 echo "Deleting migrated files from the frozen vm0 directories is allowed." >&2

--- a/.github/scripts/check-connector-source-freeze.sh
+++ b/.github/scripts/check-connector-source-freeze.sh
@@ -13,6 +13,19 @@ frozen_paths=(
   "turbo/packages/firewalls-generator/src"
 )
 
+is_frozen_path() {
+  local path="$1"
+  local frozen_path
+
+  for frozen_path in "${frozen_paths[@]}"; do
+    if [[ "$path" == "$frozen_path" || "$path" == "$frozen_path/"* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 changed_files="$(
   git diff \
     --find-renames \
@@ -24,7 +37,28 @@ changed_files="$(
     "${frozen_paths[@]}"
 )"
 
-if [ -z "$changed_files" ]; then
+rename_diff_file="$(mktemp)"
+trap 'rm -f "$rename_diff_file"' EXIT
+git diff \
+  --find-renames \
+  --name-status \
+  -z \
+  --diff-filter=R \
+  "$base_ref" \
+  "$head_ref" \
+  -- > "$rename_diff_file"
+
+renamed_out_paths=()
+while IFS= read -r -d '' status; do
+  IFS= read -r -d '' old_path
+  IFS= read -r -d '' new_path
+
+  if [[ "$status" == R* ]] && is_frozen_path "$old_path" && ! is_frozen_path "$new_path"; then
+    renamed_out_paths+=("$old_path" "$new_path")
+  fi
+done < "$rename_diff_file"
+
+if [ -z "$changed_files" ] && [ "${#renamed_out_paths[@]}" -eq 0 ]; then
   echo "Connector source freeze validated."
   exit 0
 fi
@@ -35,7 +69,14 @@ else
   echo "ERROR: Connector source data in vm0 is frozen." >&2
 fi
 
-printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
+if [ -n "$changed_files" ]; then
+  printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
+fi
+for ((index = 0; index < ${#renamed_out_paths[@]}; index += 2)); do
+  printf '  %q -> %q\n' \
+    "${renamed_out_paths[$index]}" \
+    "${renamed_out_paths[$((index + 1))]}" >&2
+done
 echo "" >&2
 echo "Make connector source changes in https://github.com/vm0-ai/vm0-connectors instead." >&2
 echo "Deleting migrated files from the frozen vm0 directories is allowed." >&2

--- a/.github/scripts/check-connector-source-freeze.sh
+++ b/.github/scripts/check-connector-source-freeze.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <base-ref> [head-ref]" >&2
+  exit 2
+fi
+
+base_ref="$1"
+head_ref="${2:-HEAD}"
+frozen_paths=(
+  "turbo/packages/connectors/src/connectors"
+  "turbo/packages/firewalls-generator/src"
+)
+
+changed_files="$(
+  git diff \
+    --find-renames \
+    --name-only \
+    --diff-filter=ACMRTUXB \
+    "$base_ref" \
+    "$head_ref" \
+    -- \
+    "${frozen_paths[@]}"
+)"
+
+if [ -z "$changed_files" ]; then
+  echo "Connector source freeze validated."
+  exit 0
+fi
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  echo "::error::Connector source data in vm0 is frozen; add or modify it in vm0-ai/vm0-connectors instead." >&2
+else
+  echo "ERROR: Connector source data in vm0 is frozen." >&2
+fi
+
+printf '%s\n' "$changed_files" | sed 's/^/  /' >&2
+echo "" >&2
+echo "Make connector source changes in https://github.com/vm0-ai/vm0-connectors instead." >&2
+echo "Deleting migrated files from the frozen vm0 directories is allowed." >&2
+
+exit 1

--- a/.github/scripts/tests/check-connector-source-freeze-test.sh
+++ b/.github/scripts/tests/check-connector-source-freeze-test.sh
@@ -91,6 +91,14 @@ commit_case "rename connector"
 expect_fail "a connector rename" "turbo/packages/connectors/src/connectors/renamed.ts"
 
 start_case
+mkdir -p "${repo}/archive"
+mv "${connector_dir}/example.ts" "${repo}/archive/example.ts"
+commit_case "rename connector outside frozen directories"
+expect_fail \
+  "a connector rename outside the frozen directories" \
+  "turbo/packages/connectors/src/connectors/example.ts -> archive/example.ts"
+
+start_case
 printf 'export const firewall = "new";\n' > "${firewall_dir}/new.ts"
 commit_case "add firewall source"
 expect_fail "a firewall source addition" "turbo/packages/firewalls-generator/src/new.ts"

--- a/.github/scripts/tests/check-connector-source-freeze-test.sh
+++ b/.github/scripts/tests/check-connector-source-freeze-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="${SCRIPT_DIR}/check-connector-source-freeze.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+expect_pass() {
+  local description="$1"
+  local output
+
+  if ! output="$(cd "$repo" && "$CHECKER" "$base_sha" HEAD 2>&1)"; then
+    fail "expected ${description} to pass, got: ${output}"
+  fi
+}
+
+expect_fail() {
+  local description="$1"
+  local expected_path="$2"
+  local output
+
+  if output="$(cd "$repo" && "$CHECKER" "$base_sha" HEAD 2>&1)"; then
+    fail "expected ${description} to fail"
+  fi
+  if [[ "$output" != *"$expected_path"* ]]; then
+    fail "expected ${description} output to contain '${expected_path}', got: ${output}"
+  fi
+  if [[ "$output" != *"vm0-connectors"* ]]; then
+    fail "expected ${description} output to direct changes to vm0-connectors"
+  fi
+}
+
+start_case() {
+  git -C "$repo" switch -q --detach "$base_sha"
+}
+
+commit_case() {
+  local message="$1"
+
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "$message"
+}
+
+repo="${TMPDIR}/repo"
+connector_dir="${repo}/turbo/packages/connectors/src/connectors"
+connector_runtime_dir="${repo}/turbo/packages/connectors/src"
+firewall_dir="${repo}/turbo/packages/firewalls-generator/src"
+
+git init -q -b main "$repo"
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+mkdir -p "$connector_dir" "$firewall_dir"
+printf 'export const connector = "base";\n' > "${connector_dir}/example.ts"
+printf 'export const runtime = "base";\n' > "${connector_runtime_dir}/runtime.ts"
+printf 'export const firewall = "base";\n' > "${firewall_dir}/example.ts"
+git -C "$repo" add .
+git -C "$repo" commit -q -m "base"
+base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+expect_pass "an unchanged tree"
+
+start_case
+printf 'export const runtime = "changed";\n' > "${connector_runtime_dir}/runtime.ts"
+commit_case "modify connector runtime"
+expect_pass "changes outside the frozen connector data directory"
+
+start_case
+printf 'export const connector = "new";\n' > "${connector_dir}/new.ts"
+commit_case "add connector"
+expect_fail "a connector addition" "turbo/packages/connectors/src/connectors/new.ts"
+
+start_case
+printf 'export const connector = "changed";\n' > "${connector_dir}/example.ts"
+commit_case "modify connector"
+expect_fail "a connector modification" "turbo/packages/connectors/src/connectors/example.ts"
+
+start_case
+rm "${connector_dir}/example.ts"
+commit_case "delete connector"
+expect_pass "a connector deletion"
+
+start_case
+mv "${connector_dir}/example.ts" "${connector_dir}/renamed.ts"
+commit_case "rename connector"
+expect_fail "a connector rename" "turbo/packages/connectors/src/connectors/renamed.ts"
+
+start_case
+printf 'export const firewall = "new";\n' > "${firewall_dir}/new.ts"
+commit_case "add firewall source"
+expect_fail "a firewall source addition" "turbo/packages/firewalls-generator/src/new.ts"
+
+start_case
+printf 'export const firewall = "changed";\n' > "${firewall_dir}/example.ts"
+commit_case "modify firewall source"
+expect_fail "a firewall source modification" "turbo/packages/firewalls-generator/src/example.ts"
+
+start_case
+rm "${firewall_dir}/example.ts"
+commit_case "delete firewall source"
+expect_pass "a firewall source deletion"
+
+echo "check-connector-source-freeze-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -274,8 +274,10 @@ jobs:
           )
           bash -n "${script_files[@]}"
           shellcheck \
+            .github/scripts/check-connector-source-freeze.sh \
             .github/scripts/check-workflow-shell-compatibility.sh \
             .github/scripts/runner-behavior-*.sh \
+            .github/scripts/tests/check-connector-source-freeze-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -346,6 +346,24 @@ jobs:
       - name: Ensure generated connector firewall files are untracked
         run: ./scripts/ensure-generated-connector-firewalls-untracked.sh
 
+  block-connector-source-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Block connector source additions and modifications
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHECKOUT_REF: ${{ github.ref }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          BASE_SHA=$(.github/scripts/changed-base-ref.sh)
+          .github/scripts/check-connector-source-freeze.sh "$BASE_SHA"
+
   # Lint jobs - split into 4 parallel jobs for faster CI
   lint-eslint:
     needs: [detect-turbo-ts-checks]
@@ -2613,6 +2631,7 @@ jobs:
       - prepare
       - file-size-check
       - block-generated-firewalls
+      - block-connector-source-changes
       - lint-eslint
       - lint-types
       - lint-types-apps
@@ -2646,6 +2665,10 @@ jobs:
         run: |
           # Auto-pass for release-please PRs, commits, and merge queue entries
           if [[ "$IS_RELEASE" == "true" ]]; then
+            if [[ "${{ needs.block-connector-source-changes.result }}" != "success" ]]; then
+              echo "::error::block-connector-source-changes: expected success, got ${{ needs.block-connector-source-changes.result }}"
+              exit 1
+            fi
             echo "✅ Release-please — skipping CI gate"
             exit 0
           fi
@@ -2697,6 +2720,7 @@ jobs:
           check_result "prepare" "${{ needs.prepare.result }}" ""
           check_result "file-size-check" "${{ needs.file-size-check.result }}" ""
           check_result "block-generated-firewalls" "${{ needs.block-generated-firewalls.result }}" ""
+          check_result "block-connector-source-changes" "${{ needs.block-connector-source-changes.result }}" ""
 
           # Turbo TypeScript checks: only 'success' is acceptable unless
           # detect-turbo-ts-checks classified this as a crates-only change set.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -349,10 +349,13 @@ jobs:
   block-connector-source-changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Block connector source additions and modifications
         env:


### PR DESCRIPTION
## Summary

- add a CI guard that rejects non-deletion changes under the connector data and firewall generator source directories
- run the guard for pull requests, merge queue entries, and pushes to `main`, and require it in the Turbo CI gate
- cover allowed deletions and blocked additions, modifications, and renames with a real temporary Git repository

## Scope

- connector runtime code outside `turbo/packages/connectors/src/connectors/` remains editable
- this PR does not migrate or delete existing connector data

## Validation

- `bash -n .github/scripts/check-connector-source-freeze.sh .github/scripts/tests/check-connector-source-freeze-test.sh`
- `shellcheck .github/scripts/check-connector-source-freeze.sh .github/scripts/tests/check-connector-source-freeze-test.sh`
- `bash .github/scripts/tests/check-connector-source-freeze-test.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml .github/workflows/security.yml`
- `actionlint`
- `git diff --check`
