### PR TITLE
perf(ci): reuse validated runner binaries before compile

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -25,8 +25,6 @@ PROFILE="${PROFILE:-vm0/default}"
 MANIFEST_PATH="${MANIFEST_PATH:-runner-image-manifest/manifest.json}"
 BIN_DIR="/var/lib/vm0-runner/bin/${job_ref}"
 RUNNER_DIR="/var/lib/vm0-runner/runners/${job_ref}"
-CARGO_TARGET_DIR="${REPO_ROOT}/crates/target"
-TARGET_DIR="${CARGO_TARGET_DIR}/${TARGET_TRIPLE}/ci"
 DERIVED_EXPECTED_REMOTE_ARCH=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
 if [ "${EXPECTED_REMOTE_ARCH+x}" = "x" ]; then
   if [ -z "$EXPECTED_REMOTE_ARCH" ]; then
@@ -62,15 +60,20 @@ done
 
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 
-FRESH_METADATA_PATH="${FRESH_METADATA_PATH:-runner-binary-fresh/metadata.json}"
+require_env RUNNER_PATH
+require_env FRESH_METADATA_PATH
+require_env EXPECTED_BINARY_INPUT_DIGEST
+if [[ "$RUNNER_PATH" != /* ]]; then
+  RUNNER_PATH="${REPO_ROOT}/${RUNNER_PATH}"
+fi
 if [[ "$FRESH_METADATA_PATH" != /* ]]; then
   FRESH_METADATA_PATH="${REPO_ROOT}/${FRESH_METADATA_PATH}"
 fi
-TARGET_TRIPLE="$TARGET_TRIPLE" \
-CARGO_TARGET_DIR="$CARGO_TARGET_DIR" \
-RUNNER_BINARY_ACTUAL_TOOLCHAIN_IMAGE="${RUNNER_BINARY_ACTUAL_TOOLCHAIN_IMAGE:-}" \
-RUNNER_BINARY_METADATA_PATH="$FRESH_METADATA_PATH" \
-  "${REPO_ROOT}/.github/scripts/runner-binary-build/build.sh" build
+FRESH_METADATA_PATH="$FRESH_METADATA_PATH" \
+RUNNER_PATH="$RUNNER_PATH" \
+EXPECTED_TARGET="$TARGET_TRIPLE" \
+EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
+  "${SCRIPT_DIR}/runner-binary-cache.sh" fresh-validate >/dev/null
 
 runner_sha=$(jq -r '.runnerSha256' "$FRESH_METADATA_PATH")
 guest_sha_json=$(jq -c '.guestSha256' "$FRESH_METADATA_PATH")
@@ -134,7 +137,7 @@ REMOTE_SCRIPT
   fi
 
   local tmp_runner="${BIN_DIR}/runner.${head_sha}.${host_index}.tmp"
-  if ! ssh "$remote" sudo install -m 755 /dev/stdin "${tmp_runner}" < "${TARGET_DIR}/runner"; then
+  if ! ssh "$remote" sudo install -m 755 /dev/stdin "${tmp_runner}" < "$RUNNER_PATH"; then
     return 1
   fi
 

--- a/.github/scripts/runner-binary-cache-plan.sh
+++ b/.github/scripts/runner-binary-cache-plan.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CACHE="${SCRIPT_DIR}/runner-binary-cache.sh"
 DIGEST="${SCRIPT_DIR}/runner-binary-build/digest.sh"
 RUNNER_BINARY_RESOLVE_TIMEOUT_SECONDS=60
+RUNNER_BINARY_RESOLVE_KILL_AFTER_SECONDS=5
 
 emit() {
   local key=$1 value=$2
@@ -89,7 +90,8 @@ while IFS= read -r encoded_entry; do
   starts+=("$(date +%s)")
   result_file="${temp_root}/${index}.out"
   error_file="${temp_root}/${index}.err"
-  timeout "${RUNNER_BINARY_RESOLVE_TIMEOUT_SECONDS}s" \
+  timeout --kill-after="${RUNNER_BINARY_RESOLVE_KILL_AFTER_SECONDS}s" \
+    "${RUNNER_BINARY_RESOLVE_TIMEOUT_SECONDS}s" \
     env GITHUB_OUTPUT= \
       EXPECTED_TARGET="$target" \
       EXPECTED_BINARY_INPUT_DIGEST="$digest" \
@@ -116,7 +118,7 @@ for index in "${!targets[@]}"; do
   wait "${pids[$index]}" || status=$?
   duration=$(($(date +%s) - starts[index]))
 
-  if [ "$status" -eq 124 ]; then
+  if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
     rm -rf "${RESOLVE_OUTPUT_DIR:?}/${target}"
     outcome=miss
     source=""

--- a/.github/scripts/runner-binary-cache-plan.sh
+++ b/.github/scripts/runner-binary-cache-plan.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
+CACHE="${SCRIPT_DIR}/runner-binary-cache.sh"
+DIGEST="${SCRIPT_DIR}/runner-binary-build/digest.sh"
+RUNNER_BINARY_RESOLVE_TIMEOUT_SECONDS=60
+
+emit() {
+  local key=$1 value=$2
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+require_env() {
+  local name=$1
+  if [ -z "${!name:-}" ]; then
+    echo "missing required env: ${name}" >&2
+    exit 2
+  fi
+}
+
+output_value() {
+  local key=$1 file=$2
+  sed -n "s/^${key}=//p" "$file" | tail -n1
+}
+
+require_env RUNNER_HOST_GROUPS_MATRIX
+require_env RESOLVE_OUTPUT_DIR
+
+case "${RUNNER_BINARY_CACHE_FORCE_MISS:-false}" in
+  true|false|"") ;;
+  *)
+    echo "invalid RUNNER_BINARY_CACHE_FORCE_MISS: ${RUNNER_BINARY_CACHE_FORCE_MISS}" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$RESOLVE_OUTPUT_DIR" = "/" ] || [ -e "$RESOLVE_OUTPUT_DIR" ] || [ -L "$RESOLVE_OUTPUT_DIR" ]; then
+  echo "runner binary plan output already exists or is unsafe: ${RESOLVE_OUTPUT_DIR}" >&2
+  exit 2
+fi
+if ! jq -e '
+  type == "array" and length > 0 and
+  all(.[];
+    type == "object" and
+    (keys | sort) == ["assetSuffix", "cacheSuffix", "id", "label", "target", "unameM"] and
+    (.id | type == "string" and length > 0) and
+    (.label | type == "string" and length > 0) and
+    (.target | type == "string" and length > 0) and
+    (.unameM | type == "string" and length > 0) and
+    (.cacheSuffix | type == "string" and length > 0) and
+    (.assetSuffix | type == "string" and length > 0)
+  ) and
+  ((map(.id) | unique | length) == length) and
+  ((map(.target) | unique | length) == length)
+' <<<"$RUNNER_HOST_GROUPS_MATRIX" >/dev/null; then
+  echo "invalid runner host groups matrix" >&2
+  exit 2
+fi
+
+mkdir -p "$RESOLVE_OUTPUT_DIR"
+temp_parent="${RUNNER_TEMP:-$(dirname "$RESOLVE_OUTPUT_DIR")}"
+mkdir -p "$temp_parent"
+temp_root=$(mktemp -d "${temp_parent}/runner-binary-plan.XXXXXX")
+PLAN_TEMP_ROOT="$temp_root"
+trap 'rm -rf "$PLAN_TEMP_ROOT"' EXIT
+
+declare -a targets=() entries=() digests=() pids=() starts=()
+while IFS= read -r encoded_entry; do
+  entry=$(base64 -d <<<"$encoded_entry")
+  target=$(jq -r '.target' <<<"$entry")
+  runner_image_validate_target "$target"
+  digest_output=$(env GITHUB_OUTPUT= "$DIGEST" "$target")
+  digest=$(sed -n 's/^binary-input-digest=//p' <<<"$digest_output" | tail -n1)
+  if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "runner binary digest command returned an invalid digest for ${target}" >&2
+    exit 2
+  fi
+
+  index=${#targets[@]}
+  targets+=("$target")
+  entries+=("$entry")
+  digests+=("$digest")
+  starts+=("$(date +%s)")
+  result_file="${temp_root}/${index}.out"
+  error_file="${temp_root}/${index}.err"
+  timeout "${RUNNER_BINARY_RESOLVE_TIMEOUT_SECONDS}s" \
+    env GITHUB_OUTPUT= \
+      EXPECTED_TARGET="$target" \
+      EXPECTED_BINARY_INPUT_DIGEST="$digest" \
+      RESOLVE_OUTPUT_DIR="${RESOLVE_OUTPUT_DIR}/${target}" \
+      "$CACHE" active-resolve \
+      >"$result_file" 2>"$error_file" &
+  pids+=("$!")
+done < <(jq -cr '.[] | @base64' <<<"$RUNNER_HOST_GROUPS_MATRIX")
+
+miss_matrix='[]'
+hit_targets='[]'
+resolution_json='[]'
+hit_count=0
+miss_count=0
+hard_failure=false
+
+for index in "${!targets[@]}"; do
+  target=${targets[$index]}
+  entry=${entries[$index]}
+  digest=${digests[$index]}
+  result_file="${temp_root}/${index}.out"
+  error_file="${temp_root}/${index}.err"
+  status=0
+  wait "${pids[$index]}" || status=$?
+  duration=$(($(date +%s) - starts[index]))
+
+  if [ "$status" -eq 124 ]; then
+    rm -rf "${RESOLVE_OUTPUT_DIR:?}/${target}"
+    outcome=miss
+    source=""
+    reason=resolve-timeout
+    producer_run_id=""
+    candidate_inspections=0
+    runner_size=0
+    object_size=0
+  elif [ "$status" -ne 0 ]; then
+    echo "runner binary resolution failed for ${target}" >&2
+    sed 's/^/  /' "$error_file" >&2
+    hard_failure=true
+    continue
+  else
+    outcome=$(output_value resolve-outcome "$result_file")
+    source=$(output_value resolve-source "$result_file")
+    reason=$(output_value resolve-reason "$result_file")
+    producer_run_id=$(output_value resolve-producer-run-id "$result_file")
+    candidate_inspections=$(output_value candidate-inspections "$result_file")
+    runner_size=$(output_value runner-size-bytes "$result_file")
+    object_size=$(output_value object-size-bytes "$result_file")
+    candidate_inspections=${candidate_inspections:-0}
+    runner_size=${runner_size:-0}
+    object_size=${object_size:-0}
+    if [ "$outcome" != "hit" ] && [ "$outcome" != "miss" ]; then
+      echo "runner binary resolution returned an invalid outcome for ${target}: ${outcome}" >&2
+      hard_failure=true
+      continue
+    fi
+  fi
+
+  if [ "$outcome" = "hit" ]; then
+    if [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/runner" ] ||
+      [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/metadata.json" ]; then
+      echo "runner binary hit transport is incomplete for ${target}" >&2
+      hard_failure=true
+      continue
+    fi
+    hit_targets=$(jq -c --arg target "$target" '. + [$target]' <<<"$hit_targets")
+    hit_count=$((hit_count + 1))
+  else
+    miss_matrix=$(jq -c --argjson entry "$entry" '. + [$entry]' <<<"$miss_matrix")
+    miss_count=$((miss_count + 1))
+  fi
+  resolution_json=$(jq -c \
+    --arg target "$target" \
+    --arg digest "$digest" \
+    --arg outcome "$outcome" \
+    --arg source "$source" \
+    --arg reason "$reason" \
+    --arg producer_run_id "$producer_run_id" \
+    --argjson duration "$duration" \
+    --argjson candidate_inspections "$candidate_inspections" \
+    --argjson runner_size "$runner_size" \
+    --argjson object_size "$object_size" '
+      . + [{
+        target: $target,
+        binaryInputDigest: $digest,
+        outcome: $outcome,
+        source: $source,
+        reason: $reason,
+        producerRunId: $producer_run_id,
+        durationSeconds: $duration,
+        candidateInspections: $candidate_inspections,
+        runnerSizeBytes: $runner_size,
+        objectSizeBytes: $object_size
+      }]
+    ' <<<"$resolution_json")
+done
+
+if [ "$hard_failure" = "true" ]; then
+  exit 1
+fi
+if [ $((hit_count + miss_count)) -ne "${#targets[@]}" ]; then
+  echo "runner binary plan did not classify every target" >&2
+  exit 1
+fi
+
+emit "compile-matrix" "$miss_matrix"
+emit "hit-targets" "$hit_targets"
+emit "hit-count" "$hit_count"
+emit "miss-count" "$miss_count"
+emit "resolution-json" "$resolution_json"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Runner binary cache plan"
+    echo
+    echo "| Target | Outcome | Source | Reason | Producer run | Candidates | R2 bytes | Duration |"
+    echo "| --- | --- | --- | --- | --- | ---: | ---: | ---: |"
+    jq -r '.[] | "| `\(.target)` | `\(.outcome)` | `\(.source // "")` | `\(.reason)` | `\(.producerRunId // "")` | \(.candidateInspections) | \(.objectSizeBytes) | \(.durationSeconds)s |"' \
+      <<<"$resolution_json"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -9,6 +9,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 RUNNER_BINARY_MAX_SIZE_BYTES=$((128 * 1024 * 1024))
 RUNNER_BINARY_MAX_COMPRESSED_BYTES=$((64 * 1024 * 1024))
+RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES=$((1024 * 1024))
+RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS=8
+RUNNER_BINARY_MAX_TRUSTED_IDENTITIES=2
 RUNNER_BINARY_WORKFLOW_PATH=".github/workflows/runner-image.yml"
 
 emit() {
@@ -248,7 +251,7 @@ publish() {
   load_fresh
   validate_producer_inputs
   require_env OUTPUT_DIR
-  if [ "$OUTPUT_DIR" = "/" ]; then
+  if [ "${OUTPUT_DIR:?}" = "/" ]; then
     echo "refusing unsafe OUTPUT_DIR=/" >&2
     exit 2
   fi
@@ -442,69 +445,113 @@ shadow_result() {
   fi
 }
 
-shadow_resolve() {
-  load_fresh
+validate_resolution_context() {
   require_env REPO
   require_env CURRENT_RUN_ID
   require_env CURRENT_EVENT
   require_env DEFAULT_BRANCH
-  require_env SHADOW_OUTPUT_DIR
-  if [ "$SHADOW_OUTPUT_DIR" = "/" ]; then
-    echo "refusing unsafe SHADOW_OUTPUT_DIR=/" >&2
-    exit 2
-  fi
   case "$CURRENT_EVENT" in
     pull_request|merge_group)
       if [[ ! "${CURRENT_PR_NUMBER:-}" =~ ^[1-9][0-9]*$ ]]; then
-        echo "${CURRENT_EVENT} shadow resolution requires a current PR number" >&2
+        echo "${CURRENT_EVENT} runner binary resolution requires a current PR number" >&2
         exit 2
       fi
       ;;
     push) ;;
     *) echo "unsupported current event: ${CURRENT_EVENT}" >&2; exit 2 ;;
   esac
-  mkdir -p "$SHADOW_OUTPUT_DIR"
+}
+
+collect_trusted_candidates() {
+  local expected_target=$1 expected_digest=$2 output_dir=$3
+  validate_resolution_context
+  mkdir -p "$output_dir"
 
   local artifact_name_value artifacts_json
-  artifact_name_value="runner-binary-asset-${FRESH_TARGET}-${FRESH_BINARY_INPUT_DIGEST}"
+  artifact_name_value="runner-binary-asset-${expected_target}-${expected_digest}"
   if ! artifacts_json=$(gh api --paginate --slurp \
     "repos/${REPO}/actions/artifacts?name=${artifact_name_value}&per_page=100" 2>/dev/null); then
-    shadow_result "error" "" "artifact-api-unavailable"
-    return 0
+    CANDIDATE_DISCOVERY_REASON="artifact-api-unavailable"
+    return 1
   fi
   if ! jq -e 'type == "array" and all(.[]; type == "object" and (.artifacts | type == "array"))' \
     <<<"$artifacts_json" >/dev/null; then
-    shadow_result "error" "" "artifact-api-malformed"
-    return 0
+    CANDIDATE_DISCOVERY_REASON="artifact-api-malformed"
+    return 1
   fi
 
-  local candidates_file
-  candidates_file="${SHADOW_OUTPUT_DIR}/trusted-candidates.tsv"
-  : > "$candidates_file"
+  local potential_file sorted_potential trusted_file identities_file
+  potential_file="${output_dir}/potential-candidates.tsv"
+  sorted_potential="${output_dir}/potential-candidates-sorted.tsv"
+  trusted_file="${output_dir}/trusted-candidates.tsv"
+  identities_file="${output_dir}/trusted-identities.tsv"
+  : > "$potential_file"
+  : > "$trusted_file"
+  : > "$identities_file"
   while IFS= read -r artifact_encoded; do
     [ -n "$artifact_encoded" ] || continue
-    local artifact_json artifact_run_id artifact_id artifact_created artifact_branch artifact_head_sha
+    local artifact_json artifact_run_id artifact_id artifact_size artifact_created artifact_branch artifact_head_sha
     artifact_json=$(base64 -d <<<"$artifact_encoded")
     artifact_run_id=$(jq -r '.workflow_run.id // empty' <<<"$artifact_json")
     artifact_id=$(jq -r '.id // empty' <<<"$artifact_json")
+    artifact_size=$(jq -r '.size_in_bytes // empty' <<<"$artifact_json")
     artifact_created=$(jq -r '.created_at // empty' <<<"$artifact_json")
     artifact_branch=$(jq -r '.workflow_run.head_branch // empty' <<<"$artifact_json")
     artifact_head_sha=$(jq -r '.workflow_run.head_sha // empty' <<<"$artifact_json")
     if [[ ! "$artifact_run_id" =~ ^[1-9][0-9]*$ ]] ||
       [[ ! "$artifact_id" =~ ^[1-9][0-9]*$ ]] ||
+      [[ ! "$artifact_size" =~ ^[1-9][0-9]*$ ]] ||
+      [ "$artifact_size" -gt "$RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES" ] ||
       [ "$artifact_run_id" = "$CURRENT_RUN_ID" ]; then
       continue
     fi
 
-    local branch_maybe_relevant=false
+    local source="" rank=""
     if [ "$artifact_branch" = "$DEFAULT_BRANCH" ]; then
-      branch_maybe_relevant=true
+      source="protected-main"
+      case "$CURRENT_EVENT" in
+        pull_request|push) rank=0 ;;
+        merge_group) rank=1 ;;
+      esac
     elif [ -n "${CURRENT_PR_HEAD_REF:-}" ] && [ "$artifact_branch" = "$CURRENT_PR_HEAD_REF" ]; then
-      branch_maybe_relevant=true
+      source="same-pr"
+      case "$CURRENT_EVENT" in
+        pull_request) rank=1 ;;
+        merge_group) rank=0 ;;
+        push) continue ;;
+      esac
     elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [[ "$artifact_branch" =~ (^|/)pr-${CURRENT_PR_NUMBER}- ]]; then
-      branch_maybe_relevant=true
+      source="same-pr"
+      case "$CURRENT_EVENT" in
+        pull_request) rank=1 ;;
+        merge_group) rank=0 ;;
+        push) continue ;;
+      esac
     fi
-    [ "$branch_maybe_relevant" = "true" ] || continue
+    [ -n "$source" ] || continue
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$rank" "$artifact_created" "$artifact_id" "$artifact_run_id" "$source" \
+      "$artifact_head_sha" >> "$potential_file"
+  done < <(jq -r \
+    --arg name "$artifact_name_value" '
+      .[] | .artifacts[]? |
+      select(.name == $name and .expired == false) |
+      @base64
+    ' <<<"$artifacts_json")
+
+  sort -t $'\t' -k1,1n -k2,2r "$potential_file" > "$sorted_potential"
+
+  local inspected=0 trusted_count=0 identity_count=0 limit_reached=false
+  local potential_count
+  potential_count=$(wc -l < "$sorted_potential" | tr -d ' ')
+  while IFS=$'\t' read -r rank artifact_created artifact_id artifact_run_id source artifact_head_sha; do
+    [ -n "$artifact_run_id" ] || continue
+    if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ]; then
+      limit_reached=true
+      break
+    fi
+    inspected=$((inspected + 1))
 
     local run_json
     if ! run_json=$(gh api "repos/${REPO}/actions/runs/${artifact_run_id}" 2>/dev/null); then
@@ -526,55 +573,25 @@ shadow_resolve() {
       continue
     fi
 
-    local source="" rank="" run_event run_branch
+    local actual_source="" run_event run_branch
     run_event=$(jq -r '.event' <<<"$run_json")
     run_branch=$(jq -r '.head_branch' <<<"$run_json")
     if [ "$run_event" = "push" ] && [ "$run_branch" = "$DEFAULT_BRANCH" ]; then
-      source="protected-main"
-      case "$CURRENT_EVENT" in
-        pull_request) rank=0 ;;
-        merge_group) rank=1 ;;
-        push) rank=0 ;;
-      esac
+      actual_source="protected-main"
     elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [ "$run_event" = "pull_request" ] &&
       jq -e --argjson pr "$CURRENT_PR_NUMBER" 'any(.pull_requests[]?; .number == $pr)' \
         <<<"$run_json" >/dev/null; then
-      source="same-pr"
-      case "$CURRENT_EVENT" in
-        pull_request) rank=1 ;;
-        merge_group) rank=0 ;;
-        push) continue ;;
-      esac
+      actual_source="same-pr"
     elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [ "$run_event" = "merge_group" ] &&
       [[ "$run_branch" =~ (^|/)pr-${CURRENT_PR_NUMBER}- ]]; then
-      source="same-pr"
-      case "$CURRENT_EVENT" in
-        pull_request) rank=1 ;;
-        merge_group) rank=0 ;;
-        push) continue ;;
-      esac
+      actual_source="same-pr"
     else
       continue
     fi
+    [ "$actual_source" = "$source" ] || continue
 
-    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$rank" "$artifact_created" "$artifact_id" "$artifact_run_id" "$source" \
-      "$(base64 -w0 <<<"$run_json")" >> "$candidates_file"
-  done < <(jq -r \
-    --arg name "$artifact_name_value" '
-      .[] | .artifacts[]? |
-      select(.name == $name and .expired == false) |
-      @base64
-    ' <<<"$artifacts_json")
-
-  local sorted_candidates
-  sorted_candidates="${SHADOW_OUTPUT_DIR}/trusted-candidates-sorted.tsv"
-  sort -t $'\t' -k1,1n -k2,2r "$candidates_file" > "$sorted_candidates"
-
-  while IFS=$'\t' read -r _rank _created artifact_id artifact_run_id source run_encoded; do
-    [ -n "$artifact_run_id" ] || continue
-    local candidate_dir manifest_path run_json
-    candidate_dir="${SHADOW_OUTPUT_DIR}/candidate-${artifact_id}"
+    local candidate_dir manifest_path
+    candidate_dir="${output_dir}/candidate-${artifact_id}"
     rm -rf "$candidate_dir"
     mkdir -p "$candidate_dir"
     if ! gh run download "$artifact_run_id" -n "$artifact_name_value" -D "$candidate_dir" \
@@ -586,10 +603,9 @@ shadow_resolve() {
       continue
     fi
     manifest_path="${manifest_candidates[0]}"
-    run_json=$(base64 -d <<<"$run_encoded")
     if ! MANIFEST_PATH="$manifest_path" \
-      EXPECTED_TARGET="$FRESH_TARGET" \
-      EXPECTED_BINARY_INPUT_DIGEST="$FRESH_BINARY_INPUT_DIGEST" \
+      EXPECTED_TARGET="$expected_target" \
+      EXPECTED_BINARY_INPUT_DIGEST="$expected_digest" \
       EXPECTED_REPOSITORY="$REPO" \
       EXPECTED_WORKFLOW_PATH="$RUNNER_BINARY_WORKFLOW_PATH" \
         "$0" manifest-validate >/dev/null 2>&1; then
@@ -624,28 +640,267 @@ shadow_resolve() {
       continue
     fi
 
-    local candidate_runner_sha candidate_runner_size candidate_guests
-    candidate_runner_sha=$(jq -r '.runner.sha256' "$manifest_path")
-    candidate_runner_size=$(jq -r '.runner.sizeBytes' "$manifest_path")
-    candidate_guests=$(jq -cS '.guests' "$manifest_path")
-    if [ "$candidate_runner_sha" != "$FRESH_RUNNER_SHA" ] ||
-      [ "$candidate_runner_size" != "$FRESH_RUNNER_SIZE" ] ||
-      [ "$candidate_guests" != "$FRESH_GUESTS" ]; then
-      shadow_result "conflict" "$source" "equal-input-output-mismatch" "$artifact_run_id"
-      echo "equal runner binary input digest produced conflicting output identity: current run ${CURRENT_RUN_ID}, candidate run ${artifact_run_id}" >&2
-      return 1
+    local identity identity_key
+    identity=$(jq -cS '{runner, guests}' "$manifest_path")
+    identity_key=$(sha256sum <<<"$identity" | awk '{print $1}')
+    if ! grep -qxF "$identity_key" "$identities_file"; then
+      printf '%s\n' "$identity_key" >> "$identities_file"
+      identity_count=$((identity_count + 1))
     fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$rank" "$artifact_created" "$artifact_id" "$artifact_run_id" "$source" \
+      "$manifest_path" >> "$trusted_file"
+    trusted_count=$((trusted_count + 1))
+    if [ "$identity_count" -ge "$RUNNER_BINARY_MAX_TRUSTED_IDENTITIES" ]; then
+      break
+    fi
+  done < "$sorted_potential"
 
-    shadow_result "hit" "$source" "equal-output" "$artifact_run_id"
+  if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ] &&
+    [ "$potential_count" -gt "$inspected" ]; then
+    limit_reached=true
+  fi
+
+  TRUSTED_CANDIDATES_FILE="$trusted_file"
+  TRUSTED_CANDIDATE_COUNT="$trusted_count"
+  TRUSTED_IDENTITY_COUNT="$identity_count"
+  TRUSTED_INSPECTION_COUNT="$inspected"
+  if [ "$trusted_count" -eq 0 ]; then
+    if [ "$limit_reached" = "true" ]; then
+      CANDIDATE_DISCOVERY_REASON="candidate-limit-exhausted"
+    else
+      CANDIDATE_DISCOVERY_REASON="no-trusted-candidate"
+    fi
+  elif [ "$identity_count" -gt 1 ]; then
+    CANDIDATE_DISCOVERY_REASON="trusted-output-conflict"
+  else
+    CANDIDATE_DISCOVERY_REASON="trusted-candidate"
+  fi
+}
+
+first_trusted_candidate() {
+  IFS=$'\t' read -r _ _ _ \
+    TRUSTED_RUN_ID TRUSTED_SOURCE TRUSTED_MANIFEST_PATH < "$TRUSTED_CANDIDATES_FILE"
+  [ -n "${TRUSTED_RUN_ID:-}" ]
+}
+
+shadow_resolve() {
+  load_fresh
+  require_env SHADOW_OUTPUT_DIR
+  if [ "$SHADOW_OUTPUT_DIR" = "/" ]; then
+    echo "refusing unsafe SHADOW_OUTPUT_DIR=/" >&2
+    exit 2
+  fi
+  mkdir -p "$SHADOW_OUTPUT_DIR"
+
+  if ! collect_trusted_candidates \
+    "$FRESH_TARGET" "$FRESH_BINARY_INPUT_DIGEST" "$SHADOW_OUTPUT_DIR"; then
+    shadow_result "error" "" "$CANDIDATE_DISCOVERY_REASON"
     return 0
-  done < "$sorted_candidates"
+  fi
+  if [ "$TRUSTED_IDENTITY_COUNT" -gt 1 ]; then
+    first_trusted_candidate
+    shadow_result "conflict" "$TRUSTED_SOURCE" \
+      "equal-input-output-mismatch" "$TRUSTED_RUN_ID"
+    echo "equal runner binary input digest produced conflicting output identity: current run ${CURRENT_RUN_ID}, candidate run ${TRUSTED_RUN_ID}" >&2
+    return 1
+  fi
+  if [ "$TRUSTED_CANDIDATE_COUNT" -eq 0 ]; then
+    shadow_result "miss" "" "$CANDIDATE_DISCOVERY_REASON"
+    return 0
+  fi
 
-  shadow_result "miss" "" "no-trusted-candidate"
+  first_trusted_candidate
+  local candidate_runner_sha candidate_runner_size candidate_guests
+  candidate_runner_sha=$(jq -r '.runner.sha256' "$TRUSTED_MANIFEST_PATH")
+  candidate_runner_size=$(jq -r '.runner.sizeBytes' "$TRUSTED_MANIFEST_PATH")
+  candidate_guests=$(jq -cS '.guests' "$TRUSTED_MANIFEST_PATH")
+  if [ "$candidate_runner_sha" != "$FRESH_RUNNER_SHA" ] ||
+    [ "$candidate_runner_size" != "$FRESH_RUNNER_SIZE" ] ||
+    [ "$candidate_guests" != "$FRESH_GUESTS" ]; then
+    shadow_result "conflict" "$TRUSTED_SOURCE" \
+      "equal-input-output-mismatch" "$TRUSTED_RUN_ID"
+    echo "equal runner binary input digest produced conflicting output identity: current run ${CURRENT_RUN_ID}, candidate run ${TRUSTED_RUN_ID}" >&2
+    return 1
+  fi
+
+  shadow_result "hit" "$TRUSTED_SOURCE" "equal-output" "$TRUSTED_RUN_ID"
+}
+
+resolve_result() {
+  local outcome=$1 source=$2 reason=$3 run_id=${4:-}
+  emit "resolve-outcome" "$outcome"
+  emit "resolve-source" "$source"
+  emit "resolve-reason" "$reason"
+  emit "resolve-producer-run-id" "$run_id"
+}
+
+active_resolve() {
+  require_env EXPECTED_TARGET
+  require_env EXPECTED_BINARY_INPUT_DIGEST
+  require_env RESOLVE_OUTPUT_DIR
+  runner_image_validate_target "$EXPECTED_TARGET"
+  if [[ ! "$EXPECTED_BINARY_INPUT_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "invalid expected runner binary input digest: ${EXPECTED_BINARY_INPUT_DIGEST}" >&2
+    exit 2
+  fi
+  if [ "$RESOLVE_OUTPUT_DIR" = "/" ] || [ -e "$RESOLVE_OUTPUT_DIR" ] || [ -L "$RESOLVE_OUTPUT_DIR" ]; then
+    echo "runner binary resolve output already exists or is unsafe: ${RESOLVE_OUTPUT_DIR}" >&2
+    exit 2
+  fi
+  validate_resolution_context
+
+  case "${RUNNER_BINARY_CACHE_FORCE_MISS:-false}" in
+    true)
+      resolve_result "miss" "" "force-miss"
+      return 0
+      ;;
+    false|"") ;;
+    *)
+      echo "invalid RUNNER_BINARY_CACHE_FORCE_MISS: ${RUNNER_BINARY_CACHE_FORCE_MISS}" >&2
+      exit 2
+      ;;
+  esac
+  if [ "$CURRENT_EVENT" = "push" ]; then
+    resolve_result "miss" "" "protected-main-full-build"
+    return 0
+  fi
+  if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${R2_BUCKET_NAME:-}" ] ||
+    [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    resolve_result "miss" "" "missing-r2-config"
+    return 0
+  fi
+  if ! command -v aws >/dev/null; then
+    resolve_result "miss" "" "aws-unavailable"
+    return 0
+  fi
+  if ! command -v zstd >/dev/null; then
+    resolve_result "miss" "" "zstd-unavailable"
+    return 0
+  fi
+
+  local output_parent temp_root candidate_dir error_log
+  output_parent=$(dirname "$RESOLVE_OUTPUT_DIR")
+  mkdir -p "$output_parent"
+  temp_root=$(mktemp -d "${RUNNER_TEMP:-${output_parent}}/runner-binary-resolve.XXXXXX")
+  candidate_dir="${temp_root}/candidates"
+  error_log="${temp_root}/remote.err"
+  ACTIVE_RESOLVE_TEMP_ROOT="$temp_root"
+  trap 'rm -rf "$ACTIVE_RESOLVE_TEMP_ROOT"' EXIT
+
+  if ! collect_trusted_candidates \
+    "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST" "$candidate_dir"; then
+    emit "candidate-inspections" "0"
+    resolve_result "miss" "" "$CANDIDATE_DISCOVERY_REASON"
+    return 0
+  fi
+  emit "candidate-inspections" "$TRUSTED_INSPECTION_COUNT"
+  if [ "$TRUSTED_IDENTITY_COUNT" -gt 1 ]; then
+    resolve_result "miss" "" "trusted-output-conflict"
+    return 0
+  fi
+  if [ "$TRUSTED_CANDIDATE_COUNT" -eq 0 ]; then
+    resolve_result "miss" "" "$CANDIDATE_DISCOVERY_REASON"
+    return 0
+  fi
+  first_trusted_candidate
+
+  local object_key object_size runner_sha runner_size endpoint head_json retained_size
+  object_key=$(jq -r '.object.key' "$TRUSTED_MANIFEST_PATH")
+  object_size=$(jq -r '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")
+  runner_sha=$(jq -r '.runner.sha256' "$TRUSTED_MANIFEST_PATH")
+  runner_size=$(jq -r '.runner.sizeBytes' "$TRUSTED_MANIFEST_PATH")
+  endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+  if ! head_json=$(aws s3api head-object \
+    --endpoint-url "$endpoint" \
+    --bucket "$R2_BUCKET_NAME" \
+    --key "$object_key" \
+    --output json \
+    --cli-connect-timeout 5 \
+    --cli-read-timeout 30 2>"$error_log"); then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-head-failed" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+  if ! retained_size=$(jq -er '.ContentLength | select(type == "number" and floor == .)' \
+    <<<"$head_json" 2>/dev/null); then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-head-malformed" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+  if [ "$retained_size" != "$object_size" ] ||
+    [ "$retained_size" -le 0 ] || [ "$retained_size" -gt "$RUNNER_BINARY_MAX_COMPRESSED_BYTES" ]; then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-size-mismatch" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+
+  local compressed decompressed get_status=0 decompress_status=0
+  compressed="${temp_root}/runner.zst"
+  decompressed="${temp_root}/runner"
+  aws s3api get-object \
+    --endpoint-url "$endpoint" \
+    --bucket "$R2_BUCKET_NAME" \
+    --key "$object_key" \
+    --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
+    --cli-connect-timeout 5 \
+    --cli-read-timeout 30 \
+    "$compressed" \
+    >/dev/null 2>"$error_log" || get_status=$?
+  if [ "$get_status" -ne 0 ]; then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-get-failed" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+  if [ "$(stat -c '%s' "$compressed")" != "$object_size" ]; then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-size-changed" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+
+  set +e
+  set -o pipefail
+  zstd -q -d -c "$compressed" \
+    2>"${temp_root}/zstd.err" \
+    | head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" \
+      > "$decompressed"
+  decompress_status=$?
+  set -e
+  if [ "$decompress_status" -ne 0 ] ||
+    [ "$(stat -c '%s' "$decompressed")" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-decompression-invalid" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+  if [ "$(stat -c '%s' "$decompressed")" != "$runner_size" ] ||
+    [ "$(sha256sum "$decompressed" | awk '{print $1}')" != "$runner_sha" ]; then
+    resolve_result "miss" "$TRUSTED_SOURCE" "r2-content-mismatch" "$TRUSTED_RUN_ID"
+    return 0
+  fi
+
+  local transport_dir
+  transport_dir="${temp_root}/transport"
+  mkdir -p "$transport_dir"
+  install -m 755 "$decompressed" "${transport_dir}/runner"
+  jq '{
+    schemaVersion,
+    binaryInputDigest,
+    target,
+    toolchainImage,
+    runnerSha256: .runner.sha256,
+    runnerSizeBytes: .runner.sizeBytes,
+    guestSha256: .guests
+  }' "$TRUSTED_MANIFEST_PATH" > "${transport_dir}/metadata.json"
+  FRESH_METADATA_PATH="${transport_dir}/metadata.json" \
+  RUNNER_PATH="${transport_dir}/runner" \
+  EXPECTED_TARGET="$EXPECTED_TARGET" \
+  EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
+    "$0" fresh-validate >/dev/null
+  mv "$transport_dir" "$RESOLVE_OUTPUT_DIR"
+
+  emit "binary-input-digest" "$EXPECTED_BINARY_INPUT_DIGEST"
+  emit "runner-size-bytes" "$runner_size"
+  emit "object-size-bytes" "$object_size"
+  resolve_result "hit" "$TRUSTED_SOURCE" "validated" "$TRUSTED_RUN_ID"
 }
 
 usage() {
   cat <<'USAGE'
-Usage: runner-binary-cache.sh <fresh-validate|artifact-name|manifest-validate|publish|shadow-resolve>
+Usage: runner-binary-cache.sh <fresh-validate|artifact-name|manifest-validate|publish|shadow-resolve|active-resolve>
 USAGE
 }
 
@@ -655,6 +910,7 @@ case "${1:-}" in
   manifest-validate) manifest_validate ;;
   publish) publish ;;
   shadow-resolve) shadow_resolve ;;
+  active-resolve) active_resolve ;;
   -h|--help|help) usage ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -194,6 +194,11 @@ manifest_validate() {
   emit "object-size-bytes" "$REUSABLE_OBJECT_SIZE"
 }
 
+reusable_artifact_name() {
+  local target=$1 digest=$2
+  printf 'runner-binary-asset-%s-%s\n' "$target" "$digest"
+}
+
 artifact_name() {
   require_env EXPECTED_TARGET
   require_env EXPECTED_BINARY_INPUT_DIGEST
@@ -202,7 +207,7 @@ artifact_name() {
     echo "invalid runner binary input digest: ${EXPECTED_BINARY_INPUT_DIGEST}" >&2
     exit 2
   fi
-  emit "artifact-name" "runner-binary-asset-${EXPECTED_TARGET}-${EXPECTED_BINARY_INPUT_DIGEST}"
+  emit "artifact-name" "$(reusable_artifact_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")"
 }
 
 publish_soft_failure() {
@@ -210,6 +215,95 @@ publish_soft_failure() {
   echo "::warning::Runner binary cache publication skipped (${reason}): ${message}"
   emit "published" "false"
   emit "publish-reason" "$reason"
+}
+
+fetch_verified_r2_runner() {
+  local object_key=$1
+  local expected_object_size=$2
+  local expected_runner_size=$3
+  local expected_runner_sha=$4
+  local compressed_path=$5
+  local runner_path=$6
+  local endpoint head_json observed_object_size downloaded_size decompressed_size actual_sha
+  local get_status=0 decompress_status=0
+  local aws_error_log="${compressed_path}.aws.err"
+  local zstd_error_log="${compressed_path}.zstd.err"
+
+  R2_VERIFICATION_REASON=""
+  R2_VERIFICATION_MESSAGE=""
+  R2_VERIFIED_OBJECT_SIZE=""
+  endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+  if ! head_json=$(aws s3api head-object \
+    --endpoint-url "$endpoint" \
+    --bucket "$R2_BUCKET_NAME" \
+    --key "$object_key" \
+    --output json \
+    --cli-connect-timeout 5 \
+    --cli-read-timeout 30 2>"$aws_error_log"); then
+    R2_VERIFICATION_REASON="head-failed"
+    R2_VERIFICATION_MESSAGE="the R2 object could not be inspected"
+    return 1
+  fi
+  if ! observed_object_size=$(jq -er '.ContentLength | select(type == "number" and floor == .)' \
+    <<<"$head_json" 2>/dev/null); then
+    R2_VERIFICATION_REASON="head-malformed"
+    R2_VERIFICATION_MESSAGE="the R2 object metadata was malformed"
+    return 1
+  fi
+  if [[ ! "$observed_object_size" =~ ^[1-9][0-9]*$ ]] ||
+    [ "$observed_object_size" -gt "$RUNNER_BINARY_MAX_COMPRESSED_BYTES" ]; then
+    R2_VERIFICATION_REASON="size-mismatch"
+    R2_VERIFICATION_MESSAGE="the R2 object is outside the configured bound"
+    return 1
+  fi
+  if [ -n "$expected_object_size" ] && [ "$observed_object_size" != "$expected_object_size" ]; then
+    R2_VERIFICATION_REASON="size-mismatch"
+    R2_VERIFICATION_MESSAGE="the R2 object size does not match the reusable manifest"
+    return 1
+  fi
+
+  aws s3api get-object \
+    --endpoint-url "$endpoint" \
+    --bucket "$R2_BUCKET_NAME" \
+    --key "$object_key" \
+    --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
+    --cli-connect-timeout 5 \
+    --cli-read-timeout 30 \
+    "$compressed_path" \
+    >/dev/null 2>"$aws_error_log" || get_status=$?
+  if [ "$get_status" -ne 0 ]; then
+    R2_VERIFICATION_REASON="get-failed"
+    R2_VERIFICATION_MESSAGE="the R2 object could not be downloaded"
+    return 1
+  fi
+  downloaded_size=$(stat -c '%s' "$compressed_path")
+  if [ "$downloaded_size" != "$observed_object_size" ]; then
+    R2_VERIFICATION_REASON="size-changed"
+    R2_VERIFICATION_MESSAGE="the R2 object changed during validation"
+    return 1
+  fi
+
+  zstd -q -d -c "$compressed_path" \
+    2>"$zstd_error_log" \
+    | head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" \
+      > "$runner_path" || decompress_status=$?
+  decompressed_size=$(stat -c '%s' "$runner_path")
+  if [ "$decompress_status" -ne 0 ] ||
+    [ "$decompressed_size" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
+    R2_VERIFICATION_REASON="decompression-invalid"
+    R2_VERIFICATION_MESSAGE="the R2 object is not a bounded zstd runner"
+    return 1
+  fi
+  actual_sha=$(sha256sum "$runner_path" | awk '{print $1}')
+  if [ "$decompressed_size" != "$expected_runner_size" ] ||
+    [ "$actual_sha" != "$expected_runner_sha" ]; then
+    R2_VERIFICATION_REASON="content-mismatch"
+    R2_VERIFICATION_MESSAGE="the R2 object does not match the expected runner identity"
+    return 1
+  fi
+
+  R2_VERIFIED_OBJECT_SIZE="$observed_object_size"
 }
 
 validate_producer_inputs() {
@@ -309,60 +403,20 @@ publish() {
     return 0
   fi
 
-  local head_json retained_size get_status
-  if ! head_json=$(aws s3api head-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
-    --key "$object_key" \
-    --output json 2>"$error_log"); then
-    publish_soft_failure "head-failed" "the retained R2 object could not be inspected"
+  local retained_size publish_reason
+  if ! fetch_verified_r2_runner \
+    "$object_key" "" "$FRESH_RUNNER_SIZE" "$FRESH_RUNNER_SHA" \
+    "$retained" "$decompressed"; then
+    case "$R2_VERIFICATION_REASON" in
+      size-mismatch) publish_reason="retained-size-invalid" ;;
+      size-changed) publish_reason="retained-size-changed" ;;
+      content-mismatch) publish_reason="retained-content-mismatch" ;;
+      *) publish_reason="$R2_VERIFICATION_REASON" ;;
+    esac
+    publish_soft_failure "$publish_reason" "$R2_VERIFICATION_MESSAGE"
     return 0
   fi
-  if ! retained_size=$(jq -er '.ContentLength | select(type == "number" and floor == .)' \
-    <<<"$head_json" 2>/dev/null); then
-    publish_soft_failure "head-malformed" "the retained R2 object metadata was malformed"
-    return 0
-  fi
-  if [[ ! "$retained_size" =~ ^[1-9][0-9]*$ ]] || [ "$retained_size" -gt "$RUNNER_BINARY_MAX_COMPRESSED_BYTES" ]; then
-    publish_soft_failure "retained-size-invalid" "the retained R2 object is outside the configured bound"
-    return 0
-  fi
-
-  get_status=0
-  aws s3api get-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
-    --key "$object_key" \
-    --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
-    "$retained" \
-    >/dev/null 2>"$error_log" || get_status=$?
-  if [ "$get_status" -ne 0 ]; then
-    publish_soft_failure "get-failed" "the retained R2 object could not be downloaded"
-    return 0
-  fi
-  if [ "$(stat -c '%s' "$retained")" != "$retained_size" ]; then
-    publish_soft_failure "retained-size-changed" "the retained R2 object changed during validation"
-    return 0
-  fi
-
-  local decompress_status=0
-  set +e
-  set -o pipefail
-  zstd -q -d -c "$retained" \
-    2>"${temp_root}/zstd.err" \
-    | head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" \
-      > "$decompressed"
-  decompress_status=$?
-  set -e
-  if [ "$decompress_status" -ne 0 ] || [ "$(stat -c '%s' "$decompressed")" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
-    publish_soft_failure "decompression-invalid" "the retained R2 object is not a bounded zstd runner"
-    return 0
-  fi
-  if [ "$(stat -c '%s' "$decompressed")" != "$FRESH_RUNNER_SIZE" ] ||
-    [ "$(sha256sum "$decompressed" | awk '{print $1}')" != "$FRESH_RUNNER_SHA" ]; then
-    publish_soft_failure "retained-content-mismatch" "the retained R2 object does not match the fresh runner identity"
-    return 0
-  fi
+  retained_size="$R2_VERIFIED_OBJECT_SIZE"
 
   local pr_number_json created_at manifest_tmp
   if [ -n "${PRODUCER_PR_NUMBER:-}" ]; then
@@ -468,7 +522,7 @@ collect_trusted_candidates() {
   mkdir -p "$output_dir"
 
   local artifact_name_value artifacts_json
-  artifact_name_value="runner-binary-asset-${expected_target}-${expected_digest}"
+  artifact_name_value=$(reusable_artifact_name "$expected_target" "$expected_digest")
   if ! artifacts_json=$(gh api --paginate --slurp \
     "repos/${REPO}/actions/artifacts?name=${artifact_name_value}&per_page=100" 2>/dev/null); then
     CANDIDATE_DISCOVERY_REASON="artifact-api-unavailable"
@@ -612,11 +666,8 @@ collect_trusted_candidates() {
       continue
     fi
 
-    local run_attempt run_event run_head_sha manifest_pr expected_pr_json
+    local run_attempt expected_pr_json
     run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
-    run_event=$(jq -r '.event' <<<"$run_json")
-    run_head_sha=$(jq -r '.head_sha' <<<"$run_json")
-    manifest_pr=$(jq -r '.producer.prNumber // empty' "$manifest_path")
     if [ "$source" = "same-pr" ]; then
       expected_pr_json="$CURRENT_PR_NUMBER"
     else
@@ -626,7 +677,7 @@ collect_trusted_candidates() {
       --argjson run_id "$artifact_run_id" \
       --argjson run_attempt "$run_attempt" \
       --arg event "$run_event" \
-      --arg head_sha "$run_head_sha" \
+      --arg head_sha "$artifact_head_sha" \
       --argjson pr_number "$expected_pr_json" '
         .producer.runId == $run_id and
         .producer.runAttempt == $run_attempt and
@@ -634,9 +685,6 @@ collect_trusted_candidates() {
         .producer.headSha == $head_sha and
         .producer.prNumber == $pr_number
       ' "$manifest_path" >/dev/null; then
-      continue
-    fi
-    if [ "$source" = "same-pr" ] && [ "$manifest_pr" != "$CURRENT_PR_NUMBER" ]; then
       continue
     fi
 
@@ -779,12 +827,11 @@ active_resolve() {
     return 0
   fi
 
-  local output_parent temp_root candidate_dir error_log
+  local output_parent temp_root candidate_dir
   output_parent=$(dirname "$RESOLVE_OUTPUT_DIR")
   mkdir -p "$output_parent"
   temp_root=$(mktemp -d "${RUNNER_TEMP:-${output_parent}}/runner-binary-resolve.XXXXXX")
   candidate_dir="${temp_root}/candidates"
-  error_log="${temp_root}/remote.err"
   ACTIVE_RESOLVE_TEMP_ROOT="$temp_root"
   trap 'rm -rf "$ACTIVE_RESOLVE_TEMP_ROOT"' EXIT
 
@@ -805,70 +852,19 @@ active_resolve() {
   fi
   first_trusted_candidate
 
-  local object_key object_size runner_sha runner_size endpoint head_json retained_size
+  local object_key object_size runner_sha runner_size
   object_key=$(jq -r '.object.key' "$TRUSTED_MANIFEST_PATH")
   object_size=$(jq -r '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")
   runner_sha=$(jq -r '.runner.sha256' "$TRUSTED_MANIFEST_PATH")
   runner_size=$(jq -r '.runner.sizeBytes' "$TRUSTED_MANIFEST_PATH")
-  endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-  if ! head_json=$(aws s3api head-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
-    --key "$object_key" \
-    --output json \
-    --cli-connect-timeout 5 \
-    --cli-read-timeout 30 2>"$error_log"); then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-head-failed" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-  if ! retained_size=$(jq -er '.ContentLength | select(type == "number" and floor == .)' \
-    <<<"$head_json" 2>/dev/null); then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-head-malformed" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-  if [ "$retained_size" != "$object_size" ] ||
-    [ "$retained_size" -le 0 ] || [ "$retained_size" -gt "$RUNNER_BINARY_MAX_COMPRESSED_BYTES" ]; then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-size-mismatch" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-
-  local compressed decompressed get_status=0 decompress_status=0
+  local compressed decompressed
   compressed="${temp_root}/runner.zst"
   decompressed="${temp_root}/runner"
-  aws s3api get-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
-    --key "$object_key" \
-    --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
-    --cli-connect-timeout 5 \
-    --cli-read-timeout 30 \
-    "$compressed" \
-    >/dev/null 2>"$error_log" || get_status=$?
-  if [ "$get_status" -ne 0 ]; then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-get-failed" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-  if [ "$(stat -c '%s' "$compressed")" != "$object_size" ]; then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-size-changed" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-
-  set +e
-  set -o pipefail
-  zstd -q -d -c "$compressed" \
-    2>"${temp_root}/zstd.err" \
-    | head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" \
-      > "$decompressed"
-  decompress_status=$?
-  set -e
-  if [ "$decompress_status" -ne 0 ] ||
-    [ "$(stat -c '%s' "$decompressed")" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-decompression-invalid" "$TRUSTED_RUN_ID"
-    return 0
-  fi
-  if [ "$(stat -c '%s' "$decompressed")" != "$runner_size" ] ||
-    [ "$(sha256sum "$decompressed" | awk '{print $1}')" != "$runner_sha" ]; then
-    resolve_result "miss" "$TRUSTED_SOURCE" "r2-content-mismatch" "$TRUSTED_RUN_ID"
+  if ! fetch_verified_r2_runner \
+    "$object_key" "$object_size" "$runner_size" "$runner_sha" \
+    "$compressed" "$decompressed"; then
+    resolve_result "miss" "$TRUSTED_SOURCE" \
+      "r2-${R2_VERIFICATION_REASON}" "$TRUSTED_RUN_ID"
     return 0
   fi
 

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -15,7 +15,7 @@ if JOB_REF=pr-123 \
   HEAD_SHA=abc \
   METAL_HOSTS=dev-1 \
   METAL_USER=ci \
-  TARGET_TRIPLE= \
+  TARGET_TRIPLE='' \
   "$PREPARE" >"${TMPDIR}/empty.out" 2>"${TMPDIR}/empty.err"; then
   fail "expected empty target to fail"
 fi
@@ -102,7 +102,7 @@ if JOB_REF=pr-123 \
   METAL_HOSTS=dev-1 \
   METAL_USER=ci \
   TARGET_TRIPLE=aarch64-unknown-linux-musl \
-  EXPECTED_REMOTE_ARCH= \
+  EXPECTED_REMOTE_ARCH='' \
   "$PREPARE" >"${TMPDIR}/arch-empty.out" 2>"${TMPDIR}/arch-empty.err"; then
   fail "expected empty expected remote arch to fail"
 fi
@@ -118,5 +118,106 @@ if JOB_REF=pr-123 \
   fail "expected expected remote arch mismatch to fail"
 fi
 grep -q "EXPECTED_REMOTE_ARCH mismatch: aarch64-unknown-linux-musl maps to aarch64, got x86_64" "${TMPDIR}/arch-mismatch.err" || fail "expected expected remote arch mismatch message"
+
+if grep -q 'runner-binary-build/build.sh' "$PREPARE"; then
+  fail "host preparation must not invoke the runner binary build"
+fi
+
+if JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE=aarch64-unknown-linux-musl \
+  EXPECTED_REMOTE_ARCH=aarch64 \
+  "$PREPARE" >"${TMPDIR}/missing-runner.out" 2>"${TMPDIR}/missing-runner.err"; then
+  fail "expected a missing supplied runner to fail"
+fi
+grep -q "missing required env: RUNNER_PATH" "${TMPDIR}/missing-runner.err" || fail "expected missing runner path message"
+
+. "${SCRIPT_DIR}/runner-guest-binaries.sh"
+. "${SCRIPT_DIR}/runner-binary-build/contract.env"
+runner_guest_binaries_load
+runner="${TMPDIR}/runner"
+printf 'prepared runner fixture\n' > "$runner"
+runner_sha=$(sha256sum "$runner" | awk '{print $1}')
+runner_size=$(stat -c '%s' "$runner")
+input_digest=$(printf 'a%.0s' {1..64})
+guest_json='{}'
+for guest in "${RUNNER_GUEST_BINARIES[@]}"; do
+  guest_sha=$(printf '%s' "$guest" | sha256sum | awk '{print $1}')
+  guest_json=$(jq -c --arg guest "$guest" --arg sha "$guest_sha" '. + {($guest): $sha}' <<<"$guest_json")
+done
+metadata="${TMPDIR}/metadata.json"
+jq -n \
+  --arg digest "$input_digest" \
+  --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
+  --arg sha "$runner_sha" \
+  --argjson size "$runner_size" \
+  --argjson guests "$guest_json" '
+    {
+      schemaVersion: 1,
+      binaryInputDigest: $digest,
+      target: "aarch64-unknown-linux-musl",
+      toolchainImage: $toolchain,
+      runnerSha256: $sha,
+      runnerSizeBytes: $size,
+      guestSha256: $guests
+    }
+  ' > "$metadata"
+
+printf 'wrong bytes\n' > "${TMPDIR}/wrong-runner"
+if JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE=aarch64-unknown-linux-musl \
+  EXPECTED_REMOTE_ARCH=aarch64 \
+  RUNNER_PATH="${TMPDIR}/wrong-runner" \
+  FRESH_METADATA_PATH="$metadata" \
+  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+  "$PREPARE" >"${TMPDIR}/wrong-bytes.out" 2>"${TMPDIR}/wrong-bytes.err"; then
+  fail "expected mismatched supplied runner bytes to fail"
+fi
+grep -q "fresh runner size mismatch" "${TMPDIR}/wrong-bytes.err" || fail "expected supplied runner validation message"
+
+ln -s "$metadata" "${TMPDIR}/metadata-link.json"
+if JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE=aarch64-unknown-linux-musl \
+  EXPECTED_REMOTE_ARCH=aarch64 \
+  RUNNER_PATH="$runner" \
+  FRESH_METADATA_PATH="${TMPDIR}/metadata-link.json" \
+  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+  "$PREPARE" >"${TMPDIR}/metadata-link.out" 2>"${TMPDIR}/metadata-link.err"; then
+  fail "expected symlinked supplied metadata to fail"
+fi
+grep -q "fresh runner metadata is not a regular file" "${TMPDIR}/metadata-link.err" || fail "expected metadata symlink validation message"
+
+mkdir -p "${TMPDIR}/bin"
+cat > "${TMPDIR}/bin/ssh" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$SSH_LOG"
+exit 42
+BASH
+chmod +x "${TMPDIR}/bin/ssh"
+: > "${TMPDIR}/ssh.log"
+if PATH="${TMPDIR}/bin:${PATH}" \
+  SSH_LOG="${TMPDIR}/ssh.log" \
+  JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE=aarch64-unknown-linux-musl \
+  EXPECTED_REMOTE_ARCH=aarch64 \
+  RUNNER_PATH="$runner" \
+  FRESH_METADATA_PATH="$metadata" \
+  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+  "$PREPARE" >"${TMPDIR}/valid-input.out" 2>"${TMPDIR}/valid-input.err"; then
+  fail "expected mocked SSH boundary to fail"
+fi
+grep -q 'ci@dev-1 uname -m' "${TMPDIR}/ssh.log" || fail "valid supplied runner must reach the SSH boundary"
 
 echo "prepare-runner-image-test: ok"

--- a/.github/scripts/tests/runner-binary-build-test.sh
+++ b/.github/scripts/tests/runner-binary-build-test.sh
@@ -135,8 +135,8 @@ if TARGET_TRIPLE=powerpc-unknown-linux-musl \
 fi
 
 workflow_toolchain=$(awk '
-  /^  build:$/ { in_build = 1; next }
-  in_build && /^      image: / { sub(/^      image: /, ""); print; exit }
+  /^  compile:$/ { in_compile = 1; next }
+  in_compile && /^      image: / { sub(/^      image: /, ""); print; exit }
 ' "${REPO_ROOT}/.github/workflows/runner-image.yml")
 . "${REPO_ROOT}/.github/scripts/runner-binary-build/contract.env"
 [ "$workflow_toolchain" = "$RUNNER_BINARY_TOOLCHAIN_IMAGE" ] \

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PLAN="${SCRIPT_DIR}/runner-binary-cache-plan.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local output=$1 expected=$2
+  grep -qF "$expected" <<<"$output" || fail "expected '${expected}' in: ${output}"
+}
+
+command -v zstd >/dev/null || fail "zstd is required"
+
+arm_target=aarch64-unknown-linux-musl
+x86_target=x86_64-unknown-linux-musl
+arm_digest=$("${SCRIPT_DIR}/runner-binary-build/digest.sh" "$arm_target" | sed -n 's/^binary-input-digest=//p')
+x86_digest=$("${SCRIPT_DIR}/runner-binary-build/digest.sh" "$x86_target" | sed -n 's/^binary-input-digest=//p')
+arm_artifact="runner-binary-asset-${arm_target}-${arm_digest}"
+x86_artifact="runner-binary-asset-${x86_target}-${x86_digest}"
+matrix=$(jq -cn \
+  --arg arm_target "$arm_target" \
+  --arg x86_target "$x86_target" '[
+    {
+      id: "arm64", label: "arm64", target: $arm_target, unameM: "aarch64",
+      cacheSuffix: "arm64", assetSuffix: "arm64"
+    },
+    {
+      id: "x86_64", label: "x86_64", target: $x86_target, unameM: "x86_64",
+      cacheSuffix: "x86_64", assetSuffix: "x86_64"
+    }
+  ]')
+
+. "${SCRIPT_DIR}/runner-guest-binaries.sh"
+. "${REPO_ROOT}/.github/scripts/runner-binary-build/contract.env"
+runner_guest_binaries_load
+guest_json='{}'
+for guest in "${RUNNER_GUEST_BINARIES[@]}"; do
+  guest_sha=$(printf '%s' "$guest" | sha256sum | awk '{print $1}')
+  guest_json=$(jq -c --arg guest "$guest" --arg sha "$guest_sha" '. + {($guest): $sha}' <<<"$guest_json")
+done
+
+mkdir -p "${TMPDIR}/bin" "${TMPDIR}/fixtures" "${TMPDIR}/objects" "${TMPDIR}/runner-temp"
+runner="${TMPDIR}/runner"
+printf 'runner binary cache plan fixture\n' > "$runner"
+runner_sha=$(sha256sum "$runner" | awk '{print $1}')
+runner_size=$(stat -c '%s' "$runner")
+main_head=$(printf 'b%.0s' {1..40})
+
+create_fixture() {
+  local target=$1 digest=$2 name=$3
+  local object="${TMPDIR}/objects/${target}.zst"
+  zstd -q -3 -f -o "$object" "$runner"
+  object_size=$(stat -c '%s' "$object")
+  jq -n \
+    --arg digest "$digest" \
+    --arg target "$target" \
+    --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
+    --arg runner_sha "$runner_sha" \
+    --argjson runner_size "$runner_size" \
+    --argjson guests "$guest_json" \
+    --arg object_key "runner-binaries/${target}/${runner_sha}.zst" \
+    --argjson object_size "$object_size" \
+    --arg head "$main_head" '
+      {
+        schemaVersion: 1,
+        binaryInputDigest: $digest,
+        target: $target,
+        toolchainImage: $toolchain,
+        runner: {sha256: $runner_sha, sizeBytes: $runner_size},
+        guests: $guests,
+        object: {key: $object_key, compression: "zstd", sizeBytes: $object_size},
+        producer: {
+          repository: "vm0-ai/vm0",
+          workflowPath: ".github/workflows/runner-image.yml",
+          runId: 20,
+          runAttempt: 1,
+          event: "push",
+          headSha: $head,
+          prNumber: null
+        },
+        createdAt: "2026-07-22T00:00:00Z"
+      }
+    ' > "${TMPDIR}/fixtures/${name}.json"
+}
+
+create_fixture "$arm_target" "$arm_digest" "$arm_artifact"
+create_fixture "$x86_target" "$x86_digest" "$x86_artifact"
+
+cat > "${TMPDIR}/fixtures/run-20.json" <<JSON
+{"id":20,"run_attempt":1,"event":"push","status":"completed","conclusion":"success","head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
+JSON
+
+cat > "${TMPDIR}/bin/gh" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ "$1" = "api" ]; then
+  endpoint="${*: -1}"
+  if [[ "$endpoint" == *'/actions/artifacts?'* ]]; then
+    name=${endpoint#*name=}
+    name=${name%%&*}
+    if [ "${GH_SCENARIO:-all-hit}" = "all-miss" ] ||
+      { [ "${GH_SCENARIO:-all-hit}" = "mixed" ] && [ "$name" = "$X86_ARTIFACT" ]; }; then
+      printf '[{"artifacts":[]}]\n'
+    else
+      printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-22T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
+        "$name" "$MAIN_HEAD"
+    fi
+    exit 0
+  fi
+  cp "${FIXTURES}/run-20.json" /dev/stdout
+  exit 0
+fi
+if [ "$1" = "run" ] && [ "$2" = "download" ]; then
+  artifact_name=""
+  output_dir=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -n) artifact_name=$2; shift 2 ;;
+      -D) output_dir=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  mkdir -p "$output_dir"
+  cp "${FIXTURES}/${artifact_name}.json" "${output_dir}/manifest.json"
+  exit 0
+fi
+exit 2
+BASH
+chmod +x "${TMPDIR}/bin/gh"
+
+cat > "${TMPDIR}/bin/aws" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "s3api" ] || exit 2
+operation=$2
+shift 2
+key=""
+destination=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --key) key=$2; shift 2 ;;
+    --endpoint-url|--bucket|--output|--range|--cli-connect-timeout|--cli-read-timeout) shift 2 ;;
+    --*) shift ;;
+    *) destination=$1; shift ;;
+  esac
+done
+target=${key#runner-binaries/}
+target=${target%%/*}
+object="${OBJECTS}/${target}.zst"
+case "$operation" in
+  head-object) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
+  get-object) cp "$object" "$destination"; printf '{}\n' ;;
+  *) exit 2 ;;
+esac
+BASH
+chmod +x "${TMPDIR}/bin/aws"
+
+run_plan() {
+  local scenario=$1 output_dir=$2 event=${3:-pull_request}
+  local pr_number=123 pr_head_ref=feature
+  if [ "$event" = "push" ]; then
+    pr_number=""
+    pr_head_ref=""
+  fi
+  PATH="${TMPDIR}/bin:${PATH}" \
+  GH_LOG="${TMPDIR}/gh.log" \
+  GH_SCENARIO="$scenario" \
+  FIXTURES="${TMPDIR}/fixtures" \
+  OBJECTS="${TMPDIR}/objects" \
+  ARM_ARTIFACT="$arm_artifact" \
+  X86_ARTIFACT="$x86_artifact" \
+  MAIN_HEAD="$main_head" \
+  AWS_ACCESS_KEY_ID=test-access \
+  AWS_SECRET_ACCESS_KEY=test-secret \
+  R2_ACCOUNT_ID=test-account \
+  R2_BUCKET_NAME=test-bucket \
+  RUNNER_TEMP="${TMPDIR}/runner-temp" \
+  REPO=vm0-ai/vm0 \
+  CURRENT_RUN_ID=99 \
+  CURRENT_EVENT="$event" \
+  CURRENT_PR_NUMBER="$pr_number" \
+  CURRENT_PR_HEAD_REF="$pr_head_ref" \
+  DEFAULT_BRANCH=main \
+  RUNNER_HOST_GROUPS_MATRIX="$matrix" \
+  RESOLVE_OUTPUT_DIR="$output_dir" \
+    "$PLAN"
+}
+
+: > "${TMPDIR}/gh.log"
+all_hit=$(run_plan all-hit "${TMPDIR}/all-hit")
+assert_contains "$all_hit" 'compile-matrix=[]'
+assert_contains "$all_hit" 'hit-count=2'
+assert_contains "$all_hit" 'miss-count=0'
+cmp -s "$runner" "${TMPDIR}/all-hit/${arm_target}/runner" || fail "arm hit bytes were not staged"
+cmp -s "$runner" "${TMPDIR}/all-hit/${x86_target}/runner" || fail "x86 hit bytes were not staged"
+
+mixed=$(run_plan mixed "${TMPDIR}/mixed")
+assert_contains "$mixed" 'hit-count=1'
+assert_contains "$mixed" 'miss-count=1'
+mixed_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$mixed")
+[ "$(jq -r '.[0].target' <<<"$mixed_matrix")" = "$x86_target" ] || fail "mixed plan must compile x86 only"
+[ -f "${TMPDIR}/mixed/${arm_target}/runner" ] || fail "mixed plan must stage the arm hit"
+[ ! -e "${TMPDIR}/mixed/${x86_target}" ] || fail "mixed plan must not stage a missed target"
+
+: > "${TMPDIR}/gh.log"
+forced=$(RUNNER_BINARY_CACHE_FORCE_MISS=true run_plan all-hit "${TMPDIR}/forced")
+assert_contains "$forced" 'hit-count=0'
+assert_contains "$forced" 'miss-count=2'
+assert_contains "$forced" '"reason":"force-miss"'
+[ ! -s "${TMPDIR}/gh.log" ] || fail "force-miss plan must not query GitHub"
+
+: > "${TMPDIR}/gh.log"
+main=$(run_plan all-hit "${TMPDIR}/main" push)
+assert_contains "$main" 'hit-count=0'
+assert_contains "$main" 'miss-count=2'
+assert_contains "$main" '"reason":"protected-main-full-build"'
+[ ! -s "${TMPDIR}/gh.log" ] || fail "protected-main plan must not query GitHub"
+
+mkdir -p "${TMPDIR}/timeout-bin"
+cat > "${TMPDIR}/timeout-bin/timeout" <<'BASH'
+#!/usr/bin/env bash
+exit 124
+BASH
+chmod +x "${TMPDIR}/timeout-bin/timeout"
+timed_out=$(PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
+  GH_LOG="${TMPDIR}/gh.log" \
+  RUNNER_HOST_GROUPS_MATRIX="$matrix" \
+  RESOLVE_OUTPUT_DIR="${TMPDIR}/timed-out" \
+  REPO=vm0-ai/vm0 \
+  CURRENT_RUN_ID=99 \
+  CURRENT_EVENT=pull_request \
+  CURRENT_PR_NUMBER=123 \
+  CURRENT_PR_HEAD_REF=feature \
+  DEFAULT_BRANCH=main \
+  "$PLAN")
+assert_contains "$timed_out" 'hit-count=0'
+assert_contains "$timed_out" 'miss-count=2'
+assert_contains "$timed_out" '"reason":"resolve-timeout"'
+
+echo "runner-binary-cache-plan-test: ok"

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -211,6 +211,12 @@ mixed_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$mixed")
 [ -f "${TMPDIR}/mixed/${arm_target}/runner" ] || fail "mixed plan must stage the arm hit"
 [ ! -e "${TMPDIR}/mixed/${x86_target}" ] || fail "mixed plan must not stage a missed target"
 
+all_miss=$(run_plan all-miss "${TMPDIR}/all-miss")
+assert_contains "$all_miss" 'hit-count=0'
+assert_contains "$all_miss" 'miss-count=2'
+all_miss_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$all_miss")
+[ "$(jq 'length' <<<"$all_miss_matrix")" -eq 2 ] || fail "all-miss plan must compile both targets"
+
 : > "${TMPDIR}/gh.log"
 forced=$(RUNNER_BINARY_CACHE_FORCE_MISS=true run_plan all-hit "${TMPDIR}/forced")
 assert_contains "$forced" 'hit-count=0'
@@ -228,7 +234,7 @@ assert_contains "$main" '"reason":"protected-main-full-build"'
 mkdir -p "${TMPDIR}/timeout-bin"
 cat > "${TMPDIR}/timeout-bin/timeout" <<'BASH'
 #!/usr/bin/env bash
-exit 124
+exit "${TIMEOUT_STATUS:-124}"
 BASH
 chmod +x "${TMPDIR}/timeout-bin/timeout"
 timed_out=$(PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
@@ -245,5 +251,21 @@ timed_out=$(PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
 assert_contains "$timed_out" 'hit-count=0'
 assert_contains "$timed_out" 'miss-count=2'
 assert_contains "$timed_out" '"reason":"resolve-timeout"'
+
+killed=$(TIMEOUT_STATUS=137 \
+  PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
+  GH_LOG="${TMPDIR}/gh.log" \
+  RUNNER_HOST_GROUPS_MATRIX="$matrix" \
+  RESOLVE_OUTPUT_DIR="${TMPDIR}/killed" \
+  REPO=vm0-ai/vm0 \
+  CURRENT_RUN_ID=99 \
+  CURRENT_EVENT=pull_request \
+  CURRENT_PR_NUMBER=123 \
+  CURRENT_PR_HEAD_REF=feature \
+  DEFAULT_BRANCH=main \
+  "$PLAN")
+assert_contains "$killed" 'hit-count=0'
+assert_contains "$killed" 'miss-count=2'
+assert_contains "$killed" '"reason":"resolve-timeout"'
 
 echo "runner-binary-cache-plan-test: ok"

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -110,7 +110,7 @@ destination=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --body) body=$2; shift 2 ;;
-    --endpoint-url|--bucket|--key|--content-type|--cache-control|--if-none-match|--output|--range)
+    --endpoint-url|--bucket|--key|--content-type|--cache-control|--if-none-match|--output|--range|--cli-connect-timeout|--cli-read-timeout)
       shift 2
       ;;
     --*) shift ;;
@@ -134,8 +134,10 @@ case "$operation" in
   head-object)
     [ -f "$object" ] || exit 1
     case "${AWS_MODE:-success}" in
+      head-fail) exit 6 ;;
       malformed-head) printf 'not-json\n' ;;
       oversized-head) printf '{"ContentLength":67108865}\n' ;;
+      size-mismatch) printf '{"ContentLength":1}\n' ;;
       *) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
     esac
     ;;
@@ -344,6 +346,10 @@ jq --arg sha "$conflict_sha" '
   .runner.sha256 = $sha |
   .object.key = ("runner-binaries/" + .target + "/" + $sha + ".zst")
 ' "$main_manifest" > "${TMPDIR}/conflict-manifest.json"
+jq --arg sha "$conflict_sha" '
+  .runner.sha256 = $sha |
+  .object.key = ("runner-binaries/" + .target + "/" + $sha + ".zst")
+' "$main_manifest" > "${TMPDIR}/content-mismatch-manifest.json"
 guest_conflict_sha=$(printf 'f%.0s' {1..64})
 jq --arg guest "$first_guest" --arg sha "$guest_conflict_sha" \
   '.guests[$guest] = $sha' \
@@ -376,6 +382,15 @@ if [ "$1" = "api" ]; then
         ;;
       empty)
         printf '[{"artifacts":[]}]\n'
+        ;;
+      expired)
+        printf '[{"artifacts":[{"id":120,"name":"%s","expired":true,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        ;;
+      oversized-artifact)
+        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1048577,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        ;;
+      content-mismatch)
+        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
       many-invalid)
         printf '[{"artifacts":['
@@ -413,6 +428,8 @@ if [ "$1" = "run" ] && [ "$2" = "download" ]; then
   mkdir -p "$output_dir"
   if [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "untrusted" ]; then
     cp "${GH_FIXTURES}/untrusted-manifest.json" "${output_dir}/manifest.json"
+  elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "content-mismatch" ]; then
+    cp "${GH_FIXTURES}/content-mismatch-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "conflict" ]; then
     cp "${GH_FIXTURES}/conflict-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "guest-conflict" ]; then
@@ -568,9 +585,33 @@ api_miss=$(run_active pull_request api-fail "${TMPDIR}/active-api-fail")
 assert_contains "$api_miss" "resolve-outcome=miss"
 assert_contains "$api_miss" "resolve-reason=artifact-api-unavailable"
 
+expired_miss=$(run_active pull_request expired "${TMPDIR}/active-expired")
+assert_contains "$expired_miss" "resolve-reason=no-trusted-candidate"
+
+oversized_artifact_miss=$(run_active pull_request oversized-artifact "${TMPDIR}/active-oversized-artifact")
+assert_contains "$oversized_artifact_miss" "resolve-reason=no-trusted-candidate"
+
 conflict_miss=$(run_active pull_request conflict "${TMPDIR}/active-conflict")
 assert_contains "$conflict_miss" "resolve-outcome=miss"
 assert_contains "$conflict_miss" "resolve-reason=trusted-output-conflict"
+
+head_failure_miss=$(run_active pull_request rank "${TMPDIR}/active-head-failure" head-fail)
+assert_contains "$head_failure_miss" "resolve-reason=r2-head-failed"
+
+malformed_head_miss=$(run_active pull_request rank "${TMPDIR}/active-malformed-head" malformed-head)
+assert_contains "$malformed_head_miss" "resolve-reason=r2-head-malformed"
+
+oversized_head_miss=$(run_active pull_request rank "${TMPDIR}/active-oversized-head" oversized-head)
+assert_contains "$oversized_head_miss" "resolve-reason=r2-size-mismatch"
+
+size_mismatch_miss=$(run_active pull_request rank "${TMPDIR}/active-size-mismatch" size-mismatch)
+assert_contains "$size_mismatch_miss" "resolve-reason=r2-size-mismatch"
+
+get_failure_miss=$(run_active pull_request rank "${TMPDIR}/active-get-failure" get-fail)
+assert_contains "$get_failure_miss" "resolve-reason=r2-get-failed"
+
+content_mismatch_miss=$(run_active pull_request content-mismatch "${TMPDIR}/active-content-mismatch")
+assert_contains "$content_mismatch_miss" "resolve-reason=r2-content-mismatch"
 
 compressed_size=$(stat -c '%s' "${TMPDIR}/store/object.zst")
 dd if=/dev/zero of="${TMPDIR}/store/object.zst" bs="$compressed_size" count=1 status=none

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -185,6 +185,14 @@ assert_contains "$publish_out" "publish-reason=uploaded"
 [ -f "${TMPDIR}/published/manifest.json" ] || fail "expected reusable manifest"
 zstd -q -d -c "${TMPDIR}/store/object.zst" > "${TMPDIR}/stored-runner"
 cmp -s "$runner" "${TMPDIR}/stored-runner" || fail "R2 object must contain the fresh runner"
+if ! grep -F 's3api head-object' "${TMPDIR}/aws.log" |
+  grep -qF -- '--cli-connect-timeout 5 --cli-read-timeout 30'; then
+  fail "R2 HEAD validation must use bounded AWS timeouts"
+fi
+if ! grep -F 's3api get-object' "${TMPDIR}/aws.log" |
+  grep -qF -- '--cli-connect-timeout 5 --cli-read-timeout 30'; then
+  fail "R2 GET validation must use bounded AWS timeouts"
+fi
 
 MANIFEST_PATH="${TMPDIR}/published/manifest.json" \
 EXPECTED_TARGET="$target" \
@@ -289,6 +297,14 @@ corrupt_out=$(run_publish "${TMPDIR}/corrupt")
 assert_contains "$corrupt_out" "published=false"
 assert_contains "$corrupt_out" "publish-reason=decompression-invalid"
 [ ! -e "${TMPDIR}/corrupt/manifest.json" ] || fail "corrupt R2 bytes must not be advertised"
+
+printf 'different runner binary fixture\n' > "${TMPDIR}/different-runner"
+zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "${TMPDIR}/different-runner"
+content_mismatch_out=$(run_publish "${TMPDIR}/publish-content-mismatch")
+assert_contains "$content_mismatch_out" "published=false"
+assert_contains "$content_mismatch_out" "publish-reason=retained-content-mismatch"
+[ ! -e "${TMPDIR}/publish-content-mismatch/manifest.json" ] ||
+  fail "mismatched R2 bytes must not be advertised"
 
 rm -f "${TMPDIR}/store/object.zst"
 put_failure=$(run_publish "${TMPDIR}/put-failure" put-fail 2>&1)

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -369,16 +369,26 @@ if [ "$1" = "api" ]; then
     [ "${GH_SCENARIO:-rank}" != "api-fail" ] || exit 8
     case "${GH_SCENARIO:-rank}" in
       failed)
-        printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
       untrusted)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
+        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
       empty)
         printf '[{"artifacts":[]}]\n'
         ;;
+      many-invalid)
+        printf '[{"artifacts":['
+        separator=""
+        for run_id in $(seq 30 38); do
+          printf '%s{"id":%s,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T%02d:00:00Z","workflow_run":{"id":%s,"head_branch":"main","head_sha":"%s"}}' \
+            "$separator" "$((run_id + 100))" "$EXPECTED_ARTIFACT_NAME" "$((run_id - 30))" "$run_id" "$MAIN_HEAD"
+          separator=,
+        done
+        printf ']}]\n'
+        ;;
       *)
-        printf '[{"artifacts":[{"id":199,"name":"%s","expired":false,"created_at":"2026-07-21T03:00:00Z","workflow_run":{"id":99,"head_branch":"feature","head_sha":"%s"}},{"id":130,"name":"%s","expired":false,"created_at":"2026-07-21T02:30:00Z","workflow_run":{"id":30,"head_branch":"other","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]},{"artifacts":[{"id":120,"name":"%s","expired":false,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
+        printf '[{"artifacts":[{"id":199,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T03:00:00Z","workflow_run":{"id":99,"head_branch":"feature","head_sha":"%s"}},{"id":130,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:30:00Z","workflow_run":{"id":30,"head_branch":"other","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]},{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
@@ -494,5 +504,86 @@ if run_shadow pull_request guest-conflict "${TMPDIR}/shadow-guest-conflict" \
 fi
 grep -q 'equal runner binary input digest produced conflicting output identity' \
   "${TMPDIR}/guest-conflict.err" || fail "expected guest conflict diagnostic"
+
+run_active() {
+  local current_event=$1 scenario=$2 output_dir=$3 aws_mode=${4:-success}
+  local current_pr_number=123 current_pr_head_ref=feature
+  if [ "$current_event" = "push" ]; then
+    current_pr_number=""
+    current_pr_head_ref=""
+  fi
+  PATH="${TMPDIR}/bin:${PATH}" \
+  GH_LOG="${TMPDIR}/gh.log" \
+  GH_SCENARIO="$scenario" \
+  GH_FIXTURES="$TMPDIR" \
+  EXPECTED_ARTIFACT_NAME="$expected_artifact" \
+  MAIN_HEAD="$main_head" \
+  PR_HEAD="$pr_head" \
+  AWS_LOG="${TMPDIR}/aws.log" \
+  AWS_MODE="$aws_mode" \
+  AWS_STORE="${TMPDIR}/store" \
+  AWS_ACCESS_KEY_ID=test-access \
+  AWS_SECRET_ACCESS_KEY=test-secret \
+  R2_ACCOUNT_ID=test-account \
+  R2_BUCKET_NAME=test-bucket \
+  RUNNER_TEMP="${TMPDIR}/runner-temp" \
+  EXPECTED_TARGET="$target" \
+  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+  RESOLVE_OUTPUT_DIR="$output_dir" \
+  REPO=vm0-ai/vm0 \
+  CURRENT_RUN_ID=99 \
+  CURRENT_EVENT="$current_event" \
+  CURRENT_PR_NUMBER="$current_pr_number" \
+  CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
+  DEFAULT_BRANCH=main \
+    "$CACHE" active-resolve
+}
+
+zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
+: > "${TMPDIR}/gh.log"
+active_hit=$(run_active pull_request rank "${TMPDIR}/active-hit")
+assert_contains "$active_hit" "resolve-outcome=hit"
+assert_contains "$active_hit" "resolve-source=protected-main"
+assert_contains "$active_hit" "resolve-producer-run-id=20"
+cmp -s "$runner" "${TMPDIR}/active-hit/runner" || fail "active hit must materialize verified runner bytes"
+FRESH_METADATA_PATH="${TMPDIR}/active-hit/metadata.json" \
+RUNNER_PATH="${TMPDIR}/active-hit/runner" \
+EXPECTED_TARGET="$target" \
+EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+  "$CACHE" fresh-validate >/dev/null
+
+: > "${TMPDIR}/gh.log"
+main_miss=$(run_active push rank "${TMPDIR}/active-main")
+assert_contains "$main_miss" "resolve-outcome=miss"
+assert_contains "$main_miss" "resolve-reason=protected-main-full-build"
+[ ! -s "${TMPDIR}/gh.log" ] || fail "protected main must bypass candidate lookup"
+
+: > "${TMPDIR}/gh.log"
+force_miss=$(RUNNER_BINARY_CACHE_FORCE_MISS=true \
+  run_active pull_request rank "${TMPDIR}/active-force")
+assert_contains "$force_miss" "resolve-reason=force-miss"
+[ ! -s "${TMPDIR}/gh.log" ] || fail "force miss must bypass candidate lookup"
+
+api_miss=$(run_active pull_request api-fail "${TMPDIR}/active-api-fail")
+assert_contains "$api_miss" "resolve-outcome=miss"
+assert_contains "$api_miss" "resolve-reason=artifact-api-unavailable"
+
+conflict_miss=$(run_active pull_request conflict "${TMPDIR}/active-conflict")
+assert_contains "$conflict_miss" "resolve-outcome=miss"
+assert_contains "$conflict_miss" "resolve-reason=trusted-output-conflict"
+
+compressed_size=$(stat -c '%s' "${TMPDIR}/store/object.zst")
+dd if=/dev/zero of="${TMPDIR}/store/object.zst" bs="$compressed_size" count=1 status=none
+corrupt_miss=$(run_active pull_request rank "${TMPDIR}/active-corrupt")
+assert_contains "$corrupt_miss" "resolve-outcome=miss"
+assert_contains "$corrupt_miss" "resolve-reason=r2-decompression-invalid"
+zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
+
+: > "${TMPDIR}/gh.log"
+bounded_miss=$(run_active pull_request many-invalid "${TMPDIR}/active-bounded")
+assert_contains "$bounded_miss" "resolve-outcome=miss"
+assert_contains "$bounded_miss" "resolve-reason=candidate-limit-exhausted"
+run_queries=$(grep -c 'actions/runs/' "${TMPDIR}/gh.log")
+[ "$run_queries" -eq 8 ] || fail "active resolution must inspect at most eight candidate runs"
 
 echo "runner-binary-cache-test: ok"

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/runner-image.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null || fail "yq is required"
+workflow_json=$(yq -o=json '.' "$WORKFLOW")
+
+jq -e '
+  .jobs.prepare["runs-on"] == "ubuntu-latest" and
+  (.jobs.prepare | has("container") | not) and
+  .jobs.prepare.permissions.actions == "read" and
+  .jobs.prepare.outputs["runner-binary-compile-matrix"] == "${{ steps.binary-plan.outputs.compile-matrix }}" and
+  any(.jobs.prepare.steps[];
+    .id == "binary-plan" and
+    .run == ".github/scripts/runner-binary-cache-plan.sh" and
+    .env.RUNNER_BINARY_CACHE_FORCE_MISS == "${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}"
+  ) and
+  any(.jobs.prepare.steps[];
+    .uses == "actions/upload-artifact@v7" and
+    .with.name == "runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}" and
+    .with["compression-level"] == 1 and
+    (. | has("continue-on-error") | not)
+  )
+' <<<"$workflow_json" >/dev/null || fail "prepare must own bounded pre-container hit planning and required transport upload"
+
+jq -e '
+  .jobs.compile["runs-on"] == "ubuntu-latest-8-cores" and
+  (.jobs.compile.container.image | startswith("ghcr.io/vm0-ai/vm0-toolchain-rust@sha256:")) and
+  (.jobs.compile.if | contains("runner-binary-miss-count != '\''0'\''")) and
+  .jobs.compile.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
+  any(.jobs.compile.steps[]; .uses == "mozilla-actions/sccache-action@v0.0.10") and
+  any(.jobs.compile.steps[]; .uses == "Swatinem/rust-cache@v2") and
+  any(.jobs.compile.steps[]; .run == ".github/scripts/runner-binary-build/build.sh build") and
+  any(.jobs.compile.steps[];
+    .uses == "actions/upload-artifact@v7" and
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}" and
+    (. | has("continue-on-error") | not)
+  )
+' <<<"$workflow_json" >/dev/null || fail "compile must be a required miss-only Rust/cache/build matrix"
+
+jq -e '
+  ([.jobs | to_entries[] |
+    select(any(.value.steps[]?; .uses == "mozilla-actions/sccache-action@v0.0.10")) |
+    .key] == ["compile"]) and
+  ([.jobs | to_entries[] |
+    select(any(.value.steps[]?; .uses == "Swatinem/rust-cache@v2")) |
+    .key] == ["compile"])
+' <<<"$workflow_json" >/dev/null || fail "compiler caches must exist only in the miss-only compile job"
+
+jq -e '
+  .jobs.build.name == "Build runner image (${{ matrix.label }})" and
+  .jobs.build["runs-on"] == "ubuntu-latest" and
+  (.jobs.build | has("container") | not) and
+  .jobs.build.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-host-groups-matrix) }}" and
+  (.jobs.build.if | contains("needs.compile.result == '\''skipped'\''")) and
+  (.jobs.build.if | contains("needs.compile.result == '\''success'\''")) and
+  any(.jobs.build.steps[];
+    .name == "Download validated runner binary hit" and
+    (.if | contains("runner-binary-hit-targets"))
+  ) and
+  any(.jobs.build.steps[];
+    .name == "Download compiled runner binary" and
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}"
+  ) and
+  any(.jobs.build.steps[];
+    .run == ".github/scripts/prepare-runner-image.sh" and
+    .env.RUNNER_PATH == "runner-binary-transport/${{ matrix.target }}/runner" and
+    .env.EXPECTED_BINARY_INPUT_DIGEST == "${{ steps.binary-input.outputs.binary-input-digest }}"
+  )
+' <<<"$workflow_json" >/dev/null || fail "build must preserve the all-target host readiness contract for hits and misses"
+
+jq -e '
+  (.jobs.asset.needs | sort) == ["compile", "prepare"] and
+  (.jobs.asset.if | contains("runner-binary-miss-count != '\''0'\''")) and
+  .jobs.asset.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
+  any(.jobs.asset.steps[];
+    .name == "Download compiled runner binary" and
+    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}"
+  )
+' <<<"$workflow_json" >/dev/null || fail "reusable publication must run only for compiled misses"
+
+prepare_consumers=$(jq -r '[.jobs | to_entries[] |
+  select(any(.value.steps[]?; .run == ".github/scripts/prepare-runner-image.sh")) |
+  .key] | join(",")' <<<"$workflow_json")
+[ "$prepare_consumers" = "build" ] || fail "host preparation must run only in the all-target build job"
+
+echo "runner-image-workflow-test: ok"

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -36,6 +36,13 @@ jq -e '
   (.jobs.compile.container.image | startswith("ghcr.io/vm0-ai/vm0-toolchain-rust@sha256:")) and
   (.jobs.compile.if | contains("runner-binary-miss-count != '\''0'\''")) and
   .jobs.compile.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
+  any(.jobs.compile.steps[];
+    .name == "Configure git safe directory" and
+    .shell == "bash" and
+    .run == "git config --global --add safe.directory \"$GITHUB_WORKSPACE\""
+  ) and
+  ((.jobs.compile.steps | map(.uses // .name) | index("Configure git safe directory")) <
+    (.jobs.compile.steps | map(.uses // .name) | index("Build runner binary"))) and
   any(.jobs.compile.steps[]; .uses == "mozilla-actions/sccache-action@v0.0.10") and
   any(.jobs.compile.steps[]; .uses == "Swatinem/rust-cache@v2") and
   any(.jobs.compile.steps[]; .run == ".github/scripts/runner-binary-build/build.sh build") and

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -280,6 +280,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Configure git safe directory
+        shell: bash
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: "v0.15.0"

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -35,6 +36,11 @@ jobs:
       image-selection-reason: ${{ steps.needed.outputs.image-selection-reason }}
       runner-host-groups-matrix: ${{ steps.host-groups.outputs.matrix }}
       runner-host-groups-configured: ${{ steps.host-group-presence.outputs.configured }}
+      runner-binary-compile-matrix: ${{ steps.binary-plan.outputs.compile-matrix }}
+      runner-binary-hit-targets: ${{ steps.binary-plan.outputs.hit-targets }}
+      runner-binary-hit-count: ${{ steps.binary-plan.outputs.hit-count }}
+      runner-binary-miss-count: ${{ steps.binary-plan.outputs.miss-count }}
+      runner-binary-resolution-json: ${{ steps.binary-plan.outputs.resolution-json }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -154,7 +160,7 @@ jobs:
           set -euo pipefail
 
           runner_image_ci_changed=false
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
             runner_image_ci_changed=true
           fi
 
@@ -219,23 +225,57 @@ jobs:
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
           echo "Configured runner host architecture groups: $(jq -r 'map(.id) | join(",") // ""' <<<"$matrix")"
 
-  build:
-    name: Build runner image (${{ matrix.label }})
+      - name: Plan runner binary reuse
+        id: binary-plan
+        if: steps.needed.outputs.current-runner-image-needed == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CURRENT_EVENT: ${{ github.event_name }}
+          CURRENT_PR_HEAD_REF: ${{ steps.identity.outputs.pr-head-ref }}
+          CURRENT_PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+          RESOLVE_OUTPUT_DIR: runner-binary-hits
+          RUNNER_BINARY_CACHE_FORCE_MISS: ${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}
+          RUNNER_HOST_GROUPS_MATRIX: ${{ steps.host-groups.outputs.matrix }}
+        run: .github/scripts/runner-binary-cache-plan.sh
+
+      - name: Upload validated runner binary hits
+        if: steps.binary-plan.outputs.hit-count != '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}
+          path: runner-binary-hits/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 1
+
+  compile:
+    name: Compile runner binary (${{ matrix.label }})
     runs-on: ubuntu-latest-8-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust@sha256:45b223a0b80494cc0d6517807c37d7a244799a19b476325a5d6dde82865e845c
     permissions:
       contents: read
     needs: [prepare]
-    if: needs.prepare.outputs.current-runner-image-needed == 'true'
+    if: >-
+      ${{
+        needs.prepare.outputs.current-runner-image-needed == 'true' &&
+        needs.prepare.outputs.runner-binary-miss-count != '0'
+      }}
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.runner-host-groups-matrix) }}
+        include: ${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}
     env:
       TARGET_TRIPLE: ${{ matrix.target }}
-      PROFILE: vm0/default
       RUNNER_BINARY_ACTUAL_TOOLCHAIN_IMAGE: ghcr.io/vm0-ai/vm0-toolchain-rust@sha256:45b223a0b80494cc0d6517807c37d7a244799a19b476325a5d6dde82865e845c
     steps:
       - uses: actions/checkout@v7
@@ -268,6 +308,89 @@ jobs:
           workspaces: crates -> target
           shared-key: ${{ matrix.cacheSuffix }}-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build runner binary
+        id: build
+        env:
+          RUNNER_BINARY_METADATA_PATH: runner-binary-fresh/metadata.json
+        run: .github/scripts/runner-binary-build/build.sh build
+
+      - name: Stage runner binary transport
+        env:
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.build.outputs.binary-input-digest }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
+          RUNNER_PATH: runner-binary-fresh/runner
+        run: |
+          install -m 755 \
+            "crates/target/${TARGET_TRIPLE}/ci/runner" \
+            "$RUNNER_PATH"
+          .github/scripts/runner-binary-cache.sh fresh-validate
+
+      - name: Upload compiled runner binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          path: runner-binary-fresh/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 1
+
+  build:
+    name: Build runner image (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    needs: [prepare, compile]
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.prepare.outputs.current-runner-image-needed == 'true' &&
+        (
+          (needs.prepare.outputs.runner-binary-miss-count == '0' && needs.compile.result == 'skipped') ||
+          (needs.prepare.outputs.runner-binary-miss-count != '0' && needs.compile.result == 'success')
+        )
+      }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.runner-host-groups-matrix) }}
+    env:
+      TARGET_TRIPLE: ${{ matrix.target }}
+      PROFILE: vm0/default
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve runner binary input
+        id: binary-input
+        env:
+          TARGET_TRIPLE: ${{ matrix.target }}
+        run: .github/scripts/runner-binary-build/digest.sh "$TARGET_TRIPLE"
+
+      - name: Download validated runner binary hit
+        if: contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target)
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: runner-binary-hits-${{ github.run_id }}-${{ github.run_attempt }}
+          path: runner-binary-transport
+
+      - name: Download compiled runner binary
+        if: ${{ !contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target) }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          path: runner-binary-transport/${{ matrix.target }}
+
+      - name: Validate runner binary transport
+        env:
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          FRESH_METADATA_PATH: runner-binary-transport/${{ matrix.target }}/metadata.json
+          RUNNER_PATH: runner-binary-transport/${{ matrix.target }}/runner
+        run: .github/scripts/runner-binary-cache.sh fresh-validate
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -305,8 +428,8 @@ jobs:
           env-label: dev
 
       - name: Build runner image on all metal hosts
-        id: build
         env:
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           HEAD_SHA: ${{ needs.prepare.outputs.head-sha }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
@@ -317,6 +440,8 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+          FRESH_METADATA_PATH: runner-binary-transport/${{ matrix.target }}/metadata.json
+          RUNNER_PATH: runner-binary-transport/${{ matrix.target }}/runner
         run: .github/scripts/prepare-runner-image.sh
 
       - name: Validate manifest
@@ -344,47 +469,26 @@ jobs:
           path: runner-image-manifest/manifest.json
           retention-days: 7
 
-      - name: Stage fresh runner binary
-        env:
-          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.build.outputs.binary-input-digest }}
-          EXPECTED_TARGET: ${{ matrix.target }}
-          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
-          RUNNER_PATH: runner-binary-fresh/runner
-        run: |
-          install -m 755 \
-            "crates/target/${TARGET_TRIPLE}/ci/runner" \
-            "$RUNNER_PATH"
-          .github/scripts/runner-binary-cache.sh fresh-validate
-
-      - name: Upload fresh runner binary
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: runner-binary-fresh-${{ github.run_id }}-${{ matrix.target }}
-          path: runner-binary-fresh/
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
-
   asset:
     name: Publish runner binary asset (${{ matrix.label }})
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
-    needs: [prepare, build]
+    needs: [prepare, compile]
     if: >-
       ${{
         always() &&
         needs.prepare.result == 'success' &&
         needs.prepare.outputs.current-runner-image-needed == 'true' &&
-        needs.build.result == 'success'
+        needs.prepare.outputs.runner-binary-miss-count != '0' &&
+        needs.compile.result == 'success'
       }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.runner-host-groups-matrix) }}
+        include: ${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -394,29 +498,14 @@ jobs:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: .github/scripts/runner-binary-build/digest.sh "$TARGET_TRIPLE"
 
-      - name: Download fresh runner binary
-        id: fresh-download
-        continue-on-error: true
+      - name: Download compiled runner binary
         uses: actions/download-artifact@v8.0.1
         with:
-          name: runner-binary-fresh-${{ github.run_id }}-${{ matrix.target }}
+          name: runner-binary-compiled-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
           path: runner-binary-fresh
-
-      - name: Report unavailable fresh runner binary
-        if: steps.fresh-download.outcome != 'success'
-        env:
-          TARGET_TRIPLE: ${{ matrix.target }}
-        run: |
-          {
-            echo "### Runner binary cache"
-            echo
-            echo "Fresh transport unavailable for \`${TARGET_TRIPLE}\`; cache publication was skipped."
-          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate fresh runner binary
         id: fresh
-        if: steps.fresh-download.outcome == 'success'
-        continue-on-error: true
         env:
           EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
           EXPECTED_TARGET: ${{ matrix.target }}
@@ -491,7 +580,7 @@ jobs:
           retention-days: 3
 
       - name: Summarize runner binary asset
-        if: always() && steps.fresh-download.outcome == 'success'
+        if: always()
         env:
           BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
           FRESH_VALIDATION: ${{ steps.fresh.outcome }}


### PR DESCRIPTION
## Summary

- resolve trusted runner-binary candidates on ordinary Ubuntu before the Rust-container matrix
- compile only cache misses, so validated hits omit the toolchain container, sccache, `Swatinem/rust-cache`, Cargo, and fresh compile upload
- keep one all-target `Build runner image (<label>)` host-readiness path with the existing jobRef runner, host-local GC, setup, snapshot, and schema-v1 manifest contracts
- bound each target lookup to eight potential producers, two valid output identities, and 60 seconds; cache/API/R2 failures fall back to compilation
- force protected-main current-image runs through the full build while allowing exact PR and merge-group reuse

## Implementation

The prepare job now emits a miss-only compile matrix and relays fully verified R2 hits through a short-lived compressed Actions artifact. Miss builds emit the same local `runner` plus strict metadata shape. Host preparation validates that selected transport before SSH and no longer invokes Cargo itself.

Reusable publication remains miss-only and non-authoritative for current-run correctness. Post-build shadow comparison still hard-fails deterministic output conflicts.

## Compatibility and exclusions

- unchanged Turbo and Crates current-manifest artifact names and schema v1
- unchanged `/var/lib/vm0-runner/bin/<jobRef>/runner` and required host check names
- no shared runner cache or direct R2 download on metal
- no narrowing of the conservative full-`crates/` digest
- no removal of host-local `runner gc --keep-latest 6`

## Validation

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `shellcheck --severity=warning` on all changed shell scripts and tests
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint .github/workflows/runner-image.yml`
- every `.github/scripts/tests/*.sh` integration test, sequentially
- pre-commit file-size and generated-firewall checks
- commitlint

Closes #22438

Parent context: #22340
