### PR TITLE
fix: log fable usage limits at info

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -297,17 +297,19 @@ fn classify_cli_failure_reason(
     }
     // Subscription/usage limits are an expected quota state for both Codex
     // (ChatGPT plan "usage limit" or API billing "quota exceeded") and Claude
-    // Code (Max plan "session limit" / "weekly limit" / org monthly spend
-    // limit), so classify them regardless of framework where the wording is
-    // shared. This lets the runner log these expected outcomes at info instead
-    // of error.
+    // Code (Max plan "session limit" / "weekly limit" / Fable model limit /
+    // org monthly spend limit), so classify them regardless of framework where
+    // the wording is shared. This lets the runner log these expected outcomes
+    // at info instead of error.
     if normalized.contains("usage limit")
         || (matches!(framework, AgentFramework::Codex)
             && normalized.contains("quota exceeded. check your plan and billing details"))
         || normalized.contains("session limit")
         || normalized.contains("weekly limit")
         || (matches!(framework, AgentFramework::ClaudeCode)
-            && (is_claude_subscription_access_disabled_error(&normalized)
+            && (normalized.contains("fable 5 requires usage credits")
+                || normalized.contains("reached your fable 5 limit")
+                || is_claude_subscription_access_disabled_error(&normalized)
                 || is_claude_monthly_spend_limit_error(&normalized)))
     {
         return Some(FailureReason::UsageLimit);

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1092,6 +1092,22 @@ fn cli_failure_reason_classifies_claude_usage_limit() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_claude_fable_limits() {
+    for message in [
+        "Fable 5 requires usage credits. /model to switch models.",
+        "You've reached your Fable 5 limit. /model to switch models.",
+    ] {
+        let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
+
+        assert_eq!(
+            reason,
+            Some(FailureReason::UsageLimit),
+            "message: {message}"
+        );
+    }
+}
+
+#[test]
 fn cli_failure_reason_classifies_claude_subscription_access_disabled_as_usage_limit() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,


### PR DESCRIPTION
## Summary

- classify the canonical Claude Fable 5 usage-credit and model-limit diagnostics as the existing `usage_limit` failure reason
- reuse the runner's expected-failure path so these job failures are logged at info instead of error
- add regression coverage for both messages observed in production

## Scope

- runs still fail and retain their original error details
- no retries, model fallback, API changes, schema changes, or persisted-data changes
- no changes to upstream Fable 5 entitlement or quota behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason_classifies_claude_fable_limits`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent -- --test-threads=1`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`

Closes #22480
