### PR TITLE
feat: serve the morning brief unsubscribe page from the platform app

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -533,7 +533,8 @@ describe("cron execute morning briefs", () => {
       "/api/email/morning-brief/unsubscribe",
     );
 
-    // The one-click unsubscribe link turns the preference off.
+    // The email body links to the platform unsubscribe page, which performs
+    // the actual unsubscribe through the one-click POST endpoint.
     const manageUrlMatch = email.html.match(
       /href="([^"]*morning-brief\/unsubscribe[^"]*)"/u,
     );
@@ -541,9 +542,23 @@ describe("cron execute morning briefs", () => {
       throw new Error("Expected the manage link in the email");
     }
     const manageUrl = new URL(manageUrlMatch[1].replaceAll("&amp;", "&"));
+    expect(manageUrl.pathname).toBe("/email/morning-brief/unsubscribe");
+    const token = manageUrl.searchParams.get("token");
+    expect(token).toBeTruthy();
+
+    // Legacy links in already-sent emails hit the API GET route, which now
+    // forwards to the platform page with the token preserved.
+    const legacyResponse = await createApp({ signal: context.signal }).request(
+      `/api/email/morning-brief/unsubscribe?token=${token}`,
+    );
+    expect(legacyResponse.status).toBe(302);
+    expect(legacyResponse.headers.get("Location")).toBe(manageUrl.toString());
+
     const unsubscribeResponse = await createApp({
       signal: context.signal,
-    }).request(`${manageUrl.pathname}${manageUrl.search}`);
+    }).request(`/api/email/morning-brief/unsubscribe?token=${token}`, {
+      method: "POST",
+    });
     expect(unsubscribeResponse.status).toBe(200);
 
     routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);

--- a/turbo/apps/api/src/signals/routes/email-morning-brief-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-morning-brief-unsubscribe.ts
@@ -52,22 +52,33 @@ const disableMorningBrief$ = command(
 );
 
 // Links in already-sent emails point at this API route. The unsubscribe page
-// now lives in the platform app, so forward the browser there with the token;
-// the page performs the actual unsubscribe via the POST endpoint.
-const getMorningBriefUnsubscribe$ = command(({ get }) => {
-  const query = get(queryOf(emailMorningBriefUnsubscribeContract.get));
-  const target = new URL(`${env("APP_URL")}/email/morning-brief/unsubscribe`);
-  if (query.token) {
-    target.searchParams.set("token", query.token);
-  }
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: target.toString(),
-      "Cache-Control": "no-store",
-    },
-  });
-});
+// now lives in the platform app, so forward the browser there with the token.
+// Rollout compatibility: the API can go live before the platform bundle that
+// serves the target route, so a valid token is still unsubscribed here before
+// redirecting; the platform page's POST is an idempotent no-op afterwards.
+// Remove the side effect once the platform route has fully rolled out.
+const getMorningBriefUnsubscribe$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const query = get(queryOf(emailMorningBriefUnsubscribeContract.get));
+    if (query.token) {
+      const verified = verifyMorningBriefUnsubscribeToken(query.token);
+      if (verified) {
+        await set(disableMorningBrief$, verified, signal);
+      }
+    }
+    const target = new URL(`${env("APP_URL")}/email/morning-brief/unsubscribe`);
+    if (query.token) {
+      target.searchParams.set("token", query.token);
+    }
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: target.toString(),
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+);
 
 const postMorningBriefUnsubscribe$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/routes/email-morning-brief-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-morning-brief-unsubscribe.ts
@@ -18,37 +18,6 @@ function invalidTokenResponse() {
   return { status: 400 as const, body: { error: "Invalid token" } };
 }
 
-function confirmationHtmlResponse(): Response {
-  const appUrl = env("APP_URL");
-  const html = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Morning Brief turned off - VM0</title>
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f6f9fc; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
-    .card { background: #fff; padding: 32px; border-radius: 8px; max-width: 480px; text-align: center; }
-    h1 { font-size: 20px; color: #111827; margin: 0 0 12px; }
-    p { font-size: 14px; color: #6b7280; line-height: 1.6; margin: 0 0 20px; }
-    a { color: #2563eb; text-decoration: underline; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Morning Brief turned off</h1>
-    <p>You will no longer receive the daily Morning Brief email. You can turn it back on any time in Settings.</p>
-    <p><a href="${appUrl}/settings">Manage preferences</a></p>
-  </div>
-</body>
-</html>`;
-
-  return new Response(html, {
-    status: 200,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  });
-}
-
 const disableMorningBrief$ = command(
   async (
     { set },
@@ -82,20 +51,23 @@ const disableMorningBrief$ = command(
   },
 );
 
-const getMorningBriefUnsubscribe$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const query = get(queryOf(emailMorningBriefUnsubscribeContract.get));
-    if (!query.token) {
-      return missingTokenResponse();
-    }
-    const verified = verifyMorningBriefUnsubscribeToken(query.token);
-    if (!verified) {
-      return invalidTokenResponse();
-    }
-    await set(disableMorningBrief$, verified, signal);
-    return confirmationHtmlResponse();
-  },
-);
+// Links in already-sent emails point at this API route. The unsubscribe page
+// now lives in the platform app, so forward the browser there with the token;
+// the page performs the actual unsubscribe via the POST endpoint.
+const getMorningBriefUnsubscribe$ = command(({ get }) => {
+  const query = get(queryOf(emailMorningBriefUnsubscribeContract.get));
+  const target = new URL(`${env("APP_URL")}/email/morning-brief/unsubscribe`);
+  if (query.token) {
+    target.searchParams.set("token", query.token);
+  }
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: target.toString(),
+      "Cache-Control": "no-store",
+    },
+  });
+});
 
 const postMorningBriefUnsubscribe$ = command(
   async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-morning-brief-run-callback.service.ts
@@ -24,6 +24,7 @@ import {
   getUserEmail,
 } from "./zero-email-common.service";
 import {
+  buildMorningBriefUnsubscribePageUrl,
   buildMorningBriefUnsubscribeUrl,
   MORNING_BRIEF_PREHEADER,
 } from "./morning-brief-email-link.service";
@@ -177,7 +178,7 @@ async function enqueueMorningBriefEmail(
     .limit(1);
 
   const dateLabel = morningBriefDateLabel(delivery.briefDate);
-  const manageUrl = buildMorningBriefUnsubscribeUrl(
+  const manageUrl = buildMorningBriefUnsubscribePageUrl(
     delivery.orgId,
     delivery.userId,
   );
@@ -189,7 +190,9 @@ async function enqueueMorningBriefEmail(
     fromAddress: buildFromAddress("zero"),
     toAddresses: userEmail,
     subject: `Morning Briefing - ${dateLabel}`,
-    headers: buildUnsubscribeHeaders(manageUrl),
+    headers: buildUnsubscribeHeaders(
+      buildMorningBriefUnsubscribeUrl(delivery.orgId, delivery.userId),
+    ),
     template: {
       template: "morning-brief",
       props: {

--- a/turbo/apps/api/src/signals/services/morning-brief-email-link.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-email-link.service.ts
@@ -17,12 +17,30 @@ function tokenSignature(orgId: string, userId: string): string {
     .slice(0, SIGNATURE_HEX_LENGTH);
 }
 
+function buildToken(orgId: string, userId: string): string {
+  return `${orgId}.${userId}.${tokenSignature(orgId, userId)}`;
+}
+
+/**
+ * One-click List-Unsubscribe target for email headers. Mail providers POST
+ * to this URL directly, so it must stay on the API origin.
+ */
 export function buildMorningBriefUnsubscribeUrl(
   orgId: string,
   userId: string,
 ): string {
-  const token = `${orgId}.${userId}.${tokenSignature(orgId, userId)}`;
-  return `${env("VM0_WEB_URL")}/api/email/morning-brief/unsubscribe?token=${token}`;
+  return `${env("VM0_WEB_URL")}/api/email/morning-brief/unsubscribe?token=${buildToken(orgId, userId)}`;
+}
+
+/**
+ * Human-facing unsubscribe page in the platform app, used for links inside
+ * the email body. The page performs the actual unsubscribe via the API.
+ */
+export function buildMorningBriefUnsubscribePageUrl(
+  orgId: string,
+  userId: string,
+): string {
+  return `${env("APP_URL")}/email/morning-brief/unsubscribe?token=${buildToken(orgId, userId)}`;
 }
 
 export function verifyMorningBriefUnsubscribeToken(

--- a/turbo/apps/platform/src/mocks/handlers/api-email-morning-brief-unsubscribe.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-email-morning-brief-unsubscribe.ts
@@ -1,0 +1,17 @@
+import { emailMorningBriefUnsubscribeContract } from "@vm0/api-contracts/contracts/email-morning-brief-unsubscribe";
+import { mockApi } from "../msw-contract.ts";
+
+/** Token accepted by the mock one-click unsubscribe endpoint. */
+export const MOCK_MORNING_BRIEF_UNSUBSCRIBE_TOKEN = "valid-token";
+
+export const apiEmailMorningBriefUnsubscribeHandlers = [
+  mockApi(
+    emailMorningBriefUnsubscribeContract.unsubscribe,
+    ({ query, respond }) => {
+      if (query.token === MOCK_MORNING_BRIEF_UNSUBSCRIBE_TOKEN) {
+        return respond(200, { unsubscribed: true });
+      }
+      return respond(400, { error: "Invalid token" });
+    },
+  ),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -89,6 +89,7 @@ import {
 } from "./api-onboarding.ts";
 import { apiBillingHandlers, resetMockBilling } from "./api-billing.ts";
 import { apiAttributionHandlers } from "./api-attribution.ts";
+import { apiEmailMorningBriefUnsubscribeHandlers } from "./api-email-morning-brief-unsubscribe.ts";
 import { resetMockWorkflowAutomations } from "./workflow-automations-store.ts";
 import { apiInsightsHandlers } from "./api-insights.ts";
 import { apiQueuePositionHandlers } from "./api-queue-position.ts";
@@ -133,6 +134,7 @@ export const handlers = [
   ...apiOnboardingHandlers,
   ...apiBillingHandlers,
   ...apiAttributionHandlers,
+  ...apiEmailMorningBriefUnsubscribeHandlers,
   ...apiIntegrationsSlackConnectHandlers,
   ...apiFeatureSwitchesHandlers,
   ...apiRealtimeHandlers,

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -49,6 +49,7 @@ import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-pa
 import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
 import { setupConnectorRedirectingPage$ } from "./connectors-page/connector-redirecting-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
+import { setupMorningBriefUnsubscribePage$ } from "./morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts";
 import { setupSignInPage$, setupSignUpPage$ } from "./auth-page-setup.ts";
 import { setupPermissionAllowPage$ } from "./permission-allow/permission-allow-page-setup.ts";
 import { setupReportErrorPage$ } from "./report-error/report-error-page-setup.ts";
@@ -293,6 +294,11 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.signInToken,
     setup: setupSignInTokenPage$,
+  },
+  {
+    // Public route: opened from the Morning Brief email, no auth guard.
+    path: ROUTES.morningBriefUnsubscribe,
+    setup: setupMorningBriefUnsubscribePage$,
   },
   {
     path: ROUTES.redeemCampaign,

--- a/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts
+++ b/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts
@@ -20,6 +20,9 @@ import { setMorningBriefUnsubscribeStatus$ } from "./morning-brief-unsubscribe-s
  */
 export const setupMorningBriefUnsubscribePage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    // Reset any result left over from a previous visit to this route; the
+    // module-level status state outlives the page setup.
+    set(setMorningBriefUnsubscribeStatus$, null);
     set(updatePage$, createElement(MorningBriefUnsubscribePage));
     set(updateDocumentTitle$, "Morning Brief");
 

--- a/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts
+++ b/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-page-setup.ts
@@ -1,0 +1,46 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { emailMorningBriefUnsubscribeContract } from "@vm0/api-contracts/contracts/email-morning-brief-unsubscribe";
+import { MorningBriefUnsubscribePage } from "../../views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { searchParams$ } from "../route.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
+import { setMorningBriefUnsubscribeStatus$ } from "./morning-brief-unsubscribe-signals.ts";
+
+/**
+ * Setup command for the public `/email/morning-brief/unsubscribe` route.
+ *
+ * This route has no auth guard — it is opened straight from the Morning
+ * Brief email, possibly on a device without a session. The signed token in
+ * the query string is the only credential; the API validates it on the
+ * one-click unsubscribe endpoint.
+ */
+export const setupMorningBriefUnsubscribePage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(MorningBriefUnsubscribePage));
+    set(updateDocumentTitle$, "Morning Brief");
+
+    const token = get(searchParams$).get("token");
+    if (!token) {
+      set(setMorningBriefUnsubscribeStatus$, "invalid");
+      await set(hideAppSkeleton$, signal);
+      return;
+    }
+
+    const client = get(zeroClient$)(emailMorningBriefUnsubscribeContract);
+    const result = await accept(
+      client.unsubscribe({ query: { token }, body: undefined }),
+      [200, 400],
+    );
+    signal.throwIfAborted();
+    set(
+      setMorningBriefUnsubscribeStatus$,
+      result.status === 200 ? "unsubscribed" : "invalid",
+    );
+
+    await set(hideAppSkeleton$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-signals.ts
+++ b/turbo/apps/platform/src/signals/morning-brief-unsubscribe/morning-brief-unsubscribe-signals.ts
@@ -1,0 +1,19 @@
+import { command, computed, state } from "ccstate";
+
+export type MorningBriefUnsubscribeStatus = "unsubscribed" | "invalid";
+
+/**
+ * Result of the unsubscribe API call. Populated by the page setup before
+ * `hideAppSkeleton$` fires so the view never renders a loading state.
+ */
+const internalStatus$ = state<MorningBriefUnsubscribeStatus | null>(null);
+
+export const morningBriefUnsubscribeStatus$ = computed((get) => {
+  return get(internalStatus$);
+});
+
+export const setMorningBriefUnsubscribeStatus$ = command(
+  ({ set }, status: MorningBriefUnsubscribeStatus | null) => {
+    set(internalStatus$, status);
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -38,6 +38,7 @@ export const ROUTES = {
   signUp: "/sign-up",
   signUpCatchAll: "/sign-up{/*path}",
   signInToken: "/sign-in-token",
+  morningBriefUnsubscribe: "/email/morning-brief/unsubscribe",
   lab: "/_/lab",
   insights: "/insights",
   usage: "/usage",

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/__tests__/morning-brief-unsubscribe-page.test.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/__tests__/morning-brief-unsubscribe-page.test.tsx
@@ -1,0 +1,43 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { MOCK_MORNING_BRIEF_UNSUBSCRIBE_TOKEN } from "../../../mocks/handlers/api-email-morning-brief-unsubscribe.ts";
+
+const context = testContext();
+
+describe("morning brief unsubscribe page", () => {
+  it("unsubscribes with a valid token from the email link", async () => {
+    detachedSetupPage({
+      context,
+      path: `/email/morning-brief/unsubscribe?token=${MOCK_MORNING_BRIEF_UNSUBSCRIBE_TOKEN}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Brief turned off")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/no longer receive the daily Morning Brief email/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the invalid state when the API rejects the token", async () => {
+    detachedSetupPage({
+      context,
+      path: "/email/morning-brief/unsubscribe?token=tampered-token",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("This link is invalid")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the invalid state without calling the API when the token is missing", async () => {
+    detachedSetupPage({ context, path: "/email/morning-brief/unsubscribe" });
+
+    await waitFor(() => {
+      expect(screen.getByText("This link is invalid")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { useGet } from "ccstate-react";
+import { IconCheck, IconLoader2, IconX } from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import {
+  morningBriefUnsubscribeStatus$,
+  type MorningBriefUnsubscribeStatus,
+} from "../../signals/morning-brief-unsubscribe/morning-brief-unsubscribe-signals.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
+import { Link } from "../router/link.tsx";
+import { VM0Logo } from "../components/vm0-logo.tsx";
+
+interface CardInfo {
+  title: string;
+  body: string;
+}
+
+function resolveCard(status: MorningBriefUnsubscribeStatus): CardInfo {
+  if (status === "unsubscribed") {
+    return {
+      title: "Morning Brief turned off",
+      body: "You will no longer receive the daily Morning Brief email. You can turn it back on any time in Settings.",
+    };
+  }
+  return {
+    title: "This link is invalid",
+    body: "The unsubscribe link is invalid or incomplete. Open the latest Morning Brief email and use its unsubscribe link, or manage the preference in Settings.",
+  };
+}
+
+function CardIcon({
+  status,
+}: {
+  status: MorningBriefUnsubscribeStatus;
+}): ReactNode {
+  if (status === "unsubscribed") {
+    return <IconCheck size={40} className="text-green-600 opacity-80" />;
+  }
+  return <IconX size={40} className="text-destructive opacity-70" />;
+}
+
+export function MorningBriefUnsubscribePage() {
+  const status = useGet(morningBriefUnsubscribeStatus$);
+
+  if (!status) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const info = resolveCard(status);
+
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center px-6">
+      <div className="flex w-[500px] max-w-full flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
+        <VM0Logo />
+        <div className="flex flex-col items-center gap-4">
+          <CardIcon status={status} />
+          <p className="text-center text-lg font-medium leading-7 text-foreground">
+            {info.title}
+          </p>
+          <p className="text-center text-sm text-muted-foreground">
+            {info.body}
+          </p>
+        </div>
+        <Button className="w-full" asChild>
+          <Link pathname={ROUTES.settings}>Manage preferences</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/turbo/packages/api-contracts/src/contracts/email-morning-brief-unsubscribe.ts
+++ b/turbo/packages/api-contracts/src/contracts/email-morning-brief-unsubscribe.ts
@@ -22,13 +22,9 @@ export const emailMorningBriefUnsubscribeContract = c.router({
     path: "/api/email/morning-brief/unsubscribe",
     query: emailMorningBriefUnsubscribeQuerySchema,
     responses: {
-      200: c.otherResponse({
-        contentType: "text/html",
-        body: z.unknown(),
-      }),
-      400: emailMorningBriefUnsubscribeErrorSchema,
+      302: c.noBody(),
     },
-    summary: "Turn off the Morning Brief from an email link",
+    summary: "Redirect legacy email links to the platform unsubscribe page",
   },
   unsubscribe: {
     method: "POST",


### PR DESCRIPTION
## Summary

The Morning Brief unsubscribe confirmation page was rendered as inline HTML inside the API route (`GET /api/email/morning-brief/unsubscribe`). This PR moves the user-facing page into the platform app (app.vm0.ai) and keeps the API responsible only for the unsubscribe action itself.

### User-visible impact
- The unsubscribe link in the Morning Brief email body now opens `app.vm0.ai/email/morning-brief/unsubscribe?token=...`, a public route with **no auth guard** (recipients may open it on a device without a session). The page calls the existing one-click `POST /api/email/morning-brief/unsubscribe` on api.vm0.ai with the signed token, then shows a success card, or an invalid-link card when the token is missing/tampered.
- Links in **already-sent** emails still work: the legacy API `GET` route now returns a 302 redirect to the new platform page, preserving the token.
- Mail-client one-click unsubscribe is unchanged: the `List-Unsubscribe` header still points at the API `POST` endpoint (mail providers POST there directly, so it must stay on the API origin).

### Implementation
- `apps/api`: `buildMorningBriefUnsubscribePageUrl` (APP_URL) is used for the email body link; `buildMorningBriefUnsubscribeUrl` (API origin) remains for the `List-Unsubscribe` header. The GET route drops its inline HTML and 302-redirects; the contract's GET response is now `302: c.noBody()`.
- `apps/platform`: new public route registered without `setupAuthPageWrapper`, with a `none`-layout page (the `minimal` layout pulls session-dependent signals and breaks on unauthenticated visits). Unsubscribe result is stored in a ccstate signal populated before the app skeleton hides.
- MSW contract mock for the POST endpoint added for platform tests.

### Verification
- Platform integration tests (3 new cases: valid token, rejected token, missing token) pass locally; platform and api type checks pass; changed-file lint clean.
- Updated the API morning-brief cron test to assert the email links to the platform page, the legacy GET 302-redirects with the token preserved, and the POST endpoint unsubscribes. The cron test suite fails in my sandbox on unmodified main as well (runner queue infra unavailable), so relying on CI for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)